### PR TITLE
fix(core): suppress TypeScript error for runtime-generated test-manifest.js

### DIFF
--- a/packages/core/src/manifest/test-manifest-loader.ts
+++ b/packages/core/src/manifest/test-manifest-loader.ts
@@ -10,6 +10,7 @@ let loadedTestManifest: SmartObjectManifest | null = null;
 
 try {
   // This will be replaced by the actual manifest after pretest script runs
+  // @ts-expect-error - test-manifest.js is generated at build/test time, won't exist during tsc
   const { testManifest } = await import('./test-manifest.js');
   loadedTestManifest = testManifest;
 } catch {


### PR DESCRIPTION
## Summary

Fixes TypeScript compilation error in CI when running `typecheck` step.

## Problem

After the workflow standardization (#276), the `typecheck` task began failing in CI with:

```
src/manifest/test-manifest-loader.ts:13:3 - error TS2307: Cannot find module './test-manifest.js' or its corresponding type declarations.
```

The `test-manifest.js` file is generated at build/test time by the `pretest` script and doesn't exist during TypeScript compilation in CI fresh environments.

## Solution

Added `@ts-expect-error` directive to suppress this expected error. The file is safely handled with a try/catch block that falls back to an empty manifest if the import fails.

## Testing

- ✅ Local build succeeds
- ✅ Pre-commit hooks pass
- ✅ Format check passes
- CI will verify the typecheck step now passes

## Related

- Fixes failing workflow: https://github.com/happyvertical/smrt/actions/runs/19281724155
- Similar fix was applied in commit 6691bad but was lost during workflow standardization

closes #<will auto-detect if there's an open issue>