### PR TITLE
fix: add missing packages to changeset fixed array and sync versions

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -14,11 +14,15 @@
       "@happyvertical/smrt-docs-mcp",
       "@happyvertical/smrt-events",
       "@happyvertical/smrt-gnode",
+      "@happyvertical/smrt-messages",
       "@happyvertical/smrt-places",
       "@happyvertical/smrt-products",
       "@happyvertical/smrt-profiles",
+      "@happyvertical/smrt-projects",
       "@happyvertical/smrt-svelte",
       "@happyvertical/smrt-tags",
+      "@happyvertical/smrt-template-site-static-json",
+      "@happyvertical/smrt-template-sveltekit",
       "@happyvertical/smrt-types"
     ]
   ],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -698,6 +698,66 @@ This project uses [Changesets](https://github.com/changesets/changesets) for ver
 
 For complete changeset workflow and troubleshooting, see [CHANGESETS.md](./CHANGESETS.md).
 
+### Adding New Packages
+
+When creating a new package in the monorepo, you **MUST** complete these steps to ensure proper versioning and release:
+
+#### 1. Add to Changeset Fixed Array
+
+All packages must be added to the `fixed` array in `.changeset/config.json` to ensure they stay version-locked together:
+
+```json
+{
+  "fixed": [
+    [
+      "@happyvertical/smrt-agents",
+      "@happyvertical/smrt-assets",
+      // ... existing packages ...
+      "@happyvertical/smrt-YOUR-NEW-PACKAGE"  // ADD HERE
+    ]
+  ]
+}
+```
+
+#### 2. Match Current Version
+
+Set the new package's version to match all other packages:
+
+```json
+{
+  "name": "@happyvertical/smrt-your-package",
+  "version": "0.17.34"  // Match current version of other packages
+}
+```
+
+Check current version: `node -p "require('./packages/core/package.json').version"`
+
+#### 3. Required Package.json Fields
+
+Ensure these fields are set correctly:
+
+```json
+{
+  "name": "@happyvertical/smrt-your-package",
+  "version": "0.17.34",
+  "type": "module",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  }
+}
+```
+
+#### Why This Matters
+
+All `@happyvertical/smrt-*` packages are **version-locked** using Changeset's `fixed` configuration. This means:
+
+- When ANY package in the fixed group gets a bump, ALL packages bump together
+- This prevents version mismatches between interdependent packages (e.g., `smrt-core` vs `smrt-cli`)
+- Downstream projects can reliably use `@happyvertical/smrt-*@0.17.x` knowing all packages are compatible
+
+**Failure to add new packages to the fixed array** will cause them to drift to different versions, breaking compatibility.
+
 ### Testing Requirements
 
 All code changes must include tests following [TESTING_STANDARD.md](../TESTING_STANDARD.md):

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-messages",
-  "version": "0.18.13",
+  "version": "0.17.34",
   "description": "SMRT-based email message persistence with AI integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/projects/package.json
+++ b/packages/projects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-projects",
-  "version": "0.17.33",
+  "version": "0.17.34",
   "description": "Provider-agnostic project management models (Issues, PRs, Repositories, Projects) for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/template-site-static-json/package.json
+++ b/packages/template-site-static-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-template-site-static-json",
-  "version": "0.0.1",
+  "version": "0.17.34",
   "description": "Static community site template with JSON data storage and SMRT framework",
   "type": "module",
   "main": "index.js",

--- a/packages/template-sveltekit/package.json
+++ b/packages/template-sveltekit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-template-sveltekit",
-  "version": "0.0.1",
+  "version": "0.17.34",
   "description": "SvelteKit project template with SMRT framework integration",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
## Summary

Four packages were missing from the changeset `fixed` array, causing version drift between smrt packages. This broke CLI command discovery when downstream projects updated only some packages.

### Problem

| Package | Was | Now |
|---------|-----|-----|
| `@happyvertical/smrt-messages` | 0.18.13 | 0.17.34 |
| `@happyvertical/smrt-projects` | 0.17.33 | 0.17.34 |
| `@happyvertical/smrt-template-site-static-json` | 0.0.1 | 0.17.34 |
| `@happyvertical/smrt-template-sveltekit` | 0.0.1 | 0.17.34 |

### Changes

1. **`.changeset/config.json`** - Added 4 missing packages to the `fixed` array
2. **Package versions synced** - Updated all 4 out-of-sync packages to `0.17.34`
3. **`CLAUDE.md`** - Added new "Adding New Packages" section documenting:
   - Adding packages to changeset fixed array
   - Matching the current version
   - Required package.json fields
   - Explanation of why this matters

### Root Cause

When new packages were added to the monorepo, they weren't added to the `fixed` array in changeset config. This caused them to be versioned independently rather than staying in sync with all other `@happyvertical/smrt-*` packages.

## Test plan

- [ ] CI passes
- [ ] All packages show same version after merge