### PR TITLE
fix(smrt-svelte): make package browser-compatible

### DIFF
--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -100,14 +100,19 @@
   },
   "dependencies": {
     "@happyvertical/browser-ai": "workspace:*",
-    "@happyvertical/smrt-agents": "workspace:*",
-    "@happyvertical/smrt-profiles": "workspace:*",
     "@happyvertical/smrt-types": "workspace:*",
-    "@happyvertical/smrt-users": "workspace:*",
     "chrono-node": "^2.9.0"
   },
   "peerDependencies": {
-    "svelte": "^5.18.2"
+    "svelte": "^5.18.2",
+    "@happyvertical/smrt-agents": "workspace:*",
+    "@happyvertical/smrt-profiles": "workspace:*",
+    "@happyvertical/smrt-users": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@happyvertical/smrt-agents": { "optional": true },
+    "@happyvertical/smrt-profiles": { "optional": true },
+    "@happyvertical/smrt-users": { "optional": true }
   },
   "devDependencies": {
     "@sveltejs/package": "^2.5.7",

--- a/packages/smrt-svelte/src/components/users/UserForm.svelte
+++ b/packages/smrt-svelte/src/components/users/UserForm.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { Profile } from '@happyvertical/smrt-profiles';
-import { type User, UserStatus } from '@happyvertical/smrt-users';
+import { UserStatus } from '@happyvertical/smrt-types';
+import type { User } from '@happyvertical/smrt-users';
 
 interface Props {
   user?: User | null;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -14,3 +14,12 @@ export type {
   SmrtModuleMeta,
 } from './module.js';
 export type { Signal, SignalAdapter, SignalType } from './signals.js';
+
+// User status enums (browser-safe, no server dependencies)
+export {
+  MembershipStatus,
+  OverrideEffect,
+  SessionStatus,
+  TenantStatus,
+  UserStatus,
+} from './user.js';

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -1,0 +1,79 @@
+/**
+ * User-related type definitions
+ *
+ * These enums and types are exported from smrt-types to allow
+ * browser-safe packages (like smrt-svelte) to import them without
+ * pulling in server-side dependencies from smrt-users.
+ */
+
+// ============= User Status =============
+
+/**
+ * User account status
+ */
+export enum UserStatus {
+  /** Active user account */
+  ACTIVE = 'active',
+  /** Inactive user account */
+  INACTIVE = 'inactive',
+  /** Suspended user account */
+  SUSPENDED = 'suspended',
+  /** Pending email verification */
+  PENDING = 'pending',
+}
+
+// ============= Tenant Status =============
+
+/**
+ * Tenant (organization) status
+ */
+export enum TenantStatus {
+  /** Active tenant */
+  ACTIVE = 'active',
+  /** Inactive tenant */
+  INACTIVE = 'inactive',
+  /** Suspended tenant */
+  SUSPENDED = 'suspended',
+  /** Archived tenant (soft-deleted) */
+  ARCHIVED = 'archived',
+}
+
+// ============= Membership Status =============
+
+/**
+ * User membership status within a tenant
+ */
+export enum MembershipStatus {
+  /** Active membership */
+  ACTIVE = 'active',
+  /** Inactive membership */
+  INACTIVE = 'inactive',
+  /** Pending invitation acceptance */
+  PENDING = 'pending',
+}
+
+// ============= Session Status =============
+
+/**
+ * Session status
+ */
+export enum SessionStatus {
+  /** Active session */
+  ACTIVE = 'active',
+  /** Expired session (past expiresAt) */
+  EXPIRED = 'expired',
+  /** Revoked by user or admin */
+  REVOKED = 'revoked',
+}
+
+// ============= Permission Override =============
+
+/**
+ * Effect of a permission override
+ */
+export enum OverrideEffect {
+  /** Grant the permission */
+  GRANT = 'grant',
+  /** Deny the permission */
+  DENY = 'deny',
+}

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -48,7 +48,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@happyvertical/smrt-core": "workspace:*"
+    "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-types": "workspace:*"
   },
   "peerDependencies": {
     "@happyvertical/smrt-profiles": "workspace:*"

--- a/packages/users/src/types/index.ts
+++ b/packages/users/src/types/index.ts
@@ -3,77 +3,15 @@
  * @packageDocumentation
  */
 
-// ============= User Status =============
-
-/**
- * User account status
- */
-export enum UserStatus {
-  /** Active user account */
-  ACTIVE = 'active',
-  /** Inactive user account */
-  INACTIVE = 'inactive',
-  /** Suspended user account */
-  SUSPENDED = 'suspended',
-  /** Pending email verification */
-  PENDING = 'pending',
-}
-
-// ============= Tenant Status =============
-
-/**
- * Tenant (organization) status
- */
-export enum TenantStatus {
-  /** Active tenant */
-  ACTIVE = 'active',
-  /** Inactive tenant */
-  INACTIVE = 'inactive',
-  /** Suspended tenant */
-  SUSPENDED = 'suspended',
-  /** Archived tenant (soft-deleted) */
-  ARCHIVED = 'archived',
-}
-
-// ============= Membership Status =============
-
-/**
- * User membership status within a tenant
- */
-export enum MembershipStatus {
-  /** Active membership */
-  ACTIVE = 'active',
-  /** Inactive membership */
-  INACTIVE = 'inactive',
-  /** Pending invitation acceptance */
-  PENDING = 'pending',
-}
-
-// ============= Session Status =============
-
-/**
- * Session status
- */
-export enum SessionStatus {
-  /** Active session */
-  ACTIVE = 'active',
-  /** Expired session (past expiresAt) */
-  EXPIRED = 'expired',
-  /** Revoked by user or admin */
-  REVOKED = 'revoked',
-}
-
-// ============= Permission Override =============
-
-/**
- * Effect of a permission override
- */
-export enum OverrideEffect {
-  /** Grant the permission */
-  GRANT = 'grant',
-  /** Deny the permission */
-  DENY = 'deny',
-}
+// Re-export status enums from smrt-types for backwards compatibility
+// These are defined in smrt-types to allow browser-safe packages to import them
+export {
+  MembershipStatus,
+  OverrideEffect,
+  SessionStatus,
+  TenantStatus,
+  UserStatus,
+} from '@happyvertical/smrt-types';
 
 // ============= Default System Roles =============
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1190,6 +1190,9 @@ importers:
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
+      '@happyvertical/smrt-types':
+        specifier: workspace:*
+        version: link:../types
     devDependencies:
       '@happyvertical/smrt-profiles':
         specifier: workspace:*
@@ -2519,6 +2522,11 @@ packages:
     peerDependencies:
       jimp: '>=1.6.0'
       sharp: '>=0.34.5'
+    peerDependenciesMeta:
+      jimp:
+        optional: true
+      sharp:
+        optional: true
 
   '@happyvertical/logger@0.59.0':
     resolution: {integrity: sha512-GR9oh+vfe2fe8TDkkqMJySmHRA3W5Vk0U/P2pxmvV6eQBaQ5h34/3bh7xYjzp4JDng2nmdK23JJIVSWvxD7CRQ==, tarball: https://npm.pkg.github.com/download/@happyvertical/logger/0.59.0/1c794cf030c539a09a1e971a35fd7b2756d157ee}
@@ -12098,7 +12106,7 @@ snapshots:
       agentkeepalive: 4.6.0
       axios: 1.13.2(debug@4.4.3)
       query-string: 7.1.3
-      retry-axios: 2.6.0(axios@1.13.2(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.13.2)
     transitivePeerDependencies:
       - debug
 
@@ -12257,8 +12265,9 @@ snapshots:
   '@happyvertical/images@0.66.4(jimp@1.6.0)(sharp@0.34.5)':
     dependencies:
       '@resvg/resvg-js': 2.6.2
-      jimp: 1.6.0
       satori: 0.18.3
+    optionalDependencies:
+      jimp: 1.6.0
       sharp: 0.34.5
 
   '@happyvertical/logger@0.59.0':
@@ -12637,6 +12646,7 @@ snapshots:
       exif-parser: 0.1.12
       file-type: 16.5.4
       mime: 3.0.0
+    optional: true
 
   '@jimp/diff@1.6.0':
     dependencies:
@@ -12644,8 +12654,10 @@ snapshots:
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
       pixelmatch: 5.3.0
+    optional: true
 
-  '@jimp/file-ops@1.6.0': {}
+  '@jimp/file-ops@1.6.0':
+    optional: true
 
   '@jimp/js-bmp@1.6.0':
     dependencies:
@@ -12653,6 +12665,7 @@ snapshots:
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
       bmp-ts: 1.0.9
+    optional: true
 
   '@jimp/js-gif@1.6.0':
     dependencies:
@@ -12660,40 +12673,47 @@ snapshots:
       '@jimp/types': 1.6.0
       gifwrap: 0.10.1
       omggif: 1.0.10
+    optional: true
 
   '@jimp/js-jpeg@1.6.0':
     dependencies:
       '@jimp/core': 1.6.0
       '@jimp/types': 1.6.0
       jpeg-js: 0.4.4
+    optional: true
 
   '@jimp/js-png@1.6.0':
     dependencies:
       '@jimp/core': 1.6.0
       '@jimp/types': 1.6.0
       pngjs: 7.0.0
+    optional: true
 
   '@jimp/js-tiff@1.6.0':
     dependencies:
       '@jimp/core': 1.6.0
       '@jimp/types': 1.6.0
       utif2: 4.1.0
+    optional: true
 
   '@jimp/plugin-blit@1.6.0':
     dependencies:
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-blur@1.6.0':
     dependencies:
       '@jimp/core': 1.6.0
       '@jimp/utils': 1.6.0
+    optional: true
 
   '@jimp/plugin-circle@1.6.0':
     dependencies:
       '@jimp/types': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-color@1.6.0':
     dependencies:
@@ -12702,6 +12722,7 @@ snapshots:
       '@jimp/utils': 1.6.0
       tinycolor2: 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-contain@1.6.0':
     dependencies:
@@ -12711,6 +12732,7 @@ snapshots:
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-cover@1.6.0':
     dependencies:
@@ -12719,6 +12741,7 @@ snapshots:
       '@jimp/plugin-resize': 1.6.0
       '@jimp/types': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-crop@1.6.0':
     dependencies:
@@ -12726,27 +12749,32 @@ snapshots:
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-displace@1.6.0':
     dependencies:
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-dither@1.6.0':
     dependencies:
       '@jimp/types': 1.6.0
+    optional: true
 
   '@jimp/plugin-fisheye@1.6.0':
     dependencies:
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-flip@1.6.0':
     dependencies:
       '@jimp/types': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-hash@1.6.0':
     dependencies:
@@ -12760,11 +12788,13 @@ snapshots:
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
       any-base: 1.1.0
+    optional: true
 
   '@jimp/plugin-mask@1.6.0':
     dependencies:
       '@jimp/types': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-print@1.6.0':
     dependencies:
@@ -12778,17 +12808,20 @@ snapshots:
       parse-bmfont-xml: 1.1.6
       simple-xml-to-json: 1.2.3
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-quantize@1.6.0':
     dependencies:
       image-q: 4.0.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-resize@1.6.0':
     dependencies:
       '@jimp/core': 1.6.0
       '@jimp/types': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-rotate@1.6.0':
     dependencies:
@@ -12798,6 +12831,7 @@ snapshots:
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-threshold@1.6.0':
     dependencies:
@@ -12807,15 +12841,18 @@ snapshots:
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/types@1.6.0':
     dependencies:
       zod: 3.25.76
+    optional: true
 
   '@jimp/utils@1.6.0':
     dependencies:
       '@jimp/types': 1.6.0
       tinycolor2: 1.6.0
+    optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -14801,7 +14838,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
-  any-base@1.1.0: {}
+  any-base@1.1.0:
+    optional: true
 
   any-promise@1.3.0: {}
 
@@ -14832,7 +14870,8 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
-  await-to-js@3.0.0: {}
+  await-to-js@3.0.0:
+    optional: true
 
   axios@1.13.2(debug@4.4.3):
     dependencies:
@@ -14915,7 +14954,8 @@ snapshots:
 
   bmp-js@0.1.0: {}
 
-  bmp-ts@1.0.9: {}
+  bmp-ts@1.0.9:
+    optional: true
 
   body-parser@1.20.4:
     dependencies:
@@ -15789,7 +15829,8 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
-  exif-parser@0.1.12: {}
+  exif-parser@0.1.12:
+    optional: true
 
   expand-template@2.0.3: {}
 
@@ -16162,6 +16203,7 @@ snapshots:
     dependencies:
       image-q: 4.0.0
       omggif: 1.0.10
+    optional: true
 
   git-log-parser@1.2.1:
     dependencies:
@@ -16475,7 +16517,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.13.2(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.13.2)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -16509,6 +16551,7 @@ snapshots:
   image-q@4.0.0:
     dependencies:
       '@types/node': 24.0.0
+    optional: true
 
   imapflow@1.2.4:
     dependencies:
@@ -16732,6 +16775,7 @@ snapshots:
       '@jimp/plugin-threshold': 1.6.0
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
+    optional: true
 
   jiti@2.6.1: {}
 
@@ -17244,7 +17288,8 @@ snapshots:
 
   mime@1.6.0: {}
 
-  mime@3.0.0: {}
+  mime@3.0.0:
+    optional: true
 
   mime@4.1.0: {}
 
@@ -17448,7 +17493,8 @@ snapshots:
 
   obug@2.1.1: {}
 
-  omggif@1.0.10: {}
+  omggif@1.0.10:
+    optional: true
 
   on-exit-leak-free@2.1.2: {}
 
@@ -17686,7 +17732,8 @@ snapshots:
 
   pako@0.2.9: {}
 
-  pako@1.0.11: {}
+  pako@1.0.11:
+    optional: true
 
   parent-module@1.0.1:
     dependencies:
@@ -17694,14 +17741,17 @@ snapshots:
 
   parent-require@1.0.0: {}
 
-  parse-bmfont-ascii@1.0.6: {}
+  parse-bmfont-ascii@1.0.6:
+    optional: true
 
-  parse-bmfont-binary@1.0.6: {}
+  parse-bmfont-binary@1.0.6:
+    optional: true
 
   parse-bmfont-xml@1.1.6:
     dependencies:
       xml-parse-from-string: 1.0.1
       xml2js: 0.5.0
+    optional: true
 
   parse-css-color@0.2.1:
     dependencies:
@@ -17874,6 +17924,7 @@ snapshots:
   pixelmatch@5.3.0:
     dependencies:
       pngjs: 6.0.0
+    optional: true
 
   pkce-challenge@5.0.1: {}
 
@@ -17914,7 +17965,8 @@ snapshots:
 
   pluralize@8.0.0: {}
 
-  pngjs@6.0.0: {}
+  pngjs@6.0.0:
+    optional: true
 
   pngjs@7.0.0: {}
 
@@ -18204,7 +18256,7 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
-  retry-axios@2.6.0(axios@1.13.2(debug@4.4.3)):
+  retry-axios@2.6.0(axios@1.13.2):
     dependencies:
       axios: 1.13.2(debug@4.4.3)
 
@@ -18613,7 +18665,8 @@ snapshots:
 
   simple-wcswidth@1.1.2: {}
 
-  simple-xml-to-json@1.2.3: {}
+  simple-xml-to-json@1.2.3:
+    optional: true
 
   sirv@3.0.2:
     dependencies:
@@ -18989,7 +19042,8 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinycolor2@1.6.0: {}
+  tinycolor2@1.6.0:
+    optional: true
 
   tinyexec@0.3.2: {}
 
@@ -19243,6 +19297,7 @@ snapshots:
   utif2@4.1.0:
     dependencies:
       pako: 1.0.11
+    optional: true
 
   util-deprecate@1.0.2: {}
 
@@ -19552,14 +19607,17 @@ snapshots:
 
   xml-name-validator@5.0.0: {}
 
-  xml-parse-from-string@1.0.1: {}
+  xml-parse-from-string@1.0.1:
+    optional: true
 
   xml2js@0.5.0:
     dependencies:
       sax: 1.4.3
       xmlbuilder: 11.0.1
+    optional: true
 
-  xmlbuilder@11.0.1: {}
+  xmlbuilder@11.0.1:
+    optional: true
 
   xmlchars@2.2.0: {}
 


### PR DESCRIPTION
## Summary
- Move status enums (UserStatus, TenantStatus, etc.) from smrt-users to smrt-types
- Update smrt-svelte to import UserStatus from smrt-types instead of smrt-users
- Move smrt-agents, smrt-profiles, smrt-users to optional peer dependencies

## Problem
Browser builds of SvelteKit static sites fail with errors like:
```
"resolve" is not exported by "__vite-browser-external"
```

This happens because smrt-svelte imports `UserStatus` from smrt-users, which pulls in smrt-core, which pulls in @happyvertical/files (Node.js only).

## Solution
1. Move status enums to smrt-types (which has no server dependencies)
2. Re-export enums from smrt-users for backwards compatibility
3. Update smrt-svelte to import enums from smrt-types
4. Make smrt-agents, smrt-profiles, smrt-users optional peer deps (they're only used for type imports)

## Test plan
- [x] Build succeeds
- [x] Tests pass (1108 passed)
- [ ] Test browser build in bentleyalberta.com with new version

Closes #681