### PR TITLE
fix(core): exclude @oneToMany fields from SQL statements

### DIFF
--- a/.changeset/fix-issue-324-onetomany-sql.md
+++ b/.changeset/fix-issue-324-onetomany-sql.md
@@ -1,0 +1,22 @@
+---
+"@happyvertical/smrt-core": patch
+---
+
+fix(@oneToMany): exclude relationship fields from SQL INSERT/UPDATE statements
+
+Fixes #324 where @oneToMany decorated fields were incorrectly included in SQL INSERT/UPDATE statements as database columns, causing SQLITE_ERROR: table has no column named <field>.
+
+**Changes:**
+- Added transient field filtering to `SchemaGenerator.generateColumns()` method
+- Added explicit filtering for `oneToMany` and `manyToMany` relationship types
+- Added filtering for `meta` field types (STI support)
+- Exported `Meta<T>` type for STI meta field annotations
+
+**Impact:**
+- All CRUD operations now work correctly for models with @oneToMany relationships
+- Inheritance hierarchies (e.g., Council extends Organization extends Profile) work as expected
+- No breaking changes - only fixes incorrect behavior
+
+**Testing:**
+- Added comprehensive test suite in `issue-324-onetomany-sql.test.ts`
+- Existing transient field tests continue to pass

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -8,6 +8,30 @@
 import { ObjectRegistry } from '../registry.js';
 
 /**
+ * Meta type wrapper for STI (Single Table Inheritance) meta fields
+ *
+ * Fields typed as Meta<T> are stored in the _meta_data JSONB column
+ * rather than as direct table columns. Used for child-specific fields
+ * in STI hierarchies.
+ *
+ * @example
+ * ```typescript
+ * @smrt({ tableStrategy: 'sti' })
+ * class Event extends SmrtObject {
+ *   title: string = '';
+ * }
+ *
+ * @smrt()
+ * class Meeting extends Event {
+ *   // Stored in _meta_data JSONB column
+ *   roomNumber: Meta<string> = '';
+ *   attendees: Meta<string[]> = [];
+ * }
+ * ```
+ */
+export type Meta<T> = T;
+
+/**
  * Base field options
  */
 export interface FieldOptions {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,7 @@ export {
   type FieldOptions,
   field,
   foreignKey,
+  type Meta,
   manyToMany,
   meta,
   type NumericFieldOptions,

--- a/packages/core/src/schema/generator.ts
+++ b/packages/core/src/schema/generator.ts
@@ -105,6 +105,24 @@ export class SchemaGenerator {
         continue;
       }
 
+      // Skip transient fields (non-persisted)
+      if (fieldDef.transient || fieldDef._meta?.transient) {
+        continue;
+      }
+
+      // Skip relationship fields that don't create columns
+      // oneToMany and manyToMany are relationship metadata, not actual database columns
+      // foreignKey DOES create a column (it stores the foreign key ID)
+      if (fieldDef.type === 'oneToMany' || fieldDef.type === 'manyToMany') {
+        continue;
+      }
+
+      // Skip meta fields - they're stored in _meta_data JSONB column (STI only)
+      // In CTI mode, meta fields shouldn't be used, but skip them anyway for safety
+      if (fieldDef.type === 'meta') {
+        continue;
+      }
+
       const column: ColumnDefinition = {
         type: this.mapFieldTypeToSQL(fieldDef.type),
         // If _meta.nullable is true, the field can be null regardless of required


### PR DESCRIPTION
## Summary

Fixes #324 where  decorated fields were incorrectly included in SQL INSERT/UPDATE statements as database columns, causing `SQLITE_ERROR: table has no column named <field>`.

## Changes

- Added transient field filtering to `SchemaGenerator.generateColumns()` method
- Added explicit filtering for `oneToMany` and `manyToMany` relationship types  
- Added filtering for `meta` field types (STI support)
- Exported `Meta<T>` type for STI meta field annotations
- Added comprehensive test suite in `issue-324-onetomany-sql.test.ts`

## Impact

- All CRUD operations now work correctly for models with @oneToMany relationships
- Inheritance hierarchies (e.g., Council extends Organization extends Profile) work as expected
- **No breaking changes** - only fixes incorrect behavior

## Testing

- Existing transient field tests continue to pass
- New test suite validates @oneToMany fields are excluded from schema
- Verified fix resolves the original error in issue #324

## Related

- Issue #324
- PR #322 (field.options → field._meta rename)

Fixes #324