### PR TITLE
fix(commerce): use foreignKey as decorator not property initializer

### DIFF
--- a/packages/commerce/src/models/Contract.ts
+++ b/packages/commerce/src/models/Contract.ts
@@ -57,12 +57,14 @@ export class Contract extends SmrtObject {
   /**
    * Customer ID (for sales contracts: Estimate, Order, Agreement)
    */
-  customerId = foreignKey(Customer);
+  @foreignKey(Customer)
+  customerId: string = '';
 
   /**
    * Vendor ID (for purchase contracts: PurchaseOrder)
    */
-  vendorId = foreignKey(Vendor);
+  @foreignKey(Vendor)
+  vendorId: string = '';
 
   /**
    * Subtotal before tax


### PR DESCRIPTION
## Summary

- Fix Contract.customerId and vendorId to use `@foreignKey()` as a decorator instead of a property initializer

## Problem

The properties were incorrectly using:
```typescript
customerId = foreignKey(Customer);
vendorId = foreignKey(Vendor);
```

This caused TypeScript to infer the type as `(target: any, propertyKey: string) => void` (the decorator function type) instead of `string`.

## Solution

Use the decorator syntax as documented:
```typescript
@foreignKey(Customer)
customerId: string = '';

@foreignKey(Vendor)
vendorId: string = '';
```

## Test plan

- [x] All smrt-commerce tests pass (51 tests)
- [x] Build succeeds

Fixes #629