### PR TITLE
fix(core): replace SQLite-specific INSERT OR REPLACE with portable upsert

### DIFF
--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -857,24 +857,30 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     const id = options.id || crypto.randomUUID();
     const now = new Date();
 
-    await this.systemDb.query(
-      `INSERT OR REPLACE INTO _smrt_contexts (
-        id, owner_class, owner_id, scope, key, value, metadata,
-        version, confidence, created_at, updated_at, last_used_at, expires_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      id,
-      this._itemClass.name,
-      '__collection__',
-      options.scope,
-      options.key,
-      JSON.stringify(options.value),
-      options.metadata ? JSON.stringify(options.metadata) : null,
-      options.version ?? 1,
-      options.confidence ?? 1.0,
-      now,
-      now,
-      now,
-      options.expiresAt ?? null,
+    // Use upsert() for database-agnostic INSERT OR REPLACE
+    // SQLite: INSERT OR REPLACE
+    // Postgres/DuckDB: INSERT ... ON CONFLICT ... DO UPDATE
+    await this.systemDb.upsert(
+      '_smrt_contexts',
+      // UNIQUE constraint: (owner_class, owner_id, scope, key, version)
+      ['owner_class', 'owner_id', 'scope', 'key', 'version'],
+      {
+        id,
+        owner_class: this._itemClass.name,
+        owner_id: '__collection__',
+        scope: options.scope,
+        key: options.key,
+        value: JSON.stringify(options.value),
+        metadata: options.metadata ? JSON.stringify(options.metadata) : null,
+        version: options.version ?? 1,
+        confidence: options.confidence ?? 1.0,
+        success_count: 0,
+        failure_count: 0,
+        created_at: now,
+        updated_at: now,
+        last_used_at: now,
+        expires_at: options.expiresAt ?? null,
+      },
     );
   }
 

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1290,21 +1290,27 @@ export class ObjectRegistry {
         };
       }
 
-      await db.query(
-        `INSERT OR REPLACE INTO _smrt_registry
-         (class_name, schema_version, fields, relationships, config, manifest, last_updated)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
-        className,
-        '1.0.0', // Could be derived from package version
-        JSON.stringify(fieldsData),
-        JSON.stringify(ObjectRegistry.getRelationships(className)),
-        JSON.stringify(registered.config),
-        JSON.stringify({
-          name: registered.name,
-          tableName: registered.schema?.tableName,
-          tools: registered.tools,
-        }),
-        new Date(),
+      // Use upsert() for database-agnostic INSERT OR REPLACE
+      // SQLite: INSERT OR REPLACE
+      // Postgres/DuckDB: INSERT ... ON CONFLICT ... DO UPDATE
+      await db.upsert(
+        '_smrt_registry',
+        ['class_name'], // PRIMARY KEY for conflict detection
+        {
+          class_name: className,
+          schema_version: '1.0.0', // Could be derived from package version
+          fields: JSON.stringify(fieldsData),
+          relationships: JSON.stringify(
+            ObjectRegistry.getRelationships(className),
+          ),
+          config: JSON.stringify(registered.config),
+          manifest: JSON.stringify({
+            name: registered.name,
+            tableName: registered.schema?.tableName,
+            tools: registered.tools,
+          }),
+          last_updated: new Date(),
+        },
       );
     }
   }


### PR DESCRIPTION
## Summary

Replaced SQLite-specific `INSERT OR REPLACE` syntax with database-agnostic `db.upsert()` method calls for cross-database compatibility. This fixes JSON adapter compatibility since it uses DuckDB which requires `ON CONFLICT` syntax instead of `INSERT OR REPLACE`.

## Changes

**Files Modified:**
- `packages/core/src/collection.ts`: Use `upsert()` for `_smrt_contexts` table writes
- `packages/core/src/registry.ts`: Use `upsert()` for `_smrt_registry` table writes

**Database-Specific Syntax Handled by Adapter:**
- SQLite: `INSERT OR REPLACE INTO...`
- Postgres/DuckDB: `INSERT ... ON CONFLICT ... DO UPDATE SET...`

## Testing

✅ Verified existing tests still pass
✅ SQL portability achieved through adapter methods
✅ No breaking changes to public API

## Technical Details

### Before (SQLite-specific):
```typescript
await db.query(
  `INSERT OR REPLACE INTO _smrt_contexts (...)
   VALUES (?, ?, ?)`,
  val1, val2, val3
);
```

### After (Database-agnostic):
```typescript
await db.upsert(
  '_smrt_contexts',
  ['owner_class', 'owner_id', 'scope', 'key', 'version'], // Conflict columns
  {
    owner_class: val1,
    owner_id: val2,
    // ...
  }
);
```

## Impact

- ✅ JSON adapter now works with SMRT system tables
- ✅ Praeco's `remember()`/`recall()` feature works
- ✅ All collection methods work with JSON adapter
- ✅ Better cross-database compatibility

## Checklist

- [x] Tests pass
- [x] Code linted
- [x] Code formatted
- [x] Conventional commit message
- [x] Issue reference included

Fixes #99