### PR TITLE
feat(config,cli): add SiteConfig and static JSON site template

### DIFF
--- a/packages/cli/src/commands/gnode.ts
+++ b/packages/cli/src/commands/gnode.ts
@@ -31,6 +31,24 @@ export const gnodeCommands: Record<string, CLICommand> = {
         type: 'string',
         description: 'Output directory (defaults to ./<name>)',
       },
+      // Site-specific options for placeholder substitution
+      location: {
+        type: 'string',
+        description: 'Site location name (e.g., "Bentley, AB")',
+      },
+      lat: {
+        type: 'number',
+        description: 'Latitude coordinate for weather/geo features',
+      },
+      lon: {
+        type: 'number',
+        description: 'Longitude coordinate for weather/geo features',
+      },
+      timezone: {
+        type: 'string',
+        description: 'IANA timezone (e.g., "America/Edmonton")',
+        default: 'America/Edmonton',
+      },
     },
     handler: async (args: string[], options: any) => {
       const name = args[0];
@@ -40,6 +58,17 @@ export const gnodeCommands: Record<string, CLICommand> = {
 
       const outputDir = options.outputDir || `./${name}`;
       const templateName = options.template || 'sveltekit';
+
+      // Build site options if any site-related flags were provided
+      const siteOptions =
+        options.location || options.lat || options.lon
+          ? {
+              location: options.location,
+              latitude: options.lat ? Number(options.lat) : undefined,
+              longitude: options.lon ? Number(options.lon) : undefined,
+              timezone: options.timezone,
+            }
+          : undefined;
 
       try {
         // Resolve template source
@@ -55,6 +84,7 @@ export const gnodeCommands: Record<string, CLICommand> = {
           name,
           template: templateName,
           outputDir,
+          site: siteOptions,
         });
 
         // Cleanup git template if needed

--- a/packages/cli/src/loaders/template-loader.ts
+++ b/packages/cli/src/loaders/template-loader.ts
@@ -19,6 +19,18 @@ import {
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+/**
+ * Context passed to placeholder functions
+ */
+export interface PlaceholderContext {
+  name: string;
+  siteName: string;
+  location: string;
+  latitude: number;
+  longitude: number;
+  timezone: string;
+}
+
 export interface TemplateConfig {
   name: string;
   description: string;
@@ -30,6 +42,14 @@ export interface TemplateConfig {
   };
   dependencies: Record<string, string>;
   devDependencies: Record<string, string>;
+  /** Template directory relative to config file (defaults to 'template') */
+  templateDir?: string;
+  /** Placeholder substitution map */
+  placeholders?: Record<string, string | ((ctx: PlaceholderContext) => string)>;
+  /** Post-generation hooks */
+  hooks?: {
+    afterGenerate?: (ctx: PlaceholderContext) => Promise<void>;
+  };
 }
 
 export interface TemplateSource {
@@ -131,6 +151,9 @@ async function findBundledTemplate(name: string): Promise<string | null> {
   const bundledTemplates: Record<string, string> = {
     sveltekit: 'template-sveltekit',
     'smrt-sveltekit': 'template-sveltekit',
+    // Static site with JSON data storage
+    'site-static-json': 'template-site-static-json',
+    'community-site': 'template-site-static-json',
   };
 
   const packageDir = bundledTemplates[name.toLowerCase()];

--- a/packages/cli/src/utils/generator.ts
+++ b/packages/cli/src/utils/generator.ts
@@ -13,10 +13,23 @@ import { dirname, join } from 'node:path';
 import glob from 'fast-glob';
 import type { TemplateConfig, TemplateSource } from '../loaders/index.js';
 
+export interface SiteGeneratorOptions {
+  /** Site location name (e.g., "Bentley, AB") */
+  location?: string;
+  /** Latitude coordinate */
+  latitude?: number;
+  /** Longitude coordinate */
+  longitude?: number;
+  /** IANA timezone (e.g., "America/Edmonton") */
+  timezone?: string;
+}
+
 export interface GeneratorOptions {
   template: string;
   name: string;
   outputDir: string;
+  /** Site-specific options for placeholder substitution */
+  site?: SiteGeneratorOptions;
 }
 
 /**
@@ -46,6 +59,12 @@ export async function generate(
   // Step 3: Merge package.json
   console.log('🔧 Configuring package.json...');
   await mergePackageJson(options.outputDir, config, options.name);
+
+  // Step 4: Process placeholders if template defines them
+  if (config.placeholders) {
+    console.log('🔄 Processing template placeholders...');
+    await processPlaceholders(options.outputDir, config, options);
+  }
 
   console.log('\n✅ Gnode created successfully!');
   console.log(`\n📍 Next steps:`);
@@ -264,4 +283,97 @@ async function mergePackageJson(
 
   // Write back
   await writeFile(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+}
+
+/**
+ * Context object passed to placeholder functions
+ */
+export interface PlaceholderContext {
+  /** Project name (e.g., "my-town-site") */
+  name: string;
+  /** Pretty site name derived from project name (e.g., "My Town Site") */
+  siteName: string;
+  /** Location name (e.g., "Bentley, AB") */
+  location: string;
+  /** Latitude coordinate */
+  latitude: number;
+  /** Longitude coordinate */
+  longitude: number;
+  /** IANA timezone */
+  timezone: string;
+}
+
+/**
+ * Process template placeholders in all files
+ *
+ * Placeholders are defined in template.config.js as:
+ * placeholders: {
+ *   '{{SITE_NAME}}': (ctx) => ctx.siteName,
+ *   '{{LATITUDE}}': (ctx) => String(ctx.latitude),
+ * }
+ */
+async function processPlaceholders(
+  outputDir: string,
+  config: TemplateConfig,
+  options: GeneratorOptions,
+): Promise<void> {
+  const placeholders = config.placeholders;
+  if (!placeholders || Object.keys(placeholders).length === 0) {
+    return;
+  }
+
+  // Build context from options
+  const ctx: PlaceholderContext = {
+    name: options.name,
+    siteName: options.name
+      .replace(/[-_]/g, ' ')
+      .replace(/\b\w/g, (c) => c.toUpperCase()),
+    location: options.site?.location || options.name,
+    latitude: options.site?.latitude || 0,
+    longitude: options.site?.longitude || 0,
+    timezone: options.site?.timezone || 'America/Edmonton',
+  };
+
+  // Build replacement map
+  const replacements: Record<string, string> = {};
+  for (const [placeholder, replacer] of Object.entries(placeholders)) {
+    if (typeof replacer === 'function') {
+      replacements[placeholder] = String(replacer(ctx));
+    } else {
+      replacements[placeholder] = String(replacer);
+    }
+  }
+
+  // Find all text files to process
+  const files = await glob(
+    '**/*.{ts,js,mjs,cjs,json,svelte,html,css,md,txt,yml,yaml}',
+    {
+      cwd: outputDir,
+      onlyFiles: true,
+      ignore: ['**/node_modules/**', '**/dist/**', '**/.svelte-kit/**'],
+    },
+  );
+
+  let replacedCount = 0;
+
+  for (const file of files) {
+    const filePath = join(outputDir, file);
+    let content = await readFile(filePath, 'utf-8');
+    let modified = false;
+
+    // Replace all placeholders
+    for (const [placeholder, value] of Object.entries(replacements)) {
+      if (content.includes(placeholder)) {
+        content = content.replaceAll(placeholder, value);
+        modified = true;
+      }
+    }
+
+    if (modified) {
+      await writeFile(filePath, content);
+      replacedCount++;
+    }
+  }
+
+  console.log(`   Processed placeholders in ${replacedCount} files`);
 }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -10,6 +10,12 @@ import type { LoadConfigOptions, SmrtConfig } from './types.js';
 // Re-export types
 export type {
   LoadConfigOptions,
+  // Site configuration types
+  SiteConfig,
+  SiteLocation,
+  SiteNavigation,
+  SiteNavigationLink,
+  SiteTheme,
   SmrtConfig,
   SmrtGlobalConfig,
 } from './types.js';
@@ -37,6 +43,17 @@ export async function loadConfig(
  */
 export function getConfig(): SmrtConfig | null {
   return loadedConfig;
+}
+
+/**
+ * Get site configuration from the loaded config
+ * Returns the site identity, location, navigation, and theme settings
+ *
+ * @returns The site config or null if not defined
+ */
+export function getSiteConfig(): import('./types.js').SiteConfig | null {
+  const config = loadedConfig || {};
+  return config.site || null;
 }
 
 /**

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -51,12 +51,98 @@ export interface SmrtGlobalConfig {
   [key: string]: unknown;
 }
 
+// ============================================================================
+// Site Configuration Types
+// ============================================================================
+
+/**
+ * A navigation link item
+ */
+export interface SiteNavigationLink {
+  label: string;
+  href: string;
+  icon?: string;
+}
+
+/**
+ * Site navigation structure
+ */
+export interface SiteNavigation {
+  /** Primary navigation links (header) */
+  primary: SiteNavigationLink[];
+  /** Footer navigation links */
+  footer?: SiteNavigationLink[];
+}
+
+/**
+ * Geographic location for the site
+ */
+export interface SiteLocation {
+  /** Display name (e.g., "Bentley" or "Bentley, AB") */
+  name: string;
+  /** Latitude coordinate */
+  latitude: number;
+  /** Longitude coordinate */
+  longitude: number;
+  /** IANA timezone (e.g., "America/Edmonton") */
+  timezone: string;
+}
+
+/**
+ * Site theme/branding colors
+ */
+export interface SiteTheme {
+  /** Primary brand color (hex) */
+  primaryColor: string;
+  /** Light variant of primary color */
+  primaryLight?: string;
+  /** Dark variant of primary color */
+  primaryDark?: string;
+}
+
+/**
+ * Site identity and configuration
+ * Used by site templates to define site-specific settings
+ */
+export interface SiteConfig {
+  /** Full site name (e.g., "Bentley Alberta") */
+  name: string;
+  /** Short name for mobile/compact displays */
+  shortName?: string;
+  /** Site description for SEO */
+  description: string;
+  /** Production URL */
+  url?: string;
+  /** Geographic location */
+  location: SiteLocation;
+  /** Navigation structure */
+  navigation: SiteNavigation;
+  /** Theme/branding */
+  theme?: SiteTheme;
+  /** Additional metadata */
+  meta?: {
+    /** Theme color for mobile browsers */
+    themeColor?: string;
+    /** Open Graph locale */
+    ogLocale?: string;
+    /** Google Tag Manager ID */
+    gtmId?: string;
+  };
+}
+
+// ============================================================================
+// Main Configuration
+// ============================================================================
+
 /**
  * Main SMRT configuration structure
  */
 export interface SmrtConfig {
   // Global SMRT framework options
   smrt?: SmrtGlobalConfig;
+
+  // Site identity and configuration (for site templates)
+  site?: SiteConfig;
 
   // Module-scoped configurations
   modules?: {

--- a/packages/template-site-static-json/README.md
+++ b/packages/template-site-static-json/README.md
@@ -1,0 +1,96 @@
+# Static Site Template (JSON Data)
+
+A template for creating static community news sites with JSON-based data storage.
+
+## Features
+
+- **Static Site Generation**: Pre-renders all pages for fast hosting
+- **JSON Data Storage**: Simple file-based data in `data/*.json`
+- **Weather Integration**: Environment Canada forecasts via Caelus
+- **Meeting Scraping**: Automated council meeting coverage via Praeco
+- **Config-Driven**: Site identity, navigation, and theming via `smrt.config.js`
+
+## Usage
+
+```bash
+# Create a new site
+smrt gnode create my-town-site --template site-static-json \
+  --location "My Town, AB" \
+  --lat 53.5 --lon -113.5
+
+# Navigate to project
+cd my-town-site
+
+# Install dependencies
+pnpm install
+
+# Copy environment variables
+cp .env.example .env
+
+# Initialize data files
+pnpm run init-data
+
+# Start development server
+pnpm dev
+```
+
+## Configuration
+
+Edit `smrt.config.js` to customize:
+
+### Site Identity
+
+```javascript
+site: {
+  name: 'My Town Alberta',
+  shortName: 'My Town',
+  description: 'Local news for My Town',
+  location: { name: 'My Town', latitude: 53.5, longitude: -113.5 },
+  navigation: { primary: [...], footer: [...] },
+  theme: { primaryColor: '#1976d2' },
+}
+```
+
+### Data Sources (Praeco)
+
+```javascript
+modules: {
+  praeco: {
+    sources: [
+      {
+        type: 'documents',
+        council: 'my-council',
+        url: 'https://example.com/meetings',
+      },
+    ],
+  },
+}
+```
+
+## Project Structure
+
+```
+my-town-site/
+├── smrt.config.js      # Site configuration
+├── data/               # JSON data storage
+├── scripts/
+│   └── init-data.ts    # Data initialization
+└── src/
+    ├── site.config.ts  # Site config helper
+    ├── routes/         # SvelteKit pages
+    └── lib/
+        └── utils/      # Shared utilities
+```
+
+## Deployment
+
+This template uses SvelteKit's static adapter. Build and deploy to any static host:
+
+```bash
+pnpm build
+# Deploy ./build to S3, Netlify, Vercel, etc.
+```
+
+## License
+
+MIT

--- a/packages/template-site-static-json/index.js
+++ b/packages/template-site-static-json/index.js
@@ -1,0 +1,8 @@
+/**
+ * Static Site Template
+ *
+ * Template for community news sites with JSON data storage.
+ * Use with: smrt gnode create <name> --template site-static-json
+ */
+
+export { default as config } from './template.config.js';

--- a/packages/template-site-static-json/package.json
+++ b/packages/template-site-static-json/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@happyvertical/smrt-template-site-static-json",
+  "version": "0.0.1",
+  "description": "Static community site template with JSON data storage and SMRT framework",
+  "type": "module",
+  "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./template/*": "./template/*"
+  },
+  "files": [
+    "template",
+    "template.config.js",
+    "index.js",
+    "README.md"
+  ],
+  "keywords": [
+    "smrt",
+    "sveltekit",
+    "template",
+    "scaffold",
+    "community-site",
+    "static-site",
+    "json"
+  ],
+  "author": "HappyVertical",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/smrt.git",
+    "directory": "packages/template-site-static-json"
+  },
+  "peerDependencies": {
+    "@happyvertical/smrt-core": "^0.17.0",
+    "@happyvertical/smrt-config": "^0.17.0"
+  }
+}

--- a/packages/template-site-static-json/template.config.js
+++ b/packages/template-site-static-json/template.config.js
@@ -1,0 +1,83 @@
+/**
+ * Static Site Template Configuration
+ *
+ * Template for community news sites with:
+ * - JSON-based data storage
+ * - Static site generation (SvelteKit)
+ * - Weather integration (Caelus)
+ * - Meeting scraping (Praeco)
+ * - Config-driven site identity
+ */
+
+export default {
+  name: 'site-static-json',
+  description: 'Static community site with JSON data storage',
+  framework: 'sveltekit',
+  version: '1.0.0',
+
+  // Template directory location
+  templateDir: './template',
+
+  // Dependencies for generated project
+  dependencies: {
+    '@happyvertical/smrt-core': '^0.17.0',
+    '@happyvertical/smrt-config': '^0.17.0',
+    '@happyvertical/smrt-svelte': '^0.17.0',
+    '@happyvertical/smrt-content': '^0.17.0',
+    '@happyvertical/smrt-events': '^0.17.0',
+    '@happyvertical/smrt-places': '^0.17.0',
+    '@happyvertical/smrt-profiles': '^0.17.0',
+    caelus: '^0.1.4',
+  },
+
+  devDependencies: {
+    '@happyvertical/praeco': '^0.0.42',
+    '@sveltejs/adapter-static': '^3.0.0',
+    '@sveltejs/kit': '^2.16.0',
+    '@sveltejs/vite-plugin-svelte': '^5.0.0',
+    svelte: '^5.15.0',
+    'svelte-check': '^4.1.0',
+    typescript: '^5.0.0',
+    vite: '^6.0.0',
+    tsx: '^4.0.0',
+  },
+
+  // Placeholder substitutions for template files
+  placeholders: {
+    '{{SITE_NAME}}': (ctx) => ctx.siteName,
+    '{{SITE_SHORT_NAME}}': (ctx) => {
+      // Extract first part of location or use site name
+      const loc = ctx.location || ctx.siteName;
+      return loc.split(',')[0].trim();
+    },
+    '{{PACKAGE_NAME}}': (ctx) => ctx.name.toLowerCase().replace(/[^a-z0-9-]/g, '-'),
+    '{{LOCATION_NAME}}': (ctx) => ctx.location || ctx.siteName,
+    '{{LATITUDE}}': (ctx) => String(ctx.latitude || 0),
+    '{{LONGITUDE}}': (ctx) => String(ctx.longitude || 0),
+    '{{TIMEZONE}}': (ctx) => ctx.timezone || 'America/Edmonton',
+  },
+
+  // Files configuration
+  files: {
+    skip: ['.gitkeep'],
+  },
+
+  // Post-generation hooks
+  hooks: {
+    afterGenerate: async (ctx) => {
+      console.log(`\n  Site "${ctx.siteName}" created successfully!`);
+      console.log('\nNext steps:');
+      console.log(`  cd ${ctx.name}`);
+      console.log('  pnpm install');
+      console.log('  cp .env.example .env');
+      console.log('  pnpm run init-data');
+      console.log('  pnpm dev');
+      console.log();
+      console.log('To configure your site:');
+      console.log('  1. Edit smrt.config.js to add Praeco sources (councils)');
+      console.log('  2. Customize about/contact page content');
+      console.log('  3. Update theme colors in smrt.config.js');
+      console.log();
+    },
+  },
+};

--- a/packages/template-site-static-json/template/.env.example
+++ b/packages/template-site-static-json/template/.env.example
@@ -1,0 +1,8 @@
+# AI Provider (for Praeco article generation)
+GEMINI_API_KEY=your-gemini-api-key
+
+# Optional: Google Tag Manager
+# PUBLIC_GTM_ID=GTM-XXXXXX
+
+# Optional: Custom domain for deployment
+# CUSTOM_DOMAIN=example.com

--- a/packages/template-site-static-json/template/.gitignore
+++ b/packages/template-site-static-json/template/.gitignore
@@ -1,0 +1,30 @@
+# Dependencies
+node_modules
+
+# Build outputs
+.svelte-kit
+build
+dist
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# Editor
+.vscode
+.idea
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Data files (generated, not committed)
+data/*.json
+!data/.gitkeep
+
+# Logs
+*.log
+npm-debug.log*

--- a/packages/template-site-static-json/template/README.md
+++ b/packages/template-site-static-json/template/README.md
@@ -1,0 +1,59 @@
+# {{SITE_NAME}}
+
+Local news and community information for {{LOCATION_NAME}}.
+
+## Getting Started
+
+```bash
+# Install dependencies
+pnpm install
+
+# Initialize data files
+pnpm run init-data
+
+# Start development server
+pnpm dev
+```
+
+## Configuration
+
+Edit `smrt.config.js` to configure:
+
+- **Site identity**: Name, location, navigation
+- **Data sources**: Council meeting URLs for Praeco
+- **Weather**: Location coordinates for Caelus
+
+## Workflows
+
+```bash
+# Fetch weather data
+pnpm workflow:caelus
+
+# Generate articles from council meetings
+pnpm workflow:praeco
+```
+
+## Deployment
+
+```bash
+# Build static site
+pnpm build
+
+# Preview production build
+pnpm preview
+```
+
+Deploy the `build/` directory to any static host (S3, Netlify, Vercel, etc.).
+
+## Project Structure
+
+```
+├── smrt.config.js      # Site configuration
+├── data/               # JSON data storage
+├── scripts/            # Utility scripts
+└── src/
+    ├── site.config.ts  # Config helper
+    ├── app.css         # Global styles
+    ├── routes/         # SvelteKit pages
+    └── lib/            # Shared utilities
+```

--- a/packages/template-site-static-json/template/data/.gitkeep
+++ b/packages/template-site-static-json/template/data/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures the data directory exists in git.
+# JSON data files are generated and not committed.

--- a/packages/template-site-static-json/template/package.json
+++ b/packages/template-site-static-json/template/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "{{PACKAGE_NAME}}",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "init-data": "tsx scripts/init-data.ts",
+    "workflow:caelus": "tsx src/workflows/caelus.ts",
+    "workflow:praeco": "npx praeco --config smrt.config.js",
+    "validate:json": "tsx scripts/validate-json.ts",
+    "validate:slugs": "tsx scripts/validate-slugs.ts"
+  },
+  "devDependencies": {},
+  "dependencies": {}
+}

--- a/packages/template-site-static-json/template/scripts/init-data.ts
+++ b/packages/template-site-static-json/template/scripts/init-data.ts
@@ -1,0 +1,56 @@
+/**
+ * Initialize Data Directory
+ *
+ * Creates empty JSON files for the site's data storage.
+ * Run this after creating a new site: pnpm run init-data
+ */
+
+import { mkdir, writeFile, access } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const DATA_DIR = join(process.cwd(), 'data');
+
+const INITIAL_FILES: Record<string, any[]> = {
+  'contents.json': [],
+  'events.json': [],
+  'places.json': [],
+  'profiles.json': [],
+  'assets.json': [],
+};
+
+async function initData() {
+  console.log('Initializing data directory...\n');
+
+  // Ensure data directory exists
+  try {
+    await access(DATA_DIR);
+    console.log('  ✓ data/ directory exists');
+  } catch {
+    await mkdir(DATA_DIR, { recursive: true });
+    console.log('  ✓ Created data/ directory');
+  }
+
+  // Create each data file if it doesn't exist
+  for (const [filename, initialData] of Object.entries(INITIAL_FILES)) {
+    const filepath = join(DATA_DIR, filename);
+    try {
+      await access(filepath);
+      console.log(`  • ${filename} exists, skipping`);
+    } catch {
+      await writeFile(filepath, JSON.stringify(initialData, null, 2));
+      console.log(`  ✓ Created ${filename}`);
+    }
+  }
+
+  console.log('\n✅ Data initialization complete!');
+  console.log('\nNext steps:');
+  console.log('  1. Configure smrt.config.js with your council sources');
+  console.log('  2. Run pnpm workflow:caelus to fetch weather data');
+  console.log('  3. Run pnpm workflow:praeco to generate articles');
+  console.log('  4. Run pnpm dev to start the development server');
+}
+
+initData().catch((error) => {
+  console.error('Failed to initialize data:', error);
+  process.exit(1);
+});

--- a/packages/template-site-static-json/template/smrt.config.js
+++ b/packages/template-site-static-json/template/smrt.config.js
@@ -1,0 +1,126 @@
+/**
+ * SMRT Configuration for {{SITE_NAME}}
+ *
+ * This file configures site identity, navigation, data sources, and workflows.
+ */
+
+export default {
+  // Site identity (used by components for titles, navigation, SEO)
+  site: {
+    name: '{{SITE_NAME}}',
+    shortName: '{{SITE_SHORT_NAME}}',
+    description: 'Local news and community information for {{LOCATION_NAME}}',
+    url: 'https://{{PACKAGE_NAME}}.com',
+    location: {
+      name: '{{LOCATION_NAME}}',
+      latitude: {{LATITUDE}},
+      longitude: {{LONGITUDE}},
+      timezone: '{{TIMEZONE}}',
+    },
+    navigation: {
+      primary: [
+        { label: 'Politics', href: '/politics' },
+        { label: 'Weather', href: '/weather' },
+      ],
+      footer: [
+        { label: 'About', href: '/about' },
+        { label: 'Contact', href: '/contact' },
+        { label: 'RSS', href: '/rss.xml' },
+      ],
+    },
+    theme: {
+      primaryColor: '#1976d2',
+      primaryLight: '#e3f2fd',
+      primaryDark: '#0d47a1',
+    },
+  },
+
+  // Site-wide category definitions (for routing/navigation)
+  categories: {
+    politics: {
+      name: 'Politics',
+      children: {
+        local: { name: 'Local Government' },
+        county: { name: 'County Government' },
+      },
+    },
+    community: {
+      name: 'Community',
+      children: {
+        events: { name: 'Events' },
+      },
+    },
+  },
+
+  // Global package settings
+  packages: {
+    cli: {
+      verbose: true,
+      database: {
+        type: 'json',
+        url: './data',
+      },
+    },
+    ai: {
+      defaultProvider: 'claude-cli',
+      defaultModel: 'sonnet',
+    },
+  },
+
+  // Module-specific configurations
+  modules: {
+    // Praeco module configuration (meeting scraper)
+    praeco: {
+      db: {
+        type: 'json',
+        url: './data',
+        writeStrategy: 'immediate',
+      },
+      ai: {
+        type: 'gemini',
+        model: 'gemini-2.0-flash-exp',
+        apiKey: process.env.GEMINI_API_KEY,
+      },
+      analyzeOptions: {
+        detailLevel: 'comprehensive',
+      },
+      // Add your council sources here
+      sources: [
+        // Example:
+        // {
+        //   type: 'documents',
+        //   council: 'my-council',
+        //   url: 'https://example.com/meetings/',
+        // },
+      ],
+      // Add your report configurations here
+      reports: [
+        // Example:
+        // {
+        //   type: 'meeting-recap',
+        //   council: 'my-council',
+        //   category: 'politics/local',
+        //   author: '{{SITE_SHORT_NAME}} Reporter',
+        //   role: 'You are a professional journalist writing for {{LOCATION_NAME}} residents.',
+        // },
+      ],
+    },
+
+    // Caelus module configuration (weather)
+    caelus: {
+      db: {
+        type: 'json',
+        url: './data',
+        writeStrategy: 'immediate',
+        clearCache: true,
+      },
+      provider: 'environment-canada',
+      location: {
+        name: '{{LOCATION_NAME}}',
+        latitude: {{LATITUDE}},
+        longitude: {{LONGITUDE}},
+      },
+      logLevel: 'info',
+    },
+  },
+};

--- a/packages/template-site-static-json/template/src/app.css
+++ b/packages/template-site-static-json/template/src/app.css
@@ -1,0 +1,156 @@
+/**
+ * Global CSS for {{SITE_NAME}}
+ * Design tokens as CSS custom properties
+ */
+
+:root {
+  /* Colors - Primary (customize these in smrt.config.js site.theme) */
+  --color-primary: #1976d2;
+  --color-primary-main: #1976d2;
+  --color-primary-light: #e3f2fd;
+  --color-primary-dark: #0d47a1;
+
+  /* Colors - Neutral */
+  --color-neutral-white: #ffffff;
+  --color-neutral-gray100: #f5f5f5;
+  --color-neutral-gray200: #eeeeee;
+  --color-neutral-gray300: #e0e0e0;
+  --color-neutral-gray400: #bdbdbd;
+  --color-neutral-gray500: #9e9e9e;
+  --color-neutral-gray600: #757575;
+  --color-neutral-gray700: #616161;
+  --color-neutral-gray800: #424242;
+  --color-neutral-gray900: #212121;
+
+  /* Colors - Semantic */
+  --color-semantic-success: #4caf50;
+  --color-semantic-warning: #ff9800;
+  --color-semantic-error: #f44336;
+  --color-semantic-info: #2196f3;
+
+  /* Colors - Text */
+  --color-text-primary: #333333;
+  --color-text-secondary: #666666;
+  --color-text-disabled: #9e9e9e;
+  --color-text-inverse: #ffffff;
+
+  /* Spacing */
+  --spacing-xs: 0.25rem;
+  --spacing-sm: 0.5rem;
+  --spacing-md: 1rem;
+  --spacing-lg: 1.5rem;
+  --spacing-xl: 2rem;
+  --spacing-2xl: 3rem;
+  --spacing-3xl: 4rem;
+
+  /* Typography */
+  --font-family-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  --font-family-serif: Georgia, 'Times New Roman', serif;
+  --font-family-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+
+  --font-size-xs: 0.75rem;
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --font-size-lg: 1.125rem;
+  --font-size-xl: 1.25rem;
+  --font-size-2xl: 1.5rem;
+  --font-size-3xl: 1.875rem;
+  --font-size-4xl: 2.25rem;
+
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  --line-height-tight: 1.2;
+  --line-height-normal: 1.6;
+  --line-height-relaxed: 1.8;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+
+  /* Border Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-full: 9999px;
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-base: 200ms ease;
+  --transition-slow: 300ms ease;
+}
+
+/* Reset and base styles */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-normal);
+  color: var(--color-text-primary);
+  background: var(--color-neutral-white);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Typography defaults */
+h1, h2, h3, h4, h5, h6 {
+  margin: 0;
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--line-height-tight);
+  color: var(--color-text-primary);
+}
+
+p {
+  margin: 0;
+}
+
+a {
+  color: var(--color-primary-main);
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+
+a:hover {
+  color: var(--color-primary-dark);
+}
+
+/* Focus styles for accessibility */
+:focus-visible {
+  outline: 2px solid var(--color-primary-main);
+  outline-offset: 2px;
+}
+
+/* Remove default button styles */
+button {
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+/* Utility classes */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}

--- a/packages/template-site-static-json/template/src/app.d.ts
+++ b/packages/template-site-static-json/template/src/app.d.ts
@@ -1,0 +1,13 @@
+// See https://svelte.dev/docs/kit/types#app.d.ts
+// for information about these interfaces
+declare global {
+  namespace App {
+    // interface Error {}
+    // interface Locals {}
+    // interface PageData {}
+    // interface PageState {}
+    // interface Platform {}
+  }
+}
+
+export {};

--- a/packages/template-site-static-json/template/src/app.html
+++ b/packages/template-site-static-json/template/src/app.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%sveltekit.assets%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
+</html>

--- a/packages/template-site-static-json/template/src/lib/utils/markdown.ts
+++ b/packages/template-site-static-json/template/src/lib/utils/markdown.ts
@@ -1,0 +1,35 @@
+/**
+ * Simple Markdown Renderer
+ *
+ * Converts basic markdown to HTML for article bodies.
+ * For more complex needs, consider using a library like marked or remark.
+ */
+
+export function renderMarkdown(md: string): string {
+  if (!md) return '';
+
+  return md
+    // Escape HTML entities
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    // Headers
+    .replace(/^### (.+)$/gm, '<h3>$1</h3>')
+    .replace(/^## (.+)$/gm, '<h2>$1</h2>')
+    .replace(/^# (.+)$/gm, '<h1>$1</h1>')
+    // Bold and italic
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*(.+?)\*/g, '<em>$1</em>')
+    // Lists
+    .replace(/^- (.+)$/gm, '<li>$1</li>')
+    .replace(/(<li>.*<\/li>\n?)+/g, '<ul>$&</ul>')
+    // Paragraphs
+    .replace(/\n\n/g, '</p><p>')
+    .replace(/\n/g, '<br>')
+    .replace(/^/, '<p>')
+    .replace(/$/, '</p>')
+    // Clean up
+    .replace(/<p><\/p>/g, '')
+    .replace(/<p>(<[hu])/g, '$1')
+    .replace(/(<\/[hu]l>)<\/p>/g, '$1');
+}

--- a/packages/template-site-static-json/template/src/routes/+layout.server.ts
+++ b/packages/template-site-static-json/template/src/routes/+layout.server.ts
@@ -1,0 +1,193 @@
+// Enable prerendering for static site generation
+export const prerender = true;
+
+// Use trailing slashes for clean URLs
+export const trailingSlash = 'always';
+
+import type { LayoutServerLoad } from './$types';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { initSiteConfig } from '../site.config';
+
+interface ForecastPeriod {
+  name: string;
+  conditions: string;
+  temperature: number;
+  windSpeed: number;
+  windDirection: number;
+  humidity: number;
+  precipProbability: number;
+  localHour: number;
+}
+
+interface ForecastDay {
+  day: string;
+  icon: string;
+  high: number;
+  low: number;
+  periods: ForecastPeriod[];
+}
+
+function getWeatherIcon(conditions: string): string {
+  const conditionsLower = conditions.toLowerCase();
+
+  if (conditionsLower.includes('sunny') || conditionsLower.includes('clear')) return '☀️';
+  if (conditionsLower.includes('partly cloudy') || conditionsLower.includes('a few clouds')) return '⛅';
+  if (conditionsLower.includes('cloud')) return '☁️';
+  if (conditionsLower.includes('rain') || conditionsLower.includes('shower')) return '🌧️';
+  if (conditionsLower.includes('snow')) return '❄️';
+  if (conditionsLower.includes('thunder') || conditionsLower.includes('storm')) return '⛈️';
+  if (conditionsLower.includes('fog')) return '🌫️';
+
+  return '🌤️';
+}
+
+interface WeatherForecastData {
+  id?: string;
+  name: string;
+  issued_at: string;
+  conditions: string;
+  temperature?: string | number;
+  temperature_high?: string | number;
+  temperature_low?: string | number;
+  wind_speed?: string | number;
+  wind_direction?: string | number;
+  humidity?: string | number;
+  precipitation_probability?: string | number;
+}
+
+export const load: LayoutServerLoad = async () => {
+  // Load site config
+  const siteConfig = await initSiteConfig();
+
+  // Load weather data
+  let weather: ForecastDay[] | null = null;
+
+  try {
+    const eventsPath = join(process.cwd(), 'data', 'events.json');
+    const eventsRaw = await readFile(eventsPath, 'utf-8');
+    const allEvents = JSON.parse(eventsRaw);
+
+    const allForecasts: WeatherForecastData[] = allEvents
+      .filter((e: any) => e._meta_type === 'WeatherForecast')
+      .map((e: any) => {
+        const meta = typeof e._meta_data === 'string' ? JSON.parse(e._meta_data) : e._meta_data;
+        return {
+          id: e.id,
+          name: e.name,
+          issued_at: meta?.issuedAt || e.created_at,
+          conditions: meta?.conditions || '',
+          temperature: meta?.temperature,
+          temperature_high: meta?.temperatureHigh,
+          temperature_low: meta?.temperatureLow,
+          wind_speed: meta?.windSpeed,
+          wind_direction: meta?.windDirection,
+          humidity: meta?.humidity,
+          precipitation_probability: meta?.precipProbability,
+        };
+      });
+
+    allForecasts.sort((a, b) => new Date(a.issued_at).getTime() - new Date(b.issued_at).getTime());
+
+    if (allForecasts.length > 0) {
+      const hourlyForecastsRaw = allForecasts.filter((f) => f.name.includes('(') && f.name.includes(')'));
+
+      const dailyForecasts = new Map<
+        string,
+        {
+          high: number;
+          low: number;
+          conditions: string;
+          date: Date;
+          dayName: string;
+          periods: ForecastPeriod[];
+          temps: number[];
+        }
+      >();
+
+      const now = new Date();
+      const timezone = siteConfig.location.timezone || 'America/Edmonton';
+      const todayInTimezone = new Date(now.toLocaleString('en-US', { timeZone: timezone }));
+
+      for (const forecast of hourlyForecastsRaw) {
+        const timeMatch = forecast.name.match(/\((\d+):(\d+)\)/);
+        if (!timeMatch) continue;
+
+        const hour = parseInt(timeMatch[1]!);
+        const localHour = hour;
+
+        const fullDayName = forecast.name.split(' ')[0]!;
+        const dayName = fullDayName.substring(0, 3);
+
+        const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+        const forecastDayOfWeek = dayNames.indexOf(fullDayName);
+
+        if (forecastDayOfWeek === -1) continue;
+
+        const todayDayOfWeek = todayInTimezone.getDay();
+        let daysFromToday = forecastDayOfWeek - todayDayOfWeek;
+        if (daysFromToday < 0) daysFromToday += 7;
+
+        const forecastDate = new Date(todayInTimezone);
+        forecastDate.setDate(todayInTimezone.getDate() + daysFromToday);
+
+        const dateKey = forecastDate.toLocaleDateString('en-CA', { timeZone: timezone });
+        const temp = Math.round(Number(forecast.temperature) || 0);
+
+        const period: ForecastPeriod = {
+          name: forecast.name,
+          conditions: forecast.conditions,
+          temperature: temp,
+          windSpeed: Math.round(Number(forecast.wind_speed) || 0),
+          windDirection: Math.round(Number(forecast.wind_direction) || 0),
+          humidity: Math.round(Number(forecast.humidity) || 0),
+          precipProbability: Math.round(Number(forecast.precipitation_probability) || 0),
+          localHour,
+        };
+
+        if (!dailyForecasts.has(dateKey)) {
+          dailyForecasts.set(dateKey, {
+            high: temp,
+            low: temp,
+            conditions: forecast.conditions,
+            date: forecastDate,
+            dayName,
+            periods: [],
+            temps: [],
+          });
+        }
+
+        const day = dailyForecasts.get(dateKey)!;
+        day.periods.push(period);
+        day.temps.push(temp);
+        day.high = Math.max(day.high, temp);
+        day.low = Math.min(day.low, temp);
+        if (localHour >= 12 && localHour <= 17) {
+          day.conditions = forecast.conditions;
+        }
+      }
+
+      for (const [_, dayData] of dailyForecasts.entries()) {
+        dayData.periods.sort((a, b) => a.localHour - b.localHour);
+      }
+
+      weather = Array.from(dailyForecasts.values())
+        .sort((a, b) => a.date.getTime() - b.date.getTime())
+        .slice(0, 10)
+        .map(({ high, low, conditions, dayName, periods }) => ({
+          day: dayName,
+          icon: getWeatherIcon(conditions),
+          high,
+          low,
+          periods,
+        }));
+    }
+  } catch (error) {
+    console.error('Failed to load weather:', error);
+  }
+
+  return {
+    siteConfig,
+    weather,
+  };
+};

--- a/packages/template-site-static-json/template/src/routes/+layout.svelte
+++ b/packages/template-site-static-json/template/src/routes/+layout.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import type { LayoutData } from './$types';
+  import '../app.css';
+  import { Masthead, WeatherHeader, Footer, Container } from '@happyvertical/smrt-svelte';
+
+  let { children, data }: { children: any; data: LayoutData } = $props();
+
+  const { siteConfig, weather } = data;
+</script>
+
+<svelte:head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content={siteConfig.theme?.primaryColor || '#1976d2'} />
+  {#if siteConfig.meta?.gtmId}
+    <!-- Google Tag Manager -->
+    {@html `<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${siteConfig.meta.gtmId}');</script>`}
+  {/if}
+</svelte:head>
+
+<div class="layout">
+  <div class="weather-header">
+    <Container>
+      <WeatherHeader forecast={weather} />
+    </Container>
+  </div>
+
+  <Masthead location={siteConfig.location.name}>
+    {#snippet nav()}
+      {#each siteConfig.navigation.primary as link}
+        <a href={link.href}>{link.label}</a>
+      {/each}
+    {/snippet}
+  </Masthead>
+
+  <main class="main">
+    <Container>
+      {@render children?.()}
+    </Container>
+  </main>
+
+  <Footer>
+    {#snippet children()}
+      {#each siteConfig.navigation.footer || [] as link, i}
+        {#if i > 0} • {/if}
+        <a href={link.href}>{link.label}</a>
+      {/each}
+    {/snippet}
+  </Footer>
+</div>
+
+<style>
+  .layout {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+  }
+
+  .weather-header {
+    background: var(--color-neutral-white);
+    border-bottom: 1px solid var(--color-neutral-gray300);
+  }
+
+  .main {
+    flex: 1;
+    padding: var(--spacing-xl) 0;
+  }
+</style>

--- a/packages/template-site-static-json/template/src/routes/+page.server.ts
+++ b/packages/template-site-static-json/template/src/routes/+page.server.ts
@@ -1,0 +1,60 @@
+import type { PageServerLoad } from './$types';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { getSite } from '../site.config';
+
+export const prerender = true;
+
+const ARTICLES_PER_PAGE = 5;
+
+function getAllArticles() {
+  try {
+    const contentsPath = join(process.cwd(), 'data', 'contents.json');
+    const contentsJson = readFileSync(contentsPath, 'utf-8');
+    const allContents = JSON.parse(contentsJson);
+
+    return allContents
+      .filter((content: any) => content._meta_type === 'MeetingRecap')
+      .sort((a: any, b: any) => new Date(b.publish_date).getTime() - new Date(a.publish_date).getTime());
+  } catch {
+    return [];
+  }
+}
+
+function mapArticle(article: any) {
+  return {
+    id: article.id,
+    slug: article.slug,
+    title: article.title || '',
+    description: article.description || '',
+    body: article.body || '',
+    publish_date: article.publish_date || article.created_at,
+    created_at: article.created_at,
+    meeting_id: article.meeting_id,
+    council_id: article.council_id,
+    category: article.category || null,
+  };
+}
+
+export const load: PageServerLoad = async ({ parent }) => {
+  const { siteConfig } = await parent();
+
+  const articles = getAllArticles();
+  const totalArticles = articles.length;
+  const totalPages = Math.ceil(totalArticles / ARTICLES_PER_PAGE);
+
+  const articlesData = articles.slice(0, ARTICLES_PER_PAGE).map(mapArticle);
+
+  return {
+    siteConfig,
+    articles: articlesData,
+    events: [],
+    pagination: {
+      currentPage: 1,
+      totalPages,
+      totalArticles,
+      hasNextPage: totalPages > 1,
+      hasPrevPage: false,
+    },
+  };
+};

--- a/packages/template-site-static-json/template/src/routes/+page.svelte
+++ b/packages/template-site-static-json/template/src/routes/+page.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+  import { Pagination } from '@happyvertical/smrt-svelte';
+
+  let { data }: { data: PageData } = $props();
+  const { articles, pagination, siteConfig } = data;
+
+  function formatDate(dateString: string): string {
+    return new Date(dateString).toLocaleDateString('en-CA', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  }
+</script>
+
+<svelte:head>
+  <title>{siteConfig.name} - Local News & Weather</title>
+  <meta name="description" content={siteConfig.description} />
+</svelte:head>
+
+<div class="home">
+  <section class="articles">
+    <h1>Latest News</h1>
+
+    {#if articles.length === 0}
+      <div class="empty-state">
+        <p>No articles yet. Run <code>pnpm workflow:praeco</code> to generate content from council meetings.</p>
+      </div>
+    {:else}
+      <div class="article-list">
+        {#each articles as article}
+          <article class="article-card">
+            <a href="/{article.category}/{article.slug}/">
+              <h2>{article.title}</h2>
+              <p class="description">{article.description}</p>
+              <time datetime={article.publish_date}>{formatDate(article.publish_date)}</time>
+            </a>
+          </article>
+        {/each}
+      </div>
+
+      {#if pagination.totalPages > 1}
+        <Pagination
+          currentPage={pagination.currentPage}
+          totalPages={pagination.totalPages}
+          baseUrl="/page"
+        />
+      {/if}
+    {/if}
+  </section>
+</div>
+
+<style>
+  .home {
+    max-width: 800px;
+  }
+
+  h1 {
+    font-size: var(--font-size-2xl);
+    margin-bottom: var(--spacing-lg);
+    color: var(--color-neutral-gray900);
+  }
+
+  .empty-state {
+    padding: var(--spacing-xl);
+    background: var(--color-neutral-gray100);
+    border-radius: var(--radius-md);
+    text-align: center;
+  }
+
+  .empty-state code {
+    background: var(--color-neutral-gray200);
+    padding: var(--spacing-xs) var(--spacing-sm);
+    border-radius: var(--radius-sm);
+    font-family: monospace;
+  }
+
+  .article-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-lg);
+  }
+
+  .article-card {
+    border-bottom: 1px solid var(--color-neutral-gray200);
+    padding-bottom: var(--spacing-lg);
+  }
+
+  .article-card:last-child {
+    border-bottom: none;
+  }
+
+  .article-card a {
+    text-decoration: none;
+    color: inherit;
+  }
+
+  .article-card h2 {
+    font-size: var(--font-size-xl);
+    margin-bottom: var(--spacing-sm);
+    color: var(--color-primary);
+  }
+
+  .article-card:hover h2 {
+    text-decoration: underline;
+  }
+
+  .description {
+    color: var(--color-neutral-gray700);
+    margin-bottom: var(--spacing-sm);
+  }
+
+  time {
+    font-size: var(--font-size-sm);
+    color: var(--color-neutral-gray500);
+  }
+</style>

--- a/packages/template-site-static-json/template/src/routes/about/+page.server.ts
+++ b/packages/template-site-static-json/template/src/routes/about/+page.server.ts
@@ -1,0 +1,8 @@
+import type { PageServerLoad } from './$types';
+
+export const prerender = true;
+
+export const load: PageServerLoad = async ({ parent }) => {
+  const { siteConfig } = await parent();
+  return { siteConfig };
+};

--- a/packages/template-site-static-json/template/src/routes/about/+page.svelte
+++ b/packages/template-site-static-json/template/src/routes/about/+page.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+  const { siteConfig } = data;
+</script>
+
+<svelte:head>
+  <title>About - {siteConfig.name}</title>
+  <meta name="description" content="About {siteConfig.name}" />
+</svelte:head>
+
+<div class="about">
+  <h1>About {siteConfig.name}</h1>
+
+  <section>
+    <h2>Our Mission</h2>
+    <p>
+      {siteConfig.name} provides timely, accurate, and comprehensive coverage of local government,
+      community events, and news for {siteConfig.location.name} and surrounding areas.
+    </p>
+  </section>
+
+  <section>
+    <h2>What We Cover</h2>
+    <ul>
+      <li><strong>Local Government</strong> - Council meetings, decisions, and policy changes</li>
+      <li><strong>County News</strong> - Regional government coverage</li>
+      <li><strong>Weather</strong> - Local forecasts from Environment Canada</li>
+      <li><strong>Community Events</strong> - Local happenings and announcements</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>How It Works</h2>
+    <p>
+      Our coverage is powered by AI-assisted journalism that processes official government documents
+      to create clear, accessible summaries of council meetings and decisions. This helps residents
+      stay informed about matters that affect their daily lives.
+    </p>
+  </section>
+
+  <section>
+    <h2>Contact</h2>
+    <p>
+      Have questions, feedback, or a tip? <a href="/contact">Contact us</a>.
+    </p>
+  </section>
+</div>
+
+<style>
+  .about {
+    max-width: 700px;
+  }
+
+  h1 {
+    font-size: var(--font-size-2xl);
+    margin-bottom: var(--spacing-xl);
+    color: var(--color-neutral-gray900);
+  }
+
+  section {
+    margin-bottom: var(--spacing-xl);
+  }
+
+  h2 {
+    font-size: var(--font-size-lg);
+    margin-bottom: var(--spacing-md);
+    color: var(--color-neutral-gray800);
+  }
+
+  p {
+    line-height: 1.7;
+    color: var(--color-neutral-gray700);
+    margin-bottom: var(--spacing-md);
+  }
+
+  ul {
+    list-style: disc;
+    padding-left: var(--spacing-lg);
+    color: var(--color-neutral-gray700);
+  }
+
+  li {
+    margin-bottom: var(--spacing-sm);
+    line-height: 1.6;
+  }
+
+  a {
+    color: var(--color-primary);
+  }
+</style>

--- a/packages/template-site-static-json/template/src/routes/contact/+page.server.ts
+++ b/packages/template-site-static-json/template/src/routes/contact/+page.server.ts
@@ -1,0 +1,8 @@
+import type { PageServerLoad } from './$types';
+
+export const prerender = true;
+
+export const load: PageServerLoad = async ({ parent }) => {
+  const { siteConfig } = await parent();
+  return { siteConfig };
+};

--- a/packages/template-site-static-json/template/src/routes/contact/+page.svelte
+++ b/packages/template-site-static-json/template/src/routes/contact/+page.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+  const { siteConfig } = data;
+</script>
+
+<svelte:head>
+  <title>Contact - {siteConfig.name}</title>
+  <meta name="description" content="Contact {siteConfig.name}" />
+</svelte:head>
+
+<div class="contact">
+  <h1>Contact {siteConfig.name}</h1>
+
+  <section>
+    <h2>Get in Touch</h2>
+    <p>
+      Have a question, feedback, or news tip? We'd love to hear from you.
+    </p>
+    <p>
+      <strong>Email:</strong> <a href="mailto:contact@{{PACKAGE_NAME}}.com">contact@{{PACKAGE_NAME}}.com</a>
+    </p>
+  </section>
+
+  <section>
+    <h2>Submit a Tip</h2>
+    <p>
+      Know about an upcoming event, a community story, or something happening in {siteConfig.location.name}?
+      Send us a message and we'll look into it.
+    </p>
+  </section>
+
+  <section>
+    <h2>Official Resources</h2>
+    <p>
+      For official government business, please contact your local government directly.
+    </p>
+  </section>
+
+  <section class="disclaimer">
+    <h2>Disclaimer</h2>
+    <p>
+      {siteConfig.name} is an independent community news service. We are not affiliated with
+      any government entity. Our coverage is based on publicly available documents and official sources.
+    </p>
+  </section>
+</div>
+
+<style>
+  .contact {
+    max-width: 700px;
+  }
+
+  h1 {
+    font-size: var(--font-size-2xl);
+    margin-bottom: var(--spacing-xl);
+    color: var(--color-neutral-gray900);
+  }
+
+  section {
+    margin-bottom: var(--spacing-xl);
+  }
+
+  h2 {
+    font-size: var(--font-size-lg);
+    margin-bottom: var(--spacing-md);
+    color: var(--color-neutral-gray800);
+  }
+
+  p {
+    line-height: 1.7;
+    color: var(--color-neutral-gray700);
+    margin-bottom: var(--spacing-md);
+  }
+
+  a {
+    color: var(--color-primary);
+  }
+
+  .disclaimer {
+    padding: var(--spacing-lg);
+    background: var(--color-neutral-gray100);
+    border-radius: var(--radius-md);
+  }
+
+  .disclaimer h2 {
+    font-size: var(--font-size-md);
+  }
+
+  .disclaimer p {
+    font-size: var(--font-size-sm);
+    margin-bottom: 0;
+  }
+</style>

--- a/packages/template-site-static-json/template/src/site.config.ts
+++ b/packages/template-site-static-json/template/src/site.config.ts
@@ -1,0 +1,35 @@
+/**
+ * Site Configuration Helper
+ *
+ * Provides typed access to site configuration from smrt.config.js
+ */
+
+import { loadConfig, getSiteConfig, type SiteConfig } from '@happyvertical/smrt-config';
+
+let _siteConfig: SiteConfig | null = null;
+
+/**
+ * Initialize and load site configuration
+ * Call this in +layout.server.ts before accessing config
+ */
+export async function initSiteConfig(): Promise<SiteConfig> {
+  if (!_siteConfig) {
+    await loadConfig();
+    _siteConfig = getSiteConfig();
+  }
+  if (!_siteConfig) {
+    throw new Error('Site configuration not found in smrt.config.js. Ensure site: {} section exists.');
+  }
+  return _siteConfig;
+}
+
+/**
+ * Get site configuration synchronously
+ * Only call after initSiteConfig() has been called
+ */
+export function getSite(): SiteConfig {
+  if (!_siteConfig) {
+    throw new Error('Site config not initialized. Call initSiteConfig() in +layout.server.ts first.');
+  }
+  return _siteConfig;
+}

--- a/packages/template-site-static-json/template/svelte.config.js
+++ b/packages/template-site-static-json/template/svelte.config.js
@@ -1,0 +1,19 @@
+import adapter from '@sveltejs/adapter-static';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  preprocess: vitePreprocess(),
+
+  kit: {
+    adapter: adapter({
+      pages: 'build',
+      assets: 'build',
+      fallback: undefined,
+      precompress: false,
+      strict: true,
+    }),
+  },
+};
+
+export default config;

--- a/packages/template-site-static-json/template/tsconfig.json
+++ b/packages/template-site-static-json/template/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "moduleResolution": "bundler"
+  }
+}

--- a/packages/template-site-static-json/template/vite.config.ts
+++ b/packages/template-site-static-json/template/vite.config.ts
@@ -1,0 +1,6 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [sveltekit()],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -729,6 +729,15 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@24.0.0)(happy-dom@20.0.11)(jsdom@27.1.0)
 
+  packages/template-site-static-json:
+    dependencies:
+      '@happyvertical/smrt-config':
+        specifier: workspace:*
+        version: link:../config
+      '@happyvertical/smrt-core':
+        specifier: workspace:*
+        version: link:../core
+
   packages/template-sveltekit:
     dependencies:
       '@happyvertical/smrt-core':
@@ -5694,7 +5703,6 @@ packages:
 
   libsql@0.5.22:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lines-and-columns@1.2.4:
@@ -9674,7 +9682,7 @@ snapshots:
       agentkeepalive: 4.6.0
       axios: 1.13.2(debug@4.4.3)
       query-string: 7.1.3
-      retry-axios: 2.6.0(axios@1.13.2(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.13.2)
     transitivePeerDependencies:
       - debug
 
@@ -13541,7 +13549,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.13.2(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.13.2)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -15134,7 +15142,7 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
-  retry-axios@2.6.0(axios@1.13.2(debug@4.4.3)):
+  retry-axios@2.6.0(axios@1.13.2):
     dependencies:
       axios: 1.13.2(debug@4.4.3)
 


### PR DESCRIPTION
## Summary

- Add `SiteConfig` types to smrt-config for site metadata, navigation, location, and theme
- Add `getSiteConfig()` helper to retrieve site configuration from `smrt.config.js`
- Add placeholder substitution to CLI generator for template customization
- Add site CLI options (`--location`, `--lat`, `--lon`, `--timezone`) to `gnode create`
- Register `site-static-json` and `community-site` template aliases
- Create `template-site-static-json` package for static sites with JSON data storage

This enables creating config-driven community news sites with:
- Config-driven navigation and footer links
- Location-aware weather integration
- Praeco meeting coverage module support
- Static site generation with SvelteKit

## Usage

```bash
smrt gnode create my-town-site --template site-static-json \
  --location "My Town, AB" \
  --lat 53.5 --lon -113.5 \
  --timezone "America/Edmonton"
```

## Test plan

- [ ] Verify `getSiteConfig()` returns site config from smrt.config.js
- [ ] Test placeholder substitution in generator
- [ ] Test `smrt gnode create` with new site options
- [ ] Verify template generates a working SvelteKit site