### PR TITLE
fix(ci): pass required secrets and add actionlint to PR validation

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -127,32 +127,31 @@ jobs:
 
           echo "✅ YAML syntax validation passed"
 
-      - name: Install act
+      - name: Install actionlint
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-          # Install specific version of act for security and stability
-          mkdir -p bin
-          curl --proto '=https' --tlsv1.2 -sSfL \
-            https://raw.githubusercontent.com/nektos/act/master/install.sh \
-            | sudo bash -s -- -b bin v0.2.82
+          # Install actionlint for comprehensive workflow validation
+          bash <(curl \
+            https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          sudo mv actionlint /usr/local/bin/
 
-      - name: Validate with act
+      - name: Validate with actionlint
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-          if ! ./bin/act --list > /tmp/act-output.txt 2>&1; then
-            echo "❌ act --list failed - workflow syntax issue"
-            echo "Error output:"
-            cat /tmp/act-output.txt
-            exit 1
-          fi
-          echo "✅ act validation passed"
+          echo "🔍 Running actionlint on changed workflows..."
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            echo "  Checking $file with actionlint..."
+            actionlint "$file" || exit 1
+          done
+          echo "✅ actionlint validation passed"
 
       - name: Workflow validation summary
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           echo "✅ All workflow validations passed:"
           echo "  - YAML syntax validated with yamllint"
-          echo "  - Workflow parsing verified with act"
+          echo "  - Workflow errors checked with actionlint"
+          echo "  - Shellcheck warnings validated"
 
   changeset-check:
     name: Check for Changeset

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,8 @@ jobs:
       node-version: '24'
       registry-url: 'https://npm.pkg.github.com'
     secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      HAVE_RELEASE_APP_ID: ${{ secrets.HAVE_RELEASE_APP_ID }}
+      HAVE_RELEASE_APP_PRIVATE_KEY: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
 
   cascade:
     name: Trigger Dependency Cascade


### PR DESCRIPTION
## Summary

Fixes the on-merge-main workflow failure caused by missing secrets and improves PR validation to catch workflow errors before merge.

## Problem

The on-merge-main workflow failed with:
```
Secret HAVE_RELEASE_APP_ID is required, but not provided while calling
Secret HAVE_RELEASE_APP_PRIVATE_KEY is required, but not provided while calling
```

This error wasn't caught in PR validation because we were using `act` instead of `actionlint` for workflow validation.

## Changes

### 1. Fix publish.yml secrets
- Pass `HAVE_RELEASE_APP_ID` and `HAVE_RELEASE_APP_PRIVATE_KEY` secrets
- These are required by the `shared-direct-publish.yml` reusable workflow from SDK repo
- Removed `GH_TOKEN` which was incorrect

### 2. Upgrade PR validation to use actionlint
- Replace `act --list` with `actionlint` in on-pull-request.yml
- actionlint provides better validation:
  - Catches shellcheck warnings in workflow scripts
  - Validates action inputs and outputs
  - Better error messages

## Why wasn't this caught?

`act` only validates workflow parsing, not:
- Cross-repository workflow_call contracts
- Required secrets in reusable workflows
- Shellcheck warnings in run scripts

`actionlint` catches most of these issues (except cross-repo secrets which only GitHub's runtime can validate).

## Test Plan

- [x] Local validation with actionlint passes
- [x] Pre-commit and pre-push hooks pass
- [ ] PR validation will test actionlint on these workflow changes
- [ ] After merge, on-merge-main should succeed with correct secrets

Fixes https://github.com/happyvertical/smrt/actions/runs/19521243333