### PR TITLE
fix(workflows): allow workflow_dispatch to trigger build and publish jobs

### DIFF
--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -122,10 +122,11 @@ jobs:
   build:
     name: Build
     needs: test
-    # Only run on direct pushes to main (not cascade events)
+    # Only run on direct pushes to main or manual triggers (not cascade events)
     if: |
       always() &&
-      github.event_name == 'push' &&
+      (github.event_name == 'push' ||
+       github.event_name == 'workflow_dispatch') &&
       needs.test.result == 'success'
     uses: ./.github/workflows/build.yml
     permissions:


### PR DESCRIPTION
## Problem

The on-merge-main workflow was manually triggered for PR #387 merge (commit 65f6acf), but the build and publish jobs were skipped:

```
Test: ✅ success  
Build: ⏭️ skipped
Publish: ⏭️ skipped
```

## Root Cause

The `build` job had this condition:

```yaml
if: |
  always() &&
  github.event_name == 'push' &&     # ❌ Only allows push events!
  needs.test.result == 'success'
```

When we manually triggered the workflow with `workflow_dispatch`, the event name was `'workflow_dispatch'`, not `'push'`, so the condition failed and build was skipped.

## Solution

Updated the condition to allow both `push` and `workflow_dispatch` events:

```yaml
if: |
  always() &&
  (github.event_name == 'push' ||
   github.event_name == 'workflow_dispatch') &&
  needs.test.result == 'success'
```

## Impact

After merging:
- ✅ Manual workflow triggers will now build and publish packages
- ✅ Automatic push-based triggers still work as before
- ✅ Cascade dependency updates still skip (as intended)

## Testing

After merge, re-run the on-merge-main workflow manually to publish packages from PR #387.

Fixes: on-merge-main workflow not publishing when manually triggered