### PR TITLE
fix(cli): load user classes even without local manifest

### DIFF
--- a/packages/cli/src/cli-generator.ts
+++ b/packages/cli/src/cli-generator.ts
@@ -452,12 +452,13 @@ export class CLIGenerator {
           manifest.packageName,
         );
       }
-
-      // IMPORTANT: Try to load actual compiled classes for runtime execution
-      // The manifest registration above provides metadata for command generation,
-      // but we need real class constructors for executing commands (CRUD, custom methods)
-      await this.tryLoadUserClasses();
     }
+
+    // IMPORTANT: Try to load actual compiled classes for runtime execution
+    // This must run even when no local manifest exists - the project may use
+    // external packages (like praeco) that have their own manifests and classes.
+    // The .smrt/register.js file imports these external packages and registers them.
+    await this.tryLoadUserClasses();
 
     const registeredClasses = ObjectRegistry.getAllClasses();
 


### PR DESCRIPTION
## Summary
- Move `tryLoadUserClasses()` outside the manifest existence check
- Allows external packages (like praeco) to register their classes via `.smrt/register.js` even when the project has no local SMRT objects

## Problem
Projects using external SMRT packages (e.g., `@happyvertical/praeco`) that don't define their own SMRT objects were getting "Unknown command 'praeco'" errors because the CLI never attempted to load user classes when no local manifest existed.

## Solution
The `.smrt/register.js` file imports external packages and registers them with the ObjectRegistry. By moving `tryLoadUserClasses()` to run unconditionally, external package classes are now loaded properly.

## Test plan
- [x] Test downstream project (bentleyalberta.com) with praeco dependency
- [x] Verify `pnpm smrt praeco` command works
- [x] Verify no regressions for projects with local SMRT objects