### PR TITLE
fix(cli): validator uses snake_case for JSON file field lookups

### DIFF
--- a/packages/cli/src/commands/__tests__/db-validate.test.ts
+++ b/packages/cli/src/commands/__tests__/db-validate.test.ts
@@ -646,6 +646,46 @@ describe('db:validate', () => {
     });
   });
 
+  describe('snake_case field name handling (issue #549)', () => {
+    it('should correctly validate fields with snake_case names in JSON', async () => {
+      // JSON files use snake_case field names (matching database columns)
+      // This tests the fix for issue #549 where the validator was looking
+      // for camelCase field names (typeId) instead of snake_case (type_id)
+      await writeFile(
+        resolve(dataDir, 'profiles.json'),
+        JSON.stringify([
+          {
+            id: '5e75e8fa-c12f-45d6-bbfa-667a3b6a832e',
+            _meta_type: 'Person',
+            type_id: 'e0f5c6f6-31e7-416c-8f58-4d2a5d0748e2',
+            name: 'Mayor Hansen',
+            created_at: '2024-01-01T00:00:00.000Z',
+            updated_at: '2024-01-01T00:00:00.000Z',
+          },
+        ]),
+      );
+
+      const validator = new JsonDatabaseValidator({
+        dataPath: dataDir,
+        quickMode: true,
+        verbose: false,
+      });
+
+      const files = await discoverJsonFiles(dataDir);
+      const results = await validator.validate(files);
+
+      // Should not have MISSING_REQUIRED_FIELD errors for snake_case fields
+      const missingFieldErrors = results.objectResults[0].issues.filter(
+        (i) =>
+          i.code === ValidationCodes.MISSING_REQUIRED_FIELD &&
+          (i.field === 'typeId' ||
+            i.field === 'createdAt' ||
+            i.field === 'updatedAt'),
+      );
+      expect(missingFieldErrors).toHaveLength(0);
+    });
+  });
+
   describe('command structure', () => {
     it('should have correct command definition', async () => {
       const { utilityCommands } = await import('../utilities.js');

--- a/packages/cli/src/commands/json-validator.ts
+++ b/packages/cli/src/commands/json-validator.ts
@@ -19,6 +19,29 @@ import {
   type ValidationSummary,
 } from './validation-types.js';
 
+/**
+ * Converts a camelCase string to snake_case
+ *
+ * JSON database files store data with snake_case field names (matching database columns),
+ * but ObjectRegistry field names use camelCase (matching JavaScript conventions).
+ * This function bridges the gap when validating JSON files.
+ *
+ * @param str - String in camelCase format
+ * @returns String in snake_case format
+ * @example
+ * ```typescript
+ * toSnakeCase('typeId'); // 'type_id'
+ * toSnakeCase('createdAt'); // 'created_at'
+ * toSnakeCase('id'); // 'id'
+ * ```
+ */
+function toSnakeCase(str: string): string {
+  return str
+    .replace(/([A-Z])/g, '_$1')
+    .toLowerCase()
+    .replace(/^_/, '');
+}
+
 interface ValidatorOptions {
   dataPath: string;
   quickMode: boolean;
@@ -571,7 +594,11 @@ export class JsonDatabaseValidator {
     objectId: string,
   ): ValidationIssue[] {
     const issues: ValidationIssue[] = [];
-    const value = record[fieldName];
+    // JSON files use snake_case field names (matching database columns)
+    // ObjectRegistry uses camelCase (matching JavaScript conventions)
+    // Convert camelCase to snake_case for lookup in JSON data
+    const snakeCaseFieldName = toSnakeCase(fieldName);
+    const value = record[snakeCaseFieldName];
     const fieldType = fieldDef.type as string;
 
     // Check required fields
@@ -896,7 +923,9 @@ export class JsonDatabaseValidator {
         const recordId = (rec.id as string) || `[unknown]`;
 
         for (const [fieldName, fieldDef] of fkFields) {
-          const fkValue = rec[fieldName];
+          // Convert camelCase field name to snake_case for JSON lookup
+          const snakeCaseFieldName = toSnakeCase(fieldName);
+          const fkValue = rec[snakeCaseFieldName];
           if (!fkValue) continue;
 
           const def = fieldDef as Record<string, unknown>;
@@ -1014,7 +1043,9 @@ export class JsonDatabaseValidator {
                 | Record<string, unknown>
                 | undefined;
               if (fieldDef?.default !== undefined) {
-                record[issue.field] = fieldDef.default;
+                // Convert camelCase field name to snake_case for JSON storage
+                const snakeCaseField = toSnakeCase(issue.field);
+                record[snakeCaseField] = fieldDef.default;
                 fixedCount++;
               }
             }


### PR DESCRIPTION
## Summary

The `db:validate` command was incorrectly looking up field values using camelCase names (e.g., `typeId`) when JSON files store data with snake_case names (e.g., `type_id`). This caused false "MISSING_REQUIRED_FIELD" errors.

**Root cause**: JSON database files use snake_case field names (matching database columns), but `ObjectRegistry.getFields()` returns camelCase field names (matching JavaScript conventions). The validator was using camelCase names directly to look up values in JSON data.

## Changes

- Add `toSnakeCase()` helper function to convert camelCase field names to snake_case
- Convert field names when:
  - Validating field values in `validateField()`
  - Validating foreign key references in `validateForeignKeys()`
  - Applying fixes in `applyFixes()`
- Add test case for snake_case field name handling

## Architecture Context

The SMRT framework uses:
- **JavaScript code**: camelCase property names (`typeId`, `createdAt`)
- **Database storage**: snake_case column names (`type_id`, `created_at`)
- **JSON files**: snake_case field names (same as database - they're exported from DuckDB)

The adapter layer (`formatDataSql()` / `formatDataJs()`) handles the translation between these conventions for normal CRUD operations. The validator was bypassing this translation when reading JSON files directly.

## Test Plan

- [x] Added unit test for snake_case field name handling
- [x] All 206 CLI tests pass
- [x] Build succeeds

Fixes #549
Related to #444 (this may already be resolved - needs verification with current codebase)