### PR TITLE
feat(ci): optimize workflow with auto-merge and cascade triggers

### DIFF
--- a/.changeset/workflow-consolidation.md
+++ b/.changeset/workflow-consolidation.md
@@ -1,0 +1,11 @@
+---
+"@happyvertical/smrt": patch
+---
+
+Optimize workflow with auto-merge, cascade triggers, and eliminate redundant builds
+
+- Added auto-merge for changesets version PRs when CI passes
+- Added git tag creation for published packages
+- Added cascade trigger to praeco after publishing
+- Removed redundant build step from release job (test job already builds)
+- Changed deploy-docs dependency from release to test (parallel execution)

--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -55,11 +55,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
-      - name: Build packages
-        run: pnpm run build
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Create Release PR or Publish
         id: changesets
         uses: changesets/action@v1
@@ -73,9 +68,53 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Enable auto-merge for version PR
+        if: steps.changesets.outputs.pullRequestNumber != ''
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          echo "🔀 Enabling auto-merge for version PR #${{ steps.changesets.outputs.pullRequestNumber }}"
+          gh pr merge ${{ steps.changesets.outputs.pullRequestNumber }} \
+            --auto --squash \
+            --delete-branch
+
+      - name: Create git tags
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          # Create tags for each published package
+          echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[] | "\(.name)@\(.version)"' | while read tag; do
+            echo "🏷️  Creating tag: $tag"
+            git tag "$tag" || echo "Tag $tag already exists"
+          done
+
+          git push --tags || echo "No new tags to push"
+
+      - name: Trigger dependency cascade
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          echo "📢 Triggering dependency cascade for downstream repositories..."
+
+          # Extract published packages info
+          PUBLISHED_PACKAGES='${{ steps.changesets.outputs.publishedPackages }}'
+          echo "Published packages: $PUBLISHED_PACKAGES"
+
+          # Trigger praeco with full package information
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/happyvertical/praeco/dispatches \
+            -f event_type='dependency-updated' \
+            -f 'client_payload[repository]=happyvertical/smrt' \
+            -f "client_payload[packages]=$PUBLISHED_PACKAGES"
+
+          echo "✅ Triggered praeco dependency cascade"
+
   deploy-docs:
     name: Deploy Documentation
-    needs: release
+    needs: test
     if: ${{ github.event.inputs.skip-docs != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -108,11 +147,6 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-
-      - name: Build packages
-        run: pnpm run build
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install docs dependencies
         run: |


### PR DESCRIPTION
## Summary

Optimizes the `on-merge-main.yml` workflow to match SDK best practices with auto-merge, cascade triggers, and elimination of redundant builds.

## Changes

- ✅ Added auto-merge for changesets version PRs when CI passes
- ✅ Added git tag creation for published packages
- ✅ Added cascade trigger to praeco after publishing packages
- ✅ Removed redundant build step from release job (test job already builds)
- ✅ Changed deploy-docs dependency from release to test (enables parallel execution)

## Benefits

- **Faster CI**: No duplicate build execution (test builds once, release reuses)
- **Automated workflow**: Version PRs auto-merge when tests pass
- **Proper versioning**: Git tags created for all published packages
- **Cascade propagation**: Downstream repos (praeco) automatically receive updates
- **Parallel execution**: Docs deploy in parallel with release (both depend on test)

## Workflow Structure (After)

```yaml
jobs:
  test:           # Builds and tests packages
  release:        # depends on: [test], no build step
  deploy-docs:    # depends on: [test], parallel with release
```

## Testing Plan

- [x] Created feature branch and committed changes
- [ ] PR validation runs successfully
- [ ] Merge to main
- [ ] Verify workflow runs in correct order
- [ ] Verify version PR is created with auto-merge
- [ ] Let version PR auto-merge
- [ ] Verify packages publish and cascade triggers praeco