### PR TITLE
fix(cli): trigger release with #413 fix included

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,7 +1,8 @@
 /**
  * Code Generation CLI Commands
  *
- * Commands for generating code, types, and other artifacts
+ * Commands for generating code, types, and other artifacts.
+ * Includes generate-types, generate-mcp, and generate-routes commands.
  */
 
 import { ObjectRegistry } from '@happyvertical/smrt-core';


### PR DESCRIPTION
## Summary
Trigger a fresh release to include the complete fix from #413.

## Problem
The fix from #413 (local variables with defaults in generate-routes) was not included in the 0.17.11 build due to timing - the build ran before the merge was fully processed.

Published 0.17.11 has:
```javascript
routesDir: t["routes-dir"]  // No fallback default
```

Source on main has:
```typescript
const routesDir = options['routes-dir'] || 'src/routes/api';
```

## Changes
- Minor JSDoc improvement to trigger rebuild

## Related
- #411 (original issue)
- #413 (fix PR that wasn't fully included in 0.17.11)