### PR TITLE
feat(ci): enable fixed versioning with root package

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,6 +4,7 @@
   "commit": false,
   "fixed": [
     [
+      "@happyvertical/smrt",
       "@happyvertical/smrt-agents",
       "@happyvertical/smrt-assets",
       "@happyvertical/smrt-cli",

--- a/.changeset/enable-fixed-versioning.md
+++ b/.changeset/enable-fixed-versioning.md
@@ -1,0 +1,9 @@
+---
+'@happyvertical/smrt': patch
+---
+
+feat(ci): enable fixed versioning with root package included
+
+Configure monorepo for fixed versioning where all packages share the same version number.
+Any change to the repository will bump all packages together, with the root package.json
+as the single source of truth.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
+  - '.'
   - 'packages/*'
 
 # pnpm workspace configuration for SMRT Framework monorepo
-# All SMRT framework and module packages
+# Includes root package (@happyvertical/smrt) and all child packages
 # SDK packages are now consumed as published dependencies from GitHub Package Registry


### PR DESCRIPTION
## Summary

Configures the monorepo for **fixed versioning** where all packages share the same version number, as requested.

## Changes

### 1. Add Root to Workspace (`pnpm-workspace.yaml`)
```yaml
packages:
  - '.'           # Root package now included
  - 'packages/*'
```

### 2. Add Root to Fixed Versioning (`.changeset/config.json`)
```json
"fixed": [[
  "@happyvertical/smrt",  // Root package
  "@happyvertical/smrt-agents",
  "@happyvertical/smrt-assets",
  // ... all other packages
]]
```

### 3. Created Changeset
- References `@happyvertical/smrt` (root package)
- Will trigger patch version bump for ALL packages

## Behavior

With fixed versioning enabled:

✅ **All packages share the same version** (0.7.1 → 0.7.2)  
✅ **Any change to the repo bumps all packages**  
✅ **Root package.json is the single source of truth**  
✅ **Creating a changeset for ANY package versions ALL packages**

## What Happens on Merge

1. Workflow runs `changeset version`
2. **All 17 packages** bump from 0.7.1 → 0.7.2
3. **All package.json files** updated
4. **CHANGELOGs** generated/updated
5. **All packages** published to GitHub Packages
6. Version changes committed back to main

## Testing

You can test locally:
```bash
npx changeset version
# Should bump ALL packages to 0.7.2
```