### PR TITLE
fix(migrations): correct DatabaseInterface.query return type

### DIFF
--- a/packages/core/src/migrations/index.ts
+++ b/packages/core/src/migrations/index.ts
@@ -59,6 +59,7 @@ export type {
   MigrationTrackerOptions,
   ParsedMigrationFile,
   ParseMigrationOptions,
+  QueryResult,
   RollbackOptions,
   SchemaChange,
   SchemaDiff,

--- a/packages/core/src/migrations/tracker.ts
+++ b/packages/core/src/migrations/tracker.ts
@@ -25,6 +25,28 @@ import type {
 } from './types.js';
 
 /**
+ * Row type for _smrt_schema_migrations table
+ */
+interface MigrationRow {
+  id: string;
+  name: string;
+  version: string;
+  checksum: string;
+  applied_checksum?: string | null;
+  applied_at: string;
+  execution_time_ms?: number | null;
+  package_name?: string | null;
+  source_file?: string | null;
+  status: string;
+  error_message?: string | null;
+  attempts: number;
+  is_reversible: number | boolean;
+  rolled_back_at?: string | null;
+  applied_by?: string | null;
+  batch: number;
+}
+
+/**
  * Default options for MigrationTracker
  */
 const DEFAULT_OPTIONS = {
@@ -107,16 +129,14 @@ export class MigrationTracker {
   async getAppliedMigrations(): Promise<SchemaMigrationRecord[]> {
     await this.initialize();
 
-    const result = await this.db.query(
+    const result = await this.db.query<MigrationRow>(
       `SELECT * FROM _smrt_schema_migrations WHERE status = 'completed' ORDER BY applied_at ASC`,
     );
 
     return result.rows.map((row) => ({
       ...row,
-      applied_at: new Date(row.applied_at as unknown as string),
-      rolled_back_at: row.rolled_back_at
-        ? new Date(row.rolled_back_at as unknown as string)
-        : null,
+      applied_at: new Date(row.applied_at),
+      rolled_back_at: row.rolled_back_at ? new Date(row.rolled_back_at) : null,
       is_reversible: Boolean(row.is_reversible),
     })) as SchemaMigrationRecord[];
   }
@@ -152,7 +172,7 @@ export class MigrationTracker {
   async getMigration(name: string): Promise<SchemaMigrationRecord | null> {
     await this.initialize();
 
-    const result = await this.db.query(
+    const result = await this.db.query<MigrationRow>(
       `SELECT * FROM _smrt_schema_migrations WHERE name = ? LIMIT 1`,
       [name],
     );
@@ -162,10 +182,8 @@ export class MigrationTracker {
     const row = result.rows[0];
     return {
       ...row,
-      applied_at: new Date(row.applied_at as unknown as string),
-      rolled_back_at: row.rolled_back_at
-        ? new Date(row.rolled_back_at as unknown as string)
-        : null,
+      applied_at: new Date(row.applied_at),
+      rolled_back_at: row.rolled_back_at ? new Date(row.rolled_back_at) : null,
       is_reversible: Boolean(row.is_reversible),
     } as SchemaMigrationRecord;
   }
@@ -176,11 +194,11 @@ export class MigrationTracker {
   async getNextBatch(): Promise<number> {
     await this.initialize();
 
-    const result = await this.db.query(
+    const result = await this.db.query<{ max_batch: number | null }>(
       `SELECT MAX(batch) as max_batch FROM _smrt_schema_migrations`,
     );
 
-    return ((result.rows[0]?.max_batch as number | null) ?? 0) + 1;
+    return (result.rows[0]?.max_batch ?? 0) + 1;
   }
 
   /**
@@ -566,14 +584,12 @@ export class MigrationTracker {
       params.push(options.limit);
     }
 
-    const result = await this.db.query(sql, params);
+    const result = await this.db.query<MigrationRow>(sql, params);
 
     return result.rows.map((row) => ({
       ...row,
-      applied_at: new Date(row.applied_at as unknown as string),
-      rolled_back_at: row.rolled_back_at
-        ? new Date(row.rolled_back_at as unknown as string)
-        : null,
+      applied_at: new Date(row.applied_at),
+      rolled_back_at: row.rolled_back_at ? new Date(row.rolled_back_at) : null,
       is_reversible: Boolean(row.is_reversible),
     })) as SchemaMigrationRecord[];
   }

--- a/packages/core/src/migrations/types.ts
+++ b/packages/core/src/migrations/types.ts
@@ -30,11 +30,22 @@ export interface MigrationTrackerOptions {
 }
 
 /**
+ * Query result type from database
+ */
+export interface QueryResult<T = unknown> {
+  rows: T[];
+  rowCount?: number;
+}
+
+/**
  * Database interface type (imported from @happyvertical/sql)
  */
 export interface DatabaseInterface {
   url?: string;
-  query: (sql: string, params?: unknown[]) => Promise<unknown[]>;
+  query: <T = unknown>(
+    sql: string,
+    params?: unknown[],
+  ) => Promise<QueryResult<T>>;
   execute?: (sql: string, params?: unknown[]) => Promise<void>;
   get?: (table: string, filter: Record<string, unknown>) => Promise<unknown>;
   list?: (


### PR DESCRIPTION
## Summary

Fixes TypeScript errors in the publish workflow caused by incorrect return type for `DatabaseInterface.query`.

**Changes:**
- Add `QueryResult<T>` interface with `{ rows: T[], rowCount?: number }`
- Update `DatabaseInterface.query` to return `Promise<QueryResult<T>>` (matching `@happyvertical/sql`)
- Add `MigrationRow` interface for type-safe query results in tracker
- Export `QueryResult` from migrations module

## Context

The migration system was merged in PR #651, but the publish workflow failed because the TypeScript types for database queries didn't match `@happyvertical/sql`'s actual return type. The code expected `{ rows: T[] }` but the type declared `Promise<unknown[]>`.

## Test plan

- [x] Build passes locally (`npm run build`)
- [ ] CI validation passes
- [ ] Publish workflow succeeds after merge