### PR TITLE
ci: use self-hosted arc-happyvertical runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - arc-happyvertical

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -28,7 +28,7 @@ jobs:
   cancel-pr-checks:
     name: Cancel PR Validation Checks
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   validate-commits:
     name: Validate Conventional Commits
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
 
     steps:
       - name: Checkout PR branch
@@ -32,7 +32,7 @@ jobs:
 
   validate-workflows:
     name: Validate Workflow Files
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   release:
     name: Version and Publish
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 20
     outputs:
       published: ${{ steps.publish.outputs.published }}
@@ -190,7 +190,7 @@ jobs:
 
   deploy-docs:
     name: Deploy Documentation
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     steps:
       - name: Mark stale issues and PRs
         uses: actions/stale@v9

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 30
 
     services:


### PR DESCRIPTION
## Summary

Migrate all GitHub Actions workflows from `ubuntu-latest` to the organization's self-hosted `arc-happyvertical` runners for improved performance and cost efficiency.

## Changes

- Update `runs-on` in all workflow files to use `arc-happyvertical`
- Add `.github/actionlint.yaml` to recognize the self-hosted runner label

## Testing

- Workflow validation passes locally (yamllint + actionlint)
- Self-hosted runner label is properly configured

Closes #N/A - Organization-wide CI improvement initiative