### PR TITLE
fix(ci): downgrade version after changeset runs, add PR preview

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -100,6 +100,56 @@ jobs:
           echo "  - Workflow errors checked with actionlint"
           echo "  - Shellcheck warnings validated"
 
+  validate-version:
+    name: Validate Version Bump
+    runs-on: arc-happyvertical
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+        with:
+          node-version: '24'
+          install-deps: 'true'
+          registry-url: 'https://npm.pkg.github.com'
+          auth-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Preview changeset version bump
+        run: |
+          echo "🔍 Simulating changeset version bump..."
+
+          BEFORE_VERSION=$(node -p "require('./packages/core/package.json').version")
+          echo "Current version: $BEFORE_VERSION"
+
+          # Generate changeset from commits (dry-run simulation)
+          pnpm run changeset:auto
+
+          # Run changeset version to see what it would produce
+          pnpm run changeset:version
+
+          AFTER_VERSION=$(node -p "require('./packages/core/package.json').version")
+          echo "Would bump to: $AFTER_VERSION"
+
+          # Check if this would bump to 1.0.0+
+          AFTER_MAJOR=$(echo "$AFTER_VERSION" | cut -d. -f1)
+          if [ "$AFTER_MAJOR" -ge 1 ]; then
+            echo ""
+            echo "❌ ERROR: This PR would bump version to $AFTER_VERSION (1.0.0+)"
+            echo ""
+            echo "This is caused by changesets interpreting peer dependency"
+            echo "changes as breaking. The publish workflow will reject this."
+            echo ""
+            echo "The version will be automatically downgraded to 0.x on merge."
+            echo ""
+            # Don't fail - just warn. The publish workflow will handle it.
+            echo "⚠️  WARNING: Version will be downgraded on merge"
+          else
+            echo "✅ Version bump is acceptable: $BEFORE_VERSION → $AFTER_VERSION"
+          fi
+
   test:
     name: Validate Changes
     uses: ./.github/workflows/test-suite.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,47 +84,63 @@ jobs:
           echo "Version before release: $BEFORE_VERSION"
 
           pnpm run changeset:auto
-
-          # Downgrade any 'major' bumps to 'minor' (prevent 1.0.0 releases)
-          # This ensures we stay on 0.x versions until ready for 1.0
-          echo "🔒 Checking for major bumps to downgrade..."
-          for file in .changeset/*.md; do
-            if [ -f "$file" ] && [ "$(basename "$file")" != "README.md" ]; then
-              if grep -q ": major" "$file"; then
-                echo "  ⚠️  Downgrading major to minor in: $file"
-                sed -i 's/: major/: minor/g' "$file"
-              fi
-            fi
-          done
-
           pnpm run changeset:version
 
-          # Sync root package.json version with workspace packages
-          # (SMRT uses core not utils)
-          WORKSPACE_VERSION=$(node -p \
-            "require('./packages/core/package.json').version")
+          # Get version after changeset version ran
+          CHANGESET_VERSION=$(node -p "require('./packages/core/package.json').version")
+          echo "Changeset produced version: $CHANGESET_VERSION"
+
+          # Check if changeset bumped to 1.0.0+ (due to peer dep handling)
+          CHANGESET_MAJOR=$(echo "$CHANGESET_VERSION" | cut -d. -f1)
+          if [ "$CHANGESET_MAJOR" -ge 1 ]; then
+            echo "⚠️  Changesets bumped to $CHANGESET_VERSION (1.0.0+)"
+            echo "🔒 Downgrading to minor bump instead..."
+
+            # Calculate correct minor bump (0.17.x -> 0.18.0)
+            BEFORE_MINOR=$(echo "$BEFORE_VERSION" | cut -d. -f2)
+            NEW_MINOR=$((BEFORE_MINOR + 1))
+            CORRECTED_VERSION="0.${NEW_MINOR}.0"
+            echo "📝 Correcting version to: $CORRECTED_VERSION"
+
+            # Update all package.json files with corrected version
+            node -e "
+              const fs = require('fs');
+              const glob = require('fast-glob');
+
+              const version = '$CORRECTED_VERSION';
+              const pkgFiles = glob.sync(['package.json', 'packages/*/package.json']);
+
+              for (const file of pkgFiles) {
+                const pkg = JSON.parse(fs.readFileSync(file, 'utf-8'));
+                if (pkg.version && pkg.version.startsWith('1.')) {
+                  console.log('  Fixing: ' + file + ' (' + pkg.version + ' -> ' + version + ')');
+                  pkg.version = version;
+                  fs.writeFileSync(file, JSON.stringify(pkg, null, 2) + '\\n');
+                }
+              }
+            "
+
+            AFTER_VERSION="$CORRECTED_VERSION"
+          else
+            AFTER_VERSION="$CHANGESET_VERSION"
+          fi
+
+          # Sync root package.json version
           ROOT_VERSION=$(node -p "require('./package.json').version")
-          if [ -n "$WORKSPACE_VERSION" ] && \
-             [ "$WORKSPACE_VERSION" != "$ROOT_VERSION" ]; then
-            echo "📝 Syncing root package version to match" \
-              "workspace: $WORKSPACE_VERSION"
+          if [ "$AFTER_VERSION" != "$ROOT_VERSION" ]; then
+            echo "📝 Syncing root package version: $AFTER_VERSION"
             node -e "const pkg = require('./package.json'); \
-              pkg.version = '$WORKSPACE_VERSION'; \
+              pkg.version = '$AFTER_VERSION'; \
               require('fs').writeFileSync('./package.json', \
               JSON.stringify(pkg, null, 2) + '\n');"
           fi
 
-          AFTER_VERSION=$(node -p "require('./package.json').version")
           echo "Version after versioning: $AFTER_VERSION"
 
-          # Post-version safeguard: fail if changeset bumped to 1.0.0+
-          AFTER_MAJOR=$(echo "$AFTER_VERSION" | cut -d. -f1)
-          if [ "$AFTER_MAJOR" -ge 1 ]; then
-            echo "❌ CRITICAL: Changeset would bump to $AFTER_VERSION (1.0.0+)"
-            echo "This is caused by a 'major' bump in a changeset file."
-            echo "The workflow should have downgraded it to 'minor'."
-            echo ""
-            echo "To fix: check .changeset/*.md files for 'major' entries"
+          # Final safeguard: fail if still 1.0.0+
+          FINAL_MAJOR=$(echo "$AFTER_VERSION" | cut -d. -f1)
+          if [ "$FINAL_MAJOR" -ge 1 ]; then
+            echo "❌ CRITICAL: Version correction failed. Still at $AFTER_VERSION"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Fixes the 1.0.0 release prevention that failed in #668. The previous approach tried to downgrade `.md` changeset files, but changesets internally bumps to major for peer dependency changes regardless of what the changeset file says.

## Changes

**publish.yml:**
- Move version downgrade to AFTER `changeset version` runs
- Calculate correct `0.x.0` minor bump from `BEFORE_VERSION`
- Update all `package.json` files when 1.0.0+ is detected
- Keep final safeguard as fallback

**on-pull-request.yml:**
- Add `validate-version` job that simulates changeset versioning
- Shows early warning if PR would bump to 1.0.0+
- Doesn't fail the PR (publish workflow handles the fix)

## Why the previous fix didn't work

The issue is that changesets decides on major bumps internally based on peer dependency relationships, NOT based on what's written in the changeset `.md` files. Our auto-changeset generates `minor`, but changesets overrides this when it detects peer dependency changes.

## Test plan

- [ ] Verify PR validation shows version bump preview
- [ ] Verify publish workflow correctly downgrades 1.0.0 → 0.18.0