### PR TITLE
fix(migrations): resolve type compatibility issues with @happyvertical/sql

### DIFF
--- a/packages/core/src/migrations/differ.ts
+++ b/packages/core/src/migrations/differ.ts
@@ -12,7 +12,7 @@ import type {
   SchemaDefinition,
   SchemaDiff,
 } from '../schema/types.js';
-import type { DatabaseInterface, TableSchemaInfo } from './types.js';
+import type { DatabaseInterface, SqlTableSchemaInfo } from './types.js';
 
 /**
  * Options for schema comparison
@@ -125,7 +125,7 @@ export class SchemaComparer {
   private compareColumns(
     tableName: string,
     manifest: SchemaDefinition,
-    dbSchema: TableSchemaInfo,
+    dbSchema: SqlTableSchemaInfo,
   ): SchemaChange[] {
     const changes: SchemaChange[] = [];
     const dbColumnNames = new Set(Object.keys(dbSchema.columns));
@@ -187,7 +187,7 @@ export class SchemaComparer {
   private compareIndexes(
     tableName: string,
     manifest: SchemaDefinition,
-    dbSchema: TableSchemaInfo,
+    dbSchema: SqlTableSchemaInfo,
   ): SchemaChange[] {
     const changes: SchemaChange[] = [];
     const dbIndexNames = new Set(dbSchema.indexes.map((idx) => idx.name));
@@ -223,10 +223,8 @@ export class SchemaComparer {
       query = `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`;
     }
 
-    const result = await this.db.query<{ name?: string; table_name?: string }>(
-      query,
-    );
-    const rows = result.rows || [];
+    const result = await this.db.query(query);
+    const rows = result.rows as { name?: string; table_name?: string }[];
     return new Set(
       rows.map((r) => r.name || r.table_name || '').filter(Boolean),
     );

--- a/packages/core/src/migrations/types.ts
+++ b/packages/core/src/migrations/types.ts
@@ -4,13 +4,21 @@
  * Re-exports migration types from schema and adds migration-specific types.
  */
 
-// Re-export database types from @happyvertical/sql for compatibility
-export type {
-  ColumnDefinitionWithName as SqlColumnDefinitionWithName,
+// Import and re-export database types from @happyvertical/sql for compatibility
+import type {
   DatabaseInterface,
+  ColumnDefinitionWithName as SqlColumnDefinitionWithName,
   IndexDefinition as SqlIndexDefinition,
   TableSchemaInfo as SqlTableSchemaInfo,
 } from '@happyvertical/sql';
+
+export type {
+  SqlColumnDefinitionWithName,
+  DatabaseInterface,
+  SqlIndexDefinition,
+  SqlTableSchemaInfo,
+};
+
 // Re-export schema migration types
 export type {
   DriftReport,


### PR DESCRIPTION
## Summary

Fixes TypeScript type errors that were causing the publish workflow to fail after PRs #652 and #653. These errors were triggered during `npm publish` when the package was rebuilt fresh.

### Issues Fixed

1. **`Cannot find name 'DatabaseInterface'` in types.ts:30**
   - The type was re-exported but not imported for local scope use
   - Fixed by importing the type in addition to re-exporting it

2. **`TableSchemaInfo` type incompatibility in differ.ts:112,116**
   - Local `TableSchemaInfo` had `columns: Record<string, ColumnInfo>` with redundant `name` field
   - SDK's `TableSchemaInfo` has `columns: Record<string, ColumnDefinition>` without `name`
   - Fixed by using `SqlTableSchemaInfo` from the SDK directly

3. **`query<T>()` generic type parameter rejected in differ.ts:226**
   - SDK's `query()` method doesn't accept generic type parameters
   - Fixed by removing generic and casting result rows instead

### Changes

- `types.ts`: Import `DatabaseInterface` for local use, not just re-export
- `differ.ts`: Use `SqlTableSchemaInfo` type from SDK, remove query generic

## Test plan

- [x] Local build passes (`npm run build`)
- [ ] CI checks pass
- [ ] Publish workflow succeeds after merge