### PR TITLE
fix(ci): use force flag when creating/pushing tags to handle duplicates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -128,8 +128,8 @@ jobs:
             pnpm run build
             pnpm run changeset:publish
 
-            git tag "v$AFTER_VERSION"
-            git push origin "v$AFTER_VERSION"
+            git tag -f "v$AFTER_VERSION"
+            git push -f origin "v$AFTER_VERSION"
             git push origin main
 
             RELEASE_NOTES="## Published Packages"$'\n\n'


### PR DESCRIPTION
## Summary

Prevents 'tag already exists' errors when the publish workflow runs after a previous partial failure.

## Changes

- Use `git tag -f` to force-overwrite existing tags
- Use `git push -f` for tags to allow tag updates

## Problem

When a publish workflow partially succeeds (creates the tag) but then fails before completing, subsequent runs fail with:
```
fatal: tag 'v0.16.2' already exists
```

## Solution

Using the force flag allows the workflow to overwrite existing tags, enabling recovery from partial failures without manual intervention.