### PR TITLE
docs: update CLAUDE.md files to reflect recent refactoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ The SMRT framework is organized as a pnpm workspace with the following packages:
 **Core Framework:**
 - **core**: Core framework with ORM, code generation, and AI integration
 - **types**: Shared TypeScript type definitions
+- **config**: Configuration management with cosmiconfig integration
 
 **Domain Modules:**
 - **accounts**: Accounting ledger with multi-currency support
@@ -37,12 +38,12 @@ The SMRT framework is organized as a pnpm workspace with the following packages:
 - **tags**: Hierarchical tagging system
 
 **External SDK Dependencies:**
-The framework depends on these infrastructure packages from @have/sdk:
-- **@have/ai**: Multi-provider AI client (OpenAI, Anthropic, Google, AWS)
-- **@have/files**: File system operations and utilities
-- **@have/sql**: Database operations (SQLite, Postgres, DuckDB)
-- **@have/utils**: Shared utility functions
-- **@have/logger**: Logging infrastructure
+The framework depends on these infrastructure packages from @happyvertical/sdk:
+- **@happyvertical/ai**: Multi-provider AI client (OpenAI, Anthropic, Google, AWS)
+- **@happyvertical/files**: File system operations and utilities
+- **@happyvertical/sql**: Database operations (SQLite, Postgres, DuckDB)
+- **@happyvertical/utils**: Shared utility functions
+- **@happyvertical/logger**: Logging infrastructure
 
 ## Development Patterns
 
@@ -58,11 +59,12 @@ The framework depends on these infrastructure packages from @have/sdk:
 
 The build process follows a specific order to respect internal dependencies:
 
-1. `@smrt/types` (shared type definitions)
-2. `@smrt/core` (core framework - depends on types)
-3. Domain modules (depend on core): accounts, agents, assets, content, events, gnode, places, products, profiles, tags
+1. `@happyvertical/smrt-types` (shared type definitions)
+2. `@happyvertical/smrt-config` (configuration management)
+3. `@happyvertical/smrt-core` (core framework - depends on types and config)
+4. Domain modules (depend on core): accounts, agents, assets, content, events, gnode, places, products, profiles, tags
 
-External dependencies from @have/sdk are installed from npm.
+External dependencies from @happyvertical/sdk are installed from npm.
 
 ### TypeScript Project References
 
@@ -80,6 +82,7 @@ Each package must have:
 {
   "references": [
     { "path": "./packages/types" },
+    { "path": "./packages/config" },
     { "path": "./packages/core" },
     { "path": "./packages/accounts" },
     { "path": "./packages/agents" },
@@ -155,7 +158,7 @@ npm run format
 **IMPORTANT**: This SOP should be followed automatically whenever beginning implementation work, whether explicitly asked or implied.
 
 **Related Standards**:
-- [Organization-Wide Testing Standard](../../TESTING_STANDARD.md) - Must be followed for all test writing
+- [Organization-Wide Testing Standard](../TESTING_STANDARD.md) - Must be followed for all test writing
 - [Definition of Ready](https://github.com/happyvertical/sdk/blob/main/docs/workflow/DEFINITION_OF_READY.md) - Issue readiness criteria
 - [Definition of Done](https://github.com/happyvertical/sdk/blob/main/docs/workflow/DEFINITION_OF_DONE.md) - PR completion checklist
 
@@ -317,7 +320,7 @@ gh issue comment {issue-number} --body "$(cat <<'EOF'
 2. [Decision 2 and rationale]
 
 ### Test Strategy
-Following [Organization-Wide Testing Standard](../../TESTING_STANDARD.md):
+Following [Organization-Wide Testing Standard](../TESTING_STANDARD.md):
 
 **Test Types**:
 - [ ] Unit tests (`*.test.ts`) - [if needed, describe what]
@@ -423,7 +426,7 @@ For **all work**:
 **IMPORTANT**: This SOP should be followed automatically when work is complete, before pushing changes.
 
 **Related Standards**:
-- [Organization-Wide Testing Standard](../../TESTING_STANDARD.md) - Enforced by code reviewer
+- [Organization-Wide Testing Standard](../TESTING_STANDARD.md) - Enforced by code reviewer
 - [Definition of Done](https://github.com/happyvertical/sdk/blob/main/docs/workflow/DEFINITION_OF_DONE.md) - Verified before PR creation
 - [Code Reviewer Agent](./.claude/agents/code-reviewer.md) - Automated review process
 
@@ -617,7 +620,7 @@ Generate comprehensive PR description using this template:
 
 ## Testing
 
-Following [Organization-Wide Testing Standard](../../TESTING_STANDARD.md):
+Following [Organization-Wide Testing Standard](../TESTING_STANDARD.md):
 
 **Test Types Added**:
 - [x] Unit tests (`*.test.ts`) - {describe what}
@@ -744,14 +747,15 @@ echo "You can continue with other work or wait for review feedback"
 The packages have these dependency relationships:
 
 **Within SMRT framework:**
-- `@smrt/types`: No internal dependencies
-- `@smrt/core`: Depends on `@smrt/types` and external SDK packages (`@have/*`)
-- Domain modules: All depend on `@smrt/core`, some have cross-dependencies:
-  - `@smrt/assets` → depends on `@smrt/tags`
-  - `@smrt/events` → depends on `@smrt/places`, `@smrt/profiles`
+- `@happyvertical/smrt-types`: No internal dependencies
+- `@happyvertical/smrt-config`: No internal dependencies
+- `@happyvertical/smrt-core`: Depends on `@happyvertical/smrt-types`, `@happyvertical/smrt-config`, and external SDK packages (`@happyvertical/*`)
+- Domain modules: All depend on `@happyvertical/smrt-core`, some have cross-dependencies:
+  - `@happyvertical/smrt-assets` → depends on `@happyvertical/smrt-tags`
+  - `@happyvertical/smrt-events` → depends on `@happyvertical/smrt-places`, `@happyvertical/smrt-profiles`
 
 **External dependencies:**
-All SMRT packages can depend on SDK infrastructure packages (`@have/ai`, `@have/files`, `@have/sql`, `@have/utils`, `@have/logger`) which are installed from npm.
+All SMRT packages can depend on SDK infrastructure packages (`@happyvertical/ai`, `@happyvertical/files`, `@happyvertical/sql`, `@happyvertical/utils`, `@happyvertical/logger`) which are installed from npm.
 
 When adding new features, maintain this dependency hierarchy to avoid circular dependencies within the SMRT framework.
 
@@ -825,6 +829,45 @@ See [.github/TRIAGE_SOP.md](.github/TRIAGE_SOP.md) for complete details.
 ## Recent Infrastructure Changes
 
 Important PRs that modified development workflow, tooling, or publishing:
+
+### PR #81 - CLI Spinner TTY Detection (Oct 2024)
+**Issue**: #80
+
+**Changes**:
+- Fixed CLI crash in non-TTY environments (tsx, CI/CD, pipes)
+- Added TTY detection before using clearLine/cursorTo methods
+- Graceful fallback to console.log when TTY unavailable
+- Added regression test for non-TTY spinner behavior
+
+**Impact**: CLI commands (list, create, etc.) now work reliably in all environments including tsx, CI pipelines, and piped output.
+
+**Reference**: https://github.com/happyvertical/smrt/pull/81
+
+### PR #79 - Database Adapter Method Migration (Oct 2024)
+**Issue**: #78
+
+**Changes**:
+- Replaced raw SQL queries with semantic database adapter methods
+- Converted `db.pluck()`, `db.query()`, `db.execute()` to `db.get()`, `db.list()`, `db.delete()`
+- Improved cross-adapter compatibility (SQLite, Postgres, DuckDB, JSON)
+- Better type safety and maintainability
+- Simplified LIKE pattern handling
+
+**Impact**: Code is now more maintainable, type-safe, and works consistently across all database adapters.
+
+**Reference**: https://github.com/happyvertical/smrt/pull/79
+
+### PR #77 - System Tables Initialization Tracking (Oct 2024)
+**Issue**: #35
+
+**Changes**:
+- Simplified system tables initialization tracking
+- Fixed race conditions in concurrent initialization
+- Improved database setup reliability
+
+**Impact**: More reliable database initialization, especially for concurrent operations.
+
+**Reference**: https://github.com/happyvertical/smrt/pull/77
 
 ### PR #44 - GitHub Packages Publishing & Testing Standard (Oct 2024)
 **Issues**: #43, #42, #38

--- a/docs/content/api/core/_media/CLAUDE.md
+++ b/docs/content/api/core/_media/CLAUDE.md
@@ -15,7 +15,7 @@ The `@happyvertical/smrt-core` package is the core framework for building vertic
 - **CLI Generators**: Create administrative command-line tools from SMRT objects
 - **REST API Generators**: Auto-generate complete REST APIs with OpenAPI documentation
 - **MCP Server Generators**: Generate Model Context Protocol servers for AI integration
-- **Vite Plugin Integration**: Automatic service generation with virtual modules (@smrt/routes, @smrt/client, @smrt/mcp)
+- **Vite Plugin Integration**: Automatic service generation with virtual modules (@happyvertical/smrt-routes, @happyvertical/smrt-client, @happyvertical/smrt-mcp)
 
 ### Runtime Environment Support
 - **Node.js Only**: Package now focused on Node.js for simplified deployment and better performance
@@ -143,7 +143,7 @@ await doc.initialize();
 
 #### Supported Providers
 
-The framework supports all providers from `@have/ai`:
+The framework supports all providers from `@happyvertical/ai`:
 
 - **openai** - OpenAI models (GPT-4, GPT-3.5, etc.)
 - **anthropic** - Anthropic models (Claude 3 Opus, Sonnet, Haiku)
@@ -179,11 +179,11 @@ export CLAUDE_API_KEY=your-claude-key
 
 **Using loadEnvConfig Directly:**
 ```typescript
-// Import from @happyvertical/smrt-core/config (re-exported from @have/utils)
+// Import from @happyvertical/smrt-core/config (re-exported from @happyvertical/utils)
 import { loadEnvConfig } from '@happyvertical/smrt-core/config';
 
-// Or import directly from @have/utils
-// import { loadEnvConfig } from '@have/utils';
+// Or import directly from @happyvertical/utils
+// import { loadEnvConfig } from '@happyvertical/utils';
 
 // Load SMRT_AI_* environment variables
 const aiConfig = loadEnvConfig({}, {
@@ -230,7 +230,7 @@ node dist/mcp-server.js
 
 ### Environment Variable Configuration
 
-The SMRT framework uses `loadEnvConfig()` from `@have/utils` (SDK package) for loading configuration from environment variables with automatic type conversion and validation. This utility is re-exported by `@happyvertical/smrt-core/config` for convenience.
+The SMRT framework uses `loadEnvConfig()` from `@happyvertical/utils` (SDK package) for loading configuration from environment variables with automatic type conversion and validation. This utility is re-exported by `@happyvertical/smrt-core/config` for convenience.
 
 #### Features
 
@@ -243,7 +243,7 @@ The SMRT framework uses `loadEnvConfig()` from `@have/utils` (SDK package) for l
 
 #### Source
 
-`loadEnvConfig()` is implemented in `@have/utils` (SDK) and re-exported by `@happyvertical/smrt-core/config` for convenience. See [SDK env-config documentation](https://github.com/happyvertical/sdk/blob/main/packages/utils/src/config/env-config.ts) for the full implementation.
+`loadEnvConfig()` is implemented in `@happyvertical/utils` (SDK) and re-exported by `@happyvertical/smrt-core/config` for convenience. See [SDK env-config documentation](https://github.com/happyvertical/sdk/blob/main/packages/utils/src/config/env-config.ts) for the full implementation.
 
 #### API
 
@@ -251,8 +251,8 @@ The SMRT framework uses `loadEnvConfig()` from `@have/utils` (SDK package) for l
 // Import from @happyvertical/smrt-core/config (re-exported)
 import { loadEnvConfig } from '@happyvertical/smrt-core/config';
 
-// Or import directly from @have/utils
-// import { loadEnvConfig } from '@have/utils';
+// Or import directly from @happyvertical/utils
+// import { loadEnvConfig } from '@happyvertical/utils';
 
 interface MyConfig {
   provider: string;
@@ -1277,10 +1277,10 @@ export default {
 };
 
 // Auto-generated virtual modules available:
-import { setupRoutes } from '@smrt/routes';        // REST routes
-import { createClient } from '@smrt/client';       // API client
-import { tools } from '@smrt/mcp';                 // MCP tools
-import { manifest } from '@smrt/manifest';         // Object manifest
+import { setupRoutes } from '@happyvertical/smrt-routes';        // REST routes
+import { createClient } from '@happyvertical/smrt-client';       // API client
+import { tools } from '@happyvertical/smrt-mcp';                 // MCP tools
+import { manifest } from '@happyvertical/smrt-manifest';         // Object manifest
 ```
 
 #### Consumer Plugin (for SMRT Package Users)
@@ -1304,8 +1304,8 @@ export default {
 };
 
 // Resolves virtual modules from consumed SMRT packages:
-import { createClient } from '@smrt/client';       // Generated from consumed packages
-import { setupRoutes } from '@smrt/routes';        // Combined routes from all packages
+import { createClient } from '@happyvertical/smrt-client';       // Generated from consumed packages
+import { setupRoutes } from '@happyvertical/smrt-routes';        // Combined routes from all packages
 import type { ProductData } from '@happyvertical/smrt-types';    // Generated TypeScript types
 ```
 
@@ -1339,8 +1339,8 @@ export default {
 };
 
 // Access both local and external virtual modules:
-import { setupRoutes as localRoutes } from '@smrt/routes';    // From local objects
-import { createClient } from '@smrt/client';                   // Combined client
+import { setupRoutes as localRoutes } from '@happyvertical/smrt-routes';    // From local objects
+import { createClient } from '@happyvertical/smrt-client';                   // Combined client
 import type { LocalModel, ExternalModel } from '@happyvertical/smrt-types'; // All types
 ```
 
@@ -1559,9 +1559,9 @@ The plugin generates comprehensive TypeScript declarations for consumed SMRT pac
 └── smrt-objects.d.ts    // Individual object interfaces
 
 // Auto-imported virtual modules:
-import { createClient } from '@smrt/client';
-import { setupRoutes } from '@smrt/routes';
-import { tools } from '@smrt/mcp';
+import { createClient } from '@happyvertical/smrt-client';
+import { setupRoutes } from '@happyvertical/smrt-routes';
+import { tools } from '@happyvertical/smrt-mcp';
 import type { ProductData, CategoryData } from '@happyvertical/smrt-types';
 ```
 
@@ -1631,7 +1631,7 @@ smrtConsumer({
 })
 
 // Access combined APIs from all services
-import { createClient } from '@smrt/client';
+import { createClient } from '@happyvertical/smrt-client';
 const client = createClient('/api/v1');
 
 // Type-safe access to all service APIs
@@ -1757,19 +1757,19 @@ The package uses:
 - Schema generation based on class properties
 - SQLite triggers for automatic timestamp management
 - A consistent pattern for database operations
-- Integration with AI models via the `@have/ai` package
+- Integration with AI models via the `@happyvertical/ai` package
 
 ## Dependencies
 
 The SMRT framework integrates with multiple packages to provide comprehensive agent capabilities:
 
 ### Internal HAVE SDK Dependencies
-- **@have/ai**: AI model interactions and completions across multiple providers
-- **@have/files**: File system operations and content management
-- **@have/pdf**: PDF document processing and text extraction
-- **@have/sql**: Database operations with SQLite and PostgreSQL support
-- **@have/spider**: Web content extraction and processing
-- **@have/utils**: Shared utility functions and type definitions
+- **@happyvertical/ai**: AI model interactions and completions across multiple providers
+- **@happyvertical/files**: File system operations and content management
+- **@happyvertical/pdf**: PDF document processing and text extraction
+- **@happyvertical/sql**: Database operations with SQLite and PostgreSQL support
+- **@happyvertical/spider**: Web content extraction and processing
+- **@happyvertical/utils**: Shared utility functions and type definitions
 
 ### External Dependencies
 - **@langchain/community**: Third-party integrations for LLM applications
@@ -2031,10 +2031,10 @@ npm run docs              # Generate API documentation
 - Cache expensive AI operations appropriately
 
 **Cross-Package Integration**
-- Leverage @have/spider for content ingestion
-- Use @have/pdf for document processing workflows
-- Integrate @have/files for asset management
-- Apply @have/sql for complex querying needs
+- Leverage @happyvertical/spider for content ingestion
+- Use @happyvertical/pdf for document processing workflows
+- Integrate @happyvertical/files for asset management
+- Apply @happyvertical/sql for complex querying needs
 
 **Code Generation**
 - Use AST scanning for automatic service discovery
@@ -2114,12 +2114,12 @@ Always reference the latest documentation when developing AI agents with the SMR
   - Critical for configuration management in agent deployments
 
 ### HAVE SDK Integration Points
-- **@have/ai**: AI model interactions and completions
-- **@have/files**: File system operations and content management
-- **@have/pdf**: PDF processing and document analysis
-- **@have/sql**: Database operations and schema management
-- **@have/spider**: Web content extraction and processing
-- **@have/utils**: Utility functions and type definitions
+- **@happyvertical/ai**: AI model interactions and completions
+- **@happyvertical/files**: File system operations and content management
+- **@happyvertical/pdf**: PDF processing and document analysis
+- **@happyvertical/sql**: Database operations and schema management
+- **@happyvertical/spider**: Web content extraction and processing
+- **@happyvertical/utils**: Utility functions and type definitions
 
 ### Expert Agent Instructions
 
@@ -2329,11 +2329,11 @@ class Document extends SmrtObject {
 **Virtual modules only work with Vite plugin**:
 ```typescript
 // ✅ WORKS - With smrtPlugin() in vite.config.js
-import { setupRoutes } from '@smrt/routes';
-import { createClient } from '@smrt/client';
+import { setupRoutes } from '@happyvertical/smrt-routes';
+import { createClient } from '@happyvertical/smrt-client';
 
 // ❌ DOESN'T WORK - Without Vite plugin configured
-// Will get "Cannot find module '@smrt/routes'" error
+// Will get "Cannot find module '@happyvertical/smrt-routes'" error
 ```
 
 **Consumer projects need smrtConsumer()**:

--- a/packages/content/CLAUDE.md
+++ b/packages/content/CLAUDE.md
@@ -1,8 +1,8 @@
-# @have/content: Content Processing Module
+# @happyvertical/content: Content Processing Module
 
 ## Purpose and Responsibilities
 
-The `@have/content` package is a SMRT-specific module that provides comprehensive content processing capabilities for the HAVE SDK. It is **not part of the main build pipeline** and is designed specifically for use with the SMRT framework. The package handles:
+The `@happyvertical/content` package is a SMRT-specific module that provides comprehensive content processing capabilities for the HAVE SDK. It is **not part of the main build pipeline** and is designed specifically for use with the SMRT framework. The package handles:
 
 - **Document Processing**: Unified interface for working with documents (PDFs, text files, web content)
 - **Content Management**: Structured content objects with metadata, versioning, and references
@@ -89,7 +89,7 @@ Use this instead of direct instantiation to ensure proper initialization.
 
 **`mirror(options: { url: string; mirrorDir?: string; context?: string })`**
 - Downloads and stores content from remote URL
-- Extracts text using Document class
+- Extracts text using fetchDocument from @happyvertical/documents
 - Auto-generates title/slug from filename
 - Checks for existing content by URL (won't duplicate)
 - Returns Content object with type='mirror'
@@ -123,72 +123,69 @@ Use this instead of direct instantiation to ensure proper initialization.
 - Loading cache (`loaded` Map) available for performance optimization
 - Access database via `getDb()` method
 
-### Document Class (`document.ts`)
-Specialized handler for extracting text from various document types.
+### Document Processing (`fetchDocument`)
+
+**⚠️ IMPORTANT**: The Document class has been removed from this package. Use `fetchDocument` from `@happyvertical/documents` instead.
+
+The content package uses `fetchDocument` for extracting text from various document types:
 
 **Supported File Types**:
-- **PDFs**: Via @have/pdf package with OCR fallback
+- **PDFs**: Via @happyvertical/pdf package with OCR fallback
 - **Text files**: .txt, .md, .json, .xml, .html, .css, .js, .ts, .yaml, .yml
-- **Web content**: Remote URLs via Spider package
+- **Web content**: Remote URLs via @happyvertical/spider package
 - **Detection**: Automatic MIME type detection or file extension fallback
+
+**Usage**:
+```typescript
+import { fetchDocument } from '@happyvertical/documents';
+
+// Fetch and extract text from a PDF
+const pdfText = await fetchDocument('https://example.com/document.pdf');
+
+// Fetch and extract text from a local file
+const localText = await fetchDocument('file:///path/to/document.txt');
+
+// Fetch and extract text from a web page
+const webText = await fetchDocument('https://example.com/article');
+```
+
+**Key Features**:
+- **Automatic caching**: Downloaded files are cached to avoid re-downloading
+- **Smart text extraction**: Automatically detects file type and uses appropriate extraction method
+- **PDF support**: Full PDF text extraction with OCR fallback for scanned documents
+- **Web scraping**: Extracts readable content from web pages
+- **MIME type detection**: Automatic detection with file extension fallback
 
 **Configuration**:
 ```typescript
-interface DocumentOptions {
-  fs?: FilesystemAdapter;
-  cacheDir?: string;           // Default: os.tmpdir()/.cache/have-sdk
-  url?: string;                // file://, http://, https:// URLs
-  localPath?: string;          // Override computed local path
-  type?: string;               // MIME type override
-}
+// fetchDocument accepts a URL string or file path
+// Caching is handled automatically via @happyvertical/files
+// Cache location: os.tmpdir()/.cache/have-sdk
+
+// Example with local file
+const text = await fetchDocument('file:///Users/me/Documents/report.pdf');
+
+// Example with remote file
+const text = await fetchDocument('https://example.com/whitepaper.pdf');
 ```
 
-**Static Factory**:
+**Migration from Document Class**:
 ```typescript
-static async create(options: DocumentOptions): Promise<Document>
+// ❌ OLD: Document class (removed)
+import { Document } from '@happyvertical/smrt-content';
+const doc = await Document.create({ url: 'https://example.com/doc.pdf' });
+const text = await doc.getText();
+
+// ✅ NEW: fetchDocument function
+import { fetchDocument } from '@happyvertical/documents';
+const text = await fetchDocument('https://example.com/doc.pdf');
 ```
-Handles initialization and downloads remote files automatically.
 
-**Key Properties**:
-- `url` (URL): Parsed URL object
-- `type` (string): MIME type
-- `localPath` (string, read-only): Local file path (computed or provided)
-- `cacheDir` (string, read-only): Cache directory location
-- `isRemote` (boolean, protected): Flag for remote vs local files
-
-**Key Methods**:
-
-**`getText()`**
-- Extracts text content from document
-- Uses caching (`.extracted_text` suffix) to avoid reprocessing
-- PDF extraction via @have/pdf's getPDFReader()
-- Text file reading via fs.readFile
-- Throws error for unsupported types
-- Returns extracted text string
-
-**`isTextFile()`**
-- Checks if file can be read as plain text
-- Checks MIME type patterns (text/*, application/json, etc.)
-- Checks file extension fallbacks
-- Returns boolean
-
-**`initialize()`**
-- Downloads remote files to cache directory
-- Uses downloadFileWithCache from @have/files
-- No-op for local files
-- Called automatically by static create()
-
-**Important Implementation Details**:
-- Remote file paths: `{cacheDir}/{hostname-slug}/{pathname}`
-- Local file paths: Direct from file:// URL pathname
-- Caching uses @have/files getCached/setCached with `.extracted_text` suffix
-- MIME type detection via getMimeType from @have/files
-- PDF processing may involve OCR for scanned documents
-
-**Gotchas**:
-- Must call initialize() or use static create() before getText()
-- Unsupported types throw "not yet implemented" error
-- Cache keys are based on localPath, so moving files breaks cache
+**Important Notes**:
+- The Document class is no longer available in this package
+- Use `@happyvertical/documents` for all document processing needs
+- The content package internally uses `fetchDocument` for PDF and document handling
+- Caching behavior and extraction methods remain the same
 
 ### Utility Functions (`utils.ts`)
 Content serialization utilities for markdown/YAML interoperability.
@@ -215,11 +212,11 @@ Content serialization utilities for markdown/YAML interoperability.
 ## Dependencies
 
 ### Internal HAVE SDK Dependencies
-- **@have/smrt**: Core framework (SmrtObject, SmrtCollection, decorators)
-- **@have/pdf**: PDF text extraction capabilities
-- **@have/spider**: Web content scraping (via Document class)
-- **@have/files**: File system operations, caching, download management
-- **@have/utils**: Utility functions (makeSlug, etc.)
+- **@happyvertical/smrt-core**: Core framework (SmrtObject, SmrtCollection, decorators)
+- **@happyvertical/pdf**: PDF text extraction capabilities
+- **@happyvertical/spider**: Web content scraping (via fetchDocument from @happyvertical/documents)
+- **@happyvertical/files**: File system operations, caching, download management
+- **@happyvertical/utils**: Utility functions (makeSlug, etc.)
 
 ### External Dependencies
 - **yaml**: YAML parsing and stringification for frontmatter handling
@@ -236,7 +233,7 @@ Content serialization utilities for markdown/YAML interoperability.
 ### Basic Content Management
 
 ```typescript
-import { Content, Contents } from '@have/content';
+import { Content, Contents } from '@happyvertical/content';
 
 // Initialize collection with database and AI config
 const contents = await Contents.create({
@@ -277,23 +274,17 @@ await contents.add(article);
 ### Document Processing Workflow
 
 ```typescript
-import { Document, Content, Contents } from '@have/content';
+import { fetchDocument } from '@happyvertical/documents';
+import { Content } from '@happyvertical/smrt-content';
 
 // Process PDF document
-const doc = await Document.create({
-  url: 'https://example.com/research.pdf',
-  cacheDir: './cache'
-});
-
-// Extract text content
-const extractedText = await doc.getText();
+const extractedText = await fetchDocument('https://example.com/research.pdf');
 
 // Create content from document
 const content = new Content({
   title: 'Extracted Research Paper',
   body: extractedText,
   type: 'document',
-  fileKey: doc.localPath,
   source: 'pdf_extraction',
   original_url: 'https://example.com/research.pdf'
 });
@@ -305,7 +296,7 @@ await content.save();
 ### Web Content Mirroring
 
 ```typescript
-import { Contents } from '@have/content';
+import { Contents } from '@happyvertical/content';
 
 const contents = await Contents.create({
   db: { url: 'sqlite:./mirrors.db' }
@@ -326,7 +317,7 @@ console.log(mirrored.body);  // Extracted text content
 ### Content Export and Synchronization
 
 ```typescript
-import { Contents } from '@have/content';
+import { Contents } from '@happyvertical/content';
 
 const contents = await Contents.create({
   db: { url: 'sqlite:./content.db' },
@@ -348,7 +339,7 @@ await contents.writeContentFile({
 ### Content Utilities
 
 ```typescript
-import { contentToString, stringToContent } from '@have/content';
+import { contentToString, stringToContent } from '@happyvertical/content';
 
 // Serialize content to markdown with YAML frontmatter
 const markdownString = contentToString(article);
@@ -407,7 +398,7 @@ const content = await contents.getOrUpsert({
 
 ## Integration with SMRT Framework
 
-The @have/content package is a full SMRT module with:
+The @happyvertical/content package is a full SMRT module with:
 
 ### SMRT Decorators
 ```typescript
@@ -438,7 +429,9 @@ Always use static factory methods for proper async initialization:
 ```typescript
 // ✅ Correct - use static create()
 const contents = await Contents.create({ db: { url: 'sqlite:./content.db' } });
-const doc = await Document.create({ url: 'https://example.com/file.pdf' });
+
+// ✅ Correct - use fetchDocument for document processing
+const text = await fetchDocument('https://example.com/file.pdf');
 
 // ❌ Incorrect - missing initialization
 const contents = new Contents({ db: { url: 'sqlite:./content.db' } });
@@ -493,12 +486,13 @@ try {
   // Handle other errors
 }
 
-// Document getText with type checking
-const doc = await Document.create({ url });
-if (doc.isTextFile() || doc.type === 'application/pdf') {
-  const text = await doc.getText();
-} else {
-  console.log('Unsupported file type:', doc.type);
+// Document text extraction with fetchDocument
+try {
+  const text = await fetchDocument(url);
+  // Successfully extracted text
+} catch (error) {
+  // fetchDocument throws for unsupported file types
+  console.error('Failed to extract text:', error.message);
 }
 ```
 
@@ -506,12 +500,12 @@ if (doc.isTextFile() || doc.type === 'application/pdf') {
 Leverage built-in caching to avoid reprocessing:
 
 ```typescript
-// Document getText caches extracted text automatically
-const doc = await Document.create({ url: 'large-file.pdf' });
-const text1 = await doc.getText(); // Extracts and caches
-const text2 = await doc.getText(); // Returns cached result instantly
+// fetchDocument caches extracted text automatically
+const text1 = await fetchDocument('large-file.pdf'); // Extracts and caches
+const text2 = await fetchDocument('large-file.pdf'); // Returns cached result instantly
 
-// Cache location: {localPath}.extracted_text
+// Caching is handled by @happyvertical/files
+// Cache location: os.tmpdir()/.cache/have-sdk
 ```
 
 ### AI Integration Patterns
@@ -690,7 +684,7 @@ tsx packages/content/src/server.ts
 ### Server Configuration
 
 ```typescript
-import { startRestServer } from '@have/smrt';
+import { startRestServer } from '@happyvertical/smrt-core';
 import { Content } from './content';
 
 const shutdown = await startRestServer(
@@ -811,18 +805,22 @@ try {
 ```
 
 ### 4. Document Type Support
-**Problem**: Calling `getText()` on unsupported file types
+**Problem**: Calling `fetchDocument` on unsupported file types
 
 ```typescript
-// ❌ Will throw "not yet implemented"
-const doc = await Document.create({ url: 'file:///path/to/video.mp4' });
-await doc.getText(); // Error!
+// ❌ Will throw error for unsupported types
+try {
+  const text = await fetchDocument('file:///path/to/video.mp4');
+} catch (error) {
+  console.error('Unsupported file type:', error.message);
+}
 
-// ✅ Check type first
-if (doc.isTextFile() || doc.type === 'application/pdf') {
-  const text = await doc.getText();
-} else {
-  console.log('Unsupported type:', doc.type);
+// ✅ Use try-catch to handle errors
+try {
+  const text = await fetchDocument(url);
+  console.log('Successfully extracted:', text.substring(0, 100));
+} catch (error) {
+  console.log('Could not extract text from:', url);
 }
 ```
 
@@ -830,17 +828,17 @@ if (doc.isTextFile() || doc.type === 'application/pdf') {
 **Problem**: Cached extraction results persist even when source changes
 
 ```typescript
-// Document extraction is cached by localPath
-const doc = await Document.create({ url: 'file:///path/to/file.pdf' });
-const text1 = await doc.getText(); // Extracts and caches
+// fetchDocument caches extracted text automatically
+const text1 = await fetchDocument('file:///path/to/file.pdf'); // Extracts and caches
 
-// If file changes on disk, cache is stale
-// Manual cache clearing needed
+// If file changes on disk, cache may be stale
+// Caching is managed by @happyvertical/files
+// Cache location: os.tmpdir()/.cache/have-sdk
 ```
 
 **Solution**: Be aware of cache locations and clear when needed:
 - Document text cache: `{localPath}.extracted_text`
-- Uses @have/files `getCached/setCached` functions
+- Uses @happyvertical/files `getCached/setCached` functions
 
 ### 6. Title vs Name Field
 **Problem**: Confusion between `title` and `name` properties
@@ -938,7 +936,7 @@ function getTestDbUrl(testName: string): string {
 ✅ **Web Content**: URL mirroring with automatic text extraction and caching
 ✅ **Filesystem Export**: Markdown generation with YAML frontmatter in organized directory structure
 ✅ **Reference System**: In-memory content linking and relationship management
-✅ **Caching**: Automatic extraction result caching with @have/files integration
+✅ **Caching**: Automatic extraction result caching with @happyvertical/files integration
 ✅ **Collection Operations**: Batch processing, advanced querying, and getOrUpsert patterns
 ✅ **Context Organization**: Namespace isolation for multi-project/multi-source content
 ✅ **TypeScript**: Full type safety and IntelliSense support with comprehensive interfaces
@@ -963,7 +961,7 @@ import {
   // Utils
   contentToString,   // Serialize to markdown + frontmatter
   stringToContent    // Parse markdown + frontmatter
-} from '@have/content';
+} from '@happyvertical/content';
 ```
 
 ## Quick Reference
@@ -988,9 +986,10 @@ import {
 - `writeContentFile(options)`: Export content to markdown file
 - `syncContentDir(options)`: Export all articles to directory
 
-### Document Methods
-- `Document.create(options)`: Factory method with auto-initialization
-- `getText()`: Extract text content (with caching)
-- `isTextFile()`: Check if file is text-based
+### Document Processing
+- `fetchDocument(url)`: Extract text from documents (from @happyvertical/documents)
+  - Supports PDFs, text files, and web content
+  - Automatic caching via @happyvertical/files
+  - Use try-catch to handle unsupported file types
 
 This package enables sophisticated content processing workflows while maintaining the modular architecture and AI-first design principles of the HAVE SDK.

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -1,8 +1,8 @@
-# @smrt/core: AI Agent Framework Package
+# @happyvertical/smrt-core: AI Agent Framework Package
 
 ## Purpose and Responsibilities
 
-The `@smrt/core` package is the core framework for building vertical AI agents in the HAVE SDK. It provides a comprehensive foundation for creating intelligent agents with persistent storage, cross-package integration, and automatic code generation capabilities.
+The `@happyvertical/smrt-core` package is the core framework for building vertical AI agents in the HAVE SDK. It provides a comprehensive foundation for creating intelligent agents with persistent storage, cross-package integration, and automatic code generation capabilities.
 
 ### Core Framework Architecture
 - **Object-Relational Mapping**: Automatic schema generation from TypeScript class properties with application-level timestamp management
@@ -15,7 +15,7 @@ The `@smrt/core` package is the core framework for building vertical AI agents i
 - **CLI Generators**: Create administrative command-line tools from SMRT objects
 - **REST API Generators**: Auto-generate complete REST APIs with OpenAPI documentation
 - **MCP Server Generators**: Generate Model Context Protocol servers for AI integration
-- **Vite Plugin Integration**: Automatic service generation with virtual modules (@smrt/routes, @smrt/client, @smrt/mcp)
+- **Vite Plugin Integration**: Automatic service generation with virtual modules (@happyvertical/smrt-routes, @happyvertical/smrt-client, @happyvertical/smrt-mcp)
 
 ### Runtime Environment Support
 - **Node.js Only**: Package now focused on Node.js for simplified deployment and better performance
@@ -74,7 +74,7 @@ The SMRT framework supports flexible AI provider configuration through both glob
 Set application-wide AI defaults using the global config system:
 
 ```typescript
-import { config } from '@smrt/core';
+import { config } from '@happyvertical/smrt-core';
 
 // Configure global AI provider
 config({
@@ -143,7 +143,7 @@ await doc.initialize();
 
 #### Supported Providers
 
-The framework supports all providers from `@have/ai`:
+The framework supports all providers from `@happyvertical/ai`:
 
 - **openai** - OpenAI models (GPT-4, GPT-3.5, etc.)
 - **anthropic** - Anthropic models (Claude 3 Opus, Sonnet, Haiku)
@@ -179,11 +179,11 @@ export CLAUDE_API_KEY=your-claude-key
 
 **Using loadEnvConfig Directly:**
 ```typescript
-// Import from @smrt/core/config (re-exported from @have/utils)
-import { loadEnvConfig } from '@smrt/core/config';
+// Import from @happyvertical/smrt-core/config (re-exported from @happyvertical/utils)
+import { loadEnvConfig } from '@happyvertical/smrt-core/config';
 
-// Or import directly from @have/utils
-// import { loadEnvConfig } from '@have/utils';
+// Or import directly from @happyvertical/utils
+// import { loadEnvConfig } from '@happyvertical/utils';
 
 // Load SMRT_AI_* environment variables
 const aiConfig = loadEnvConfig({}, {
@@ -230,7 +230,7 @@ node dist/mcp-server.js
 
 ### Environment Variable Configuration
 
-The SMRT framework uses `loadEnvConfig()` from `@have/utils` (SDK package) for loading configuration from environment variables with automatic type conversion and validation. This utility is re-exported by `@smrt/core/config` for convenience.
+The SMRT framework uses `loadEnvConfig()` from `@happyvertical/utils` (SDK package) for loading configuration from environment variables with automatic type conversion and validation. This utility is re-exported by `@happyvertical/smrt-core/config` for convenience.
 
 #### Features
 
@@ -243,16 +243,16 @@ The SMRT framework uses `loadEnvConfig()` from `@have/utils` (SDK package) for l
 
 #### Source
 
-`loadEnvConfig()` is implemented in `@have/utils` (SDK) and re-exported by `@smrt/core/config` for convenience. See [SDK env-config documentation](https://github.com/happyvertical/sdk/blob/main/packages/utils/src/config/env-config.ts) for the full implementation.
+`loadEnvConfig()` is implemented in `@happyvertical/utils` (SDK) and re-exported by `@happyvertical/smrt-core/config` for convenience. See [SDK env-config documentation](https://github.com/happyvertical/sdk/blob/main/packages/utils/src/config/env-config.ts) for the full implementation.
 
 #### API
 
 ```typescript
-// Import from @smrt/core/config (re-exported)
-import { loadEnvConfig } from '@smrt/core/config';
+// Import from @happyvertical/smrt-core/config (re-exported)
+import { loadEnvConfig } from '@happyvertical/smrt-core/config';
 
-// Or import directly from @have/utils
-// import { loadEnvConfig } from '@have/utils';
+// Or import directly from @happyvertical/utils
+// import { loadEnvConfig } from '@happyvertical/utils';
 
 interface MyConfig {
   provider: string;
@@ -320,7 +320,7 @@ const config = loadEnvConfig({}, {
 
 **Case Conversion:**
 ```typescript
-import { toCamelCase, toScreamingSnakeCase } from '@smrt/core/config';
+import { toCamelCase, toScreamingSnakeCase } from '@happyvertical/smrt-core/config';
 
 toCamelCase('max_retries');           // → 'maxRetries'
 toScreamingSnakeCase('maxRetries');   // → 'MAX_RETRIES'
@@ -328,7 +328,7 @@ toScreamingSnakeCase('maxRetries');   // → 'MAX_RETRIES'
 
 **Type Conversion:**
 ```typescript
-import { convertType } from '@smrt/core/config';
+import { convertType } from '@happyvertical/smrt-core/config';
 
 convertType('123', 'number');          // → 123
 convertType('true', 'boolean');        // → true
@@ -340,7 +340,7 @@ convertType('{"foo":"bar"}', 'json');  // → { foo: 'bar' }
 The framework provides a typed field definition system for schema generation:
 
 ```typescript
-import { text, integer, decimal, boolean, datetime, json, foreignKey } from '@smrt/core/fields';
+import { text, integer, decimal, boolean, datetime, json, foreignKey } from '@happyvertical/smrt-core/fields';
 
 class Product extends SmrtObject {
   name = text({ required: true, maxLength: 100 });
@@ -375,7 +375,7 @@ class Product extends SmrtObject {
 The `@smrt()` decorator automatically registers classes:
 
 ```typescript
-import { smrt } from '@smrt/core';
+import { smrt } from '@happyvertical/smrt-core';
 
 @smrt({
   api: { exclude: ['delete'] },
@@ -793,13 +793,117 @@ const orders = await orderCollection.list({
 // 70% performance improvement!
 ```
 
+### Database Adapter Methods
+
+The SMRT framework uses semantic database adapter methods for type-safe, cross-adapter database operations. These methods replace raw SQL queries and provide consistent behavior across SQLite, Postgres, DuckDB, and REST adapters.
+
+**Core Methods**:
+
+```typescript
+// Get a single record
+const record = await db.get(tableName, {
+  id: '123e4567-e89b-12d3-a456-426614174000'
+});
+
+// List records with filtering
+const records = await db.list(tableName, {
+  where: {
+    status: 'active',
+    'created_at >': '2024-01-01'
+  },
+  orderBy: 'created_at DESC',
+  limit: 20
+});
+
+// Delete records
+await db.delete(tableName, {
+  'updated_at <': '2023-01-01',
+  status: 'archived'
+});
+
+// Upsert (insert or update)
+await db.upsert(tableName, {
+  id: '123e4567-e89b-12d3-a456-426614174000',
+  name: 'Updated Name',
+  status: 'active'
+}, ['id']); // Unique columns for conflict resolution
+```
+
+**Key Benefits**:
+- **Type Safety**: Semantic methods with clear parameter types
+- **Cross-Adapter**: Works consistently across all database adapters
+- **Maintainability**: Eliminates raw SQL strings scattered throughout code
+- **Error Handling**: Built-in constraint violation detection and user-friendly error messages
+
+**Migration from Raw SQL**:
+
+```typescript
+// ❌ OLD: Raw SQL (before PR #79)
+const { rows } = await db.query(
+  `SELECT * FROM ${tableName} WHERE id = ?`,
+  [id]
+);
+const record = rows[0];
+
+// ✅ NEW: Semantic adapter method
+const record = await db.get(tableName, { id });
+
+// ❌ OLD: Raw SQL with complex WHERE
+const { rows } = await db.query(
+  `SELECT * FROM ${tableName} WHERE status = ? AND created_at > ? ORDER BY created_at DESC LIMIT ?`,
+  ['active', '2024-01-01', 20]
+);
+
+// ✅ NEW: Semantic adapter method
+const records = await db.list(tableName, {
+  where: {
+    status: 'active',
+    'created_at >': '2024-01-01'
+  },
+  orderBy: 'created_at DESC',
+  limit: 20
+});
+
+// ❌ OLD: Raw SQL for deletion
+await db.execute(
+  `DELETE FROM ${tableName} WHERE updated_at < ? AND status = ?`,
+  ['2023-01-01', 'archived']
+);
+
+// ✅ NEW: Semantic adapter method
+await db.delete(tableName, {
+  'updated_at <': '2023-01-01',
+  status: 'archived'
+});
+```
+
+**Operator Support**:
+
+The `where` clause in `db.get()`, `db.list()`, and `db.delete()` supports these operators:
+- `=` (default): Exact match - `{ status: 'active' }`
+- `>`: Greater than - `{ 'price >': 100 }`
+- `<`: Less than - `{ 'price <': 200 }`
+- `>=`: Greater than or equal - `{ 'price >=': 100 }`
+- `<=`: Less than or equal - `{ 'price <=': 200 }`
+- `!=`: Not equal - `{ 'deleted_at !=': null }`
+- `in`: IN operator - `{ 'status in': ['active', 'pending'] }`
+- `like`: LIKE pattern - `{ 'name like': '%search%' }`
+
+**Important Notes**:
+- Always use semantic methods instead of raw SQL in application code
+- Raw SQL is still available via `db.query()` for complex queries, but should be used sparingly
+- The framework's internal collection methods (`list()`, `get()`, etc.) use these adapter methods
+- When extending SmrtCollection, prefer using these methods for custom queries
+
+**Reference**: See PR #79 for the complete refactoring that introduced this pattern.
+
 ## Key APIs
 
 ### Defining Custom SMRT Objects with Custom Actions
 
 ```typescript
-import { SmrtObject } from '@smrt/core';
-import { Field } from '@smrt/core/fields';
+import { SmrtObject } from '@happyvertical/smrt-core';
+import { Field } from '@happyvertical/smrt-core/fields';
 
 @smrt({
   api: {
@@ -896,7 +1000,7 @@ This automatically generates:
 ### Advanced Collection Management
 
 ```typescript
-import { SmrtCollection } from '@smrt/core';
+import { SmrtCollection } from '@happyvertical/smrt-core';
 import { Document } from './document';
 
 class DocumentCollection extends SmrtCollection<Document> {
@@ -959,7 +1063,7 @@ The SMRT framework supports automatic AI function calling, allowing LLMs to invo
 Configure which methods AI can call using the `ai` configuration in the `@smrt()` decorator:
 
 ```typescript
-import { smrt, SmrtObject } from '@smrt/core';
+import { smrt, SmrtObject } from '@happyvertical/smrt-core';
 
 @smrt({
   ai: {
@@ -1095,7 +1199,7 @@ async analyze(options: {
 Execute tool calls manually using the `executeToolCall()` method:
 
 ```typescript
-import type { ToolCall } from '@smrt/core';
+import type { ToolCall } from '@happyvertical/smrt-core';
 
 const document = await documents.get('doc-123');
 
@@ -1183,7 +1287,7 @@ if (tools.length > 0) {
 
 **Tool Call Batching:**
 ```typescript
-import { executeToolCalls } from '@smrt/core';
+import { executeToolCalls } from '@happyvertical/smrt-core';
 
 const toolCalls = [
   { id: '1', type: 'function', function: { name: 'analyze', arguments: '{}' } },
@@ -1217,7 +1321,7 @@ console.log(`Executed ${results.length} tool calls`);
 ### Code Generation and Automation
 
 ```typescript
-import { CLIGenerator, APIGenerator, MCPGenerator } from '@smrt/core/generators';
+import { CLIGenerator, APIGenerator, MCPGenerator } from '@happyvertical/smrt-core/generators';
 import { DocumentCollection } from './documentCollection';
 
 // Generate CLI tools automatically
@@ -1262,7 +1366,7 @@ Use `smrtPlugin` when creating SMRT objects in your project:
 
 ```typescript
 // vite.config.js - For projects defining SMRT objects
-import { smrtPlugin } from '@smrt/core/vite-plugin';
+import { smrtPlugin } from '@happyvertical/smrt-core/vite-plugin';
 
 export default {
   plugins: [
@@ -1277,10 +1381,10 @@ export default {
 };
 
 // Auto-generated virtual modules available:
-import { setupRoutes } from '@smrt/routes';        // REST routes
-import { createClient } from '@smrt/client';       // API client
-import { tools } from '@smrt/mcp';                 // MCP tools
-import { manifest } from '@smrt/manifest';         // Object manifest
+import { setupRoutes } from '@happyvertical/smrt-routes';        // REST routes
+import { createClient } from '@happyvertical/smrt-client';       // API client
+import { tools } from '@happyvertical/smrt-mcp';                 // MCP tools
+import { manifest } from '@happyvertical/smrt-manifest';         // Object manifest
 ```
 
 #### Consumer Plugin (for SMRT Package Users)
@@ -1289,7 +1393,7 @@ Use `smrtConsumer` when consuming packages that contain SMRT objects:
 
 ```typescript
 // vite.config.js - For projects consuming SMRT packages
-import { smrtConsumer } from '@smrt/core/consumer-plugin';
+import { smrtConsumer } from '@happyvertical/smrt-core/consumer-plugin';
 
 export default {
   plugins: [
@@ -1304,9 +1408,9 @@ export default {
 };
 
 // Resolves virtual modules from consumed SMRT packages:
-import { createClient } from '@smrt/client';       // Generated from consumed packages
-import { setupRoutes } from '@smrt/routes';        // Combined routes from all packages
-import type { ProductData } from '@smrt/types';    // Generated TypeScript types
+import { createClient } from '@happyvertical/smrt-client';       // Generated from consumed packages
+import { setupRoutes } from '@happyvertical/smrt-routes';        // Combined routes from all packages
+import type { ProductData } from '@happyvertical/smrt-types';    // Generated TypeScript types
 ```
 
 #### Dual Plugin Usage
@@ -1315,8 +1419,8 @@ For projects that both define and consume SMRT objects:
 
 ```typescript
 // vite.config.js - Using both plugins together
-import { smrtPlugin } from '@smrt/core/vite-plugin';
-import { smrtConsumer } from '@smrt/core/consumer-plugin';
+import { smrtPlugin } from '@happyvertical/smrt-core/vite-plugin';
+import { smrtConsumer } from '@happyvertical/smrt-core/consumer-plugin';
 
 export default {
   plugins: [
@@ -1339,9 +1443,9 @@ export default {
 };
 
 // Access both local and external virtual modules:
-import { setupRoutes as localRoutes } from '@smrt/routes';    // From local objects
-import { createClient } from '@smrt/client';                   // Combined client
-import type { LocalModel, ExternalModel } from '@smrt/types'; // All types
+import { setupRoutes as localRoutes } from '@happyvertical/smrt-routes';    // From local objects
+import { createClient } from '@happyvertical/smrt-client';                   // Combined client
+import type { LocalModel, ExternalModel } from '@happyvertical/smrt-types'; // All types
 ```
 
 ### Advanced Querying and Relationships
@@ -1507,7 +1611,7 @@ The `smrtConsumer` plugin enables projects to consume SMRT packages without defi
 ### Consumer Plugin Options
 
 ```typescript
-import { smrtConsumer, type SmrtConsumerOptions } from '@smrt/core/consumer-plugin';
+import { smrtConsumer, type SmrtConsumerOptions } from '@happyvertical/smrt-core/consumer-plugin';
 
 interface SmrtConsumerOptions {
   /** SMRT packages to scan (e.g., ['@my-org/products', '@my-org/content']) */
@@ -1559,10 +1663,10 @@ The plugin generates comprehensive TypeScript declarations for consumed SMRT pac
 └── smrt-objects.d.ts    // Individual object interfaces
 
 // Auto-imported virtual modules:
-import { createClient } from '@smrt/client';
-import { setupRoutes } from '@smrt/routes';
-import { tools } from '@smrt/mcp';
-import type { ProductData, CategoryData } from '@smrt/types';
+import { createClient } from '@happyvertical/smrt-client';
+import { setupRoutes } from '@happyvertical/smrt-routes';
+import { tools } from '@happyvertical/smrt-mcp';
+import type { ProductData, CategoryData } from '@happyvertical/smrt-types';
 ```
 
 ### Pre-build Type Generation
@@ -1604,7 +1708,7 @@ smrtConsumer({
 ```typescript
 // vite.config.js for SvelteKit
 import { sveltekit } from '@sveltejs/kit/vite';
-import { smrtConsumer } from '@smrt/core/consumer-plugin';
+import { smrtConsumer } from '@happyvertical/smrt-core/consumer-plugin';
 
 export default {
   plugins: [
@@ -1631,7 +1735,7 @@ smrtConsumer({
 })
 
 // Access combined APIs from all services
-import { createClient } from '@smrt/client';
+import { createClient } from '@happyvertical/smrt-client';
 const client = createClient('/api/v1');
 
 // Type-safe access to all service APIs
@@ -1644,7 +1748,7 @@ const analytics = await client.analytics.query({});
 ```typescript
 // Creating a library that extends SMRT functionality
 smrtConsumer({
-  packages: ['@smrt/core-core-models'],
+  packages: ['@happyvertical/smrt-core-core-models'],
   staticTypes: true,
   typesDir: 'src/types/core',
   disableScanning: true  // Faster builds for libraries
@@ -1659,7 +1763,7 @@ The SMRT package follows industry standards (like AWS SDK) for distributing buil
 
 **Published Package Structure:**
 ```
-@smrt/core/
+@happyvertical/smrt-core/
 ├── dist/                           # Built artifacts (gitignored in development)
 │   ├── consumer-plugin/index.js    # Vite plugin for consumers
 │   ├── vite-plugin/index.js        # Vite plugin for SMRT creators
@@ -1685,7 +1789,7 @@ The SMRT package follows industry standards (like AWS SDK) for distributing buil
 **Published Package Usage** (Standard):
 ```typescript
 // Consuming from published npm package
-import { smrtConsumer } from '@smrt/core/consumer-plugin';
+import { smrtConsumer } from '@happyvertical/smrt-core/consumer-plugin';
 
 export default defineConfig({
   plugins: [smrtConsumer({ packages: ['@my-org/products'] })]
@@ -1698,7 +1802,7 @@ export default defineConfig({
 npm run build
 
 # 2. Then use in consuming applications
-npm link @smrt/core  # or workspace linking
+npm link @happyvertical/smrt-core  # or workspace linking
 ```
 
 **Key Points:**
@@ -1725,13 +1829,13 @@ npm link
 **For Consumer Application Development:**
 ```bash
 # Link to local SMRT package (if developing SDK)
-npm link @smrt/core
+npm link @happyvertical/smrt-core
 
 # Or install published version (standard usage)
-npm install @smrt/core
+npm install @happyvertical/smrt-core
 
 # Use consumer plugin in vite.config.js
-import { smrtConsumer } from '@smrt/core/consumer-plugin';
+import { smrtConsumer } from '@happyvertical/smrt-core/consumer-plugin';
 ```
 
 ### Tree-Shaking and Subpath Exports
@@ -1740,9 +1844,9 @@ The package supports efficient tree-shaking through granular exports:
 
 ```typescript
 // Import only what you need
-import { smrtConsumer } from '@smrt/core/consumer-plugin';        // ~8KB
-import { CLIGenerator } from '@smrt/core/generators/cli';         // ~22KB
-import { SmrtObject } from '@smrt/core';                          // Core framework
+import { smrtConsumer } from '@happyvertical/smrt-core/consumer-plugin';        // ~8KB
+import { CLIGenerator } from '@happyvertical/smrt-core/generators/cli';         // ~22KB
+import { SmrtObject } from '@happyvertical/smrt-core';                          // Core framework
 ```
 
 **Vite Configuration for Tree-Shaking:**
@@ -1757,19 +1861,19 @@ The package uses:
 - Schema generation based on class properties
 - SQLite triggers for automatic timestamp management
 - A consistent pattern for database operations
-- Integration with AI models via the `@have/ai` package
+- Integration with AI models via the `@happyvertical/ai` package
 
 ## Dependencies
 
 The SMRT framework integrates with multiple packages to provide comprehensive agent capabilities:
 
 ### Internal HAVE SDK Dependencies
-- **@have/ai**: AI model interactions and completions across multiple providers
-- **@have/files**: File system operations and content management
-- **@have/pdf**: PDF document processing and text extraction
-- **@have/sql**: Database operations with SQLite and PostgreSQL support
-- **@have/spider**: Web content extraction and processing
-- **@have/utils**: Shared utility functions and type definitions
+- **@happyvertical/ai**: AI model interactions and completions across multiple providers
+- **@happyvertical/files**: File system operations and content management
+- **@happyvertical/pdf**: PDF document processing and text extraction
+- **@happyvertical/sql**: Database operations with SQLite and PostgreSQL support
+- **@happyvertical/spider**: Web content extraction and processing
+- **@happyvertical/utils**: Shared utility functions and type definitions
 
 ### External Dependencies
 - **@langchain/community**: Third-party integrations for LLM applications
@@ -1934,7 +2038,7 @@ async analyze(options: any = {}) {
 **CLI Development**
 ```bash
 # Generate CLI tools from SMRT objects
-import { CLIGenerator } from '@smrt/core/generators';
+import { CLIGenerator } from '@happyvertical/smrt-core/generators';
 const generator = new CLIGenerator({
   collections: [MyCollection],
   outputDir: './cli'
@@ -1942,10 +2046,35 @@ const generator = new CLIGenerator({
 await generator.generate();
 ```
 
+**CLI TTY Detection**
+
+The SMRT CLI framework automatically detects TTY environments and adjusts spinner behavior accordingly to prevent crashes in non-interactive environments.
+
+```typescript
+// The framework automatically handles TTY detection internally
+// No explicit configuration needed - spinners work correctly in:
+// - Interactive terminals (TTY): Animated spinners with clearLine/cursorTo
+// - Non-TTY environments: Fallback to console.log (tsx, CI/CD, pipes)
+// - Redirected output: No ANSI escape codes in logs
+
+// Example: CLI commands work in all environments
+// $ myapp list              // TTY: Shows animated spinner
+// $ tsx myapp-cli.ts list   // Non-TTY: Falls back to console.log
+// $ myapp list > output.txt // Redirected: Clean text output
+```
+
+**Implementation Details**:
+- TTY check: `process.stdout.isTTY` before using `clearLine()` or `cursorTo()`
+- Graceful degradation: Spinners fall back to `console.log()` in non-TTY environments
+- No crashes: Safe to use in tsx, CI/CD pipelines, and piped output
+- Regression tests: Automated testing for both TTY and non-TTY scenarios
+
+**Reference**: See PR #81 for the TTY detection implementation.
+
 **API Generation**
 ```bash
 # Create REST APIs with OpenAPI documentation
-import { APIGenerator } from '@smrt/core/generators';
+import { APIGenerator } from '@happyvertical/smrt-core/generators';
 const generator = new APIGenerator({
   collections: [MyCollection],
   includeSwagger: true,
@@ -1957,7 +2086,7 @@ await generator.generate();
 **MCP Server Generation**
 ```bash
 # Generate Model Context Protocol servers
-import { MCPGenerator } from '@smrt/core/generators';
+import { MCPGenerator } from '@happyvertical/smrt-core/generators';
 const generator = new MCPGenerator({
   collections: [MyCollection],
   tools: ['list', 'search', 'analyze']
@@ -2031,10 +2160,10 @@ npm run docs              # Generate API documentation
 - Cache expensive AI operations appropriately
 
 **Cross-Package Integration**
-- Leverage @have/spider for content ingestion
-- Use @have/pdf for document processing workflows
-- Integrate @have/files for asset management
-- Apply @have/sql for complex querying needs
+- Leverage @happyvertical/spider for content ingestion
+- Use @happyvertical/pdf for document processing workflows
+- Integrate @happyvertical/files for asset management
+- Apply @happyvertical/sql for complex querying needs
 
 **Code Generation**
 - Use AST scanning for automatic service discovery
@@ -2055,7 +2184,7 @@ When building agents with the SMRT framework:
 
 ## API Documentation
 
-The @smrt/core package generates comprehensive API documentation in both HTML and markdown formats using TypeDoc:
+The @happyvertical/smrt-core package generates comprehensive API documentation in both HTML and markdown formats using TypeDoc:
 
 ### Generated Documentation Formats
 
@@ -2114,16 +2243,16 @@ Always reference the latest documentation when developing AI agents with the SMR
   - Critical for configuration management in agent deployments
 
 ### HAVE SDK Integration Points
-- **@have/ai**: AI model interactions and completions
-- **@have/files**: File system operations and content management
-- **@have/pdf**: PDF processing and document analysis
-- **@have/sql**: Database operations and schema management
-- **@have/spider**: Web content extraction and processing
-- **@have/utils**: Utility functions and type definitions
+- **@happyvertical/ai**: AI model interactions and completions
+- **@happyvertical/files**: File system operations and content management
+- **@happyvertical/pdf**: PDF processing and document analysis
+- **@happyvertical/sql**: Database operations and schema management
+- **@happyvertical/spider**: Web content extraction and processing
+- **@happyvertical/utils**: Utility functions and type definitions
 
 ### Expert Agent Instructions
 
-When working with @smrt/core:
+When working with @happyvertical/smrt-core:
 
 1. **Always check latest documentation** before implementing agent solutions using WebFetch tool
 2. **Stay current with framework updates** - agent frameworks evolve rapidly with new AI capabilities
@@ -2329,17 +2458,17 @@ class Document extends SmrtObject {
 **Virtual modules only work with Vite plugin**:
 ```typescript
 // ✅ WORKS - With smrtPlugin() in vite.config.js
-import { setupRoutes } from '@smrt/routes';
-import { createClient } from '@smrt/client';
+import { setupRoutes } from '@happyvertical/smrt-routes';
+import { createClient } from '@happyvertical/smrt-client';
 
 // ❌ DOESN'T WORK - Without Vite plugin configured
-// Will get "Cannot find module '@smrt/routes'" error
+// Will get "Cannot find module '@happyvertical/smrt-routes'" error
 ```
 
 **Consumer projects need smrtConsumer()**:
 ```typescript
 // vite.config.js in consuming project
-import { smrtConsumer } from '@smrt/core/consumer-plugin';
+import { smrtConsumer } from '@happyvertical/smrt-core/consumer-plugin';
 
 export default {
   plugins: [

--- a/packages/products/CLAUDE.md
+++ b/packages/products/CLAUDE.md
@@ -1,8 +1,8 @@
-# @have/products: Triple-Purpose SMRT Microservice Template
+# @happyvertical/products: Triple-Purpose SMRT Microservice Template
 
 ## Purpose and Responsibilities
 
-The `@have/products` package is a comprehensive reference implementation demonstrating the SMRT framework's code generation capabilities. It serves as both a working example and a template for building production-ready microservices that leverage auto-generation from `@smrt()` decorated classes.
+The `@happyvertical/products` package is a comprehensive reference implementation demonstrating the SMRT framework's code generation capabilities. It serves as both a working example and a template for building production-ready microservices that leverage auto-generation from `@smrt()` decorated classes.
 
 ### Three Consumption Patterns
 
@@ -15,12 +15,12 @@ This package demonstrates how to create a single codebase that can be consumed i
 ### What Gets Auto-Generated
 
 The `@smrt()` decorator on model classes automatically generates:
-- **REST APIs**: Full CRUD endpoints (list, get, create, update, delete) via `@have/smrt`'s `startRestServer()`
-- **TypeScript Client**: Type-safe API client with IntelliSense support (via `@smrt/client` virtual module)
-- **MCP Tools**: Model Context Protocol tools for AI agent integration (via `@smrt/mcp` virtual module)
-- **Type Definitions**: Complete TypeScript types for all models and API responses (via `@smrt/types` virtual module)
-- **Route Setup**: Express route handlers (via `@smrt/routes` virtual module)
-- **Manifest**: Metadata about models and their configurations (via `@smrt/manifest` virtual module)
+- **REST APIs**: Full CRUD endpoints (list, get, create, update, delete) via `@happyvertical/smrt-core`'s `startRestServer()`
+- **TypeScript Client**: Type-safe API client with IntelliSense support (via `@happyvertical/smrt-client` virtual module)
+- **MCP Tools**: Model Context Protocol tools for AI agent integration (via `@happyvertical/smrt-mcp` virtual module)
+- **Type Definitions**: Complete TypeScript types for all models and API responses (via `@happyvertical/smrt-types` virtual module)
+- **Route Setup**: Express route handlers (via `@happyvertical/smrt-routes` virtual module)
+- **Manifest**: Metadata about models and their configurations (via `@happyvertical/smrt-manifest` virtual module)
 
 ### Current Status
 
@@ -41,11 +41,11 @@ The `@smrt()` decorator on model classes automatically generates:
 ### Key Implementation Details
 
 **Virtual Modules System**: The package relies heavily on Vite plugins (`smrtPlugin` and `smrtConsumer`) that generate "virtual modules" - modules that don't exist as physical files but are resolved at build/runtime. These include:
-- `@smrt/client` - Auto-generated TypeScript API client
-- `@smrt/types` - Auto-generated TypeScript type definitions
-- `@smrt/routes` - Auto-generated Express route handlers
-- `@smrt/mcp` - Auto-generated MCP tool definitions
-- `@smrt/manifest` - Metadata manifest with decorator configs
+- `@happyvertical/smrt-client` - Auto-generated TypeScript API client
+- `@happyvertical/smrt-types` - Auto-generated TypeScript type definitions
+- `@happyvertical/smrt-routes` - Auto-generated Express route handlers
+- `@happyvertical/smrt-mcp` - Auto-generated MCP tool definitions
+- `@happyvertical/smrt-manifest` - Metadata manifest with decorator configs
 
 **Mock Client**: Currently uses `src/lib/mock-smrt-client.ts` for development and testing since the virtual module generation is still in progress. This provides a working implementation that demonstrates the intended API structure.
 
@@ -75,7 +75,7 @@ packages/products/
 │   │   │   └── index.ts
 │   │   ├── utils/                   # Utility functions
 │   │   │   └── index.ts
-│   │   ├── mock-smrt-client.ts      # Mock client (temporary, replaces @smrt/client)
+│   │   ├── mock-smrt-client.ts      # Mock client (temporary, replaces @happyvertical/smrt-client)
 │   │   ├── types.ts                 # Core type definitions (ProductData, etc.)
 │   │   ├── federation-entry.ts      # Module federation entry point
 │   │   └── index.ts                 # Main library export (re-exports all modules)
@@ -116,14 +116,14 @@ The most common and production-ready usage pattern:
 
 ```typescript
 // Import models
-import { Product, Category } from '@have/products';
-import type { ProductData, CategoryData } from '@have/products';
+import { Product, Category } from '@happyvertical/products';
+import type { ProductData, CategoryData } from '@happyvertical/products';
 
 // Import auto-generated client
-import { createClient } from '@have/products';
+import { createClient } from '@happyvertical/products';
 
 // Import stores (Svelte 5 runes)
-import { productStore } from '@have/products/stores';
+import { productStore } from '@happyvertical/products/stores';
 
 // Create model instances
 const product = new Product({
@@ -157,7 +157,7 @@ await client.products.update('product-id', {
 Start the auto-generated REST API server:
 
 ```typescript
-import { startServer } from '@have/products';
+import { startServer } from '@happyvertical/products';
 
 // Starts Express server with auto-generated routes
 const { shutdown } = await startServer();
@@ -173,12 +173,49 @@ const { shutdown } = await startServer();
 // PUT    /api/v1/categories/:id  - Update category
 ```
 
+**Using `startRestServer` directly** (from `@happyvertical/smrt-core`):
+
+```typescript
+import { startRestServer } from '@happyvertical/smrt-core';
+import { Product, Category } from './lib/models';
+
+// API Signature:
+// startRestServer(
+//   objects: (typeof SmrtObject)[],    // Array of SMRT model classes
+//   context: APIContext = {},          // Shared context (db, ai, fs config)
+//   config: RestServerConfig = {}      // Server configuration
+// ): Promise<() => Promise<void>>      // Returns shutdown function
+
+const shutdown = await startRestServer(
+  [Product, Category],  // Models to expose via REST API
+  {},                   // Context (empty = use model defaults)
+  {
+    port: 3000,
+    hostname: 'localhost',
+    basePath: '/api/v1',
+    enableCors: true,
+  },
+);
+
+// Call shutdown() to stop the server
+// await shutdown();
+```
+
+**Parameters Explained**:
+- **`objects`**: Array of SMRT model classes (not instances) decorated with `@smrt()`
+- **`context`**: Shared configuration for db, ai, and fs - overrides model-level defaults
+- **`config`**: Server settings:
+  - `port` (number): Port to listen on (default: 3000)
+  - `hostname` (string): Host to bind to (default: 'localhost')
+  - `basePath` (string): API base path (default: '/api/v1')
+  - `enableCors` (boolean): Enable CORS (default: true)
+
 ### 3. MCP Server for AI Integration
 
 Enable AI agents to interact with your models:
 
 ```typescript
-import { startMCPServer } from '@have/products';
+import { startMCPServer } from '@happyvertical/products';
 
 // Starts Model Context Protocol server
 const mcp = await startMCPServer();
@@ -196,7 +233,7 @@ Use the reactive store for state management:
 
 ```svelte
 <script>
-  import { productStore } from '@have/products/stores';
+  import { productStore } from '@happyvertical/products/stores';
 
   // Load products on mount
   $effect(() => {
@@ -243,7 +280,7 @@ Use the reactive store for state management:
 The Product model demonstrates all SMRT decorator capabilities:
 
 ```typescript
-import { SmrtObject, type SmrtObjectOptions, smrt } from '@have/smrt';
+import { SmrtObject, type SmrtObjectOptions, smrt } from '@happyvertical/smrt-core';
 
 export interface ProductOptions extends SmrtObjectOptions {
   name?: string;
@@ -530,33 +567,55 @@ export const productStore = new ProductStoreClass();
 
 ## Virtual Module System
 
-The SMRT framework uses Vite plugins to generate virtual modules that don't exist as physical files but are available at build time and runtime. These are auto-generated from your `@smrt()` decorated classes.
+**What are Virtual Modules?**
+
+Virtual modules are code modules that **don't exist as physical `.ts` or `.js` files** in your project, but are dynamically generated by Vite plugins during the build process. The SMRT framework uses this technique to automatically generate TypeScript client code, type definitions, API routes, and MCP tools based on your `@smrt()` decorated model classes.
+
+**Why Virtual Modules?**
+- **Auto-sync**: Client and types stay in sync with server models automatically
+- **Type Safety**: Full TypeScript IntelliSense without manual typing
+- **Zero Boilerplate**: No need to manually write API client code
+- **Single Source of Truth**: Your SMRT model classes define everything
+
+**How It Works**:
+1. You write SMRT model classes with `@smrt()` decorator (e.g., `Product`, `Category`)
+2. Vite plugins scan your code at build time
+3. Plugins generate virtual module code based on your models
+4. You import from virtual module names (e.g., `@happyvertical/smrt-client`)
+5. TypeScript gets generated `.d.ts` files for IntelliSense
+
+**Important**: Virtual modules require running `npm run prebuild` to generate TypeScript declarations. Your IDE will show errors until this runs.
 
 ### Available Virtual Modules
 
 ```typescript
 // Auto-generated TypeScript client for API calls
-import createClient from '@smrt/client';
+// Generated from: Your SMRT model classes decorated with @smrt()
+import createClient from '@happyvertical/smrt-client';
 
 // Auto-generated TypeScript type definitions
-import type { ProductData, CategoryData } from '@smrt/types';
+// Generated from: Model properties and Field decorators
+import type { ProductData, CategoryData } from '@happyvertical/smrt-types';
 
 // Auto-generated REST route setup (server-side)
-import setupRoutes from '@smrt/routes';
+// Generated from: @smrt() decorator api configuration
+import setupRoutes from '@happyvertical/smrt-routes';
 
 // Auto-generated MCP tools for AI integration
-import createMCPServer from '@smrt/mcp';
-import { tools } from '@smrt/mcp';
+// Generated from: @smrt() decorator mcp configuration
+import createMCPServer from '@happyvertical/smrt-mcp';
+import { tools } from '@happyvertical/smrt-mcp';
 
 // Metadata manifest (decorator configs, field info, etc.)
-import { manifest } from '@smrt/manifest';
+// Generated from: @smrt() decorator options and model metadata
+import { manifest } from '@happyvertical/smrt-manifest';
 ```
 
 ### How Virtual Modules Work
 
 1. **Build-Time Generation**: During `npm run prebuild`, the `scripts/generate-smrt-types.js` script scans your models and creates type declarations in `src/lib/types/smrt-generated/`
 
-2. **Vite Plugin Resolution**: The `smrtPlugin` and `smrtConsumer` plugins intercept imports of `@smrt/*` modules and provide the generated code
+2. **Vite Plugin Resolution**: The `smrtPlugin` and `smrtConsumer` plugins intercept imports of `@happyvertical/smrt-*` modules and provide the generated code
 
 3. **Type Safety**: TypeScript gets full IntelliSense support through the generated `.d.ts` files
 
@@ -564,7 +623,7 @@ import { manifest } from '@smrt/manifest';
 
 ```typescript
 // server.ts - Start REST API with auto-generated routes
-import { createRestServer, startRestServer } from '@have/smrt';
+import { createRestServer, startRestServer } from '@happyvertical/smrt-core';
 import { Product, Category } from './lib/models';
 
 const shutdown = await startRestServer(
@@ -579,8 +638,8 @@ const shutdown = await startRestServer(
 );
 
 // client.ts - Use auto-generated TypeScript client
-import createClient from '@smrt/client';
-import type { ProductData } from '@smrt/types';
+import createClient from '@happyvertical/smrt-client';
+import type { ProductData } from '@happyvertical/smrt-types';
 
 const api = createClient('http://localhost:3000/api/v1');
 
@@ -604,8 +663,8 @@ The package uses a sophisticated Vite configuration that supports three build mo
 ### Key Configuration Points
 
 ```typescript
-import { smrtPlugin } from '@have/smrt/vite-plugin';
-import { smrtConsumer } from '@have/smrt/consumer-plugin';
+import { smrtPlugin } from '@happyvertical/smrt-core/vite-plugin';
+import { smrtConsumer } from '@happyvertical/smrt-core/consumer-plugin';
 import federation from '@originjs/vite-plugin-federation';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 
@@ -777,7 +836,7 @@ The package uses a prebuild script to generate TypeScript types:
 
 ```json
 {
-  "@have/smrt": "workspace:*"  // Core SMRT framework
+  "@happyvertical/smrt-core": "workspace:*"  // Core SMRT framework
 }
 ```
 
@@ -801,7 +860,7 @@ The package uses a prebuild script to generate TypeScript types:
 ### Peer Dependencies
 
 When using this package as a library, consuming applications should have:
-- `@have/smrt` - Core SMRT framework
+- `@happyvertical/smrt-core` - Core SMRT framework
 - `svelte` (if using Svelte components)
 - Node.js 20+ or Bun 1.0+
 
@@ -842,13 +901,13 @@ The package provides multiple entry points for different use cases:
 
 ```typescript
 // Import from main entry point
-import { Product, Category, createClient } from '@have/products';
+import { Product, Category, createClient } from '@happyvertical/products';
 
 // Import specific exports
-import { Product } from '@have/products/models';
-import { productStore } from '@have/products/stores';
-import { createClient } from '@have/products';
-import type { ProductData } from '@have/products';
+import { Product } from '@happyvertical/products/models';
+import { productStore } from '@happyvertical/products/stores';
+import { createClient } from '@happyvertical/products';
+import type { ProductData } from '@happyvertical/products';
 ```
 
 ## Common Coding Patterns and Conventions
@@ -859,7 +918,7 @@ When adding a new model to this package, follow this pattern:
 
 ```typescript
 // src/lib/models/YourModel.ts
-import { SmrtObject, type SmrtObjectOptions, smrt } from '@have/smrt';
+import { SmrtObject, type SmrtObjectOptions, smrt } from '@happyvertical/smrt-core';
 
 // 1. Define options interface extending SmrtObjectOptions
 export interface YourModelOptions extends SmrtObjectOptions {
@@ -939,12 +998,12 @@ This automatically generates:
 
 **Import Pattern**:
 ```typescript
-// Always import from @smrt/* for virtual modules
-import createClient from '@smrt/client';
-import type { ProductData, CategoryData } from '@smrt/types';
-import { manifest } from '@smrt/manifest';
-import setupRoutes from '@smrt/routes';
-import createMCPServer from '@smrt/mcp';
+// Always import from @happyvertical/smrt-* for virtual modules
+import createClient from '@happyvertical/smrt-client';
+import type { ProductData, CategoryData } from '@happyvertical/smrt-types';
+import { manifest } from '@happyvertical/smrt-manifest';
+import setupRoutes from '@happyvertical/smrt-routes';
+import createMCPServer from '@happyvertical/smrt-mcp';
 
 // Use the generated code
 const api = createClient('/api/v1');
@@ -952,7 +1011,7 @@ const products = await api.products.list();
 ```
 
 **Troubleshooting Virtual Modules**:
-- If TypeScript can't find `@smrt/*`, run `npm run prebuild`
+- If TypeScript can't find `@happyvertical/smrt-*`, run `npm run prebuild`
 - If changes to models aren't reflected, run `npm run clean && npm run build`
 - Virtual modules are resolved by `smrtPlugin` and `smrtConsumer` in vite.config.ts
 - Type declarations are generated in `src/lib/types/smrt-generated/`
@@ -1179,7 +1238,7 @@ export class BadStore {
 **Important Notes**:
 
 1. **Prebuild Required**: Always run `npm run prebuild` before building if types are missing
-2. **Virtual Module Imports**: Imports from `@smrt/*` don't exist as physical files
+2. **Virtual Module Imports**: Imports from `@happyvertical/smrt-*` don't exist as physical files
 3. **Type Generation**: Types are generated at build time, not runtime
 4. **Plugin Order Matters**: `smrtPlugin` must come before `smrtConsumer` in Vite config
 5. **Mode-Specific Behavior**: Different build modes use different plugin configurations
@@ -1188,7 +1247,7 @@ export class BadStore {
 
 #### Virtual Module Issues
 
-**Issue**: `Cannot find module '@smrt/client'` or other `@smrt/*` imports
+**Issue**: `Cannot find module '@happyvertical/smrt-client'` or other `@happyvertical/smrt-*` imports
 ```bash
 # Solution: Run prebuild to generate types
 npm run prebuild
@@ -1199,7 +1258,7 @@ npm run prebuild
 npm run build
 ```
 
-**Cause**: The `@smrt/*` virtual modules are generated by Vite plugins at build time. If the prebuild script hasn't run, TypeScript won't find the type declarations.
+**Cause**: The `@happyvertical/smrt-*` virtual modules are generated by Vite plugins at build time. If the prebuild script hasn't run, TypeScript won't find the type declarations.
 
 **Issue**: Virtual modules not resolving in IDE (red squiggles but builds fine)
 ```bash
@@ -1272,16 +1331,16 @@ const data = $state({ items: [] });
 
 #### Build and Configuration Issues
 
-**Issue**: Build fails with "Cannot find module @have/smrt"
+**Issue**: Build fails with "Cannot find module @happyvertical/smrt-core"
 ```bash
-# Solution: Make sure @have/smrt is built first
+# Solution: Make sure @happyvertical/smrt-core is built first
 cd ../smrt
 npm run build
 cd ../products
 npm run build
 ```
 
-**Cause**: The products package depends on @have/smrt. Build order matters in monorepos.
+**Cause**: The products package depends on @happyvertical/smrt-core. Build order matters in monorepos.
 
 **Issue**: Module federation build fails
 ```bash
@@ -1426,7 +1485,7 @@ static async findByName(_name: string): Promise<Product[]> {
 **Gotcha**: Virtual modules are only available after prebuild
 ```typescript
 // ❌ This will fail in tests/scripts without prebuild
-import createClient from '@smrt/client';
+import createClient from '@happyvertical/smrt-client';
 
 // ✅ Either run prebuild first, or use mock client
 import { createClient } from '../lib/mock-smrt-client';
@@ -1568,7 +1627,7 @@ export const itemCount = derived(items, $items => $items.length);
 Reference these when working with the package:
 
 ### SMRT Framework
-- **@have/smrt package**: Core framework documentation (see `/packages/smrt/CLAUDE.md`)
+- **@happyvertical/smrt-core package**: Core framework documentation (see `/packages/smrt/CLAUDE.md`)
 - **SMRT Vite Plugin**: Virtual module generation (see `/packages/smrt/src/vite-plugin/`)
 - **SMRT Consumer Plugin**: External package consumption (see `/packages/smrt/src/consumer-plugin/`)
 
@@ -1603,7 +1662,7 @@ Reference these when working with the package:
 2. **Update package.json**:
    ```json
    {
-     "name": "@have/your-service",
+     "name": "@happyvertical/your-service",
      "description": "Your service description"
    }
    ```
@@ -1611,7 +1670,7 @@ Reference these when working with the package:
 3. **Create your models**:
    ```typescript
    // src/lib/models/YourModel.ts
-   import { SmrtObject, smrt } from '@have/smrt';
+   import { SmrtObject, smrt } from '@happyvertical/smrt-core';
 
    @smrt({ api: { include: ['list', 'get', 'create'] } })
    export class YourModel extends SmrtObject {
@@ -1634,12 +1693,12 @@ Reference these when working with the package:
 ### For Library Consumers (Using as NPM Package)
 
 ```bash
-npm install @have/products
+npm install @happyvertical/products
 ```
 
 ```typescript
-import { Product, createClient } from '@have/products';
-import { productStore } from '@have/products/stores';
+import { Product, createClient } from '@happyvertical/products';
+import { productStore } from '@happyvertical/products/stores';
 
 // Use models
 const product = new Product({ name: 'Test', price: 29.99 });
@@ -1649,7 +1708,7 @@ const api = createClient('/api/v1');
 const products = await api.products.list();
 
 // Use store in Svelte components
-import { productStore } from '@have/products/stores';
+import { productStore } from '@happyvertical/products/stores';
 ```
 
 ## Quick Reference Cheat Sheet
@@ -1724,16 +1783,16 @@ Generated Files (don't edit):
 
 ```typescript
 // Virtual modules (require prebuild)
-import createClient from '@smrt/client';
-import type { ProductData, CategoryData } from '@smrt/types';
-import { manifest } from '@smrt/manifest';
-import setupRoutes from '@smrt/routes';
-import createMCPServer, { tools } from '@smrt/mcp';
+import createClient from '@happyvertical/smrt-client';
+import type { ProductData, CategoryData } from '@happyvertical/smrt-types';
+import { manifest } from '@happyvertical/smrt-manifest';
+import setupRoutes from '@happyvertical/smrt-routes';
+import createMCPServer, { tools } from '@happyvertical/smrt-mcp';
 
 // Real modules (always available)
-import { Product, Category } from '@have/products/models';
-import { productStore } from '@have/products/stores';
-import { ProductCard } from '@have/products/components';
+import { Product, Category } from '@happyvertical/products/models';
+import { productStore } from '@happyvertical/products/stores';
+import { ProductCard } from '@happyvertical/products/components';
 ```
 
 ### Svelte 5 Runes Quick Reference
@@ -1774,7 +1833,7 @@ PUT    /api/v1/categories/:id  # Update category
 ### Common Error Messages and Quick Fixes
 
 ```
-Error: Cannot find module '@smrt/client'
+Error: Cannot find module '@happyvertical/smrt-client'
 → Run: npm run prebuild
 
 Error: Port 3000 already in use
@@ -1783,7 +1842,7 @@ Error: Port 3000 already in use
 Error: Cannot find name '$state'
 → Check file extension is .svelte.ts (not just .ts)
 
-Error: Module not found: @have/smrt
+Error: Module not found: @happyvertical/smrt-core
 → Build smrt package first: cd ../smrt && npm run build
 
 Type error: Property 'price' may be undefined
@@ -1792,7 +1851,7 @@ Type error: Property 'price' may be undefined
 
 ## Summary
 
-The `@have/products` package is a **reference implementation** and **template** demonstrating:
+The `@happyvertical/products` package is a **reference implementation** and **template** demonstrating:
 
 1. **SMRT Framework Capabilities**: Auto-generation of REST APIs, TypeScript clients, and MCP tools from decorated classes
 2. **Svelte 5 Patterns**: Modern reactive state management using runes (`$state`, `$derived`, `$effect`, `$props`)


### PR DESCRIPTION
## Summary

Comprehensive update of all CLAUDE.md documentation files across the monorepo to reflect recent refactoring work. Addresses outdated examples appearing in downstream projects by synchronizing documentation with current codebase state.

## Changes

**Phase 1: Global Package Name Updates**
- Replace `@smrt/*` → `@happyvertical/smrt-*` across all documentation
- Replace `@have/*` → `@happyvertical/*` throughout

**Phase 2: Root CLAUDE.md**
- Add `@happyvertical/smrt-config` package documentation
- Document recent PRs (#77, #79, #81) in "Recent Infrastructure Changes"
- Fix broken TESTING_STANDARD.md links (`../../` → `../`)

**Phase 3: packages/core/CLAUDE.md**
- Add "Database Adapter Methods" section with migration guide (PR #79)
- Add "CLI TTY Detection" section (PR #81)
- Document semantic methods: `db.get()`, `db.list()`, `db.delete()`, `db.upsert()`
- Include operator support and cross-adapter compatibility notes

**Phase 4: packages/content/CLAUDE.md**
- Remove deprecated `Document` class section (65+ lines)
- Add `fetchDocument` documentation from `@happyvertical/documents`
- Update all code examples to use `fetchDocument` instead of `Document.create()`
- Create migration guide showing old vs new patterns

**Phase 5: packages/products/CLAUDE.md**
- Clarify `startRestServer` API signature with parameter explanations
- Enhance virtual modules documentation with beginner-friendly explanations
- Add "What are Virtual Modules?" section with clear definitions

## Testing

**Standards Verified**:
- ✅ Documentation changes only (no code modifications)
- ✅ Build passes successfully
- ✅ All links verified (TESTING_STANDARD.md paths corrected)
- ✅ Conventional commit format
- ✅ Code formatted (Biome check passed)

**Test Results**:
```
✅ Build successful (documentation-only changes)
✅ Format check passed
✅ Pre-push hooks passed
```

## Checklist

- [x] Documentation updated
- [x] Links verified and corrected
- [x] Conventional commit message
- [x] Code formatted
- [x] Build passes
- [x] All recent PRs documented (#77, #79, #81)