### PR TITLE
feat(ci): implement direct publish on merge to main

### DIFF
--- a/.changeset/direct-publish.md
+++ b/.changeset/direct-publish.md
@@ -1,0 +1,15 @@
+---
+'@happyvertical/smrt': patch
+---
+
+feat(ci): implement direct publish on merge to main
+
+Removes the intermediate "Version Packages" PR step to reduce CI overhead. The workflow now:
+- Versions packages directly when merged to main
+- Publishes immediately after versioning
+- Commits version changes back to main automatically
+- **Validates against major version bumps** - prevents accidental 1.0.0+ releases
+
+This reduces test runs from 3 to 2 per PR while maintaining changeset-based versioning and changelog generation.
+
+The workflow includes safeguards to block major version releases, requiring manual coordination for 1.0.0+ versions.

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -50,11 +50,7 @@ jobs:
           # Check if changeset files exist (excluding README.md)
           changeset_count=$(find .changeset -name '*.md' ! -name 'README.md' 2>/dev/null | wc -l)
 
-          if [ "$changeset_count" -gt 0 ]; then
-            echo "✅ Found $changeset_count changeset(s)"
-            find .changeset -name '*.md' ! -name 'README.md' -exec basename {} \;
-            exit 0
-          else
+          if [ "$changeset_count" -eq 0 ]; then
             echo "❌ No changeset found"
             echo ""
             echo "Please add a changeset by running:"
@@ -64,3 +60,25 @@ jobs:
             echo "(e.g., documentation changes, test updates, workflow changes)"
             exit 1
           fi
+
+          echo "✅ Found $changeset_count changeset(s)"
+          find .changeset -name '*.md' ! -name 'README.md' -exec basename {} \;
+
+          # Validate no major version bumps
+          echo ""
+          echo "🔍 Validating changeset types..."
+
+          if find .changeset -name '*.md' ! -name 'README.md' -type f -exec grep -l '"major"' {} + 2>/dev/null | grep -q .; then
+            echo "❌ ERROR: Major version bump detected in changeset!"
+            echo ""
+            echo "Files with major bumps:"
+            find .changeset -name '*.md' ! -name 'README.md' -type f -exec grep -l '"major"' {} + 2>/dev/null || true
+            echo ""
+            echo "Major version releases (1.0.0+) must be manually approved and coordinated."
+            echo "Please change the version bump type to 'minor' or 'patch'."
+            echo ""
+            echo "If you truly need a major version bump, coordinate with maintainers first."
+            exit 1
+          fi
+
+          echo "✅ No major version bumps detected"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,8 @@
 # This workflow is called by .github/workflows/happyvertical/on-merge-main.yml
 # when code is merged to the main branch, after tests and build pass.
 #
-# SMRT uses changesets for automated versioning and publishing.
+# This workflow directly versions and publishes packages based on changeset
+# files without creating an intermediate "Version Packages" PR.
 # =============================================================================
 
 name: Publish
@@ -31,6 +32,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Use GH_TOKEN to allow pushing version commits back to main
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -48,30 +51,52 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
-      - name: Create Release PR or Publish
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Validate No Major Version Bumps
+        run: |
+          echo "🔍 Checking for major version bumps in changesets..."
+
+          # Check if any changeset files contain major version bumps
+          if find .changeset -name '*.md' ! -name 'README.md' -type f -exec grep -l '"major"' {} + 2>/dev/null | grep -q .; then
+            echo "❌ ERROR: Major version bump detected in changeset files!"
+            echo ""
+            echo "Found major version bumps in:"
+            find .changeset -name '*.md' ! -name 'README.md' -type f -exec grep -l '"major"' {} + 2>/dev/null || true
+            echo ""
+            echo "Major version releases (1.0.0+) must be manually approved."
+            echo "Please remove the major bump from changesets or coordinate with maintainers."
+            exit 1
+          fi
+
+          # Also check for current version to prevent bumping to 1.0.0+
+          current_version=$(node -p "require('./package.json').version")
+          echo "Current version: $current_version"
+
+          # Extract major version number
+          major_version=$(echo "$current_version" | cut -d. -f1)
+
+          if [ "$major_version" -ge 1 ]; then
+            echo "❌ ERROR: Package is already at version 1.0.0 or higher ($current_version)"
+            echo "Manual review required for versions >= 1.0.0"
+            exit 1
+          fi
+
+          echo "✅ No major version bumps detected. Safe to proceed."
+
+      - name: Version and Publish
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm run version
           publish: pnpm run release
           commit: 'chore(release): version packages'
-          title: 'chore(release): version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Enable auto-merge for version PR
-        if: steps.changesets.outputs.pullRequestNumber != ''
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          echo "🔀 Enabling auto-merge for version PR #${{ steps.changesets.outputs.pullRequestNumber }}"
-          echo "⏳ Waiting 30 seconds for status checks to start..."
-          sleep 30
-          gh pr merge ${{ steps.changesets.outputs.pullRequestNumber }} \
-            --auto --squash \
-            --delete-branch
 
       - name: Check if packages were published
         id: check_published


### PR DESCRIPTION
## Summary

Removes the intermediate 'Version Packages' PR step to reduce CI overhead and streamline the release process.

## Changes

- **Modified `.github/workflows/publish.yml`**:
  - Removed `version` parameter from changesets action
  - Removed auto-merge step (no longer needed)
  - Added git configuration for direct commits to main
  - Added validation against major version bumps
  - Updated comments to reflect direct publishing approach

- **Updated `.github/workflows/changeset-check.yml`**:
  - Added validation to reject major version bumps in PRs
  - Provides early feedback before merge

## Benefits

✅ **Reduces test runs from 3 to 2** per PR  
✅ **Eliminates auto-merge complexity** - no more version PRs to manage  
✅ **Faster deployments** - publish happens immediately on merge  
✅ **Maintains changeset-based versioning** and changelog generation  
✅ **Prevents accidental major releases** - blocks 1.0.0+ bumps  

## Tradeoffs

⚠️ **Version changes committed directly to main** - no PR to review version bumps  
⚠️ **No preview of what gets published** - versions determined at merge time  
⚠️ **Harder to rollback version bumps** - would require manual revert  

## How It Works

**Before (3 test runs):**
1. PR Validation → Tests + Build
2. Merge to Main → Tests + Build + Create Version PR
3. Auto-merge Version PR → Tests + Build + Publish

**After (2 test runs):**  
1. PR Validation → Tests + Build
2. Merge to Main → Tests + Build + **Version + Publish**

## Major Version Protection

Both workflows now validate against major version bumps:
- ❌ PR check fails if changeset contains `major` bump
- ❌ Publish workflow fails before versioning if major bump detected
- ❌ Publish workflow fails if version is already ≥ 1.0.0

This ensures SMRT stays safely on 0.x.x versions until we're ready for a coordinated 1.0.0 release.

## Related

Implements same workflow as SDK PR #466