### PR TITLE
fix: update .npmrc to use NPM_TOKEN for GitHub Packages auth

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
-# GitHub Packages configuration for @have and @happyvertical scopes
-@have:registry=https://npm.pkg.github.com
+# GitHub Packages authentication and registry configuration
+# The NPM_TOKEN is provided by CI/CD environments (Renovate, GitHub Actions)
+//npm.pkg.github.com/:_authToken=${NPM_TOKEN}
 @happyvertical:registry=https://npm.pkg.github.com


### PR DESCRIPTION
## Summary
- Add authentication token using `${NPM_TOKEN}` environment variable
- Remove deprecated `@have` scope (no longer in use)

## Why
When Renovate runs `pnpm install --no-frozen-lockfile` in postUpgradeTasks, pnpm reads the repo's `.npmrc` directly from disk. Without the auth token in the file, pnpm cannot authenticate to GitHub Packages for `@happyvertical/*` packages.

The Renovate deployment now exports `NPM_TOKEN` environment variable, so this `.npmrc` change enables authentication during lockfile regeneration.

## Test plan
- Merge this PR
- Retrigger Renovate on PR #503 (or any @happyvertical/* dependency update)
- Verify artifact update no longer fails with ERR_PNPM_FETCH_401