### PR TITLE
fix(core): gracefully handle missing _smrt_contexts table in DuckDB

### DIFF
--- a/packages/core/src/class.ts
+++ b/packages/core/src/class.ts
@@ -263,23 +263,35 @@ export class SmrtClass {
       return;
     }
 
-    // Create all system tables
-    for (const createTableSQL of ALL_SYSTEM_TABLES) {
-      // Execute as raw SQL (not a parameterized query)
-      await this._db.query(createTableSQL);
+    try {
+      // Create all system tables
+      for (const createTableSQL of ALL_SYSTEM_TABLES) {
+        // Execute as raw SQL (not a parameterized query)
+        await this._db.query(createTableSQL);
+      }
+
+      // Record current schema version
+      // Use ON CONFLICT for DuckDB compatibility (not INSERT OR IGNORE)
+      const id = crypto.randomUUID();
+      const version = SMRT_SCHEMA_VERSION;
+      const description = 'Initial SMRT system tables';
+      await this._db.execute`
+        INSERT INTO _smrt_migrations (id, version, description)
+        VALUES (${id}, ${version}, ${description})
+        ON CONFLICT(version) DO NOTHING
+      `;
+
+      // Mark this database as initialized
+      SmrtClass._systemTablesInitialized.add(dbKey);
+    } catch (error) {
+      // Log error but don't fail - system tables are optional for basic operations
+      console.warn(
+        `[SmrtClass] Failed to create system tables for ${dbKey}:`,
+        error instanceof Error ? error.message : String(error),
+      );
+      // Mark as initialized even on failure to avoid repeated attempts
+      SmrtClass._systemTablesInitialized.add(dbKey);
     }
-
-    // Record current schema version
-    const id = crypto.randomUUID();
-    const version = SMRT_SCHEMA_VERSION;
-    const description = 'Initial SMRT system tables';
-    await this._db.execute`
-      INSERT OR IGNORE INTO _smrt_migrations (id, version, description)
-      VALUES (${id}, ${version}, ${description})
-    `;
-
-    // Mark this database as initialized
-    SmrtClass._systemTablesInitialized.add(dbKey);
   }
 
   /**

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -851,35 +851,49 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       throw new Error('Database not initialized. Call initialize() first.');
     }
 
-    // Use single() with template literals for custom SQL query
-    let result: Record<string, any> | null;
-    if (options.minConfidence !== undefined) {
-      result = await this.systemDb.single`
-        SELECT value, confidence
-        FROM _smrt_contexts
-        WHERE owner_class = ${this._itemClass.name}
-          AND owner_id = ${'__collection__'}
-          AND scope = ${options.scope}
-          AND key = ${options.key}
-          AND confidence >= ${options.minConfidence}
-        ORDER BY confidence DESC, version DESC
-        LIMIT 1
-      `;
-    } else {
-      result = await this.systemDb.single`
-        SELECT value, confidence
-        FROM _smrt_contexts
-        WHERE owner_class = ${this._itemClass.name}
-          AND owner_id = ${'__collection__'}
-          AND scope = ${options.scope}
-          AND key = ${options.key}
-        ORDER BY confidence DESC, version DESC
-        LIMIT 1
-      `;
-    }
+    try {
+      // Use single() with template literals for custom SQL query
+      let result: Record<string, any> | null;
+      if (options.minConfidence !== undefined) {
+        result = await this.systemDb.single`
+          SELECT value, confidence
+          FROM _smrt_contexts
+          WHERE owner_class = ${this._itemClass.name}
+            AND owner_id = ${'__collection__'}
+            AND scope = ${options.scope}
+            AND key = ${options.key}
+            AND confidence >= ${options.minConfidence}
+          ORDER BY confidence DESC, version DESC
+          LIMIT 1
+        `;
+      } else {
+        result = await this.systemDb.single`
+          SELECT value, confidence
+          FROM _smrt_contexts
+          WHERE owner_class = ${this._itemClass.name}
+            AND owner_id = ${'__collection__'}
+            AND scope = ${options.scope}
+            AND key = ${options.key}
+          ORDER BY confidence DESC, version DESC
+          LIMIT 1
+        `;
+      }
 
-    if (result) {
-      return JSON.parse(result.value);
+      if (result) {
+        return JSON.parse(result.value);
+      }
+    } catch (error) {
+      // Gracefully handle missing _smrt_contexts table
+      // This can happen in DuckDB JSON mode or when system tables aren't initialized
+      if (
+        error instanceof Error &&
+        error.message.includes('_smrt_contexts does not exist')
+      ) {
+        // Return null - no context found (table doesn't exist)
+        return null;
+      }
+      // Re-throw other errors
+      throw error;
     }
 
     // Hierarchical fallback to parent scopes

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -1124,35 +1124,49 @@ export class SmrtObject extends SmrtClass {
       throw new Error('Database not initialized. Call initialize() first.');
     }
 
-    // Use single() with template literals for custom SQL query
-    let result: Record<string, any> | null;
-    if (options.minConfidence !== undefined) {
-      result = await this.systemDb.single`
-        SELECT value, confidence
-        FROM _smrt_contexts
-        WHERE owner_class = ${this._className}
-          AND owner_id = ${this.id}
-          AND scope = ${options.scope}
-          AND key = ${options.key}
-          AND confidence >= ${options.minConfidence}
-        ORDER BY confidence DESC, version DESC
-        LIMIT 1
-      `;
-    } else {
-      result = await this.systemDb.single`
-        SELECT value, confidence
-        FROM _smrt_contexts
-        WHERE owner_class = ${this._className}
-          AND owner_id = ${this.id}
-          AND scope = ${options.scope}
-          AND key = ${options.key}
-        ORDER BY confidence DESC, version DESC
-        LIMIT 1
-      `;
-    }
+    try {
+      // Use single() with template literals for custom SQL query
+      let result: Record<string, any> | null;
+      if (options.minConfidence !== undefined) {
+        result = await this.systemDb.single`
+          SELECT value, confidence
+          FROM _smrt_contexts
+          WHERE owner_class = ${this._className}
+            AND owner_id = ${this.id}
+            AND scope = ${options.scope}
+            AND key = ${options.key}
+            AND confidence >= ${options.minConfidence}
+          ORDER BY confidence DESC, version DESC
+          LIMIT 1
+        `;
+      } else {
+        result = await this.systemDb.single`
+          SELECT value, confidence
+          FROM _smrt_contexts
+          WHERE owner_class = ${this._className}
+            AND owner_id = ${this.id}
+            AND scope = ${options.scope}
+            AND key = ${options.key}
+          ORDER BY confidence DESC, version DESC
+          LIMIT 1
+        `;
+      }
 
-    if (result) {
-      return JSON.parse(result.value);
+      if (result) {
+        return JSON.parse(result.value);
+      }
+    } catch (error) {
+      // Gracefully handle missing _smrt_contexts table
+      // This can happen in DuckDB JSON mode or when system tables aren't initialized
+      if (
+        error instanceof Error &&
+        error.message.includes('_smrt_contexts does not exist')
+      ) {
+        // Return null - no context found (table doesn't exist)
+        return null;
+      }
+      // Re-throw other errors
+      throw error;
     }
 
     // Hierarchical fallback to parent scopes


### PR DESCRIPTION
## Summary

Fixes #35

This PR makes the SMRT framework work gracefully in DuckDB JSON mode even when system tables cannot be created.

## Changes

### 1. DuckDB-Compatible SQL Syntax (`packages/core/src/class.ts`)
- Changed `INSERT OR IGNORE` (SQLite-only) to `INSERT ... ON CONFLICT DO NOTHING` (DuckDB-compatible)
- Added try-catch to gracefully handle table creation failures
- Log warning instead of throwing error when system tables can't be created
- Mark database as initialized even on failure to avoid repeated attempts

### 2. Graceful Error Handling in recall() Methods
- **`packages/core/src/collection.ts`**: Wrapped recall() SQL query in try-catch
- **`packages/core/src/object.ts`**: Wrapped recall() SQL query in try-catch
- Both methods now:
  - Return `null` when `_smrt_contexts` table doesn't exist
  - Re-throw other errors for proper debugging
  - Allow framework to work without system tables

## Test Plan

- [x] Build passes
- [x] All tests pass (1058 passed, 72 skipped)
- [x] Formatting checks pass
- [x] Manual verification: DuckDB JSON mode works without system tables

## Root Cause

The issue had two root causes:
1. **SQL Syntax Incompatibility**: `INSERT OR IGNORE` is SQLite-specific and not supported in DuckDB
2. **Lack of Graceful Degradation**: When table creation failed or table was missing, recall() would throw errors instead of gracefully returning null

## Impact

- Framework now works in DuckDB JSON mode (e.g., `praeco` package)
- System tables are truly optional for basic operations
- Better error messages and debugging (warnings instead of crashes)
- No impact on existing SQLite or Postgres usage