### PR TITLE
fix(ci): remove gh CLI setup step

### DIFF
--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -36,9 +36,6 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Setup GitHub CLI
-        uses: actions4gh/setup-gh@v1
-
       - name: Extract PR number from merge commit
         id: get-pr
         run: |


### PR DESCRIPTION
Custom arc-happyvertical runner image now includes gh CLI - no setup step needed.