### PR TITLE
fix(core): fix STI table name inheritance for child classes

### DIFF
--- a/packages/core/src/__tests__/sti-table-name-inheritance.test.ts
+++ b/packages/core/src/__tests__/sti-table-name-inheritance.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for STI table name inheritance
+ *
+ * Verifies that child classes correctly use the parent's table name
+ * when the parent uses STI (Single Table Inheritance) strategy.
+ *
+ * Regression test for issue #298: STI subclass incorrectly creates own table
+ * instead of using parent table.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SmrtObject } from '../object';
+import { ObjectRegistry, smrt } from '../registry';
+
+describe('STI Table Name Inheritance', () => {
+  beforeEach(() => {
+    ObjectRegistry.clear();
+  });
+
+  afterEach(() => {
+    ObjectRegistry.clear();
+  });
+
+  it('should use parent table name when parent has explicit STI strategy', () => {
+    @smrt({ tableStrategy: 'sti' })
+    class Event extends SmrtObject {
+      title: string = '';
+    }
+
+    @smrt()
+    class Meeting extends Event {
+      roomNumber: string = '';
+    }
+
+    // Both should use 'events' table
+    expect(ObjectRegistry.getTableName('Event')).toBe('events');
+    expect(ObjectRegistry.getTableName('Meeting')).toBe('events');
+  });
+
+  it('should use parent table name through multiple inheritance levels', () => {
+    @smrt({ tableStrategy: 'sti' })
+    class Event extends SmrtObject {
+      title: string = '';
+    }
+
+    @smrt()
+    class SportingEvent extends Event {
+      sport: string = '';
+    }
+
+    @smrt()
+    class HockeyGame extends SportingEvent {
+      homeTeam: string = '';
+    }
+
+    // All should use 'events' table
+    expect(ObjectRegistry.getTableName('Event')).toBe('events');
+    expect(ObjectRegistry.getTableName('SportingEvent')).toBe('events');
+    expect(ObjectRegistry.getTableName('HockeyGame')).toBe('events');
+  });
+
+  it('should use own table name when using CTI (default)', () => {
+    @smrt()
+    class Product extends SmrtObject {
+      name: string = '';
+    }
+
+    @smrt()
+    class DigitalProduct extends Product {
+      downloadUrl: string = '';
+    }
+
+    // Each should have own table
+    expect(ObjectRegistry.getTableName('Product')).toBe('products');
+    expect(ObjectRegistry.getTableName('DigitalProduct')).toBe(
+      'digital_products',
+    );
+  });
+
+  it('should handle ProfileRelationship STI inheritance (issue #298)', () => {
+    @smrt({ tableStrategy: 'sti' })
+    class ProfileRelationship extends SmrtObject {
+      fromProfileId: string = '';
+      toProfileId: string = '';
+      typeId: string = '';
+    }
+
+    @smrt()
+    class CouncilMember extends ProfileRelationship {
+      ward: string = '';
+      position: string = '';
+      electionDate: Date = new Date();
+    }
+
+    // Both should use 'profile_relationships' table
+    expect(ObjectRegistry.getTableName('ProfileRelationship')).toBe(
+      'profile_relationships',
+    );
+    expect(ObjectRegistry.getTableName('CouncilMember')).toBe(
+      'profile_relationships',
+    );
+  });
+
+  it('should detect STI strategy from parent even without explicit config on child', () => {
+    @smrt({ tableStrategy: 'sti' })
+    class Vehicle extends SmrtObject {
+      baseField: string = '';
+    }
+
+    // Child with NO explicit strategy should inherit STI
+    @smrt()
+    class Car extends Vehicle {
+      childField: string = '';
+    }
+
+    // Verify strategy is inherited
+    expect(ObjectRegistry.getTableStrategy('Vehicle')).toBe('sti');
+    expect(ObjectRegistry.getTableStrategy('Car')).toBe('sti');
+
+    // Verify both use same table
+    expect(ObjectRegistry.getTableName('Vehicle')).toBe('vehicles');
+    expect(ObjectRegistry.getTableName('Car')).toBe('vehicles');
+  });
+
+  it('should use grandparent table name when parent has no explicit strategy', () => {
+    @smrt({ tableStrategy: 'sti' })
+    class Grandparent extends SmrtObject {
+      gField: string = '';
+    }
+
+    // Parent with no explicit strategy (inherits STI from Grandparent)
+    @smrt()
+    class Parent extends Grandparent {
+      pField: string = '';
+    }
+
+    // Child with no explicit strategy (inherits STI through Parent)
+    @smrt()
+    class Child extends Parent {
+      cField: string = '';
+    }
+
+    // All should use grandparent's table
+    expect(ObjectRegistry.getTableName('Grandparent')).toBe('grandparents');
+    expect(ObjectRegistry.getTableName('Parent')).toBe('grandparents');
+    expect(ObjectRegistry.getTableName('Child')).toBe('grandparents');
+  });
+
+  it('should throw error when child explicitly sets CTI while parent uses STI', () => {
+    @smrt({ tableStrategy: 'sti' })
+    class Event extends SmrtObject {
+      title: string = '';
+    }
+
+    // Attempting to override parent's STI with explicit CTI should fail
+    expect(() => {
+      @smrt({ tableStrategy: 'cti' })
+      class SpecialEvent extends Event {
+        special: string = '';
+      }
+    }).toThrow('Incompatible table strategy');
+  });
+
+  it('should use STI base class table name for deeply nested hierarchy', () => {
+    @smrt({ tableStrategy: 'sti' })
+    class Level1 extends SmrtObject {
+      l1: string = '';
+    }
+
+    @smrt()
+    class Level2 extends Level1 {
+      l2: string = '';
+    }
+
+    @smrt()
+    class Level3 extends Level2 {
+      l3: string = '';
+    }
+
+    @smrt()
+    class Level4 extends Level3 {
+      l4: string = '';
+    }
+
+    const expectedTable = 'level1s';
+
+    expect(ObjectRegistry.getTableName('Level1')).toBe(expectedTable);
+    expect(ObjectRegistry.getTableName('Level2')).toBe(expectedTable);
+    expect(ObjectRegistry.getTableName('Level3')).toBe(expectedTable);
+    expect(ObjectRegistry.getTableName('Level4')).toBe(expectedTable);
+  });
+});

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -2274,9 +2274,10 @@ export function smrt(config: SmartObjectConfig = {}) {
           let stiBaseName: string | null = null;
 
           while (proto?.name && proto.name !== 'SmrtObject') {
-            const parentClass = ObjectRegistry.getClass(proto.name);
-            if (parentClass?.decorator?.tableStrategy === 'sti') {
-              stiBaseName = proto.name;
+            // Use getTableStrategy() to properly detect inherited STI strategy
+            if (ObjectRegistry.getTableStrategy(proto.name) === 'sti') {
+              // Get the actual STI base (may be higher up the chain)
+              stiBaseName = ObjectRegistry.getSTIBase(proto.name);
               break;
             }
             proto = Object.getPrototypeOf(proto);

--- a/packages/profiles/src/models/ProfileRelationship.ts
+++ b/packages/profiles/src/models/ProfileRelationship.ts
@@ -22,6 +22,7 @@ export interface ProfileRelationshipOptions extends SmrtObjectOptions {
 }
 
 @smrt({
+  tableStrategy: 'sti',
   api: { include: ['list', 'get', 'create', 'delete'] },
   mcp: { include: ['list', 'get'] },
   cli: true,


### PR DESCRIPTION
Fixes #298

## Problem

STI (Single Table Inheritance) subclasses were incorrectly creating their own tables instead of using the parent's table. For example, `CouncilMember extends ProfileRelationship` created a `council_members` table instead of using `profile_relationships`.

## Root Cause

The `@smrt()` decorator's table name logic only checked for **explicit** `tableStrategy: 'sti'` in the immediate parent's decorator config. It didn't:
1. Use `ObjectRegistry.getTableStrategy()` which implements proper strategy inheritance
2. Find the actual STI base class (may be multiple levels up the chain)

## Changes

### 1. Fixed decorator table name logic (registry.ts:2276-2284)
- Use `ObjectRegistry.getTableStrategy()` for inherited STI detection
- Use `ObjectRegistry.getSTIBase()` to find actual base class
- Correctly handles multi-level inheritance (3+ levels)

**Before:**
```typescript
if (parentClass?.decorator?.tableStrategy === 'sti') {
  stiBaseName = proto.name;  // Wrong: immediate parent might not be base
}
```

**After:**
```typescript
if (ObjectRegistry.getTableStrategy(proto.name) === 'sti') {
  stiBaseName = ObjectRegistry.getSTIBase(proto.name);  // Correct: finds actual base
}
```

### 2. Added explicit STI to ProfileRelationship (ProfileRelationship.ts:25)
- Added `tableStrategy: 'sti'` to match Event pattern
- Makes STI intent explicit for child classes

### 3. Added comprehensive tests (sti-table-name-inheritance.test.ts)
- 8 test cases covering all inheritance scenarios
- Regression test for issue #298
- Multi-level inheritance (up to 4 levels)

## Test Results

✅ **All tests passing**
- Core package: 641 tests passed (8 new STI table name tests)
- All packages: 62 test files passed

## Example

**Before** (Broken):
```typescript
@smrt()  // No explicit STI
class ProfileRelationship extends SmrtObject { ... }

@smrt()
class CouncilMember extends ProfileRelationship { ... }

// Result: Creates 'council_members' table ❌
```

**After** (Fixed):
```typescript
@smrt({ tableStrategy: 'sti' })  // Explicit STI
class ProfileRelationship extends SmrtObject { ... }

@smrt()  // Inherits STI from parent
class CouncilMember extends ProfileRelationship { ... }

// Result: Uses 'profile_relationships' table ✅
```

## Verification

The fix correctly handles:
- ✅ Direct inheritance: `Event → Meeting` (2 levels)
- ✅ Multi-level inheritance: `Event → SportingEvent → HockeyGame` (3+ levels)
- ✅ Cross-package inheritance: `ProfileRelationship → CouncilMember` (external packages)
- ✅ Mixed hierarchies: Works when middle classes have no explicit strategy