### PR TITLE
refactor(assets): migrate Image embeddings to centralized system

### DIFF
--- a/packages/assets/src/__tests__/image-adapter-parity.test.ts
+++ b/packages/assets/src/__tests__/image-adapter-parity.test.ts
@@ -7,8 +7,10 @@
  * Test Coverage:
  * 1. Basic CRUD operations with Image fields
  * 2. STI inheritance and polymorphic queries
- * 3. Embedding storage/retrieval across adapters
- * 4. Type preservation across save/load cycles
+ * 3. Type preservation across save/load cycles
+ *
+ * Note: For semantic search on images, use the centralized embedding system
+ * in @happyvertical/smrt-core via @smrt({ embeddings: { fields: ['alt', 'description'] } })
  */
 
 import { existsSync, rmSync, unlinkSync } from 'node:fs';
@@ -44,16 +46,6 @@ const fixtures = {
       width: 256,
       height: 256,
       alt: 'App icon',
-    },
-    withEmbedding: {
-      _meta_type: 'Image',
-      name: 'embedded.jpg',
-      sourceUri: 'file:///images/embedded.jpg',
-      mimeType: 'image/jpeg',
-      width: 512,
-      height: 512,
-      embedding: [0.1, 0.2, 0.3, 0.4, 0.5],
-      descriptionEmbedding: [0.5, 0.4, 0.3, 0.2, 0.1],
     },
   },
   asset: {
@@ -161,50 +153,6 @@ function runBasicCRUDTests(getContext: () => { images: ImageCollection }) {
   });
 }
 
-function runEmbeddingTests(getContext: () => { images: ImageCollection }) {
-  describe('Embedding Storage', () => {
-    it('should store and retrieve embedding vectors', async () => {
-      const { images } = getContext();
-      const image = await images.create(fixtures.image.withEmbedding);
-      await image.save();
-
-      const loaded = await images.get({ id: image.id });
-      expect(loaded?.embedding).toEqual([0.1, 0.2, 0.3, 0.4, 0.5]);
-      expect(loaded?.descriptionEmbedding).toEqual([0.5, 0.4, 0.3, 0.2, 0.1]);
-    });
-
-    it('should handle large embedding vectors', async () => {
-      const { images } = getContext();
-      const largeEmbedding = Array.from({ length: 1536 }, (_, i) => i * 0.001);
-
-      const image = await images.create({
-        ...fixtures.image.jpeg,
-        embedding: largeEmbedding,
-      });
-      await image.save();
-
-      const loaded = await images.get({ id: image.id });
-      expect(loaded?.embedding).toHaveLength(1536);
-      expect(loaded?.embedding?.[0]).toBeCloseTo(0);
-      expect(loaded?.embedding?.[1535]).toBeCloseTo(1.535);
-    });
-
-    it('should handle empty embeddings', async () => {
-      const { images } = getContext();
-      const image = await images.create({
-        ...fixtures.image.jpeg,
-        embedding: [],
-        descriptionEmbedding: [],
-      });
-      await image.save();
-
-      const loaded = await images.get({ id: image.id });
-      expect(loaded?.embedding).toEqual([]);
-      expect(loaded?.descriptionEmbedding).toEqual([]);
-    });
-  });
-}
-
 function runPolymorphicTests(
   getContext: () => {
     images: ImageCollection;
@@ -241,18 +189,16 @@ function runPolymorphicTests(
     it('should preserve Image fields in mixed queries', async () => {
       const { images, assets } = getContext();
 
-      await (await images.create(fixtures.image.withEmbedding)).save();
+      await (await images.create(fixtures.image.jpeg)).save();
       await (await assets.create(fixtures.asset.document)).save();
 
       const allAssets = await assets.list({});
-      const imageAsset = allAssets.find(
-        (a) => a.name === 'embedded.jpg',
-      ) as Image;
+      const imageAsset = allAssets.find((a) => a.name === 'photo.jpg') as Image;
 
       expect(imageAsset).toBeInstanceOf(Image);
-      expect(imageAsset.width).toBe(512);
-      expect(imageAsset.height).toBe(512);
-      expect(imageAsset.embedding).toEqual([0.1, 0.2, 0.3, 0.4, 0.5]);
+      expect(imageAsset.width).toBe(1920);
+      expect(imageAsset.height).toBe(1080);
+      expect(imageAsset.alt).toBe('A scenic photo');
     });
   });
 }
@@ -288,16 +234,6 @@ function runTypePreservationTests(
       const loaded = await images.get({ id: image.id });
       expect(typeof loaded?.alt).toBe('string');
     });
-
-    it('should preserve array types for embeddings', async () => {
-      const { images } = getContext();
-      const image = await images.create(fixtures.image.withEmbedding);
-      await image.save();
-
-      const loaded = await images.get({ id: image.id });
-      expect(Array.isArray(loaded?.embedding)).toBe(true);
-      expect(Array.isArray(loaded?.descriptionEmbedding)).toBe(true);
-    });
   });
 }
 
@@ -331,7 +267,6 @@ describe('Image Adapter Parity', () => {
       const getFullContext = () => ({ images, assets });
 
       runBasicCRUDTests(getImageContext);
-      runEmbeddingTests(getImageContext);
       runPolymorphicTests(getFullContext);
       runTypePreservationTests(getImageContext);
     });

--- a/packages/assets/src/__tests__/image.test.ts
+++ b/packages/assets/src/__tests__/image.test.ts
@@ -4,9 +4,11 @@
  * Tests for:
  * 1. Image CRUD operations
  * 2. STI polymorphic queries (Asset collection returning Image instances)
- * 3. Embedding storage/retrieval
- * 4. Existing Asset functionality (inheritance of tag management, versioning)
- * 5. Image-specific computed properties
+ * 3. Existing Asset functionality (inheritance of tag management, versioning)
+ * 4. Image-specific computed properties
+ *
+ * Note: For semantic search on images, use the centralized embedding system
+ * in @happyvertical/smrt-core via @smrt({ embeddings: { fields: ['alt', 'description'] } })
  */
 
 import { existsSync, rmSync } from 'node:fs';
@@ -115,93 +117,6 @@ describe('Image', () => {
 
       const loaded = await images.get({ id: image.id });
       expect(loaded).toBeNull();
-    });
-  });
-
-  describe('Embedding Storage', () => {
-    it('should store and retrieve embedding vectors', async () => {
-      const images = await ImageCollection.create({
-        db: { type: 'sqlite', url: dbPath },
-      });
-
-      const embedding = [0.1, 0.2, 0.3, 0.4, 0.5];
-      const image = await images.create({
-        name: 'embedded-image.jpg',
-        sourceUri: 'file:///images/embedded.jpg',
-        mimeType: 'image/jpeg',
-        width: 512,
-        height: 512,
-        embedding,
-      });
-      await image.save();
-
-      const loaded = await images.get({ id: image.id });
-      expect(loaded?.embedding).toEqual(embedding);
-    });
-
-    it('should store description embedding separately', async () => {
-      const images = await ImageCollection.create({
-        db: { type: 'sqlite', url: dbPath },
-      });
-
-      const embedding = [0.1, 0.2, 0.3];
-      const descriptionEmbedding = [0.4, 0.5, 0.6];
-
-      const image = await images.create({
-        name: 'dual-embedded.jpg',
-        sourceUri: 'file:///images/dual.jpg',
-        mimeType: 'image/jpeg',
-        width: 256,
-        height: 256,
-        embedding,
-        descriptionEmbedding,
-      });
-      await image.save();
-
-      const loaded = await images.get({ id: image.id });
-      expect(loaded?.embedding).toEqual(embedding);
-      expect(loaded?.descriptionEmbedding).toEqual(descriptionEmbedding);
-    });
-
-    it('should handle large embedding vectors (1536 dimensions)', async () => {
-      const images = await ImageCollection.create({
-        db: { type: 'sqlite', url: dbPath },
-      });
-
-      // OpenAI ada-002 embedding size
-      const largeEmbedding = Array.from({ length: 1536 }, (_, i) => i * 0.001);
-
-      const image = await images.create({
-        name: 'large-embedding.jpg',
-        mimeType: 'image/jpeg',
-        width: 512,
-        height: 512,
-        embedding: largeEmbedding,
-      });
-      await image.save();
-
-      const loaded = await images.get({ id: image.id });
-      expect(loaded?.embedding).toHaveLength(1536);
-      expect(loaded?.embedding?.[0]).toBeCloseTo(0);
-      expect(loaded?.embedding?.[1535]).toBeCloseTo(1.535);
-    });
-
-    it('should handle empty embeddings', async () => {
-      const images = await ImageCollection.create({
-        db: { type: 'sqlite', url: dbPath },
-      });
-
-      const image = await images.create({
-        name: 'no-embedding.jpg',
-        mimeType: 'image/jpeg',
-        width: 256,
-        height: 256,
-      });
-      await image.save();
-
-      const loaded = await images.get({ id: image.id });
-      expect(loaded?.embedding).toEqual([]);
-      expect(loaded?.descriptionEmbedding).toEqual([]);
     });
   });
 
@@ -529,25 +444,6 @@ describe('Image', () => {
       const missing = await images.getMissingAltText();
       expect(missing).toHaveLength(1);
       expect(missing[0].name).toBe('no-alt.jpg');
-    });
-
-    it('should get images with embeddings', async () => {
-      const images = await ImageCollection.create({
-        db: { type: 'sqlite', url: dbPath },
-      });
-
-      await (
-        await images.create({ name: 'with-embed.jpg', embedding: [0.1, 0.2] })
-      ).save();
-      await (await images.create({ name: 'no-embed.jpg' })).save();
-
-      const withEmbed = await images.getWithEmbeddings();
-      expect(withEmbed).toHaveLength(1);
-      expect(withEmbed[0].name).toBe('with-embed.jpg');
-
-      const withoutEmbed = await images.getWithoutEmbeddings();
-      expect(withoutEmbed).toHaveLength(1);
-      expect(withoutEmbed[0].name).toBe('no-embed.jpg');
     });
 
     it('should get high resolution images', async () => {

--- a/packages/assets/src/image.ts
+++ b/packages/assets/src/image.ts
@@ -1,11 +1,14 @@
 /**
  * Image model - Asset subclass for image files
  *
- * Represents an image asset with dimensions, accessibility text, and AI embeddings.
+ * Represents an image asset with dimensions and accessibility text.
  * Uses STI (Single Table Inheritance) - stored in the assets table with _meta_type='Image'.
+ *
+ * For semantic search on images, use the centralized embedding system:
+ * @smrt({ embeddings: { fields: ['alt', 'description'] } })
  */
 
-import { type Meta, smrt } from '@happyvertical/smrt-core';
+import { smrt } from '@happyvertical/smrt-core';
 import { Asset } from './asset';
 import type { ImageOptions } from './types';
 
@@ -22,18 +25,11 @@ export class Image extends Asset {
   // Accessibility text
   alt: string = '';
 
-  // AI embeddings stored in _meta_data JSONB (child-specific fields)
-  embedding: Meta<number[]> = [];
-  descriptionEmbedding: Meta<number[]> = [];
-
   constructor(options: ImageOptions = {}) {
     super(options);
     if (options.width !== undefined) this.width = options.width;
     if (options.height !== undefined) this.height = options.height;
     if (options.alt !== undefined) this.alt = options.alt;
-    if (options.embedding) this.embedding = options.embedding;
-    if (options.descriptionEmbedding)
-      this.descriptionEmbedding = options.descriptionEmbedding;
   }
 
   /**

--- a/packages/assets/src/images.ts
+++ b/packages/assets/src/images.ts
@@ -90,26 +90,6 @@ export class ImageCollection extends SmrtCollection<Image> {
   }
 
   /**
-   * Get images with embeddings
-   *
-   * @returns Array of images that have embedding vectors
-   */
-  async getWithEmbeddings(): Promise<Image[]> {
-    const images = (await this.list({})) as Image[];
-    return images.filter((img) => img.embedding && img.embedding.length > 0);
-  }
-
-  /**
-   * Get images without embeddings
-   *
-   * @returns Array of images missing embedding vectors
-   */
-  async getWithoutEmbeddings(): Promise<Image[]> {
-    const images = (await this.list({})) as Image[];
-    return images.filter((img) => !img.embedding || img.embedding.length === 0);
-  }
-
-  /**
    * Get high resolution images (4K+)
    *
    * @returns Array of high resolution images

--- a/packages/assets/src/types.ts
+++ b/packages/assets/src/types.ts
@@ -57,6 +57,4 @@ export interface ImageOptions extends AssetOptions {
   width?: number;
   height?: number;
   alt?: string;
-  embedding?: number[];
-  descriptionEmbedding?: number[];
 }


### PR DESCRIPTION
## Summary

- Remove Image-specific embedding storage (`embedding`, `descriptionEmbedding` fields) from the Image class
- Migrate to the centralized embedding system introduced in PR #577
- Remove `getWithEmbeddings()`/`getWithoutEmbeddings()` methods from ImageCollection
- Update tests to remove embedding-specific test cases

The centralized system uses `@smrt({ embeddings: { fields: ['alt', 'description'] } })` and stores embeddings in the `_smrt_embeddings` system table, providing a consistent approach across all SMRT objects.

## Test plan

- [x] Run existing Image tests to verify CRUD operations still work
- [x] Verify STI polymorphic queries continue to function
- [x] Confirm adapter parity tests pass across SQLite and JSON adapters