### PR TITLE
fix(core): await async fieldsFromClass() calls

### DIFF
--- a/packages/core/src/manifest/test-manifest-stub.ts
+++ b/packages/core/src/manifest/test-manifest-stub.ts
@@ -10,7 +10,7 @@ import type { SmartObjectManifest } from '../scanner/types';
 
 export const testManifest: SmartObjectManifest = {
   "version": "1.0.0",
-  "timestamp": 1762768325244,
+  "timestamp": 1762772138495,
   "objects": {
     "testobject": {
       "name": "testobject",

--- a/packages/core/src/object.spec.ts
+++ b/packages/core/src/object.spec.ts
@@ -171,9 +171,7 @@ describe('SmrtObject', () => {
       };
 
       // loadDataFromDb should not throw when encountering readonly tableName
-      expect(() => {
-        council.loadDataFromDb(dbData);
-      }).not.toThrow();
+      await council.loadDataFromDb(dbData);
 
       // Verify data was loaded correctly
       expect(council.name).toBe('Database Council');

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -195,7 +195,7 @@ export class SmrtObject extends SmrtClass {
    * This ensures option values take precedence over default field initializer values
    * Uses smart cloning to prevent array/object aliasing (Issue #22)
    */
-  private initializePropertiesFromOptions(): void {
+  private async initializePropertiesFromOptions(): Promise<void> {
     const options = this.options;
 
     // Set base properties that exist on SmrtObject
@@ -203,7 +203,7 @@ export class SmrtObject extends SmrtClass {
     if (options.updated_at !== undefined) this.updated_at = options.updated_at;
 
     // Get all fields (both Field instances and plain properties)
-    const fields = fieldsFromClass(
+    const fields = await fieldsFromClass(
       this.constructor as new (
         ...args: any[]
       ) => any,
@@ -313,7 +313,7 @@ export class SmrtObject extends SmrtClass {
     // Initialize properties from options AFTER all field initializers have run
     // This prevents TypeScript field initializers from overwriting option values
     if (!this.options._extractingFields) {
-      this.initializePropertiesFromOptions();
+      await this.initializePropertiesFromOptions();
     }
 
     // NOTE: Database table setup is now deferred until first database operation (lazy initialization)
@@ -362,8 +362,8 @@ export class SmrtObject extends SmrtClass {
    *
    * @param data - Database row data
    */
-  loadDataFromDb(data: any) {
-    const fields = this.getFields();
+  async loadDataFromDb(data: any) {
+    const fields = await this.getFields();
     for (const field in fields) {
       if (Object.hasOwn(fields, field)) {
         // Check if property is writable before setting (Issue #63)
@@ -424,10 +424,10 @@ export class SmrtObject extends SmrtClass {
    *
    * @returns Object containing field definitions with current values
    */
-  getFields() {
+  async getFields() {
     // Use cached field definitions from ObjectRegistry (via fieldsFromClass)
     // This is much more efficient than creating temporary instances
-    const fields = fieldsFromClass(
+    const fields = await fieldsFromClass(
       this.constructor as new (
         ...args: any[]
       ) => any,
@@ -685,7 +685,7 @@ export class SmrtObject extends SmrtClass {
     } else {
       // Fallback to old validation logic if no cached validators
       // (for classes not registered with ObjectRegistry)
-      const fields = fieldsFromClass(this.constructor as any);
+      const fields = await fieldsFromClass(this.constructor as any);
 
       for (const [fieldName, field] of Object.entries(fields)) {
         if (field instanceof Field && field.options.required) {
@@ -771,7 +771,7 @@ export class SmrtObject extends SmrtClass {
               id: this._id,
             });
             if (existing) {
-              this.loadDataFromDb(existing);
+              await this.loadDataFromDb(existing);
             }
           } catch (error) {
             throw DatabaseError.queryFailed(
@@ -809,7 +809,7 @@ export class SmrtObject extends SmrtClass {
       context: this._context || '',
     });
     if (existing) {
-      this.loadDataFromDb(existing);
+      await this.loadDataFromDb(existing);
     }
   }
 

--- a/packages/core/src/utils.spec.ts
+++ b/packages/core/src/utils.spec.ts
@@ -20,8 +20,8 @@ class TestClass extends SmrtObject {
   }
 }
 
-it('should get fields from a class without values', () => {
-  const fields = fieldsFromClass(TestClass);
+it('should get fields from a class without values', async () => {
+  const fields = await fieldsFromClass(TestClass);
   expect(fields).toEqual({
     // Inherited fields from SmrtObject
     id: {
@@ -64,7 +64,7 @@ it('should get fields from a class without values', () => {
   expect(fields).not.toHaveProperty('methodField');
 });
 
-it('should get fields from a class with values', () => {
+it('should get fields from a class with values', async () => {
   const values = {
     test_string: 'custom value',
     test_number: 456,
@@ -72,7 +72,7 @@ it('should get fields from a class with values', () => {
     extraField: 'should not appear',
   };
 
-  const fields = fieldsFromClass(TestClass, values);
+  const fields = await fieldsFromClass(TestClass, values);
 
   expect(fields).toEqual({
     // Inherited fields from SmrtObject (no values set)


### PR DESCRIPTION
## Problem

PR #265 made `getAllFields()` async, which made `fieldsFromClass()` async, but several callers weren't updated to await it. This caused a critical regression where:

- Properties were being set to Promise objects instead of actual values
- `obj.name` would return a Field object instead of the string value
- Tests failed with: `expected Field { type: 'text', value: undefined } to be 'Test Object'`

## Solution

Updated all calls to async functions to properly await:

### Functions Made Async
1. `initializePropertiesFromOptions()` - awaits `fieldsFromClass()`
2. `getFields()` - awaits `fieldsFromClass()` 
3. `loadDataFromDb()` - awaits `getFields()`
4. `validateBeforeSave()` - already async, added await to `fieldsFromClass()`

### Callers Updated
- `initialize()` - awaits `initializePropertiesFromOptions()`
- `loadFromId()` - awaits `loadDataFromDb()`
- `loadFromSlug()` - awaits `loadDataFromDb()`
- Test files updated to await async calls

## Test Results

✅ All `object.spec.ts` tests now pass (11/11)
✅ All `utils.spec.ts` tests pass
✅ Property values correctly assigned from options
✅ Database data loaded correctly

## Verification

```typescript
const obj = new TestObject({ name: 'Test Object' });
await obj.initialize();
expect(obj.name).toBe('Test Object'); // ✅ Now passes!
```

Closes #266