### PR TITLE
docs(core): align documentation with TypeScript-first pattern

### DIFF
--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -771,6 +771,46 @@ cliGen.prompt(fields);          // "name (required, max 100 chars)", "price (min
 mcpGen.parameters(fields);      // name: { type: "string", maxLength: 100 }, price: { type: "number", minimum: 0 }
 ```
 
+**TypeScript Types vs Field Helpers**:
+
+The framework supports two approaches for defining properties. Both are processed identically by all generators:
+
+```typescript
+// Field helpers (when constraints needed)
+class ProductWithConstraints extends SmrtObject {
+  name = text({ required: true, maxLength: 100 });  // Validation needed
+  price = decimal({ min: 0 });                       // Constraint needed
+  categoryId = foreignKey(Category);                 // Relationship
+}
+
+// TypeScript types (when no constraints)
+class ProductSimple extends SmrtObject {
+  name: string = '';          // → TEXT
+  description: string = '';   // → TEXT
+  quantity: number = 0;       // → INTEGER (no decimal point)
+  price: number = 0.0;        // → DECIMAL (has decimal point)
+  active: boolean = true;     // → BOOLEAN
+  tags: string[] = [];        // → JSON
+}
+
+// Mixed approach (common in practice)
+class ProductMixed extends SmrtObject {
+  // TypeScript types for simple fields
+  name: string = '';
+  description: string = '';
+  quantity: number = 0;       // INTEGER
+  price: number = 0.0;        // DECIMAL
+
+  // Field helpers only where needed
+  sku = text({ required: true, unique: true });  // Constraint
+  categoryId = foreignKey(Category);             // Relationship
+}
+```
+
+All three approaches produce identical field definitions in `ObjectRegistry.getFields()` and are processed consistently by all generators (CLI, API, MCP, Swagger).
+
+**The 0 vs 0.0 Heuristic**: Numeric literals without decimal point (0, 1, 42) → INTEGER; with decimal point (0.0, 4.5, 1.0) → DECIMAL.
+
 ### 3. Collection Name Consistency
 
 **Guarantee**: All generators use identical collection names (pluralization).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -38,19 +38,25 @@ bun add @happyvertical/smrt-core
 
 ## Usage
 
-### Define SMRT Objects with Fields
+### Define SMRT Objects with TypeScript Types
 
 ```typescript
 import { SmrtObject } from '@happyvertical/smrt-core';
-import { text, integer, boolean, datetime } from '@happyvertical/smrt-core/fields';
+import { text } from '@happyvertical/smrt-core/fields';
 
-// Define a document object with typed fields
+// Define a document object using TypeScript types (primary pattern)
 class Document extends SmrtObject {
-  title = text({ required: true, maxLength: 200 });
-  content = text({ required: true });
-  wordCount = integer({ min: 0, default: 0 });
-  isPublished = boolean({ default: false });
-  publishedAt = datetime();
+  // TypeScript types → Automatic schema generation
+  title: string = '';
+  content: string = '';
+  wordCount: number = 0;        // INTEGER (no decimal point)
+  rating: number = 0.0;          // DECIMAL (has decimal point)
+  isPublished: boolean = false;
+  publishedAt: Date = new Date();
+  tags: string[] = [];
+
+  // Field helpers only when constraints needed
+  slug = text({ required: true, unique: true });
 
   constructor(options: any = {}) {
     super(options);
@@ -75,6 +81,28 @@ class Document extends SmrtObject {
   }
 }
 ```
+
+#### When to Use Field Helpers
+
+**Use TypeScript types** for most properties (preferred):
+```typescript
+name: string = '';           // → TEXT
+count: number = 0;           // → INTEGER (no decimal point)
+price: number = 0.0;         // → DECIMAL (has decimal point)
+active: boolean = true;      // → BOOLEAN
+created: Date = new Date();  // → DATETIME
+tags: string[] = [];         // → JSON
+```
+
+**Use field helpers** only when you need:
+1. **Relationships**: `categoryId = foreignKey(Category)`
+2. **Constraints**: `email = text({ required: true, pattern: /^.+@.+$/ })`
+3. **Nullable decimals**: `latitude = decimal({ nullable: true })`
+
+**The 0 vs 0.0 Heuristic**:
+- `quantity: number = 0` → INTEGER column (no decimal point)
+- `price: number = 0.0` → DECIMAL column (has decimal point)
+- `rating: number = 4.5` → DECIMAL column (has decimal point)
 
 ### Create and Manage Collections
 


### PR DESCRIPTION
## Summary

Updated core package documentation to align with the TypeScript-first approach implemented in PR #146 (0 vs 0.0 heuristic). The main user-facing documentation (README.md) was showing outdated field helper patterns that contradicted the CLAUDE.md guidance.

## Changes

**README.md**:
- Updated main example to use TypeScript types instead of field helpers
- Added "When to Use Field Helpers" section with decision guidance
- Documented the 0 vs 0.0 heuristic for integer/decimal type inference
- Reduced field helper imports to only what's needed (just `text` for constraints)
- Added inline comments showing INTEGER vs DECIMAL inference

**ARCHITECTURE.md**:
- Added "TypeScript Types vs Field Helpers" comparison section
- Showed three approaches: field helpers only, TypeScript only, and mixed
- Explained that all approaches are processed identically by generators
- Included 0 vs 0.0 heuristic documentation

## Documentation Consistency

All three core documentation files now consistently show:
- ✅ TypeScript types as the primary pattern for defining properties
- ✅ Field helpers documented as "only when needed" (relationships, constraints, nullable decimals)
- ✅ The 0 vs 0.0 heuristic explained identically across all sections
- ✅ No contradictions between CLAUDE.md, README.md, and ARCHITECTURE.md

## Testing

- [x] README.md examples are consistent with CLAUDE.md
- [x] ARCHITECTURE.md examples align with framework behavior
- [x] All documentation cross-references are valid
- [x] No broken examples or incorrect guidance

## Checklist

- [x] Documentation updated
- [x] Examples validated
- [x] Consistency verified across all core docs
- [x] Conventional commit message
- [x] All pre-commit hooks passed