### PR TITLE
fix(ci): exclude SDK docs from build in deploy-docs job

### DIFF
--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Build SDK packages
         run: |
           cd sdk
-          pnpm run build
+          pnpm -r --workspace-concurrency=4 --filter='!@have/docs' --filter='!@happyvertical/docs' run build
           cd ..
 
       - name: Build packages


### PR DESCRIPTION
The deploy-docs job was failing because it tried to build the SDK docs package without installing its dependencies (docusaurus). This resulted in 'docusaurus: not found' error.

Fixed by filtering out SDK docs packages from the build step, consistent with how test-suite.yml handles it.