### PR TITLE
fix(ci): downgrade major changesets to minor to prevent 1.0.0 releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,6 +84,19 @@ jobs:
           echo "Version before release: $BEFORE_VERSION"
 
           pnpm run changeset:auto
+
+          # Downgrade any 'major' bumps to 'minor' (prevent 1.0.0 releases)
+          # This ensures we stay on 0.x versions until ready for 1.0
+          echo "🔒 Checking for major bumps to downgrade..."
+          for file in .changeset/*.md; do
+            if [ -f "$file" ] && [ "$(basename "$file")" != "README.md" ]; then
+              if grep -q ": major" "$file"; then
+                echo "  ⚠️  Downgrading major to minor in: $file"
+                sed -i 's/: major/: minor/g' "$file"
+              fi
+            fi
+          done
+
           pnpm run changeset:version
 
           # Sync root package.json version with workspace packages
@@ -108,10 +121,10 @@ jobs:
           AFTER_MAJOR=$(echo "$AFTER_VERSION" | cut -d. -f1)
           if [ "$AFTER_MAJOR" -ge 1 ]; then
             echo "❌ CRITICAL: Changeset would bump to $AFTER_VERSION (1.0.0+)"
-            echo "This is likely caused by using 'minor' on a 0.x version."
-            echo "Use 'patch' instead of 'minor' for 0.x releases."
+            echo "This is caused by a 'major' bump in a changeset file."
+            echo "The workflow should have downgraded it to 'minor'."
             echo ""
-            echo "To fix: update .changeset/*.md files to use 'patch'"
+            echo "To fix: check .changeset/*.md files for 'major' entries"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Prevents accidental 1.0.0 releases by automatically downgrading any `major` bump in changeset files to `minor` before running `changeset version`.

## Changes

- Add pre-version step in publish workflow to convert `: major` → `: minor` in all changeset files
- Fix misleading safeguard error message (was incorrectly blaming `minor` bumps for 1.0.0)
- Ensures project stays on 0.x versions until intentionally ready for 1.0

## Why

Changesets treats peer dependency changes as major bumps by design. For packages at 0.x versions, a "major" bump results in jumping to 1.0.0. The existing safeguard catches this but doesn't prevent it - now we actively downgrade before versioning.

## Test plan

- [ ] Verify workflow syntax passes validation
- [ ] Verify manual changeset with `major` gets downgraded to `minor`