### PR TITLE
fix(accounts): add explicit name field to Account model

### DIFF
--- a/packages/accounts/src/models/Account.ts
+++ b/packages/accounts/src/models/Account.ts
@@ -5,6 +5,7 @@
  */
 
 import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { text } from '@happyvertical/smrt-core/fields';
 import type { AccountOptions, AccountType, CurrencyCode } from '../types';
 
 @smrt({
@@ -13,8 +14,7 @@ import type { AccountOptions, AccountType, CurrencyCode } from '../types';
   cli: true,
 })
 export class Account extends SmrtObject {
-  // id, slug, name inherited from SmrtObject
-
+  name = text({ required: true });
   type: AccountType = 'asset';
   currency: CurrencyCode = 'USD'; // Default to USD, should be set explicitly
   parentId = ''; // FK to parent Account (nullable for root accounts)


### PR DESCRIPTION
## Summary

Add explicit `name` field to Account model after PR #113 removed it from SmrtObject base class.

This fixes the CI workflow failure where AccountCollection.searchByName() was trying to access `account.name` but the field no longer exists after the base class removal.

## Problem

After PR #113 merged, CI workflow failed with TypeScript compilation error:

```
error TS2339: Property 'name' does not exist on type 'Account'.
  at src/collections/AccountCollection.ts(79,35)
  at src/collections/AccountCollection.ts(79,63)
```

The Account class had an outdated comment claiming `name` was inherited from SmrtObject, but PR #113 removed that field from the base class.

## Changes

- **Account.ts**: Add explicit `name = text({ required: true })` field
- **Account.ts**: Import `text` field helper from `@happyvertical/smrt-core/fields`
- **Account.ts**: Remove outdated comment about inherited fields

## Testing

**Typecheck Results**:
```
✅ @happyvertical/smrt-accounts typecheck passes
✅ No TypeScript compilation errors
```

**Impact Analysis**:
- AccountCollection.searchByName() now works correctly
- All Account operations that rely on name field will function properly
- Consistent with other domain packages (events, tags, content, places, profiles, products)

## Code Review

**Standards Verified**:
- ✅ Coding standards (CLAUDE.md)
- ✅ Follows pattern from PR #113 for other packages
- ✅ Uses field helper instead of plain types
- ✅ Conventional commit format

## Checklist

- [x] Typecheck passes
- [x] Code linted (via pre-commit hook)
- [x] Code formatted (via pre-commit hook)
- [x] Conventional commit message
- [x] Clear problem description
- [x] Impact analysis documented

## Related

- Fixes CI failure from PR #113
- Follows same pattern as events, tags, content packages updated in PR #113