### PR TITLE
fix(ci): remove GITHUB_TOKEN from workflow secrets

### DIFF
--- a/.changeset/fix-github-token.md
+++ b/.changeset/fix-github-token.md
@@ -1,0 +1,8 @@
+---
+'@happyvertical/smrt-core': patch
+---
+
+fix(ci): remove GITHUB_TOKEN from workflow secrets
+
+Remove GITHUB_TOKEN from publish.yml secrets since it's automatically
+provided by GitHub Actions. Fixes 'secret name collision' errors.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,6 @@ jobs:
       registry-url: 'https://npm.pkg.github.com'
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   cascade:
     name: Trigger Dependency Cascade


### PR DESCRIPTION
## Problem

Workflow is failing with:
```
Secret name `GITHUB_TOKEN` within `workflow_call` can not be used 
since it would collide with system reserved name
```

Failure: https://github.com/happyvertical/smrt/actions/runs/19451015165

## Solution

Remove `GITHUB_TOKEN` from the secrets passed to the shared workflow. The `GITHUB_TOKEN` is automatically available in all GitHub Actions workflows and doesn't need to be (and can't be) passed explicitly.

## Dependencies

This PR depends on SDK PR #469 being merged first to fix the shared workflow.

## Related

- SDK fix: https://github.com/happyvertical/sdk/pull/469
- Fixes workflow failure after PR #355 was merged