### PR TITLE
fix(ci): add NODE_AUTH_TOKEN for update dependencies step

### DIFF
--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Update @happyvertical dependencies
         id: update
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           echo "🔄 Updating @happyvertical packages..."
           pnpm update '@happyvertical/*' --latest


### PR DESCRIPTION
## Problem

The `update-dependencies` job in the `on-merge-main` workflow was failing with a 401 Unauthorized error:

```
ERR_PNPM_FETCH_401  GET https://npm.pkg.github.com/@happyvertical%2Futils: Unauthorized - 401
```

**Root cause**: The `NODE_AUTH_TOKEN` environment variable was only set in the `install-deps` step of the `setup-environment` action (line 139), but that step is skipped when `install-deps: 'false'`. When `pnpm update` runs without authentication, it can't access private packages on GitHub Packages registry.

## Solution

Add `NODE_AUTH_TOKEN` to the environment of the "Update @happyvertical dependencies" step so pnpm can authenticate with GitHub Packages.

## Testing

This fix should resolve the 401 errors in workflows triggered by `repository_dispatch` events (e.g., from SDK updates).

**Failed workflow run**: https://github.com/happyvertical/smrt/actions/runs/19636150975

## Changes

- Added `NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}` to the environment of the update step