### PR TITLE
fix(core): support @smrt() decorator on abstract classes (TS 5.9)

### DIFF
--- a/packages/core/src/manifest/__tests__/generator.test.ts
+++ b/packages/core/src/manifest/__tests__/generator.test.ts
@@ -54,7 +54,7 @@ class TestClass extends SmrtObject {
         const manifest = await builder.generate({
           include: ['src/**/*.ts'],
           exclude: ['src/**/*.d.ts'],
-          outputDir: 'output',
+          outputDir: testOutputDir,
           generateTypeStub: false,
         });
 
@@ -99,7 +99,7 @@ class User extends SmrtObject {
         const manifest = await builder.generate({
           include: ['src/**/*.ts'],
           exclude: ['**/*.test.ts', '**/__tests__/**'],
-          outputDir: 'output',
+          outputDir: testOutputDir,
           generateTypeStub: false,
         });
 
@@ -119,7 +119,7 @@ class User extends SmrtObject {
 
         const manifest = await builder.generate({
           include: ['nonexistent/**/*.ts'],
-          outputDir: 'output',
+          outputDir: testOutputDir,
           generateTypeStub: false,
         });
 
@@ -154,7 +154,7 @@ class Product extends SmrtObject {
 
         const manifest = await builder.generate({
           include: ['src/**/*.ts'],
-          outputDir: 'output',
+          outputDir: testOutputDir,
           generateTypeStub: false,
         });
 
@@ -187,7 +187,7 @@ class CustomClass extends SmrtClass {
         const manifest = await builder.generate({
           include: ['src/**/*.ts'],
           baseClasses: ['CustomClass'],
-          outputDir: 'output',
+          outputDir: testOutputDir,
           generateTypeStub: false,
         });
 
@@ -221,7 +221,7 @@ class TestClass extends SmrtObject {
         await builder.generate({
           include: ['src/**/*.ts'],
           followImports: true,
-          outputDir: 'output',
+          outputDir: testOutputDir,
           outputName: 'manifest-with-imports.json',
           generateTypeStub: false,
         });
@@ -230,7 +230,7 @@ class TestClass extends SmrtObject {
         await builder.generate({
           include: ['src/**/*.ts'],
           followImports: false,
-          outputDir: 'output',
+          outputDir: testOutputDir,
           outputName: 'manifest-no-imports.json',
           generateTypeStub: false,
         });
@@ -280,7 +280,7 @@ class Item extends SmrtObject {
         const manifest = await builder.generate({
           include: ['src/**/*.ts'],
           injectPackageInfo: true,
-          outputDir: 'output',
+          outputDir: testOutputDir,
           generateTypeStub: false,
         });
 
@@ -300,7 +300,7 @@ class Item extends SmrtObject {
         const manifest = await builder.generate({
           include: ['src/**/*.ts'],
           moduleType: 'smrt',
-          outputDir: 'output',
+          outputDir: testOutputDir,
           generateTypeStub: false,
         });
 
@@ -320,7 +320,7 @@ class Item extends SmrtObject {
         const manifest = await builder.generate({
           include: ['src/**/*.ts'],
           discoverExternalPackages: true,
-          outputDir: 'output',
+          outputDir: testOutputDir,
           generateTypeStub: false,
         });
 
@@ -353,7 +353,7 @@ class Document extends SmrtObject {
 
         await builder.generate({
           include: ['src/**/*.ts'],
-          outputDir: 'output',
+          outputDir: testOutputDir,
           outputName: 'test-manifest.json',
           generateTypeStub: false,
         });
@@ -386,7 +386,7 @@ class Article extends SmrtObject {
 
         await builder.generate({
           include: ['src/**/*.ts'],
-          outputDir: 'output',
+          outputDir: testOutputDir,
           outputName: 'manifest.json',
           generateTypeStub: true,
           stubName: 'manifest.ts',
@@ -422,7 +422,7 @@ class TestClass extends SmrtObject {
         // Build manifest
         await builder.generate({
           include: ['src/**/*.ts'],
-          outputDir: 'output',
+          outputDir: testOutputDir,
           outputName: 'static-manifest.json',
           generateTypeStub: true,
           stubName: 'static-manifest.ts',
@@ -431,7 +431,7 @@ class TestClass extends SmrtObject {
         // Test manifest
         await builder.generate({
           include: ['src/**/*.ts'],
-          outputDir: 'output',
+          outputDir: testOutputDir,
           outputName: 'test-manifest.json',
           generateTypeStub: true,
           stubName: 'test-manifest-stub.ts',
@@ -459,7 +459,7 @@ class TestClass extends SmrtObject {
 
         const manifest = await builder.generate({
           include: ['nonexistent/**/*.ts'],
-          outputDir: 'output',
+          outputDir: testOutputDir,
           generateTypeStub: false,
         });
 
@@ -488,7 +488,7 @@ class TestClass extends SmrtObject {
           include: ['nonexistent/**/*.ts'],
           injectPackageInfo: true,
           discoverExternalPackages: true,
-          outputDir: 'output',
+          outputDir: testOutputDir,
           generateTypeStub: false,
         });
 
@@ -533,7 +533,7 @@ class Model extends SmrtObject {
           loadViteConfig: false,
           discoverExternalPackages: true,
           includeExternalBaseClasses: false,
-          outputDir: 'output',
+          outputDir: testOutputDir,
           outputName: 'static-manifest.json',
           generateTypeStub: true,
           stubName: 'static-manifest.ts',
@@ -586,7 +586,7 @@ class TestClass extends SmrtObject {
           loadViteConfig: false, // Would be true in real scenario with vite.config.ts
           discoverExternalPackages: true,
           includeExternalBaseClasses: true,
-          outputDir: 'output',
+          outputDir: testOutputDir,
           outputName: 'test-manifest.json',
           generateTypeStub: true,
           stubName: 'test-manifest-stub.ts',

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -3552,7 +3552,7 @@ export class ObjectRegistry {
  * ```
  */
 export function smrt(config: SmartObjectConfig = {}) {
-  return <T extends new (...args: any[]) => any>(ctor: T): T => {
+  return <T extends abstract new (...args: any[]) => any>(ctor: T): T => {
     // Check if this is a SmrtCollection class
     const isCollection = ctor.prototype instanceof SmrtCollection;
 


### PR DESCRIPTION
## Summary

- Change `@smrt()` decorator type from `new (...args: any[]) => any` to `abstract new (...args: any[]) => any` to support both concrete and abstract classes
- Fix ManifestBuilder tests to use absolute paths for `outputDir` instead of relative paths that fail after `process.chdir()`

## Problem

TypeScript 5.9.3 enforces stricter type checking on class decorators. The original decorator type only accepted concrete constructors (`new`), causing compilation errors when applied to abstract classes like `Agent`:

```
TS1238: Unable to resolve signature of class decorator when called as an expression.
  The call would have succeeded against this implementation, but implementation 
  signatures of overloads are not externally visible.
TS1270: Decorator function return type 'typeof Agent' is not assignable to type 
  'typeof Agent'. Cannot assign an abstract constructor type to a non-abstract 
  constructor type.
```

## Solution

Change the decorator's generic constraint from:
```typescript
<T extends new (...args: any[]) => any>
```
to:
```typescript
<T extends abstract new (...args: any[]) => any>
```

This allows both abstract and concrete classes to use the decorator. Concrete classes are still assignable to `abstract new` since they satisfy all requirements of an abstract constructor plus the ability to be instantiated.

## Pre-Existing Test Failures

During investigation, I verified that the following test failures exist on `main` branch and are **NOT caused by this PR**:

- `collection-query.test.ts` - 38 failed tests with UPSERT errors (appears to be `@happyvertical/sql` adapter issue)
- `sti-adapter-parity.test.ts` - 6-7 failed tests
- `image.test.ts` - 1 failed test

These are pre-existing issues that should be tracked separately.

## Test Plan

- [x] Build passes locally (`npm run build`)
- [x] ManifestBuilder tests use absolute paths and should pass in CI
- [x] Decorator fix verified against `packages/agents/src/agent.ts`