### PR TITLE
fix(core): use package imports for external packages in generate-routes

### DIFF
--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -58,7 +58,24 @@ async function generateRegistrationFile(
   const configDir = join(projectRoot, configPath);
   const registrationFilePath = join(configDir, 'smrt-register.ts');
 
-  const imports = Object.entries(manifest.objects)
+  // Group objects by package for efficient imports
+  const localObjects: Array<[string, (typeof manifest.objects)[string]]> = [];
+  const packageObjects = new Map<string, string[]>(); // packageName -> classNames
+
+  for (const [className, objectDef] of Object.entries(manifest.objects)) {
+    if (objectDef.packageName) {
+      // External package - group by package name
+      const classes = packageObjects.get(objectDef.packageName) || [];
+      classes.push(className);
+      packageObjects.set(objectDef.packageName, classes);
+    } else {
+      // Local object - use file path
+      localObjects.push([className, objectDef]);
+    }
+  }
+
+  // Generate imports for local objects
+  const localImports = localObjects
     .map(([className, objectDef]) => {
       const importPath = getSvelteKitImportPath(
         projectRoot,
@@ -70,6 +87,16 @@ async function generateRegistrationFile(
       return `import { ${actualClassName} } from '${importPath}';`;
     })
     .join('\n');
+
+  // Generate imports for external packages
+  const packageImports = Array.from(packageObjects.entries())
+    .map(([packageName, classNames]) => {
+      // Import all classes from the package
+      return `import { ${classNames.join(', ')} } from '${packageName}';`;
+    })
+    .join('\n');
+
+  const imports = [packageImports, localImports].filter(Boolean).join('\n');
 
   const registrationContent = `/**
  * Auto-generated SMRT object registration


### PR DESCRIPTION
## Summary
Fix `smrt generate-routes` to use package names for external package imports instead of absolute file paths.

## Problem
The generated `smrt-register.ts` was using the absolute `filePath` from the manifest, which contains CI runner paths:

```typescript
// Before (broken):
import { WeatherForecast } from '$lib/objects/../../../../../home/runner/work/caelus/caelus/src/lib/models/WeatherForecast';
```

## Solution
Check if `objectDef.packageName` exists and use it for imports:

```typescript
// After (fixed):
import { WeatherForecast } from '@happyvertical/caelus';
```

Also groups multiple classes from the same package into a single import statement for cleaner output.

## Test plan
- [x] All existing tests pass
- [ ] Manual test with consumer project using external packages

Closes #415