### PR TITLE
fix(changesets): remove non-existent smrt-accounts from fixed config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,6 @@
   "commit": false,
   "fixed": [
     [
-      "@happyvertical/smrt-accounts",
       "@happyvertical/smrt-agents",
       "@happyvertical/smrt-assets",
       "@happyvertical/smrt-cli",

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1637,7 +1637,8 @@ export class ObjectRegistry {
         if (ancestorChain.length > 1) {
           // Has ancestors - recursively get all fields
           // Check cache before recursive call to avoid redundant recursion
-          const cachedFields = ObjectRegistry._allFieldsCache?.get(ancestorName);
+          const cachedFields =
+            ObjectRegistry._allFieldsCache?.get(ancestorName);
           if (cachedFields) {
             fieldsToMerge = cachedFields;
           } else {


### PR DESCRIPTION
## Problem

The changesets version/publish commands were failing with:

```
ValidationError: The package or glob expression "@happyvertical/smrt-accounts" 
specified in the `fixed` option does not match any package in the project.
```

This was preventing:
- The publish workflow from running successfully
- Version PRs from being created automatically
- Releases from being published to npm

## Root Cause

The `@happyvertical/smrt-accounts` package was removed in commit 3b50c40 but remained in the `.changeset/config.json` fixed array, causing changesets to fail validation.

## Solution

Removed `@happyvertical/smrt-accounts` from the fixed packages array in `.changeset/config.json`.

Also formatted `packages/core/src/registry.ts` to fix pre-push hook failures.

## Testing

After this fix, the changesets validation should pass and version/publish workflows should run successfully.

Closes #304