### PR TITLE
fix(agents): add @smrt() decorator to Agent for inheritance chain discovery

### DIFF
--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -4,6 +4,7 @@ import {
   type SmrtCollection,
   SmrtObject,
   type SmrtObjectOptions,
+  smrt,
 } from '@happyvertical/smrt-core';
 import type {
   AgentWithInterestsOptions,
@@ -35,7 +36,8 @@ export interface AgentOptions
  * Agents can define their own properties for state management - since they extend
  * SmrtObject, any properties defined will be automatically persisted to the database.
  *
- * **Important**: Extending classes must add the `@smrt()` decorator themselves.
+ * **Important**: Extending classes must add the `@smrt()` decorator themselves
+ * to configure CLI/API/MCP exposure.
  *
  * @example
  * ```typescript
@@ -72,6 +74,15 @@ export interface AgentOptions
  * await agent.execute();
  * ```
  */
+@smrt({
+  // Abstract class - no direct CLI/API/MCP exposure
+  // But must be registered for inheritance chain to work (issue #523)
+  cli: false,
+  api: false,
+  mcp: false,
+  // STI: All agents share 'agents' table for polymorphic queries
+  tableStrategy: 'sti',
+})
 export abstract class Agent extends SmrtObject {
   /**
    * Current agent status


### PR DESCRIPTION
## Summary

- Add `@smrt()` decorator to the abstract `Agent` class to enable proper inheritance chain discovery
- Configure STI (Single Table Inheritance) strategy so all agents share the `agents` table
- Disable direct CLI/API/MCP exposure since Agent is abstract

## Problem

The Agent abstract class was missing the `@smrt()` decorator, which caused classes extending Agent (like Praeco) to not have their inheritance chain properly discovered by the CLI. This resulted in "Unknown command" errors when trying to run CLI commands on Agent subclasses.

**Root cause**: When `ObjectRegistry.getInheritanceChain('Praeco')` was called, it looked for Agent in the registry. Since Agent wasn't registered (no `@smrt()` decorator), the chain broke at Praeco instead of continuing to Agent → SmrtObject.

## Solution

Add `@smrt()` to the Agent class with:
- `cli: false`, `api: false`, `mcp: false` - abstract class shouldn't have direct exposure
- `tableStrategy: 'sti'` - all agents share the `agents` table for polymorphic queries

This enables:
- ✅ Proper inheritance chain discovery for Agent subclasses
- ✅ Polymorphic queries across all agent types from a single `agents` table
- ✅ CLI command generation for classes extending Agent

## Test plan

- [x] Build succeeds (`npm run build`)
- [x] All 824 core tests pass
- [x] All 34 agent tests pass
- [x] Agent manifest includes STI columns (`_meta_type`, `_meta_data`)

Closes #523