### PR TITLE
fix(content): resolve TypeScript error in thumbnail-generator

### DIFF
--- a/packages/content/src/thumbnail-generator.ts
+++ b/packages/content/src/thumbnail-generator.ts
@@ -245,7 +245,9 @@ export class ThumbnailGenerator {
       );
     }
 
-    type FetchStaticMapOptions = Parameters<typeof fetchStaticMap>[2];
+    type FetchStaticMapOptions = NonNullable<
+      Parameters<typeof fetchStaticMap>[2]
+    >;
     const mapboxStyle = options.mapboxStyle as
       | FetchStaticMapOptions['mapboxStyle']
       | undefined;


### PR DESCRIPTION
## Summary

- Fix TypeScript error TS2339 in `thumbnail-generator.ts` that was breaking the build
- Wrap `Parameters<typeof fetchStaticMap>[2]` with `NonNullable` to handle optional parameter type

## Problem

The CI build was failing on main with:

```
src/thumbnail-generator.ts:250:31 - error TS2339: Property 'mapboxStyle' does not exist on type 'StaticMapOptions | undefined'.
```

The `fetchStaticMap` function has an optional third parameter (`options?: StaticMapOptions`), so `Parameters<typeof fetchStaticMap>[2]` resolves to `StaticMapOptions | undefined`. TypeScript cannot access `['mapboxStyle']` on `undefined`.

## Root Cause

This type error was introduced in PR #575 (Dec 26) but was not caught by CI. The likely reasons:
1. `vite-plugin-dts` has timing-dependent type checking behavior
2. Turborepo caching may have served a previously-built version
3. The content package lacks a dedicated `typecheck` script

## Fix

Wrap the parameter type with `NonNullable`:

```typescript
type FetchStaticMapOptions = NonNullable<Parameters<typeof fetchStaticMap>[2]>;
```

## Test plan

- [x] `pnpm run build` succeeds locally
- [ ] CI build passes on PR