### PR TITLE
fix(ci): add yamllint config for GitHub Actions workflows

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,20 @@
+---
+extends: default
+
+rules:
+  # GitHub Actions with pinned digests create long lines
+  # e.g., uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+  line-length:
+    max: 120
+    level: warning
+
+  # GitHub Actions workflows don't require document start
+  document-start: disable
+
+  # GitHub Actions uses 'on:' which yamllint considers truthy
+  truthy:
+    allowed-values: ['true', 'false', 'on']
+
+  # Allow single space before inline comments (common in workflows)
+  comments:
+    min-spaces-from-content: 1


### PR DESCRIPTION
## Summary

GitHub Actions with pinned SHA digests create long lines that exceed yamllint's default 80 character limit, causing CI failures.

For example, Renovate's `pinDigests: true` creates lines like:
```yaml
uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
```

This PR adds a `.yamllint.yml` config that:
- Increases line-length max to 120 (warning only)
- Disables document-start requirement (not needed for GHA)
- Allows `on:` as truthy value (required for GHA triggers)
- Relaxes comment spacing (common in workflow files)

## Test plan

- [ ] CI passes on this PR
- [ ] Renovate PRs (#492) should pass after rebasing on main