### PR TITLE
feat(core): make smrt-scanner a direct dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,6 +41,7 @@
     "@happyvertical/files": "^0.60.9",
     "@happyvertical/logger": "^0.60.9",
     "@happyvertical/smrt-config": "workspace:*",
+    "@happyvertical/smrt-scanner": "workspace:*",
     "@happyvertical/smrt-types": "workspace:*",
     "@happyvertical/sql": "^0.60.9",
     "@happyvertical/utils": "^0.60.9",
@@ -69,20 +70,15 @@
     "prepack": "npm run build:fresh"
   },
   "peerDependencies": {
-    "@xenova/transformers": "^2.17.0",
-    "@happyvertical/smrt-scanner": "workspace:*"
+    "@xenova/transformers": "^2.17.0"
   },
   "peerDependenciesMeta": {
     "@xenova/transformers": {
-      "optional": true
-    },
-    "@happyvertical/smrt-scanner": {
       "optional": true
     }
   },
   "devDependencies": {
     "@faker-js/faker": "^9.4.0",
-    "@happyvertical/smrt-scanner": "workspace:*",
     "@types/node": "^24.0.0",
     "@xenova/transformers": "^2.17.0",
     "tsx": "^4.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,6 +449,9 @@ importers:
       '@happyvertical/smrt-config':
         specifier: workspace:*
         version: link:../config
+      '@happyvertical/smrt-scanner':
+        specifier: workspace:*
+        version: link:../scanner
       '@happyvertical/smrt-types':
         specifier: workspace:*
         version: link:../types
@@ -483,9 +486,6 @@ importers:
       '@faker-js/faker':
         specifier: ^9.4.0
         version: 9.9.0
-      '@happyvertical/smrt-scanner':
-        specifier: workspace:*
-        version: link:../scanner
       '@types/node':
         specifier: 24.0.0
         version: 24.0.0
@@ -11505,7 +11505,7 @@ snapshots:
       agentkeepalive: 4.6.0
       axios: 1.13.2(debug@4.4.3)
       query-string: 7.1.3
-      retry-axios: 2.6.0(axios@1.13.2)
+      retry-axios: 2.6.0(axios@1.13.2(debug@4.4.3))
     transitivePeerDependencies:
       - debug
 
@@ -15943,7 +15943,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.13.2)
+      retry-axios: 2.6.0(axios@1.13.2(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -17676,7 +17676,7 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
-  retry-axios@2.6.0(axios@1.13.2):
+  retry-axios@2.6.0(axios@1.13.2(debug@4.4.3)):
     dependencies:
       axios: 1.13.2(debug@4.4.3)
 


### PR DESCRIPTION
## Summary
- Move `@happyvertical/smrt-scanner` from optional peer dependency to direct dependency of `@happyvertical/smrt-core`
- Downstream projects will now automatically get OXC-based scanning without manual installation
- OXC scanner provides 2-3x faster TypeScript parsing compared to the TS Compiler API fallback

## Test plan
- [x] Verify scanner imports successfully from core package
- [ ] CI build passes
- [ ] Downstream project gets scanner automatically after updating smrt-core