### PR TITLE
chore(release): v0.17.96

### DIFF
--- a/.changeset/migrations-export.md
+++ b/.changeset/migrations-export.md
@@ -1,6 +1,0 @@
----
-"@happyvertical/smrt-core": patch
-"@happyvertical/smrt-cli": patch
----
-
-Add migrations export to smrt-core package.json exports

--- a/packages/ads/CHANGELOG.md
+++ b/packages/ads/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-ads
 
+## 0.17.96
+
+### Patch Changes
+
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+  - @happyvertical/smrt-assets@0.17.96
+  - @happyvertical/smrt-commerce@0.17.96
+  - @happyvertical/smrt-properties@0.17.96
+  - @happyvertical/smrt-tags@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/ads/package.json
+++ b/packages/ads/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-ads",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "Advertising delivery and tracking models for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/CHANGELOG.md
+++ b/packages/agents/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-agents
 
+## 0.17.96
+
+### Patch Changes
+
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-agents",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "type": "module",
   "description": "Agent framework for building autonomous actors in the SMRT ecosystem",
   "author": "HappyVertical",

--- a/packages/analytics/CHANGELOG.md
+++ b/packages/analytics/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-analytics
 
+## 0.17.96
+
+### Patch Changes
+
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-analytics",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "Analytics integration models for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/assets/CHANGELOG.md
+++ b/packages/assets/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-assets
 
+## 0.17.96
+
+### Patch Changes
+
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+  - @happyvertical/smrt-tags@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-assets",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "Asset management system with versioning, metadata, and AI-powered operations for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-cli
 
+## 0.17.96
+
+### Patch Changes
+
+- 97f13ce: Add migrations export to smrt-core package.json exports
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+  - @happyvertical/smrt-config@0.17.96
+  - @happyvertical/smrt-types@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-cli",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "Developer CLI for SMRT framework - introspection, testing, and project management",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/commerce/CHANGELOG.md
+++ b/packages/commerce/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-commerce
 
+## 0.17.96
+
+### Patch Changes
+
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+  - @happyvertical/smrt-ledgers@0.17.96
+  - @happyvertical/smrt-profiles@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/commerce/package.json
+++ b/packages/commerce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-commerce",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "Commerce models for the SMRT framework - contracts, fulfillments, payments",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-config
 
+## 0.17.96
+
 ## 0.17.95
 
 ## 0.17.94

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-config",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "type": "module",
   "description": "Centralized configuration management for SMRT modules",
   "author": "HappyVertical",

--- a/packages/content/CHANGELOG.md
+++ b/packages/content/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-content
 
+## 0.17.96
+
+### Patch Changes
+
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+  - @happyvertical/smrt-assets@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-content",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "Content processing module for SMRT framework - handles documents, web content, and media",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-core
 
+## 0.17.96
+
+### Patch Changes
+
+- 97f13ce: Add migrations export to smrt-core package.json exports
+  - @happyvertical/smrt-scanner@0.17.96
+  - @happyvertical/smrt-config@0.17.96
+  - @happyvertical/smrt-types@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-core",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "Core AI agent framework with standardized collections, object-relational mapping, and code generators",
   "author": "Will Griffin <willgriffin@gmail.com>",
   "type": "module",

--- a/packages/events/CHANGELOG.md
+++ b/packages/events/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-events
 
+## 0.17.96
+
+### Patch Changes
+
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+  - @happyvertical/smrt-places@0.17.96
+  - @happyvertical/smrt-profiles@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-events",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "Hierarchical event management with participant tracking and SMRT framework support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gnode/CHANGELOG.md
+++ b/packages/gnode/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-gnode
 
+## 0.17.96
+
+### Patch Changes
+
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/gnode/package.json
+++ b/packages/gnode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-gnode",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "SMRT federation library for building federated local knowledge bases (gnodes)",
   "author": "Will Griffin <willgriffin@gmail.com>",
   "type": "module",

--- a/packages/ledgers/CHANGELOG.md
+++ b/packages/ledgers/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-ledgers
 
+## 0.17.96
+
+### Patch Changes
+
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/ledgers/package.json
+++ b/packages/ledgers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-ledgers",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "Double-entry accounting ledger for the SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/messages/CHANGELOG.md
+++ b/packages/messages/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-messages
 
+## 0.17.96
+
+### Patch Changes
+
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-messages",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "SMRT-based email message persistence with AI integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/places/CHANGELOG.md
+++ b/packages/places/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-places
 
+## 0.17.96
+
+### Patch Changes
+
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/places/package.json
+++ b/packages/places/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-places",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "Hierarchical place management with geo integration and SMRT framework support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/products/CHANGELOG.md
+++ b/packages/products/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-products
 
+## 0.17.96
+
+### Patch Changes
+
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/products/package.json
+++ b/packages/products/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-products",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "SMRT products module: triple-purpose microservice template for standalone apps, federated modules, and NPM libraries",
   "author": "Will Griffin <willgriffin@gmail.com>",
   "type": "module",

--- a/packages/profiles/CHANGELOG.md
+++ b/packages/profiles/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-profiles
 
+## 0.17.96
+
+### Patch Changes
+
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/profiles/package.json
+++ b/packages/profiles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-profiles",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "Profile management system with relationships, metadata, and reciprocal associations for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/projects/CHANGELOG.md
+++ b/packages/projects/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-projects
 
+## 0.17.96
+
+### Patch Changes
+
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+  - @happyvertical/smrt-config@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/projects/package.json
+++ b/packages/projects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-projects",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "Provider-agnostic project management models (Issues, PRs, Repositories, Projects) for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/properties/CHANGELOG.md
+++ b/packages/properties/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-properties
 
+## 0.17.96
+
+### Patch Changes
+
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+  - @happyvertical/smrt-profiles@0.17.96
+  - @happyvertical/smrt-projects@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/properties/package.json
+++ b/packages/properties/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-properties",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "Digital property and zone management models for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/scanner/CHANGELOG.md
+++ b/packages/scanner/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-scanner
 
+## 0.17.96
+
+### Patch Changes
+
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-scanner",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "High-performance TypeScript scanner using OXC for SMRT manifest generation",
   "author": "Will Griffin <willgriffin@gmail.com>",
   "type": "module",

--- a/packages/smrt-dev-mcp/CHANGELOG.md
+++ b/packages/smrt-dev-mcp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-dev-mcp
 
+## 0.17.96
+
+### Patch Changes
+
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/smrt-dev-mcp/package.json
+++ b/packages/smrt-dev-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-dev-mcp",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "Development MCP server for SMRT framework - Code generation and project introspection",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-svelte/CHANGELOG.md
+++ b/packages/smrt-svelte/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-svelte
 
+## 0.17.96
+
+### Patch Changes
+
+- @happyvertical/smrt-profiles@0.17.96
+- @happyvertical/smrt-users@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-svelte",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "Svelte 5 components for SMRT user management - auth, users, tenants, roles, permissions, groups",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/tags/CHANGELOG.md
+++ b/packages/tags/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-tags
 
+## 0.17.96
+
+### Patch Changes
+
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-tags",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "Reusable tagging system with hierarchies, contexts, and multi-language support for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/template-site-static-json/CHANGELOG.md
+++ b/packages/template-site-static-json/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-template-site-static-json
 
+## 0.17.96
+
 ## 0.17.95
 
 ## 0.17.94

--- a/packages/template-site-static-json/package.json
+++ b/packages/template-site-static-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-template-site-static-json",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "Static community site template with JSON data storage and SMRT framework",
   "type": "module",
   "main": "index.js",

--- a/packages/template-sveltekit/CHANGELOG.md
+++ b/packages/template-sveltekit/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-template-sveltekit
 
+## 0.17.96
+
 ## 0.17.95
 
 ## 0.17.94

--- a/packages/template-sveltekit/package.json
+++ b/packages/template-sveltekit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-template-sveltekit",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "SvelteKit project template with SMRT framework integration",
   "type": "module",
   "main": "index.js",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-types
 
+## 0.17.96
+
 ## 0.17.95
 
 ## 0.17.94

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-types",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "Shared type definitions for the HAVE SDK",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/users/CHANGELOG.md
+++ b/packages/users/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-users
 
+## 0.17.96
+
+### Patch Changes
+
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+  - @happyvertical/smrt-profiles@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-users",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "Multi-tenant user management for the SMRT framework - users, tenants, roles, permissions, groups",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-vitest
 
+## 0.17.96
+
+### Patch Changes
+
+- Updated dependencies [97f13ce]
+  - @happyvertical/smrt-core@0.17.96
+
 ## 0.17.95
 
 ### Patch Changes

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-vitest",
-  "version": "0.17.95",
+  "version": "0.17.96",
   "description": "Vitest plugin for automatic cross-package manifest loading in SMRT tests",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release v0.17.96 with migrations export fix for smrt-core.

This enables `@happyvertical/smrt-core/migrations` import needed for `smrt db:migrate` command.