### PR TITLE
fix(ci): use ubuntu-latest for cancel-pr-checks job

### DIFF
--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -28,16 +28,14 @@ jobs:
   cancel-pr-checks:
     name: Cancel PR Validation Checks
     if: github.event_name == 'push'
-    runs-on: arc-happyvertical
+    # Use GitHub-hosted runner - has gh CLI preinstalled, no build tools needed
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
-
-      - name: Setup GitHub CLI
-        uses: actions4gh/setup-gh@v1
 
       - name: Extract PR number from merge commit
         id: get-pr


### PR DESCRIPTION
## Summary

The `actions4gh/setup-gh@v1` action doesn't work reliably on self-hosted `arc-happyvertical` runners:

```
##[error]File not found: '/home/runner/_work/_actions/actions4gh/setup-gh/v1/dist/main.js'
```

Since this job only needs `gh` CLI (no Node.js, pnpm, or build tools), use `ubuntu-latest` which has `gh` preinstalled.

## Test plan

- [ ] Merge and verify cancel-pr-checks job succeeds on next main push