### PR TITLE
fix(agents): address review feedback on STI manifest loading

### DIFF
--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -447,13 +447,32 @@ export abstract class Agent extends SmrtObject {
       // Ensure manifest is loaded for this class and its ancestors (Issue #515)
       // This is critical for cross-package STI where getTableStrategy() needs
       // the complete inheritance chain to detect inherited STI configuration
+      //
+      // We walk the extends chain directly (not using cached getInheritanceChain)
+      // to avoid caching an incomplete chain before all manifests are loaded.
+      // After loading all ancestors, we invalidate the cache so getTableStrategy
+      // rebuilds it with complete data.
       await ObjectRegistry.ensureManifestLoaded(_className);
-      const preliminaryChain = ObjectRegistry.getInheritanceChain(_className);
-      for (const ancestorName of preliminaryChain) {
-        if (ancestorName !== _className) {
-          await ObjectRegistry.ensureManifestLoaded(ancestorName);
+      let currentClass = ObjectRegistry.getClass(_className);
+      while (currentClass?.extends) {
+        const parentName = currentClass.extends;
+        // Skip framework base classes
+        if (
+          parentName === 'SmrtObject' ||
+          parentName === 'SmrtClass' ||
+          parentName === 'SmrtCollection'
+        ) {
+          break;
         }
+        try {
+          await ObjectRegistry.ensureManifestLoaded(parentName);
+        } catch {
+          // Manifest loading can fail for classes not in manifest - continue
+        }
+        currentClass = ObjectRegistry.getClass(parentName);
       }
+      // Invalidate cached chain so getTableStrategy rebuilds with complete data
+      ObjectRegistry.invalidateInheritanceCache(_className);
 
       // Add STI discriminator filter if this is an STI child class
       const tableStrategy = ObjectRegistry.getTableStrategy(_className);


### PR DESCRIPTION
## Summary

Addresses Copilot review comments from PR #517.

## Changes

### 1. Fix cache invalidation issue

**Problem**: The original fix called `getInheritanceChain()` before all ancestor manifests were loaded, caching an incomplete chain that `getTableStrategy()` would then use.

**Solution**: Walk the `extends` chain directly using `ObjectRegistry.getClass()` instead of relying on `getInheritanceChain()`. After all manifests are loaded, explicitly invalidate the cache with `invalidateInheritanceCache()` so `getTableStrategy()` rebuilds it with complete data.

### 2. Add error handling

**Problem**: `ensureManifestLoaded()` throws for classes not in manifests (like framework base classes).

**Solution**: Wrap calls in try-catch to continue gracefully when manifest loading fails.

### 3. Skip framework classes

Explicitly break when hitting `SmrtObject`, `SmrtClass`, or `SmrtCollection` to avoid unnecessary manifest lookups.

## Test plan

- [x] All 34 tests in `@happyvertical/smrt-agents` pass
- [x] Build succeeds

## Related

- Follow-up to #517
- Fixes #515