### PR TITLE
perf(core): cache STI sibling discovery and skip for framework base classes

### DIFF
--- a/packages/ads/src/manifest/manifest.json
+++ b/packages/ads/src/manifest/manifest.json
@@ -1,0 +1,1832 @@
+{
+  "version": "1.0.0",
+  "timestamp": 1767322692093,
+  "objects": {
+    "addeliverytier": {
+      "name": "addeliverytier",
+      "className": "AdDeliveryTier",
+      "collection": "addeliverytiers",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/ads/src/models/AdDeliveryTier.ts",
+      "fields": {
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "priority": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "pricingModel": {
+          "type": "text",
+          "required": false
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        }
+      },
+      "methods": {
+        "isHigherPriorityThan": {
+          "name": "isHigherPriorityThan",
+          "async": false,
+          "parameters": [
+            {
+              "name": "other",
+              "type": "AdDeliveryTier",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isFixedPricing": {
+          "name": "isFixedPricing",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isPerformanceBased": {
+          "name": "isPerformanceBased",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "AdDeliveryTier",
+      "collectionExportName": "AdDeliveryTierCollection",
+      "schema": {
+        "tableName": "ad_delivery_tiers",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_delivery_tiers\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"priority\" INTEGER DEFAULT 0,\n  \"pricing_model\" TEXT,\n  \"description\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "priority": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "pricing_model": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "ad_delivery_tiers_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "ad_delivery_tiers_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "b4e18e96"
+      }
+    },
+    "addeliverytiercollection": {
+      "name": "addeliverytiercollection",
+      "className": "AdDeliveryTierCollection",
+      "collection": "addeliverytiers",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/ads/src/collections/AdDeliveryTierCollection.ts",
+      "fields": {},
+      "methods": {
+        "findByPriority": {
+          "name": "findByPriority",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdDeliveryTier[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByPricingModel": {
+          "name": "findByPricingModel",
+          "async": true,
+          "parameters": [
+            {
+              "name": "pricingModel",
+              "type": "PricingModel",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdDeliveryTier[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getHighestPriority": {
+          "name": "getHighestPriority",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdDeliveryTier | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findFixedPricing": {
+          "name": "findFixedPricing",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdDeliveryTier[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findCPM": {
+          "name": "findCPM",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdDeliveryTier[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findPerformanceBased": {
+          "name": "findPerformanceBased",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdDeliveryTier[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "AdDeliveryTier",
+      "exportName": "AdDeliveryTierCollection",
+      "collectionExportName": "AdDeliveryTierCollectionCollection",
+      "schema": {
+        "tableName": "ad_delivery_tier_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_delivery_tier_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "ad_delivery_tier_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "ad_delivery_tier_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "9efdebfd"
+      }
+    },
+    "adformat": {
+      "name": "adformat",
+      "className": "AdFormat",
+      "collection": "adformats",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/ads/src/models/AdFormat.ts",
+      "fields": {
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "width": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "height": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "formatType": {
+          "type": "text",
+          "required": false
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        }
+      },
+      "methods": {
+        "getDimensions": {
+          "name": "getDimensions",
+          "async": false,
+          "parameters": [],
+          "returnType": "string",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "matchesDimensions": {
+          "name": "matchesDimensions",
+          "async": false,
+          "parameters": [
+            {
+              "name": "width",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "height",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "AdFormat",
+      "collectionExportName": "AdFormatCollection",
+      "schema": {
+        "tableName": "ad_formats",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_formats\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"width\" INTEGER DEFAULT 0,\n  \"height\" INTEGER DEFAULT 0,\n  \"format_type\" TEXT,\n  \"description\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "width": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "height": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "format_type": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "ad_formats_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "ad_formats_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "ee6160ff"
+      }
+    },
+    "adgroup": {
+      "name": "adgroup",
+      "className": "AdGroup",
+      "collection": "adgroups",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/ads/src/models/AdGroup.ts",
+      "fields": {
+        "contractId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "tierId": {
+          "type": "foreignKey",
+          "required": false
+        },
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "verticalSlug": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "targeting": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "zoneIds": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "startDate": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "endDate": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "dailyBudget": {
+          "type": "decimal",
+          "required": false,
+          "default": 0
+        },
+        "totalBudget": {
+          "type": "decimal",
+          "required": false,
+          "default": 0
+        },
+        "status": {
+          "type": "text",
+          "required": false
+        }
+      },
+      "methods": {
+        "getZoneIds": {
+          "name": "getZoneIds",
+          "async": false,
+          "parameters": [],
+          "returnType": "string[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setZoneIds": {
+          "name": "setZoneIds",
+          "async": false,
+          "parameters": [
+            {
+              "name": "ids",
+              "type": "string[]",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addZoneId": {
+          "name": "addZoneId",
+          "async": false,
+          "parameters": [
+            {
+              "name": "zoneId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeZoneId": {
+          "name": "removeZoneId",
+          "async": false,
+          "parameters": [
+            {
+              "name": "zoneId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasZoneId": {
+          "name": "hasZoneId",
+          "async": false,
+          "parameters": [
+            {
+              "name": "zoneId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getTargeting": {
+          "name": "getTargeting",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setTargeting": {
+          "name": "setTargeting",
+          "async": false,
+          "parameters": [
+            {
+              "name": "rules",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isDraft": {
+          "name": "isDraft",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isPaused": {
+          "name": "isPaused",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isCompleted": {
+          "name": "isCompleted",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasEnded": {
+          "name": "hasEnded",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStarted": {
+          "name": "hasStarted",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "AdGroup",
+      "collectionExportName": "AdGroupCollection",
+      "schema": {
+        "tableName": "ad_groups",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_groups\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"contract_id\" TEXT DEFAULT '',\n  \"tier_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"vertical_slug\" TEXT DEFAULT '',\n  \"targeting\" TEXT DEFAULT '',\n  \"zone_ids\" TEXT DEFAULT '',\n  \"start_date\" TIMESTAMP DEFAULT current_timestamp,\n  \"end_date\" TIMESTAMP DEFAULT current_timestamp,\n  \"daily_budget\" REAL DEFAULT 0,\n  \"total_budget\" REAL DEFAULT 0,\n  \"status\" TEXT\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "contract_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "tier_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "vertical_slug": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "targeting": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "zone_ids": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "start_date": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "end_date": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "daily_budget": {
+            "type": "REAL",
+            "notNull": false,
+            "default": 0
+          },
+          "total_budget": {
+            "type": "REAL",
+            "notNull": false,
+            "default": 0
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "ad_groups_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "ad_groups_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "4f417b94"
+      }
+    },
+    "advariation": {
+      "name": "advariation",
+      "className": "AdVariation",
+      "collection": "advariations",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/ads/src/models/AdVariation.ts",
+      "fields": {
+        "groupId": {
+          "type": "foreignKey",
+          "required": false
+        },
+        "formatId": {
+          "type": "foreignKey",
+          "required": false
+        },
+        "assetId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "clickUrl": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "altText": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "weight": {
+          "type": "integer",
+          "required": false,
+          "default": 1
+        },
+        "status": {
+          "type": "text",
+          "required": false
+        },
+        "impressions": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "clicks": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        }
+      },
+      "methods": {
+        "isActive": {
+          "name": "isActive",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isDraft": {
+          "name": "isDraft",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isPaused": {
+          "name": "isPaused",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getCTR": {
+          "name": "getCTR",
+          "async": false,
+          "parameters": [],
+          "returnType": "number",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recordImpression": {
+          "name": "recordImpression",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recordClick": {
+          "name": "recordClick",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "AdVariation",
+      "collectionExportName": "AdVariationCollection",
+      "schema": {
+        "tableName": "ad_variations",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_variations\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"group_id\" TEXT,\n  \"format_id\" TEXT,\n  \"asset_id\" TEXT DEFAULT '',\n  \"name\" TEXT DEFAULT '',\n  \"click_url\" TEXT DEFAULT '',\n  \"alt_text\" TEXT DEFAULT '',\n  \"weight\" INTEGER DEFAULT 1,\n  \"status\" TEXT,\n  \"impressions\" INTEGER DEFAULT 0,\n  \"clicks\" INTEGER DEFAULT 0\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "group_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "format_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "asset_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "click_url": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "alt_text": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "weight": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 1
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "impressions": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "clicks": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          }
+        },
+        "indexes": [
+          {
+            "name": "ad_variations_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "ad_variations_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "7f60948f"
+      }
+    },
+    "adevent": {
+      "name": "adevent",
+      "className": "AdEvent",
+      "collection": "adevents",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/ads/src/models/AdEvent.ts",
+      "fields": {
+        "variationId": {
+          "type": "foreignKey",
+          "required": false
+        },
+        "zoneId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "siteId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "eventType": {
+          "type": "text",
+          "required": false
+        },
+        "timestamp": {
+          "type": "datetime",
+          "required": false
+        },
+        "metadata": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        }
+      },
+      "methods": {
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setMetadata": {
+          "name": "setMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isImpression": {
+          "name": "isImpression",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isClick": {
+          "name": "isClick",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isConversion": {
+          "name": "isConversion",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "create",
+            "list"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "create"
+          ]
+        },
+        "cli": false
+      },
+      "extends": "SmrtObject",
+      "exportName": "AdEvent",
+      "collectionExportName": "AdEventCollection",
+      "schema": {
+        "tableName": "ad_events",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_events\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"variation_id\" TEXT,\n  \"zone_id\" TEXT DEFAULT '',\n  \"site_id\" TEXT DEFAULT '',\n  \"event_type\" TEXT,\n  \"timestamp\" TIMESTAMP,\n  \"metadata\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "variation_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "zone_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "site_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "event_type": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "timestamp": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          },
+          "metadata": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "ad_events_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "ad_events_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "04ca2f13"
+      }
+    },
+    "adeventcollection": {
+      "name": "adeventcollection",
+      "className": "AdEventCollection",
+      "collection": "adevents",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/ads/src/collections/AdEventCollection.ts",
+      "fields": {},
+      "methods": {
+        "findByVariation": {
+          "name": "findByVariation",
+          "async": true,
+          "parameters": [
+            {
+              "name": "variationId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByZone": {
+          "name": "findByZone",
+          "async": true,
+          "parameters": [
+            {
+              "name": "zoneId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findBySite": {
+          "name": "findBySite",
+          "async": true,
+          "parameters": [
+            {
+              "name": "siteId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByDateRange": {
+          "name": "findByDateRange",
+          "async": true,
+          "parameters": [
+            {
+              "name": "start",
+              "type": "Date",
+              "optional": false
+            },
+            {
+              "name": "end",
+              "type": "Date",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByType": {
+          "name": "findByType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "eventType",
+              "type": "AdEventType",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "countByType": {
+          "name": "countByType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "variationId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "eventType",
+              "type": "AdEventType",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "countImpressions": {
+          "name": "countImpressions",
+          "async": true,
+          "parameters": [
+            {
+              "name": "variationId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "countClicks": {
+          "name": "countClicks",
+          "async": true,
+          "parameters": [
+            {
+              "name": "variationId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "countConversions": {
+          "name": "countConversions",
+          "async": true,
+          "parameters": [
+            {
+              "name": "variationId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findImpressions": {
+          "name": "findImpressions",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findClicks": {
+          "name": "findClicks",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findConversions": {
+          "name": "findConversions",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getVariationStats": {
+          "name": "getVariationStats",
+          "async": true,
+          "parameters": [
+            {
+              "name": "variationId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<{\n    impressions: number;\n    clicks: number;\n    conversions: number;\n    ctr: number;\n    conversionRate: number;\n  }>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "AdEvent",
+      "exportName": "AdEventCollection",
+      "collectionExportName": "AdEventCollectionCollection",
+      "schema": {
+        "tableName": "ad_event_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_event_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "ad_event_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "ad_event_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "ee9d6da6"
+      }
+    },
+    "adformatcollection": {
+      "name": "adformatcollection",
+      "className": "AdFormatCollection",
+      "collection": "adformats",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/ads/src/collections/AdFormatCollection.ts",
+      "fields": {},
+      "methods": {
+        "findByDimensions": {
+          "name": "findByDimensions",
+          "async": true,
+          "parameters": [
+            {
+              "name": "width",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "height",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdFormat | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByType": {
+          "name": "findByType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "formatType",
+              "type": "AdFormatType",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdFormat[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findBanners": {
+          "name": "findBanners",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdFormat[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findNative": {
+          "name": "findNative",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdFormat[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findVideo": {
+          "name": "findVideo",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdFormat[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "AdFormat",
+      "exportName": "AdFormatCollection",
+      "collectionExportName": "AdFormatCollectionCollection",
+      "schema": {
+        "tableName": "ad_format_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_format_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "ad_format_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "ad_format_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "70d685a1"
+      }
+    },
+    "adgroupcollection": {
+      "name": "adgroupcollection",
+      "className": "AdGroupCollection",
+      "collection": "adgroups",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/ads/src/collections/AdGroupCollection.ts",
+      "fields": {},
+      "methods": {
+        "findByContract": {
+          "name": "findByContract",
+          "async": true,
+          "parameters": [
+            {
+              "name": "contractId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByTier": {
+          "name": "findByTier",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tierId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByStatus": {
+          "name": "findByStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "status",
+              "type": "AdGroupStatus",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findActive": {
+          "name": "findActive",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByVertical": {
+          "name": "findByVertical",
+          "async": true,
+          "parameters": [
+            {
+              "name": "verticalSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByZone": {
+          "name": "findByZone",
+          "async": true,
+          "parameters": [
+            {
+              "name": "zoneId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findEligibleForZone": {
+          "name": "findEligibleForZone",
+          "async": true,
+          "parameters": [
+            {
+              "name": "zoneId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findDrafts": {
+          "name": "findDrafts",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findPaused": {
+          "name": "findPaused",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findCompleted": {
+          "name": "findCompleted",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "AdGroup",
+      "exportName": "AdGroupCollection",
+      "collectionExportName": "AdGroupCollectionCollection",
+      "schema": {
+        "tableName": "ad_group_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_group_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "ad_group_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "ad_group_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "6d84a15a"
+      }
+    },
+    "advariationcollection": {
+      "name": "advariationcollection",
+      "className": "AdVariationCollection",
+      "collection": "advariations",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/ads/src/collections/AdVariationCollection.ts",
+      "fields": {},
+      "methods": {
+        "findByGroup": {
+          "name": "findByGroup",
+          "async": true,
+          "parameters": [
+            {
+              "name": "groupId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByFormat": {
+          "name": "findByFormat",
+          "async": true,
+          "parameters": [
+            {
+              "name": "formatId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findActiveByGroup": {
+          "name": "findActiveByGroup",
+          "async": true,
+          "parameters": [
+            {
+              "name": "groupId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "selectByWeight": {
+          "name": "selectByWeight",
+          "async": true,
+          "parameters": [
+            {
+              "name": "groupId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdVariation | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByStatus": {
+          "name": "findByStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "status",
+              "type": "AdVariationStatus",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findActive": {
+          "name": "findActive",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findDrafts": {
+          "name": "findDrafts",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findPaused": {
+          "name": "findPaused",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findTopPerformers": {
+          "name": "findTopPerformers",
+          "async": true,
+          "parameters": [
+            {
+              "name": "limit",
+              "type": "number",
+              "optional": false,
+              "default": 10
+            }
+          ],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "AdVariation",
+      "exportName": "AdVariationCollection",
+      "collectionExportName": "AdVariationCollectionCollection",
+      "schema": {
+        "tableName": "ad_variation_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_variation_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "ad_variation_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "ad_variation_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "4af1ef95"
+      }
+    }
+  },
+  "moduleType": "smrt",
+  "packageName": "@happyvertical/smrt-ads"
+}

--- a/packages/agents/src/manifest/manifest.json
+++ b/packages/agents/src/manifest/manifest.json
@@ -1,0 +1,182 @@
+{
+  "version": "1.0.0",
+  "timestamp": 1767322692069,
+  "objects": {
+    "agent": {
+      "name": "agent",
+      "className": "Agent",
+      "collection": "agents",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/agents/src/agent.ts",
+      "fields": {
+        "status": {
+          "type": "text",
+          "required": false,
+          "default": "idle"
+        }
+      },
+      "methods": {
+        "getDispatch": {
+          "name": "getDispatch",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<DispatchBus>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "handleDispatch": {
+          "name": "handleDispatch",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_payload",
+              "type": "unknown",
+              "optional": false
+            },
+            {
+              "name": "_metadata",
+              "type": "DispatchMetadata",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "processDispatches": {
+          "name": "processDispatches",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<this>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "validate": {
+          "name": "validate",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "run": {
+          "name": "run",
+          "async": false,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "shutdown": {
+          "name": "shutdown",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "execute": {
+          "name": "execute",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "interesting": {
+          "name": "interesting",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<InterestResult[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "cli": false,
+        "api": false,
+        "mcp": false,
+        "tableStrategy": "sti"
+      },
+      "extends": "SmrtObject",
+      "exportName": "Agent",
+      "collectionExportName": "AgentCollection",
+      "schema": {
+        "tableName": "agents",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"agents\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"status\" TEXT DEFAULT 'idle'\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "idle"
+          }
+        },
+        "indexes": [
+          {
+            "name": "agents_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "agents_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "agents_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "0298c555"
+      }
+    }
+  },
+  "moduleType": "smrt",
+  "packageName": "@happyvertical/smrt-agents"
+}

--- a/packages/analytics/src/manifest/manifest.json
+++ b/packages/analytics/src/manifest/manifest.json
@@ -1,0 +1,2054 @@
+{
+  "version": "1.0.0",
+  "timestamp": 1767322692161,
+  "objects": {
+    "analyticsdatastream": {
+      "name": "analyticsdatastream",
+      "className": "AnalyticsDataStream",
+      "collection": "analyticsdatastreams",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/analytics/src/models/AnalyticsDataStream.ts",
+      "fields": {
+        "propertyId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "displayName": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "streamType": {
+          "type": "text",
+          "required": false
+        },
+        "externalId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "measurementId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "firebaseAppId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "defaultUri": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "bundleId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "packageName": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "status": {
+          "type": "text",
+          "required": false
+        },
+        "enhancedMeasurement": {
+          "type": "boolean",
+          "required": false,
+          "default": true
+        }
+      },
+      "methods": {
+        "isWeb": {
+          "name": "isWeb",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isIOS": {
+          "name": "isIOS",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isAndroid": {
+          "name": "isAndroid",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isMobileApp": {
+          "name": "isMobileApp",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getPlatformId": {
+          "name": "getPlatformId",
+          "async": false,
+          "parameters": [],
+          "returnType": "string",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "AnalyticsDataStream",
+      "collectionExportName": "AnalyticsDataStreamCollection",
+      "schema": {
+        "tableName": "analytics_data_streams",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_data_streams\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"property_id\" TEXT DEFAULT '',\n  \"display_name\" TEXT DEFAULT '',\n  \"stream_type\" TEXT,\n  \"external_id\" TEXT DEFAULT '',\n  \"measurement_id\" TEXT DEFAULT '',\n  \"firebase_app_id\" TEXT DEFAULT '',\n  \"default_uri\" TEXT DEFAULT '',\n  \"bundle_id\" TEXT DEFAULT '',\n  \"package_name\" TEXT DEFAULT '',\n  \"status\" TEXT,\n  \"enhanced_measurement\" BOOLEAN DEFAULT TRUE\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "property_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "display_name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "stream_type": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "external_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "measurement_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "firebase_app_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "default_uri": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "bundle_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "package_name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "enhanced_measurement": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": true
+          }
+        },
+        "indexes": [
+          {
+            "name": "analytics_data_streams_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "analytics_data_streams_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "3049f8aa"
+      }
+    },
+    "analyticsdatastreamcollection": {
+      "name": "analyticsdatastreamcollection",
+      "className": "AnalyticsDataStreamCollection",
+      "collection": "analyticsdatastreams",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/analytics/src/collections/AnalyticsDataStreamCollection.ts",
+      "fields": {},
+      "methods": {
+        "findByProperty": {
+          "name": "findByProperty",
+          "async": true,
+          "parameters": [
+            {
+              "name": "propertyId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsDataStream[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByExternalId": {
+          "name": "findByExternalId",
+          "async": true,
+          "parameters": [
+            {
+              "name": "externalId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsDataStream | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByMeasurementId": {
+          "name": "findByMeasurementId",
+          "async": true,
+          "parameters": [
+            {
+              "name": "measurementId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsDataStream | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByType": {
+          "name": "findByType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "streamType",
+              "type": "DataStreamType",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsDataStream[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWebStreams": {
+          "name": "findWebStreams",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AnalyticsDataStream[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findIOSStreams": {
+          "name": "findIOSStreams",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AnalyticsDataStream[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findAndroidStreams": {
+          "name": "findAndroidStreams",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AnalyticsDataStream[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findMobileStreams": {
+          "name": "findMobileStreams",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AnalyticsDataStream[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByStatus": {
+          "name": "findByStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "status",
+              "type": "DataStreamStatus",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsDataStream[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findActive": {
+          "name": "findActive",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AnalyticsDataStream[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findActiveByProperty": {
+          "name": "findActiveByProperty",
+          "async": true,
+          "parameters": [
+            {
+              "name": "propertyId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsDataStream[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "AnalyticsDataStream",
+      "exportName": "AnalyticsDataStreamCollection",
+      "collectionExportName": "AnalyticsDataStreamCollectionCollection",
+      "schema": {
+        "tableName": "analytics_data_stream_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_data_stream_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "analytics_data_stream_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "analytics_data_stream_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "6beb016f"
+      }
+    },
+    "analyticsevent": {
+      "name": "analyticsevent",
+      "className": "AnalyticsEvent",
+      "collection": "analyticsevents",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/analytics/src/models/AnalyticsEvent.ts",
+      "fields": {
+        "propertyId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "eventName": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "clientId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "userId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "params": {
+          "type": "text",
+          "required": false,
+          "default": "{}"
+        },
+        "eventTimestamp": {
+          "type": "datetime",
+          "required": false
+        },
+        "status": {
+          "type": "text",
+          "required": false
+        },
+        "sentAt": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "errorMessage": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "retryCount": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "nonPersonalizedAds": {
+          "type": "boolean",
+          "required": false,
+          "default": false
+        },
+        "sessionId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "pagePath": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "pageTitle": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "userAgent": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "ipAddress": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        }
+      },
+      "methods": {
+        "getParams": {
+          "name": "getParams",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, string | number | boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setParams": {
+          "name": "setParams",
+          "async": false,
+          "parameters": [
+            {
+              "name": "params",
+              "type": "Record<string, string | number | boolean>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addParam": {
+          "name": "addParam",
+          "async": false,
+          "parameters": [
+            {
+              "name": "key",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "value",
+              "type": "string | number | boolean",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isPageview": {
+          "name": "isPageview",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isConversion": {
+          "name": "isConversion",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markSent": {
+          "name": "markSent",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markFailed": {
+          "name": "markFailed",
+          "async": false,
+          "parameters": [
+            {
+              "name": "error",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetForRetry": {
+          "name": "resetForRetry",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "shouldRetry": {
+          "name": "shouldRetry",
+          "async": false,
+          "parameters": [
+            {
+              "name": "maxRetries",
+              "type": "number",
+              "optional": false,
+              "default": 3
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toTrackEvent": {
+          "name": "toTrackEvent",
+          "async": false,
+          "parameters": [],
+          "returnType": "{\n    name: string;\n    params?: Record<string, string | number | boolean>;\n    clientId?: string;\n    userId?: string;\n    timestamp?: number;\n    nonPersonalizedAds?: boolean;\n  }",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "track"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "AnalyticsEvent",
+      "collectionExportName": "AnalyticsEventCollection",
+      "schema": {
+        "tableName": "analytics_events",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_events\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"property_id\" TEXT DEFAULT '',\n  \"event_name\" TEXT DEFAULT '',\n  \"client_id\" TEXT DEFAULT '',\n  \"user_id\" TEXT DEFAULT '',\n  \"params\" TEXT DEFAULT '{}',\n  \"event_timestamp\" TIMESTAMP,\n  \"status\" TEXT,\n  \"sent_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"error_message\" TEXT DEFAULT '',\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"non_personalized_ads\" BOOLEAN DEFAULT FALSE,\n  \"session_id\" TEXT DEFAULT '',\n  \"page_path\" TEXT DEFAULT '',\n  \"page_title\" TEXT DEFAULT '',\n  \"user_agent\" TEXT DEFAULT '',\n  \"ip_address\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "property_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "event_name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "client_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "user_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "params": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "{}"
+          },
+          "event_timestamp": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "sent_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "error_message": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "retry_count": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "non_personalized_ads": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": false
+          },
+          "session_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "page_path": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "page_title": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "user_agent": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "ip_address": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "analytics_events_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "analytics_events_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "17eba562"
+      }
+    },
+    "analyticseventcollection": {
+      "name": "analyticseventcollection",
+      "className": "AnalyticsEventCollection",
+      "collection": "analyticsevents",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/analytics/src/collections/AnalyticsEventCollection.ts",
+      "fields": {},
+      "methods": {
+        "findByProperty": {
+          "name": "findByProperty",
+          "async": true,
+          "parameters": [
+            {
+              "name": "propertyId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByEventName": {
+          "name": "findByEventName",
+          "async": true,
+          "parameters": [
+            {
+              "name": "eventName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByClientId": {
+          "name": "findByClientId",
+          "async": true,
+          "parameters": [
+            {
+              "name": "clientId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByUserId": {
+          "name": "findByUserId",
+          "async": true,
+          "parameters": [
+            {
+              "name": "userId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByStatus": {
+          "name": "findByStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "status",
+              "type": "TrackingEventStatus",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findPending": {
+          "name": "findPending",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AnalyticsEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findSent": {
+          "name": "findSent",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AnalyticsEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findFailed": {
+          "name": "findFailed",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AnalyticsEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findForRetry": {
+          "name": "findForRetry",
+          "async": true,
+          "parameters": [
+            {
+              "name": "maxRetries",
+              "type": "number",
+              "optional": false,
+              "default": 3
+            }
+          ],
+          "returnType": "Promise<AnalyticsEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findPendingByProperty": {
+          "name": "findPendingByProperty",
+          "async": true,
+          "parameters": [
+            {
+              "name": "propertyId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByDateRange": {
+          "name": "findByDateRange",
+          "async": true,
+          "parameters": [
+            {
+              "name": "startDate",
+              "type": "Date",
+              "optional": false
+            },
+            {
+              "name": "endDate",
+              "type": "Date",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findConversions": {
+          "name": "findConversions",
+          "async": true,
+          "parameters": [
+            {
+              "name": "propertyId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<AnalyticsEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findPageviews": {
+          "name": "findPageviews",
+          "async": true,
+          "parameters": [
+            {
+              "name": "propertyId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<AnalyticsEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "countByEventName": {
+          "name": "countByEventName",
+          "async": true,
+          "parameters": [
+            {
+              "name": "propertyId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Map<string, number>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getPropertyStats": {
+          "name": "getPropertyStats",
+          "async": true,
+          "parameters": [
+            {
+              "name": "propertyId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<{\n    total: number;\n    pending: number;\n    sent: number;\n    failed: number;\n    conversions: number;\n    pageviews: number;\n  }>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "AnalyticsEvent",
+      "exportName": "AnalyticsEventCollection",
+      "collectionExportName": "AnalyticsEventCollectionCollection",
+      "schema": {
+        "tableName": "analytics_event_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_event_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "analytics_event_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "analytics_event_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "11b34b89"
+      }
+    },
+    "analyticsproperty": {
+      "name": "analyticsproperty",
+      "className": "AnalyticsProperty",
+      "collection": "analyticsproperties",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/analytics/src/models/AnalyticsProperty.ts",
+      "fields": {
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "displayName": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "provider": {
+          "type": "text",
+          "required": false
+        },
+        "externalId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "measurementId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "apiSecret": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "siteDomain": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "timeZone": {
+          "type": "text",
+          "required": false,
+          "default": "America/Los_Angeles"
+        },
+        "currencyCode": {
+          "type": "text",
+          "required": false,
+          "default": "USD"
+        },
+        "industryCategory": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "serviceLevel": {
+          "type": "text",
+          "required": false,
+          "default": "STANDARD"
+        },
+        "status": {
+          "type": "text",
+          "required": false
+        },
+        "lastSyncAt": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "providerMetadata": {
+          "type": "text",
+          "required": false,
+          "default": "{}"
+        }
+      },
+      "methods": {
+        "isGA4": {
+          "name": "isGA4",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isPlausible": {
+          "name": "isPlausible",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getProviderMetadata": {
+          "name": "getProviderMetadata",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, unknown>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setProviderMetadata": {
+          "name": "setProviderMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "metadata",
+              "type": "Record<string, unknown>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markSynced": {
+          "name": "markSynced",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "analyzePerformance": {
+          "name": "analyzePerformance",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{ period?: string }",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<{\n    action: string;\n    period: string;\n    analysis: string;\n  }>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isPerformingWell": {
+          "name": "isPerformingWell",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "sync",
+            "runReport"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "AnalyticsProperty",
+      "collectionExportName": "AnalyticsPropertyCollection",
+      "schema": {
+        "tableName": "analytics_propertys",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_propertys\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"display_name\" TEXT DEFAULT '',\n  \"provider\" TEXT,\n  \"external_id\" TEXT DEFAULT '',\n  \"measurement_id\" TEXT DEFAULT '',\n  \"api_secret\" TEXT DEFAULT '',\n  \"site_domain\" TEXT DEFAULT '',\n  \"time_zone\" TEXT DEFAULT 'America/Los_Angeles',\n  \"currency_code\" TEXT DEFAULT 'USD',\n  \"industry_category\" TEXT DEFAULT '',\n  \"service_level\" TEXT DEFAULT 'STANDARD',\n  \"status\" TEXT,\n  \"last_sync_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"provider_metadata\" TEXT DEFAULT '{}'\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "display_name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "provider": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "external_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "measurement_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "api_secret": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "site_domain": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "time_zone": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "America/Los_Angeles"
+          },
+          "currency_code": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "USD"
+          },
+          "industry_category": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "service_level": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "STANDARD"
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "last_sync_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "provider_metadata": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "{}"
+          }
+        },
+        "indexes": [
+          {
+            "name": "analytics_propertys_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "analytics_propertys_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "e3ea21e0"
+      }
+    },
+    "analyticspropertycollection": {
+      "name": "analyticspropertycollection",
+      "className": "AnalyticsPropertyCollection",
+      "collection": "analyticsproperties",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/analytics/src/collections/AnalyticsPropertyCollection.ts",
+      "fields": {},
+      "methods": {
+        "findByExternalId": {
+          "name": "findByExternalId",
+          "async": true,
+          "parameters": [
+            {
+              "name": "externalId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsProperty | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByMeasurementId": {
+          "name": "findByMeasurementId",
+          "async": true,
+          "parameters": [
+            {
+              "name": "measurementId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsProperty | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findBySiteDomain": {
+          "name": "findBySiteDomain",
+          "async": true,
+          "parameters": [
+            {
+              "name": "siteDomain",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsProperty | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByProvider": {
+          "name": "findByProvider",
+          "async": true,
+          "parameters": [
+            {
+              "name": "provider",
+              "type": "AnalyticsProvider",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsProperty[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGA4Properties": {
+          "name": "findGA4Properties",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AnalyticsProperty[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findPlausibleSites": {
+          "name": "findPlausibleSites",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AnalyticsProperty[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByStatus": {
+          "name": "findByStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "status",
+              "type": "AnalyticsPropertyStatus",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsProperty[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findActive": {
+          "name": "findActive",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AnalyticsProperty[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findNeedingSync": {
+          "name": "findNeedingSync",
+          "async": true,
+          "parameters": [
+            {
+              "name": "hoursAgo",
+              "type": "number",
+              "optional": false,
+              "default": 24
+            }
+          ],
+          "returnType": "Promise<AnalyticsProperty[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "AnalyticsProperty",
+      "exportName": "AnalyticsPropertyCollection",
+      "collectionExportName": "AnalyticsPropertyCollectionCollection",
+      "schema": {
+        "tableName": "analytics_property_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_property_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "analytics_property_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "analytics_property_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "f4081c9a"
+      }
+    },
+    "analyticsreport": {
+      "name": "analyticsreport",
+      "className": "AnalyticsReport",
+      "collection": "analyticsreports",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/analytics/src/models/AnalyticsReport.ts",
+      "fields": {
+        "propertyId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "dimensions": {
+          "type": "text",
+          "required": false,
+          "default": "[]"
+        },
+        "metrics": {
+          "type": "text",
+          "required": false,
+          "default": "[]"
+        },
+        "dateRangeStart": {
+          "type": "text",
+          "required": false,
+          "default": "7daysAgo"
+        },
+        "dateRangeEnd": {
+          "type": "text",
+          "required": false,
+          "default": "today"
+        },
+        "dimensionFilter": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "metricFilter": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "orderBy": {
+          "type": "text",
+          "required": false,
+          "default": "[]"
+        },
+        "maxResults": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "status": {
+          "type": "text",
+          "required": false
+        },
+        "frequency": {
+          "type": "text",
+          "required": false
+        },
+        "lastRunAt": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "nextRunAt": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "resultData": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "rowCount": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "lastError": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        }
+      },
+      "methods": {
+        "getDimensions": {
+          "name": "getDimensions",
+          "async": false,
+          "parameters": [],
+          "returnType": "Array<{ name: string }>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setDimensions": {
+          "name": "setDimensions",
+          "async": false,
+          "parameters": [
+            {
+              "name": "dimensions",
+              "type": "Array<{ name: string }>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getMetrics": {
+          "name": "getMetrics",
+          "async": false,
+          "parameters": [],
+          "returnType": "Array<{ name: string }>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setMetrics": {
+          "name": "setMetrics",
+          "async": false,
+          "parameters": [
+            {
+              "name": "metrics",
+              "type": "Array<{ name: string }>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getResultData": {
+          "name": "getResultData",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, unknown> | null",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setResultData": {
+          "name": "setResultData",
+          "async": false,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "Record<string, unknown>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markRunning": {
+          "name": "markRunning",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markCompleted": {
+          "name": "markCompleted",
+          "async": false,
+          "parameters": [
+            {
+              "name": "rowCount",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markFailed": {
+          "name": "markFailed",
+          "async": false,
+          "parameters": [
+            {
+              "name": "error",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "calculateNextRun": {
+          "name": "calculateNextRun",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isDue": {
+          "name": "isDue",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "analyzeResults": {
+          "name": "analyzeResults",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_options",
+              "type": "any",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<{\n    action: string;\n    analysis: string;\n    insights: string;\n  }>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasPositiveTrends": {
+          "name": "hasPositiveTrends",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "run"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "run",
+            "analyze"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "AnalyticsReport",
+      "collectionExportName": "AnalyticsReportCollection",
+      "schema": {
+        "tableName": "analytics_reports",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_reports\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"property_id\" TEXT DEFAULT '',\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"dimensions\" TEXT DEFAULT '[]',\n  \"metrics\" TEXT DEFAULT '[]',\n  \"date_range_start\" TEXT DEFAULT '7daysAgo',\n  \"date_range_end\" TEXT DEFAULT 'today',\n  \"dimension_filter\" TEXT DEFAULT '',\n  \"metric_filter\" TEXT DEFAULT '',\n  \"order_by\" TEXT DEFAULT '[]',\n  \"max_results\" INTEGER DEFAULT 0,\n  \"status\" TEXT,\n  \"frequency\" TEXT,\n  \"last_run_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"next_run_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"result_data\" TEXT DEFAULT '',\n  \"row_count\" INTEGER DEFAULT 0,\n  \"last_error\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "property_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "dimensions": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "[]"
+          },
+          "metrics": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "[]"
+          },
+          "date_range_start": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "7daysAgo"
+          },
+          "date_range_end": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "today"
+          },
+          "dimension_filter": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "metric_filter": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "order_by": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "[]"
+          },
+          "max_results": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "frequency": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "last_run_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "next_run_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "result_data": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "row_count": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "last_error": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "analytics_reports_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "analytics_reports_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "9452cffc"
+      }
+    },
+    "analyticsreportcollection": {
+      "name": "analyticsreportcollection",
+      "className": "AnalyticsReportCollection",
+      "collection": "analyticsreports",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/analytics/src/collections/AnalyticsReportCollection.ts",
+      "fields": {},
+      "methods": {
+        "findByProperty": {
+          "name": "findByProperty",
+          "async": true,
+          "parameters": [
+            {
+              "name": "propertyId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsReport[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByStatus": {
+          "name": "findByStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "status",
+              "type": "ReportStatus",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsReport[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findDrafts": {
+          "name": "findDrafts",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AnalyticsReport[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findScheduled": {
+          "name": "findScheduled",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AnalyticsReport[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findCompleted": {
+          "name": "findCompleted",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AnalyticsReport[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findFailed": {
+          "name": "findFailed",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AnalyticsReport[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByFrequency": {
+          "name": "findByFrequency",
+          "async": true,
+          "parameters": [
+            {
+              "name": "frequency",
+              "type": "ReportFrequency",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsReport[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findRecurring": {
+          "name": "findRecurring",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AnalyticsReport[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findDue": {
+          "name": "findDue",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AnalyticsReport[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByPropertyAndStatus": {
+          "name": "findByPropertyAndStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "propertyId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "status",
+              "type": "ReportStatus",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AnalyticsReport[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findRecentlyRun": {
+          "name": "findRecentlyRun",
+          "async": true,
+          "parameters": [
+            {
+              "name": "hoursAgo",
+              "type": "number",
+              "optional": false,
+              "default": 24
+            }
+          ],
+          "returnType": "Promise<AnalyticsReport[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "AnalyticsReport",
+      "exportName": "AnalyticsReportCollection",
+      "collectionExportName": "AnalyticsReportCollectionCollection",
+      "schema": {
+        "tableName": "analytics_report_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_report_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "analytics_report_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "analytics_report_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "e21049fe"
+      }
+    }
+  },
+  "moduleType": "smrt",
+  "packageName": "@happyvertical/smrt-analytics"
+}

--- a/packages/assets/src/manifest/manifest.json
+++ b/packages/assets/src/manifest/manifest.json
@@ -1,0 +1,1707 @@
+{
+  "version": "1.0.0",
+  "timestamp": 1767322693643,
+  "objects": {
+    "assetmetafield": {
+      "name": "assetmetafield",
+      "className": "AssetMetafield",
+      "collection": "assetmetafields",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/assets/src/asset-metafield.ts",
+      "fields": {
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "validation": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        }
+      },
+      "methods": {
+        "getValidation": {
+          "name": "getValidation",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, unknown>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setValidation": {
+          "name": "setValidation",
+          "async": false,
+          "parameters": [
+            {
+              "name": "rules",
+              "type": "Record<string, unknown>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getBySlug": {
+          "name": "getBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AssetMetafield | null>",
+          "isStatic": true,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "AssetMetafield",
+      "collectionExportName": "AssetMetafieldCollection",
+      "schema": {
+        "tableName": "asset_metafields",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_metafields\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"validation\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "validation": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "asset_metafields_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "asset_metafields_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "asset_metafields_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "a0450430"
+      }
+    },
+    "assetmetafieldcollection": {
+      "name": "assetmetafieldcollection",
+      "className": "AssetMetafieldCollection",
+      "collection": "assetmetafields",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/assets/src/asset-metafields.ts",
+      "fields": {},
+      "methods": {
+        "getOrCreate": {
+          "name": "getOrCreate",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "optional": true
+            },
+            {
+              "name": "validation",
+              "type": "string | Record<string, unknown>",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<AssetMetafield>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initializeCommonMetafields": {
+          "name": "initializeCommonMetafields",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "AssetMetafield",
+      "exportName": "AssetMetafieldCollection",
+      "collectionExportName": "AssetMetafieldCollectionCollection",
+      "schema": {
+        "tableName": "asset_metafield_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_metafield_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "asset_metafield_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "asset_metafield_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "d4538b87"
+      }
+    },
+    "assetstatus": {
+      "name": "assetstatus",
+      "className": "AssetStatus",
+      "collection": "assetstatuses",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/assets/src/asset-status.ts",
+      "fields": {
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        }
+      },
+      "methods": {
+        "getBySlug": {
+          "name": "getBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AssetStatus | null>",
+          "isStatic": true,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "AssetStatus",
+      "collectionExportName": "AssetStatusCollection",
+      "schema": {
+        "tableName": "asset_status",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_status\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "asset_status_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "asset_status_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "asset_status_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "464617a1"
+      }
+    },
+    "assetstatuscollection": {
+      "name": "assetstatuscollection",
+      "className": "AssetStatusCollection",
+      "collection": "assetstatuses",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/assets/src/asset-statuses.ts",
+      "fields": {},
+      "methods": {
+        "getOrCreate": {
+          "name": "getOrCreate",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "optional": true
+            },
+            {
+              "name": "description",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<AssetStatus>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initializeCommonStatuses": {
+          "name": "initializeCommonStatuses",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "AssetStatus",
+      "exportName": "AssetStatusCollection",
+      "collectionExportName": "AssetStatusCollectionCollection",
+      "schema": {
+        "tableName": "asset_status_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_status_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "asset_status_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "asset_status_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "589b4e08"
+      }
+    },
+    "assettype": {
+      "name": "assettype",
+      "className": "AssetType",
+      "collection": "assettypes",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/assets/src/asset-type.ts",
+      "fields": {
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        }
+      },
+      "methods": {
+        "getBySlug": {
+          "name": "getBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AssetType | null>",
+          "isStatic": true,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "AssetType",
+      "collectionExportName": "AssetTypeCollection",
+      "schema": {
+        "tableName": "asset_types",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_types\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "asset_types_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "asset_types_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "asset_types_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "5f243f09"
+      }
+    },
+    "assettypecollection": {
+      "name": "assettypecollection",
+      "className": "AssetTypeCollection",
+      "collection": "assettypes",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/assets/src/asset-types.ts",
+      "fields": {},
+      "methods": {
+        "getOrCreate": {
+          "name": "getOrCreate",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "optional": true
+            },
+            {
+              "name": "description",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<AssetType>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initializeCommonTypes": {
+          "name": "initializeCommonTypes",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "AssetType",
+      "exportName": "AssetTypeCollection",
+      "collectionExportName": "AssetTypeCollectionCollection",
+      "schema": {
+        "tableName": "asset_type_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_type_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "asset_type_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "asset_type_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "0f069611"
+      }
+    },
+    "asset": {
+      "name": "asset",
+      "className": "Asset",
+      "collection": "assets",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/assets/src/asset.ts",
+      "fields": {
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "sourceUri": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "mimeType": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "version": {
+          "type": "integer",
+          "required": false,
+          "default": 1
+        },
+        "primaryVersionId": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "typeSlug": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "statusSlug": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "ownerProfileId": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "parentId": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "createdAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "updatedAt": {
+          "type": "datetime",
+          "required": false
+        }
+      },
+      "methods": {
+        "getTags": {
+          "name": "getTags",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Tag[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasTag": {
+          "name": "hasTag",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tagSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParent": {
+          "name": "getParent",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Asset | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getChildren": {
+          "name": "getChildren",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getType": {
+          "name": "getType",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AssetType | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getStatus": {
+          "name": "getStatus",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AssetStatus | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getBySlug": {
+          "name": "getBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Asset | null>",
+          "isStatic": true,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "Asset",
+      "collectionExportName": "AssetCollection",
+      "schema": {
+        "tableName": "assets",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"assets\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"source_uri\" TEXT DEFAULT '',\n  \"mime_type\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"version\" INTEGER DEFAULT 1,\n  \"primary_version_id\" TEXT DEFAULT 'null',\n  \"type_slug\" TEXT DEFAULT '',\n  \"status_slug\" TEXT DEFAULT '',\n  \"owner_profile_id\" TEXT DEFAULT 'null',\n  \"parent_id\" TEXT DEFAULT 'null',\n  \"width\" INTEGER DEFAULT 0,\n  \"height\" INTEGER DEFAULT 0,\n  \"alt\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "source_uri": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "mime_type": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "version": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 1
+          },
+          "primary_version_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "type_slug": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "status_slug": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "owner_profile_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "parent_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "width": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "height": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "alt": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "assets_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "assets_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "assets_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "523d27c7"
+      }
+    },
+    "assetcollection": {
+      "name": "assetcollection",
+      "className": "AssetCollection",
+      "collection": "assets",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/assets/src/assets.ts",
+      "fields": {},
+      "methods": {
+        "addTag": {
+          "name": "addTag",
+          "async": true,
+          "parameters": [
+            {
+              "name": "assetId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "tagSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeTag": {
+          "name": "removeTag",
+          "async": true,
+          "parameters": [
+            {
+              "name": "assetId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "tagSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByTag": {
+          "name": "getByTag",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tagSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByType": {
+          "name": "getByType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "typeSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByStatus": {
+          "name": "getByStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "statusSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByOwner": {
+          "name": "getByOwner",
+          "async": true,
+          "parameters": [
+            {
+              "name": "ownerProfileId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "createNewVersion": {
+          "name": "createNewVersion",
+          "async": true,
+          "parameters": [
+            {
+              "name": "primaryVersionId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "newSourceUri",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "updates",
+              "type": "Partial<Asset>",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<Asset>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getLatestVersion": {
+          "name": "getLatestVersion",
+          "async": true,
+          "parameters": [
+            {
+              "name": "primaryVersionId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Asset | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listVersions": {
+          "name": "listVersions",
+          "async": true,
+          "parameters": [
+            {
+              "name": "primaryVersionId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getChildren": {
+          "name": "getChildren",
+          "async": true,
+          "parameters": [
+            {
+              "name": "parentId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByMimeType": {
+          "name": "getByMimeType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "mimePattern",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "Asset",
+      "exportName": "AssetCollection",
+      "collectionExportName": "AssetCollectionCollection",
+      "schema": {
+        "tableName": "asset_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "asset_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "asset_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "fbe7f4cf"
+      }
+    },
+    "image": {
+      "name": "image",
+      "className": "Image",
+      "collection": "assets",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/assets/src/image.ts",
+      "fields": {
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "sourceUri": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "mimeType": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "version": {
+          "type": "integer",
+          "required": false,
+          "default": 1
+        },
+        "primaryVersionId": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "typeSlug": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "statusSlug": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "ownerProfileId": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "parentId": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "createdAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "updatedAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "width": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "height": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "alt": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        }
+      },
+      "methods": {
+        "getTags": {
+          "name": "getTags",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Tag[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasTag": {
+          "name": "hasTag",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tagSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParent": {
+          "name": "getParent",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Asset | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getChildren": {
+          "name": "getChildren",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getType": {
+          "name": "getType",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AssetType | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getStatus": {
+          "name": "getStatus",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AssetStatus | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getBySlug": {
+          "name": "getBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Asset | null>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "isValidImageFormat": {
+          "name": "isValidImageFormat",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isHighResolution": {
+          "name": "isHighResolution",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateAltText": {
+          "name": "generateAltText",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "generateAltText"
+          ]
+        },
+        "cli": true,
+        "tableName": "assets",
+        "tableStrategy": "sti"
+      },
+      "extends": "Asset",
+      "exportName": "Image",
+      "collectionExportName": "ImageCollection",
+      "schema": {
+        "tableName": "assets",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"assets\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"source_uri\" TEXT DEFAULT '',\n  \"mime_type\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"version\" INTEGER DEFAULT 1,\n  \"primary_version_id\" TEXT DEFAULT 'null',\n  \"type_slug\" TEXT DEFAULT '',\n  \"status_slug\" TEXT DEFAULT '',\n  \"owner_profile_id\" TEXT DEFAULT 'null',\n  \"parent_id\" TEXT DEFAULT 'null',\n  \"width\" INTEGER DEFAULT 0,\n  \"height\" INTEGER DEFAULT 0,\n  \"alt\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "source_uri": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "mime_type": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "version": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 1
+          },
+          "primary_version_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "type_slug": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "status_slug": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "owner_profile_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "parent_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "width": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "height": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "alt": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "assets_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "assets_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "assets_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "23e04c30"
+      }
+    },
+    "imagecollection": {
+      "name": "imagecollection",
+      "className": "ImageCollection",
+      "collection": "assets",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/assets/src/images.ts",
+      "fields": {},
+      "methods": {
+        "getByMinDimensions": {
+          "name": "getByMinDimensions",
+          "async": true,
+          "parameters": [
+            {
+              "name": "minWidth",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "minHeight",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Image[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByMaxDimensions": {
+          "name": "getByMaxDimensions",
+          "async": true,
+          "parameters": [
+            {
+              "name": "maxWidth",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "maxHeight",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Image[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getLandscape": {
+          "name": "getLandscape",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Image[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getPortrait": {
+          "name": "getPortrait",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Image[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSquare": {
+          "name": "getSquare",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Image[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getMissingAltText": {
+          "name": "getMissingAltText",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Image[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getHighResolution": {
+          "name": "getHighResolution",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Image[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByAspectRatio": {
+          "name": "getByAspectRatio",
+          "async": true,
+          "parameters": [
+            {
+              "name": "minRatio",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "maxRatio",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Image[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableName": "assets"
+      },
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "Image",
+      "exportName": "ImageCollection",
+      "collectionExportName": "ImageCollectionCollection",
+      "schema": {
+        "tableName": "assets",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"assets\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "assets_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "assets_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "411d565d"
+      }
+    }
+  },
+  "moduleType": "smrt",
+  "packageName": "@happyvertical/smrt-assets"
+}

--- a/packages/content/src/manifest/manifest.json
+++ b/packages/content/src/manifest/manifest.json
@@ -1,0 +1,2003 @@
+{
+  "version": "1.0.0",
+  "timestamp": 1767322696491,
+  "objects": {
+    "content": {
+      "name": "content",
+      "className": "Content",
+      "collection": "contents",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/content/src/content.ts",
+      "fields": {
+        "type": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "variant": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "fileKey": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "author": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "name": {
+          "type": "text",
+          "required": true,
+          "_meta": {},
+          "default": ""
+        },
+        "title": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "body": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "publish_date": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "url": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "source": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "original_url": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "language": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "tags": {
+          "type": "json",
+          "required": false,
+          "default": []
+        },
+        "category": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "status": {
+          "type": "text",
+          "required": false,
+          "default": "draft"
+        },
+        "state": {
+          "type": "text",
+          "required": false,
+          "default": "active"
+        },
+        "metadata": {
+          "type": "json",
+          "required": false,
+          "default": {}
+        },
+        "thumbnailAssetId": {
+          "type": "text",
+          "required": false,
+          "default": null
+        }
+      },
+      "methods": {
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<this>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadReferences": {
+          "name": "loadReferences",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addReference": {
+          "name": "addReference",
+          "async": true,
+          "parameters": [
+            {
+              "name": "content",
+              "type": "Content | string",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getReferences": {
+          "name": "getReferences",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getCategorySegments": {
+          "name": "getCategorySegments",
+          "async": false,
+          "parameters": [],
+          "returnType": "string[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParentCategory": {
+          "name": "getParentCategory",
+          "async": false,
+          "parameters": [],
+          "returnType": "string | null",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRootCategory": {
+          "name": "getRootCategory",
+          "async": false,
+          "parameters": [],
+          "returnType": "string | null",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAncestorPaths": {
+          "name": "getAncestorPaths",
+          "async": false,
+          "parameters": [],
+          "returnType": "string[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isInCategory": {
+          "name": "isInCategory",
+          "async": false,
+          "parameters": [
+            {
+              "name": "categoryPath",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "includeChildren",
+              "type": "any",
+              "optional": false,
+              "default": true
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAssets": {
+          "name": "getAssets",
+          "async": true,
+          "parameters": [
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addAsset": {
+          "name": "addAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "asset",
+              "type": "Asset",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "any",
+              "optional": false,
+              "default": "attachment"
+            },
+            {
+              "name": "sortOrder",
+              "type": "any",
+              "optional": false,
+              "default": 0
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeAsset": {
+          "name": "removeAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "assetId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getThumbnail": {
+          "name": "getThumbnail",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Image | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setThumbnail": {
+          "name": "setThumbnail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "image",
+              "type": "Image",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateThumbnail": {
+          "name": "generateThumbnail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "ThumbnailOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Image>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "Content",
+      "collectionExportName": "ContentCollection",
+      "schema": {
+        "tableName": "contents",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"type\" TEXT DEFAULT 'null',\n  \"variant\" TEXT DEFAULT 'null',\n  \"file_key\" TEXT DEFAULT 'null',\n  \"author\" TEXT DEFAULT 'null',\n  \"name\" TEXT DEFAULT '',\n  \"title\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT 'null',\n  \"body\" TEXT DEFAULT '',\n  \"publish_date\" TIMESTAMP DEFAULT current_timestamp,\n  \"url\" TEXT DEFAULT 'null',\n  \"source\" TEXT DEFAULT 'null',\n  \"original_url\" TEXT DEFAULT 'null',\n  \"language\" TEXT DEFAULT 'null',\n  \"tags\" JSON DEFAULT '',\n  \"category\" TEXT DEFAULT 'null',\n  \"status\" TEXT DEFAULT 'draft',\n  \"state\" TEXT DEFAULT 'active',\n  \"metadata\" JSON DEFAULT '[object Object]',\n  \"thumbnail_asset_id\" TEXT DEFAULT 'null'\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "type": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "variant": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "file_key": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "author": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "title": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "body": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "publish_date": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "url": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "source": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "original_url": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "language": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "tags": {
+            "type": "JSON",
+            "notNull": false,
+            "default": []
+          },
+          "category": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "draft"
+          },
+          "state": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "active"
+          },
+          "metadata": {
+            "type": "JSON",
+            "notNull": false,
+            "default": {}
+          },
+          "thumbnail_asset_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          }
+        },
+        "indexes": [
+          {
+            "name": "contents_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "contents_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "contents_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "ef3122cf"
+      }
+    },
+    "article": {
+      "name": "article",
+      "className": "Article",
+      "collection": "contents",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/content/src/content-types.ts",
+      "fields": {
+        "type": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "variant": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "fileKey": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "author": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "name": {
+          "type": "text",
+          "required": true,
+          "_meta": {},
+          "default": ""
+        },
+        "title": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "body": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "publish_date": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "url": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "source": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "original_url": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "language": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "tags": {
+          "type": "json",
+          "required": false,
+          "default": []
+        },
+        "category": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "status": {
+          "type": "text",
+          "required": false,
+          "default": "draft"
+        },
+        "state": {
+          "type": "text",
+          "required": false,
+          "default": "active"
+        },
+        "metadata": {
+          "type": "json",
+          "required": false,
+          "default": {}
+        },
+        "thumbnailAssetId": {
+          "type": "text",
+          "required": false,
+          "default": null
+        }
+      },
+      "methods": {
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<this>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadReferences": {
+          "name": "loadReferences",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addReference": {
+          "name": "addReference",
+          "async": true,
+          "parameters": [
+            {
+              "name": "content",
+              "type": "Content | string",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getReferences": {
+          "name": "getReferences",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getCategorySegments": {
+          "name": "getCategorySegments",
+          "async": false,
+          "parameters": [],
+          "returnType": "string[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParentCategory": {
+          "name": "getParentCategory",
+          "async": false,
+          "parameters": [],
+          "returnType": "string | null",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRootCategory": {
+          "name": "getRootCategory",
+          "async": false,
+          "parameters": [],
+          "returnType": "string | null",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAncestorPaths": {
+          "name": "getAncestorPaths",
+          "async": false,
+          "parameters": [],
+          "returnType": "string[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isInCategory": {
+          "name": "isInCategory",
+          "async": false,
+          "parameters": [
+            {
+              "name": "categoryPath",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "includeChildren",
+              "type": "any",
+              "optional": false,
+              "default": true
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAssets": {
+          "name": "getAssets",
+          "async": true,
+          "parameters": [
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addAsset": {
+          "name": "addAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "asset",
+              "type": "Asset",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "any",
+              "optional": false,
+              "default": "attachment"
+            },
+            {
+              "name": "sortOrder",
+              "type": "any",
+              "optional": false,
+              "default": 0
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeAsset": {
+          "name": "removeAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "assetId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getThumbnail": {
+          "name": "getThumbnail",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Image | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setThumbnail": {
+          "name": "setThumbnail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "image",
+              "type": "Image",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateThumbnail": {
+          "name": "generateThumbnail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "ThumbnailOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Image>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "tableName": "contents"
+      },
+      "extends": "Content",
+      "exportName": "Article",
+      "collectionExportName": "ArticleCollection",
+      "schema": {
+        "tableName": "contents",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"type\" TEXT DEFAULT 'null',\n  \"variant\" TEXT DEFAULT 'null',\n  \"file_key\" TEXT DEFAULT 'null',\n  \"author\" TEXT DEFAULT 'null',\n  \"name\" TEXT DEFAULT '',\n  \"title\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT 'null',\n  \"body\" TEXT DEFAULT '',\n  \"publish_date\" TIMESTAMP DEFAULT current_timestamp,\n  \"url\" TEXT DEFAULT 'null',\n  \"source\" TEXT DEFAULT 'null',\n  \"original_url\" TEXT DEFAULT 'null',\n  \"language\" TEXT DEFAULT 'null',\n  \"tags\" JSON DEFAULT '',\n  \"category\" TEXT DEFAULT 'null',\n  \"status\" TEXT DEFAULT 'draft',\n  \"state\" TEXT DEFAULT 'active',\n  \"metadata\" JSON DEFAULT '[object Object]',\n  \"thumbnail_asset_id\" TEXT DEFAULT 'null'\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "type": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "variant": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "file_key": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "author": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "title": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "body": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "publish_date": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "url": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "source": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "original_url": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "language": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "tags": {
+            "type": "JSON",
+            "notNull": false,
+            "default": []
+          },
+          "category": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "draft"
+          },
+          "state": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "active"
+          },
+          "metadata": {
+            "type": "JSON",
+            "notNull": false,
+            "default": {}
+          },
+          "thumbnail_asset_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          }
+        },
+        "indexes": [
+          {
+            "name": "contents_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "contents_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "contents_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "24beae85"
+      }
+    },
+    "contentdocument": {
+      "name": "contentdocument",
+      "className": "ContentDocument",
+      "collection": "contents",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/content/src/content-types.ts",
+      "fields": {
+        "type": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "variant": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "fileKey": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "author": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "name": {
+          "type": "text",
+          "required": true,
+          "_meta": {},
+          "default": ""
+        },
+        "title": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "body": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "publish_date": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "url": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "source": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "original_url": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "language": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "tags": {
+          "type": "json",
+          "required": false,
+          "default": []
+        },
+        "category": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "status": {
+          "type": "text",
+          "required": false,
+          "default": "draft"
+        },
+        "state": {
+          "type": "text",
+          "required": false,
+          "default": "active"
+        },
+        "metadata": {
+          "type": "json",
+          "required": false,
+          "default": {}
+        },
+        "thumbnailAssetId": {
+          "type": "text",
+          "required": false,
+          "default": null
+        }
+      },
+      "methods": {
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<this>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadReferences": {
+          "name": "loadReferences",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addReference": {
+          "name": "addReference",
+          "async": true,
+          "parameters": [
+            {
+              "name": "content",
+              "type": "Content | string",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getReferences": {
+          "name": "getReferences",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getCategorySegments": {
+          "name": "getCategorySegments",
+          "async": false,
+          "parameters": [],
+          "returnType": "string[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParentCategory": {
+          "name": "getParentCategory",
+          "async": false,
+          "parameters": [],
+          "returnType": "string | null",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRootCategory": {
+          "name": "getRootCategory",
+          "async": false,
+          "parameters": [],
+          "returnType": "string | null",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAncestorPaths": {
+          "name": "getAncestorPaths",
+          "async": false,
+          "parameters": [],
+          "returnType": "string[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isInCategory": {
+          "name": "isInCategory",
+          "async": false,
+          "parameters": [
+            {
+              "name": "categoryPath",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "includeChildren",
+              "type": "any",
+              "optional": false,
+              "default": true
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAssets": {
+          "name": "getAssets",
+          "async": true,
+          "parameters": [
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addAsset": {
+          "name": "addAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "asset",
+              "type": "Asset",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "any",
+              "optional": false,
+              "default": "attachment"
+            },
+            {
+              "name": "sortOrder",
+              "type": "any",
+              "optional": false,
+              "default": 0
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeAsset": {
+          "name": "removeAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "assetId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getThumbnail": {
+          "name": "getThumbnail",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Image | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setThumbnail": {
+          "name": "setThumbnail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "image",
+              "type": "Image",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateThumbnail": {
+          "name": "generateThumbnail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "ThumbnailOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Image>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "tableName": "contents"
+      },
+      "extends": "Content",
+      "exportName": "ContentDocument",
+      "collectionExportName": "ContentDocumentCollection",
+      "schema": {
+        "tableName": "contents",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"type\" TEXT DEFAULT 'null',\n  \"variant\" TEXT DEFAULT 'null',\n  \"file_key\" TEXT DEFAULT 'null',\n  \"author\" TEXT DEFAULT 'null',\n  \"name\" TEXT DEFAULT '',\n  \"title\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT 'null',\n  \"body\" TEXT DEFAULT '',\n  \"publish_date\" TIMESTAMP DEFAULT current_timestamp,\n  \"url\" TEXT DEFAULT 'null',\n  \"source\" TEXT DEFAULT 'null',\n  \"original_url\" TEXT DEFAULT 'null',\n  \"language\" TEXT DEFAULT 'null',\n  \"tags\" JSON DEFAULT '',\n  \"category\" TEXT DEFAULT 'null',\n  \"status\" TEXT DEFAULT 'draft',\n  \"state\" TEXT DEFAULT 'active',\n  \"metadata\" JSON DEFAULT '[object Object]',\n  \"thumbnail_asset_id\" TEXT DEFAULT 'null'\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "type": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "variant": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "file_key": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "author": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "title": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "body": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "publish_date": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "url": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "source": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "original_url": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "language": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "tags": {
+            "type": "JSON",
+            "notNull": false,
+            "default": []
+          },
+          "category": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "draft"
+          },
+          "state": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "active"
+          },
+          "metadata": {
+            "type": "JSON",
+            "notNull": false,
+            "default": {}
+          },
+          "thumbnail_asset_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          }
+        },
+        "indexes": [
+          {
+            "name": "contents_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "contents_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "contents_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "de2c819b"
+      }
+    },
+    "mirror": {
+      "name": "mirror",
+      "className": "Mirror",
+      "collection": "contents",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/content/src/content-types.ts",
+      "fields": {
+        "type": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "variant": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "fileKey": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "author": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "name": {
+          "type": "text",
+          "required": true,
+          "_meta": {},
+          "default": ""
+        },
+        "title": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "body": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "publish_date": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "url": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "source": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "original_url": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "language": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "tags": {
+          "type": "json",
+          "required": false,
+          "default": []
+        },
+        "category": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "status": {
+          "type": "text",
+          "required": false,
+          "default": "draft"
+        },
+        "state": {
+          "type": "text",
+          "required": false,
+          "default": "active"
+        },
+        "metadata": {
+          "type": "json",
+          "required": false,
+          "default": {}
+        },
+        "thumbnailAssetId": {
+          "type": "text",
+          "required": false,
+          "default": null
+        }
+      },
+      "methods": {
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<this>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadReferences": {
+          "name": "loadReferences",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addReference": {
+          "name": "addReference",
+          "async": true,
+          "parameters": [
+            {
+              "name": "content",
+              "type": "Content | string",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getReferences": {
+          "name": "getReferences",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getCategorySegments": {
+          "name": "getCategorySegments",
+          "async": false,
+          "parameters": [],
+          "returnType": "string[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParentCategory": {
+          "name": "getParentCategory",
+          "async": false,
+          "parameters": [],
+          "returnType": "string | null",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRootCategory": {
+          "name": "getRootCategory",
+          "async": false,
+          "parameters": [],
+          "returnType": "string | null",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAncestorPaths": {
+          "name": "getAncestorPaths",
+          "async": false,
+          "parameters": [],
+          "returnType": "string[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isInCategory": {
+          "name": "isInCategory",
+          "async": false,
+          "parameters": [
+            {
+              "name": "categoryPath",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "includeChildren",
+              "type": "any",
+              "optional": false,
+              "default": true
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAssets": {
+          "name": "getAssets",
+          "async": true,
+          "parameters": [
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addAsset": {
+          "name": "addAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "asset",
+              "type": "Asset",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "any",
+              "optional": false,
+              "default": "attachment"
+            },
+            {
+              "name": "sortOrder",
+              "type": "any",
+              "optional": false,
+              "default": 0
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeAsset": {
+          "name": "removeAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "assetId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getThumbnail": {
+          "name": "getThumbnail",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Image | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setThumbnail": {
+          "name": "setThumbnail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "image",
+              "type": "Image",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateThumbnail": {
+          "name": "generateThumbnail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "ThumbnailOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Image>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "tableName": "contents"
+      },
+      "extends": "Content",
+      "exportName": "Mirror",
+      "collectionExportName": "MirrorCollection",
+      "schema": {
+        "tableName": "contents",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"type\" TEXT DEFAULT 'null',\n  \"variant\" TEXT DEFAULT 'null',\n  \"file_key\" TEXT DEFAULT 'null',\n  \"author\" TEXT DEFAULT 'null',\n  \"name\" TEXT DEFAULT '',\n  \"title\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT 'null',\n  \"body\" TEXT DEFAULT '',\n  \"publish_date\" TIMESTAMP DEFAULT current_timestamp,\n  \"url\" TEXT DEFAULT 'null',\n  \"source\" TEXT DEFAULT 'null',\n  \"original_url\" TEXT DEFAULT 'null',\n  \"language\" TEXT DEFAULT 'null',\n  \"tags\" JSON DEFAULT '',\n  \"category\" TEXT DEFAULT 'null',\n  \"status\" TEXT DEFAULT 'draft',\n  \"state\" TEXT DEFAULT 'active',\n  \"metadata\" JSON DEFAULT '[object Object]',\n  \"thumbnail_asset_id\" TEXT DEFAULT 'null'\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "type": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "variant": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "file_key": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "author": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "title": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "body": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "publish_date": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "url": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "source": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "original_url": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "language": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "tags": {
+            "type": "JSON",
+            "notNull": false,
+            "default": []
+          },
+          "category": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "draft"
+          },
+          "state": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "active"
+          },
+          "metadata": {
+            "type": "JSON",
+            "notNull": false,
+            "default": {}
+          },
+          "thumbnail_asset_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          }
+        },
+        "indexes": [
+          {
+            "name": "contents_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "contents_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "contents_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "d62a1d51"
+      }
+    },
+    "contents": {
+      "name": "contents",
+      "className": "Contents",
+      "collection": "contents",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/content/src/contents.ts",
+      "fields": {
+        "options": {
+          "type": "json",
+          "required": false
+        },
+        "contentDir": {
+          "type": "text",
+          "required": false
+        },
+        "loaded": {
+          "type": "text",
+          "required": true
+        }
+      },
+      "methods": {
+        "getDb": {
+          "name": "getDb",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<this>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "mirror": {
+          "name": "mirror",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{\n    url: string;\n    mirrorDir?: string;\n    context?: string;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "writeContentFile": {
+          "name": "writeContentFile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{\n    content: Content;\n    contentDir: string;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "syncContentDir": {
+          "name": "syncContentDir",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{ contentDir?: string }",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateMissingThumbnails": {
+          "name": "generateMissingThumbnails",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{\n    /**\n     * Thumbnail generation strategy\n     */\n    strategy: ThumbnailStrategy;\n\n    /**\n     * Optional filter for content to process\n     */\n    where?: Record<string, any>;\n\n    /**\n     * Maximum number of thumbnails to generate\n     */\n    limit?: number;\n\n    // Headline card options\n    brandColor?: string;\n    backgroundColor?: string;\n    logoUrl?: string;\n    template?: 'default' | 'news' | 'minimal';\n\n    // Static map options\n    mapProvider?: 'mapbox' | 'google';\n    zoom?: number;\n\n    // AI options\n    style?: 'photorealistic' | 'illustration' | 'abstract' | 'minimal';\n\n    // Common options\n    width?: number;\n    height?: number;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<{\n    images: Image[];\n    failed: Array<{ contentId: string; error: string }>;\n  }>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "Content",
+      "exportName": "Contents",
+      "collectionExportName": "ContentsCollection",
+      "schema": {
+        "tableName": "contents",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"options\" JSON,\n  \"content_dir\" TEXT,\n  \"loaded\" TEXT NOT NULL\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "options": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "content_dir": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "loaded": {
+            "type": "TEXT",
+            "notNull": true
+          }
+        },
+        "indexes": [
+          {
+            "name": "contents_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "contents_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "b902578a"
+      }
+    }
+  },
+  "moduleType": "smrt",
+  "packageName": "@happyvertical/smrt-content"
+}

--- a/packages/core/src/manifest/manifest-loader.ts
+++ b/packages/core/src/manifest/manifest-loader.ts
@@ -1124,9 +1124,6 @@ export function discoverSTISiblingsSync(
   const cache = getSTISiblingCache();
   const cached = cache.get(collection);
   if (cached !== undefined) {
-    console.log(
-      `[manifest-loader] discoverSTISiblingsSync cache hit for collection: ${collection} (${cached.length} siblings)`,
-    );
     return cached;
   }
 

--- a/packages/core/src/schema/utils.ts
+++ b/packages/core/src/schema/utils.ts
@@ -16,6 +16,17 @@ import { tableNameFromClass, toSnakeCase } from '../utils';
 import { SchemaManager } from './schema-manager';
 
 /**
+ * Framework base classes that are never registered in ObjectRegistry.
+ * These are known bases that don't need STI sibling discovery.
+ * Defined at module level to avoid recreating on every ensureSchema() call.
+ */
+const FRAMEWORK_BASE_CLASSES = new Set([
+  'SmrtObject',
+  'SmrtClass',
+  'SmrtCollection',
+]);
+
+/**
  * Get schema migration configuration from global config
  *
  * @returns Schema migration strategy ('warn' or 'auto-add')
@@ -373,14 +384,6 @@ export async function ensureSchema(db: any, className: string): Promise<void> {
   // FIX #623: For STI child classes from external packages, ensure the parent class
   // is loaded before calling getSTIBase(). The parent might not be registered yet
   // if it's from an external package manifest.
-  // Framework base classes that are never registered in ObjectRegistry
-  // These are known bases that don't need STI sibling discovery
-  const FRAMEWORK_BASE_CLASSES = new Set([
-    'SmrtObject',
-    'SmrtClass',
-    'SmrtCollection',
-  ]);
-
   const registered = ObjectRegistry.getClass(className);
   if (registered?.extends) {
     // Skip STI discovery if parent is a framework base class (never registered)

--- a/packages/events/src/manifest/manifest.json
+++ b/packages/events/src/manifest/manifest.json
@@ -1,0 +1,1791 @@
+{
+  "version": "1.0.0",
+  "timestamp": 1767322698151,
+  "objects": {
+    "eventtype": {
+      "name": "eventtype",
+      "className": "EventType",
+      "collection": "eventtypes",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/events/src/models/EventType.ts",
+      "fields": {
+        "name": {
+          "type": "text",
+          "required": true,
+          "_meta": {},
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "schema": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "participantSchema": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "createdAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "updatedAt": {
+          "type": "datetime",
+          "required": false
+        }
+      },
+      "methods": {
+        "getSchema": {
+          "name": "getSchema",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setSchema": {
+          "name": "setSchema",
+          "async": false,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParticipantSchema": {
+          "name": "getParticipantSchema",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setParticipantSchema": {
+          "name": "setParticipantSchema",
+          "async": false,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getBySlug": {
+          "name": "getBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventType | null>",
+          "isStatic": true,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "EventType",
+      "collectionExportName": "EventTypeCollection",
+      "schema": {
+        "tableName": "event_types",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_types\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"schema\" TEXT DEFAULT '',\n  \"participant_schema\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "schema": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "participant_schema": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "event_types_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "event_types_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "event_types_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "1208f39b"
+      }
+    },
+    "eventtypecollection": {
+      "name": "eventtypecollection",
+      "className": "EventTypeCollection",
+      "collection": "eventtypes",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/events/src/collections/EventTypeCollection.ts",
+      "fields": {},
+      "methods": {
+        "getOrCreate": {
+          "name": "getOrCreate",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<EventType>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getBySlug": {
+          "name": "getBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventType | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initializeDefaults": {
+          "name": "initializeDefaults",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<EventType[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "EventType",
+      "exportName": "EventTypeCollection",
+      "collectionExportName": "EventTypeCollectionCollection",
+      "schema": {
+        "tableName": "event_type_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_type_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "event_type_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "event_type_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "9d8686f6"
+      }
+    },
+    "eventseries": {
+      "name": "eventseries",
+      "className": "EventSeries",
+      "collection": "eventserieses",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/events/src/models/EventSeries.ts",
+      "fields": {
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "typeId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "organizerId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "startDate": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "endDate": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "recurrence": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "metadata": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "externalId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "source": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "createdAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "updatedAt": {
+          "type": "datetime",
+          "required": false
+        }
+      },
+      "methods": {
+        "getRecurrence": {
+          "name": "getRecurrence",
+          "async": false,
+          "parameters": [],
+          "returnType": "RecurrencePattern | null",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setRecurrence": {
+          "name": "setRecurrence",
+          "async": false,
+          "parameters": [
+            {
+              "name": "pattern",
+              "type": "RecurrencePattern",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setMetadata": {
+          "name": "setMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateMetadata": {
+          "name": "updateMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "updates",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getType": {
+          "name": "getType",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getOrganizer": {
+          "name": "getOrganizer",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEvents": {
+          "name": "getEvents",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "EventSeries",
+      "collectionExportName": "EventSeriesCollection",
+      "schema": {
+        "tableName": "event_series",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_series\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"type_id\" TEXT DEFAULT '',\n  \"organizer_id\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"start_date\" TIMESTAMP DEFAULT current_timestamp,\n  \"end_date\" TIMESTAMP DEFAULT current_timestamp,\n  \"recurrence\" TEXT DEFAULT '',\n  \"metadata\" TEXT DEFAULT '',\n  \"external_id\" TEXT DEFAULT '',\n  \"source\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "type_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "organizer_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "start_date": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "end_date": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "recurrence": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "metadata": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "external_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "source": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "event_series_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "event_series_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "event_series_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "04c5089d"
+      }
+    },
+    "eventseriescollection": {
+      "name": "eventseriescollection",
+      "className": "EventSeriesCollection",
+      "collection": "eventserieses",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/events/src/collections/EventSeriesCollection.ts",
+      "fields": {},
+      "methods": {
+        "getByOrganizer": {
+          "name": "getByOrganizer",
+          "async": true,
+          "parameters": [
+            {
+              "name": "organizerId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventSeries[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getActive": {
+          "name": "getActive",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<EventSeries[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getUpcoming": {
+          "name": "getUpcoming",
+          "async": true,
+          "parameters": [
+            {
+              "name": "limit",
+              "type": "number",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<EventSeries[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByType": {
+          "name": "getByType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "typeId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventSeries[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "search": {
+          "name": "search",
+          "async": true,
+          "parameters": [
+            {
+              "name": "query",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "filters",
+              "type": "EventSeriesSearchFilters",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<EventSeries[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "EventSeries",
+      "exportName": "EventSeriesCollection",
+      "collectionExportName": "EventSeriesCollectionCollection",
+      "schema": {
+        "tableName": "event_series_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_series_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "event_series_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "event_series_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "a67c8f62"
+      }
+    },
+    "eventparticipant": {
+      "name": "eventparticipant",
+      "className": "EventParticipant",
+      "collection": "eventparticipants",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/events/src/models/EventParticipant.ts",
+      "fields": {
+        "eventId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "profileId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "role": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "placement": {
+          "type": "decimal",
+          "required": false,
+          "default": null
+        },
+        "groupId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "metadata": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "externalId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "source": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "createdAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "updatedAt": {
+          "type": "datetime",
+          "required": false
+        }
+      },
+      "methods": {
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setMetadata": {
+          "name": "setMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateMetadata": {
+          "name": "updateMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "updates",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEvent": {
+          "name": "getEvent",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getProfile": {
+          "name": "getProfile",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getGroupParticipants": {
+          "name": "getGroupParticipants",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<EventParticipant[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isHome": {
+          "name": "isHome",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isAway": {
+          "name": "isAway",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "EventParticipant",
+      "collectionExportName": "EventParticipantCollection",
+      "schema": {
+        "tableName": "event_participants",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_participants\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"event_id\" TEXT DEFAULT '',\n  \"profile_id\" TEXT DEFAULT '',\n  \"role\" TEXT DEFAULT '',\n  \"placement\" REAL DEFAULT NULL,\n  \"group_id\" TEXT DEFAULT '',\n  \"metadata\" TEXT DEFAULT '',\n  \"external_id\" TEXT DEFAULT '',\n  \"source\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "event_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "profile_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "role": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "placement": {
+            "type": "REAL",
+            "notNull": false,
+            "default": null
+          },
+          "group_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "metadata": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "external_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "source": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "event_participants_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "event_participants_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "event_participants_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "e28cbb28"
+      }
+    },
+    "eventparticipantcollection": {
+      "name": "eventparticipantcollection",
+      "className": "EventParticipantCollection",
+      "collection": "eventparticipants",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/events/src/collections/EventParticipantCollection.ts",
+      "fields": {},
+      "methods": {
+        "getByEvent": {
+          "name": "getByEvent",
+          "async": true,
+          "parameters": [
+            {
+              "name": "eventId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventParticipant[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByProfile": {
+          "name": "getByProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventParticipant[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByRole": {
+          "name": "getByRole",
+          "async": true,
+          "parameters": [
+            {
+              "name": "eventId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "role",
+              "type": "ParticipantRole | string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventParticipant[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByPlacement": {
+          "name": "getByPlacement",
+          "async": true,
+          "parameters": [
+            {
+              "name": "eventId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventParticipant[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByGroup": {
+          "name": "getByGroup",
+          "async": true,
+          "parameters": [
+            {
+              "name": "eventId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "groupId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventParticipant[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getHome": {
+          "name": "getHome",
+          "async": true,
+          "parameters": [
+            {
+              "name": "eventId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventParticipant[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAway": {
+          "name": "getAway",
+          "async": true,
+          "parameters": [
+            {
+              "name": "eventId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventParticipant[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "search": {
+          "name": "search",
+          "async": true,
+          "parameters": [
+            {
+              "name": "filters",
+              "type": "ParticipantSearchFilters",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventParticipant[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParticipantStats": {
+          "name": "getParticipantStats",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "eventTypeId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<{\n    totalEvents: number;\n    byRole: Record<string, number>;\n    byPlacement: Record<number, number>;\n  }>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "EventParticipant",
+      "exportName": "EventParticipantCollection",
+      "collectionExportName": "EventParticipantCollectionCollection",
+      "schema": {
+        "tableName": "event_participant_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_participant_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "event_participant_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "event_participant_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "f6e133f3"
+      }
+    },
+    "event": {
+      "name": "event",
+      "className": "Event",
+      "collection": "events",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/events/src/models/Event.ts",
+      "fields": {
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "seriesId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "parentEventId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "typeId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "placeId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "startDate": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "endDate": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "status": {
+          "type": "text",
+          "required": false,
+          "default": "scheduled"
+        },
+        "round": {
+          "type": "decimal",
+          "required": false,
+          "default": null
+        },
+        "metadata": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "externalId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "source": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "createdAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "updatedAt": {
+          "type": "datetime",
+          "required": false
+        }
+      },
+      "methods": {
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setMetadata": {
+          "name": "setMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateMetadata": {
+          "name": "updateMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "updates",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateStatus": {
+          "name": "updateStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "newStatus",
+              "type": "EventStatus",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSeries": {
+          "name": "getSeries",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getType": {
+          "name": "getType",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getPlace": {
+          "name": "getPlace",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParent": {
+          "name": "getParent",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Event | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getChildren": {
+          "name": "getChildren",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Event[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAncestors": {
+          "name": "getAncestors",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Event[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getDescendants": {
+          "name": "getDescendants",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Event[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRootEvent": {
+          "name": "getRootEvent",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Event>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getHierarchy": {
+          "name": "getHierarchy",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<{\n    ancestors: Event[];\n    current: Event;\n    descendants: Event[];\n  }>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParticipants": {
+          "name": "getParticipants",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isInProgress": {
+          "name": "isInProgress",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRoot": {
+          "name": "isRoot",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "Event",
+      "collectionExportName": "EventCollection",
+      "schema": {
+        "tableName": "events",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"events\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"series_id\" TEXT DEFAULT '',\n  \"parent_event_id\" TEXT DEFAULT '',\n  \"type_id\" TEXT DEFAULT '',\n  \"place_id\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"start_date\" TIMESTAMP DEFAULT current_timestamp,\n  \"end_date\" TIMESTAMP DEFAULT current_timestamp,\n  \"status\" TEXT DEFAULT 'scheduled',\n  \"round\" REAL DEFAULT NULL,\n  \"metadata\" TEXT DEFAULT '',\n  \"external_id\" TEXT DEFAULT '',\n  \"source\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "series_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "parent_event_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "type_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "place_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "start_date": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "end_date": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "scheduled"
+          },
+          "round": {
+            "type": "REAL",
+            "notNull": false,
+            "default": null
+          },
+          "metadata": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "external_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "source": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "events_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "events_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "events_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "31a5eb8a"
+      }
+    },
+    "eventcollection": {
+      "name": "eventcollection",
+      "className": "EventCollection",
+      "collection": "events",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/events/src/collections/EventCollection.ts",
+      "fields": {},
+      "methods": {
+        "getBySeriesId": {
+          "name": "getBySeriesId",
+          "async": true,
+          "parameters": [
+            {
+              "name": "seriesId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Event[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByPlace": {
+          "name": "getByPlace",
+          "async": true,
+          "parameters": [
+            {
+              "name": "placeId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Event[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByDateRange": {
+          "name": "getByDateRange",
+          "async": true,
+          "parameters": [
+            {
+              "name": "startDate",
+              "type": "Date",
+              "optional": false
+            },
+            {
+              "name": "endDate",
+              "type": "Date",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Event[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getUpcoming": {
+          "name": "getUpcoming",
+          "async": true,
+          "parameters": [
+            {
+              "name": "limit",
+              "type": "number",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Event[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByStatus": {
+          "name": "getByStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "status",
+              "type": "EventStatus",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Event[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByType": {
+          "name": "getByType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "typeId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Event[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRootEvents": {
+          "name": "getRootEvents",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Event[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByParent": {
+          "name": "getByParent",
+          "async": true,
+          "parameters": [
+            {
+              "name": "parentEventId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Event[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEventTree": {
+          "name": "getEventTree",
+          "async": true,
+          "parameters": [
+            {
+              "name": "eventId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Event | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "search": {
+          "name": "search",
+          "async": true,
+          "parameters": [
+            {
+              "name": "query",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "filters",
+              "type": "EventSearchFilters",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Event[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getInProgress": {
+          "name": "getInProgress",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Event[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "Event",
+      "exportName": "EventCollection",
+      "collectionExportName": "EventCollectionCollection",
+      "schema": {
+        "tableName": "event_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "event_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "event_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "548d1610"
+      }
+    }
+  },
+  "moduleType": "smrt",
+  "packageName": "@happyvertical/smrt-events"
+}

--- a/packages/gnode/src/manifest/manifest.json
+++ b/packages/gnode/src/manifest/manifest.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0",
+  "timestamp": 1767322690409,
+  "objects": {},
+  "moduleType": "smrt",
+  "packageName": "@happyvertical/smrt-gnode"
+}

--- a/packages/messages/src/manifest/manifest.json
+++ b/packages/messages/src/manifest/manifest.json
@@ -1,0 +1,2256 @@
+{
+  "version": "1.0.0",
+  "timestamp": 1767322690806,
+  "objects": {
+    "emailfolder": {
+      "name": "emailfolder",
+      "className": "EmailFolder",
+      "collection": "emailfolders",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/messages/src/models/EmailFolder.ts",
+      "fields": {
+        "accountId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "path": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "delimiter": {
+          "type": "text",
+          "required": false,
+          "default": "/"
+        },
+        "specialUse": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "messageCount": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "unreadCount": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "subscribed": {
+          "type": "boolean",
+          "required": false,
+          "default": true
+        },
+        "createdAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "updatedAt": {
+          "type": "datetime",
+          "required": false
+        }
+      },
+      "methods": {
+        "getAccount": {
+          "name": "getAccount",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmails": {
+          "name": "getEmails",
+          "async": true,
+          "parameters": [
+            {
+              "name": "limit",
+              "type": "number",
+              "optional": true
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getUnreadEmails": {
+          "name": "getUnreadEmails",
+          "async": true,
+          "parameters": [
+            {
+              "name": "limit",
+              "type": "number",
+              "optional": true
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "refreshCounts": {
+          "name": "refreshCounts",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isInbox": {
+          "name": "isInbox",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSent": {
+          "name": "isSent",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isDrafts": {
+          "name": "isDrafts",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isTrash": {
+          "name": "isTrash",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSpam": {
+          "name": "isSpam",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSystemFolder": {
+          "name": "isSystemFolder",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "subscribe": {
+          "name": "subscribe",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "unsubscribe": {
+          "name": "unsubscribe",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "EmailFolder",
+      "collectionExportName": "EmailFolderCollection",
+      "schema": {
+        "tableName": "email_folders",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"email_folders\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"account_id\" TEXT DEFAULT '',\n  \"name\" TEXT DEFAULT '',\n  \"path\" TEXT DEFAULT '',\n  \"delimiter\" TEXT DEFAULT '/',\n  \"special_use\" TEXT DEFAULT '',\n  \"message_count\" INTEGER DEFAULT 0,\n  \"unread_count\" INTEGER DEFAULT 0,\n  \"subscribed\" BOOLEAN DEFAULT TRUE\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "account_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "path": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "delimiter": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "/"
+          },
+          "special_use": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "message_count": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "unread_count": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "subscribed": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": true
+          }
+        },
+        "indexes": [
+          {
+            "name": "email_folders_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "email_folders_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "aad895b3"
+      }
+    },
+    "emailfoldercollection": {
+      "name": "emailfoldercollection",
+      "className": "EmailFolderCollection",
+      "collection": "emailfolders",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/messages/src/collections/EmailFolderCollection.ts",
+      "fields": {},
+      "methods": {
+        "getByPath": {
+          "name": "getByPath",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "path",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EmailFolder | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByAccount": {
+          "name": "getByAccount",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EmailFolder[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getInbox": {
+          "name": "getInbox",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EmailFolder | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSent": {
+          "name": "getSent",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EmailFolder | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getDrafts": {
+          "name": "getDrafts",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EmailFolder | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getTrash": {
+          "name": "getTrash",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EmailFolder | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSpam": {
+          "name": "getSpam",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EmailFolder | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSystemFolders": {
+          "name": "getSystemFolders",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EmailFolder[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getUserFolders": {
+          "name": "getUserFolders",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EmailFolder[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSubscribed": {
+          "name": "getSubscribed",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<EmailFolder[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getWithUnread": {
+          "name": "getWithUnread",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<EmailFolder[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "search": {
+          "name": "search",
+          "async": true,
+          "parameters": [
+            {
+              "name": "query",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "filters",
+              "type": "EmailFolderSearchFilters",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<EmailFolder[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "refreshAllCounts": {
+          "name": "refreshAllCounts",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAccountStats": {
+          "name": "getAccountStats",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<{\n    totalFolders: number;\n    totalMessages: number;\n    totalUnread: number;\n    systemFolders: number;\n    userFolders: number;\n  }>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "createSystemFolders": {
+          "name": "createSystemFolders",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "EmailFolder",
+      "exportName": "EmailFolderCollection",
+      "collectionExportName": "EmailFolderCollectionCollection",
+      "schema": {
+        "tableName": "email_folder_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"email_folder_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "email_folder_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "email_folder_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "e38e1675"
+      }
+    },
+    "emailattachment": {
+      "name": "emailattachment",
+      "className": "EmailAttachment",
+      "collection": "emailattachments",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/messages/src/models/EmailAttachment.ts",
+      "fields": {
+        "emailId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "filename": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "contentType": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "size": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "contentId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "contentDisposition": {
+          "type": "text",
+          "required": false,
+          "default": "attachment"
+        },
+        "filePath": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "createdAt": {
+          "type": "datetime",
+          "required": false
+        }
+      },
+      "methods": {
+        "getEmail": {
+          "name": "getEmail",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isImage": {
+          "name": "isImage",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isPdf": {
+          "name": "isPdf",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isInline": {
+          "name": "isInline",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getExtension": {
+          "name": "getExtension",
+          "async": false,
+          "parameters": [],
+          "returnType": "string",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFormattedSize": {
+          "name": "getFormattedSize",
+          "async": false,
+          "parameters": [],
+          "returnType": "string",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasExternalFile": {
+          "name": "hasExternalFile",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "readContent": {
+          "name": "readContent",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Buffer | null>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "EmailAttachment",
+      "collectionExportName": "EmailAttachmentCollection",
+      "schema": {
+        "tableName": "email_attachments",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"email_attachments\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"email_id\" TEXT DEFAULT '',\n  \"filename\" TEXT DEFAULT '',\n  \"content_type\" TEXT DEFAULT '',\n  \"size\" INTEGER DEFAULT 0,\n  \"content_id\" TEXT DEFAULT '',\n  \"content_disposition\" TEXT DEFAULT 'attachment',\n  \"file_path\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "email_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "filename": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "content_type": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "size": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "content_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "content_disposition": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "attachment"
+          },
+          "file_path": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "email_attachments_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "email_attachments_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "f3729eeb"
+      }
+    },
+    "emailattachmentcollection": {
+      "name": "emailattachmentcollection",
+      "className": "EmailAttachmentCollection",
+      "collection": "emailattachments",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/messages/src/collections/EmailAttachmentCollection.ts",
+      "fields": {},
+      "methods": {
+        "getByEmail": {
+          "name": "getByEmail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "emailId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EmailAttachment[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByContentType": {
+          "name": "getByContentType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "contentType",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EmailAttachment[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getImages": {
+          "name": "getImages",
+          "async": true,
+          "parameters": [
+            {
+              "name": "emailId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<EmailAttachment[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getPdfs": {
+          "name": "getPdfs",
+          "async": true,
+          "parameters": [
+            {
+              "name": "emailId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<EmailAttachment[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getInline": {
+          "name": "getInline",
+          "async": true,
+          "parameters": [
+            {
+              "name": "emailId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EmailAttachment[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRegular": {
+          "name": "getRegular",
+          "async": true,
+          "parameters": [
+            {
+              "name": "emailId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EmailAttachment[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getWithExternalFiles": {
+          "name": "getWithExternalFiles",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<EmailAttachment[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getTotalSize": {
+          "name": "getTotalSize",
+          "async": true,
+          "parameters": [
+            {
+              "name": "emailId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getLargest": {
+          "name": "getLargest",
+          "async": true,
+          "parameters": [
+            {
+              "name": "limit",
+              "type": "any",
+              "optional": false,
+              "default": 10
+            }
+          ],
+          "returnType": "Promise<EmailAttachment[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "searchByFilename": {
+          "name": "searchByFilename",
+          "async": true,
+          "parameters": [
+            {
+              "name": "query",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EmailAttachment[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByExtension": {
+          "name": "getByExtension",
+          "async": true,
+          "parameters": [
+            {
+              "name": "extension",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EmailAttachment[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getStats": {
+          "name": "getStats",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<{\n    total: number;\n    totalSize: number;\n    byType: Record<string, number>;\n    inline: number;\n    regular: number;\n  }>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "deleteByEmail": {
+          "name": "deleteByEmail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "emailId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "EmailAttachment",
+      "exportName": "EmailAttachmentCollection",
+      "collectionExportName": "EmailAttachmentCollectionCollection",
+      "schema": {
+        "tableName": "email_attachment_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"email_attachment_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "email_attachment_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "email_attachment_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "3cbd21e3"
+      }
+    },
+    "email": {
+      "name": "email",
+      "className": "Email",
+      "collection": "emails",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/messages/src/models/Email.ts",
+      "fields": {
+        "accountId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "messageId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "threadId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "inReplyTo": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "fromAddress": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "fromName": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "toAddresses": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "ccAddresses": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "bccAddresses": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "replyToAddress": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "replyToName": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "subject": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "date": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "textBody": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "htmlBody": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "folderId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "folderPath": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "labels": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "flags": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "isRead": {
+          "type": "boolean",
+          "required": false,
+          "default": false
+        },
+        "isFlagged": {
+          "type": "boolean",
+          "required": false,
+          "default": false
+        },
+        "isAnswered": {
+          "type": "boolean",
+          "required": false,
+          "default": false
+        },
+        "isDraft": {
+          "type": "boolean",
+          "required": false,
+          "default": false
+        },
+        "hasAttachments": {
+          "type": "boolean",
+          "required": false,
+          "default": false
+        },
+        "size": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "rawMessage": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "headers": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "createdAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "updatedAt": {
+          "type": "datetime",
+          "required": false
+        }
+      },
+      "methods": {
+        "getToAddresses": {
+          "name": "getToAddresses",
+          "async": false,
+          "parameters": [],
+          "returnType": "Array<{ address: string; name?: string }>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setToAddresses": {
+          "name": "setToAddresses",
+          "async": false,
+          "parameters": [
+            {
+              "name": "addresses",
+              "type": "Array<{ address: string; name?: string }>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getCcAddresses": {
+          "name": "getCcAddresses",
+          "async": false,
+          "parameters": [],
+          "returnType": "Array<{ address: string; name?: string }>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getBccAddresses": {
+          "name": "getBccAddresses",
+          "async": false,
+          "parameters": [],
+          "returnType": "Array<{ address: string; name?: string }>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getLabels": {
+          "name": "getLabels",
+          "async": false,
+          "parameters": [],
+          "returnType": "string[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setLabels": {
+          "name": "setLabels",
+          "async": false,
+          "parameters": [
+            {
+              "name": "labels",
+              "type": "string[]",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFlags": {
+          "name": "getFlags",
+          "async": false,
+          "parameters": [],
+          "returnType": "string[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setFlags": {
+          "name": "setFlags",
+          "async": false,
+          "parameters": [
+            {
+              "name": "flags",
+              "type": "string[]",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getHeaders": {
+          "name": "getHeaders",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, string | string[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setHeaders": {
+          "name": "setHeaders",
+          "async": false,
+          "parameters": [
+            {
+              "name": "headers",
+              "type": "Record<string, string | string[]>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markRead": {
+          "name": "markRead",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markUnread": {
+          "name": "markUnread",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toggleFlagged": {
+          "name": "toggleFlagged",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAccount": {
+          "name": "getAccount",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFolder": {
+          "name": "getFolder",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAttachments": {
+          "name": "getAttachments",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getThreadEmails": {
+          "name": "getThreadEmails",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Email[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isUnread": {
+          "name": "isUnread",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getPreview": {
+          "name": "getPreview",
+          "async": false,
+          "parameters": [
+            {
+              "name": "maxLength",
+              "type": "any",
+              "optional": false,
+              "default": 200
+            }
+          ],
+          "returnType": "string",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "Email",
+      "collectionExportName": "EmailCollection",
+      "schema": {
+        "tableName": "emails",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"emails\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"account_id\" TEXT DEFAULT '',\n  \"message_id\" TEXT DEFAULT '',\n  \"thread_id\" TEXT DEFAULT '',\n  \"in_reply_to\" TEXT DEFAULT '',\n  \"from_address\" TEXT DEFAULT '',\n  \"from_name\" TEXT DEFAULT '',\n  \"to_addresses\" TEXT DEFAULT '',\n  \"cc_addresses\" TEXT DEFAULT '',\n  \"bcc_addresses\" TEXT DEFAULT '',\n  \"reply_to_address\" TEXT DEFAULT '',\n  \"reply_to_name\" TEXT DEFAULT '',\n  \"subject\" TEXT DEFAULT '',\n  \"date\" TIMESTAMP DEFAULT current_timestamp,\n  \"text_body\" TEXT DEFAULT '',\n  \"html_body\" TEXT DEFAULT '',\n  \"folder_id\" TEXT DEFAULT '',\n  \"folder_path\" TEXT DEFAULT '',\n  \"labels\" TEXT DEFAULT '',\n  \"flags\" TEXT DEFAULT '',\n  \"is_read\" BOOLEAN DEFAULT FALSE,\n  \"is_flagged\" BOOLEAN DEFAULT FALSE,\n  \"is_answered\" BOOLEAN DEFAULT FALSE,\n  \"is_draft\" BOOLEAN DEFAULT FALSE,\n  \"has_attachments\" BOOLEAN DEFAULT FALSE,\n  \"size\" INTEGER DEFAULT 0,\n  \"raw_message\" TEXT DEFAULT '',\n  \"headers\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "account_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "message_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "thread_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "in_reply_to": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "from_address": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "from_name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "to_addresses": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "cc_addresses": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "bcc_addresses": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "reply_to_address": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "reply_to_name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "subject": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "date": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "text_body": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "html_body": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "folder_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "folder_path": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "labels": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "flags": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "is_read": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": false
+          },
+          "is_flagged": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": false
+          },
+          "is_answered": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": false
+          },
+          "is_draft": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": false
+          },
+          "has_attachments": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": false
+          },
+          "size": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "raw_message": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "headers": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "emails_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "emails_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "901eefc8"
+      }
+    },
+    "emailcollection": {
+      "name": "emailcollection",
+      "className": "EmailCollection",
+      "collection": "emails",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/messages/src/collections/EmailCollection.ts",
+      "fields": {},
+      "methods": {
+        "getByMessageId": {
+          "name": "getByMessageId",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "messageId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Email | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByAccount": {
+          "name": "getByAccount",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Email[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByFolder": {
+          "name": "getByFolder",
+          "async": true,
+          "parameters": [
+            {
+              "name": "folderId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Email[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByThread": {
+          "name": "getByThread",
+          "async": true,
+          "parameters": [
+            {
+              "name": "threadId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Email[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getUnread": {
+          "name": "getUnread",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Email[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFlagged": {
+          "name": "getFlagged",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Email[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getWithAttachments": {
+          "name": "getWithAttachments",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Email[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRecent": {
+          "name": "getRecent",
+          "async": true,
+          "parameters": [
+            {
+              "name": "limit",
+              "type": "any",
+              "optional": false,
+              "default": 20
+            },
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Email[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "countByFolder": {
+          "name": "countByFolder",
+          "async": true,
+          "parameters": [
+            {
+              "name": "folderId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "countUnreadByFolder": {
+          "name": "countUnreadByFolder",
+          "async": true,
+          "parameters": [
+            {
+              "name": "folderId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "countUnreadByAccount": {
+          "name": "countUnreadByAccount",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "search": {
+          "name": "search",
+          "async": true,
+          "parameters": [
+            {
+              "name": "query",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "filters",
+              "type": "EmailSearchFilters",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Email[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markAllRead": {
+          "name": "markAllRead",
+          "async": true,
+          "parameters": [
+            {
+              "name": "emailIds",
+              "type": "string[]",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markFolderRead": {
+          "name": "markFolderRead",
+          "async": true,
+          "parameters": [
+            {
+              "name": "folderId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "deleteByFolder": {
+          "name": "deleteByFolder",
+          "async": true,
+          "parameters": [
+            {
+              "name": "folderId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAccountStats": {
+          "name": "getAccountStats",
+          "async": true,
+          "parameters": [
+            {
+              "name": "accountId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<{\n    total: number;\n    unread: number;\n    flagged: number;\n    withAttachments: number;\n  }>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "Email",
+      "exportName": "EmailCollection",
+      "collectionExportName": "EmailCollectionCollection",
+      "schema": {
+        "tableName": "email_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"email_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "email_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "email_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "2a0a034a"
+      }
+    },
+    "emailaccount": {
+      "name": "emailaccount",
+      "className": "EmailAccount",
+      "collection": "emailaccounts",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/messages/src/models/EmailAccount.ts",
+      "fields": {
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "email": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "providerType": {
+          "type": "text",
+          "required": false,
+          "default": "imap"
+        },
+        "settings": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "lastSyncAt": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "isActive": {
+          "type": "boolean",
+          "required": false,
+          "default": true
+        },
+        "createdAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "updatedAt": {
+          "type": "datetime",
+          "required": false
+        }
+      },
+      "methods": {
+        "getSettings": {
+          "name": "getSettings",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setSettings": {
+          "name": "setSettings",
+          "async": false,
+          "parameters": [
+            {
+              "name": "settings",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "createClient": {
+          "name": "createClient",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "syncFrom": {
+          "name": "syncFrom",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "SyncOptions",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<SyncResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFolders": {
+          "name": "getFolders",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmails": {
+          "name": "getEmails",
+          "async": true,
+          "parameters": [
+            {
+              "name": "limit",
+              "type": "number",
+              "optional": true
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getUnreadCount": {
+          "name": "getUnreadCount",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "activate": {
+          "name": "activate",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "deactivate": {
+          "name": "deactivate",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "EmailAccount",
+      "collectionExportName": "EmailAccountCollection",
+      "schema": {
+        "tableName": "email_accounts",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"email_accounts\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"email\" TEXT DEFAULT '',\n  \"provider_type\" TEXT DEFAULT 'imap',\n  \"settings\" TEXT DEFAULT '',\n  \"last_sync_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"is_active\" BOOLEAN DEFAULT TRUE\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "email": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "provider_type": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "imap"
+          },
+          "settings": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "last_sync_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "is_active": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": true
+          }
+        },
+        "indexes": [
+          {
+            "name": "email_accounts_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "email_accounts_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "3565da7e"
+      }
+    },
+    "emailaccountcollection": {
+      "name": "emailaccountcollection",
+      "className": "EmailAccountCollection",
+      "collection": "emailaccounts",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/messages/src/collections/EmailAccountCollection.ts",
+      "fields": {},
+      "methods": {
+        "getByEmail": {
+          "name": "getByEmail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "email",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EmailAccount | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByProviderType": {
+          "name": "getByProviderType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "providerType",
+              "type": "ProviderType",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EmailAccount[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getActive": {
+          "name": "getActive",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<EmailAccount[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getInactive": {
+          "name": "getInactive",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<EmailAccount[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getNeedingSync": {
+          "name": "getNeedingSync",
+          "async": true,
+          "parameters": [
+            {
+              "name": "maxAgeMinutes",
+              "type": "any",
+              "optional": false,
+              "default": 60
+            }
+          ],
+          "returnType": "Promise<EmailAccount[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "search": {
+          "name": "search",
+          "async": true,
+          "parameters": [
+            {
+              "name": "query",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "filters",
+              "type": "EmailAccountSearchFilters",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<EmailAccount[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "syncAll": {
+          "name": "syncAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "Record<string, any>",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, { success: boolean; error?: Error }>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getTotalUnreadCount": {
+          "name": "getTotalUnreadCount",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getStats": {
+          "name": "getStats",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<{\n    total: number;\n    active: number;\n    inactive: number;\n    byProvider: Record<ProviderType, number>;\n  }>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "EmailAccount",
+      "exportName": "EmailAccountCollection",
+      "collectionExportName": "EmailAccountCollectionCollection",
+      "schema": {
+        "tableName": "email_account_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"email_account_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "email_account_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "email_account_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "bd13b311"
+      }
+    }
+  },
+  "moduleType": "smrt",
+  "packageName": "@happyvertical/smrt-messages"
+}

--- a/packages/places/src/manifest/manifest.json
+++ b/packages/places/src/manifest/manifest.json
@@ -1,0 +1,776 @@
+{
+  "version": "1.0.0",
+  "timestamp": 1767322690568,
+  "objects": {
+    "placetype": {
+      "name": "placetype",
+      "className": "PlaceType",
+      "collection": "placetypes",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/places/src/models/PlaceType.ts",
+      "fields": {
+        "name": {
+          "type": "text",
+          "required": true,
+          "_meta": {},
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false
+        },
+        "createdAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "updatedAt": {
+          "type": "datetime",
+          "required": false
+        }
+      },
+      "methods": {
+        "getBySlug": {
+          "name": "getBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<PlaceType | null>",
+          "isStatic": true,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "PlaceType",
+      "collectionExportName": "PlaceTypeCollection",
+      "schema": {
+        "tableName": "place_types",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"place_types\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "place_types_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "place_types_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "place_types_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "2ef46db6"
+      }
+    },
+    "placetypecollection": {
+      "name": "placetypecollection",
+      "className": "PlaceTypeCollection",
+      "collection": "placetypes",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/places/src/collections/PlaceTypeCollection.ts",
+      "fields": {},
+      "methods": {
+        "getOrCreate": {
+          "name": "getOrCreate",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<PlaceType>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getBySlug": {
+          "name": "getBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<PlaceType | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initializeDefaults": {
+          "name": "initializeDefaults",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<PlaceType[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "PlaceType",
+      "exportName": "PlaceTypeCollection",
+      "collectionExportName": "PlaceTypeCollectionCollection",
+      "schema": {
+        "tableName": "place_type_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"place_type_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "place_type_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "place_type_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "8095a99e"
+      }
+    },
+    "place": {
+      "name": "place",
+      "className": "Place",
+      "collection": "places",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/places/src/models/Place.ts",
+      "fields": {
+        "typeId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "parentId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "latitude": {
+          "type": "decimal",
+          "required": false,
+          "default": null
+        },
+        "longitude": {
+          "type": "decimal",
+          "required": false,
+          "default": null
+        },
+        "streetNumber": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "streetName": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "city": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "region": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "country": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "postalCode": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "countryCode": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "timezone": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "externalId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "source": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "metadata": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "createdAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "updatedAt": {
+          "type": "datetime",
+          "required": false
+        }
+      },
+      "methods": {
+        "getGeoData": {
+          "name": "getGeoData",
+          "async": false,
+          "parameters": [],
+          "returnType": "GeoData",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasCoordinates": {
+          "name": "hasCoordinates",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setMetadata": {
+          "name": "setMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateMetadata": {
+          "name": "updateMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "updates",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getType": {
+          "name": "getType",
+          "async": true,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParent": {
+          "name": "getParent",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Place | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getChildren": {
+          "name": "getChildren",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Place[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAncestors": {
+          "name": "getAncestors",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Place[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getDescendants": {
+          "name": "getDescendants",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Place[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getHierarchy": {
+          "name": "getHierarchy",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<{\n    ancestors: Place[];\n    current: Place;\n    descendants: Place[];\n  }>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "Place",
+      "collectionExportName": "PlaceCollection",
+      "schema": {
+        "tableName": "places",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"places\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"type_id\" TEXT DEFAULT '',\n  \"parent_id\" TEXT DEFAULT '',\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"latitude\" REAL DEFAULT NULL,\n  \"longitude\" REAL DEFAULT NULL,\n  \"street_number\" TEXT DEFAULT '',\n  \"street_name\" TEXT DEFAULT '',\n  \"city\" TEXT DEFAULT '',\n  \"region\" TEXT DEFAULT '',\n  \"country\" TEXT DEFAULT '',\n  \"postal_code\" TEXT DEFAULT '',\n  \"country_code\" TEXT DEFAULT '',\n  \"timezone\" TEXT DEFAULT '',\n  \"external_id\" TEXT DEFAULT '',\n  \"source\" TEXT DEFAULT '',\n  \"metadata\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "type_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "parent_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "latitude": {
+            "type": "REAL",
+            "notNull": false,
+            "default": null
+          },
+          "longitude": {
+            "type": "REAL",
+            "notNull": false,
+            "default": null
+          },
+          "street_number": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "street_name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "city": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "region": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "country": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "postal_code": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "country_code": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "timezone": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "external_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "source": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "metadata": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "places_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "places_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "places_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "a00e5ff0"
+      }
+    },
+    "placecollection": {
+      "name": "placecollection",
+      "className": "PlaceCollection",
+      "collection": "places",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/places/src/collections/PlaceCollection.ts",
+      "fields": {},
+      "methods": {
+        "lookupOrCreate": {
+          "name": "lookupOrCreate",
+          "async": true,
+          "parameters": [
+            {
+              "name": "query",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "LookupOrCreateOptions",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<Place | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getChildren": {
+          "name": "getChildren",
+          "async": true,
+          "parameters": [
+            {
+              "name": "parentId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Place[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRootPlaces": {
+          "name": "getRootPlaces",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Place[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByType": {
+          "name": "getByType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "typeSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Place[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getHierarchy": {
+          "name": "getHierarchy",
+          "async": true,
+          "parameters": [
+            {
+              "name": "placeId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "searchByProximity": {
+          "name": "searchByProximity",
+          "async": true,
+          "parameters": [
+            {
+              "name": "latitude",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "longitude",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "radiusKm",
+              "type": "number",
+              "optional": false,
+              "default": 10
+            }
+          ],
+          "returnType": "Promise<Place[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "Place",
+      "exportName": "PlaceCollection",
+      "collectionExportName": "PlaceCollectionCollection",
+      "schema": {
+        "tableName": "place_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"place_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "place_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "place_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "9bc5d1e0"
+      }
+    }
+  },
+  "moduleType": "smrt",
+  "packageName": "@happyvertical/smrt-places"
+}

--- a/packages/profiles/src/manifest/manifest.json
+++ b/packages/profiles/src/manifest/manifest.json
@@ -1,0 +1,5938 @@
+{
+  "version": "1.0.0",
+  "timestamp": 1767322695426,
+  "objects": {
+    "profilerelationshipterm": {
+      "name": "profilerelationshipterm",
+      "className": "ProfileRelationshipTerm",
+      "collection": "profilerelationshipterms",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/models/ProfileRelationshipTerm.ts",
+      "fields": {
+        "relationshipId": {
+          "type": "foreignKey",
+          "required": true,
+          "_meta": {},
+          "related": "ProfileRelationship"
+        },
+        "startedAt": {
+          "type": "datetime",
+          "required": true,
+          "_meta": {}
+        },
+        "endedAt": {
+          "type": "datetime",
+          "required": false
+        }
+      },
+      "methods": {
+        "isActive": {
+          "name": "isActive",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "end": {
+          "name": "end",
+          "async": true,
+          "parameters": [
+            {
+              "name": "endedAt",
+              "type": "Date",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getDurationDays": {
+          "name": "getDurationDays",
+          "async": false,
+          "parameters": [],
+          "returnType": "number",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "ProfileRelationshipTerm",
+      "collectionExportName": "ProfileRelationshipTermCollection",
+      "schema": {
+        "tableName": "profile_relationship_terms",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_terms\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"relationship_id\" TEXT,\n  \"started_at\" TIMESTAMP,\n  \"ended_at\" TIMESTAMP\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "relationship_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "started_at": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          },
+          "ended_at": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "profile_relationship_terms_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "profile_relationship_terms_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "profile_relationship_terms_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "05566169"
+      }
+    },
+    "profilerelationshiptermcollection": {
+      "name": "profilerelationshiptermcollection",
+      "className": "ProfileRelationshipTermCollection",
+      "collection": "profilerelationshipterms",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/collections/ProfileRelationshipTermCollection.ts",
+      "fields": {},
+      "methods": {
+        "getByRelationship": {
+          "name": "getByRelationship",
+          "async": true,
+          "parameters": [
+            {
+              "name": "relationshipId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ProfileRelationshipTerm[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getActiveTerm": {
+          "name": "getActiveTerm",
+          "async": true,
+          "parameters": [
+            {
+              "name": "relationshipId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ProfileRelationshipTerm | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getHistoricalTerms": {
+          "name": "getHistoricalTerms",
+          "async": true,
+          "parameters": [
+            {
+              "name": "relationshipId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ProfileRelationshipTerm[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "ProfileRelationshipTerm",
+      "exportName": "ProfileRelationshipTermCollection",
+      "collectionExportName": "ProfileRelationshipTermCollectionCollection",
+      "schema": {
+        "tableName": "profile_relationship_term_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_term_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "profile_relationship_term_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "profile_relationship_term_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "a7d89674"
+      }
+    },
+    "profilerelationship": {
+      "name": "profilerelationship",
+      "className": "ProfileRelationship",
+      "collection": "profilerelationships",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/models/ProfileRelationship.ts",
+      "fields": {
+        "fromProfileId": {
+          "type": "foreignKey",
+          "required": true,
+          "_meta": {},
+          "related": "Profile"
+        },
+        "toProfileId": {
+          "type": "foreignKey",
+          "required": true,
+          "_meta": {},
+          "related": "Profile"
+        },
+        "typeId": {
+          "type": "foreignKey",
+          "required": true,
+          "_meta": {},
+          "related": "ProfileRelationshipType"
+        },
+        "contextProfileId": {
+          "type": "foreignKey",
+          "required": false,
+          "_meta": {},
+          "related": "Profile"
+        },
+        "terms": {
+          "type": "oneToMany",
+          "required": false,
+          "_meta": {
+            "transient": true
+          },
+          "transient": true,
+          "related": "ProfileRelationshipTerm",
+          "default": []
+        }
+      },
+      "methods": {
+        "getTypeSlug": {
+          "name": "getTypeSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addTerm": {
+          "name": "addTerm",
+          "async": true,
+          "parameters": [
+            {
+              "name": "startedAt",
+              "type": "Date",
+              "optional": false
+            },
+            {
+              "name": "endedAt",
+              "type": "Date",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "endCurrentTerm": {
+          "name": "endCurrentTerm",
+          "async": true,
+          "parameters": [
+            {
+              "name": "endedAt",
+              "type": "Date",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getTerms": {
+          "name": "getTerms",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<ProfileRelationshipTerm[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getActiveTerm": {
+          "name": "getActiveTerm",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<ProfileRelationshipTerm | null>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "ProfileRelationship",
+      "collectionExportName": "ProfileRelationshipCollection",
+      "schema": {
+        "tableName": "profile_relationships",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationships\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"from_profile_id\" TEXT,\n  \"to_profile_id\" TEXT,\n  \"type_id\" TEXT,\n  \"context_profile_id\" TEXT\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "from_profile_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "to_profile_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "type_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "context_profile_id": {
+            "type": "TEXT",
+            "notNull": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "profile_relationships_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "profile_relationships_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "profile_relationships_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "604e027a"
+      }
+    },
+    "profiletype": {
+      "name": "profiletype",
+      "className": "ProfileType",
+      "collection": "profiletypes",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/models/ProfileType.ts",
+      "fields": {
+        "name": {
+          "type": "text",
+          "required": true,
+          "_meta": {},
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false
+        }
+      },
+      "methods": {
+        "getBySlug": {
+          "name": "getBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ProfileType | null>",
+          "isStatic": true,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "ProfileType",
+      "collectionExportName": "ProfileTypeCollection",
+      "schema": {
+        "tableName": "profile_types",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_types\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "profile_types_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "profile_types_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "profile_types_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "11632546"
+      }
+    },
+    "profilemetafield": {
+      "name": "profilemetafield",
+      "className": "ProfileMetafield",
+      "collection": "profilemetafields",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/models/ProfileMetafield.ts",
+      "fields": {
+        "name": {
+          "type": "text",
+          "required": true,
+          "_meta": {},
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false
+        },
+        "validation": {
+          "type": "json",
+          "required": false
+        }
+      },
+      "methods": {
+        "getBySlug": {
+          "name": "getBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ProfileMetafield | null>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "registerValidator": {
+          "name": "registerValidator",
+          "async": false,
+          "parameters": [
+            {
+              "name": "name",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "validator",
+              "type": "ValidatorFunction",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "getValidator": {
+          "name": "getValidator",
+          "async": false,
+          "parameters": [
+            {
+              "name": "name",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "ValidatorFunction | undefined",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "validateValue": {
+          "name": "validateValue",
+          "async": true,
+          "parameters": [
+            {
+              "name": "value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "ProfileMetafield",
+      "collectionExportName": "ProfileMetafieldCollection",
+      "schema": {
+        "tableName": "profile_metafields",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metafields\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT,\n  \"validation\" JSON\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "validation": {
+            "type": "JSON",
+            "notNull": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "profile_metafields_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "profile_metafields_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "profile_metafields_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "e943656d"
+      }
+    },
+    "profilemetafieldcollection": {
+      "name": "profilemetafieldcollection",
+      "className": "ProfileMetafieldCollection",
+      "collection": "profilemetafields",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/collections/ProfileMetafieldCollection.ts",
+      "fields": {},
+      "methods": {
+        "getBySlug": {
+          "name": "getBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ProfileMetafield | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getOrCreateBySlug": {
+          "name": "getOrCreateBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "defaults",
+              "type": "{\n      name: string;\n      description?: string;\n      validation?: ValidationSchema;\n    }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ProfileMetafield>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "ProfileMetafield",
+      "exportName": "ProfileMetafieldCollection",
+      "collectionExportName": "ProfileMetafieldCollectionCollection",
+      "schema": {
+        "tableName": "profile_metafield_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metafield_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "profile_metafield_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "profile_metafield_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "f4531635"
+      }
+    },
+    "profilemetadata": {
+      "name": "profilemetadata",
+      "className": "ProfileMetadata",
+      "collection": "profilemetadatas",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/models/ProfileMetadata.ts",
+      "fields": {
+        "profileId": {
+          "type": "foreignKey",
+          "required": true,
+          "_meta": {},
+          "related": "Profile"
+        },
+        "metafieldId": {
+          "type": "foreignKey",
+          "required": true,
+          "_meta": {},
+          "related": "ProfileMetafield"
+        },
+        "value": {
+          "type": "text",
+          "required": true,
+          "_meta": {},
+          "default": ""
+        }
+      },
+      "methods": {
+        "validate": {
+          "name": "validate",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getMetafieldSlug": {
+          "name": "getMetafieldSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "ProfileMetadata",
+      "collectionExportName": "ProfileMetadataCollection",
+      "schema": {
+        "tableName": "profile_metadatas",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metadatas\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" TEXT,\n  \"metafield_id\" TEXT,\n  \"value\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "profile_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "metafield_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "value": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "profile_metadatas_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "profile_metadatas_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "profile_metadatas_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "95a51719"
+      }
+    },
+    "profilemetadatacollection": {
+      "name": "profilemetadatacollection",
+      "className": "ProfileMetadataCollection",
+      "collection": "profilemetadatas",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/collections/ProfileMetadataCollection.ts",
+      "fields": {},
+      "methods": {
+        "getByProfile": {
+          "name": "getByProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ProfileMetadata[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getMetadataObject": {
+          "name": "getMetadataObject",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Record<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findProfilesByMetadata": {
+          "name": "findProfilesByMetadata",
+          "async": true,
+          "parameters": [
+            {
+              "name": "metafieldId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<string[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "ProfileMetadata",
+      "exportName": "ProfileMetadataCollection",
+      "collectionExportName": "ProfileMetadataCollectionCollection",
+      "schema": {
+        "tableName": "profile_metadata_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metadata_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "profile_metadata_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "profile_metadata_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "49482483"
+      }
+    },
+    "profilerelationshiptype": {
+      "name": "profilerelationshiptype",
+      "className": "ProfileRelationshipType",
+      "collection": "profilerelationshiptypes",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/models/ProfileRelationshipType.ts",
+      "fields": {
+        "name": {
+          "type": "text",
+          "required": true,
+          "_meta": {},
+          "default": ""
+        },
+        "reciprocal": {
+          "type": "boolean",
+          "required": false,
+          "default": true
+        }
+      },
+      "methods": {
+        "getBySlug": {
+          "name": "getBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ProfileRelationshipType | null>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "registerReciprocalHandler": {
+          "name": "registerReciprocalHandler",
+          "async": false,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "handler",
+              "type": "ReciprocalHandler",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "getReciprocalHandler": {
+          "name": "getReciprocalHandler",
+          "async": false,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "ReciprocalHandler | undefined",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "isReciprocal": {
+          "name": "isReciprocal",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<boolean>",
+          "isStatic": true,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "ProfileRelationshipType",
+      "collectionExportName": "ProfileRelationshipTypeCollection",
+      "schema": {
+        "tableName": "profile_relationship_types",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_types\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"reciprocal\" BOOLEAN DEFAULT TRUE\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "reciprocal": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": true
+          }
+        },
+        "indexes": [
+          {
+            "name": "profile_relationship_types_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "profile_relationship_types_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "profile_relationship_types_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "cb94b103"
+      }
+    },
+    "profilerelationshiptypecollection": {
+      "name": "profilerelationshiptypecollection",
+      "className": "ProfileRelationshipTypeCollection",
+      "collection": "profilerelationshiptypes",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/collections/ProfileRelationshipTypeCollection.ts",
+      "fields": {},
+      "methods": {
+        "getBySlug": {
+          "name": "getBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ProfileRelationshipType | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getOrCreateBySlug": {
+          "name": "getOrCreateBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "defaults",
+              "type": "{ name: string; reciprocal?: boolean }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ProfileRelationshipType>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getReciprocal": {
+          "name": "getReciprocal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<ProfileRelationshipType[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getDirectional": {
+          "name": "getDirectional",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<ProfileRelationshipType[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "ProfileRelationshipType",
+      "exportName": "ProfileRelationshipTypeCollection",
+      "collectionExportName": "ProfileRelationshipTypeCollectionCollection",
+      "schema": {
+        "tableName": "profile_relationship_type_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_type_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "profile_relationship_type_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "profile_relationship_type_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "9d97e26c"
+      }
+    },
+    "profilerelationshipcollection": {
+      "name": "profilerelationshipcollection",
+      "className": "ProfileRelationshipCollection",
+      "collection": "profilerelationships",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/collections/ProfileRelationshipCollection.ts",
+      "fields": {},
+      "methods": {
+        "getFromProfile": {
+          "name": "getFromProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fromProfileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "typeId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<ProfileRelationship[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getToProfile": {
+          "name": "getToProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toProfileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "typeId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<ProfileRelationship[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getForProfile": {
+          "name": "getForProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "typeId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<ProfileRelationship[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "exists": {
+          "name": "exists",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fromProfileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "toProfileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "typeId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "ProfileRelationship",
+      "exportName": "ProfileRelationshipCollection",
+      "collectionExportName": "ProfileRelationshipCollectionCollection",
+      "schema": {
+        "tableName": "profile_relationship_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "profile_relationship_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "profile_relationship_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "48d3dd05"
+      }
+    },
+    "profilecollection": {
+      "name": "profilecollection",
+      "className": "ProfileCollection",
+      "collection": "profiles",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/collections/ProfileCollection.ts",
+      "fields": {},
+      "methods": {
+        "findByEmail": {
+          "name": "findByEmail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "email",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Profile | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByType": {
+          "name": "findByType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "typeSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Profile[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "batchGetMetadata": {
+          "name": "batchGetMetadata",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileIds",
+              "type": "string[]",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Map<string, Record<string, any>>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "batchUpdateMetadata": {
+          "name": "batchUpdateMetadata",
+          "async": true,
+          "parameters": [
+            {
+              "name": "updates",
+              "type": "Array<{ profileId: string; data: Record<string, any> }>",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findRelated": {
+          "name": "findRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationshipSlug",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Profile[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelationshipNetwork": {
+          "name": "getRelationshipNetwork",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "{ maxDepth?: number }",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<Map<string, number>>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "Profile",
+      "exportName": "ProfileCollection",
+      "collectionExportName": "ProfileCollectionCollection",
+      "schema": {
+        "tableName": "profile_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "profile_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "profile_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "d98eb39e"
+      }
+    },
+    "apikey": {
+      "name": "apikey",
+      "className": "ApiKey",
+      "collection": "apikeies",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/models/ApiKey.ts",
+      "fields": {
+        "profileId": {
+          "type": "foreignKey",
+          "required": true,
+          "_meta": {},
+          "related": "Profile"
+        },
+        "keyHash": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "keyPrefix": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "scopes": {
+          "type": "json",
+          "required": false,
+          "default": []
+        },
+        "lastUsedAt": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "expiresAt": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "revokedAt": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        }
+      },
+      "methods": {
+        "getProfile": {
+          "name": "getProfile",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Profile | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isValid": {
+          "name": "isValid",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasScope": {
+          "name": "hasScope",
+          "async": false,
+          "parameters": [
+            {
+              "name": "scope",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "revoke": {
+          "name": "revoke",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recordUsage": {
+          "name": "recordUsage",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hashKey": {
+          "name": "hashKey",
+          "async": false,
+          "parameters": [
+            {
+              "name": "key",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "string",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "generate": {
+          "name": "generate",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profile",
+              "type": "Profile",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "{\n      name: string;\n      scopes?: string[];\n      expiresAt?: Date | null;\n      db?: SmrtObjectOptions['db'];\n    }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<GenerateKeyResult>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "verify": {
+          "name": "verify",
+          "async": true,
+          "parameters": [
+            {
+              "name": "key",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "SmrtObjectOptions",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<ApiKey | null>",
+          "isStatic": true,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableName": "api_keys",
+        "api": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "revoke"
+          ]
+        }
+      },
+      "extends": "SmrtObject",
+      "exportName": "ApiKey",
+      "collectionExportName": "ApiKeyCollection",
+      "schema": {
+        "tableName": "api_keys",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"api_keys\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" TEXT NOT NULL,\n  \"key_hash\" TEXT DEFAULT '',\n  \"key_prefix\" TEXT DEFAULT '',\n  \"name\" TEXT DEFAULT '',\n  \"scopes\" JSON DEFAULT '',\n  \"last_used_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"expires_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"revoked_at\" TIMESTAMP DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "profile_id": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "key_hash": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "key_prefix": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "scopes": {
+            "type": "JSON",
+            "notNull": false,
+            "default": []
+          },
+          "last_used_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "expires_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "revoked_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          }
+        },
+        "indexes": [
+          {
+            "name": "api_keys_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "api_keys_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "967b45df"
+      }
+    },
+    "apikeycollection": {
+      "name": "apikeycollection",
+      "className": "ApiKeyCollection",
+      "collection": "apikeies",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/collections/ApiKeyCollection.ts",
+      "fields": {},
+      "methods": {
+        "findByProfile": {
+          "name": "findByProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ApiKey[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findActiveByProfile": {
+          "name": "findActiveByProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ApiKey[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByHash": {
+          "name": "findByHash",
+          "async": true,
+          "parameters": [
+            {
+              "name": "keyHash",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ApiKey | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "verify": {
+          "name": "verify",
+          "async": true,
+          "parameters": [
+            {
+              "name": "key",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ApiKey | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateForProfile": {
+          "name": "generateForProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profile",
+              "type": "Profile",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "{\n      name: string;\n      scopes?: string[];\n      expiresAt?: Date | null;\n    }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<GenerateKeyResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "revokeAllForProfile": {
+          "name": "revokeAllForProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "revokeByPrefix": {
+          "name": "revokeByPrefix",
+          "async": true,
+          "parameters": [
+            {
+              "name": "keyPrefix",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "cleanupExpired": {
+          "name": "cleanupExpired",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableName": "api_keys"
+      },
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "ApiKey",
+      "exportName": "ApiKeyCollection",
+      "collectionExportName": "ApiKeyCollectionCollection",
+      "schema": {
+        "tableName": "api_keys",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"api_keys\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "api_keys_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "api_keys_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "a3641207"
+      }
+    },
+    "oidcidentity": {
+      "name": "oidcidentity",
+      "className": "OidcIdentity",
+      "collection": "oidcidentities",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/models/OidcIdentity.ts",
+      "fields": {
+        "profileId": {
+          "type": "foreignKey",
+          "required": true,
+          "_meta": {},
+          "related": "Profile"
+        },
+        "provider": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "issuer": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "subject": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "email": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "lastUsedAt": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        }
+      },
+      "methods": {
+        "getProfile": {
+          "name": "getProfile",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Profile | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findBySubject": {
+          "name": "findBySubject",
+          "async": true,
+          "parameters": [
+            {
+              "name": "issuer",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "subject",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "SmrtObjectOptions",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<OidcIdentity | null>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "findOrCreate": {
+          "name": "findOrCreate",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profile",
+              "type": "Profile",
+              "optional": false
+            },
+            {
+              "name": "oidcData",
+              "type": "{\n      provider: string;\n      issuer: string;\n      subject: string;\n      email?: string;\n    }",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "SmrtObjectOptions",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<OidcIdentity>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "recordUsage": {
+          "name": "recordUsage",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableName": "oidc_identities",
+        "api": {
+          "exclude": [
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": {
+          "include": [
+            "list",
+            "get"
+          ]
+        }
+      },
+      "extends": "SmrtObject",
+      "exportName": "OidcIdentity",
+      "collectionExportName": "OidcIdentityCollection",
+      "schema": {
+        "tableName": "oidc_identities",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"oidc_identities\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" TEXT NOT NULL,\n  \"provider\" TEXT DEFAULT '',\n  \"issuer\" TEXT DEFAULT '',\n  \"subject\" TEXT DEFAULT '',\n  \"email\" TEXT DEFAULT '',\n  \"last_used_at\" TIMESTAMP DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "profile_id": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "provider": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "issuer": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "subject": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "email": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "last_used_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          }
+        },
+        "indexes": [
+          {
+            "name": "oidc_identities_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "oidc_identities_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "f359b855"
+      }
+    },
+    "oidcidentitycollection": {
+      "name": "oidcidentitycollection",
+      "className": "OidcIdentityCollection",
+      "collection": "oidcidentities",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/collections/OidcIdentityCollection.ts",
+      "fields": {},
+      "methods": {
+        "findByProfile": {
+          "name": "findByProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<OidcIdentity[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findBySubject": {
+          "name": "findBySubject",
+          "async": true,
+          "parameters": [
+            {
+              "name": "issuer",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "subject",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<OidcIdentity | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByProvider": {
+          "name": "findByProvider",
+          "async": true,
+          "parameters": [
+            {
+              "name": "provider",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<OidcIdentity[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "linkToProfile": {
+          "name": "linkToProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profile",
+              "type": "Profile",
+              "optional": false
+            },
+            {
+              "name": "oidcData",
+              "type": "{\n      provider: string;\n      issuer: string;\n      subject: string;\n      email?: string;\n    }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<OidcIdentity>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "unlinkFromProfile": {
+          "name": "unlinkFromProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "issuer",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "subject",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableName": "oidc_identities"
+      },
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "OidcIdentity",
+      "exportName": "OidcIdentityCollection",
+      "collectionExportName": "OidcIdentityCollectionCollection",
+      "schema": {
+        "tableName": "oidc_identities",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"oidc_identities\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "oidc_identities_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "oidc_identities_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "90c5598d"
+      }
+    },
+    "nostridentitycollection": {
+      "name": "nostridentitycollection",
+      "className": "NostrIdentityCollection",
+      "collection": "nostridentities",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/collections/NostrIdentityCollection.ts",
+      "fields": {},
+      "methods": {
+        "findByProfile": {
+          "name": "findByProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<NostrIdentity[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByPubkey": {
+          "name": "findByPubkey",
+          "async": true,
+          "parameters": [
+            {
+              "name": "pubkey",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<NostrIdentity | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByEmail": {
+          "name": "findByEmail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "email",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<NostrIdentity | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByNip05": {
+          "name": "findByNip05",
+          "async": true,
+          "parameters": [
+            {
+              "name": "username",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<NostrIdentity | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "createForProfile": {
+          "name": "createForProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profile",
+              "type": "Profile",
+              "optional": false
+            },
+            {
+              "name": "email",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "masterSecret",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "nip05Username",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<NostrIdentity>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "linkToProfile": {
+          "name": "linkToProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profile",
+              "type": "Profile",
+              "optional": false
+            },
+            {
+              "name": "nostrData",
+              "type": "{\n      pubkey: string;\n      encryptedPrivkey: string;\n      encryptionIv: string;\n      encryptionTag: string;\n      email: string;\n      nip05Username?: string;\n    }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<NostrIdentity>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "unlinkFromProfile": {
+          "name": "unlinkFromProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "pubkey",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getNip05Response": {
+          "name": "getNip05Response",
+          "async": true,
+          "parameters": [
+            {
+              "name": "username",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Nip05Response>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isNip05Available": {
+          "name": "isNip05Available",
+          "async": true,
+          "parameters": [
+            {
+              "name": "username",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateNip05Username": {
+          "name": "updateNip05Username",
+          "async": true,
+          "parameters": [
+            {
+              "name": "identity",
+              "type": "NostrIdentity",
+              "optional": false
+            },
+            {
+              "name": "newUsername",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<NostrIdentity>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableName": "nostr_identities"
+      },
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "NostrIdentity",
+      "exportName": "NostrIdentityCollection",
+      "collectionExportName": "NostrIdentityCollectionCollection",
+      "schema": {
+        "tableName": "nostr_identities",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"nostr_identities\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "nostr_identities_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "nostr_identities_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "219e883c"
+      }
+    },
+    "auditlog": {
+      "name": "auditlog",
+      "className": "AuditLog",
+      "collection": "auditlogs",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/models/AuditLog.ts",
+      "fields": {
+        "profileId": {
+          "type": "foreignKey",
+          "required": true,
+          "_meta": {},
+          "related": "Profile"
+        },
+        "action": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "resourceType": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "resourceId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "source": {
+          "type": "text",
+          "required": false,
+          "default": "web"
+        },
+        "metadata": {
+          "type": "json",
+          "required": false,
+          "default": {}
+        },
+        "onBehalfOfId": {
+          "type": "foreignKey",
+          "required": false,
+          "_meta": {
+            "nullable": true
+          },
+          "related": "Profile"
+        }
+      },
+      "methods": {
+        "getProfile": {
+          "name": "getProfile",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Profile | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getOnBehalfOf": {
+          "name": "getOnBehalfOf",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Profile | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEffectiveActor": {
+          "name": "getEffectiveActor",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Profile | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "record": {
+          "name": "record",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AuditLogOptions & {\n      profile: Profile;\n      onBehalfOf?: Profile | null;\n    }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AuditLog>",
+          "isStatic": true,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableName": "audit_logs",
+        "api": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": {
+          "include": [
+            "list"
+          ]
+        }
+      },
+      "extends": "SmrtObject",
+      "exportName": "AuditLog",
+      "collectionExportName": "AuditLogCollection",
+      "schema": {
+        "tableName": "audit_logs",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"audit_logs\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" TEXT NOT NULL,\n  \"action\" TEXT DEFAULT '',\n  \"resource_type\" TEXT DEFAULT '',\n  \"resource_id\" TEXT DEFAULT '',\n  \"source\" TEXT DEFAULT 'web',\n  \"metadata\" JSON DEFAULT '[object Object]',\n  \"on_behalf_of_id\" TEXT\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "profile_id": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "action": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "resource_type": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "resource_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "source": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "web"
+          },
+          "metadata": {
+            "type": "JSON",
+            "notNull": false,
+            "default": {}
+          },
+          "on_behalf_of_id": {
+            "type": "TEXT",
+            "notNull": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "audit_logs_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "audit_logs_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "b4f4f914"
+      }
+    },
+    "auditlogcollection": {
+      "name": "auditlogcollection",
+      "className": "AuditLogCollection",
+      "collection": "auditlogs",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/collections/AuditLogCollection.ts",
+      "fields": {},
+      "methods": {
+        "findByProfile": {
+          "name": "findByProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AuditLog[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByResource": {
+          "name": "findByResource",
+          "async": true,
+          "parameters": [
+            {
+              "name": "resourceType",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "resourceId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AuditLog[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByAction": {
+          "name": "findByAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "action",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AuditLog[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findBySource": {
+          "name": "findBySource",
+          "async": true,
+          "parameters": [
+            {
+              "name": "source",
+              "type": "AuditSource",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AuditLog[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findOnBehalfOf": {
+          "name": "findOnBehalfOf",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AuditLog[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "record": {
+          "name": "record",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{\n    profile: Profile;\n    action: string;\n    resourceType: string;\n    resourceId: string;\n    source?: AuditSource;\n    metadata?: Record<string, any>;\n    onBehalfOf?: Profile | null;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AuditLog>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRecentActivity": {
+          "name": "getRecentActivity",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "limit",
+              "type": "number",
+              "optional": false,
+              "default": 50
+            }
+          ],
+          "returnType": "Promise<AuditLog[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getResourceTimeline": {
+          "name": "getResourceTimeline",
+          "async": true,
+          "parameters": [
+            {
+              "name": "resourceType",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "resourceId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AuditLog[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableName": "audit_logs"
+      },
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "AuditLog",
+      "exportName": "AuditLogCollection",
+      "collectionExportName": "AuditLogCollectionCollection",
+      "schema": {
+        "tableName": "audit_logs",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"audit_logs\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "audit_logs_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "audit_logs_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "c985303d"
+      }
+    },
+    "profile": {
+      "name": "profile",
+      "className": "Profile",
+      "collection": "profiles",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/models/Profile.ts",
+      "fields": {
+        "typeId": {
+          "type": "foreignKey",
+          "required": true,
+          "_meta": {},
+          "related": "ProfileType"
+        },
+        "email": {
+          "type": "text",
+          "required": false,
+          "_meta": {
+            "unique": true
+          }
+        },
+        "name": {
+          "type": "text",
+          "required": true,
+          "_meta": {},
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false
+        },
+        "metadata": {
+          "type": "oneToMany",
+          "required": false,
+          "_meta": {
+            "transient": true
+          },
+          "transient": true,
+          "related": "ProfileMetadata",
+          "default": []
+        },
+        "relationshipsFrom": {
+          "type": "oneToMany",
+          "required": false,
+          "_meta": {
+            "transient": true
+          },
+          "transient": true,
+          "related": "ProfileRelationship",
+          "default": []
+        },
+        "relationshipsTo": {
+          "type": "oneToMany",
+          "required": false,
+          "_meta": {
+            "transient": true
+          },
+          "transient": true,
+          "related": "ProfileRelationship",
+          "default": []
+        }
+      },
+      "methods": {
+        "getTypeSlug": {
+          "name": "getTypeSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setTypeBySlug": {
+          "name": "setTypeBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addMetadata": {
+          "name": "addMetadata",
+          "async": true,
+          "parameters": [
+            {
+              "name": "metafieldSlug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Record<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateMetadata": {
+          "name": "updateMetadata",
+          "async": true,
+          "parameters": [
+            {
+              "name": "metadata",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeMetadata": {
+          "name": "removeMetadata",
+          "async": true,
+          "parameters": [
+            {
+              "name": "metafieldSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addRelationship": {
+          "name": "addRelationship",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toProfile",
+              "type": "Profile",
+              "optional": false
+            },
+            {
+              "name": "relationshipSlug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "contextProfile",
+              "type": "Profile",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelationships": {
+          "name": "getRelationships",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{\n    typeSlug?: string;\n    direction?: 'from' | 'to' | 'all';\n  }",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<ProfileRelationship[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelatedProfiles": {
+          "name": "getRelatedProfiles",
+          "async": true,
+          "parameters": [
+            {
+              "name": "relationshipSlug",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Profile[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeRelationship": {
+          "name": "removeRelationship",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toProfile",
+              "type": "Profile",
+              "optional": false
+            },
+            {
+              "name": "relationshipSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateBio": {
+          "name": "generateBio",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "matches": {
+          "name": "matches",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByMetadata": {
+          "name": "findByMetadata",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_metafieldSlug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "_value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Profile[]>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "findByType": {
+          "name": "findByType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_typeSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Profile[]>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "findRelated": {
+          "name": "findRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_profileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "_relationshipSlug",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Profile[]>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "searchByEmail": {
+          "name": "searchByEmail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_email",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Profile | null>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "getApiKeys": {
+          "name": "getApiKeys",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getActiveApiKeys": {
+          "name": "getActiveApiKeys",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateApiKey": {
+          "name": "generateApiKey",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{\n    name: string;\n    scopes?: string[];\n    expiresAt?: Date | null;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<{ key: string; apiKey: any }>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getOidcIdentities": {
+          "name": "getOidcIdentities",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "linkOidcIdentity": {
+          "name": "linkOidcIdentity",
+          "async": true,
+          "parameters": [
+            {
+              "name": "oidcData",
+              "type": "{\n    provider: string;\n    issuer: string;\n    subject: string;\n    email?: string;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getNostrIdentities": {
+          "name": "getNostrIdentities",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "linkNostrIdentity": {
+          "name": "linkNostrIdentity",
+          "async": true,
+          "parameters": [
+            {
+              "name": "nostrData",
+              "type": "{\n    pubkey: string;\n    encryptedPrivkey: string;\n    encryptionIv: string;\n    encryptionTag: string;\n    email: string;\n    nip05Username?: string;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAuditLogs": {
+          "name": "getAuditLogs",
+          "async": true,
+          "parameters": [
+            {
+              "name": "limit",
+              "type": "number",
+              "optional": false,
+              "default": 50
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recordAction": {
+          "name": "recordAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{\n    action: string;\n    resourceType: string;\n    resourceId: string;\n    source?: 'web' | 'cli' | 'ci' | 'webhook' | 'mcp';\n    metadata?: Record<string, any>;\n    onBehalfOf?: Profile | null;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "Profile",
+      "collectionExportName": "ProfileCollection",
+      "schema": {
+        "tableName": "profiles",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"type_id\" TEXT,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "type_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "email": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "profiles_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "profiles_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "profiles_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "1b30b29b"
+      }
+    },
+    "nostridentity": {
+      "name": "nostridentity",
+      "className": "NostrIdentity",
+      "collection": "nostridentities",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/models/NostrIdentity.ts",
+      "fields": {
+        "profileId": {
+          "type": "foreignKey",
+          "required": true,
+          "_meta": {},
+          "related": "Profile"
+        },
+        "pubkey": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "encryptedPrivkey": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "encryptionIv": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "encryptionTag": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "email": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "nip05Username": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "lastUsedAt": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "verifiedAt": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        }
+      },
+      "methods": {
+        "getProfile": {
+          "name": "getProfile",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Profile | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByPubkey": {
+          "name": "findByPubkey",
+          "async": true,
+          "parameters": [
+            {
+              "name": "pubkey",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "SmrtObjectOptions",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<NostrIdentity | null>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "findByEmail": {
+          "name": "findByEmail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "email",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "SmrtObjectOptions",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<NostrIdentity | null>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "findByNip05": {
+          "name": "findByNip05",
+          "async": true,
+          "parameters": [
+            {
+              "name": "username",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "SmrtObjectOptions",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<NostrIdentity | null>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "decryptPrivkey": {
+          "name": "decryptPrivkey",
+          "async": false,
+          "parameters": [
+            {
+              "name": "masterSecret",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "string",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getKeypair": {
+          "name": "getKeypair",
+          "async": false,
+          "parameters": [
+            {
+              "name": "masterSecret",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "{\n    pubkey: string;\n    privkey: string;\n    npub: string;\n    nsec: string;\n  }",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recordUsage": {
+          "name": "recordUsage",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markVerified": {
+          "name": "markVerified",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isVerified": {
+          "name": "isVerified",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getNip05Identifier": {
+          "name": "getNip05Identifier",
+          "async": false,
+          "parameters": [
+            {
+              "name": "domain",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "string",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableName": "nostr_identities",
+        "api": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": {
+          "include": [
+            "list",
+            "get"
+          ]
+        }
+      },
+      "extends": "SmrtObject",
+      "exportName": "NostrIdentity",
+      "collectionExportName": "NostrIdentityCollection",
+      "schema": {
+        "tableName": "nostr_identities",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"nostr_identities\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" TEXT NOT NULL,\n  \"pubkey\" TEXT DEFAULT '',\n  \"encrypted_privkey\" TEXT DEFAULT '',\n  \"encryption_iv\" TEXT DEFAULT '',\n  \"encryption_tag\" TEXT DEFAULT '',\n  \"email\" TEXT DEFAULT '',\n  \"nip05_username\" TEXT DEFAULT '',\n  \"last_used_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"verified_at\" TIMESTAMP DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "profile_id": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "pubkey": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "encrypted_privkey": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "encryption_iv": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "encryption_tag": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "email": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "nip05_username": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "last_used_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "verified_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          }
+        },
+        "indexes": [
+          {
+            "name": "nostr_identities_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "nostr_identities_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "af0aeb0f"
+      }
+    },
+    "magiclinktoken": {
+      "name": "magiclinktoken",
+      "className": "MagicLinkToken",
+      "collection": "magiclinktokens",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/models/MagicLinkToken.ts",
+      "fields": {
+        "nostrIdentityId": {
+          "type": "foreignKey",
+          "required": true,
+          "_meta": {},
+          "related": "NostrIdentity"
+        },
+        "tokenHash": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "email": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "expiresAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "usedAt": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "requestedFromIp": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "createdAt": {
+          "type": "datetime",
+          "required": false
+        }
+      },
+      "methods": {
+        "hashToken": {
+          "name": "hashToken",
+          "async": false,
+          "parameters": [
+            {
+              "name": "token",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "string",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "generate": {
+          "name": "generate",
+          "async": true,
+          "parameters": [
+            {
+              "name": "nostrIdentity",
+              "type": "NostrIdentity",
+              "optional": false
+            },
+            {
+              "name": "email",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "{\n      expiresInMinutes?: number;\n      requestedFromIp?: string;\n      db?: SmrtObjectOptions['db'];\n    }",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<GenerateTokenResult>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "verify": {
+          "name": "verify",
+          "async": true,
+          "parameters": [
+            {
+              "name": "token",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "SmrtObjectOptions",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<MagicLinkToken | null>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "isValid": {
+          "name": "isValid",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isExpired": {
+          "name": "isExpired",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isUsed": {
+          "name": "isUsed",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markUsed": {
+          "name": "markUsed",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getNostrIdentity": {
+          "name": "getNostrIdentity",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<NostrIdentity | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getTimeRemainingSeconds": {
+          "name": "getTimeRemainingSeconds",
+          "async": false,
+          "parameters": [],
+          "returnType": "number",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableName": "magic_link_tokens",
+        "api": {
+          "exclude": [
+            "*"
+          ]
+        },
+        "mcp": {
+          "exclude": [
+            "*"
+          ]
+        },
+        "cli": {
+          "include": [
+            "list"
+          ]
+        }
+      },
+      "extends": "SmrtObject",
+      "exportName": "MagicLinkToken",
+      "collectionExportName": "MagicLinkTokenCollection",
+      "schema": {
+        "tableName": "magic_link_tokens",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"magic_link_tokens\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"nostr_identity_id\" TEXT NOT NULL,\n  \"token_hash\" TEXT DEFAULT '',\n  \"email\" TEXT DEFAULT '',\n  \"expires_at\" TIMESTAMP,\n  \"used_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"requested_from_ip\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "nostr_identity_id": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "token_hash": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "email": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "expires_at": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          },
+          "used_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "requested_from_ip": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "magic_link_tokens_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "magic_link_tokens_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "46460a8d"
+      }
+    },
+    "magiclinktokencollection": {
+      "name": "magiclinktokencollection",
+      "className": "MagicLinkTokenCollection",
+      "collection": "magiclinktokens",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/collections/MagicLinkTokenCollection.ts",
+      "fields": {},
+      "methods": {
+        "findByTokenHash": {
+          "name": "findByTokenHash",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tokenHash",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<MagicLinkToken | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findActiveForEmail": {
+          "name": "findActiveForEmail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "email",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<MagicLinkToken[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByIdentity": {
+          "name": "findByIdentity",
+          "async": true,
+          "parameters": [
+            {
+              "name": "nostrIdentityId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<MagicLinkToken[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "countRecentByEmail": {
+          "name": "countRecentByEmail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "email",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "withinMinutes",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "countRecentByIp": {
+          "name": "countRecentByIp",
+          "async": true,
+          "parameters": [
+            {
+              "name": "ip",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "withinMinutes",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "verify": {
+          "name": "verify",
+          "async": true,
+          "parameters": [
+            {
+              "name": "token",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<MagicLinkToken | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "cleanupExpired": {
+          "name": "cleanupExpired",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "revokeForIdentity": {
+          "name": "revokeForIdentity",
+          "async": true,
+          "parameters": [
+            {
+              "name": "nostrIdentityId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRateLimitedByEmail": {
+          "name": "isRateLimitedByEmail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "email",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "maxPerHour",
+              "type": "number",
+              "optional": false,
+              "default": 5
+            }
+          ],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRateLimitedByIp": {
+          "name": "isRateLimitedByIp",
+          "async": true,
+          "parameters": [
+            {
+              "name": "ip",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "maxPerHour",
+              "type": "number",
+              "optional": false,
+              "default": 10
+            }
+          ],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableName": "magic_link_tokens"
+      },
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "MagicLinkToken",
+      "exportName": "MagicLinkTokenCollection",
+      "collectionExportName": "MagicLinkTokenCollectionCollection",
+      "schema": {
+        "tableName": "magic_link_tokens",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"magic_link_tokens\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "magic_link_tokens_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "magic_link_tokens_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "2370bbb5"
+      }
+    },
+    "person": {
+      "name": "person",
+      "className": "Person",
+      "collection": "profiles",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/models/ProfileTypes.ts",
+      "fields": {
+        "typeId": {
+          "type": "foreignKey",
+          "required": true,
+          "_meta": {},
+          "related": "ProfileType"
+        },
+        "email": {
+          "type": "text",
+          "required": false,
+          "_meta": {
+            "unique": true
+          }
+        },
+        "name": {
+          "type": "text",
+          "required": true,
+          "_meta": {},
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false
+        },
+        "metadata": {
+          "type": "oneToMany",
+          "required": false,
+          "_meta": {
+            "transient": true
+          },
+          "transient": true,
+          "related": "ProfileMetadata",
+          "default": []
+        },
+        "relationshipsFrom": {
+          "type": "oneToMany",
+          "required": false,
+          "_meta": {
+            "transient": true
+          },
+          "transient": true,
+          "related": "ProfileRelationship",
+          "default": []
+        },
+        "relationshipsTo": {
+          "type": "oneToMany",
+          "required": false,
+          "_meta": {
+            "transient": true
+          },
+          "transient": true,
+          "related": "ProfileRelationship",
+          "default": []
+        }
+      },
+      "methods": {
+        "getTypeSlug": {
+          "name": "getTypeSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setTypeBySlug": {
+          "name": "setTypeBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addMetadata": {
+          "name": "addMetadata",
+          "async": true,
+          "parameters": [
+            {
+              "name": "metafieldSlug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Record<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateMetadata": {
+          "name": "updateMetadata",
+          "async": true,
+          "parameters": [
+            {
+              "name": "metadata",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeMetadata": {
+          "name": "removeMetadata",
+          "async": true,
+          "parameters": [
+            {
+              "name": "metafieldSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addRelationship": {
+          "name": "addRelationship",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toProfile",
+              "type": "Profile",
+              "optional": false
+            },
+            {
+              "name": "relationshipSlug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "contextProfile",
+              "type": "Profile",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelationships": {
+          "name": "getRelationships",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{\n    typeSlug?: string;\n    direction?: 'from' | 'to' | 'all';\n  }",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<ProfileRelationship[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelatedProfiles": {
+          "name": "getRelatedProfiles",
+          "async": true,
+          "parameters": [
+            {
+              "name": "relationshipSlug",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Profile[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeRelationship": {
+          "name": "removeRelationship",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toProfile",
+              "type": "Profile",
+              "optional": false
+            },
+            {
+              "name": "relationshipSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateBio": {
+          "name": "generateBio",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "matches": {
+          "name": "matches",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByMetadata": {
+          "name": "findByMetadata",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_metafieldSlug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "_value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Profile[]>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "findByType": {
+          "name": "findByType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_typeSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Profile[]>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "findRelated": {
+          "name": "findRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_profileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "_relationshipSlug",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Profile[]>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "searchByEmail": {
+          "name": "searchByEmail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_email",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Profile | null>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "getApiKeys": {
+          "name": "getApiKeys",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getActiveApiKeys": {
+          "name": "getActiveApiKeys",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateApiKey": {
+          "name": "generateApiKey",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{\n    name: string;\n    scopes?: string[];\n    expiresAt?: Date | null;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<{ key: string; apiKey: any }>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getOidcIdentities": {
+          "name": "getOidcIdentities",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "linkOidcIdentity": {
+          "name": "linkOidcIdentity",
+          "async": true,
+          "parameters": [
+            {
+              "name": "oidcData",
+              "type": "{\n    provider: string;\n    issuer: string;\n    subject: string;\n    email?: string;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getNostrIdentities": {
+          "name": "getNostrIdentities",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "linkNostrIdentity": {
+          "name": "linkNostrIdentity",
+          "async": true,
+          "parameters": [
+            {
+              "name": "nostrData",
+              "type": "{\n    pubkey: string;\n    encryptedPrivkey: string;\n    encryptionIv: string;\n    encryptionTag: string;\n    email: string;\n    nip05Username?: string;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAuditLogs": {
+          "name": "getAuditLogs",
+          "async": true,
+          "parameters": [
+            {
+              "name": "limit",
+              "type": "number",
+              "optional": false,
+              "default": 50
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recordAction": {
+          "name": "recordAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{\n    action: string;\n    resourceType: string;\n    resourceId: string;\n    source?: 'web' | 'cli' | 'ci' | 'webhook' | 'mcp';\n    metadata?: Record<string, any>;\n    onBehalfOf?: Profile | null;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "tableName": "profiles"
+      },
+      "extends": "Profile",
+      "exportName": "Person",
+      "collectionExportName": "PersonCollection",
+      "schema": {
+        "tableName": "profiles",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"type_id\" TEXT,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "type_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "email": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "profiles_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "profiles_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "profiles_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "d4c9abe8"
+      }
+    },
+    "organization": {
+      "name": "organization",
+      "className": "Organization",
+      "collection": "profiles",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/models/ProfileTypes.ts",
+      "fields": {
+        "typeId": {
+          "type": "foreignKey",
+          "required": true,
+          "_meta": {},
+          "related": "ProfileType"
+        },
+        "email": {
+          "type": "text",
+          "required": false,
+          "_meta": {
+            "unique": true
+          }
+        },
+        "name": {
+          "type": "text",
+          "required": true,
+          "_meta": {},
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false
+        },
+        "metadata": {
+          "type": "oneToMany",
+          "required": false,
+          "_meta": {
+            "transient": true
+          },
+          "transient": true,
+          "related": "ProfileMetadata",
+          "default": []
+        },
+        "relationshipsFrom": {
+          "type": "oneToMany",
+          "required": false,
+          "_meta": {
+            "transient": true
+          },
+          "transient": true,
+          "related": "ProfileRelationship",
+          "default": []
+        },
+        "relationshipsTo": {
+          "type": "oneToMany",
+          "required": false,
+          "_meta": {
+            "transient": true
+          },
+          "transient": true,
+          "related": "ProfileRelationship",
+          "default": []
+        }
+      },
+      "methods": {
+        "getTypeSlug": {
+          "name": "getTypeSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setTypeBySlug": {
+          "name": "setTypeBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addMetadata": {
+          "name": "addMetadata",
+          "async": true,
+          "parameters": [
+            {
+              "name": "metafieldSlug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Record<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateMetadata": {
+          "name": "updateMetadata",
+          "async": true,
+          "parameters": [
+            {
+              "name": "metadata",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeMetadata": {
+          "name": "removeMetadata",
+          "async": true,
+          "parameters": [
+            {
+              "name": "metafieldSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addRelationship": {
+          "name": "addRelationship",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toProfile",
+              "type": "Profile",
+              "optional": false
+            },
+            {
+              "name": "relationshipSlug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "contextProfile",
+              "type": "Profile",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelationships": {
+          "name": "getRelationships",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{\n    typeSlug?: string;\n    direction?: 'from' | 'to' | 'all';\n  }",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<ProfileRelationship[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelatedProfiles": {
+          "name": "getRelatedProfiles",
+          "async": true,
+          "parameters": [
+            {
+              "name": "relationshipSlug",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Profile[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeRelationship": {
+          "name": "removeRelationship",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toProfile",
+              "type": "Profile",
+              "optional": false
+            },
+            {
+              "name": "relationshipSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateBio": {
+          "name": "generateBio",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "matches": {
+          "name": "matches",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByMetadata": {
+          "name": "findByMetadata",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_metafieldSlug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "_value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Profile[]>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "findByType": {
+          "name": "findByType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_typeSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Profile[]>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "findRelated": {
+          "name": "findRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_profileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "_relationshipSlug",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Profile[]>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "searchByEmail": {
+          "name": "searchByEmail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_email",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Profile | null>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "getApiKeys": {
+          "name": "getApiKeys",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getActiveApiKeys": {
+          "name": "getActiveApiKeys",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateApiKey": {
+          "name": "generateApiKey",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{\n    name: string;\n    scopes?: string[];\n    expiresAt?: Date | null;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<{ key: string; apiKey: any }>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getOidcIdentities": {
+          "name": "getOidcIdentities",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "linkOidcIdentity": {
+          "name": "linkOidcIdentity",
+          "async": true,
+          "parameters": [
+            {
+              "name": "oidcData",
+              "type": "{\n    provider: string;\n    issuer: string;\n    subject: string;\n    email?: string;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getNostrIdentities": {
+          "name": "getNostrIdentities",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "linkNostrIdentity": {
+          "name": "linkNostrIdentity",
+          "async": true,
+          "parameters": [
+            {
+              "name": "nostrData",
+              "type": "{\n    pubkey: string;\n    encryptedPrivkey: string;\n    encryptionIv: string;\n    encryptionTag: string;\n    email: string;\n    nip05Username?: string;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAuditLogs": {
+          "name": "getAuditLogs",
+          "async": true,
+          "parameters": [
+            {
+              "name": "limit",
+              "type": "number",
+              "optional": false,
+              "default": 50
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recordAction": {
+          "name": "recordAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{\n    action: string;\n    resourceType: string;\n    resourceId: string;\n    source?: 'web' | 'cli' | 'ci' | 'webhook' | 'mcp';\n    metadata?: Record<string, any>;\n    onBehalfOf?: Profile | null;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "tableName": "profiles"
+      },
+      "extends": "Profile",
+      "exportName": "Organization",
+      "collectionExportName": "OrganizationCollection",
+      "schema": {
+        "tableName": "profiles",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"type_id\" TEXT,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "type_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "email": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "profiles_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "profiles_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "profiles_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "b4d5e74c"
+      }
+    },
+    "bot": {
+      "name": "bot",
+      "className": "Bot",
+      "collection": "profiles",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/models/ProfileTypes.ts",
+      "fields": {
+        "typeId": {
+          "type": "foreignKey",
+          "required": true,
+          "_meta": {},
+          "related": "ProfileType"
+        },
+        "email": {
+          "type": "text",
+          "required": false,
+          "_meta": {
+            "unique": true
+          }
+        },
+        "name": {
+          "type": "text",
+          "required": true,
+          "_meta": {},
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false
+        },
+        "metadata": {
+          "type": "oneToMany",
+          "required": false,
+          "_meta": {
+            "transient": true
+          },
+          "transient": true,
+          "related": "ProfileMetadata",
+          "default": []
+        },
+        "relationshipsFrom": {
+          "type": "oneToMany",
+          "required": false,
+          "_meta": {
+            "transient": true
+          },
+          "transient": true,
+          "related": "ProfileRelationship",
+          "default": []
+        },
+        "relationshipsTo": {
+          "type": "oneToMany",
+          "required": false,
+          "_meta": {
+            "transient": true
+          },
+          "transient": true,
+          "related": "ProfileRelationship",
+          "default": []
+        }
+      },
+      "methods": {
+        "getTypeSlug": {
+          "name": "getTypeSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setTypeBySlug": {
+          "name": "setTypeBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addMetadata": {
+          "name": "addMetadata",
+          "async": true,
+          "parameters": [
+            {
+              "name": "metafieldSlug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Record<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateMetadata": {
+          "name": "updateMetadata",
+          "async": true,
+          "parameters": [
+            {
+              "name": "metadata",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeMetadata": {
+          "name": "removeMetadata",
+          "async": true,
+          "parameters": [
+            {
+              "name": "metafieldSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addRelationship": {
+          "name": "addRelationship",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toProfile",
+              "type": "Profile",
+              "optional": false
+            },
+            {
+              "name": "relationshipSlug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "contextProfile",
+              "type": "Profile",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelationships": {
+          "name": "getRelationships",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{\n    typeSlug?: string;\n    direction?: 'from' | 'to' | 'all';\n  }",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<ProfileRelationship[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelatedProfiles": {
+          "name": "getRelatedProfiles",
+          "async": true,
+          "parameters": [
+            {
+              "name": "relationshipSlug",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Profile[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeRelationship": {
+          "name": "removeRelationship",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toProfile",
+              "type": "Profile",
+              "optional": false
+            },
+            {
+              "name": "relationshipSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateBio": {
+          "name": "generateBio",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "matches": {
+          "name": "matches",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByMetadata": {
+          "name": "findByMetadata",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_metafieldSlug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "_value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Profile[]>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "findByType": {
+          "name": "findByType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_typeSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Profile[]>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "findRelated": {
+          "name": "findRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_profileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "_relationshipSlug",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Profile[]>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "searchByEmail": {
+          "name": "searchByEmail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_email",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Profile | null>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "getApiKeys": {
+          "name": "getApiKeys",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getActiveApiKeys": {
+          "name": "getActiveApiKeys",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateApiKey": {
+          "name": "generateApiKey",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{\n    name: string;\n    scopes?: string[];\n    expiresAt?: Date | null;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<{ key: string; apiKey: any }>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getOidcIdentities": {
+          "name": "getOidcIdentities",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "linkOidcIdentity": {
+          "name": "linkOidcIdentity",
+          "async": true,
+          "parameters": [
+            {
+              "name": "oidcData",
+              "type": "{\n    provider: string;\n    issuer: string;\n    subject: string;\n    email?: string;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getNostrIdentities": {
+          "name": "getNostrIdentities",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "linkNostrIdentity": {
+          "name": "linkNostrIdentity",
+          "async": true,
+          "parameters": [
+            {
+              "name": "nostrData",
+              "type": "{\n    pubkey: string;\n    encryptedPrivkey: string;\n    encryptionIv: string;\n    encryptionTag: string;\n    email: string;\n    nip05Username?: string;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAuditLogs": {
+          "name": "getAuditLogs",
+          "async": true,
+          "parameters": [
+            {
+              "name": "limit",
+              "type": "number",
+              "optional": false,
+              "default": 50
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recordAction": {
+          "name": "recordAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{\n    action: string;\n    resourceType: string;\n    resourceId: string;\n    source?: 'web' | 'cli' | 'ci' | 'webhook' | 'mcp';\n    metadata?: Record<string, any>;\n    onBehalfOf?: Profile | null;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "tableName": "profiles"
+      },
+      "extends": "Profile",
+      "exportName": "Bot",
+      "collectionExportName": "BotCollection",
+      "schema": {
+        "tableName": "profiles",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"type_id\" TEXT,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "type_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "email": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "profiles_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "profiles_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "profiles_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "12b61481"
+      }
+    },
+    "profiletypecollection": {
+      "name": "profiletypecollection",
+      "className": "ProfileTypeCollection",
+      "collection": "profiletypes",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/profiles/src/collections/ProfileTypeCollection.ts",
+      "fields": {},
+      "methods": {
+        "getBySlug": {
+          "name": "getBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ProfileType | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getOrCreateBySlug": {
+          "name": "getOrCreateBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "defaults",
+              "type": "{ name: string; description?: string }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ProfileType>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "ProfileType",
+      "exportName": "ProfileTypeCollection",
+      "collectionExportName": "ProfileTypeCollectionCollection",
+      "schema": {
+        "tableName": "profile_type_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_type_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "profile_type_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "profile_type_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "40b730f6"
+      }
+    }
+  },
+  "moduleType": "smrt",
+  "packageName": "@happyvertical/smrt-profiles"
+}

--- a/packages/projects/src/manifest/manifest.json
+++ b/packages/projects/src/manifest/manifest.json
@@ -1,0 +1,2923 @@
+{
+  "version": "1.0.0",
+  "timestamp": 1767322693449,
+  "objects": {
+    "comment": {
+      "name": "comment",
+      "className": "Comment",
+      "collection": "comments",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/projects/src/models/Comment.ts",
+      "fields": {
+        "issueId": {
+          "type": "foreignKey",
+          "required": false,
+          "_meta": {},
+          "related": "Issue"
+        },
+        "commentId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "body": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "author": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "createdAt": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "updatedAt": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "url": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        }
+      },
+      "methods": {
+        "isQuestion": {
+          "name": "isQuestion",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isApproval": {
+          "name": "isApproval",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "requestsChanges": {
+          "name": "requestsChanges",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "extractActionItems": {
+          "name": "extractActionItems",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarize": {
+          "name": "summarize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSentiment": {
+          "name": "getSentiment",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<'positive' | 'negative' | 'neutral'>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": {
+          "include": [
+            "list",
+            "get"
+          ]
+        }
+      },
+      "extends": "SmrtObject",
+      "exportName": "Comment",
+      "collectionExportName": "CommentCollection",
+      "schema": {
+        "tableName": "comments",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"comments\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"issue_id\" TEXT,\n  \"comment_id\" TEXT DEFAULT '',\n  \"body\" TEXT DEFAULT '',\n  \"author\" TEXT DEFAULT '',\n  \"url\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "issue_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "comment_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "body": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "author": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "url": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "comments_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "comments_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "94852faf"
+      }
+    },
+    "pullrequest": {
+      "name": "pullrequest",
+      "className": "PullRequest",
+      "collection": "issues",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/projects/src/models/PullRequest.ts",
+      "fields": {
+        "repositoryId": {
+          "type": "foreignKey",
+          "required": true,
+          "_meta": {},
+          "related": "Repository"
+        },
+        "number": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "nodeId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "title": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "body": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "state": {
+          "type": "text",
+          "required": false,
+          "default": "open"
+        },
+        "author": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "labels": {
+          "type": "json",
+          "required": false,
+          "default": []
+        },
+        "assignees": {
+          "type": "json",
+          "required": false,
+          "default": []
+        },
+        "commentsCount": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "lastSyncedAt": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "originalBody": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "synthesisCount": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "headRef": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "baseRef": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "merged": {
+          "type": "boolean",
+          "required": false,
+          "default": false
+        },
+        "mergedAt": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "mergeable": {
+          "type": "boolean",
+          "required": false,
+          "default": true
+        },
+        "draft": {
+          "type": "boolean",
+          "required": false,
+          "default": false
+        },
+        "additions": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "deletions": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "changedFiles": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        }
+      },
+      "methods": {
+        "getRepository": {
+          "name": "getRepository",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Repository>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getClient": {
+          "name": "getClient",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<IRepository>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearCache": {
+          "name": "clearCache",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "sync": {
+          "name": "sync",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "SyncOptions",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<this>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getComments": {
+          "name": "getComments",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Comment[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addComment": {
+          "name": "addComment",
+          "async": true,
+          "parameters": [
+            {
+              "name": "body",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Comment>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "incorporateFeedback": {
+          "name": "incorporateFeedback",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "IncorporateFeedbackOptions",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<IncorporateFeedbackResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "rollback": {
+          "name": "rollback",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<{ success: boolean; message: string }>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "needsReview": {
+          "name": "needsReview",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isBugReport": {
+          "name": "isBugReport",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isFeatureRequest": {
+          "name": "isFeatureRequest",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "suggestLabels": {
+          "name": "suggestLabels",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "close": {
+          "name": "close",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addLabels": {
+          "name": "addLabels",
+          "async": true,
+          "parameters": [
+            {
+              "name": "labels",
+              "type": "string[]",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeLabel": {
+          "name": "removeLabel",
+          "async": true,
+          "parameters": [
+            {
+              "name": "label",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "assign": {
+          "name": "assign",
+          "async": true,
+          "parameters": [
+            {
+              "name": "assignees",
+              "type": "string[]",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getUrl": {
+          "name": "getUrl",
+          "async": false,
+          "parameters": [],
+          "returnType": "string",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarize": {
+          "name": "summarize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "merge": {
+          "name": "merge",
+          "async": true,
+          "parameters": [
+            {
+              "name": "method",
+              "type": "MergeMethod",
+              "optional": false,
+              "default": "squash"
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markReady": {
+          "name": "markReady",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "convertToDraft": {
+          "name": "convertToDraft",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "requestReviewers": {
+          "name": "requestReviewers",
+          "async": true,
+          "parameters": [
+            {
+              "name": "reviewers",
+              "type": "string[]",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findLinkedIssue": {
+          "name": "findLinkedIssue",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Issue | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isReadyToMerge": {
+          "name": "isReadyToMerge",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "suggestReviewers": {
+          "name": "suggestReviewers",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getChangeSize": {
+          "name": "getChangeSize",
+          "async": false,
+          "parameters": [],
+          "returnType": "'xs' | 's' | 'm' | 'l' | 'xl'",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "sync",
+            "summarize",
+            "merge"
+          ]
+        },
+        "cli": {
+          "include": [
+            "list",
+            "get",
+            "sync",
+            "summarize",
+            "merge",
+            "markReady"
+          ]
+        },
+        "tableName": "issues",
+        "tableStrategy": "sti"
+      },
+      "extends": "Issue",
+      "exportName": "PullRequest",
+      "collectionExportName": "PullRequestCollection",
+      "schema": {
+        "tableName": "issues",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"issues\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"repository_id\" TEXT,\n  \"number\" INTEGER DEFAULT 0,\n  \"node_id\" TEXT DEFAULT '',\n  \"title\" TEXT DEFAULT '',\n  \"body\" TEXT DEFAULT '',\n  \"state\" TEXT DEFAULT 'open',\n  \"author\" TEXT DEFAULT '',\n  \"labels\" JSON DEFAULT '',\n  \"assignees\" JSON DEFAULT '',\n  \"comments_count\" INTEGER DEFAULT 0,\n  \"last_synced_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"original_body\" TEXT DEFAULT '',\n  \"synthesis_count\" INTEGER DEFAULT 0,\n  \"head_ref\" TEXT DEFAULT '',\n  \"base_ref\" TEXT DEFAULT '',\n  \"merged\" BOOLEAN DEFAULT FALSE,\n  \"merged_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"mergeable\" BOOLEAN DEFAULT TRUE,\n  \"draft\" BOOLEAN DEFAULT FALSE,\n  \"additions\" INTEGER DEFAULT 0,\n  \"deletions\" INTEGER DEFAULT 0,\n  \"changed_files\" INTEGER DEFAULT 0\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "repository_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "number": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "node_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "title": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "body": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "state": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "open"
+          },
+          "author": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "labels": {
+            "type": "JSON",
+            "notNull": false,
+            "default": []
+          },
+          "assignees": {
+            "type": "JSON",
+            "notNull": false,
+            "default": []
+          },
+          "comments_count": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "last_synced_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "original_body": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "synthesis_count": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "head_ref": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "base_ref": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "merged": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": false
+          },
+          "merged_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "mergeable": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": true
+          },
+          "draft": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": false
+          },
+          "additions": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "deletions": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "changed_files": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          }
+        },
+        "indexes": [
+          {
+            "name": "issues_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "issues_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "issues_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "05e3ff9f"
+      }
+    },
+    "pullrequestcollection": {
+      "name": "pullrequestcollection",
+      "className": "PullRequestCollection",
+      "collection": "issues",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/projects/src/collections/PullRequests.ts",
+      "fields": {},
+      "methods": {
+        "discover": {
+          "name": "discover",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{\n    repository: Repository;\n    filters?: SearchFilters;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<PullRequest[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByRepository": {
+          "name": "findByRepository",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<PullRequest[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findOpen": {
+          "name": "findOpen",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<PullRequest[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findDrafts": {
+          "name": "findDrafts",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<PullRequest[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findReadyToMerge": {
+          "name": "findReadyToMerge",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<PullRequest[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByBranch": {
+          "name": "findByBranch",
+          "async": true,
+          "parameters": [
+            {
+              "name": "branch",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<PullRequest[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByNumber": {
+          "name": "findByNumber",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "number",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<PullRequest | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findAIReadyToMerge": {
+          "name": "findAIReadyToMerge",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<PullRequest[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findBySize": {
+          "name": "findBySize",
+          "async": true,
+          "parameters": [
+            {
+              "name": "size",
+              "type": "'xs' | 's' | 'm' | 'l' | 'xl'",
+              "optional": false
+            },
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<PullRequest[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "batchSync": {
+          "name": "batchSync",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repository",
+              "type": "Repository",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "{ force?: boolean }",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<PullRequest[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableName": "issues"
+      },
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "PullRequest",
+      "exportName": "PullRequestCollection",
+      "collectionExportName": "PullRequestCollectionCollection",
+      "schema": {
+        "tableName": "issues",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"issues\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "issues_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "issues_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "0b44eaa3"
+      }
+    },
+    "repositorycollection": {
+      "name": "repositorycollection",
+      "className": "RepositoryCollection",
+      "collection": "repositories",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/projects/src/collections/Repositories.ts",
+      "fields": {},
+      "methods": {
+        "findByFullName": {
+          "name": "findByFullName",
+          "async": true,
+          "parameters": [
+            {
+              "name": "owner",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Repository | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByOwner": {
+          "name": "findByOwner",
+          "async": true,
+          "parameters": [
+            {
+              "name": "owner",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Repository[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByProvider": {
+          "name": "findByProvider",
+          "async": true,
+          "parameters": [
+            {
+              "name": "providerType",
+              "type": "RepositoryProviderType",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Repository[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getOrCreate": {
+          "name": "getOrCreate",
+          "async": true,
+          "parameters": [
+            {
+              "name": "owner",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "{\n      providerType?: RepositoryProviderType;\n      tokenConfigKey?: string;\n      baseUrl?: string;\n    }",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<Repository>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "syncAll": {
+          "name": "syncAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{ force?: boolean }",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<Repository[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithOpenIssues": {
+          "name": "findWithOpenIssues",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Repository[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "Repository",
+      "exportName": "RepositoryCollection",
+      "collectionExportName": "RepositoryCollectionCollection",
+      "schema": {
+        "tableName": "repository_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"repository_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "repository_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "repository_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "bcd2ed8e"
+      }
+    },
+    "repository": {
+      "name": "repository",
+      "className": "Repository",
+      "collection": "repositories",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/projects/src/models/Repository.ts",
+      "fields": {
+        "owner": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "fullName": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "defaultBranch": {
+          "type": "text",
+          "required": false,
+          "default": "main"
+        },
+        "isPrivate": {
+          "type": "boolean",
+          "required": false,
+          "default": false
+        },
+        "providerType": {
+          "type": "text",
+          "required": false,
+          "default": "github"
+        },
+        "baseUrl": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "tokenConfigKey": {
+          "type": "text",
+          "required": false,
+          "default": "GITHUB_TOKEN"
+        },
+        "lastSyncedAt": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        }
+      },
+      "methods": {
+        "getClient": {
+          "name": "getClient",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<IRepository>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearClient": {
+          "name": "clearClient",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "sync": {
+          "name": "sync",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "SyncOptions",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<this>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getIssues": {
+          "name": "getIssues",
+          "async": true,
+          "parameters": [
+            {
+              "name": "filters",
+              "type": "SearchFilters",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getPullRequests": {
+          "name": "getPullRequests",
+          "async": true,
+          "parameters": [
+            {
+              "name": "filters",
+              "type": "SearchFilters",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<PullRequest[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "createIssue": {
+          "name": "createIssue",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "CreateIssueInput",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Issue>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "createPullRequest": {
+          "name": "createPullRequest",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "CreatePRInput",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<PullRequest>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasOpenIssuesMatching": {
+          "name": "hasOpenIssuesMatching",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeActivity": {
+          "name": "summarizeActivity",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByFullName": {
+          "name": "getByFullName",
+          "async": true,
+          "parameters": [
+            {
+              "name": "owner",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "SmrtObjectOptions",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<Repository | null>",
+          "isStatic": true,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "sync"
+          ]
+        },
+        "cli": {
+          "include": [
+            "list",
+            "get",
+            "sync",
+            "create"
+          ]
+        }
+      },
+      "extends": "SmrtObject",
+      "exportName": "Repository",
+      "collectionExportName": "RepositoryCollection",
+      "schema": {
+        "tableName": "repositorys",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"repositorys\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"owner\" TEXT DEFAULT '',\n  \"name\" TEXT DEFAULT '',\n  \"full_name\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"default_branch\" TEXT DEFAULT 'main',\n  \"is_private\" BOOLEAN DEFAULT FALSE,\n  \"provider_type\" TEXT DEFAULT 'github',\n  \"base_url\" TEXT DEFAULT '',\n  \"token_config_key\" TEXT DEFAULT 'GITHUB_TOKEN',\n  \"last_synced_at\" TIMESTAMP DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "owner": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "full_name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "default_branch": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "main"
+          },
+          "is_private": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": false
+          },
+          "provider_type": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "github"
+          },
+          "base_url": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "token_config_key": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "GITHUB_TOKEN"
+          },
+          "last_synced_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          }
+        },
+        "indexes": [
+          {
+            "name": "repositorys_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "repositorys_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "bc666d05"
+      }
+    },
+    "issue": {
+      "name": "issue",
+      "className": "Issue",
+      "collection": "issues",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/projects/src/models/Issue.ts",
+      "fields": {
+        "repositoryId": {
+          "type": "foreignKey",
+          "required": true,
+          "_meta": {},
+          "related": "Repository"
+        },
+        "number": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "nodeId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "title": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "body": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "state": {
+          "type": "text",
+          "required": false,
+          "default": "open"
+        },
+        "author": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "labels": {
+          "type": "json",
+          "required": false,
+          "default": []
+        },
+        "assignees": {
+          "type": "json",
+          "required": false,
+          "default": []
+        },
+        "commentsCount": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "lastSyncedAt": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        },
+        "originalBody": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "synthesisCount": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        }
+      },
+      "methods": {
+        "getRepository": {
+          "name": "getRepository",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Repository>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getClient": {
+          "name": "getClient",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<IRepository>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearCache": {
+          "name": "clearCache",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "sync": {
+          "name": "sync",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "SyncOptions",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<this>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getComments": {
+          "name": "getComments",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Comment[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addComment": {
+          "name": "addComment",
+          "async": true,
+          "parameters": [
+            {
+              "name": "body",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Comment>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "incorporateFeedback": {
+          "name": "incorporateFeedback",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "IncorporateFeedbackOptions",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<IncorporateFeedbackResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "rollback": {
+          "name": "rollback",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<{ success: boolean; message: string }>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "needsReview": {
+          "name": "needsReview",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isBugReport": {
+          "name": "isBugReport",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isFeatureRequest": {
+          "name": "isFeatureRequest",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "suggestLabels": {
+          "name": "suggestLabels",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "close": {
+          "name": "close",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addLabels": {
+          "name": "addLabels",
+          "async": true,
+          "parameters": [
+            {
+              "name": "labels",
+              "type": "string[]",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeLabel": {
+          "name": "removeLabel",
+          "async": true,
+          "parameters": [
+            {
+              "name": "label",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "assign": {
+          "name": "assign",
+          "async": true,
+          "parameters": [
+            {
+              "name": "assignees",
+              "type": "string[]",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getUrl": {
+          "name": "getUrl",
+          "async": false,
+          "parameters": [],
+          "returnType": "string",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "sync",
+            "incorporateFeedback"
+          ]
+        },
+        "cli": {
+          "include": [
+            "list",
+            "get",
+            "sync",
+            "incorporateFeedback",
+            "rollback"
+          ]
+        }
+      },
+      "extends": "SmrtObject",
+      "exportName": "Issue",
+      "collectionExportName": "IssueCollection",
+      "schema": {
+        "tableName": "issues",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"issues\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"repository_id\" TEXT,\n  \"number\" INTEGER DEFAULT 0,\n  \"node_id\" TEXT DEFAULT '',\n  \"title\" TEXT DEFAULT '',\n  \"body\" TEXT DEFAULT '',\n  \"state\" TEXT DEFAULT 'open',\n  \"author\" TEXT DEFAULT '',\n  \"labels\" JSON DEFAULT '',\n  \"assignees\" JSON DEFAULT '',\n  \"comments_count\" INTEGER DEFAULT 0,\n  \"last_synced_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"original_body\" TEXT DEFAULT '',\n  \"synthesis_count\" INTEGER DEFAULT 0,\n  \"head_ref\" TEXT DEFAULT '',\n  \"base_ref\" TEXT DEFAULT '',\n  \"merged\" BOOLEAN DEFAULT FALSE,\n  \"merged_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"mergeable\" BOOLEAN DEFAULT TRUE,\n  \"draft\" BOOLEAN DEFAULT FALSE,\n  \"additions\" INTEGER DEFAULT 0,\n  \"deletions\" INTEGER DEFAULT 0,\n  \"changed_files\" INTEGER DEFAULT 0\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "repository_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "number": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "node_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "title": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "body": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "state": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "open"
+          },
+          "author": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "labels": {
+            "type": "JSON",
+            "notNull": false,
+            "default": []
+          },
+          "assignees": {
+            "type": "JSON",
+            "notNull": false,
+            "default": []
+          },
+          "comments_count": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "last_synced_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "original_body": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "synthesis_count": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "head_ref": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "base_ref": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "merged": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": false
+          },
+          "merged_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          },
+          "mergeable": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": true
+          },
+          "draft": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": false
+          },
+          "additions": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "deletions": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "changed_files": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          }
+        },
+        "indexes": [
+          {
+            "name": "issues_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "issues_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "issues_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "003dd4e2"
+      }
+    },
+    "issuecollection": {
+      "name": "issuecollection",
+      "className": "IssueCollection",
+      "collection": "issues",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/projects/src/collections/Issues.ts",
+      "fields": {},
+      "methods": {
+        "discover": {
+          "name": "discover",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{\n    repository: Repository;\n    filters?: SearchFilters;\n  }",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByRepository": {
+          "name": "findByRepository",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findOpen": {
+          "name": "findOpen",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByLabel": {
+          "name": "findByLabel",
+          "async": true,
+          "parameters": [
+            {
+              "name": "label",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByAssignee": {
+          "name": "findByAssignee",
+          "async": true,
+          "parameters": [
+            {
+              "name": "assignee",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findNeedingReview": {
+          "name": "findNeedingReview",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByNumber": {
+          "name": "findByNumber",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "number",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Issue | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithUnincorporatedFeedback": {
+          "name": "findWithUnincorporatedFeedback",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "batchSync": {
+          "name": "batchSync",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repository",
+              "type": "Repository",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "{ force?: boolean }",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "Issue",
+      "exportName": "IssueCollection",
+      "collectionExportName": "IssueCollectionCollection",
+      "schema": {
+        "tableName": "issue_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"issue_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "issue_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "issue_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "bbc4903d"
+      }
+    },
+    "project": {
+      "name": "project",
+      "className": "Project",
+      "collection": "projects",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/projects/src/models/Project.ts",
+      "fields": {
+        "projectId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "projectNumber": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "title": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "owner": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "url": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "providerType": {
+          "type": "text",
+          "required": false,
+          "default": "github"
+        },
+        "tokenConfigKey": {
+          "type": "text",
+          "required": false,
+          "default": "GITHUB_TOKEN"
+        },
+        "statuses": {
+          "type": "json",
+          "required": false,
+          "default": []
+        },
+        "fields": {
+          "type": "json",
+          "required": false,
+          "default": []
+        },
+        "statusFieldId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "statusOptions": {
+          "type": "json",
+          "required": false,
+          "default": {}
+        },
+        "lastSyncedAt": {
+          "type": "datetime",
+          "required": false,
+          "default": null
+        }
+      },
+      "methods": {
+        "getClient": {
+          "name": "getClient",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<IProject>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearClient": {
+          "name": "clearClient",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "sync": {
+          "name": "sync",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "SyncOptions",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<this>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addItem": {
+          "name": "addItem",
+          "async": true,
+          "parameters": [
+            {
+              "name": "item",
+              "type": "Issue | PullRequest",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ProjectItem>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeItem": {
+          "name": "removeItem",
+          "async": true,
+          "parameters": [
+            {
+              "name": "itemId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getItem": {
+          "name": "getItem",
+          "async": true,
+          "parameters": [
+            {
+              "name": "itemId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ProjectItem | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listItems": {
+          "name": "listItems",
+          "async": true,
+          "parameters": [
+            {
+              "name": "filters",
+              "type": "ItemFilters",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<ProjectItem[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateItemStatus": {
+          "name": "updateItemStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "itemId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "status",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateItemField": {
+          "name": "updateItemField",
+          "async": true,
+          "parameters": [
+            {
+              "name": "itemId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "fieldId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "value",
+              "type": "unknown",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getStatuses": {
+          "name": "getStatuses",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<ProjectStatus[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<ProjectField[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getItemsByStatus": {
+          "name": "getItemsByStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "status",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ProjectItem[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "moveItem": {
+          "name": "moveItem",
+          "async": true,
+          "parameters": [
+            {
+              "name": "item",
+              "type": "Issue | PullRequest",
+              "optional": false
+            },
+            {
+              "name": "status",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "analyzeHealth": {
+          "name": "analyzeHealth",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByTitle": {
+          "name": "getByTitle",
+          "async": true,
+          "parameters": [
+            {
+              "name": "title",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "SmrtObjectOptions",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<Project | null>",
+          "isStatic": true,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "sync",
+            "addItem",
+            "updateItemStatus"
+          ]
+        },
+        "cli": {
+          "include": [
+            "list",
+            "get",
+            "sync",
+            "addItem",
+            "updateItemStatus",
+            "listItems"
+          ]
+        }
+      },
+      "extends": "SmrtObject",
+      "exportName": "Project",
+      "collectionExportName": "ProjectCollection",
+      "schema": {
+        "tableName": "projects",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"projects\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"project_id\" TEXT DEFAULT '',\n  \"project_number\" INTEGER DEFAULT 0,\n  \"title\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"owner\" TEXT DEFAULT '',\n  \"url\" TEXT DEFAULT '',\n  \"provider_type\" TEXT DEFAULT 'github',\n  \"token_config_key\" TEXT DEFAULT 'GITHUB_TOKEN',\n  \"statuses\" JSON DEFAULT '',\n  \"fields\" JSON DEFAULT '',\n  \"status_field_id\" TEXT DEFAULT '',\n  \"status_options\" JSON DEFAULT '[object Object]',\n  \"last_synced_at\" TIMESTAMP DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "project_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "project_number": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "title": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "owner": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "url": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "provider_type": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "github"
+          },
+          "token_config_key": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "GITHUB_TOKEN"
+          },
+          "statuses": {
+            "type": "JSON",
+            "notNull": false,
+            "default": []
+          },
+          "fields": {
+            "type": "JSON",
+            "notNull": false,
+            "default": []
+          },
+          "status_field_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "status_options": {
+            "type": "JSON",
+            "notNull": false,
+            "default": {}
+          },
+          "last_synced_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "default": null
+          }
+        },
+        "indexes": [
+          {
+            "name": "projects_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "projects_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "54280864"
+      }
+    },
+    "projectcollection": {
+      "name": "projectcollection",
+      "className": "ProjectCollection",
+      "collection": "projects",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/projects/src/collections/Projects.ts",
+      "fields": {},
+      "methods": {
+        "findByTitle": {
+          "name": "findByTitle",
+          "async": true,
+          "parameters": [
+            {
+              "name": "title",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Project | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByOwner": {
+          "name": "findByOwner",
+          "async": true,
+          "parameters": [
+            {
+              "name": "owner",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Project[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByProvider": {
+          "name": "findByProvider",
+          "async": true,
+          "parameters": [
+            {
+              "name": "providerType",
+              "type": "ProjectProviderType",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Project[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getOrCreate": {
+          "name": "getOrCreate",
+          "async": true,
+          "parameters": [
+            {
+              "name": "projectId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "{\n      title?: string;\n      owner?: string;\n      providerType?: ProjectProviderType;\n      tokenConfigKey?: string;\n      statusFieldId?: string;\n      statusOptions?: Record<string, string>;\n    }",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<Project>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "syncAll": {
+          "name": "syncAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "{ force?: boolean }",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<Project[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithItemsInStatus": {
+          "name": "findWithItemsInStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "status",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Project[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getStatistics": {
+          "name": "getStatistics",
+          "async": true,
+          "parameters": [
+            {
+              "name": "projectId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<{\n    totalItems: number;\n    itemsByStatus: Record<string, number>;\n    itemsByType: Record<string, number>;\n  }>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "Project",
+      "exportName": "ProjectCollection",
+      "collectionExportName": "ProjectCollectionCollection",
+      "schema": {
+        "tableName": "project_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"project_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "project_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "project_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "213b18c0"
+      }
+    },
+    "label": {
+      "name": "label",
+      "className": "Label",
+      "collection": "labels",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/projects/src/models/Label.ts",
+      "fields": {
+        "repositoryId": {
+          "type": "foreignKey",
+          "required": false,
+          "_meta": {},
+          "related": "Repository"
+        },
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "color": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        }
+      },
+      "methods": {
+        "isTypeLabel": {
+          "name": "isTypeLabel",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isPriorityLabel": {
+          "name": "isPriorityLabel",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isStatusLabel": {
+          "name": "isStatusLabel",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getCategory": {
+          "name": "getCategory",
+          "async": false,
+          "parameters": [],
+          "returnType": "'type' | 'priority' | 'status' | 'area' | 'other'",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getPriorityLevel": {
+          "name": "getPriorityLevel",
+          "async": false,
+          "parameters": [],
+          "returnType": "number | null",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getHexColor": {
+          "name": "getHexColor",
+          "async": false,
+          "parameters": [],
+          "returnType": "string",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "createInRepository": {
+          "name": "createInRepository",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateInRepository": {
+          "name": "updateInRepository",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create"
+          ]
+        },
+        "cli": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        }
+      },
+      "extends": "SmrtObject",
+      "exportName": "Label",
+      "collectionExportName": "LabelCollection",
+      "schema": {
+        "tableName": "labels",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"labels\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"repository_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"color\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "repository_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "color": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "labels_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "labels_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "5f873a63"
+      }
+    }
+  },
+  "moduleType": "smrt",
+  "packageName": "@happyvertical/smrt-projects"
+}

--- a/packages/properties/src/manifest/manifest.json
+++ b/packages/properties/src/manifest/manifest.json
@@ -1,0 +1,960 @@
+{
+  "version": "1.0.0",
+  "timestamp": 1767322692523,
+  "objects": {
+    "zonecollection": {
+      "name": "zonecollection",
+      "className": "ZoneCollection",
+      "collection": "zones",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/properties/src/collections/Zones.ts",
+      "fields": {},
+      "methods": {
+        "findByProperty": {
+          "name": "findByProperty",
+          "async": true,
+          "parameters": [
+            {
+              "name": "propertyId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Zone[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findTopLevel": {
+          "name": "findTopLevel",
+          "async": true,
+          "parameters": [
+            {
+              "name": "propertyId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Zone[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findChildren": {
+          "name": "findChildren",
+          "async": true,
+          "parameters": [
+            {
+              "name": "parentId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Zone[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByPath": {
+          "name": "findByPath",
+          "async": true,
+          "parameters": [
+            {
+              "name": "propertyId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "path",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Zone[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByType": {
+          "name": "findByType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "propertyId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "type",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Zone[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getTree": {
+          "name": "getTree",
+          "async": true,
+          "parameters": [
+            {
+              "name": "propertyId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ZoneTree<Zone>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAncestors": {
+          "name": "getAncestors",
+          "async": true,
+          "parameters": [
+            {
+              "name": "zoneId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Zone[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getDescendants": {
+          "name": "getDescendants",
+          "async": true,
+          "parameters": [
+            {
+              "name": "zoneId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Zone[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getMaxDepth": {
+          "name": "getMaxDepth",
+          "async": true,
+          "parameters": [
+            {
+              "name": "propertyId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByDimensions": {
+          "name": "findByDimensions",
+          "async": true,
+          "parameters": [
+            {
+              "name": "propertyId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "width",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "height",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Zone[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByAllowedFormat": {
+          "name": "findByAllowedFormat",
+          "async": true,
+          "parameters": [
+            {
+              "name": "propertyId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "format",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Zone[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "moveZone": {
+          "name": "moveZone",
+          "async": true,
+          "parameters": [
+            {
+              "name": "zoneId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "newParentId",
+              "type": "string | null",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Zone | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "deleteZone": {
+          "name": "deleteZone",
+          "async": true,
+          "parameters": [
+            {
+              "name": "zoneId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "cascade",
+              "type": "boolean",
+              "optional": false,
+              "default": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "Zone",
+      "exportName": "ZoneCollection",
+      "collectionExportName": "ZoneCollectionCollection",
+      "schema": {
+        "tableName": "zone_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"zone_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "zone_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "zone_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "5c78b453"
+      }
+    },
+    "zone": {
+      "name": "zone",
+      "className": "Zone",
+      "collection": "zones",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/properties/src/models/Zone.ts",
+      "fields": {
+        "propertyId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "parentId": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "type": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "path": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "selector": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "position": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "width": {
+          "type": "decimal",
+          "required": false,
+          "default": null
+        },
+        "height": {
+          "type": "decimal",
+          "required": false,
+          "default": null
+        },
+        "allowedFormats": {
+          "type": "json",
+          "required": false,
+          "default": []
+        },
+        "defaultContentId": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "metadata": {
+          "type": "json",
+          "required": false,
+          "default": {}
+        }
+      },
+      "methods": {
+        "isTopLevel": {
+          "name": "isTopLevel",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasDimensions": {
+          "name": "hasDimensions",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getDimensionString": {
+          "name": "getDimensionString",
+          "async": false,
+          "parameters": [],
+          "returnType": "string | null",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getProperty": {
+          "name": "getProperty",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<import('./Property').Property | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParent": {
+          "name": "getParent",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Zone | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getChildren": {
+          "name": "getChildren",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Zone[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAncestors": {
+          "name": "getAncestors",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Zone[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getDescendants": {
+          "name": "getDescendants",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Zone[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFullPath": {
+          "name": "getFullPath",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getDepth": {
+          "name": "getDepth",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "createChild": {
+          "name": "createChild",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "Omit<ZoneOptions, 'propertyId' | 'parentId'>",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Zone>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toTreeNode": {
+          "name": "toTreeNode",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<ZoneTreeNode<Zone>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isFormatAllowed": {
+          "name": "isFormatAllowed",
+          "async": false,
+          "parameters": [
+            {
+              "name": "format",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "Zone",
+      "collectionExportName": "ZoneCollection",
+      "schema": {
+        "tableName": "zones",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"zones\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"property_id\" TEXT DEFAULT '',\n  \"parent_id\" TEXT DEFAULT 'null',\n  \"name\" TEXT DEFAULT '',\n  \"type\" TEXT DEFAULT '',\n  \"path\" TEXT DEFAULT '',\n  \"selector\" TEXT DEFAULT '',\n  \"position\" TEXT DEFAULT '',\n  \"width\" REAL DEFAULT NULL,\n  \"height\" REAL DEFAULT NULL,\n  \"allowed_formats\" JSON DEFAULT '',\n  \"default_content_id\" TEXT DEFAULT 'null',\n  \"metadata\" JSON DEFAULT '[object Object]'\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "property_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "parent_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "type": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "path": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "selector": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "position": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "width": {
+            "type": "REAL",
+            "notNull": false,
+            "default": null
+          },
+          "height": {
+            "type": "REAL",
+            "notNull": false,
+            "default": null
+          },
+          "allowed_formats": {
+            "type": "JSON",
+            "notNull": false,
+            "default": []
+          },
+          "default_content_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "metadata": {
+            "type": "JSON",
+            "notNull": false,
+            "default": {}
+          }
+        },
+        "indexes": [
+          {
+            "name": "zones_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "zones_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "c22f2541"
+      }
+    },
+    "property": {
+      "name": "property",
+      "className": "Property",
+      "collection": "properties",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/properties/src/models/Property.ts",
+      "fields": {
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "domain": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "url": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "repositoryId": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "ownerId": {
+          "type": "text",
+          "required": false,
+          "default": null
+        },
+        "status": {
+          "type": "text",
+          "required": false,
+          "default": "active"
+        },
+        "metadata": {
+          "type": "json",
+          "required": false,
+          "default": {}
+        }
+      },
+      "methods": {
+        "getZones": {
+          "name": "getZones",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<import('./Zone').Zone[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getZoneTree": {
+          "name": "getZoneTree",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<\n    import('../types').ZoneTree<import('./Zone').Zone>\n  >",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "createZone": {
+          "name": "createZone",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "Omit<import('../types').ZoneOptions, 'propertyId'>",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<import('./Zone').Zone>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarize": {
+          "name": "summarize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "Property",
+      "collectionExportName": "PropertyCollection",
+      "schema": {
+        "tableName": "propertys",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"propertys\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"domain\" TEXT DEFAULT '',\n  \"url\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"repository_id\" TEXT DEFAULT 'null',\n  \"owner_id\" TEXT DEFAULT 'null',\n  \"status\" TEXT DEFAULT 'active',\n  \"metadata\" JSON DEFAULT '[object Object]'\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "domain": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "url": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "repository_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "owner_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": null
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "active"
+          },
+          "metadata": {
+            "type": "JSON",
+            "notNull": false,
+            "default": {}
+          }
+        },
+        "indexes": [
+          {
+            "name": "propertys_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "propertys_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "e2b370d2"
+      }
+    },
+    "propertycollection": {
+      "name": "propertycollection",
+      "className": "PropertyCollection",
+      "collection": "properties",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/properties/src/collections/Properties.ts",
+      "fields": {},
+      "methods": {
+        "findByDomain": {
+          "name": "findByDomain",
+          "async": true,
+          "parameters": [
+            {
+              "name": "domain",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Property | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByRepository": {
+          "name": "findByRepository",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Property[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByOwner": {
+          "name": "findByOwner",
+          "async": true,
+          "parameters": [
+            {
+              "name": "ownerId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Property[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findActive": {
+          "name": "findActive",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Property[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByStatus": {
+          "name": "findByStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "status",
+              "type": "PropertyStatus",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Property[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getOrCreateByDomain": {
+          "name": "getOrCreateByDomain",
+          "async": true,
+          "parameters": [
+            {
+              "name": "domain",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "defaults",
+              "type": "{\n      name?: string;\n      url?: string;\n      repositoryId?: string | null;\n      ownerId?: string | null;\n    }",
+              "optional": false,
+              "default": {}
+            }
+          ],
+          "returnType": "Promise<Property>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "countByStatus": {
+          "name": "countByStatus",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Record<PropertyStatus, number>>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "Property",
+      "exportName": "PropertyCollection",
+      "collectionExportName": "PropertyCollectionCollection",
+      "schema": {
+        "tableName": "property_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"property_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "property_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "property_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "9970f6bc"
+      }
+    }
+  },
+  "moduleType": "smrt",
+  "packageName": "@happyvertical/smrt-properties"
+}

--- a/packages/tags/src/manifest/manifest.json
+++ b/packages/tags/src/manifest/manifest.json
@@ -1,0 +1,839 @@
+{
+  "version": "1.0.0",
+  "timestamp": 1767322690629,
+  "objects": {
+    "tagalias": {
+      "name": "tagalias",
+      "className": "TagAlias",
+      "collection": "tagaliases",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/tags/src/tag-alias.ts",
+      "fields": {
+        "tagSlug": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "alias": {
+          "type": "text",
+          "required": true,
+          "_meta": {},
+          "default": ""
+        },
+        "language": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "createdAt": {
+          "type": "datetime",
+          "required": false
+        }
+      },
+      "methods": {
+        "getTag": {
+          "name": "getTag",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Tag | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "searchByAlias": {
+          "name": "searchByAlias",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_alias",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "_language",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Tag[]>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "getAliasesForTag": {
+          "name": "getAliasesForTag",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_tagSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<TagAlias[]>",
+          "isStatic": true,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "TagAlias",
+      "collectionExportName": "TagAliasCollection",
+      "schema": {
+        "tableName": "tag_alias",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"tag_alias\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tag_slug\" TEXT DEFAULT '',\n  \"alias\" TEXT DEFAULT '',\n  \"language\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "tag_slug": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "alias": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "language": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "tag_alias_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "tag_alias_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "tag_alias_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "3bbbeee1"
+      }
+    },
+    "tagaliascollection": {
+      "name": "tagaliascollection",
+      "className": "TagAliasCollection",
+      "collection": "tagaliases",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/tags/src/tag-aliases.ts",
+      "fields": {},
+      "methods": {
+        "addAlias": {
+          "name": "addAlias",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tagSlug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "alias",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "language",
+              "type": "string",
+              "optional": true
+            },
+            {
+              "name": "context",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<TagAlias>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "searchByAlias": {
+          "name": "searchByAlias",
+          "async": true,
+          "parameters": [
+            {
+              "name": "alias",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "language",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Tag[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAliasesForTag": {
+          "name": "getAliasesForTag",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tagSlug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "language",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<TagAlias[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeAlias": {
+          "name": "removeAlias",
+          "async": true,
+          "parameters": [
+            {
+              "name": "aliasId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "bulkAddAliases": {
+          "name": "bulkAddAliases",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tagSlug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "aliases",
+              "type": "Array<{\n      alias: string;\n      language?: string;\n      context?: string;\n    }>",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<TagAlias[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAliasesByLanguage": {
+          "name": "getAliasesByLanguage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tagSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Map<string, string[]>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findMatchingAliases": {
+          "name": "findMatchingAliases",
+          "async": true,
+          "parameters": [
+            {
+              "name": "query",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "language",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<TagAlias[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "TagAlias",
+      "exportName": "TagAliasCollection",
+      "collectionExportName": "TagAliasCollectionCollection",
+      "schema": {
+        "tableName": "tag_alias_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"tag_alias_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "tag_alias_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "tag_alias_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "08747314"
+      }
+    },
+    "tagcollection": {
+      "name": "tagcollection",
+      "className": "TagCollection",
+      "collection": "tags",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/tags/src/tags.ts",
+      "fields": {},
+      "methods": {
+        "getOrCreate": {
+          "name": "getOrCreate",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "context",
+              "type": "string",
+              "optional": false,
+              "default": "global"
+            }
+          ],
+          "returnType": "Promise<Tag>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listByContext": {
+          "name": "listByContext",
+          "async": true,
+          "parameters": [
+            {
+              "name": "context",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "parentSlug",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Tag[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRootTags": {
+          "name": "getRootTags",
+          "async": true,
+          "parameters": [
+            {
+              "name": "context",
+              "type": "string",
+              "optional": false,
+              "default": "global"
+            }
+          ],
+          "returnType": "Promise<Tag[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getChildren": {
+          "name": "getChildren",
+          "async": true,
+          "parameters": [
+            {
+              "name": "parentSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Tag[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getHierarchy": {
+          "name": "getHierarchy",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<TagHierarchy>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "moveTag": {
+          "name": "moveTag",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "newParentSlug",
+              "type": "string | null",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "mergeTag": {
+          "name": "mergeTag",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fromSlug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "toSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "cleanupUnused": {
+          "name": "cleanupUnused",
+          "async": true,
+          "parameters": [
+            {
+              "name": "context",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "calculateLevel": {
+          "name": "calculateLevel",
+          "async": true,
+          "parameters": [
+            {
+              "name": "parentSlug",
+              "type": "string | null",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "Tag",
+      "exportName": "TagCollection",
+      "collectionExportName": "TagCollectionCollection",
+      "schema": {
+        "tableName": "tag_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"tag_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "tag_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "tag_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "5e1695ba"
+      }
+    },
+    "tag": {
+      "name": "tag",
+      "className": "Tag",
+      "collection": "tags",
+      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/tags/src/tag.ts",
+      "fields": {
+        "name": {
+          "type": "text",
+          "required": true,
+          "_meta": {},
+          "default": ""
+        },
+        "parentSlug": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "level": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "metadata": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "createdAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "updatedAt": {
+          "type": "datetime",
+          "required": false
+        }
+      },
+      "methods": {
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": false,
+          "parameters": [],
+          "returnType": "TagMetadata",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setMetadata": {
+          "name": "setMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "TagMetadata",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateMetadata": {
+          "name": "updateMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "updates",
+              "type": "Partial<TagMetadata>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParent": {
+          "name": "getParent",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Tag | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getChildren": {
+          "name": "getChildren",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Tag[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAncestors": {
+          "name": "getAncestors",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Tag[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getDescendants": {
+          "name": "getDescendants",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Tag[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getBySlug": {
+          "name": "getBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_slug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "_context",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Tag | null>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "getRootTags": {
+          "name": "getRootTags",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_context",
+              "type": "string",
+              "optional": false,
+              "default": "global"
+            }
+          ],
+          "returnType": "Promise<Tag[]>",
+          "isStatic": true,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "Tag",
+      "collectionExportName": "TagCollection",
+      "schema": {
+        "tableName": "tags",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"tags\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"parent_slug\" TEXT DEFAULT '',\n  \"level\" INTEGER DEFAULT 0,\n  \"description\" TEXT DEFAULT '',\n  \"metadata\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "TEXT",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "parent_slug": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "level": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "metadata": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "tags_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "tags_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "tags_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "08b141ec"
+      }
+    }
+  },
+  "moduleType": "smrt",
+  "packageName": "@happyvertical/smrt-tags"
+}


### PR DESCRIPTION
## Summary

Fixes performance issue where `ensureSchema` ran `discoverSTISiblingsSync` on every request because `SmrtObject` is never registered in ObjectRegistry.

- Add `FRAMEWORK_BASE_CLASSES` set to skip STI discovery for known base classes (`SmrtObject`, `SmrtClass`, `SmrtCollection`)
- Add global cache for STI sibling discovery results in manifest-loader
- Update `clearManifestCache()` to also clear the STI sibling cache

## Test plan

- [x] Existing STI tests pass (`npm test` in packages/core)
- [x] Build succeeds across all packages
- [ ] Verify performance improvement in downstream apps (praeco, bentleyalberta.com)

closes #644