### PR TITLE
fix(docs): remove deleted accounts package references

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -89,16 +89,6 @@ const config: Config = {
     [
       'docusaurus-plugin-typedoc',
       {
-        id: 'accounts',
-        entryPoints: ['../packages/accounts/src/index.ts'],
-        tsconfig: './typedoc.tsconfig.json',
-        out: 'content/api/accounts',
-        skipErrorChecking: true,
-      },
-    ],
-    [
-      'docusaurus-plugin-typedoc',
-      {
         id: 'agents',
         entryPoints: ['../packages/agents/src/index.ts'],
         tsconfig: './typedoc.tsconfig.json',

--- a/docs/scripts/copy-readmes.js
+++ b/docs/scripts/copy-readmes.js
@@ -22,7 +22,6 @@ const packagesDir = join(repoRoot, 'packages');
 const packages = [
   'types',
   'core',
-  'accounts',
   'agents',
   'assets',
   'content',


### PR DESCRIPTION
## Summary

Removes references to the deleted `accounts` package from documentation build scripts.

## Changes

- Remove `accounts` from `copy-readmes.js` packages list
- Remove `accounts` TypeDoc plugin from `docusaurus.config.ts`

## Issue

The accounts package was deleted in commit 3b50c40 but references remained in the documentation build scripts, causing build failures with:

```
Error: ENOENT: no such file or directory, scandir '/Users/will/Work/happyvertical/repos/smrt/packages/accounts/src'
```

## Testing

✅ Verified documentation build succeeds:
```bash
pnpm run docs:site:build
# [SUCCESS] Generated static files in "build".
```

## Related

- Commit that deleted accounts package: 3b50c40