### PR TITLE
fix(core): exclude @oneToMany fields from toJSON serialization

### DIFF
--- a/.changeset/fix-issue-327-tojson.md
+++ b/.changeset/fix-issue-327-tojson.md
@@ -1,0 +1,19 @@
+---
+"@happyvertical/smrt-core": patch
+---
+
+fix(toJSON): exclude @oneToMany/@manyToMany fields from serialization
+
+Completes fix from #325 by updating toJSON() to filter out relationship fields.
+
+**Changes:**
+- Updated toJSON() to use field._meta instead of deprecated field.options
+- Added explicit filtering for oneToMany and manyToMany field types
+- Added cross-reference comments between toJSON() and SchemaGenerator
+
+**Impact:**
+- CRUD operations now work correctly for models with @oneToMany relationships
+- Fixes SQLITE_ERROR: table has no column named <field> in save() operations
+- Both schema generation AND serialization now filter relationship fields consistently
+
+Fixes #327

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -601,7 +601,19 @@ export class SmrtObject extends SmrtClass {
       const fieldDef = registeredFields.get(key);
 
       // Skip transient fields (non-persisted fields like functions, computed properties)
-      if (fieldDef && (fieldDef.transient || fieldDef.options?.transient)) {
+      // NOTE: This filtering logic must match SchemaGenerator.generateColumns()
+      // Changes to field filtering should be applied in BOTH places
+      if (fieldDef && (fieldDef.transient || fieldDef._meta?.transient)) {
+        continue;
+      }
+
+      // Skip relationship fields that don't create columns
+      // oneToMany and manyToMany are relationship metadata, not actual database columns
+      // NOTE: This must match the filtering in SchemaGenerator.generateColumns()
+      if (
+        fieldDef &&
+        (fieldDef.type === 'oneToMany' || fieldDef.type === 'manyToMany')
+      ) {
         continue;
       }
 

--- a/packages/core/src/schema/generator.ts
+++ b/packages/core/src/schema/generator.ts
@@ -106,6 +106,8 @@ export class SchemaGenerator {
       }
 
       // Skip transient fields (non-persisted)
+      // NOTE: This filtering logic must match SmrtObject.toJSON()
+      // Changes to field filtering should be applied in BOTH places
       if (fieldDef.transient || fieldDef._meta?.transient) {
         continue;
       }
@@ -113,6 +115,7 @@ export class SchemaGenerator {
       // Skip relationship fields that don't create columns
       // oneToMany and manyToMany are relationship metadata, not actual database columns
       // foreignKey DOES create a column (it stores the foreign key ID)
+      // NOTE: This must match the filtering in SmrtObject.toJSON()
       if (fieldDef.type === 'oneToMany' || fieldDef.type === 'manyToMany') {
         continue;
       }


### PR DESCRIPTION
## Summary

Completes the fix from #325 by updating `toJSON()` to filter out relationship fields. PR #325 only fixed `SchemaGenerator` but missed the serialization logic in `SmrtObject.toJSON()` that prepares data for SQL INSERT/UPDATE operations.

## The Problem

After #325 was merged, CRUD operations were still failing with:
```
SQLITE_ERROR: table profiles has no column named metadata
```

**Root Cause**: `toJSON()` at line 604 was:
1. Using deprecated `field.options?.transient` instead of `field._meta?.transient`
2. Not checking for `oneToMany`/`manyToMany` field types

## Changes

**Updated `packages/core/src/object.ts`:**
- Changed `field.options?.transient` to `field._meta?.transient`
- Added explicit filtering for `oneToMany` and `manyToMany` field types
- Added cross-reference comment to `SchemaGenerator.generateColumns()`

**Updated `packages/core/src/schema/generator.ts`:**
- Added cross-reference comment to `SmrtObject.toJSON()`
- Ensures developers know changes must be made in BOTH locations

## Testing

✅ All 592 tests passing (0 failures)

## Impact

- CRUD operations now work correctly for models with @oneToMany relationships
- Both schema generation AND serialization filter relationship fields consistently
- Fixes the remaining issues from #324

## Related

- Fixes #327
- Related to #325 (incomplete fix)
- Related to #324 (original issue)
