### PR TITLE
fix(ci): force clean rebuild during publish to avoid stale cache

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,9 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           auth-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Note: This cache is restored but the publish step forces a clean rebuild
+      # to ensure the published dist matches the latest source code.
+      # See the "Force clean rebuild" step in changesets_release.
       - name: Setup Turborepo cache
         uses: actions/cache@v4
         with:
@@ -125,7 +128,12 @@ jobs:
             git add .
             git commit -m "chore(release): v$AFTER_VERSION [skip ci]"
 
-            pnpm run build
+            # Force clean rebuild to avoid stale turbo cache
+            # This ensures all packages are rebuilt with latest source code
+            echo "🔨 Running clean build (bypassing turbo cache)..."
+            rm -rf .turbo
+            TURBO_FORCE=true pnpm run build
+
             pnpm run changeset:publish
 
             git tag -f "v$AFTER_VERSION"


### PR DESCRIPTION
## Problem

The 0.17.18 release published stale dist without the Pagination component even though PR #445 was merged. The source code had the component, but the published tarball didn't.

**Root cause:** Turborepo was using cached build outputs from before the Pagination component was added. Since no dependencies changed (only source files), the cache key matched and turbo replayed old build logs without actually rebuilding.

## Solution

Force a clean rebuild during the publish step:
- Remove `.turbo` cache directory before building
- Set `TURBO_FORCE=true` to bypass any remaining cache
- Add comments explaining the cache strategy

## Test plan

- [ ] After merge, trigger a new release and verify the dist contains latest source

## Related

Fixes the issue where 0.17.18 was published without the Pagination export.