### PR TITLE
fix(agents): ensure manifest loaded before STI check in interesting()

### DIFF
--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -444,6 +444,17 @@ export abstract class Agent extends SmrtObject {
     if (filter.query) {
       let [whereClause, params] = filter.query(collection.tableName);
 
+      // Ensure manifest is loaded for this class and its ancestors (Issue #515)
+      // This is critical for cross-package STI where getTableStrategy() needs
+      // the complete inheritance chain to detect inherited STI configuration
+      await ObjectRegistry.ensureManifestLoaded(_className);
+      const preliminaryChain = ObjectRegistry.getInheritanceChain(_className);
+      for (const ancestorName of preliminaryChain) {
+        if (ancestorName !== _className) {
+          await ObjectRegistry.ensureManifestLoaded(ancestorName);
+        }
+      }
+
       // Add STI discriminator filter if this is an STI child class
       const tableStrategy = ObjectRegistry.getTableStrategy(_className);
       if (tableStrategy === 'sti') {


### PR DESCRIPTION
## Summary
- Fix STI filter not being applied in `Agent.interesting()` for cross-package classes
- Add `ensureManifestLoaded()` calls before checking STI strategy

## Problem
The `queryInterestFilter()` method was calling `getTableStrategy()` without first ensuring manifests were loaded. For cross-package STI classes (e.g., `Meeting` extending `Event` from a different package), the inheritance chain wasn't fully registered, causing `getTableStrategy()` to return `'cti'` instead of `'sti'`.

This resulted in the `_meta_type` filter not being added, returning sibling types (e.g., `WeatherForecast`) when only `Meeting` was requested.

## Solution
Added `ensureManifestLoaded()` calls for:
1. The target class
2. All ancestors in the inheritance chain

This ensures `getInheritanceChain()` can properly walk the chain to find inherited `tableStrategy: 'sti'` config.

## Test plan
- [x] All 34 tests in `@happyvertical/smrt-agents` pass
- [ ] Manual verification in bentleyalberta.com with `pnpm smrt praeco interesting`

## Related
- closes #515
- Follow-up investigation: #516