### PR TITLE
docs: add database adapter parity testing section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -567,6 +567,16 @@ smrt test --manifest-only
 npx vitest run src/specific-test.test.ts
 ```
 
+**Database Adapter Testing:**
+
+The framework includes comprehensive adapter parity tests to ensure consistent behavior across all database backends (SQLite, JSON/DuckDB). These tests verify:
+- STI (Single Table Inheritance) operations
+- UPSERT conflict resolution
+- Type preservation across save/load cycles
+- Query operations with filtering
+
+See `packages/core/src/__tests__/sti-adapter-parity.test.ts` for the complete test suite that runs identical tests across all supported adapters.
+
 ### Build System
 
 The framework uses **Turborepo** for intelligent task orchestration:


### PR DESCRIPTION
## Summary

Improves testing documentation by adding a section about the comprehensive database adapter parity test suite.

## Changes

- Document the STI adapter parity test suite in CLAUDE.md
- Explain what the tests verify (STI operations, UPSERT, type preservation, queries)
- Reference the test file location (`packages/core/src/__tests__/sti-adapter-parity.test.ts`)
- Improve overall testing documentation completeness

## Why This PR

This PR adds documentation for the new test suite added in #397. When merged, it will:
- Trigger a version bump (patch version due to `docs:` prefix)
- Test the dependency cascade workflow
- Improve developer documentation

## Related

- Follows up on #397 (adapter parity tests)
- Part of #396 (JSON adapter testing) and #398 (cascade workflow)