### PR TITLE
fix(core): case-insensitive manifest stub replacement

### DIFF
--- a/packages/core/src/__tests__/issue-531-case-insensitive-stub-replacement.test.ts
+++ b/packages/core/src/__tests__/issue-531-case-insensitive-stub-replacement.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Test for Issue #531: CLI returns manifest stubs instead of real classes
+ *
+ * PROBLEM:
+ * - Manifest keys are stored in lowercase (e.g., 'praeco')
+ * - Real class names are PascalCase (e.g., 'Praeco')
+ * - When real class is registered via @smrt() decorator, case-sensitive check fails
+ * - Both 'praeco' (stub) and 'Praeco' (real) end up in registry
+ * - CLI finds the stub and reports "class wasn't loaded"
+ *
+ * SOLUTION:
+ * - ObjectRegistry.register() now does case-insensitive check for manifest stubs
+ * - When stub is found (case-insensitive), it's replaced with real class
+ * - Registry key is updated to use PascalCase name from real class
+ *
+ * What these tests verify:
+ * ✅ Lowercase manifest stub is replaced by PascalCase real class
+ * ✅ Registry key is updated to PascalCase after replacement
+ * ✅ No duplicate entries exist after replacement
+ * ✅ Real class constructor is used, not stub
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SmrtObject } from '../object.js';
+import { ObjectRegistry, smrt } from '../registry.js';
+
+describe('Issue #531: Case-Insensitive Manifest Stub Replacement', () => {
+  // Store original registry state
+  let originalClasses: Map<string, any>;
+
+  beforeEach(() => {
+    // Save registry state before each test
+    originalClasses = new Map(ObjectRegistry.getAllClasses());
+  });
+
+  afterEach(() => {
+    // Restore registry state after each test
+    // First clear all added classes
+    for (const [name] of ObjectRegistry.getAllClasses()) {
+      if (!originalClasses.has(name)) {
+        // @ts-expect-error - accessing private property for test cleanup
+        ObjectRegistry.classes.delete(name);
+      }
+    }
+  });
+
+  it('should replace lowercase manifest stub with PascalCase real class', () => {
+    // Simulate manifest registration (lowercase key)
+    const manifestDef = {
+      className: 'TestWidget',
+      fields: {
+        name: { type: 'text', _meta: { required: true } },
+      },
+      methods: {},
+      decoratorConfig: {},
+    };
+
+    // Register as lowercase (how manifest keys are stored)
+    ObjectRegistry.registerFromManifest(
+      'testwidget', // lowercase key
+      manifestDef,
+      '@test/package',
+    );
+
+    // Verify stub is registered
+    const stubEntry = ObjectRegistry.findClass('testwidget');
+    expect(stubEntry).toBeDefined();
+    expect((stubEntry?.constructor as any)?._isManifestStub).toBe(true);
+
+    // Now define and register the real class (PascalCase)
+    @smrt()
+    class TestWidget extends SmrtObject {
+      name: string = '';
+    }
+
+    // Verify real class replaced the stub
+    const realEntry = ObjectRegistry.findClass('TestWidget');
+    expect(realEntry).toBeDefined();
+    expect((realEntry?.constructor as any)?._isManifestStub).toBeUndefined();
+    expect(realEntry?.constructor).toBe(TestWidget);
+
+    // Verify lowercase key no longer exists (was replaced)
+    // @ts-expect-error - accessing private property
+    const hasLowercase = ObjectRegistry.classes.has('testwidget');
+    expect(hasLowercase).toBe(false);
+
+    // Verify PascalCase key exists
+    // @ts-expect-error - accessing private property
+    const hasPascalCase = ObjectRegistry.classes.has('TestWidget');
+    expect(hasPascalCase).toBe(true);
+  });
+
+  it('should preserve manifest metadata when replacing stub', () => {
+    // Simulate manifest registration with fields and methods
+    const manifestDef = {
+      className: 'TestGadget',
+      fields: {
+        title: { type: 'text', _meta: { required: true } },
+        count: { type: 'integer', _meta: {} },
+      },
+      methods: {
+        doSomething: { async: true, parameters: [], returnType: 'void' },
+      },
+      decoratorConfig: {
+        cli: true,
+        api: { include: ['list', 'get'] },
+      },
+    };
+
+    ObjectRegistry.registerFromManifest(
+      'testgadget',
+      manifestDef,
+      '@test/package',
+    );
+
+    // Register real class
+    @smrt()
+    class TestGadget extends SmrtObject {
+      title: string = '';
+      count: number = 0;
+    }
+
+    // Verify metadata was preserved
+    const entry = ObjectRegistry.findClass('TestGadget');
+    expect(entry).toBeDefined();
+
+    // Fields from manifest should be preserved
+    expect(entry?.fields.has('title')).toBe(true);
+    expect(entry?.fields.has('count')).toBe(true);
+
+    // Config should be merged (manifest config preserved, decorator can override)
+    expect(entry?.config.cli).toBe(true);
+    expect(entry?.config.api).toEqual({ include: ['list', 'get'] });
+  });
+
+  it('should handle already PascalCase manifest keys (no change needed)', () => {
+    // Some manifests might use PascalCase keys
+    const manifestDef = {
+      className: 'TestDevice',
+      fields: {},
+      methods: {},
+      decoratorConfig: {},
+    };
+
+    // Register with PascalCase (exact match case)
+    ObjectRegistry.registerFromManifest(
+      'TestDevice',
+      manifestDef,
+      '@test/package',
+    );
+
+    // Verify stub is registered
+    const stubEntry = ObjectRegistry.findClass('TestDevice');
+    expect(stubEntry).toBeDefined();
+    expect((stubEntry?.constructor as any)?._isManifestStub).toBe(true);
+
+    // Register real class
+    @smrt()
+    class TestDevice extends SmrtObject {}
+
+    // Verify real class replaced the stub (exact match case)
+    const realEntry = ObjectRegistry.findClass('TestDevice');
+    expect(realEntry).toBeDefined();
+    expect((realEntry?.constructor as any)?._isManifestStub).toBeUndefined();
+    expect(realEntry?.constructor).toBe(TestDevice);
+  });
+
+  it('should throw on case-insensitive collision with non-stub class', () => {
+    // First register a real class
+    @smrt({ name: 'collisiontest' })
+    class CollisionTest1 extends SmrtObject {}
+
+    // Verify it's registered
+    const entry = ObjectRegistry.findClass('collisiontest');
+    expect(entry).toBeDefined();
+    expect((entry?.constructor as any)?._isManifestStub).toBeUndefined();
+
+    // Now try to register a different class with case-insensitive match
+    expect(() => {
+      @smrt({ name: 'CollisionTest' })
+      class CollisionTest2 extends SmrtObject {}
+    }).toThrow(/Class Name Collision.*case-insensitive/);
+  });
+});

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -440,7 +440,7 @@ export class ObjectRegistry {
   ): void {
     const name = config.name || ctor.name;
 
-    // Prevent duplicate registrations
+    // Prevent duplicate registrations - check exact match first
     if (ObjectRegistry.classes.has(name)) {
       const existing = ObjectRegistry.classes.get(name);
       if (!existing) {
@@ -485,6 +485,49 @@ export class ObjectRegistry {
           `  - Use unique class names (e.g., ${name}_UniqueId)\n` +
           `  - Or use @smrt({ name: 'unique_name' }) to override the registration name`,
       );
+    }
+
+    // Case-insensitive check for manifest stubs (Issue #531)
+    // Manifest keys are lowercase (e.g., 'praeco') but class names are PascalCase (e.g., 'Praeco')
+    // When the real class is loaded via @smrt() decorator, we need to find and replace the stub
+    const lowerName = name.toLowerCase();
+    for (const [existingKey, existing] of ObjectRegistry.classes.entries()) {
+      if (existingKey.toLowerCase() === lowerName && existingKey !== name) {
+        // Found case-insensitive match with different casing
+        if ((existing.constructor as any)._isManifestStub === true) {
+          // Replace stub with real class
+          // Use the new PascalCase name as the canonical key
+          ObjectRegistry.classes.delete(existingKey);
+          existing.constructor = ctor;
+          existing.name = name; // Update to PascalCase
+          // Merge config from decorator (new) with manifest config (existing)
+          existing.config = { ...existing.config, ...config };
+          ObjectRegistry.classes.set(name, existing);
+          console.log(
+            `[registry] Replaced manifest stub '${existingKey}' with real class '${name}'`,
+          );
+          return;
+        }
+
+        // Non-stub case-insensitive collision - same constructor is OK
+        if (existing.constructor === ctor) {
+          return; // Same class, skip silently
+        }
+
+        // Different constructors with case-insensitive name match
+        throw new Error(
+          `SMRT Class Name Collision: "${name}" (case-insensitive match with "${existingKey}")\n\n` +
+            `A class with this name is already registered, but with a different constructor.\n` +
+            `This usually happens when:\n` +
+            `  1. Multiple test files define classes with the same name\n` +
+            `  2. Different packages export classes with the same name\n\n` +
+            `The collision will cause the wrong field definitions to be used,\n` +
+            `leading to properties not being initialized correctly.\n\n` +
+            `To fix:\n` +
+            `  - Use unique class names (e.g., ${name}_UniqueId)\n` +
+            `  - Or use @smrt({ name: 'unique_name' }) to override the registration name`,
+        );
+      }
     }
 
     // CRITICAL: Capture package name NOW, while stack trace still shows external package


### PR DESCRIPTION
## Summary

- Fixes case-sensitivity mismatch between manifest keys (lowercase) and class names (PascalCase)
- Adds case-insensitive check in `ObjectRegistry.register()` to find and replace manifest stubs
- Updates registry key to use PascalCase name from real class after replacement

## Problem

When running `smrt praeco discover`:
1. Manifest loads with lowercase keys (`'praeco'`)
2. CLI registers stub via `registerFromManifest('praeco', ...)`
3. Real class loads via `@smrt()` decorator with PascalCase name (`'Praeco'`)
4. Case-sensitive check `classes.has('Praeco')` fails (key is `'praeco'`)
5. Both `'praeco'` (stub) and `'Praeco'` (real) exist in registry
6. CLI finds stub first and reports "class wasn't loaded"

## Solution

Added case-insensitive search in `ObjectRegistry.register()`:
- After exact match fails, search for case-insensitive match
- If found and it's a manifest stub, replace it with real class
- Update registry key to PascalCase

## Test plan

- [x] Added `issue-531-case-insensitive-stub-replacement.test.ts` with 4 tests:
  - Lowercase stub replaced by PascalCase class
  - Manifest metadata preserved after replacement
  - Exact match (PascalCase key) still works
  - Case-insensitive collision with non-stub throws error
- [x] All 76 core tests pass

Closes #531