### PR TITLE
fix(core): add vitest config to prevent worker timeout errors

### DIFF
--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,69 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Vitest configuration for @happyvertical/smrt-core
+ *
+ * Uses forks pool with sequential execution to prevent worker timeout issues
+ * that occur with threads pool in CI environments.
+ *
+ * Based on SDK vitest.config.ts which resolved similar issues.
+ */
+export default defineConfig({
+  test: {
+    // Include all test file types
+    include: ['src/**/*.{test,spec}.{ts,mts}'],
+
+    // Exclude what Vitest shouldn't handle
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/docs/**',
+      '**/*.d.ts',
+      '**/coverage/**',
+    ],
+
+    // Environment configuration
+    environment: 'node',
+
+    // Increased timeouts for CI environments
+    testTimeout: 30000, // 30 seconds (up from default 5s)
+    hookTimeout: 30000, // Match testTimeout for consistency
+
+    // Reporter configuration
+    reporters: ['default'],
+
+    // Coverage configuration
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.{js,ts}'],
+      exclude: [
+        'src/**/*.{test,spec}.{js,ts}',
+        'src/**/*.d.ts',
+        'src/manifest/static-manifest.ts', // Generated file
+        'src/manifest/test-manifest-stub.ts', // Generated file
+      ],
+    },
+
+    // Use forks pool instead of threads to prevent worker timeout issues
+    // This matches the SDK configuration that resolved similar problems
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true, // Run tests sequentially to avoid race conditions
+        isolate: true, // Isolate tests for proper cleanup
+      },
+    },
+
+    // Limit to single worker to prevent timeout issues
+    maxWorkers: 1,
+  },
+
+  // Resolve workspace packages for testing
+  resolve: {
+    alias: {
+      '@happyvertical/smrt-types': resolve(__dirname, '../types/src'),
+      '@happyvertical/smrt-config': resolve(__dirname, '../config/src'),
+    },
+  },
+});


### PR DESCRIPTION
## Problem

After merging PR #279, the main branch workflow failed with:
```
Error: [vitest-worker]: Timeout calling "onTaskUpdate"
Vitest caught 1 unhandled error during the test run.
```

This is a vitest infrastructure issue where worker threads timeout during test execution in CI environments, causing tests to exit with code 1 despite all tests passing.

## Root Cause

The default vitest configuration uses thread-based workers which can experience communication timeouts in CI environments, especially when:
- Test suite is large (577 tests)
- Tests involve database operations
- CI resources are constrained

## Solution

Added `vitest.config.ts` for `@happyvertical/smrt-core` based on the SDK's proven configuration:

### Key Changes
- **Use forks pool**: `pool: 'forks'` instead of threads (prevents worker communication timeouts)
- **Sequential execution**: `singleFork: true` to run tests sequentially (avoids race conditions)
- **Test isolation**: `isolate: true` for proper cleanup between tests
- **Increased timeouts**: `testTimeout: 30000` and `hookTimeout: 30000` for CI environments
- **Limited workers**: `maxWorkers: 1` to prevent worker pool issues

### Results

**Before:**
- Tests: 577 passed
- **Errors: 1 error** (vitest worker timeout)
- Workflow: ❌ Failed

**After:**
- Tests: 577 passed
- **Errors: 0 errors**
- Workflow: ✅ Expected to pass

## Testing

Tested locally with `npx vitest run`:
- ✅ All 577 tests pass
- ✅ No "Errors" line in output
- ✅ Duration: 8.76s (acceptable)

## References

- Failed workflow: https://github.com/happyvertical/smrt/actions/runs/19299261672
- SDK vitest config: https://github.com/happyvertical/sdk/blob/main/vitest.config.ts
- Vitest worker timeout issue: vitest-dev/vitest#2008

Fixes #280