### PR TITLE
feat(users): add TenantService with configurable tenant policies

### DIFF
--- a/packages/users/src/collections/UserCollection.ts
+++ b/packages/users/src/collections/UserCollection.ts
@@ -4,8 +4,47 @@
  */
 
 import { SmrtCollection } from '@happyvertical/smrt-core';
+import type { OidcIdentity, Profile } from '@happyvertical/smrt-profiles';
 import { User } from '../models/User.js';
 import { UserStatus } from '../types/index.js';
+
+/**
+ * OIDC claims used for identity resolution
+ */
+export interface OidcClaims {
+  /** Subject identifier from IdP */
+  sub: string;
+  /** Issuer URL */
+  iss: string;
+  /** User's email address */
+  email?: string;
+  /** User's display name */
+  name?: string;
+  /** Preferred username */
+  preferred_username?: string;
+}
+
+/**
+ * Result of OIDC identity resolution
+ */
+export interface OidcIdentityResult {
+  /** The User record */
+  user: User;
+  /** The linked Profile */
+  profile: Profile;
+  /** The OidcIdentity linking profile to IdP */
+  oidcIdentity: OidcIdentity;
+  /** Whether the profile was newly created */
+  created: boolean;
+}
+
+/**
+ * Options for getOrCreateFromOidc
+ */
+export interface GetOrCreateFromOidcOptions {
+  /** If false, skip recording login timestamp (default: true) */
+  recordLogin?: boolean;
+}
 
 /**
  * Collection for managing User objects
@@ -79,5 +118,95 @@ export class UserCollection extends SmrtCollection<User> {
     });
     await user.save();
     return user;
+  }
+
+  /**
+   * Get or create user from OIDC claims
+   *
+   * This is the primary method for resolving identity from an OIDC login.
+   * It handles the full flow:
+   * 1. Find or create Profile from OIDC claims (via smrt-profiles)
+   * 2. Link OidcIdentity to the Profile
+   * 3. Find or create User linked to the Profile
+   *
+   * @param claims - OIDC token claims (sub, iss, email, name)
+   * @param provider - Provider name (e.g., 'kanidm', 'keycloak', 'google')
+   * @param options - Optional settings (recordLogin)
+   * @returns User, Profile, OidcIdentity, and whether profile was created
+   *
+   * @example
+   * ```typescript
+   * const userCollection = await UserCollection.create({ db: dbConfig });
+   *
+   * // In your OIDC callback handler:
+   * const { user, profile } = await userCollection.getOrCreateFromOidc(
+   *   {
+   *     sub: tokenClaims.sub,
+   *     iss: tokenClaims.iss,
+   *     email: tokenClaims.email,
+   *     name: tokenClaims.name,
+   *   },
+   *   'kanidm'
+   * );
+   *
+   * // User and profile are now available
+   * // Login was auto-recorded; pass { recordLogin: false } to skip
+   * ```
+   */
+  async getOrCreateFromOidc(
+    claims: OidcClaims,
+    provider: string,
+    options?: GetOrCreateFromOidcOptions,
+  ): Promise<OidcIdentityResult> {
+    // Validate required OIDC claims at runtime
+    const sub = claims?.sub?.trim();
+    const iss = claims?.iss?.trim();
+    if (!sub || !iss) {
+      throw new Error(
+        'Invalid OIDC claims: both "sub" and "iss" must be non-empty strings.',
+      );
+    }
+
+    // Email is required for user creation
+    if (!claims.email) {
+      throw new Error(
+        'OIDC claims missing required "email" for user creation.',
+      );
+    }
+
+    // Dynamic import to avoid circular dependency between smrt-users and smrt-profiles.
+    // Both packages need to reference each other's types, so we defer the import.
+    const { createProfileFromOidc } = await import(
+      '@happyvertical/smrt-profiles'
+    );
+
+    // Get database options from this collection
+    const dbOptions = { db: this.options.db };
+
+    // Create or find profile with linked OIDC identity
+    const { profile, oidcIdentity, created } = await createProfileFromOidc(
+      claims,
+      provider,
+      dbOptions,
+    );
+
+    // Get or create user for this profile
+    const user = await this.getOrCreateForProfile(
+      profile.id as string,
+      claims.email,
+      { status: UserStatus.ACTIVE },
+    );
+
+    // Record login unless disabled
+    if (options?.recordLogin !== false) {
+      await user.recordLogin();
+    }
+
+    return {
+      user,
+      profile,
+      oidcIdentity,
+      created,
+    };
   }
 }

--- a/packages/users/src/collections/index.ts
+++ b/packages/users/src/collections/index.ts
@@ -16,4 +16,9 @@ export { RoleCollection } from './RoleCollection.js';
 export { RolePermissionCollection } from './RolePermissionCollection.js';
 export { TenantCollection } from './TenantCollection.js';
 // Core collections
-export { UserCollection } from './UserCollection.js';
+export {
+  type GetOrCreateFromOidcOptions,
+  type OidcClaims,
+  type OidcIdentityResult,
+  UserCollection,
+} from './UserCollection.js';

--- a/packages/users/src/index.ts
+++ b/packages/users/src/index.ts
@@ -41,11 +41,14 @@
 
 // Collections
 export {
+  type GetOrCreateFromOidcOptions,
   GroupCollection,
   GroupMemberCollection,
   GroupRoleCollection,
   MembershipCollection,
   MembershipOverrideCollection,
+  type OidcClaims,
+  type OidcIdentityResult,
   PermissionCollection,
   RoleCollection,
   RolePermissionCollection,
@@ -68,17 +71,23 @@ export {
 
 // Services
 export {
+  type EnsureTenantResult,
   type PermissionResolutionResult,
   PermissionResolver,
+  TenantService,
+  type TenantWithOwnershipResult,
 } from './services/index.js';
 
 // Types
 export {
   DEFAULT_ROLE_SLUGS,
   DEFAULT_ROLES,
+  DEFAULT_TENANT_POLICY,
   type DefaultRoleSlug,
   MembershipStatus,
   OverrideEffect,
+  type TenantPolicy,
+  type TenantPolicyMode,
   TenantStatus,
   UserStatus,
 } from './types/index.js';

--- a/packages/users/src/services/TenantService.ts
+++ b/packages/users/src/services/TenantService.ts
@@ -1,0 +1,356 @@
+/**
+ * TenantService - Manages tenant creation with configurable policies
+ * @packageDocumentation
+ */
+
+import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+import { MembershipCollection } from '../collections/MembershipCollection.js';
+import { RoleCollection } from '../collections/RoleCollection.js';
+import { TenantCollection } from '../collections/TenantCollection.js';
+import type { Membership } from '../models/Membership.js';
+import type { Tenant } from '../models/Tenant.js';
+import {
+  DEFAULT_ROLE_SLUGS,
+  DEFAULT_TENANT_POLICY,
+  MembershipStatus,
+  type TenantPolicy,
+} from '../types/index.js';
+
+/**
+ * Result of tenant creation with ownership
+ */
+export interface TenantWithOwnershipResult {
+  tenant: Tenant;
+  membership: Membership;
+}
+
+/**
+ * Result of ensureTenantForUser
+ */
+export interface EnsureTenantResult {
+  /** The tenant (null if flexible mode and no existing tenant) */
+  tenant: Tenant | null;
+  /** The membership (null if no tenant) */
+  membership: Membership | null;
+  /** Whether a new tenant was created */
+  created: boolean;
+}
+
+/**
+ * TenantService manages tenant creation with configurable policies.
+ *
+ * Policies:
+ * - `flexible`: No tenant created on signup, user can have zero tenants
+ * - `personal`: Auto-create personal tenant on first login, can delete all
+ * - `required`: Auto-create personal tenant, must keep at least one
+ *
+ * @example
+ * ```typescript
+ * const tenantService = new TenantService(options, {
+ *   mode: 'personal',
+ *   maxTenants: 5,
+ *   defaultName: 'My Workspace',
+ * });
+ * await tenantService.initialize();
+ *
+ * // During OIDC login
+ * const { tenant, membership, created } = await tenantService.ensureTenantForUser(
+ *   user.id,
+ *   { email: user.email, name: user.name }
+ * );
+ *
+ * // Creating additional tenants
+ * if (await tenantService.canCreateTenant(user.id)) {
+ *   const { tenant } = await tenantService.createTenantWithOwnership(
+ *     user.id,
+ *     'New Organization'
+ *   );
+ * }
+ * ```
+ */
+export class TenantService {
+  private options: SmrtClassOptions;
+  private policy: TenantPolicy;
+  private tenantCollection!: TenantCollection;
+  private membershipCollection!: MembershipCollection;
+  private roleCollection!: RoleCollection;
+
+  constructor(options: SmrtClassOptions, policy?: TenantPolicy) {
+    this.options = options;
+    this.policy = policy ?? DEFAULT_TENANT_POLICY;
+  }
+
+  /**
+   * Initialize collections
+   */
+  async initialize(): Promise<void> {
+    this.tenantCollection = await (TenantCollection as any).create(
+      this.options,
+    );
+    this.membershipCollection = await (MembershipCollection as any).create(
+      this.options,
+    );
+    this.roleCollection = await (RoleCollection as any).create(this.options);
+
+    // Seed system roles if needed
+    await this.roleCollection.seedSystemRoles();
+  }
+
+  /**
+   * Get the current policy
+   */
+  getPolicy(): TenantPolicy {
+    return { ...this.policy };
+  }
+
+  /**
+   * Create a tenant and make the user the owner
+   *
+   * @param userId - The user to make owner
+   * @param name - Tenant name
+   * @param options - Optional slug override
+   * @returns The created tenant and membership
+   */
+  async createTenantWithOwnership(
+    userId: string,
+    name: string,
+    options?: { slug?: string },
+  ): Promise<TenantWithOwnershipResult> {
+    // Check if user can create
+    if (!(await this.canCreateTenant(userId))) {
+      throw new Error(
+        `User has reached maximum tenant limit (${this.policy.maxTenants})`,
+      );
+    }
+
+    // Create tenant
+    const tenant = await this.tenantCollection.create({
+      name,
+      slug: options?.slug,
+    });
+    await tenant.save();
+
+    // Get owner role
+    const ownerRole = await this.roleCollection.findBySlug(
+      DEFAULT_ROLE_SLUGS.OWNER,
+    );
+    if (!ownerRole) {
+      throw new Error('Owner role not found - run seedSystemRoles first');
+    }
+
+    // Create ownership membership
+    const membership = await this.membershipCollection.create({
+      userId,
+      tenantId: tenant.id as string,
+      roleId: ownerRole.id as string,
+      status: MembershipStatus.ACTIVE,
+    });
+    await membership.save();
+
+    return { tenant, membership };
+  }
+
+  /**
+   * Check if a user can create a new tenant
+   *
+   * Returns false if maxTenants limit is reached (0 = unlimited)
+   */
+  async canCreateTenant(userId: string): Promise<boolean> {
+    if (this.policy.maxTenants === 0) {
+      return true; // Unlimited
+    }
+
+    const ownerRole = await this.roleCollection.findBySlug(
+      DEFAULT_ROLE_SLUGS.OWNER,
+    );
+    if (!ownerRole) {
+      // Fail closed if owner role is not configured
+      return false;
+    }
+
+    const memberships =
+      await this.membershipCollection.findActiveByUser(userId);
+    const ownedCount = memberships.filter(
+      (m) => m.roleId === ownerRole.id,
+    ).length;
+
+    return ownedCount < this.policy.maxTenants;
+  }
+
+  /**
+   * Get a specific error message explaining why a tenant cannot be deleted.
+   *
+   * @returns Error message if deletion is not allowed, or null if allowed.
+   */
+  private async getDeleteTenantError(
+    userId: string,
+    tenantId: string,
+  ): Promise<string | null> {
+    // Check user has an active membership for this tenant
+    const membership = await this.membershipCollection.findByUserAndTenant(
+      userId,
+      tenantId,
+    );
+    if (!membership || membership.status !== MembershipStatus.ACTIVE) {
+      return 'You are not a member of this tenant or it does not exist.';
+    }
+
+    const ownerRole = await this.roleCollection.findBySlug(
+      DEFAULT_ROLE_SLUGS.OWNER,
+    );
+    if (!ownerRole) {
+      return 'Owner role is not configured. Cannot determine deletion permissions.';
+    }
+
+    if (membership.roleId !== ownerRole.id) {
+      return 'Only the tenant owner can delete this tenant.';
+    }
+
+    // For 'required' policy, check if this is the last tenant
+    if (this.policy.mode === 'required') {
+      const allMemberships =
+        await this.membershipCollection.findActiveByUser(userId);
+      const ownerMemberships = allMemberships.filter(
+        (m) => m.roleId === ownerRole.id,
+      );
+
+      if (ownerMemberships.length <= 1) {
+        return 'Cannot delete your last tenant. Policy requires at least one tenant.';
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Check if a user can delete a specific tenant
+   *
+   * Returns false if:
+   * - User is not an active member
+   * - User is not the owner
+   * - Policy is 'required' and this is the last tenant
+   */
+  async canDeleteTenant(userId: string, tenantId: string): Promise<boolean> {
+    const error = await this.getDeleteTenantError(userId, tenantId);
+    return error === null;
+  }
+
+  /**
+   * Delete a tenant
+   *
+   * Note: This does not cascade delete related records (memberships, etc.).
+   * The caller should handle cleanup of related data if needed.
+   *
+   * @throws Error if user cannot delete the tenant (with specific reason)
+   */
+  async deleteTenant(userId: string, tenantId: string): Promise<void> {
+    const error = await this.getDeleteTenantError(userId, tenantId);
+    if (error) {
+      throw new Error(error);
+    }
+
+    const tenant = await this.tenantCollection.get(tenantId);
+    if (tenant) {
+      await tenant.delete();
+    }
+  }
+
+  /**
+   * Ensure a tenant exists for the user based on policy
+   *
+   * Called during OIDC login to apply tenant policy:
+   * - `flexible`: Returns first existing tenant or null (no auto-create)
+   * - `personal`/`required`: Creates default tenant if none exists
+   *
+   * @param userId - The user ID
+   * @param userInfo - User info for naming the auto-created tenant
+   * @returns Tenant and membership (may be null in flexible mode)
+   */
+  async ensureTenantForUser(
+    userId: string,
+    userInfo: { email?: string; name?: string },
+  ): Promise<EnsureTenantResult> {
+    // Get existing memberships
+    const memberships =
+      await this.membershipCollection.findActiveByUser(userId);
+
+    // If user has tenants, return the first one
+    if (memberships.length > 0) {
+      const firstMembership = memberships[0];
+      const tenant = await this.tenantCollection.get(
+        firstMembership.tenantId as string,
+      );
+
+      return {
+        tenant: tenant ?? null,
+        membership: firstMembership,
+        created: false,
+      };
+    }
+
+    // No existing tenants - apply policy
+    if (this.policy.mode === 'flexible') {
+      // Flexible mode: don't auto-create
+      return {
+        tenant: null,
+        membership: null,
+        created: false,
+      };
+    }
+
+    // Personal or required mode: create default tenant
+    // Use user's name for personalized tenant name, or fall back to policy default
+    const tenantName = userInfo.name
+      ? `${userInfo.name}'s Workspace`
+      : this.policy.defaultName;
+
+    const { tenant, membership } = await this.createTenantWithOwnership(
+      userId,
+      tenantName,
+    );
+
+    return {
+      tenant,
+      membership,
+      created: true,
+    };
+  }
+
+  /**
+   * Get all tenants for a user (where they are owner)
+   */
+  async getOwnedTenants(userId: string): Promise<Tenant[]> {
+    const ownerRole = await this.roleCollection.findBySlug(
+      DEFAULT_ROLE_SLUGS.OWNER,
+    );
+    if (!ownerRole) {
+      return [];
+    }
+
+    const memberships =
+      await this.membershipCollection.findActiveByUser(userId);
+    const ownerMemberships = memberships.filter(
+      (m) => m.roleId === ownerRole.id,
+    );
+
+    // Fetch all tenants in parallel to avoid N+1 queries
+    const tenantPromises = ownerMemberships.map((m) =>
+      this.tenantCollection.get(m.tenantId as string),
+    );
+    const tenantsOrNull = await Promise.all(tenantPromises);
+
+    return tenantsOrNull.filter((tenant): tenant is Tenant => tenant !== null);
+  }
+
+  /**
+   * Static factory method
+   */
+  static async create(
+    options: SmrtClassOptions,
+    policy?: TenantPolicy,
+  ): Promise<TenantService> {
+    const service = new TenantService(options, policy);
+    await service.initialize();
+    return service;
+  }
+}

--- a/packages/users/src/services/index.ts
+++ b/packages/users/src/services/index.ts
@@ -7,3 +7,9 @@ export {
   type PermissionResolutionResult,
   PermissionResolver,
 } from './PermissionResolver.js';
+
+export {
+  type EnsureTenantResult,
+  TenantService,
+  type TenantWithOwnershipResult,
+} from './TenantService.js';

--- a/packages/users/src/types/index.ts
+++ b/packages/users/src/types/index.ts
@@ -99,3 +99,39 @@ export const DEFAULT_ROLES = [
 
 export type DefaultRoleSlug =
   (typeof DEFAULT_ROLE_SLUGS)[keyof typeof DEFAULT_ROLE_SLUGS];
+
+// ============= Tenant Policy =============
+
+/**
+ * Tenant policy mode
+ *
+ * - `flexible`: No tenant created on signup, user can have zero tenants
+ * - `personal`: Auto-create personal tenant on first login, can delete all
+ * - `required`: Auto-create personal tenant, must keep at least one
+ */
+export type TenantPolicyMode = 'flexible' | 'personal' | 'required';
+
+/**
+ * Tenant policy configuration
+ *
+ * Set in smrt.config.js to control tenant creation behavior
+ */
+export interface TenantPolicy {
+  /** Policy mode */
+  mode: TenantPolicyMode;
+
+  /** Maximum tenants per user (0 = unlimited) */
+  maxTenants: number;
+
+  /** Name for auto-created default tenant */
+  defaultName: string;
+}
+
+/**
+ * Default tenant policy (flexible, unlimited)
+ */
+export const DEFAULT_TENANT_POLICY: TenantPolicy = {
+  mode: 'flexible',
+  maxTenants: 0,
+  defaultName: 'Default Workspace',
+};


### PR DESCRIPTION
## Summary

Adds `TenantService` to smrt-users for managing tenant creation with configurable policies.

### Tenant Policy Modes

| Mode | On Signup | Min Tenants | Delete Last? |
|------|-----------|-------------|--------------|
| `flexible` | None created | 0 | Yes |
| `personal` | Auto-create | 0 | Yes |
| `required` | Auto-create | 1 | No |

### New APIs

**TenantService**
- `createTenantWithOwnership(userId, name)` - Create tenant and make user owner
- `ensureTenantForUser(userId, userInfo)` - Apply policy during login
- `canCreateTenant(userId)` / `canDeleteTenant(userId, tenantId)` - Policy checks
- `deleteTenant(userId, tenantId)` - Delete with policy enforcement
- `getOwnedTenants(userId)` - Get all owned tenants

**UserCollection**
- `getOrCreateFromOidc(claims, provider)` - Streamlined OIDC identity resolution

### Configuration

```typescript
const tenantService = await TenantService.create(dbOptions, {
  mode: 'flexible',       // 'flexible' | 'personal' | 'required'
  maxTenants: 0,          // 0 = unlimited
  defaultName: 'Default Workspace',
});
```

## Test plan

- [x] Tested flexible mode in blindmanpress.com
- [x] User login creates Profile + User, no tenant
- [x] User can create organization via "Create Organization" page
- [x] After creating org, user has membership and can access dashboard