### PR TITLE
fix(profiles): add tableStrategy: 'sti' to ProfileRelationshipTerm

### DIFF
--- a/.changeset/add-sti-to-profile-relationship-term.md
+++ b/.changeset/add-sti-to-profile-relationship-term.md
@@ -1,0 +1,16 @@
+---
+"@happyvertical/smrt-profiles": patch
+---
+
+fix(profiles): add tableStrategy: 'sti' to ProfileRelationshipTerm
+
+Enables Single Table Inheritance (STI) for ProfileRelationshipTerm subclasses by adding `tableStrategy: 'sti'` configuration. This allows child classes like `CouncilMemberTerm` to properly share the `profile_relationship_terms` table instead of creating their own separate tables.
+
+Fixes #310
+
+**Impact:**
+- ProfileRelationshipTerm subclasses can now use STI properly
+- Child classes share parent table instead of creating separate tables
+- Resolves ConfigurationError when subclasses try to use STI
+
+**Note:** ProfileRelationship already had STI configured, so only ProfileRelationshipTerm needed updating.

--- a/packages/profiles/src/models/ProfileRelationshipTerm.ts
+++ b/packages/profiles/src/models/ProfileRelationshipTerm.ts
@@ -20,6 +20,7 @@ export interface ProfileRelationshipTermOptions extends SmrtObjectOptions {
 }
 
 @smrt({
+  tableStrategy: 'sti',
   api: { include: ['list', 'get', 'create', 'update', 'delete'] },
   mcp: { include: ['list', 'get'] },
   cli: true,


### PR DESCRIPTION
## Summary

Fixes #310 - Adds `tableStrategy: 'sti'` to ProfileRelationshipTerm to enable proper Single Table Inheritance (STI) for subclasses.

## Problem

ProfileRelationshipTerm was missing `tableStrategy: 'sti'` configuration, preventing subclasses from using STI properly. When child classes like `CouncilMemberTerm` tried to use STI, they failed with:

```
ConfigurationError: Incompatible table strategy for class 'CouncilMemberTerm' (sti). 
Parent class 'ProfileRelationshipTerm' uses default strategy.
```

## Solution

Added `tableStrategy: 'sti'` to the `@smrt()` decorator in ProfileRelationshipTerm:

```typescript
@smrt({
  tableStrategy: 'sti',  // ← Added this
  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
  mcp: { include: ['list', 'get'] },
  cli: true,
})
export class ProfileRelationshipTerm extends SmrtObject {
  // ...
}
```

## Impact

- **Enables STI**: Subclasses like `CouncilMemberTerm` can now properly share the `profile_relationship_terms` table
- **Prevents separate tables**: Child classes no longer create their own tables (e.g., `council_member_terms`)
- **Consistent behavior**: ProfileRelationship already had STI configured; this brings ProfileRelationshipTerm in line

## Files Changed

- `packages/profiles/src/models/ProfileRelationshipTerm.ts` - Added `tableStrategy: 'sti'`

## Test Plan

- [x] Build profiles package successfully
- [x] Changeset created for version tracking
- [x] Pre-commit/pre-push hooks passed
- [ ] Verify subclasses can use STI without ConfigurationError (will be tested in praeco)

## Note

ProfileRelationship already had `tableStrategy: 'sti'` configured, so only ProfileRelationshipTerm needed updating. The issue description mentioned both classes, but ProfileRelationship was already correct.