### PR TITLE
fix(build): resolve TypeScript compilation errors and ESM issues

### DIFF
--- a/packages/core/src/class.ts
+++ b/packages/core/src/class.ts
@@ -215,7 +215,8 @@ export class SmrtClass {
         this._db = this.options.db as DatabaseInterface;
       } else {
         // Config object - pass directly to getDatabase
-        this._db = await getDatabase(this.options.db);
+        // Cast to any to bypass index signature incompatibility
+        this._db = await getDatabase(this.options.db as any);
       }
       await this.ensureSystemTables();
     }

--- a/packages/core/src/manifest/test-manifest-stub.ts
+++ b/packages/core/src/manifest/test-manifest-stub.ts
@@ -58,9 +58,7 @@ export const testManifest: SmartObjectManifest = {
         }
       },
       "methods": {},
-      "decoratorConfig": {
-        "tableName": "custom_councils"
-      }
+      "decoratorConfig": {}  // tableName is not part of decorator config
     },
     "perftestuser": {
       "name": "perftestuser",

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -4,7 +4,8 @@
  */
 
 export { createSmrtClient } from './client';
-export type { MCPServerOptions, MCPTool } from './mcp';
+// Note: MCPTool is exported from generators/index.ts to avoid duplicate exports
+export type { MCPServerOptions } from './mcp';
 export { createMCPServer, SmrtMCPServer } from './mcp';
 export { createSmrtServer } from './server';
 export type { SmrtClientOptions, SmrtServerOptions } from './types';

--- a/packages/core/src/scanner/types.ts
+++ b/packages/core/src/scanner/types.ts
@@ -10,14 +10,16 @@ export interface FieldDefinition {
     | 'integer'
     | 'datetime'
     | 'json'
-    | 'foreignKey';
+    | 'foreignKey'
+    | 'oneToMany'
+    | 'manyToMany';
   required?: boolean;
   default?: any;
   min?: number;
   max?: number;
   maxLength?: number;
   minLength?: number;
-  related?: string; // For foreignKey
+  related?: string; // For foreignKey, oneToMany, manyToMany
   description?: string;
   options?: Record<string, any>;
 }

--- a/packages/core/src/utils/lru-cache.ts
+++ b/packages/core/src/utils/lru-cache.ts
@@ -55,7 +55,9 @@ export class LRUCache<K, V> {
     if (this.cache.size >= this.maxSize) {
       // First entry is least recently used (Map maintains insertion order)
       const firstKey = this.cache.keys().next().value;
-      this.cache.delete(firstKey);
+      if (firstKey !== undefined) {
+        this.cache.delete(firstKey);
+      }
     }
 
     // Add as most recently used (at end)

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -509,7 +509,7 @@ export function setupRoutes(app, options = {}) {
   console.warn('[smrt] Available endpoints:');
 ${routes
   .split('\\n')
-  .map((line) => `  console.warn(\`  ${basePath}${line.trim()}\`);`)
+  .map((line) => `  console.warn(\`  \${basePath}${line.trim()}\`);`)
   .join('\\n')}
 }
 

--- a/packages/gnode/package.json
+++ b/packages/gnode/package.json
@@ -28,7 +28,7 @@
     "docs:watch": "typedoc --plugin typedoc-plugin-markdown --out docs --entryPoints ./src/index.ts --tsconfig ./tsconfig.json --excludePrivate --excludeInternal --hideGenerator --fileExtension .md --readme none --categorizeByGroup false --includeVersion false --hidePageHeader --hidePageTitle false --outputFileStrategy modules --watch",
     "clean": "rm -rf dist",
     "dev": "npm run build:watch & npm run test:watch",
-    "verify:exports": "node -e \"const pkg = require('./package.json'); const fs = require('fs'); Object.entries(pkg.exports).forEach(([key, path]) => { if (fs.existsSync(path)) { console.log('✅', key, '→', path); } else { console.error('❌', key, '→', path, '(missing)'); process.exit(1); } });\"",
+    "verify:exports": "node --input-type=module -e \"import { readFileSync, existsSync } from 'fs'; const pkg = JSON.parse(readFileSync('./package.json', 'utf-8')); Object.entries(pkg.exports).forEach(([key, path]) => { if (typeof path === 'string' && existsSync(path)) { console.log('✅', key, '→', path); } else if (typeof path === 'object' && path.import && existsSync(path.import)) { console.log('✅', key, '→', path.import); } else { console.error('❌', key, '→', path, '(missing)'); process.exit(1); } });\"",
     "build:fresh": "npm run clean && npm run build && npm run verify:exports",
     "prepack": "npm run build:fresh"
   },


### PR DESCRIPTION
Fixes all TypeScript compilation errors that prevented @happyvertical/smrt-core and @happyvertical/smrt-gnode from publishing to GitHub Package Registry.

## Changes
- fix(core): cast getDatabase argument to bypass index signature incompatibility
- fix(core): remove duplicate MCPTool export from runtime/index.ts
- fix(core): add oneToMany and manyToMany to FieldDefinition type union
- fix(core): add undefined check for LRU cache firstKey before deletion
- fix(core): escape basePath template variable in vite-plugin
- fix(core): remove invalid tableName from test-manifest-stub decorator config
- fix(gnode): update verify:exports script to use ESM syntax with --input-type=module

## Verification
- All 17 packages build successfully
- Resolves publish failures from release workflow