### PR TITLE
fix(ci): invalidate build cache to fix module resolution errors

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -57,9 +57,9 @@ jobs:
           path: |
             packages/*/dist
             .turbo
-          key: ${{ runner.os }}-build-${{ hashFiles('packages/*/src/**', 'packages/*/package.json', 'packages/*/tsconfig.json') }}
+          key: ${{ runner.os }}-build-v2-${{ hashFiles('packages/*/src/**', 'packages/*/package.json', 'packages/*/tsconfig.json', 'packages/*/vite.config.ts', 'vite.config.base.ts') }}
           restore-keys: |
-            ${{ runner.os }}-build-
+            ${{ runner.os }}-build-v2-
 
       - name: Build packages
         run: pnpm run build


### PR DESCRIPTION
## Summary

Fixes agents test failure in CI by invalidating stale build cache.

Fixes https://github.com/happyvertical/smrt/actions/runs/19156871518

## Problem

The agents test was failing in CI with a module resolution error:

```
Error: Cannot find module '/@fs/home/runner/work/smrt/smrt/packages/core/dist/fields.js' 
imported from '/home/runner/work/smrt/smrt/packages/core/dist/chunks/collection-DTIMCk94.js'
```

The `/@fs/` prefix is a Vite dev server path that should never appear in built code.

## Root Cause

PR #232 added build output caching to improve CI performance:

```yaml
- name: Cache build outputs
  with:
    key: ${{ runner.os }}-build-${{ hashFiles(...) }}
```

However, the cache key **did not include vite config files**, so when vite configuration changed, stale builds with dev server paths were being reused.

## Investigation

1. ✅ Test **passes locally** with fresh builds
2. ❌ Test **fails in CI** with cached builds
3. 🔍 Error shows Vite dev paths (`/@fs/`) in production build
4. 💡 Cache key doesn't include `vite.config.ts` or `vite.config.base.ts`

## Solution

Update the build cache key to:

1. **Invalidate existing caches**: Change key prefix from `build-` to `build-v2-`
2. **Include vite configs**: Add `vite.config.ts` and `vite.config.base.ts` to hash
3. **Prevent future issues**: Config changes now automatically bust the cache

```yaml
key: ${{ runner.os }}-build-v2-${{ hashFiles('packages/*/src/**', 'packages/*/package.json', 'packages/*/tsconfig.json', 'packages/*/vite.config.ts', 'vite.config.base.ts') }}
```

## Testing

- ✅ Agents test passes locally
- ✅ All other tests pass locally
- 🔄 CI will use fresh builds (cache invalidated)

## Impact

- Fixes immediate test failure
- Prevents future cache-related build issues
- Build cache still provides performance benefits for unchanged code