### PR TITLE
fix(core): skip collection classes in schema operations

### DIFF
--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1526,6 +1526,13 @@ export class ObjectRegistry {
     const classNames = this.getClassNames();
 
     for (const className of classNames) {
+      // Skip collection classes - they don't have their own tables
+      // Collections wrap item classes and share the item class's table
+      const registered = ObjectRegistry.classes.get(className);
+      if (registered?.extends === 'SmrtCollection') {
+        continue;
+      }
+
       await ensureSchema(db, className);
     }
   }
@@ -2262,6 +2269,12 @@ export class ObjectRegistry {
     > = {};
 
     for (const [_className, registered] of ObjectRegistry.classes) {
+      // Skip collection classes - they don't have their own tables
+      // Their schemas incorrectly contain collection properties (loaded, options, etc.)
+      if (registered.extends === 'SmrtCollection') {
+        continue;
+      }
+
       if (registered.schema?.tableName) {
         const tableName = registered.schema.tableName;
 


### PR DESCRIPTION
## Summary
- Skip collection classes (extending `SmrtCollection`) in `ensureAllSchemas()` and `getAllSchemas()`
- Collection classes don't have their own tables - they wrap item classes and share the item class's table

## Problem
When `getAllSchemas()` merged schemas by table name, it incorrectly merged collection properties (`loaded`, `options`, `contentDir`) as database columns. This caused the JSON adapter to create tables with NOT NULL constraints on non-existent columns like `loaded`, breaking cross-table queries.

The symptom was that `praeco interesting` would return meetings that already had content, because the NOT EXISTS subquery failed due to the corrupted schema.

## Test plan
- [x] Run `pnpm smrt praeco interesting` in bentleyalberta.com - should not return Budget Meeting (which has Agenda, Minutes, MeetingRecap)
- [x] Verify no errors about `NOT NULL constraint failed: contents.loaded`