### PR TITLE
fix(cli): apply default patterns in git:init command

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-cli
 
+## 0.17.45
+
+### Patch Changes
+
+- fix(cli): apply default patterns in git:init command
+
 ## 0.17.44
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-cli",
-  "version": "0.17.44",
+  "version": "0.17.45",
   "description": "Developer CLI for SMRT framework - introspection, testing, and project management",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/src/commands/git.ts
+++ b/packages/cli/src/commands/git.ts
@@ -270,7 +270,8 @@ export const gitCommands: Record<string, CLICommand> = {
       }
 
       const gitRoot = getGitRoot();
-      const patterns = options.patterns
+      const patternsStr = options.patterns || DEFAULT_DATA_PATTERNS.join(',');
+      const patterns = patternsStr
         .split(',')
         .map((p: string) => p.trim())
         .filter(Boolean);


### PR DESCRIPTION
## Summary

The `smrt git:init` command was failing with `Error: Cannot read properties of undefined (reading 'split')` because the CLI parser doesn't automatically apply default option values.

Added fallback to use `DEFAULT_DATA_PATTERNS` when `options.patterns` is undefined.

## Test Plan

- [x] Run `smrt git:init` without arguments - should use default patterns
- [x] Run `smrt git:init --patterns "data/*.json"` - should use specified pattern