### PR TITLE
fix(ci): remove [skip ci] from auto-changeset commits

### DIFF
--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -64,7 +64,7 @@ jobs:
         if: steps.check-created.outputs.changeset_created == 'true'
         run: |
           git add .changeset
-          git commit -m "chore: auto-generate changeset from commits [skip ci]"
+          git commit -m "chore: auto-generate changeset from commits"
           git push
 
       - name: Comment on PR


### PR DESCRIPTION
## Summary

Removes `[skip ci]` from the auto-changeset workflow commit message to allow the main branch workflow to trigger when PRs are merged.

## Problem

The auto-changeset workflow was adding `[skip ci]` to commits, which prevented the main branch workflow from running when PRs were merged to main. This meant releases weren't being automatically published.

## Changes

- Remove `[skip ci]` from commit message in `.github/workflows/auto-changeset.yml`

## Why This Is Safe

The workflow already has multiple safeguards against infinite loops:
1. Only runs on `pull_request` events (not `push` to main)
2. Skips if changesets already exist
3. Skips for `changeset-release/` branches

## Testing

- PR #160 was manually triggered after merge - workflow ran successfully
- This PR will test that the auto-generated changeset doesn't prevent the main workflow

Fixes #163