### PR TITLE
fix(manifest): use conditional import path for scanner types

### DIFF
--- a/packages/core/src/manifest/generator.ts
+++ b/packages/core/src/manifest/generator.ts
@@ -282,9 +282,16 @@ export class ManifestBuilder {
 
     const exportName = isTestManifest ? 'testManifest' : 'staticManifest';
 
+    // Use relative import for core package (to avoid self-reference during build),
+    // package import for all other packages
+    const isCorePackage = manifest.packageName === '@happyvertical/smrt-core';
+    const importPath = isCorePackage
+      ? '../scanner/types.js'
+      : '@happyvertical/smrt-core/scanner/types';
+
     return `${comment}
 
-import type { SmartObjectManifest } from '@happyvertical/smrt-core/scanner/types';
+import type { SmartObjectManifest } from '${importPath}';
 
 export const ${exportName}: SmartObjectManifest = ${JSON.stringify(manifest, null, 2)} as const;
 


### PR DESCRIPTION
## Summary

- Use relative import (`../scanner/types.js`) for core package to avoid self-reference during build
- Use package import (`@happyvertical/smrt-core/scanner/types`) for all other packages that depend on smrt-core

## Problem

The manifest generator was using `@happyvertical/smrt-core/scanner/types` for the TypeScript stub template. This caused the core package build to fail with:

```
error TS2307: Cannot find module '@happyvertical/smrt-core/scanner/types' or its corresponding type declarations.
```

The self-reference doesn't work during the build phase because the dist folder hasn't been created yet.

## Solution

Check if we're in the core package (via `manifest.packageName`) and use the appropriate import path:
- Core package: `../scanner/types.js` (relative)
- Other packages: `@happyvertical/smrt-core/scanner/types` (package)

## Test plan

- [x] Local build passes (`npm run build`)
- [x] Generated stubs have correct imports (core uses relative, others use package import)