### PR TITLE
fix(core): use STI base class name in schema generation for external parents

### DIFF
--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -192,8 +192,10 @@ export class ManifestGenerator {
           );
 
           // Use aggregated manifest to include all descendants
+          // FIX #527: Use actual STI base class name, not child class name
+          // This ensures findDescendantsInManifest() finds ALL STI children
           obj.schema = generator.generateSTISchemaFromManifest(
-            name,
+            stiBase?.className || name,
             baseTableName,
             obj.fields,
             aggregatedManifest,


### PR DESCRIPTION
## Summary

- Fixed issue where STI child classes with external parents weren't getting `@foreignKey` columns in the database schema
- Changed `generateSTISchemaFromManifest()` call to use the actual STI base class name instead of the child class name
- This ensures `findDescendantsInManifest()` finds ALL STI children and aggregates their fields correctly

## Root Cause

When an STI child class has an external parent (e.g., `Agenda` in praeco extends `ContentDocument` from `@happyvertical/smrt-content`):

1. The schema generator was passing the child class name ("Agenda") to `generateSTISchemaFromManifest`
2. Inside, `findDescendantsInManifest("Agenda")` found no descendants (Agenda is a leaf class)
3. Only Agenda's own fields were included, missing proper field aggregation
4. `@foreignKey` columns from child classes were never added to the schema

## The Fix

Changed line 196 in `manifest-generator.ts`:
```typescript
// Before (buggy)
name,

// After (fixed)
stiBase?.className || name,
```

## Test Plan

- [x] All 824 existing tests pass
- [ ] Manual verification with bentleyalberta.com/praeco that `meeting_id` column now exists

Closes #527