### PR TITLE
fix(svelte): derive day name from date in WeatherHeader

### DIFF
--- a/packages/svelte/src/lib/components/weather/WeatherHeader.svelte
+++ b/packages/svelte/src/lib/components/weather/WeatherHeader.svelte
@@ -75,8 +75,9 @@ function getDateFromDayName(_dayName: string, offset: number): Date {
   return today;
 }
 
-// Format date as "Sat 27 Oct"
-function formatDate(date: Date, dayName: string): string {
+// Format date as "Sat 27 Oct" - derive day name from date to stay in sync
+function formatDate(date: Date, _dayName: string): string {
+  const dayName = date.toLocaleDateString('en-US', { weekday: 'short' });
   const day = date.getDate();
   const month = date.toLocaleDateString('en-US', { month: 'short' });
   return `${dayName} ${day} ${month}`;


### PR DESCRIPTION
## Summary
- Fix `formatDate` function to derive the day name directly from the date object instead of using the passed `dayName` parameter
- This ensures the displayed day name always matches the calculated date

## Test plan
- [ ] Verify WeatherHeader displays correct day names for forecast dates
- [ ] Check that day abbreviations match the calculated dates