### PR TITLE
fix(core): correct empty string type inference for DuckDB/JSON adapters

### DIFF
--- a/packages/core/src/schema/runtime-manager.ts
+++ b/packages/core/src/schema/runtime-manager.ts
@@ -219,10 +219,23 @@ export class RuntimeSchemaManager {
         // DuckDB infers ANY type without explicit casting, causing UPSERT failures
         const isTextColumn = columnDef.type === 'TEXT';
         const isEmptyOrNull =
-          columnDef.defaultValue === "''" || columnDef.defaultValue === 'NULL';
+          columnDef.defaultValue === '' ||
+          columnDef.defaultValue === "''" ||
+          columnDef.defaultValue === null ||
+          columnDef.defaultValue === 'NULL';
 
         if (isTextColumn && isEmptyOrNull) {
-          def += ` DEFAULT CAST(${columnDef.defaultValue} AS TEXT)`;
+          // Normalize the default value to SQL format
+          let sqlValue: string;
+          if (
+            columnDef.defaultValue === '' ||
+            columnDef.defaultValue === "''"
+          ) {
+            sqlValue = "''";
+          } else {
+            sqlValue = 'NULL';
+          }
+          def += ` DEFAULT CAST(${sqlValue} AS TEXT)`;
         } else {
           def += ` DEFAULT ${columnDef.defaultValue}`;
         }


### PR DESCRIPTION
## Summary

Fixes a type inference bug where empty strings (`''`) were being inferred as FLOAT instead of TEXT, causing UPSERT operations to fail with "Could not convert string to FLOAT" errors.

## Root Cause

**File**: `packages/core/src/schema/runtime-manager.ts:221-222`

**Bug**: The condition to apply CAST checked for string literal `"''"` (two quote characters) instead of actual empty string `''`:

```typescript
// BUGGY:
const isEmptyOrNull =
  columnDef.defaultValue === "''" || columnDef.defaultValue === 'NULL';
```

**Impact**:
- The CAST was never applied because `'' !== "''"` 
- DuckDB saw `DEFAULT ''` without CAST
- DuckDB inferred column type as FLOAT/ANY instead of TEXT
- UPSERT operations failed when trying to insert string values like `'article'`

## Solution

Updated the condition to check for both empty string formats and properly normalize to SQL format:

```typescript
// FIXED:
const isEmptyOrNull =
  columnDef.defaultValue === '' ||
  columnDef.defaultValue === "''" ||
  columnDef.defaultValue === null ||
  columnDef.defaultValue === 'NULL';

if (isTextColumn && isEmptyOrNull) {
  // Normalize the default value to SQL format
  let sqlValue: string;
  if (columnDef.defaultValue === '' || columnDef.defaultValue === "''") {
    sqlValue = "''";
  } else {
    sqlValue = 'NULL';
  }
  def += ` DEFAULT CAST(${sqlValue} AS TEXT)`;
}
```

## Changes

**Modified**: `packages/core/src/schema/runtime-manager.ts`
- Lines 221-239: Fixed condition and added value normalization
- Now correctly applies `DEFAULT CAST('' AS TEXT)` for empty string defaults
- Handles both `''` and `"''"` value formats
- Handles both `null` and `'NULL'` value formats

## Testing

Following [Organization-Wide Testing Standard](../TESTING_STANDARD.md):

**Existing Tests Verified**:
- ✅ `src/schema/runtime-manager.spec.ts` - All CAST tests passing
- ✅ Runtime manager tests validate CAST is applied correctly
- ✅ No regression in schema generation

**Test Results**:
```
✓ src/schema/runtime-manager.spec.ts (5 tests | 1 skipped) 3ms
  ✓ should add CAST for TEXT columns with empty string default
  ✓ should add CAST for TEXT columns with NULL default
  ✓ should not add CAST for non-TEXT columns
  ✓ should not add CAST for non-empty defaults
```

**Pre-existing Test Failures** (unrelated to this fix):
- ❌ `src/utils.spec.ts` - 2 tests failing (field detection tests)
- These were already failing before this change (verified by stashing and testing)

## Benefits

- Empty string fields (`type = ''`) now generate TEXT columns correctly
- UPSERT operations work with string values
- DuckDB type inference works as expected
- No breaking changes to public API

## Checklist

- [x] Tests pass (runtime-manager tests)
- [x] Code linted
- [x] Code formatted  
- [x] TypeScript compiles
- [x] Documentation updated (not applicable - internal fix)
- [x] Conventional commit message
- [x] Issue reference included

Closes #107