### PR TITLE
fix(core): allow real class to replace manifest-loaded entry (Issue #584)

### DIFF
--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -719,6 +719,23 @@ export class ObjectRegistry {
         return;
       }
 
+      // Check if existing entry was registered from external package manifest data
+      // (Issue #584: Registry collision when real class tries to replace manifest-loaded entry)
+      // This happens when:
+      // 1. CLI loads manifest and registers classes using manifest data via ObjectRegistry.register()
+      // 2. Later, register.js imports the real class, triggering the @smrt() decorator
+      // 3. The real class should replace the manifest-loaded entry
+      // We detect this by checking if existing has packageName from an external package
+      const newPackageName = getPackageName(ctor, true);
+      if (existing.packageName?.startsWith('@')) {
+        // If the new class is from the same package, allow replacement
+        if (newPackageName === existing.packageName) {
+          existing.constructor = ctor;
+          existing.config = { ...existing.config, ...config };
+          return;
+        }
+      }
+
       // Check if this is the same class being re-registered from module re-evaluation
       // This happens during vitest test collection when modules are re-evaluated for isolation
       // (Issue #555: Test isolation - class name collision during vitest collection)


### PR DESCRIPTION
## Summary
- Fixes Issue #584: SMRT Class Name Collision when CLI loads manifest and then register.js imports the real class
- Adds a check in `ObjectRegistry.register()` to allow real classes to replace manifest-loaded entries from the same package

## Problem
When the CLI:
1. Loads manifest data and registers classes with `packageName` metadata
2. Then imports `register.js` which imports real classes
3. The real class's `@smrt()` decorator tries to register

The registry would throw "SMRT Class Name Collision" because it saw the existing entry as a different constructor.

## Solution
Added a check at `registry.ts:722-737` that:
1. Detects if existing entry has `packageName` starting with `@` (external package)
2. Checks if the new class is from the same package
3. Allows replacement if both conditions are met

## Test plan
- [x] Verified `pnpm smrt praeco report` works without collision errors
- [x] Verified `pnpm smrt caelus fetchWeather` works
- [x] Verified `pnpm smrt ludis discover` works

Closes #584