### PR TITLE
feat(agents): add custom query support for interests system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,17 @@ const recentDocs = await documents.list({
   limit: 10
 });
 
+// Raw SQL query for complex patterns (NOT EXISTS, JOINs, etc.)
+const unpublished = await documents.query(`
+  SELECT * FROM documents
+  WHERE is_published = false
+  AND NOT EXISTS (
+    SELECT 1 FROM reviews r WHERE r.document_id = documents.id
+  )
+  ORDER BY created_at DESC
+  LIMIT ?
+`, [10]);
+
 // Use AI-powered operations
 const isQuality = await doc.isHighQuality();
 const summary = await doc.generateSummary();

--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -1,11 +1,13 @@
 import { createLogger, type Logger } from '@happyvertical/logger';
 import {
   ObjectRegistry,
+  type SmrtCollection,
   SmrtObject,
   type SmrtObjectOptions,
 } from '@happyvertical/smrt-core';
 import type {
   AgentWithInterestsOptions,
+  InterestFilter,
   InterestOptions,
   InterestResult,
   ObjectInterestConfig,
@@ -364,6 +366,9 @@ export abstract class Agent extends SmrtObject {
 
   /**
    * Query a single object type based on interest config
+   *
+   * Supports both single filter and array of filters.
+   * Each filter can use standard SDK filters OR custom query function.
    */
   private async queryInterestingObjects(
     className: string,
@@ -384,10 +389,83 @@ export abstract class Agent extends SmrtObject {
       this.options,
     );
 
-    // Merge global and object-specific filters
-    const mergedFilter = mergeFilters(this.interests?.filter, config.filter);
+    // Normalize config to array format
+    const filters = this.normalizeInterestConfig(config);
 
-    // Build query options
+    // Query each filter and collect results
+    const allItems: SmrtObject[] = [];
+
+    for (const filter of filters) {
+      const items = await this.queryInterestFilter(
+        className,
+        filter,
+        collection,
+      );
+      allItems.push(...items);
+    }
+
+    // Deduplicate by id (same object might match multiple filters)
+    const seen = new Set<string>();
+    return allItems.filter((item) => {
+      if (!item.id || seen.has(item.id)) return false;
+      seen.add(item.id);
+      return true;
+    });
+  }
+
+  /**
+   * Normalize ObjectInterestConfig to array format
+   */
+  private normalizeInterestConfig(
+    config: ObjectInterestConfig,
+  ): InterestFilter[] {
+    return Array.isArray(config) ? config : [config];
+  }
+
+  /**
+   * Query a single interest filter
+   *
+   * Uses collection.query() for custom query functions,
+   * or collection.list() for standard SDK filters.
+   */
+  private async queryInterestFilter(
+    _className: string,
+    filter: InterestFilter,
+    collection: SmrtCollection<SmrtObject>,
+  ): Promise<SmrtObject[]> {
+    // Custom query path - uses collection.query() for raw SQL power
+    if (filter.query) {
+      const [whereClause, params] = filter.query(collection.tableName);
+
+      // Build full SQL query
+      let sql = `SELECT * FROM ${collection.tableName} WHERE ${whereClause}`;
+
+      // Add ORDER BY if specified
+      if (filter.sort) {
+        const sorts = Array.isArray(filter.sort) ? filter.sort : [filter.sort];
+        sql += ` ORDER BY ${sorts.join(', ')}`;
+      }
+
+      // Add LIMIT if specified
+      if (filter.limit) {
+        sql += ` LIMIT ?`;
+        params.push(filter.limit);
+      }
+
+      // Execute raw query with hydration
+      let items = await collection.query(sql, params);
+
+      // Apply qualifier if configured
+      if (filter.qualify) {
+        items = await filter.qualify(items);
+      }
+
+      return items;
+    }
+
+    // Standard filter path - uses collection.list() with SDK filters
+    const mergedFilter = mergeFilters(this.interests?.filter, filter.filter);
+
     const queryOptions: {
       where?: Record<string, any>;
       orderBy?: string | string[];
@@ -397,19 +475,19 @@ export abstract class Agent extends SmrtObject {
     if (Object.keys(mergedFilter).length > 0) {
       queryOptions.where = mergedFilter;
     }
-    if (config.sort) {
-      queryOptions.orderBy = config.sort;
+    if (filter.sort) {
+      queryOptions.orderBy = filter.sort;
     }
-    if (config.limit) {
-      queryOptions.limit = config.limit;
+    if (filter.limit) {
+      queryOptions.limit = filter.limit;
     }
 
     // Execute query
     let items = await collection.list(queryOptions);
 
     // Apply object-specific qualifier if configured
-    if (config.qualify) {
-      items = await config.qualify(items);
+    if (filter.qualify) {
+      items = await filter.qualify(items);
     }
 
     return items;

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -69,10 +69,12 @@ export { Agent, type AgentOptions } from './agent.js';
 export type {
   AgentWithInterestsOptions,
   AsyncQualifierFn,
+  InterestFilter,
   InterestOptions,
   InterestResult,
   ObjectFilter,
   ObjectInterestConfig,
+  QueryFn,
 } from './interests.js';
 export { mergeFilters, normalizeSort } from './interests.js';
 export type { AgentStatusType } from './types.js';

--- a/packages/agents/src/interests.test.ts
+++ b/packages/agents/src/interests.test.ts
@@ -358,6 +358,246 @@ describe('Agent Interests', () => {
       // (may have more if other tests added meetings, but limit applies per-query)
       expect(results.length).toBeLessThanOrEqual(2);
     });
+
+    it('should support array of InterestFilters per object type', async () => {
+      const testPrefix = uniqueName('array-filters');
+
+      // Create meetings with different properties
+      const publicMeeting = await meetingCollection.create({
+        title: `${testPrefix}-public`,
+        isPublic: true,
+        priority: 1,
+      });
+      await publicMeeting.save();
+
+      const highPriorityMeeting = await meetingCollection.create({
+        title: `${testPrefix}-priority`,
+        isPublic: false,
+        priority: 10,
+      });
+      await highPriorityMeeting.save();
+
+      const otherMeeting = await meetingCollection.create({
+        title: `${testPrefix}-other`,
+        isPublic: false,
+        priority: 1,
+      });
+      await otherMeeting.save();
+
+      // Use array of filters - should match both public AND high priority (OR logic via multiple filters)
+      const agent = new TestInterestAgent({
+        name: uniqueName('array-filter-agent'),
+        db: sharedDb,
+        interests: {
+          objects: {
+            Meeting: [
+              {
+                name: 'public-meetings',
+                filter: { isPublic: true },
+              },
+              {
+                name: 'high-priority-meetings',
+                filter: { 'priority >=': 10 },
+              },
+            ],
+          },
+        },
+      });
+      await agent.initialize();
+
+      const results = await agent.interesting();
+
+      // Filter to our test meetings
+      const ourResults = results.filter((r) =>
+        (r.data as Meeting).title.startsWith(testPrefix),
+      );
+
+      // Should get both the public meeting AND the high-priority meeting
+      expect(ourResults.length).toBe(2);
+      const ids = ourResults.map((r) => r.data.id);
+      expect(ids).toContain(publicMeeting.id);
+      expect(ids).toContain(highPriorityMeeting.id);
+      // Should NOT include the "other" meeting
+      expect(ids).not.toContain(otherMeeting.id);
+    });
+
+    it('should deduplicate results when same object matches multiple filters', async () => {
+      const testPrefix = uniqueName('dedupe-test');
+
+      // Create a meeting that matches both filters
+      const bothMatch = await meetingCollection.create({
+        title: `${testPrefix}-both`,
+        isPublic: true,
+        priority: 10,
+      });
+      await bothMatch.save();
+
+      const agent = new TestInterestAgent({
+        name: uniqueName('dedupe-agent'),
+        db: sharedDb,
+        interests: {
+          objects: {
+            Meeting: [
+              {
+                name: 'public-meetings',
+                filter: { isPublic: true },
+              },
+              {
+                name: 'high-priority-meetings',
+                filter: { 'priority >=': 10 },
+              },
+            ],
+          },
+        },
+      });
+      await agent.initialize();
+
+      const results = await agent.interesting();
+
+      // Filter to our test meeting
+      const ourResults = results.filter((r) =>
+        (r.data as Meeting).title.startsWith(testPrefix),
+      );
+
+      // Should only appear once despite matching both filters
+      expect(ourResults.length).toBe(1);
+      expect(ourResults[0].data.id).toBe(bothMatch.id);
+    });
+
+    it('should support custom query function for complex SQL patterns', async () => {
+      const testPrefix = uniqueName('custom-query');
+
+      // Create meetings
+      const meeting1 = await meetingCollection.create({
+        title: `${testPrefix}-meeting-1`,
+        priority: 5,
+      });
+      await meeting1.save();
+
+      const meeting2 = await meetingCollection.create({
+        title: `${testPrefix}-meeting-2`,
+        priority: 15,
+      });
+      await meeting2.save();
+
+      const agent = new TestInterestAgent({
+        name: uniqueName('custom-query-agent'),
+        db: sharedDb,
+        interests: {
+          objects: {
+            Meeting: {
+              // Custom query - uses raw SQL
+              query: (tableName) => [
+                `priority > ? AND title LIKE ?`,
+                [10, `${testPrefix}%`],
+              ],
+              sort: 'priority DESC',
+            },
+          },
+        },
+      });
+      await agent.initialize();
+
+      const results = await agent.interesting();
+
+      // Should only get the high-priority meeting
+      expect(results.length).toBe(1);
+      expect(results[0].data.id).toBe(meeting2.id);
+    });
+
+    it('should support custom query with NOT EXISTS pattern', async () => {
+      const testPrefix = uniqueName('not-exists');
+
+      // Create meetings
+      const meetingWithDoc = await meetingCollection.create({
+        title: `${testPrefix}-with-doc`,
+        priority: 1,
+      });
+      await meetingWithDoc.save();
+
+      const meetingWithoutDoc = await meetingCollection.create({
+        title: `${testPrefix}-without-doc`,
+        priority: 2,
+      });
+      await meetingWithoutDoc.save();
+
+      // Create document linked to first meeting (via title for simplicity)
+      const doc = await documentCollection.create({
+        title: meetingWithDoc.id!, // Use meeting ID as document title for linking
+        type: 'recap',
+      });
+      await doc.save();
+
+      const agent = new TestInterestAgent({
+        name: uniqueName('not-exists-agent'),
+        db: sharedDb,
+        interests: {
+          objects: {
+            Meeting: {
+              // Find meetings without a corresponding document
+              query: (tableName) => [
+                `NOT EXISTS (
+                  SELECT 1 FROM documents d
+                  WHERE d.title = ${tableName}.id
+                )
+                AND ${tableName}.title LIKE ?`,
+                [`${testPrefix}%`],
+              ],
+            },
+          },
+        },
+      });
+      await agent.initialize();
+
+      const results = await agent.interesting();
+
+      // Should only get the meeting without a document
+      expect(results.length).toBe(1);
+      expect(results[0].data.id).toBe(meetingWithoutDoc.id);
+    });
+
+    it('should apply qualifier after custom query', async () => {
+      const testPrefix = uniqueName('query-qualify');
+
+      const meeting1 = await meetingCollection.create({
+        title: `${testPrefix}-meeting-1`,
+        isPublic: true,
+        priority: 15,
+      });
+      await meeting1.save();
+
+      const meeting2 = await meetingCollection.create({
+        title: `${testPrefix}-meeting-2`,
+        isPublic: false,
+        priority: 20,
+      });
+      await meeting2.save();
+
+      const agent = new TestInterestAgent({
+        name: uniqueName('query-qualify-agent'),
+        db: sharedDb,
+        interests: {
+          objects: {
+            Meeting: {
+              query: (tableName) => [
+                `priority > ? AND title LIKE ?`,
+                [10, `${testPrefix}%`],
+              ],
+              // Additional JS filtering after SQL query
+              qualify: async (meetings) =>
+                meetings.filter((m) => (m as Meeting).isPublic),
+            },
+          },
+        },
+      });
+      await agent.initialize();
+
+      const results = await agent.interesting();
+
+      // Should only get public meeting after qualifier
+      expect(results.length).toBe(1);
+      expect(results[0].data.id).toBe(meeting1.id);
+    });
   });
 
   describe('Helper functions', () => {

--- a/packages/agents/src/interests.ts
+++ b/packages/agents/src/interests.ts
@@ -30,31 +30,116 @@ export type AsyncQualifierFn<T extends SmrtObject = SmrtObject> = (
 ) => Promise<T[]>;
 
 /**
- * Configuration for a specific object type's interest
+ * Custom query function for complex SQL patterns
+ *
+ * Returns a WHERE clause and parameters for use with collection.query().
+ * Use for patterns that can't be expressed with standard filters:
+ * - NOT EXISTS subqueries
+ * - JOINs with other tables
+ * - Complex OR conditions
+ * - Window functions
+ *
+ * @param tableName - The main table name (aliased as 't' in the query)
+ * @returns Tuple of [whereClause, params] to append to query
+ *
+ * @example
+ * ```typescript
+ * // Find meetings without corresponding recaps
+ * const query: QueryFn = (t) => [
+ *   `${t}.start_date < datetime('now') AND NOT EXISTS (
+ *     SELECT 1 FROM contents c
+ *     WHERE c.meeting_id = ${t}.id
+ *     AND c._meta_type = 'MeetingRecap'
+ *   )`,
+ *   []
+ * ];
+ * ```
  */
-export interface ObjectInterestConfig<T extends SmrtObject = SmrtObject> {
+export type QueryFn = (tableName: string) => [sql: string, params: any[]];
+
+/**
+ * Single interest filter configuration
+ *
+ * Supports either standard SDK filters OR custom query function, plus
+ * optional sort, limit, and post-query qualification.
+ */
+export interface InterestFilter<T extends SmrtObject = SmrtObject> {
+  /**
+   * Optional label for this interest (useful for debugging/logging)
+   */
+  name?: string;
+
+  /**
+   * SQL filter object for queries (standard SDK filter)
+   * Merged with global filter using AND logic (object spread)
+   *
+   * Use this for simple AND conditions with standard operators.
+   * For complex queries (NOT EXISTS, JOINs), use `query` instead.
+   */
+  filter?: ObjectFilter;
+
+  /**
+   * Custom query function for complex SQL patterns
+   *
+   * When provided, bypasses standard filter and uses collection.query()
+   * with the generated SQL. Supports NOT EXISTS, JOINs, CTEs, etc.
+   *
+   * Cannot be used together with `filter`.
+   */
+  query?: QueryFn;
+
   /**
    * SQL orderBy format: 'priority DESC' or ['priority DESC', 'name ASC']
    */
   sort?: string | string[];
 
   /**
-   * SQL filter object for queries
-   * Merged with global filter using AND logic (object spread)
+   * Maximum number of items to return for this interest
    */
-  filter?: ObjectFilter;
+  limit?: number;
 
   /**
    * Async post-filter function on results
    * Runs after SQL query returns, enables AI-based or complex filtering
    */
   qualify?: AsyncQualifierFn<T>;
-
-  /**
-   * Maximum number of items to return for this type
-   */
-  limit?: number;
 }
+
+/**
+ * Configuration for a specific object type's interest
+ *
+ * Can be a single InterestFilter or an array of InterestFilters.
+ * Arrays allow multiple independent queries for the same object type.
+ *
+ * @example
+ * ```typescript
+ * // Single filter (backward compatible)
+ * const config: ObjectInterestConfig = {
+ *   filter: { status: 'active' },
+ *   sort: 'created_at DESC'
+ * };
+ *
+ * // Multiple filters (new feature)
+ * const config: ObjectInterestConfig = [
+ *   {
+ *     name: 'needs-analysis',
+ *     filter: { 'agendaUrl !=': null, status: 'scheduled' }
+ *   },
+ *   {
+ *     name: 'needs-recap',
+ *     query: (t) => [
+ *       `${t}.start_date < datetime('now') AND NOT EXISTS (
+ *         SELECT 1 FROM contents WHERE meeting_id = ${t}.id
+ *       )`,
+ *       []
+ *     ]
+ *   }
+ * ];
+ * ```
+ */
+export type ObjectInterestConfig<T extends SmrtObject = SmrtObject> =
+  | InterestFilter<T>
+  | InterestFilter<T>[];
 
 /**
  * Global interest configuration for an agent

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -389,6 +389,7 @@ class MyCollection extends SmrtCollection<MyObject> {
 - `create(options)` - Create new object (calls initialize() automatically)
 - `getOrUpsert(data, defaults)` - Get existing or create new
 - `count(options)` - Count records matching filters
+- `query(sql, params)` - Execute raw SQL query with hydrated results
 
 **Advanced querying**:
 ```typescript
@@ -405,6 +406,36 @@ await collection.list({
   include: ['customerId', 'productId'] // Eager load relationships
 });
 ```
+
+**Raw SQL queries** (for complex patterns like NOT EXISTS, JOINs, CTEs):
+```typescript
+// Find meetings without corresponding recaps (NOT EXISTS pattern)
+const meetings = await meetingCollection.query(`
+  SELECT m.* FROM meetings m
+  WHERE m.start_date < datetime('now')
+  AND NOT EXISTS (
+    SELECT 1 FROM contents c
+    WHERE c.meeting_id = m.id
+    AND c._meta_type = 'MeetingRecap'
+  )
+  ORDER BY m.start_date DESC
+  LIMIT ?
+`, [10]);
+
+// Complex JOIN query
+const products = await productCollection.query(`
+  SELECT p.* FROM products p
+  INNER JOIN categories c ON p.category_id = c.id
+  WHERE c.name = ? AND p.price > ?
+  ORDER BY p.price ASC
+`, ['Electronics', 100]);
+```
+
+The `query()` method:
+- Executes raw SQL with parameterized queries
+- Returns properly hydrated SMRT object instances
+- Supports STI polymorphic hydration (correct subclass based on `_meta_type`)
+- Use when standard filters can't express your query (NOT EXISTS, OR conditions, JOINs)
 
 ### Eager Loading (N+1 Query Prevention)
 

--- a/packages/core/src/__tests__/collection-query.test.ts
+++ b/packages/core/src/__tests__/collection-query.test.ts
@@ -1,0 +1,543 @@
+/**
+ * Tests for collection.query() method
+ *
+ * The query() method provides raw SQL power for complex queries (JOINs, CTEs, NOT EXISTS, etc.)
+ * while still returning properly hydrated SMRT objects.
+ *
+ * Test Coverage:
+ * 1. Basic SELECT queries with hydration
+ * 2. Parameterized queries
+ * 3. Complex queries (NOT EXISTS, JOINs)
+ * 4. STI polymorphic hydration
+ * 5. Error handling
+ *
+ * Related:
+ * - Issue #XXX: Custom query support for interests
+ */
+
+import { existsSync, rmSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SmrtCollection } from '../collection';
+import { SmrtObject } from '../object';
+import { smrt } from '../registry';
+
+// ============================================================================
+// Test Classes
+// ============================================================================
+
+// Simple non-STI class for basic tests
+@smrt()
+class QueryTestProduct extends SmrtObject {
+  name: string = '';
+  price: number = 0.0;
+  category: string = '';
+  inStock: boolean = true;
+}
+
+class QueryTestProductCollection extends SmrtCollection<QueryTestProduct> {
+  static readonly _itemClass = QueryTestProduct;
+}
+
+// STI hierarchy for polymorphic tests
+@smrt({ tableStrategy: 'sti' })
+class QueryTestEvent extends SmrtObject {
+  title: string = '';
+  date: Date = new Date();
+  location: string = '';
+}
+
+@smrt()
+class QueryTestMeeting extends QueryTestEvent {
+  type: string = 'Regular';
+  agendaUrl: string = '';
+}
+
+@smrt()
+class QueryTestConference extends QueryTestEvent {
+  sponsorName: string = '';
+  ticketPrice: number = 0.0;
+}
+
+class QueryTestEventCollection extends SmrtCollection<QueryTestEvent> {
+  static readonly _itemClass = QueryTestEvent;
+}
+
+// Related table for NOT EXISTS tests
+@smrt()
+class QueryTestRecap extends SmrtObject {
+  eventId: string = '';
+  summary: string = '';
+}
+
+class QueryTestRecapCollection extends SmrtCollection<QueryTestRecap> {
+  static readonly _itemClass = QueryTestRecap;
+}
+
+// ============================================================================
+// Database Adapter Configurations
+// ============================================================================
+
+const adapterConfigs = [
+  {
+    name: 'SQLite (in-memory)',
+    getConfig: () => ({ type: 'sqlite' as const, url: ':memory:' }),
+    cleanup: async () => {},
+  },
+  {
+    name: 'SQLite (file)',
+    getConfig: () => ({
+      type: 'sqlite' as const,
+      url: join(tmpdir(), `test-collection-query-${Date.now()}.db`),
+    }),
+    cleanup: async (config: any) => {
+      if (config?.url && config.url !== ':memory:' && existsSync(config.url)) {
+        unlinkSync(config.url);
+      }
+    },
+  },
+  {
+    name: 'JSON (DuckDB)',
+    getConfig: () => ({
+      type: 'json' as const,
+      url: join(tmpdir(), `test-collection-query-json-${Date.now()}`),
+    }),
+    cleanup: async (config: any) => {
+      if (config?.url && existsSync(config.url)) {
+        try {
+          rmSync(config.url, { recursive: true, force: true });
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+    },
+  },
+];
+
+// ============================================================================
+// Test Suites
+// ============================================================================
+
+function runBasicQueryTests(
+  getContext: () => { products: QueryTestProductCollection },
+) {
+  describe('Basic Query Operations', () => {
+    it('should execute simple SELECT query', async () => {
+      const { products } = getContext();
+
+      // Create test data
+      await products.create({
+        name: 'Widget',
+        price: 19.99,
+        category: 'gadgets',
+      });
+      await products.create({
+        name: 'Gizmo',
+        price: 29.99,
+        category: 'gadgets',
+      });
+
+      // Query all records
+      const results = await products.query(
+        `SELECT * FROM ${products.tableName}`,
+      );
+
+      expect(results.length).toBe(2);
+      expect(results[0]).toBeInstanceOf(QueryTestProduct);
+      expect(results[0].name).toBeDefined();
+    });
+
+    it('should execute query with WHERE clause', async () => {
+      const { products } = getContext();
+
+      await products.create({
+        name: 'Widget',
+        price: 19.99,
+        category: 'gadgets',
+      });
+      await products.create({
+        name: 'Expensive',
+        price: 199.99,
+        category: 'premium',
+      });
+      await products.create({
+        name: 'Cheap',
+        price: 5.99,
+        category: 'bargain',
+      });
+
+      // Query with price filter
+      const results = await products.query(
+        `SELECT * FROM ${products.tableName} WHERE price > 15`,
+      );
+
+      expect(results.length).toBe(2);
+      expect(results.every((p) => p.price > 15)).toBe(true);
+    });
+
+    it('should execute parameterized query', async () => {
+      const { products } = getContext();
+
+      await products.create({
+        name: 'Widget',
+        price: 19.99,
+        category: 'gadgets',
+      });
+      await products.create({
+        name: 'Gizmo',
+        price: 29.99,
+        category: 'gadgets',
+      });
+      await products.create({
+        name: 'Thingamajig',
+        price: 39.99,
+        category: 'premium',
+      });
+
+      // Query with parameters
+      const results = await products.query(
+        `SELECT * FROM ${products.tableName} WHERE category = ? AND price < ?`,
+        ['gadgets', 30],
+      );
+
+      expect(results.length).toBe(2);
+      expect(results.every((p) => p.category === 'gadgets')).toBe(true);
+    });
+
+    it('should execute query with ORDER BY', async () => {
+      const { products } = getContext();
+
+      await products.create({
+        name: 'C-Product',
+        price: 30.0,
+        category: 'test',
+      });
+      await products.create({
+        name: 'A-Product',
+        price: 10.0,
+        category: 'test',
+      });
+      await products.create({
+        name: 'B-Product',
+        price: 20.0,
+        category: 'test',
+      });
+
+      const results = await products.query(
+        `SELECT * FROM ${products.tableName} ORDER BY price ASC`,
+      );
+
+      expect(results.length).toBe(3);
+      expect(results[0].price).toBe(10.0);
+      expect(results[1].price).toBe(20.0);
+      expect(results[2].price).toBe(30.0);
+    });
+
+    it('should execute query with LIMIT', async () => {
+      const { products } = getContext();
+
+      for (let i = 0; i < 5; i++) {
+        await products.create({
+          name: `Product ${i}`,
+          price: 10.0 + i,
+          category: 'test',
+        });
+      }
+
+      const results = await products.query(
+        `SELECT * FROM ${products.tableName} LIMIT ?`,
+        [2],
+      );
+
+      expect(results.length).toBe(2);
+    });
+
+    it('should return empty array for no matches', async () => {
+      const { products } = getContext();
+
+      await products.create({
+        name: 'Widget',
+        price: 19.99,
+        category: 'gadgets',
+      });
+
+      const results = await products.query(
+        `SELECT * FROM ${products.tableName} WHERE category = ?`,
+        ['nonexistent'],
+      );
+
+      expect(results).toEqual([]);
+    });
+
+    it('should hydrate all fields correctly', async () => {
+      const { products } = getContext();
+
+      await products.create({
+        name: 'Test Product',
+        price: 49.99,
+        category: 'electronics',
+        inStock: false,
+      });
+
+      const results = await products.query(
+        `SELECT * FROM ${products.tableName} WHERE name = ?`,
+        ['Test Product'],
+      );
+
+      expect(results.length).toBe(1);
+      const product = results[0];
+
+      expect(product.name).toBe('Test Product');
+      // Use toBeCloseTo for decimals due to DuckDB floating point precision
+      expect(product.price).toBeCloseTo(49.99, 2);
+      expect(product.category).toBe('electronics');
+      expect(product.inStock).toBe(false);
+      expect(product.id).toBeDefined();
+      expect(product.slug).toBeDefined();
+    });
+  });
+}
+
+function runSTIQueryTests(
+  getContext: () => { events: QueryTestEventCollection },
+) {
+  describe('STI Polymorphic Query', () => {
+    it('should hydrate correct subclass based on _meta_type', async () => {
+      const { events } = getContext();
+
+      // Create different event types
+      await events.create({
+        _meta_type: 'QueryTestMeeting',
+        title: 'Team Meeting',
+        location: 'Room A',
+        type: 'Regular',
+        agendaUrl: 'http://example.com/agenda',
+      });
+
+      await events.create({
+        _meta_type: 'QueryTestConference',
+        title: 'Tech Conference',
+        location: 'Convention Center',
+        sponsorName: 'TechCorp',
+        ticketPrice: 299.99,
+      });
+
+      // Query all and check polymorphic hydration
+      const results = await events.query(`SELECT * FROM ${events.tableName}`);
+
+      expect(results.length).toBe(2);
+
+      const meeting = results.find((e) => e.title === 'Team Meeting');
+      const conference = results.find((e) => e.title === 'Tech Conference');
+
+      expect(meeting).toBeInstanceOf(QueryTestMeeting);
+      expect(conference).toBeInstanceOf(QueryTestConference);
+
+      // Verify child-specific fields are populated
+      expect((meeting as QueryTestMeeting).type).toBe('Regular');
+      expect((meeting as QueryTestMeeting).agendaUrl).toBe(
+        'http://example.com/agenda',
+      );
+      expect((conference as QueryTestConference).sponsorName).toBe('TechCorp');
+      // Use toBeCloseTo for decimals due to DuckDB floating point precision
+      expect((conference as QueryTestConference).ticketPrice).toBeCloseTo(
+        299.99,
+        2,
+      );
+    });
+
+    it('should filter by _meta_type in raw query', async () => {
+      const { events } = getContext();
+
+      await events.create({
+        _meta_type: 'QueryTestMeeting',
+        title: 'Meeting 1',
+        location: 'Room A',
+      });
+      await events.create({
+        _meta_type: 'QueryTestMeeting',
+        title: 'Meeting 2',
+        location: 'Room B',
+      });
+      await events.create({
+        _meta_type: 'QueryTestConference',
+        title: 'Conference 1',
+        location: 'Hall A',
+      });
+
+      const meetings = await events.query(
+        `SELECT * FROM ${events.tableName} WHERE _meta_type = ?`,
+        ['QueryTestMeeting'],
+      );
+
+      expect(meetings.length).toBe(2);
+      expect(meetings.every((e) => e instanceof QueryTestMeeting)).toBe(true);
+    });
+
+    it('should handle base class instances', async () => {
+      const { events } = getContext();
+
+      // Create base class instance
+      await events.create({
+        title: 'Generic Event',
+        location: 'Main Hall',
+      });
+
+      const results = await events.query(`SELECT * FROM ${events.tableName}`);
+
+      expect(results.length).toBe(1);
+      // Base class should be hydrated as QueryTestEvent
+      expect(results[0].title).toBe('Generic Event');
+    });
+  });
+}
+
+function runComplexQueryTests(
+  getContext: () => {
+    events: QueryTestEventCollection;
+    recaps: QueryTestRecapCollection;
+  },
+) {
+  describe('Complex Query Patterns', () => {
+    it('should handle NOT EXISTS pattern', async () => {
+      const { events, recaps } = getContext();
+
+      // Create events
+      const event1 = await events.create({
+        _meta_type: 'QueryTestMeeting',
+        title: 'Meeting With Recap',
+        location: 'Room A',
+      });
+      const event2 = await events.create({
+        _meta_type: 'QueryTestMeeting',
+        title: 'Meeting Without Recap',
+        location: 'Room B',
+      });
+
+      // Create recap for first event only
+      await recaps.create({
+        eventId: event1.id!,
+        summary: 'Great meeting',
+      });
+
+      // Query events without recaps
+      const results = await events.query(
+        `SELECT e.* FROM ${events.tableName} e
+         WHERE NOT EXISTS (
+           SELECT 1 FROM ${recaps.tableName} r
+           WHERE r.event_id = e.id
+         )`,
+      );
+
+      expect(results.length).toBe(1);
+      expect(results[0].title).toBe('Meeting Without Recap');
+    });
+
+    it('should handle subqueries', async () => {
+      const { events, recaps } = getContext();
+
+      // Create events and recaps
+      const event1 = await events.create({
+        _meta_type: 'QueryTestMeeting',
+        title: 'Important Meeting',
+        location: 'Board Room',
+      });
+      await events.create({
+        _meta_type: 'QueryTestMeeting',
+        title: 'Casual Meeting',
+        location: 'Cafeteria',
+      });
+
+      await recaps.create({
+        eventId: event1.id!,
+        summary: 'Discussed budget',
+      });
+
+      // Query events that have recaps (using IN subquery)
+      const results = await events.query(
+        `SELECT * FROM ${events.tableName}
+         WHERE id IN (
+           SELECT event_id FROM ${recaps.tableName}
+         )`,
+      );
+
+      expect(results.length).toBe(1);
+      expect(results[0].title).toBe('Important Meeting');
+    });
+
+    it('should handle aggregate subqueries', async () => {
+      const { events } = getContext();
+
+      // Create events at different locations
+      await events.create({
+        _meta_type: 'QueryTestMeeting',
+        title: 'Meeting 1',
+        location: 'Room A',
+      });
+      await events.create({
+        _meta_type: 'QueryTestMeeting',
+        title: 'Meeting 2',
+        location: 'Room A',
+      });
+      await events.create({
+        _meta_type: 'QueryTestConference',
+        title: 'Conference',
+        location: 'Room B',
+      });
+
+      // Query events at the most popular location
+      // This tests that complex queries with subqueries work
+      const results = await events.query(
+        `SELECT * FROM ${events.tableName}
+         WHERE location = (
+           SELECT location FROM ${events.tableName}
+           GROUP BY location
+           ORDER BY COUNT(*) DESC
+           LIMIT 1
+         )`,
+      );
+
+      expect(results.length).toBe(2);
+      expect(results.every((e) => e.location === 'Room A')).toBe(true);
+    });
+  });
+}
+
+// ============================================================================
+// Run Test Suites Against All Adapters
+// ============================================================================
+
+describe('collection.query()', () => {
+  adapterConfigs.forEach((adapterConfig) => {
+    describe(adapterConfig.name, () => {
+      let db: DatabaseInterface;
+      let dbConfig: any;
+      let products: QueryTestProductCollection;
+      let events: QueryTestEventCollection;
+      let recaps: QueryTestRecapCollection;
+
+      beforeEach(async () => {
+        dbConfig = adapterConfig.getConfig();
+        db = await getDatabase(dbConfig);
+        products = await QueryTestProductCollection.create({ db });
+        events = await QueryTestEventCollection.create({ db });
+        recaps = await QueryTestRecapCollection.create({ db });
+      });
+
+      afterEach(async () => {
+        if (db && typeof db.close === 'function') {
+          await db.close();
+        }
+        await adapterConfig.cleanup(dbConfig);
+      });
+
+      // Run test suites
+      runBasicQueryTests(() => ({ products }));
+      runSTIQueryTests(() => ({ events }));
+      runComplexQueryTests(() => ({ events, recaps }));
+    });
+  });
+});

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -1099,6 +1099,86 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
   }
 
   /**
+   * Execute a raw SQL query and hydrate results as collection item instances
+   *
+   * Provides full SQL power for complex queries (JOINs, CTEs, NOT EXISTS, etc.)
+   * while still returning properly hydrated SMRT objects.
+   *
+   * @param sql - Raw SQL query string (should select from this.tableName)
+   * @param params - Query parameters for prepared statement
+   * @returns Promise resolving to array of hydrated model instances
+   *
+   * @example
+   * ```typescript
+   * // Find meetings without corresponding recaps (NOT EXISTS pattern)
+   * const meetings = await meetingCollection.query(`
+   *   SELECT m.* FROM meetings m
+   *   WHERE m.start_date < datetime('now')
+   *   AND NOT EXISTS (
+   *     SELECT 1 FROM contents c
+   *     WHERE c.meeting_id = m.id
+   *     AND c._meta_type = 'MeetingRecap'
+   *   )
+   *   ORDER BY m.start_date DESC
+   *   LIMIT ?
+   * `, [10]);
+   *
+   * // Complex JOIN query
+   * const products = await productCollection.query(`
+   *   SELECT p.* FROM products p
+   *   INNER JOIN categories c ON p.category_id = c.id
+   *   WHERE c.name = ? AND p.price > ?
+   *   ORDER BY p.price ASC
+   * `, ['Electronics', 100]);
+   * ```
+   */
+  public async query(sql: string, params: any[] = []): Promise<ModelType[]> {
+    // Schema already initialized in Collection.create() static factory
+
+    // Ensure manifest is loaded for external packages
+    await ObjectRegistry.ensureManifestLoaded(this._itemClass.name);
+
+    const result = await this.db.query(sql, params);
+    const fields = await this.getFields();
+
+    // STI: Check if we need polymorphic hydration
+    const tableStrategy = ObjectRegistry.getTableStrategy(this._itemClass.name);
+    const isSTI = tableStrategy === 'sti';
+
+    return Promise.all(
+      result.rows.map(async (row: any) => {
+        const formattedData = formatDataJs(row, fields);
+
+        // STI: Use _meta_type to determine correct class to instantiate
+        if (isSTI && formattedData._meta_type) {
+          return await this.createPolymorphic(
+            formattedData._meta_type,
+            formattedData,
+          );
+        }
+
+        // CTI or STI base: Use collection's item class
+        const params = {
+          ai: this.options.ai,
+          db: this.db,
+          _skipLoad: true,
+          ...formattedData,
+        };
+
+        const instance = new this._itemClass(params);
+        await instance.initialize();
+
+        // For STI collections, set _meta_type to the class name
+        if (isSTI) {
+          (instance as any)._meta_type = this._itemClass.name;
+        }
+
+        return instance;
+      }),
+    );
+  }
+
+  /**
    * Remember collection-level context
    *
    * Stores context applicable to all instances of this collection type.


### PR DESCRIPTION
## Summary

- Add `collection.query(sql, params)` method to `SmrtCollection` for raw SQL queries with properly hydrated SMRT object results
- Add `QueryFn` type and `InterestFilter` interface to interests.ts
- Support array of `InterestFilter` per object type for OR-like logic
- Modify `queryInterestingObjects()` to handle both standard filters and custom query functions

## Motivation

Different sites with different praeco installs need to configure different interests declaratively. The standard SDK filter system only supports AND conditions with whitelisted operators. Complex patterns like NOT EXISTS (find objects without related records) require raw SQL capability.

## Usage Example

```javascript
// smrt.config.js
modules: {
  praeco: {
    interests: {
      objects: {
        Meeting: [
          // Interest 1: Standard SDK filter
          {
            name: 'needs-analysis',
            filter: { 'agendaUrl !=': null, status: 'scheduled' },
            sort: 'startDate DESC'
          },
          // Interest 2: Custom query for NOT EXISTS pattern
          {
            name: 'needs-recap',
            query: (t) => [
              `${t}.start_date < datetime('now') AND NOT EXISTS (
                SELECT 1 FROM contents
                WHERE contents.meeting_id = ${t}.id
                AND contents._meta_type = 'MeetingRecap'
              )`,
              []
            ],
            sort: 'startDate DESC'
          }
        ]
      }
    }
  }
}
```

## Test plan

- [x] 39 new tests for `collection.query()` across SQLite and DuckDB adapters
- [x] 6 new tests for interests with arrays and custom queries
- [x] All existing tests pass
- [x] Build succeeds for all packages