### PR TITLE
fix(cli): import from source files in tests to avoid dependency resolution issues

### DIFF
--- a/packages/cli/src/cli-generator.spec.ts
+++ b/packages/cli/src/cli-generator.spec.ts
@@ -8,8 +8,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 describe('CLI Generator - Simplified Tests', () => {
   it('should import and instantiate CLI generator', async () => {
-    // Dynamic import to avoid module resolution issues
-    const { CLIGenerator } = await import('./cli-generator.js');
+    // Import from source to avoid dependency resolution issues with built chunks
+    const { CLIGenerator } = await import('./cli-generator.ts');
 
     const generator = new CLIGenerator({
       name: 'test-cli',
@@ -28,7 +28,7 @@ describe('CLI Generator - Simplified Tests', () => {
     // Set NODE_ENV to test to prevent process.exit
     process.env.NODE_ENV = 'test';
 
-    const { CLIGenerator } = await import('./cli-generator.js');
+    const { CLIGenerator } = await import('./cli-generator.ts');
 
     const generator = new CLIGenerator({
       name: 'test-cli',
@@ -72,7 +72,7 @@ describe('CLI Generator - Simplified Tests', () => {
       delete (process.stdout as any).clearLine;
       delete (process.stdout as any).cursorTo;
 
-      const { CLIGenerator } = await import('./cli-generator.js');
+      const { CLIGenerator } = await import('./cli-generator.ts');
 
       const generator = new CLIGenerator({
         name: 'test-cli',


### PR DESCRIPTION
## Summary

Fixes CI test failures where vitest couldn't resolve `@happyvertical/ai` when running CLI generator tests.

## Problem

The tests were importing from built `.js` files (e.g., `./cli-generator.js`) which contained bundled chunks from `@happyvertical/smrt-core`. These chunks have imports to external SDK packages like `@happyvertical/ai` that aren't available in the test environment, causing `Cannot find package` errors during test execution.

## Solution

Changed all imports from `./cli-generator.js` to `./cli-generator.ts` to use source files instead, which properly resolve through the TypeScript compilation and vitest's module resolution.

## Changes

- `packages/cli/src/cli-generator.spec.ts`: Updated 3 dynamic imports from `.js` to `.ts`

## Testing

- ✅ Local tests pass: `npm test` in packages/cli
- ✅ All 132 tests passing (3 skipped)

## Related Issues

Resolves CI failure from https://github.com/happyvertical/smrt/actions/runs/19183724617