### PR TITLE
fix(core): revert setId to use internal property assignment

### DIFF
--- a/packages/core/src/__tests__/test-import.mjs
+++ b/packages/core/src/__tests__/test-import.mjs
@@ -1,0 +1,6 @@
+import { Person, Organization } from '@happyvertical/smrt-profiles';
+
+console.log('Person:', Person);
+console.log('Organization:', Organization);
+console.log('Person name:', Person.name);
+console.log('Organization name:', Organization.name);

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -828,7 +828,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       );
       // Generate ID if not provided, then save
       if (!instance.id) {
-        instance.setId(crypto.randomUUID());
+        (instance as any)._id = crypto.randomUUID();
       }
       await instance.save();
       return instance;
@@ -852,7 +852,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     await instance.initialize();
     // Generate ID if not provided, then save
     if (!instance.id) {
-      instance.setId(crypto.randomUUID());
+      (instance as any)._id = crypto.randomUUID();
     }
     await instance.save();
     return instance;

--- a/packages/core/src/manifest/test-manifest-stub.ts
+++ b/packages/core/src/manifest/test-manifest-stub.ts
@@ -10,7 +10,7 @@ import type { SmartObjectManifest } from '../scanner/types';
 
 export const testManifest: SmartObjectManifest = {
   "version": "1.0.0",
-  "timestamp": 1763685662302,
+  "timestamp": 1763700512722,
   "objects": {
     "testobject": {
       "name": "testobject",


### PR DESCRIPTION
## Summary
- Fixes build error where protected `setId()` method is inaccessible from `SmrtCollection`
- `SmrtCollection` doesn't extend `SmrtObject`, so it can't access protected members
- Reverts to `(instance as any)._id` pattern which was the working approach

## Test plan
- [x] Build passes
- [x] All tests pass