### PR TITLE
docs: add changeset workflow warnings and fix release documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -661,6 +661,21 @@ class Product extends SmrtObject {
 
 For complete workflow details, see [WORKFLOW.md](./WORKFLOW.md).
 
+### Changesets and Versioning
+
+⚠️ **IMPORTANT: Never create changesets manually or use `[skip ci]` in PR commits**
+
+This project uses [Changesets](https://github.com/changesets/changesets) for versioning and package releases:
+
+- **Automated Generation**: Changesets are auto-generated from conventional commits via GitHub Actions
+- **Workflow**: When you open a PR, the workflow runs `pnpm run changeset:auto` to generate changesets
+- **No Manual Creation**: Don't run `npx changeset` or create changeset files manually
+- **Critical: Avoid `[skip ci]`**: Using `[skip ci]` in any commit message will prevent the on-merge-main workflow from running, which breaks package publishing
+
+**Why this matters**: When a PR with `[skip ci]` in any commit is merged to main, GitHub Actions skips the entire merge workflow, including building and publishing packages. This requires manual intervention to trigger the publish workflow.
+
+For complete changeset workflow and troubleshooting, see [CHANGESETS.md](./CHANGESETS.md).
+
 ### Testing Requirements
 
 All code changes must include tests following [TESTING_STANDARD.md](../TESTING_STANDARD.md):
@@ -761,13 +776,23 @@ See [.github/TRIAGE_SOP.md](.github/TRIAGE_SOP.md) for complete details.
 
 ## Release Management
 
-The framework uses semantic-release for automated versioning:
+The framework uses [Changesets](https://github.com/changesets/changesets) for automated versioning and publishing:
 
 ```bash
-npm run release:preview  # Preview next release
-npm run release:dry-run  # Dry run
-npm run release          # Full release (CI handles this)
+# Preview what will be released
+pnpm run changeset:version  # Update package versions based on changesets
+
+# Publish (handled automatically by CI on merge to main)
+pnpm run changeset:publish  # Publish packages to registry
 ```
+
+**Important**: Package releases are fully automated:
+1. PRs generate changesets from conventional commits
+2. Merging to main triggers the on-merge-main workflow
+3. Workflow builds, versions, and publishes packages automatically
+4. No manual `npm publish` needed
+
+See [CHANGESETS.md](./CHANGESETS.md) for complete release workflow documentation.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds critical documentation to prevent the issue encountered in PR #381 where `[skip ci]` in a commit message prevented the on-merge-main workflow from running.

## Changes

**1. New Section: 'Changesets and Versioning'**
- Added after line 662 in contributor guidelines
- ⚠️ Warning against manual changeset creation
- Explanation of automated changeset generation from conventional commits
- **Critical warning** about `[skip ci]` breaking the publish workflow
- Link to CHANGESETS.md for complete workflow documentation

**2. Fixed 'Release Management' Section**
- Corrected incorrect reference from 'semantic-release' to 'changesets'
- Updated npm scripts to reflect actual changeset commands
- Added explanation of automated release process on merge to main
- Link to CHANGESETS.md for complete documentation

## Why This Matters

In PR #381, a manually created changeset commit included `[skip ci]`:
```bash
git commit -m "chore: add changeset for STI safety improvements [skip ci]"
```

When the PR merged, GitHub Actions saw `[skip ci]` in ANY commit and skipped the **entire merge workflow**, which prevented:
- ❌ Building packages
- ❌ Publishing to npm registry
- ❌ Deploying documentation
- ❌ Creating git tags

This required manual intervention to trigger the workflow using:
```bash
gh workflow run on-merge-main.yml --ref main
```

## What This Documentation Prevents

Future contributors will now know:
1. **Don't create changesets manually** - GitHub Actions does this automatically from conventional commits
2. **Never use `[skip ci]` in PR commits** - it breaks the entire publish pipeline
3. How the automated changeset workflow actually works
4. Where to find complete changeset documentation (CHANGESETS.md)

## Related

- Fixes the root cause of publish failures in PR #381
- Corrects outdated semantic-release documentation (project uses changesets)