### PR TITLE
fix(core): only regenerate STI schema when descendants are from different packages

### DIFF
--- a/packages/core/src/schema/utils.ts
+++ b/packages/core/src/schema/utils.ts
@@ -422,23 +422,20 @@ export async function ensureSchema(db: any, className: string): Promise<void> {
     // FIX #527: For STI classes with cross-package descendants, regenerate schema at runtime
     // Pre-generated schemas from external packages won't have columns from
     // child classes defined in consuming packages (e.g., Agenda.meetingId from praeco)
-    const currentTableStrategy = ObjectRegistry.getTableStrategy(className);
     const descendants = ObjectRegistry.getDescendants(className);
 
     // Check if any STI descendants are from a different package than the base class
     // If so, pre-generated schema may be missing their columns
     let hasCrossPackageDescendants = false;
-    if (currentTableStrategy === 'sti' && descendants.length > 0) {
+    if (tableStrategy === 'sti' && descendants.length > 0) {
       const baseClass = ObjectRegistry.getClass(className);
       const basePackage = baseClass?.packageName;
 
       for (const descendantName of descendants) {
         const descendant = ObjectRegistry.getClass(descendantName);
-        // Descendant is from different package if:
-        // - Base has a package name AND descendant has a different one
-        // - OR base has no package (local) AND descendant has one (external)
-        // - OR descendant has no package (local) AND base has one (external)
-        if (basePackage !== descendant?.packageName) {
+        if (!descendant) continue;
+        // Descendant is from a different package if packageName values don't match
+        if (basePackage !== descendant.packageName) {
           hasCrossPackageDescendants = true;
           break;
         }


### PR DESCRIPTION
## Summary

Follow-up fix for #527: The initial fix (PR #528) always regenerated the schema when STI had descendants, which could cause issues with same-package STI hierarchies where the pre-generated schema was already complete.

## Changes

- Modified `ensureSchema()` in `schema/utils.ts` to check if descendants are from different packages than the base class
- Only regenerate schema at runtime when there are cross-package descendants
- For same-package STI hierarchies, use the pre-generated schema (it already includes all descendant columns from build time)

## Root Cause

When an STI base class is from an external package (e.g., `Content` from `@happyvertical/smrt-content`) and a child class is from a consuming package (e.g., `Agenda` from praeco), the base class's pre-generated schema doesn't include columns for the child class's `@foreignKey` fields.

This fix detects this cross-package scenario by comparing `packageName` values between the base class and its descendants.

## Test Plan

- [x] `sti-adapter-parity.test.ts` passes (84/84 tests)
- [x] Core package tests pass (same results as main branch)
- [ ] Manual verification with bentleyalberta.com that `meeting_id` column is created

Closes #527