### PR TITLE
fix(registry): merge inherited fields when loading STI classes from external packages

### DIFF
--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1488,6 +1488,11 @@ export class ObjectRegistry {
         registered.packageName = manifestEntry.packageName;
       }
 
+      // Store extends info for getAllFields() to use (if present)
+      if (manifestEntry.extends) {
+        registered.extends = manifestEntry.extends;
+      }
+
       console.log(
         `📦 Loaded manifest for external package class: ${className} (${registered.fields.size} fields, ${registered.methods.size} methods)`,
       );


### PR DESCRIPTION
## Problem

When external STI child classes (like Person from `@happyvertical/smrt-profiles`) were loaded, they showed **0 fields, 0 methods** because:

1. Person's manifest entry has `fields: {}` (child-specific fields only)
2. Profile (parent) has all the actual fields in its manifest entry  
3. `ensureManifestLoaded()` didn't store the `extends` relationship
4. `getAllFields()` couldn't find the parent to merge inherited fields
5. Result: Consuming packages (like praeco) saw Person with 0 fields

## Solution

Modified `ensureManifestLoaded()` to store the `extends` property from the manifest:

```typescript
// Store extends info for getAllFields() to use (if present)
if (manifestEntry.extends) {
  registered.extends = manifestEntry.extends;
}
```

When `getAllFields()` is called later (by schema generator, etc.), it:
- Sees that Person has `extends: "Profile"`
- Calls `ensureManifestLoaded('Profile')` to load the parent
- Recursively merges Profile's fields into Person
- Caches the result in `inheritedFields`

This approach:
- Avoids circular calls between `ensureManifestLoaded()` ↔ `getAllFields()`
- Lets `getAllFields()` handle inheritance at the right time
- Simpler and more maintainable

## Testing

**SMRT Core:**
- All existing tests pass (617 passed, 32 skipped)
- No regressions

**Verified in praeco:**
```
[getAllFields] Person computing inheritance... extends=Profile
[getAllFields] Person using cached fields (7 total)  ✅
```

**Before**: Person (0 fields, 0 methods)  
**After**: Person (7 total fields from Profile)

## Related

Fixes #343