### PR TITLE
fix(ci): correct workflow_call output to enable release and cascade

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -5,15 +5,13 @@ on:
     outputs:
       tests-passed:
         description: 'Whether all tests passed'
-        value: ${{ jobs.test.outputs.success }}
+        value: ${{ jobs.test.result == 'success' }}
 
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    outputs:
-      success: ${{ steps.tests.outcome == 'success' }}
 
     services:
       postgres:


### PR DESCRIPTION
## Problem

The **Release job was being skipped** after merges to main, which prevented:
- ❌ Packages from being published
- ❌ Downstream cascade to praeco and caelus from being triggered

### Root Cause

The `test-suite.yml` workflow_call output was misconfigured:

```yaml
on:
  workflow_call:
    outputs:
      tests-passed:
        value: ${{ jobs.test.outputs.success }}  # ❌ WRONG

jobs:
  test:
    outputs:
      success: ${{ steps.tests.outcome == 'success' }}
```

**The issue:** `workflow_call` outputs cannot reference `jobs.<job_id>.outputs`. They can only reference `jobs.<job_id>.result`.

This caused `needs.test.outputs.tests-passed` to always be `null` in `on-merge-main.yml`, which made the release job skip condition fail:

```yaml
if: |
  github.event_name == 'push' &&
  needs.test.outputs.tests-passed == 'true'  # Always null!
```

### Evidence

From workflow run 19214367707 (PR #262 merge):

```json
{
  "name": "Run Test Suite / Test",
  "conclusion": "success",
  "outputs": null  // ❌ Should be {"tests-passed": "true"}
}
```

Result:
- ✅ Test job: success
- ⏭️ Release job: **skipped** (condition failed)
- ⏭️ Cascade: **never triggered**

## Solution

Use `jobs.test.result` instead of `jobs.test.outputs.success`:

```yaml
on:
  workflow_call:
    outputs:
      tests-passed:
        value: ${{ jobs.test.result == 'success' }}  # ✅ CORRECT
```

This is the proper way to pass job status from reusable workflows.

## Changes

1. **Fix workflow output** in `test-suite.yml`:
   - Change: `jobs.test.outputs.success` → `jobs.test.result == 'success'`
   - Remove: Unnecessary job-level `outputs` declaration

## Impact

**After this fix:**
- ✅ Release job will run when tests pass
- ✅ Packages will be published via changesets
- ✅ Downstream cascade will trigger to praeco and caelus
- ✅ Full cascade chain will work: SDK → SMRT → praeco/caelus → bentleyalberta

## Testing

To verify this fix works, after merge:
1. Merge a PR with changesets to main
2. Check that Release job runs (not skipped)
3. Check that packages are published
4. Check that praeco/caelus receive `repository_dispatch` events

## Related

- Cascade config: https://github.com/happyvertical/sdk/blob/main/.github/cascade-config.json
- SMRT triggers: `["praeco", "caelus"]`
- GitHub docs: https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-outputs-from-a-reusable-workflow