### PR TITLE
fix(workflows): use repository_dispatch for cascade triggers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -228,22 +228,21 @@ jobs:
           echo "🎯 Downstream repositories: $DOWNSTREAM_REPOS"
           echo ""
 
-          # Trigger each downstream repo using workflow_dispatch
+          # Trigger each downstream repo using repository_dispatch
           success_count=0
           fail_count=0
 
           for repo in $DOWNSTREAM_REPOS; do
             echo "📤 Triggering: happyvertical/$repo"
-            if gh workflow run on-merge-main.yml \
-              --repo "happyvertical/$repo" \
-              --ref main \
-              -f upstream_package="@happyvertical/smrt" \
-              -f upstream_version="$version" \
-              -f triggered_by="${{ github.actor }}"; then
+            if gh api "repos/happyvertical/$repo/dispatches" \
+              -f event_type="sdk-updated" \
+              -f 'client_payload[upstream_package]'="@happyvertical/smrt" \
+              -f 'client_payload[upstream_version]'="$version" \
+              -f 'client_payload[triggered_by]'="${{ github.actor }}"; then
               echo "   ✅ Successfully triggered"
               ((success_count++))
             else
-              echo "   ⚠️  Failed to trigger (may not have workflow configured)"
+              echo "   ⚠️  Failed to trigger (check repo access/permissions)"
               ((fail_count++))
             fi
             echo ""


### PR DESCRIPTION
Fixes cascade job HTTP 422 errors by switching from workflow_dispatch to repository_dispatch events. Downstream workflows already support repository_dispatch with event type 'sdk-updated', so no changes needed in praeco/caelus. Passes data via client_payload instead of workflow inputs.