### PR TITLE
fix(core): collection tableName correctly inherited from STI item class

### DIFF
--- a/packages/core/src/__tests__/issue-551-collection-sti-type-arg.test.ts
+++ b/packages/core/src/__tests__/issue-551-collection-sti-type-arg.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Test for Issue #551: Collection tableName not inferred from managed STI subclass
+ *
+ * When a SmrtCollection manages an STI subclass, the collection's tableName should
+ * be inferred from the STI parent's table, not from the collection class name.
+ *
+ * Fix: Extract the generic type argument from the extends clause
+ * (e.g., "Meeting" from "SmrtCollection<Meeting>") to reliably find the item class.
+ *
+ * @see https://github.com/happyvertical/smrt/issues/551
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SmrtCollection } from '../collection';
+import { SmrtObject } from '../object';
+import { ObjectRegistry, smrt } from '../registry';
+
+describe('Issue #551: Collection STI table name from generic type argument', () => {
+  beforeEach(() => {
+    ObjectRegistry.clear();
+  });
+
+  afterEach(() => {
+    ObjectRegistry.clear();
+  });
+
+  it('should infer collection tableName from STI item class via generic type', () => {
+    // Define STI base class
+    @smrt({ tableStrategy: 'sti' })
+    class Event extends SmrtObject {
+      title: string = '';
+      date: Date = new Date();
+    }
+
+    // Define STI child class
+    @smrt()
+    class Meeting extends Event {
+      roomNumber: string = '';
+      attendees: string[] = [];
+    }
+
+    // Define collection that manages the STI child
+    // The generic type argument <Meeting> should be extracted by AST scanner
+    @smrt()
+    class Meetings extends SmrtCollection<Meeting> {
+      static readonly _itemClass = Meeting;
+    }
+
+    // Verify STI inheritance works
+    expect(ObjectRegistry.getTableName('Event')).toBe('events');
+    expect(ObjectRegistry.getTableName('Meeting')).toBe('events');
+
+    // CRITICAL: Collection should inherit tableName from Meeting -> Event
+    // Before fix: Would incorrectly use 'meetings' (from collection class name)
+    // After fix: Should use 'events' (from STI base class)
+    expect(ObjectRegistry.getTableName('Meetings')).toBe('events');
+  });
+
+  it('should work with multiple collections for different STI children', () => {
+    @smrt({ tableStrategy: 'sti' })
+    class Event extends SmrtObject {
+      title: string = '';
+    }
+
+    @smrt()
+    class Meeting extends Event {
+      roomNumber: string = '';
+    }
+
+    @smrt()
+    class Conference extends Event {
+      sponsor: string = '';
+    }
+
+    @smrt()
+    class Meetings extends SmrtCollection<Meeting> {
+      static readonly _itemClass = Meeting;
+    }
+
+    @smrt()
+    class Conferences extends SmrtCollection<Conference> {
+      static readonly _itemClass = Conference;
+    }
+
+    // Both collections should point to the same 'events' table
+    expect(ObjectRegistry.getTableName('Meetings')).toBe('events');
+    expect(ObjectRegistry.getTableName('Conferences')).toBe('events');
+  });
+
+  it('should work with "Collection" suffix naming convention', () => {
+    // Use unique class names to avoid collision with smrt-content's Article/Content
+    @smrt({ tableStrategy: 'sti' })
+    class Issue551Content extends SmrtObject {
+      body: string = '';
+    }
+
+    @smrt()
+    class Issue551Article extends Issue551Content {
+      headline: string = '';
+    }
+
+    @smrt()
+    class Issue551ArticleCollection extends SmrtCollection<Issue551Article> {
+      static readonly _itemClass = Issue551Article;
+    }
+
+    // Verify STI hierarchy is correct
+    expect(ObjectRegistry.getTableName('Issue551Content')).toBe(
+      'issue551contents',
+    );
+    expect(ObjectRegistry.getTableName('Issue551Article')).toBe(
+      'issue551contents',
+    );
+
+    // Collection should inherit tableName from Issue551Article -> Issue551Content
+    expect(ObjectRegistry.getTableName('Issue551ArticleCollection')).toBe(
+      'issue551contents',
+    );
+  });
+
+  it('should verify collection tableName is correctly set', () => {
+    @smrt({ tableStrategy: 'sti' })
+    class Event extends SmrtObject {
+      title: string = '';
+    }
+
+    @smrt()
+    class Meeting extends Event {
+      roomNumber: string = '';
+    }
+
+    @smrt()
+    class Meetings extends SmrtCollection<Meeting> {
+      static readonly _itemClass = Meeting;
+    }
+
+    // The collection should have tableName set correctly via getTableName
+    // This verifies the collection class name -> tableName mapping works
+    expect(ObjectRegistry.getTableName('Meetings')).toBe('events');
+
+    // The item class (Meeting) should also point to the STI base table
+    expect(ObjectRegistry.getTableName('Meeting')).toBe('events');
+  });
+});

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -76,6 +76,8 @@ declare global {
   var __smrtRegistryFieldDecorators: Map<string, Map<string, any>> | undefined;
   // eslint-disable-next-line no-var
   var __smrtRegistryStiSiblingsLoaded: Set<string> | undefined;
+  // eslint-disable-next-line no-var
+  var __smrtRegistryCollectionTableNames: Map<string, string> | undefined;
 }
 
 /**
@@ -338,6 +340,28 @@ export class ObjectRegistry {
       >();
     }
     return globalThis.__smrtRegistryCollections;
+  }
+
+  /**
+   * Get the collection table names map from globalThis, initializing if needed
+   * Maps collection class name -> tableName for getTableName lookups
+   */
+  private static get collectionTableNames(): Map<string, string> {
+    if (!globalThis.__smrtRegistryCollectionTableNames) {
+      globalThis.__smrtRegistryCollectionTableNames = new Map<string, string>();
+    }
+    return globalThis.__smrtRegistryCollectionTableNames;
+  }
+
+  /**
+   * Set the table name for a collection class
+   * Used by @smrt() decorator to enable getTableName lookups for collections
+   */
+  static setCollectionTableName(
+    collectionName: string,
+    tableName: string,
+  ): void {
+    ObjectRegistry.collectionTableNames.set(collectionName, tableName);
   }
 
   /**
@@ -1386,6 +1410,7 @@ export class ObjectRegistry {
     ObjectRegistry.classes.clear();
     ObjectRegistry.collections.clear();
     ObjectRegistry.collectionCache.clear();
+    ObjectRegistry.collectionTableNames.clear();
     ObjectRegistry.getInheritanceCache().clear();
     ObjectRegistry.fieldDecorators.clear();
     ObjectRegistry.stiSiblingsLoaded.clear();
@@ -1954,6 +1979,12 @@ export class ObjectRegistry {
    * ```
    */
   static getTableName(name: string): string | undefined {
+    // Check if this is a collection class - collections have their own tableName mapping
+    const collectionTableName = ObjectRegistry.collectionTableNames.get(name);
+    if (collectionTableName) {
+      return collectionTableName;
+    }
+
     // For STI classes, return the STI base class's table name
     const stiBase = ObjectRegistry.getSTIBase(name);
     if (stiBase && stiBase !== name) {
@@ -3212,6 +3243,10 @@ export function smrt(config: SmartObjectConfig = {}) {
         // Register the collection constructor using tableName (not class name)
         // This ensures CLI lookups by tableName (e.g., "meetings") find the collection
         ObjectRegistry.registerCollection(tableName, ctor as any);
+
+        // Store collection class name -> tableName mapping for getTableName lookups
+        // This enables ObjectRegistry.getTableName('CollectionClassName') to work
+        ObjectRegistry.setCollectionTableName(ctor.name, tableName);
       }
     } else {
       // Handle SmrtObject registration (existing behavior)

--- a/packages/core/src/scanner/ast-scanner.ts
+++ b/packages/core/src/scanner/ast-scanner.ts
@@ -225,8 +225,8 @@ export class ASTScanner {
     // Generate collection name (pluralized)
     const collection = this.pluralize(className.toLowerCase());
 
-    // Extract parent class name from extends clause
-    const parentClass = this.extractParentClassName(node);
+    // Extract parent class name and generic type argument from extends clause
+    const { parentClass, typeArg } = this.extractExtendsInfo(node);
 
     const objectDef: SmartObjectDefinition = {
       name: className.toLowerCase(),
@@ -236,7 +236,8 @@ export class ASTScanner {
       fields: {},
       methods: {},
       decoratorConfig,
-      extends: parentClass, // NEW: Capture inheritance
+      extends: parentClass, // Capture inheritance
+      extendsTypeArg: typeArg, // Capture generic type argument (e.g., Meeting from SmrtCollection<Meeting>)
     };
 
     // Parse class members
@@ -399,18 +400,20 @@ export class ASTScanner {
   }
 
   /**
-   * Extract parent class name from extends clause
+   * Extract parent class name and generic type argument from extends clause
    *
-   * Returns the direct parent class name, or undefined if no extends clause.
-   * This enables inheritance chain tracking in the ObjectRegistry.
+   * Parses the class declaration to find which class it extends and
+   * any generic type argument (e.g., SmrtCollection<Meeting>).
+   * This enables inheritance chain tracking and collection item class detection.
    *
    * @param node - Class declaration node
-   * @returns Parent class name or undefined
+   * @returns Object with parentClass and optional typeArg
    */
-  private extractParentClassName(
-    node: ts.ClassDeclaration,
-  ): string | undefined {
-    if (!node.heritageClauses) return undefined;
+  private extractExtendsInfo(node: ts.ClassDeclaration): {
+    parentClass?: string;
+    typeArg?: string;
+  } {
+    if (!node.heritageClauses) return {};
 
     for (const clause of node.heritageClauses) {
       if (clause.token === ts.SyntaxKind.ExtendsKeyword) {
@@ -418,21 +421,39 @@ export class ASTScanner {
         const type = clause.types[0];
         if (!type) continue;
 
+        let parentClass: string | undefined;
+
         // Handle both simple identifiers and complex expressions
         if (ts.isIdentifier(type.expression)) {
-          return type.expression.text;
+          parentClass = type.expression.text;
         } else if (ts.isPropertyAccessExpression(type.expression)) {
           // Handle cases like 'SmrtBase.SubClass'
-          return type.expression.name?.text;
+          parentClass = type.expression.name?.text;
         } else if (type.expression) {
           // Try to extract text from any expression
           const expressionText = type.expression.getText?.();
-          return expressionText?.split('.').pop()?.trim();
+          parentClass = expressionText?.split('.').pop()?.trim();
         }
+
+        // Extract generic type argument (e.g., <Meeting> from SmrtCollection<Meeting>)
+        let typeArg: string | undefined;
+        if (type.typeArguments && type.typeArguments.length > 0) {
+          const firstTypeArg = type.typeArguments[0];
+          if (ts.isTypeReferenceNode(firstTypeArg) && firstTypeArg.typeName) {
+            if (ts.isIdentifier(firstTypeArg.typeName)) {
+              typeArg = firstTypeArg.typeName.text;
+            } else if (ts.isQualifiedName(firstTypeArg.typeName)) {
+              // Handle qualified names like Namespace.ClassName
+              typeArg = firstTypeArg.typeName.right.text;
+            }
+          }
+        }
+
+        return { parentClass, typeArg };
       }
     }
 
-    return undefined;
+    return {};
   }
 
   /**

--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -630,8 +630,10 @@ export class ManifestGenerator {
   /**
    * Find the item class for a collection class
    *
-   * Looks for the _itemClass static property first, then falls back to
-   * name-based inference (e.g., "Meetings" -> "Meeting", "EventCollection" -> "Event").
+   * Lookup priority:
+   * 1. extendsTypeArg - Generic type argument from extends clause (e.g., "Meeting" from SmrtCollection<Meeting>)
+   * 2. _itemClass static property - May be captured by AST scanner
+   * 3. Name-based inference - Fallback (e.g., "Meetings" -> "Meeting")
    *
    * @param collectionObj - The collection class definition
    * @param manifest - The manifest
@@ -643,8 +645,42 @@ export class ManifestGenerator {
     manifest: SmartObjectManifest,
     objectsByName: Map<string, SmartObjectDefinition>,
   ): SmartObjectDefinition | undefined {
-    // Look for _itemClass static field in the collection class
+    // PRIORITY 1: Use generic type argument from extends clause
+    // This is the most reliable method: SmrtCollection<Meeting> -> "Meeting"
+    if (collectionObj.extendsTypeArg) {
+      const itemClassName = collectionObj.extendsTypeArg;
+      console.log(
+        `[manifest-generator] ${collectionObj.className} has extendsTypeArg: ${itemClassName}`,
+      );
+
+      // Try to find the item class by name in local manifest
+      const itemClass = objectsByName.get(itemClassName);
+      if (itemClass) {
+        console.log(
+          `[manifest-generator] Found item class ${itemClassName} in local manifest`,
+        );
+        return itemClass;
+      }
+
+      // Try loading from external packages
+      if (manifest.smrtDependencies && manifest.smrtDependencies.length > 0) {
+        const externalItemClass = this.loadParentFromExternalPackage(
+          itemClassName,
+          manifest.smrtDependencies,
+          objectsByName,
+        );
+        if (externalItemClass) {
+          console.log(
+            `[manifest-generator] Found item class ${itemClassName} in external package`,
+          );
+          return externalItemClass;
+        }
+      }
+    }
+
+    // PRIORITY 2: Look for _itemClass static field in the collection class
     // This is defined like: static readonly _itemClass = Meeting;
+    // Note: AST scanner currently skips static properties, so this rarely works
     const itemClassField = collectionObj.fields._itemClass;
 
     if (itemClassField) {
@@ -670,7 +706,7 @@ export class ManifestGenerator {
       }
     }
 
-    // Fallback: Try to infer from collection class name
+    // PRIORITY 3: Fallback - Try to infer from collection class name
     // Generate candidate item class names and check if they exist
     const collectionName = collectionObj.className;
     const candidates: string[] = [];

--- a/packages/core/src/scanner/types.ts
+++ b/packages/core/src/scanner/types.ts
@@ -90,6 +90,7 @@ export interface SmartObjectDefinition {
   methods: Record<string, MethodDefinition>;
   decoratorConfig: SmartObjectConfig;
   extends?: string; // Base class name
+  extendsTypeArg?: string; // Generic type argument (e.g., "Meeting" from "SmrtCollection<Meeting>")
   tools?: Array<{
     type: 'function';
     function: {


### PR DESCRIPTION
## Summary

Fixes #551: When a `SmrtCollection` manages an STI subclass (e.g., `class Meetings extends SmrtCollection<Meeting>`), the collection's `tableName` should be inferred from the STI parent's table, not from the collection class name.

### The Problem

Before this fix:
- `ObjectRegistry.getTableName('Meeting')` → `'events'` ✅ (correct - inherits from Event STI base)
- `ObjectRegistry.getTableName('Meetings')` → `undefined` or `'meetings'` ❌ (wrong - should be 'events')

### The Solution

1. **Extract generic type argument from extends clause** - The AST scanner now parses `SmrtCollection<Meeting>` to extract "Meeting" as the `extendsTypeArg` field.

2. **Use type argument for item class lookup** - The manifest generator's `findItemClass()` now uses the extracted type argument as the primary method to find the item class for collections.

3. **Register collection tableName** - The `@smrt()` decorator now stores a mapping from collection class name to tableName in `ObjectRegistry.collectionTableNames`, enabling `getTableName('Meetings')` to correctly return `'events'`.

### Files Changed

- `packages/core/src/scanner/types.ts` - Added `extendsTypeArg` field to `SmartObjectDefinition`
- `packages/core/src/scanner/ast-scanner.ts` - Extract generic type argument from extends clause
- `packages/core/src/scanner/manifest-generator.ts` - Use `extendsTypeArg` in `findItemClass()` lookup
- `packages/core/src/registry.ts` - Added `collectionTableNames` map and `setCollectionTableName()` method

## Test plan

- [x] New tests added in `issue-551-collection-sti-type-arg.test.ts`
- [x] `npm run build` passes
- [x] `npm run typecheck` passes  
- [x] Core package tests pass (839 tests)
- [x] All tests pass when run directly (`npm test` in cli package)

Note: There's an intermittent race condition in Turborepo's parallel test execution that sometimes causes CLI tests to fail, but the tests pass consistently when run directly.