### PR TITLE
chore: prepare for Renovate CE migration

### DIFF
--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -5,10 +5,6 @@ on:
   push:
     branches: [main]
 
-  # Triggered by upstream dependency updates (e.g., from SDK)
-  repository_dispatch:
-    types: [dependency-updated, sdk-updated]
-
   workflow_dispatch:
     inputs:
       skip-docs:
@@ -101,97 +97,10 @@ jobs:
           fi
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-  # Update dependencies when triggered by upstream cascade
-  update-dependencies:
-    name: Update Dependencies
-    if: github.event_name == 'repository_dispatch'
-    runs-on: ubuntu-latest
-    outputs:
-      updated: ${{ steps.check-updates.outputs.updated }}
-      pr-number: ${{ steps.create-pr.outputs.pull-request-number }}
-      pr-url: ${{ steps.create-pr.outputs.pull-request-url }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment
-        with:
-          node-version: '24'
-          install-deps: 'false'
-          registry-url: 'https://npm.pkg.github.com'
-          auth-token: ${{ secrets.GH_TOKEN }}
-
-      - name: Update @happyvertical dependencies
-        id: update
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          echo "🔄 Updating @happyvertical packages in all workspace packages..."
-          pnpm update -r '@happyvertical/*' --latest
-          pnpm install
-
-      - name: Check for updates
-        id: check-updates
-        run: |
-          if git diff --quiet \
-              package.json pnpm-lock.yaml packages/*/package.json \
-              2>/dev/null; then
-            echo "updated=false" >> "$GITHUB_OUTPUT"
-            echo "⏭️  No updates needed"
-          else
-            echo "updated=true" >> "$GITHUB_OUTPUT"
-            echo "✅ Dependencies updated"
-            echo "📦 Updated packages:"
-            git diff package.json packages/*/package.json | \
-              grep '^\+.*@happyvertical' | \
-              sed 's/^+//' || echo "  (lockfile changes only)"
-          fi
-
-      - name: Create Pull Request
-        id: create-pr
-        if: steps.check-updates.outputs.updated == 'true'
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.GH_TOKEN }}
-          commit-message: 'chore: update @happyvertical dependencies'
-          title: 'chore: update @happyvertical dependencies'
-          body: >
-            ## Automated Dependency Update
-
-
-            Triggered by upstream dependency changes.
-
-
-            This PR will be automatically merged after tests pass.
-          branch: cascade/update-dependencies
-          delete-branch: true
-          labels: dependencies,automated
-
-      - name: Enable auto-merge
-        if: steps.create-pr.outputs.pull-request-number
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          pr_num="${{ steps.create-pr.outputs.pull-request-number }}"
-          echo "🔀 Enabling auto-merge for PR #$pr_num"
-          echo "⏳ Waiting 30 seconds for status checks to start..."
-          sleep 30
-          gh pr merge "$pr_num" \
-            --auto --squash \
-            --delete-branch
-
-  # Run tests (for both normal merges and cascade PRs)
+  # Run tests
   test:
     name: Test
-    needs: [update-dependencies]
-    if: |
-      always() &&
-      (needs.update-dependencies.result == 'success' ||
-       needs.update-dependencies.result == 'skipped')
+    if: always()
     uses: ./.github/workflows/test.yml
     permissions:
       contents: read
@@ -201,12 +110,7 @@ jobs:
   build:
     name: Build
     needs: test
-    # Only run on direct pushes to main or manual triggers (not cascade events)
-    if: |
-      always() &&
-      (github.event_name == 'push' ||
-       github.event_name == 'workflow_dispatch') &&
-      needs.test.result == 'success'
+    if: always() && needs.test.result == 'success'
     uses: ./.github/workflows/build.yml
     permissions:
       contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -184,84 +184,9 @@ jobs:
           version="${{ steps.check_published.outputs.version }}"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-  cascade:
-    name: Trigger Dependency Cascade
-    runs-on: ubuntu-latest
-    needs: [release]
-    if: needs.release.outputs.published == 'true'
-
-    steps:
-      - name: Trigger dependency cascade
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          echo "📢 Triggering dependency cascade for downstream repositories..."
-          echo ""
-
-          # Get published version
-          version="${{ needs.release.outputs.version }}"
-          echo "📦 Published version: $version"
-          echo ""
-
-          # Get list of downstream targets from cascade config
-          echo "🔍 Fetching cascade configuration..."
-          config_url="https://raw.githubusercontent.com/happyvertical"
-          config_url="${config_url}/sdk/main/.github/cascade-config.json"
-          echo "   Config URL: $config_url"
-
-          if ! config_json=$(curl -s -f "$config_url"); then
-            echo "❌ Failed to fetch cascade configuration"
-            echo "   Check if $config_url exists and is accessible"
-            exit 1
-          fi
-
-          if [ -z "$config_json" ]; then
-            echo "❌ Cascade configuration is empty"
-            echo "   Check if $config_url contains valid JSON"
-            exit 1
-          fi
-
-          echo "✅ Configuration fetched successfully"
-          echo ""
-
-          DOWNSTREAM_REPOS=$(echo "$config_json" | \
-            jq -r '.cascade.smrt.triggers[]' 2>/dev/null | tr '\n' ' ')
-
-          if [ -z "$DOWNSTREAM_REPOS" ]; then
-            echo "⚠️  No downstream repositories configured"
-            echo "   Check cascade config: $config_url"
-            exit 0
-          fi
-
-          echo "🎯 Downstream repositories: $DOWNSTREAM_REPOS"
-          echo ""
-
-          # Trigger each downstream repo using repository_dispatch
-          success_count=0
-          fail_count=0
-
-          for repo in $DOWNSTREAM_REPOS; do
-            echo "📤 Triggering: happyvertical/$repo"
-            if gh api "repos/happyvertical/$repo/dispatches" \
-              -f event_type="sdk-updated" \
-              -f 'client_payload[upstream_package]'="@happyvertical/smrt" \
-              -f 'client_payload[upstream_version]'="$version" \
-              -f 'client_payload[triggered_by]'="${{ github.actor }}"; then
-              echo "   ✅ Successfully triggered"
-              success_count=$((success_count + 1))
-            else
-              echo "   ⚠️  Failed to trigger (check repo access/permissions)"
-              fail_count=$((fail_count + 1))
-            fi
-            echo ""
-          done
-
-          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          echo "📊 Cascade Summary:"
-          echo "   ✅ Successful: $success_count"
-          echo "   ⚠️  Failed: $fail_count"
-          echo "   📦 Version: $version"
-          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  # Note: Downstream dependency updates are handled by Renovate CE.
+  # When SMRT publishes, Renovate detects the new version and creates
+  # PRs in downstream repos (praeco, caelus, etc.) automatically.
 
   deploy-docs:
     name: Deploy Documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -818,6 +818,51 @@ See [CHANGESETS.md](./CHANGESETS.md) for complete release workflow documentation
 
 ---
 
+## Dependency Management
+
+The SMRT framework uses [Renovate CE](https://github.com/renovatebot/renovate) for automated dependency updates:
+
+### How It Works
+
+1. **Upstream Changes (SDK)**: When `@happyvertical/sdk` packages publish new versions, Renovate CE detects the update via GitHub webhooks
+2. **PR Creation**: Renovate automatically creates a PR in SMRT with the updated dependencies
+3. **Automerge**: Patch version updates are automatically merged after tests pass
+4. **Downstream Propagation**: After SMRT publishes, Renovate detects the new version and creates PRs in downstream repos (praeco, caelus, etc.)
+
+### Configuration
+
+The Renovate configuration is defined in `renovate.json` and extends the shared config from [happyvertical/renovate-config](https://github.com/happyvertical/renovate-config):
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>happyvertical/renovate-config:smrt"]
+}
+```
+
+### Expected Behavior
+
+| Scenario | Renovate Action |
+|----------|-----------------|
+| SDK patch release (0.x.Y) | Auto-create PR, automerge after tests pass |
+| SDK minor release (0.X.0) | Create PR, requires manual review |
+| External dependency update | Grouped weekly PRs |
+| Security vulnerability | Immediate PR with priority label |
+
+### Dependency Flow
+
+```
+@happyvertical/sdk
+        │
+        ▼ (Renovate detects new version)
+@happyvertical/smrt-* (this repo)
+        │
+        ▼ (Renovate detects new version)
+praeco, caelus, create-gnode (downstream repos)
+```
+
+---
+
 ## Related Projects
 
 - **[HAppyVertical SDK](https://github.com/happyvertical/sdk)**: Infrastructure packages that use SMRT


### PR DESCRIPTION
## Summary

Prepare SMRT for the migration from SDK's dependency cascade to self-hosted Renovate CE.

- Remove `repository_dispatch` event handler from on-merge-main.yml
- Remove `update-dependencies` job that handled incoming cascade events
- Remove `cascade` job from publish.yml that triggered downstream repos
- Add Renovate documentation section to CLAUDE.md

## How Renovate CE Changes Things

### Before (Cascade)
- SDK publishes → `repository_dispatch` event sent to SMRT
- Custom workflow handles update
- Manual or semi-automated dependency bumps

### After (Renovate CE)
- SDK publishes → GitHub webhook → Renovate CE
- Renovate detects new `@happyvertical/*` versions
- PR created automatically with grouped updates
- Automerge for patch versions

## Dependency Flow

```
@happyvertical/sdk
        │
        ▼ (Renovate detects new version)
@happyvertical/smrt-* (this repo)
        │
        ▼ (Renovate detects new version)
praeco, caelus, create-gnode (downstream repos)
```

## Test plan

- [x] Verify `renovate.json` is merged (PR #484)
- [x] Remove cascade-specific workflow code
- [x] Add documentation to CLAUDE.md
- [ ] CI passes on this PR

Closes #485