### PR TITLE
fix(cli): fix regression - methods with no params marked as needing ID

### DIFF
--- a/packages/cli/src/cli-generator.ts
+++ b/packages/cli/src/cli-generator.ts
@@ -744,16 +744,10 @@ export class CLIGenerator {
       }
 
       // Determine if method needs an object instance (ID lookup) vs singleton
-      // Methods with object-type parameters (options: {...}) are singleton methods
-      // Methods with no parameters or first param named 'id' need instance lookup
+      // Instance methods: first parameter is explicitly named 'id' → fetch from DB
+      // Singleton methods: everything else → create new instance, pass options
       const firstParam = (methodDef.parameters || [])[0];
-      const hasObjectTypeParam =
-        firstParam && this.isObjectTypeParameter(firstParam.type || '');
-
-      // Singleton: object-type params (options objects passed via CLI flags)
-      // Instance: no params, or first param is explicitly named 'id'
-      const needsInstance =
-        !hasObjectTypeParam && (!firstParam || firstParam.name === 'id');
+      const needsInstance = firstParam?.name === 'id';
 
       commands.push({
         name: `${lowerName}:${methodName}`,


### PR DESCRIPTION
## Summary

Fixes regression from PR #545 (released in v0.17.55). Methods with no parameters were incorrectly requiring an ID.

## Root Cause

The logic `!hasObjectTypeParam && (!firstParam || firstParam.name === 'id')` has a bug:
- When `firstParam` is `undefined` (no parameters), `!firstParam` evaluates to `true`
- So `needsInstance = true`, causing `args: ['id']` to be added

## Fix

The correct logic is simple: **only** require ID if the first parameter is explicitly named `id`:

```typescript
const needsInstance = firstParam?.name === 'id';
```

## Test Cases

| Method | firstParam | needsInstance | Result |
|--------|-----------|---------------|--------|
| `discover()` | undefined | false | singleton ✓ |
| `setup({ source })` | `options` | false | singleton ✓ |
| `fetch({ meetingId? })` | `options` | false | singleton ✓ |
| `get(id)` | `id` | true | needs instance ✓ |
| `update(id, data)` | `id` | true | needs instance ✓ |

## Test plan

- [x] All CLI tests pass (205 passed)
- [ ] Manual test with `smrt praeco discover` (no ID required)
- [ ] Manual test with `smrt praeco setup --source ...` (no ID required)