### PR TITLE
fix(users,commerce): add missing build dependency and STI strategy

### DIFF
--- a/packages/commerce/src/models/ContractLineItem.ts
+++ b/packages/commerce/src/models/ContractLineItem.ts
@@ -24,6 +24,7 @@ import { Contract } from './Contract.js';
  * ```
  */
 @smrt({
+  tableStrategy: 'sti',
   api: { include: ['list', 'get', 'create', 'update', 'delete'] },
   mcp: { include: ['list', 'get'] },
   cli: true,

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -50,6 +50,7 @@
     "@happyvertical/smrt-profiles": "workspace:*"
   },
   "devDependencies": {
+    "@happyvertical/smrt-profiles": "workspace:*",
     "@happyvertical/smrt-vitest": "workspace:*",
     "@types/node": "^24.0.0",
     "fast-glob": "^3.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -964,10 +964,10 @@ importers:
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
+    devDependencies:
       '@happyvertical/smrt-profiles':
         specifier: workspace:*
         version: link:../profiles
-    devDependencies:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
         version: link:../vitest
@@ -11427,7 +11427,7 @@ snapshots:
       agentkeepalive: 4.6.0
       axios: 1.13.2(debug@4.4.3)
       query-string: 7.1.3
-      retry-axios: 2.6.0(axios@1.13.2)
+      retry-axios: 2.6.0(axios@1.13.2(debug@4.4.3))
     transitivePeerDependencies:
       - debug
 
@@ -15737,7 +15737,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.13.2)
+      retry-axios: 2.6.0(axios@1.13.2(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -17428,7 +17428,7 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
-  retry-axios@2.6.0(axios@1.13.2):
+  retry-axios@2.6.0(axios@1.13.2(debug@4.4.3)):
     dependencies:
       axios: 1.13.2(debug@4.4.3)
 


### PR DESCRIPTION
## Summary
- Add `@happyvertical/smrt-profiles` as devDependency in smrt-users to fix CI build failure
- Add `tableStrategy: 'sti'` to `ContractLineItem` in smrt-commerce for STI consistency

## Problem
1. **CI Build Failure**: smrt-users failed to build in CI because TypeScript couldn't find `@happyvertical/smrt-profiles` module during compilation. The package was only listed as a peerDependency, but TypeScript needs it at build time for type resolution (even for `import type` statements).

2. **Issue #600**: `ContractLineItem` was missing `tableStrategy: 'sti'`, preventing child classes from using STI inheritance.

## Changes
- `packages/users/package.json`: Add smrt-profiles to devDependencies
- `packages/commerce/src/models/ContractLineItem.ts`: Add `tableStrategy: 'sti'`

## Test plan
- [x] Build succeeds locally
- [ ] CI build passes
- [ ] on-merge-main workflow succeeds after merge

Fixes #600