### PR TITLE
Fix semantic-release blocked by commit-msg hook in CI

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,6 +3,11 @@
 
 # Validate commit messages using commitlint
 commit-msg:
+  # Skip in CI to allow semantic-release commits
+  skip:
+    - ref: main
+      env:
+        - CI
   commands:
     commitlint:
       run: npx commitlint --edit {1}


### PR DESCRIPTION
## Problem

The merge workflow is failing because semantic-release cannot create release commits. The lefthook commit-msg hook runs commitlint validation on **all** commits, including those made by semantic-release in CI.

**Error from workflow:**
```
Command failed with exit code 1: git commit -m chore(release): 1.0.0 [skip ci]
🥊 commitlint: ❌ Commit message validation failed!
```

**Root Cause:**
Semantic-release creates commits with long markdown changelogs in the body:
```
chore(release): 1.0.0 [skip ci]

# 1.0.0 (2025-10-18)

### Bug Fixes
* fix: issue description
... (long changelog)
```

The commitlint hook rejects these because the body format doesn't match conventional commit rules.

## Solution

Configure lefthook to **skip the commit-msg hook in CI**:

```yaml
commit-msg:
  # Skip in CI to allow semantic-release commits
  skip:
    - ref: main
      env:
        - CI
```

This ensures:
- ✅ Local developer commits are still validated by commitlint
- ✅ Semantic-release can create release commits in CI without interference
- ✅ Hooks only run where appropriate

## Impact

- Unblocks merge workflow and semantic-release
- Enables automated package releases
- Maintains commit message quality for developer commits

## Test Plan

- ✅ Verified lefthook configuration syntax
- ✅ Local commits still trigger commitlint validation
- ⏳ CI workflow will skip hooks when merging to main