### PR TITLE
fix(changeset): remove deleted smrt-accounts package reference

### DIFF
--- a/.changeset/1763658167540-w4ztqm.md
+++ b/.changeset/1763658167540-w4ztqm.md
@@ -1,5 +1,4 @@
 ---
-"@happyvertical/smrt-accounts": patch
 "@happyvertical/smrt-agents": patch
 "@happyvertical/smrt-assets": patch
 "@happyvertical/smrt-cli": patch


### PR DESCRIPTION
## Summary

Removes stale reference to `@happyvertical/smrt-accounts` package from changeset file.

The `smrt-accounts` package was removed from the workspace, but a changeset file still referenced it, causing the publish workflow to fail with:

```
Error: Found changeset 1763658167540-w4ztqm for package @happyvertical/smrt-accounts which is not in the workspace
```

## Changes

- Remove `@happyvertical/smrt-accounts: patch` line from `.changeset/1763658167540-w4ztqm.md`

## Related

Fixes publish workflow failure: https://github.com/happyvertical/smrt/actions/runs/19556174533