### PR TITLE
fix(svelte): resolve SSR errors in layout and weather components

### DIFF
--- a/packages/svelte/src/lib/components/layout/Footer.svelte
+++ b/packages/svelte/src/lib/components/layout/Footer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { Snippet } from 'svelte';
+import Container from './Container.svelte';
 
 interface Props {
   children?: Snippet;
@@ -7,7 +8,7 @@ interface Props {
 
 const { children }: Props = $props();
 
-const _currentYear = new Date().getFullYear();
+const currentYear = new Date().getFullYear();
 </script>
 
 <footer class="site-footer">

--- a/packages/svelte/src/lib/components/layout/Masthead.svelte
+++ b/packages/svelte/src/lib/components/layout/Masthead.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { Snippet } from 'svelte';
+import Container from './Container.svelte';
 
 interface Props {
   date?: string;

--- a/packages/svelte/src/lib/components/weather/WeatherHeader.svelte
+++ b/packages/svelte/src/lib/components/weather/WeatherHeader.svelte
@@ -167,7 +167,7 @@ function getMockData(): DayForecast[] {
 }
 
 // Handle day card click
-function _handleDayClick(index: number) {
+function handleDayClick(index: number) {
   if (selectedDayIndex === index) {
     // Toggle off if clicking the same day
     selectedDayIndex = null;
@@ -178,20 +178,20 @@ function _handleDayClick(index: number) {
 }
 
 // Handle close button click
-function _handleClose() {
+function handleClose() {
   selectedDayIndex = null;
 }
 
 // Get selected day's hourly data
-const _selectedDayHourly = $derived(
+const selectedDayHourly = $derived(
   selectedDayIndex !== null ? dayForecasts[selectedDayIndex].hourlyData : [],
 );
 
 // Scroll container reference and state
 // biome-ignore lint/style/useConst: Svelte bind:this requires let, not const
 let hourlyScrollContainer: HTMLElement | null = $state(null);
-let _canScrollLeft = $state(false);
-let _canScrollRight = $state(false);
+let canScrollLeft = $state(false);
+let canScrollRight = $state(false);
 
 // Update scroll button visibility
 function updateScrollButtons() {
@@ -199,19 +199,19 @@ function updateScrollButtons() {
 
   const { scrollLeft, scrollWidth, clientWidth } = hourlyScrollContainer;
 
-  _canScrollLeft = scrollLeft > 5; // 5px threshold
-  _canScrollRight = scrollLeft < scrollWidth - clientWidth - 5; // 5px threshold
+  canScrollLeft = scrollLeft > 5; // 5px threshold
+  canScrollRight = scrollLeft < scrollWidth - clientWidth - 5; // 5px threshold
 }
 
 // Scroll left
-function _scrollLeft() {
+function scrollLeft() {
   if (!hourlyScrollContainer) return;
   hourlyScrollContainer.scrollBy({ left: -300, behavior: 'smooth' });
   setTimeout(updateScrollButtons, 350);
 }
 
 // Scroll right
-function _scrollRight() {
+function scrollRight() {
   if (!hourlyScrollContainer) return;
   hourlyScrollContainer.scrollBy({ left: 300, behavior: 'smooth' });
   setTimeout(updateScrollButtons, 350);
@@ -253,8 +253,8 @@ $effect(() => {
     };
   } else {
     // Reset scroll state when panel closes
-    _canScrollLeft = false;
-    _canScrollRight = false;
+    canScrollLeft = false;
+    canScrollRight = false;
   }
 });
 </script>


### PR DESCRIPTION
## Summary

This PR fixes multiple server-side rendering (SSR) errors in the Svelte component library that were blocking production builds.

## Issues Fixed

### 1. WeatherHeader Component (src/lib/components/weather/WeatherHeader.svelte:186)
**Problem**: Variables were defined with leading underscores but referenced without them in the template
**Error**: `ReferenceError: selectedDayHourly is not defined`

**Changes**:
- Removed leading underscores from all reactive variables and functions:
  - `_selectedDayHourly` → `selectedDayHourly`
  - `_canScrollLeft` → `canScrollLeft`
  - `_canScrollRight` → `canScrollRight`
  - `_handleDayClick` → `handleDayClick`
  - `_handleClose` → `handleClose`
  - `_scrollLeft` → `scrollLeft`
  - `_scrollRight` → `scrollRight`

### 2. Masthead Component (src/lib/components/layout/Masthead.svelte:23)
**Problem**: Component used `Container` without importing it
**Error**: `ReferenceError: Container is not defined`

**Changes**:
- Added `import Container from './Container.svelte';`

### 3. Footer Component (src/lib/components/layout/Footer.svelte:14,16)
**Problem**: 
- Component used `Container` without importing it
- Variable `currentYear` referenced but defined as `_currentYear`

**Changes**:
- Added `import Container from './Container.svelte';`
- Renamed `_currentYear` → `currentYear`

## Impact

These issues only manifested during SSR/prerendering for static site generation. They worked fine in dev mode due to different module resolution. The errors blocked production builds with:
```
ReferenceError: selectedDayHourly is not defined
ReferenceError: Container is not defined
```

## Testing

Verified the fix by:
1. Building the smrt-svelte package
2. Testing with bentleyalberta.com static site build
3. Confirming all SSR errors are resolved
4. Build now proceeds past component rendering (fails later on prerender config, which is expected)

Closes #95