### PR TITLE
fix(cli): fix heuristic for instance vs singleton custom methods

### DIFF
--- a/packages/cli/src/cli-generator.ts
+++ b/packages/cli/src/cli-generator.ts
@@ -743,13 +743,17 @@ export class CLIGenerator {
         }
       }
 
-      // Determine if method needs an object instance (has required parameters)
-      // Only require ID if method has required (non-optional) parameters
-      const hasRequiredParams = (methodDef.parameters || []).some(
-        (p: { optional?: boolean; default?: any }) =>
-          !p.optional && p.default === undefined,
-      );
-      const needsInstance = hasRequiredParams;
+      // Determine if method needs an object instance (ID lookup) vs singleton
+      // Methods with object-type parameters (options: {...}) are singleton methods
+      // Methods with no parameters or first param named 'id' need instance lookup
+      const firstParam = (methodDef.parameters || [])[0];
+      const hasObjectTypeParam =
+        firstParam && this.isObjectTypeParameter(firstParam.type || '');
+
+      // Singleton: object-type params (options objects passed via CLI flags)
+      // Instance: no params, or first param is explicitly named 'id'
+      const needsInstance =
+        !hasObjectTypeParam && (!firstParam || firstParam.name === 'id');
 
       commands.push({
         name: `${lowerName}:${methodName}`,


### PR DESCRIPTION
## Summary

Fixes the CLI generator's heuristic for determining whether custom methods need a database lookup (instance method) vs creating a new instance (singleton method).

**Problem**: The old logic used `hasRequiredParams` to determine if a method needs an instance. This was incorrect because methods like `setup({ source: string })` have required parameters but don't need to fetch an existing object from the database.

**Old behavior** (broken):
```bash
smrt praeco setup <id> --source "https://..."  # Wrong - expects ID
```

**New behavior** (fixed):
```bash
smrt praeco setup --source "https://..."       # Correct - no ID needed
```

## Changes

- Modified the heuristic in `cli-generator.ts`:
  - **Singleton methods**: Methods with object-type parameters (`options: { source: string }`) are treated as singleton methods that create a new instance
  - **Instance methods**: Methods with no parameters or first param named `id` need database lookup

## Test plan

- [x] All existing CLI tests pass (205 passed)
- [x] Build succeeds
- [ ] Manual test with praeco setup command