### PR TITLE
fix(ci): install gh CLI on self-hosted runners

### DIFF
--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -36,14 +36,8 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Install GitHub CLI
-        run: |
-          if ! command -v gh &> /dev/null; then
-            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-            sudo apt-get update
-            sudo apt-get install gh -y
-          fi
+      - name: Setup GitHub CLI
+        uses: actions4gh/setup-gh@v1
 
       - name: Extract PR number from merge commit
         id: get-pr


### PR DESCRIPTION
## Summary

The `cancel-pr-checks` job in `on-merge-main.yml` uses `gh` CLI to cancel in-progress PR workflows when a PR is merged. However, the self-hosted `arc-happyvertical` runners don't have `gh` pre-installed, causing the job to fail:

```
gh: command not found
```

This adds a step to install `gh` CLI if not already available on the runner.

## Test plan

- [ ] Merge this PR and verify the `cancel-pr-checks` job succeeds