### PR TITLE
fix(ci): exclude SDK docs from build in deploy-docs job

### DIFF
--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Build SDK packages
         run: |
           cd sdk
-          pnpm run build
+          pnpm -r --workspace-concurrency=4 --filter='!@have/docs' --filter='!@happyvertical/docs' run build
           cd ..
 
       - name: Build packages


### PR DESCRIPTION
## Summary

This PR fixes the documentation deployment workflow that was failing on the main branch. The `deploy-docs` job in `on-merge-main.yml` was attempting to build the SDK's docs package without installing its dependencies, causing a build failure.

## Problem

The workflow step "Build SDK packages" was running `pnpm run build` which tried to build all SDK packages including `@have/docs`. However, the docs package requires Docusaurus and other dependencies that were not installed, resulting in:

```
docs build: sh: 1: docusaurus: not found
ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL @have/docs@0.0.50 build: `docusaurus build`
spawn ENOENT
WARN Local package.json exists, but node_modules missing, did you mean to install?
```

## Solution

Modified the "Build SDK packages" step to filter out SDK docs packages using the same approach as `test-suite.yml`:

```yaml
- name: Build SDK packages
  run: |
    cd sdk
    pnpm -r --workspace-concurrency=4 --filter='!@have/docs' --filter='!@happyvertical/docs' run build
    cd ..
```

This approach is consistent with how the test suite already handles SDK builds and prevents trying to build docs packages without their dependencies.

## Impact

- ✅ SDK packages build successfully without docs package interference
- ✅ SMRT documentation site deployment can proceed (separate docs build step exists)
- ✅ Consistent with test-suite.yml workflow
- ✅ No changes to actual documentation - just fixes the build process

## Testing

This fix cannot be fully tested until merged to main, as the `deploy-docs` job only runs on main branch pushes. However:
- ✅ Syntax is valid (verified by linter)
- ✅ Approach matches working test-suite.yml pattern
- ✅ PR checks will verify no regressions in test suite

## Checklist

- [x] Workflow syntax verified
- [x] Code formatted
- [x] Conventional commit message
- [x] Consistent with test-suite.yml approach

Fixes documentation deployment failure on main branch.