### PR TITLE
fix(scanner): resolve type aliases to infer string union types as text

### DIFF
--- a/packages/core/src/scanner/ast-scanner.ts
+++ b/packages/core/src/scanner/ast-scanner.ts
@@ -943,6 +943,41 @@ export class ASTScanner {
       if (typeName.includes('string')) return 'text';
       if (typeName.includes('number')) return 'decimal';
       if (typeName.includes('boolean')) return 'boolean';
+
+      // Resolve type aliases using type checker
+      const typeChecker = this.program.getTypeChecker();
+      const type = typeChecker.getTypeFromTypeNode(typeNode);
+
+      // Check for union types (e.g., string literal unions)
+      if (type.isUnion()) {
+        const types = type.types;
+
+        // Check if all types are string literals
+        const allStringLiterals = types.every((t) =>
+          Boolean(t.flags & ts.TypeFlags.StringLiteral),
+        );
+        if (allStringLiterals) return 'text';
+
+        // Check if all types are number literals
+        const allNumberLiterals = types.every((t) =>
+          Boolean(t.flags & ts.TypeFlags.NumberLiteral),
+        );
+        if (allNumberLiterals) return 'decimal';
+
+        // Check if all types are boolean literals
+        const allBooleanLiterals = types.every(
+          (t) =>
+            Boolean(t.flags & ts.TypeFlags.BooleanLiteral) ||
+            t.flags === ts.TypeFlags.True ||
+            t.flags === ts.TypeFlags.False,
+        );
+        if (allBooleanLiterals) return 'boolean';
+      }
+
+      // Check for primitive types resolved through aliases
+      if (type.flags & ts.TypeFlags.String) return 'text';
+      if (type.flags & ts.TypeFlags.Number) return 'decimal';
+      if (type.flags & ts.TypeFlags.Boolean) return 'boolean';
     }
 
     // Handle string literal types and template literals

--- a/packages/core/src/scanner/scanner.test.ts
+++ b/packages/core/src/scanner/scanner.test.ts
@@ -80,6 +80,35 @@ describe('AST Scanner', () => {
     });
   });
 
+  it('should infer union types correctly', () => {
+    const scanner = new ASTScanner([testFilePath]);
+    const results = scanner.scanFiles();
+    const contentObj = results[0].objects.find(
+      (obj) => obj.className === 'ScannerTestContent',
+    );
+
+    // String union type should be inferred as 'text'
+    expect(contentObj?.fields.status).toMatchObject({
+      type: 'text',
+      required: false,
+      default: 'draft',
+    });
+
+    // Number union type should be inferred as 'decimal'
+    expect(contentObj?.fields.priority).toMatchObject({
+      type: 'decimal',
+      required: false,
+      default: 3,
+    });
+
+    // Boolean union type should be inferred as 'boolean'
+    expect(contentObj?.fields.enabled).toMatchObject({
+      type: 'boolean',
+      required: false,
+      default: true,
+    });
+  });
+
   it('should parse methods correctly', () => {
     const scanner = new ASTScanner([testFilePath], {
       includePrivateMethods: true,

--- a/packages/core/src/scanner/test-sample.ts
+++ b/packages/core/src/scanner/test-sample.ts
@@ -9,6 +9,11 @@ function smrt(_config?: any) {
   return (target: any) => target;
 }
 
+// Type aliases for testing union type inference
+export type ContentStatus = 'draft' | 'published' | 'archived' | 'deleted';
+export type Priority = 1 | 2 | 3 | 4 | 5;
+export type FeatureFlag = true | false;
+
 // Simple ScannerTestContent class
 @smrt({
   api: {
@@ -22,10 +27,12 @@ function smrt(_config?: any) {
 class ScannerTestContent extends SmrtObject {
   title = '';
   body?: string;
-  status = 'draft';
+  status: ContentStatus = 'draft'; // String union type
   published = false;
   category = 'general';
   tags: string[] = [];
+  priority: Priority = 3; // Number union type
+  enabled: FeatureFlag = true; // Boolean union type
 
   async generateSummary(maxLength: number): Promise<string> {
     return this.body?.substring(0, maxLength) || '';


### PR DESCRIPTION
Fixes #406 

## Summary

The AST scanner incorrectly inferred TypeScript string union type aliases (like `EventStatus`) as JSON instead of TEXT, causing runtime errors with the JSON adapter (DuckDB).

## Problem

When using type aliases like:
```typescript
type EventStatus = 'scheduled' | 'completed' | 'cancelled';
status: EventStatus = 'scheduled';
```

The scanner treated them as JSON type, but DuckDB strict JSON validation failed:
```
Conversion Error: Malformed JSON at byte 0: unexpected character.
Input: "scheduled"
```

## Solution

Enhanced `analyzeTypeNode()` to use TypeScript's type checker to resolve type aliases and detect union types:

- String literal unions → TEXT
- Number literal unions → DECIMAL
- Boolean literal unions → BOOLEAN
- Primitive type aliases → Their underlying type

## Changes

- Added type alias resolution using `program.getTypeChecker()`
- Added union type detection for string, number, boolean literals
- Added primitive type resolution for type aliases
- Added comprehensive test coverage

## Testing

Added test cases with three union types:
- `ContentStatus` (string union) → inferred as TEXT ✅
- `Priority` (number union) → inferred as DECIMAL ✅
- `FeatureFlag` (boolean union) → inferred as BOOLEAN ✅

All 18 scanner tests pass.

## Impact

- **SQLite adapter**: No change (already permissive)
- **JSON adapter (DuckDB)**: Now works correctly with union types
- **Event models**: Meeting, Agenda, etc. now compatible with JSON adapter