### PR TITLE
fix(core): use getTableStrategy() in getSTIBase() for proper inheritance detection

### DIFF
--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -2843,7 +2843,9 @@ export class ObjectRegistry {
     const chain = ObjectRegistry.getInheritanceChain(className);
     for (const ancestorName of chain) {
       const ancestor = ObjectRegistry.findClass(ancestorName);
-      if (ancestor?.config?.tableStrategy === 'sti') {
+      // Use getTableStrategy() to properly detect inherited STI strategy
+      // (not ancestor.config.tableStrategy which only shows explicit config)
+      if (ObjectRegistry.getTableStrategy(ancestorName) === 'sti') {
         // Check if this ancestor shares the same table
         const ancestorTableName =
           ancestor.config?.tableName || ancestor.schema?.tableName;


### PR DESCRIPTION
## Summary

Fix `getSTIBase()` to correctly detect inherited STI configuration.

## Problem

`getSTIBase('Meeting')` was returning `'Meeting'` instead of `'Event'` because line 2846 checked:

```typescript
if (ancestor?.config?.tableStrategy === 'sti')
```

This only matches classes with **explicit** `tableStrategy: 'sti'` in their decorator config. For inherited STI classes like `Meeting` (which extends `Event`), `Meeting.config.tableStrategy` is `undefined` - it inherits STI from `Event`.

## Solution

Changed to use `getTableStrategy(ancestorName)` which properly walks the inheritance chain to detect inherited STI configuration:

```typescript
if (ObjectRegistry.getTableStrategy(ancestorName) === 'sti')
```

## Impact

This was causing the STI filter in `Agent.interesting()` to not be applied because:
1. `getSTIBase('Meeting')` returned `'Meeting'`
2. The check `stiBase !== _className` evaluated to `'Meeting' !== 'Meeting'` = `false`
3. No `_meta_type` filter was added

## Test plan

- [x] All 22 STI registry tests pass
- [x] Build succeeds

## Related

- closes #519
- Related to #515, #517, #518