### PR TITLE
chore: add changeset for migrations system

### DIFF
--- a/.changeset/migrations-system.md
+++ b/.changeset/migrations-system.md
@@ -1,0 +1,6 @@
+---
+"@happyvertical/smrt-core": minor
+"@happyvertical/smrt-cli": minor
+---
+
+Add production-ready migration system with db:migrate command


### PR DESCRIPTION
Adds changeset to trigger release of the migrations feature added in #651, #652, #653.

This will publish the `./migrations` export in smrt-core needed for `smrt db:migrate` command.