### PR TITLE
fix(cli): resolve option key mismatch in generate commands

### DIFF
--- a/packages/cli/src/cli-generator.ts
+++ b/packages/cli/src/cli-generator.ts
@@ -286,9 +286,11 @@ export class CLIGenerator {
     const registerPath = path.join(process.cwd(), '.smrt', 'register.js');
 
     if (!fs.existsSync(registerPath)) {
-      if (config.verbose) {
-        console.log('[CLI] No .smrt/register.js found - run build to generate');
-      }
+      // Always show this warning (not just verbose) since it affects custom commands
+      console.log(
+        '[CLI] No .smrt/register.js found - custom commands may not work',
+      );
+      console.log('      Run "npm run build" to generate class registrations');
       return;
     }
 
@@ -1417,7 +1419,22 @@ export class CLIGenerator {
     try {
       const classInfo = ObjectRegistry.getClass(objectName);
       if (!classInfo || !classInfo.constructor) {
-        this.exitWithError(`Object class '${objectName}' not found`);
+        const availableObjects = Array.from(
+          ObjectRegistry.getAllClasses().keys(),
+        );
+        const availableList =
+          availableObjects.length > 0
+            ? `Available objects:\n  ${availableObjects.join('\n  ')}`
+            : 'No objects registered. Run "npm run build" to generate registrations.';
+
+        this.exitWithError(
+          `Object class '${objectName}' not found.\n\n` +
+            `${availableList}\n\n` +
+            `Troubleshooting:\n` +
+            `1. Run "npm run build" to generate .smrt/register.js\n` +
+            `2. Ensure package exports classes correctly\n` +
+            `3. Run "smrt doctor" for diagnostics`,
+        );
         return;
       }
 

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -33,7 +33,7 @@ export const generateCommands: Record<string, CLICommand> = {
         );
       }
 
-      const outputDir = options.outputDir || args[1];
+      const outputDir = options['output-dir'] || args[1];
 
       try {
         const cliArgs = outputDir ? [manifestPath, outputDir] : [manifestPath];
@@ -126,18 +126,18 @@ export const generateCommands: Record<string, CLICommand> = {
 
         console.log(`\n🔨 Generating MCP server...`);
         console.log(`   Server name: ${serverName}`);
-        console.log(`   Output path: ${options.outputPath}`);
+        console.log(`   Output path: ${options['output-path']}`);
         console.log(`   Modular structure: ${options.modular ? 'yes' : 'no'}`);
         console.log(`   Registered objects: ${registeredClasses.size}`);
 
         // Generate server
         await generator.generateServer({
-          outputPath: options.outputPath,
+          outputPath: options['output-path'],
           serverName,
           serverVersion: options.version,
           debug: options.debug,
-          generateClaudeConfigFile: !options.noConfig,
-          generateReadme: !options.noReadme,
+          generateClaudeConfigFile: !options['no-config'],
+          generateReadme: !options['no-readme'],
           modular: options.modular,
         });
 
@@ -237,19 +237,25 @@ export const generateCommands: Record<string, CLICommand> = {
 
         const projectRoot = process.cwd();
 
+        // Extract options with kebab-case keys (matching option definitions)
+        const routesDir = options['routes-dir'] || 'src/routes/api';
+        const objectsDir = options['objects-dir'] || 'src/lib/objects';
+        const configPath = options['config-path'] || 'src/lib/server';
+        const configFile = options['config-file'] || 'smrt.ts';
+
         console.log('🔨 Generating SvelteKit routes...');
-        console.log(`   Routes directory: ${options['routes-dir']}`);
-        console.log(`   Objects directory: ${options['objects-dir']}`);
-        console.log(`   Config path: ${options['config-path']}`);
+        console.log(`   Routes directory: ${routesDir}`);
+        console.log(`   Objects directory: ${objectsDir}`);
+        console.log(`   Config path: ${configPath}`);
         console.log();
 
         // Generate routes
         await generateSvelteKitRoutes(projectRoot, manifest, {
           enabled: true,
-          routesDir: options['routes-dir'],
-          objectsDir: options['objects-dir'],
-          configPath: options['config-path'],
-          configFileName: options['config-file'],
+          routesDir,
+          objectsDir,
+          configPath,
+          configFileName: configFile,
         });
 
         // Report results
@@ -260,7 +266,7 @@ export const generateCommands: Record<string, CLICommand> = {
         console.log(`   ${objectNames}\n`);
 
         console.log('📁 Generated structure:');
-        console.log(`   ${options['routes-dir']}/`);
+        console.log(`   ${routesDir}/`);
         for (const objectDef of Object.values(manifest.objects)) {
           const collection = (objectDef as any).collection;
           console.log(`     ${collection}/+server.ts     (list, create)`);


### PR DESCRIPTION
## Summary
- Fix kebab-case option keys being accessed with camelCase in CLI handlers
- Add better error messages when `.smrt/register.js` is missing
- Enhance troubleshooting output for singleton method failures

## Problem
CLI options were defined with kebab-case keys (e.g., `'routes-dir'`) but handlers accessed them with camelCase (e.g., `options.routesDir`), causing `undefined` values and subsequent errors like:

```
Cannot read properties of undefined (reading 'startsWith')
```

## Changes
| File | Change |
|------|--------|
| `packages/cli/src/commands/generate.ts` | Fix option key access in all generate commands |
| `packages/cli/src/cli-generator.ts` | Better error messages for missing register.js and class lookup failures |

## Test plan
- [x] All existing tests pass (759 passed)
- [x] Type checking passes
- [ ] Manual test: `smrt generate-routes -r src/routes/api -o src/lib/objects` with consumer project

Closes #411