### PR TITLE
fix(workflows): use safe arithmetic syntax in cascade loop

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -240,10 +240,10 @@ jobs:
               -f 'client_payload[upstream_version]'="$version" \
               -f 'client_payload[triggered_by]'="${{ github.actor }}"; then
               echo "   ✅ Successfully triggered"
-              ((success_count++))
+              success_count=$((success_count + 1))
             else
               echo "   ⚠️  Failed to trigger (check repo access/permissions)"
-              ((fail_count++))
+              fail_count=$((fail_count + 1))
             fi
             echo ""
           done


### PR DESCRIPTION
Fixes cascade job failure from v0.17.8 release.

## Problem

The cascade job was failing with exit code 1 after successfully triggering the first downstream repo (praeco). The issue was caused by bash -e flag behavior with arithmetic increment operators.

**Failing code:**
```bash
((success_count++))  # Returns 0 when success_count is 0
```

With `bash -e`, when `success_count` is 0, the `(( ))` expression returns 0 (the value before increment), which bash treats as false/failure, causing immediate script exit.

## Evidence

From workflow logs:
```
📤 Triggering: happyvertical/praeco
   ✅ Successfully triggered
##[error]Process completed with exit code 1.
```

The script successfully triggered praeco but exited before:
- Incrementing the success counter
- Processing caelus (second downstream repo)
- Printing the summary

## Solution

Changed to safe assignment syntax:
```bash
success_count=$((success_count + 1))
fail_count=$((fail_count + 1))
```

This syntax always returns exit code 0, preventing premature termination.

## Testing

When merged, this will trigger v0.17.9 release and test the full cascade to both praeco and caelus.

## Impact

✅ Cascade will process ALL downstream repos (praeco + caelus)
✅ Success/failure counters will be accurate
✅ Full summary will be displayed