### PR TITLE
feat: skip PR checks when PR is already merged

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -18,6 +18,8 @@ jobs:
   validate-commits:
     name: Validate Conventional Commits
     runs-on: ubuntu-latest
+    # Skip if PR is already merged
+    if: github.event.pull_request.merged != true
 
     steps:
       - name: Checkout PR branch
@@ -99,6 +101,8 @@ jobs:
   validate-workflows:
     name: Validate Workflow Files
     runs-on: ubuntu-latest
+    # Skip if PR is already merged
+    if: github.event.pull_request.merged != true
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4
@@ -155,6 +159,8 @@ jobs:
 
   test:
     name: Validate Changes
+    # Skip if PR is already merged
+    if: github.event.pull_request.merged != true
     uses: ./.github/workflows/test-suite.yml
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Automatically skip all PR validation jobs when a PR is merged, preventing wasted CI resources.

## Changes

Adds conditional checks to all PR workflow jobs:
```yaml
if: github.event.pull_request.merged != true
```

Applied to:
- `validate-commits` - Conventional commit validation
- `validate-workflows` - Workflow file validation  
- `test` - Test suite execution

## Behavior

**Before**: When you merge a PR, GitHub continues running in-progress validation jobs to completion, consuming CI minutes unnecessarily.

**After**: All validation jobs skip immediately when the PR is merged, stopping any in-progress work.

## Version Bump

This is a new **feature** (`feat:` prefix), so merging will trigger:
- Minor version bump: 0.17.4 → 0.18.0
- Package publication
- Dependency cascade to downstream repositories

## Testing the Cascade

This PR will test the full dependency cascade workflow when merged! 🎉