### PR TITLE
fix(migrations): use @happyvertical/sql DatabaseInterface for compatibility

### DIFF
--- a/packages/core/src/migrations/index.ts
+++ b/packages/core/src/migrations/index.ts
@@ -59,7 +59,6 @@ export type {
   MigrationTrackerOptions,
   ParsedMigrationFile,
   ParseMigrationOptions,
-  QueryResult,
   RollbackOptions,
   SchemaChange,
   SchemaDiff,

--- a/packages/core/src/migrations/tracker.ts
+++ b/packages/core/src/migrations/tracker.ts
@@ -129,11 +129,11 @@ export class MigrationTracker {
   async getAppliedMigrations(): Promise<SchemaMigrationRecord[]> {
     await this.initialize();
 
-    const result = await this.db.query<MigrationRow>(
+    const result = await this.db.query(
       `SELECT * FROM _smrt_schema_migrations WHERE status = 'completed' ORDER BY applied_at ASC`,
     );
 
-    return result.rows.map((row) => ({
+    return (result.rows as MigrationRow[]).map((row) => ({
       ...row,
       applied_at: new Date(row.applied_at),
       rolled_back_at: row.rolled_back_at ? new Date(row.rolled_back_at) : null,
@@ -160,7 +160,7 @@ export class MigrationTracker {
 
     const result = await this.db.query(
       `SELECT 1 FROM _smrt_schema_migrations WHERE name = ? AND status = 'completed' LIMIT 1`,
-      [migrationId],
+      migrationId,
     );
 
     return result.rows.length > 0;
@@ -172,14 +172,14 @@ export class MigrationTracker {
   async getMigration(name: string): Promise<SchemaMigrationRecord | null> {
     await this.initialize();
 
-    const result = await this.db.query<MigrationRow>(
+    const result = await this.db.query(
       `SELECT * FROM _smrt_schema_migrations WHERE name = ? LIMIT 1`,
-      [name],
+      name,
     );
 
     if (result.rows.length === 0) return null;
 
-    const row = result.rows[0];
+    const row = result.rows[0] as MigrationRow;
     return {
       ...row,
       applied_at: new Date(row.applied_at),
@@ -194,11 +194,12 @@ export class MigrationTracker {
   async getNextBatch(): Promise<number> {
     await this.initialize();
 
-    const result = await this.db.query<{ max_batch: number | null }>(
+    const result = await this.db.query(
       `SELECT MAX(batch) as max_batch FROM _smrt_schema_migrations`,
     );
 
-    return (result.rows[0]?.max_batch ?? 0) + 1;
+    const row = result.rows[0] as { max_batch: number | null } | undefined;
+    return (row?.max_batch ?? 0) + 1;
   }
 
   /**
@@ -349,7 +350,11 @@ export class MigrationTracker {
         `UPDATE _smrt_schema_migrations
          SET status = 'running', checksum = ?, attempts = ?, error_message = NULL, batch = ?, applied_by = ?
          WHERE id = ?`,
-        [checksum, attempts, this.currentBatch, hostname(), id],
+        checksum,
+        attempts,
+        this.currentBatch,
+        hostname(),
+        id,
       );
     } else {
       // Insert new record
@@ -357,17 +362,15 @@ export class MigrationTracker {
         `INSERT INTO _smrt_schema_migrations
          (id, name, version, checksum, status, attempts, is_reversible, package_name, source_file, applied_by, batch)
          VALUES (?, ?, ?, ?, 'running', 1, ?, ?, ?, ?, ?)`,
-        [
-          id,
-          definition.id,
-          definition.version,
-          checksum,
-          (definition.is_reversible ?? definition.down.length > 0) ? 1 : 0,
-          definition.package_name ?? null,
-          definition.source_file ?? null,
-          hostname(),
-          this.currentBatch,
-        ],
+        id,
+        definition.id,
+        definition.version,
+        checksum,
+        (definition.is_reversible ?? definition.down.length > 0) ? 1 : 0,
+        definition.package_name ?? null,
+        definition.source_file ?? null,
+        hostname(),
+        this.currentBatch,
       );
     }
 
@@ -378,19 +381,17 @@ export class MigrationTracker {
           `UPDATE _smrt_schema_migrations
            SET status = ?, checksum = ?, attempts = ?, error_message = ?
            WHERE id = ?`,
-          [
-            existing.status,
-            existing.checksum,
-            existing.attempts,
-            existing.error_message,
-            id,
-          ],
+          existing.status,
+          existing.checksum,
+          existing.attempts,
+          existing.error_message,
+          id,
         );
       } else {
         // Remove the newly inserted running record
         await this.db.query(
           `DELETE FROM _smrt_schema_migrations WHERE id = ?`,
-          [id],
+          id,
         );
       }
       return {
@@ -413,7 +414,9 @@ export class MigrationTracker {
         `UPDATE _smrt_schema_migrations
          SET status = 'completed', execution_time_ms = ?, applied_checksum = ?, applied_at = CURRENT_TIMESTAMP
          WHERE id = ?`,
-        [executionTime, checksum, id],
+        executionTime,
+        checksum,
+        id,
       );
 
       return {
@@ -430,7 +433,8 @@ export class MigrationTracker {
         `UPDATE _smrt_schema_migrations
          SET status = 'failed', error_message = ?
          WHERE id = ?`,
-        [error instanceof Error ? error.message : String(error), id],
+        error instanceof Error ? error.message : String(error),
+        id,
       );
 
       return {
@@ -534,7 +538,7 @@ export class MigrationTracker {
         `UPDATE _smrt_schema_migrations
          SET status = 'rolled_back', rolled_back_at = CURRENT_TIMESTAMP
          WHERE name = ?`,
-        [name],
+        name,
       );
 
       return {
@@ -584,9 +588,9 @@ export class MigrationTracker {
       params.push(options.limit);
     }
 
-    const result = await this.db.query<MigrationRow>(sql, params);
+    const result = await this.db.query(sql, ...params);
 
-    return result.rows.map((row) => ({
+    return (result.rows as MigrationRow[]).map((row) => ({
       ...row,
       applied_at: new Date(row.applied_at),
       rolled_back_at: row.rolled_back_at ? new Date(row.rolled_back_at) : null,

--- a/packages/core/src/migrations/types.ts
+++ b/packages/core/src/migrations/types.ts
@@ -4,6 +4,13 @@
  * Re-exports migration types from schema and adds migration-specific types.
  */
 
+// Re-export database types from @happyvertical/sql for compatibility
+export type {
+  ColumnDefinitionWithName as SqlColumnDefinitionWithName,
+  DatabaseInterface,
+  IndexDefinition as SqlIndexDefinition,
+  TableSchemaInfo as SqlTableSchemaInfo,
+} from '@happyvertical/sql';
 // Re-export schema migration types
 export type {
   DriftReport,
@@ -27,53 +34,6 @@ export interface MigrationTrackerOptions {
   statementTimeout?: number;
   /** Use CREATE INDEX CONCURRENTLY for indexes in PostgreSQL (default: true) */
   useConcurrentIndexes?: boolean;
-}
-
-/**
- * Query result type from database
- */
-export interface QueryResult<T = unknown> {
-  rows: T[];
-  rowCount?: number;
-}
-
-/**
- * Database interface type (imported from @happyvertical/sql)
- */
-export interface DatabaseInterface {
-  url?: string;
-  query: <T = unknown>(
-    sql: string,
-    params?: unknown[],
-  ) => Promise<QueryResult<T>>;
-  execute?: (sql: string, params?: unknown[]) => Promise<void>;
-  get?: (table: string, filter: Record<string, unknown>) => Promise<unknown>;
-  list?: (
-    table: string,
-    options?: {
-      where?: Record<string, unknown>;
-      orderBy?: string;
-      limit?: number;
-    },
-  ) => Promise<unknown[]>;
-  insert?: (table: string, data: Record<string, unknown>) => Promise<void>;
-  update?: (
-    table: string,
-    filter: Record<string, unknown>,
-    data: Record<string, unknown>,
-  ) => Promise<void>;
-  delete?: (table: string, filter: Record<string, unknown>) => Promise<void>;
-  transaction?: <T>(
-    callback: (tx: DatabaseInterface) => Promise<T>,
-  ) => Promise<T>;
-  getTableSchema?: (table: string) => Promise<TableSchemaInfo | null>;
-  alterTable?: {
-    addColumn: (
-      table: string,
-      column: ColumnDefinitionWithName,
-    ) => Promise<void>;
-    addIndex: (table: string, index: IndexDefinition) => Promise<void>;
-  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes TypeScript compatibility errors between the migrations module's `DatabaseInterface` and `@happyvertical/sql`'s `DatabaseInterface`.

**Changes:**
- Import `DatabaseInterface` directly from `@happyvertical/sql` instead of defining a custom type
- Update `tracker.ts` to use rest params for `query()` calls (matches SQL interface signature: `query(sql, ...params)` not `query(sql, [params])`)
- Remove unused `QueryResult` type export from migrations module
- Cast query results to `MigrationRow` for type safety

## Context

The previous PR (#652) fixed the query return type issue, but there were additional incompatibilities:
1. The custom `DatabaseInterface` type had different property requirements (e.g., `url` optional vs required)
2. The `query()` method used array params instead of rest params

This caused TypeScript errors in the CLI commands that pass `@happyvertical/sql` database instances to the migration tracker.

## Test plan

- [x] Build passes locally (`npm run build`)
- [ ] CI validation passes
- [ ] Publish workflow succeeds after merge