### PR TITLE
fix(core): improve test isolation with randomUUID for temp paths

### DIFF
--- a/packages/core/src/__tests__/collection-query.test.ts
+++ b/packages/core/src/__tests__/collection-query.test.ts
@@ -15,6 +15,7 @@
  * - Issue #XXX: Custom query support for interests
  */
 
+import { randomUUID } from 'node:crypto';
 import { existsSync, rmSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -91,7 +92,10 @@ const adapterConfigs = [
     name: 'SQLite (file)',
     getConfig: () => ({
       type: 'sqlite' as const,
-      url: join(tmpdir(), `test-collection-query-${Date.now()}.db`),
+      url: join(
+        tmpdir(),
+        `test-collection-query-${randomUUID().slice(0, 8)}.db`,
+      ),
     }),
     cleanup: async (config: any) => {
       if (config?.url && config.url !== ':memory:' && existsSync(config.url)) {
@@ -103,7 +107,10 @@ const adapterConfigs = [
     name: 'JSON (DuckDB)',
     getConfig: () => ({
       type: 'json' as const,
-      url: join(tmpdir(), `test-collection-query-json-${Date.now()}`),
+      url: join(
+        tmpdir(),
+        `test-collection-query-json-${randomUUID().slice(0, 8)}`,
+      ),
     }),
     cleanup: async (config: any) => {
       if (config?.url && existsSync(config.url)) {
@@ -529,8 +536,14 @@ describe('collection.query()', () => {
 
       afterEach(async () => {
         if (db && typeof db.close === 'function') {
-          await db.close();
+          try {
+            await db.close();
+          } catch {
+            // Ignore close errors
+          }
         }
+        // Small delay to allow DuckDB to release file locks before cleanup
+        await new Promise((resolve) => setTimeout(resolve, 50));
         await adapterConfig.cleanup(dbConfig);
       });
 

--- a/packages/core/src/__tests__/crud-with-relationships.test.ts
+++ b/packages/core/src/__tests__/crud-with-relationships.test.ts
@@ -5,6 +5,7 @@
  * when objects have relationship fields that should NOT be persisted.
  */
 
+import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { DatabaseInterface } from '@happyvertical/sql';
@@ -45,7 +46,10 @@ describe('CRUD Operations with @oneToMany Relationships', () => {
   let parents: ParentCollection;
 
   beforeEach(async () => {
-    dbPath = join(tmpdir(), `test-crud-relationships-${Date.now()}.db`);
+    dbPath = join(
+      tmpdir(),
+      `test-crud-relationships-${randomUUID().slice(0, 8)}.db`,
+    );
     db = await getDatabase({ type: 'sqlite', url: dbPath });
     parents = await ParentCollection.create({ db });
   });

--- a/packages/core/src/__tests__/foreign-key-queries.test.ts
+++ b/packages/core/src/__tests__/foreign-key-queries.test.ts
@@ -12,6 +12,7 @@
  * Related: https://github.com/happyvertical/smrt/issues/384
  */
 
+import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { DatabaseInterface } from '@happyvertical/sql';
@@ -80,9 +81,7 @@ describe('Foreign Key Queries in STI Models', () => {
   let dbPath: string;
 
   beforeEach(async () => {
-    // Add random component to ensure uniqueness even with same timestamp
-    const random = Math.random().toString(36).substring(7);
-    dbPath = join(tmpdir(), `test-fk-queries-${Date.now()}-${random}.db`);
+    dbPath = join(tmpdir(), `test-fk-queries-${randomUUID().slice(0, 8)}.db`);
     db = await getDatabase({ type: 'sqlite', url: dbPath });
   });
 

--- a/packages/core/src/__tests__/issue-176-transient-fields.test.ts
+++ b/packages/core/src/__tests__/issue-176-transient-fields.test.ts
@@ -5,6 +5,7 @@
  * Useful for functions, computed properties, and runtime-only data.
  */
 
+import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { DatabaseInterface } from '@happyvertical/sql';
@@ -56,7 +57,7 @@ describe('Issue #176: Transient fields', () => {
   let dbPath: string;
 
   beforeEach(async () => {
-    dbPath = join(tmpdir(), `test-transient-${Date.now()}.db`);
+    dbPath = join(tmpdir(), `test-transient-${randomUUID().slice(0, 8)}.db`);
     db = await getDatabase({ type: 'sqlite', url: dbPath });
   });
 

--- a/packages/core/src/__tests__/issue-208-optional-field-helper-undefined.test.ts
+++ b/packages/core/src/__tests__/issue-208-optional-field-helper-undefined.test.ts
@@ -9,6 +9,7 @@
  * Issue #208 specifically mentions using DuckDB via JSON adapter, so we test both.
  */
 
+import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { DatabaseInterface } from '@happyvertical/sql';
@@ -41,7 +42,7 @@ describe('Issue #208: Optional TEXT field helpers with undefined values', () => 
       // Create unique temp directory for JSON database
       dataDir = join(
         tmpdir(),
-        `test-issue-208-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        `test-issue-208-${randomUUID().slice(0, 8)}-${Math.random().toString(36).slice(2)}`,
       );
       db = await getDatabase({
         type: 'json',
@@ -134,7 +135,10 @@ describe('Issue #208: Optional TEXT field helpers with undefined values', () => 
     let dbPath: string;
 
     beforeEach(async () => {
-      dbPath = join(tmpdir(), `test-issue-208-duckdb-${Date.now()}.db`);
+      dbPath = join(
+        tmpdir(),
+        `test-issue-208-duckdb-${randomUUID().slice(0, 8)}.db`,
+      );
       db = await getDatabase({ type: 'duckdb', url: dbPath });
     });
 

--- a/packages/core/src/__tests__/issue-35-system-tables-initialization.test.ts
+++ b/packages/core/src/__tests__/issue-35-system-tables-initialization.test.ts
@@ -9,6 +9,7 @@
  * 5. DatabaseInterface instances are properly tracked without key collisions
  */
 
+import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { DatabaseInterface } from '@happyvertical/sql';
@@ -18,7 +19,7 @@ import { SmrtObject } from '../object';
 
 // Helper to create unique test database paths
 function getTempDbPath(name: string): string {
-  return join(tmpdir(), `test-issue-35-${name}-${Date.now()}.db`);
+  return join(tmpdir(), `test-issue-35-${name}-${randomUUID().slice(0, 8)}.db`);
 }
 
 // Move test classes to module level so AST scanner can pick them up during test manifest generation
@@ -126,8 +127,14 @@ describe('Issue #35: System Tables Initialization', () => {
 
   describe('JSON databases with different dataDirs', () => {
     it('should create system tables for each JSON database with different dataDir', async () => {
-      const dataDir1 = join(tmpdir(), `test-json-1-${Date.now()}`);
-      const dataDir2 = join(tmpdir(), `test-json-2-${Date.now()}`);
+      const dataDir1 = join(
+        tmpdir(),
+        `test-json-1-${randomUUID().slice(0, 8)}`,
+      );
+      const dataDir2 = join(
+        tmpdir(),
+        `test-json-2-${randomUUID().slice(0, 8)}`,
+      );
 
       // Create two JSON databases with different dataDirs
       const db1 = await getDatabase({

--- a/packages/core/src/__tests__/issue-370-sti-field-loading.test.ts
+++ b/packages/core/src/__tests__/issue-370-sti-field-loading.test.ts
@@ -18,6 +18,7 @@
  * Related: https://github.com/happyvertical/smrt/issues/370
  */
 
+import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { DatabaseInterface } from '@happyvertical/sql';
@@ -87,7 +88,7 @@ describe('Issue #370: STI Field Loading', () => {
   let dbPath: string;
 
   beforeEach(async () => {
-    dbPath = join(tmpdir(), `test-issue-370-${Date.now()}.db`);
+    dbPath = join(tmpdir(), `test-issue-370-${randomUUID().slice(0, 8)}.db`);
     db = await getDatabase({ type: 'sqlite', url: dbPath });
   });
 

--- a/packages/core/src/__tests__/issue-66-virtual-module-types.test.ts
+++ b/packages/core/src/__tests__/issue-66-virtual-module-types.test.ts
@@ -8,6 +8,7 @@
  * 4. Search method is available in CrudOperations
  */
 
+import { randomUUID } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 import type { SmartObjectManifest } from '../scanner/types';
 
@@ -19,7 +20,7 @@ describe('Issue #66: Virtual Module Type Generation', () => {
     // Create a test manifest with a SMRT object that has custom methods
     const manifest: SmartObjectManifest = {
       version: '1.0.0',
-      timestamp: Date.now(),
+      timestamp: randomUUID().slice(0, 8),
       objects: {
         praeco: {
           className: 'Praeco',
@@ -102,7 +103,7 @@ describe('Issue #66: Virtual Module Type Generation', () => {
 
     const manifest: SmartObjectManifest = {
       version: '1.0.0',
-      timestamp: Date.now(),
+      timestamp: randomUUID().slice(0, 8),
       objects: {
         praeco: {
           className: 'Praeco',

--- a/packages/core/src/__tests__/race-condition-debug.test.ts
+++ b/packages/core/src/__tests__/race-condition-debug.test.ts
@@ -2,6 +2,7 @@
  * Minimal test to debug race condition in foreign key queries
  */
 
+import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { DatabaseInterface } from '@happyvertical/sql';
@@ -43,8 +44,7 @@ describe('Race Condition Debug', () => {
   let db: DatabaseInterface;
 
   beforeEach(async () => {
-    const random = Math.random().toString(36).substring(7);
-    const dbPath = join(tmpdir(), `race-debug-${Date.now()}-${random}.db`);
+    const dbPath = join(tmpdir(), `race-debug-${randomUUID().slice(0, 8)}.db`);
     db = await getDatabase({ type: 'sqlite', url: dbPath });
   });
 

--- a/packages/core/src/__tests__/sti-adapter-parity.test.ts
+++ b/packages/core/src/__tests__/sti-adapter-parity.test.ts
@@ -22,6 +22,7 @@
  * @see Issue396Event, Issue396Meeting - Test classes with default status field
  */
 
+import { randomUUID } from 'node:crypto';
 import { existsSync, rmSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -128,7 +129,10 @@ const adapterConfigs = [
     name: 'SQLite (file)',
     getConfig: () => ({
       type: 'sqlite' as const,
-      url: join(tmpdir(), `test-issue-396-sqlite-${Date.now()}.db`),
+      url: join(
+        tmpdir(),
+        `test-issue-396-sqlite-${randomUUID().slice(0, 8)}.db`,
+      ),
     }),
     cleanup: async (config: any) => {
       if (config?.url && config.url !== ':memory:' && existsSync(config.url)) {
@@ -140,7 +144,7 @@ const adapterConfigs = [
     name: 'JSON (DuckDB)',
     getConfig: () => ({
       type: 'json' as const,
-      url: join(tmpdir(), `test-issue-396-json-${Date.now()}`),
+      url: join(tmpdir(), `test-issue-396-json-${randomUUID().slice(0, 8)}`),
     }),
     cleanup: async (config: any) => {
       if (config?.url && existsSync(config.url)) {
@@ -156,7 +160,10 @@ const adapterConfigs = [
     name: 'JSON (immediate writes)',
     getConfig: () => ({
       type: 'json' as const,
-      url: join(tmpdir(), `test-issue-396-json-immediate-${Date.now()}`),
+      url: join(
+        tmpdir(),
+        `test-issue-396-json-immediate-${randomUUID().slice(0, 8)}`,
+      ),
       writeStrategy: 'immediate' as const,
     }),
     cleanup: async (config: any) => {
@@ -586,8 +593,14 @@ describe('STI Adapter Parity', () => {
 
       afterEach(async () => {
         if (db && typeof db.close === 'function') {
-          await db.close();
+          try {
+            await db.close();
+          } catch {
+            // Ignore close errors
+          }
         }
+        // Small delay to allow DuckDB to release file locks before cleanup
+        await new Promise((resolve) => setTimeout(resolve, 50));
         await adapterConfig.cleanup(dbConfig);
       });
 

--- a/packages/core/src/__tests__/sti-multilevel.test.ts
+++ b/packages/core/src/__tests__/sti-multilevel.test.ts
@@ -7,6 +7,7 @@
  * Related to issue #332
  */
 
+import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { DatabaseInterface } from '@happyvertical/sql';
@@ -50,7 +51,10 @@ describe('Multi-Level STI Save Operations', () => {
   let profiles: STITestProfileCollection;
 
   beforeEach(async () => {
-    dbPath = join(tmpdir(), `test-sti-multilevel-${Date.now()}.db`);
+    dbPath = join(
+      tmpdir(),
+      `test-sti-multilevel-${randomUUID().slice(0, 8)}.db`,
+    );
     db = await getDatabase({ type: 'sqlite', url: dbPath });
     profiles = await STITestProfileCollection.create({ db });
   });

--- a/packages/core/src/__tests__/transform-json-hook.test.ts
+++ b/packages/core/src/__tests__/transform-json-hook.test.ts
@@ -7,6 +7,7 @@
  * Related to issue #377 - prevents unsafe toJSON() overrides that break STI.
  */
 
+import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { DatabaseInterface } from '@happyvertical/sql';
@@ -42,7 +43,10 @@ describe('transformJSON() Hook', () => {
   let dbPath: string;
 
   beforeEach(async () => {
-    dbPath = join(tmpdir(), `test-transform-json-${Date.now()}.db`);
+    dbPath = join(
+      tmpdir(),
+      `test-transform-json-${randomUUID().slice(0, 8)}.db`,
+    );
     db = await getDatabase({ type: 'sqlite', url: dbPath });
   });
 

--- a/packages/core/src/dispatch/bus.test.ts
+++ b/packages/core/src/dispatch/bus.test.ts
@@ -2,6 +2,7 @@
  * Tests for DispatchBus - Inter-Agent Communication
  */
 
+import { randomUUID } from 'node:crypto';
 import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -16,7 +17,10 @@ describe('DispatchBus', () => {
   let dbPath: string;
 
   beforeEach(async () => {
-    dbPath = join(tmpdir(), `smrt-dispatch-test-${Date.now()}.db`);
+    dbPath = join(
+      tmpdir(),
+      `smrt-dispatch-test-${randomUUID().slice(0, 8)}.db`,
+    );
     bus = await createDispatchBus({
       db: { type: 'sqlite', url: dbPath },
     });

--- a/packages/core/src/dispatch/integration.test.ts
+++ b/packages/core/src/dispatch/integration.test.ts
@@ -5,6 +5,7 @@
  * communicate through the dispatch system.
  */
 
+import { randomUUID } from 'node:crypto';
 import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -17,7 +18,10 @@ describe('Agent-to-Agent Communication', () => {
   let dbPath: string;
 
   beforeEach(async () => {
-    dbPath = join(tmpdir(), `smrt-dispatch-integration-${Date.now()}.db`);
+    dbPath = join(
+      tmpdir(),
+      `smrt-dispatch-integration-${randomUUID().slice(0, 8)}.db`,
+    );
     bus = await createDispatchBus({
       db: { type: 'sqlite', url: dbPath },
     });

--- a/packages/core/src/generators/mcp-modular.test.ts
+++ b/packages/core/src/generators/mcp-modular.test.ts
@@ -3,6 +3,7 @@
  * Tests modular generation, configuration handling, and file structure
  */
 
+import { randomUUID } from 'node:crypto';
 import { access, mkdir, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -15,7 +16,10 @@ describe('MCPGenerator - Modular Generation', () => {
 
   beforeEach(async () => {
     // Create temp directory for test output
-    tmpDir = join(tmpdir(), `smrt-mcp-modular-test-${Date.now()}`);
+    tmpDir = join(
+      tmpdir(),
+      `smrt-mcp-modular-test-${randomUUID().slice(0, 8)}`,
+    );
     await mkdir(tmpDir, { recursive: true });
 
     generator = new MCPGenerator({

--- a/packages/core/src/manifest/__tests__/generator.test.ts
+++ b/packages/core/src/manifest/__tests__/generator.test.ts
@@ -3,16 +3,27 @@
  * Tests file discovery, scanner configuration, external packages, and output generation
  */
 
+import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ManifestBuilder } from '../generator.js';
 
 describe('ManifestBuilder', () => {
-  const testFixturesDir = resolve(__dirname, 'fixtures', 'generator-test');
-  const testOutputDir = resolve(testFixturesDir, 'output');
+  // Use unique directories per test to avoid isolation issues
+  let testFixturesDir: string;
+  let testOutputDir: string;
 
   beforeEach(() => {
+    // Create unique test fixtures directory for each test
+    const uniqueId = randomUUID().slice(0, 8);
+    testFixturesDir = resolve(
+      __dirname,
+      'fixtures',
+      `generator-test-${uniqueId}`,
+    );
+    testOutputDir = resolve(testFixturesDir, 'output');
+
     // Create test fixtures directory
     mkdirSync(testFixturesDir, { recursive: true });
     mkdirSync(resolve(testFixturesDir, 'src'), { recursive: true });


### PR DESCRIPTION
## Summary
- Replace `Date.now()` with `randomUUID()` for temporary file/directory paths in tests to prevent collisions when tests run fast enough to get the same millisecond timestamp
- Add 50ms delay after `db.close()` for DuckDB/JSON adapter tests to allow file lock release before cleanup
- Use unique test fixture directories per test in generator tests

## Problem
Tests were failing intermittently when running the full test suite locally, but passing in CI. Root causes:
1. `Date.now()` can return the same value for multiple parallel tests running within the same millisecond
2. DuckDB doesn't immediately release file locks after `close()`, causing cleanup failures

## Test plan
- [x] Run full test suite locally multiple times - 943 tests pass consistently
- [x] Verify tests still pass in CI

Fixes intermittent local test failures.