### PR TITLE
fix(core): resolve STI base by inheritance chain, not tableName (#703)

### DIFF
--- a/packages/core/src/__tests__/issue-703-sti-null-tablename.test.ts
+++ b/packages/core/src/__tests__/issue-703-sti-null-tablename.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Issue #703: STI db:migrate creates separate tables when tableName is null
+ *
+ * When STI subclasses are loaded from external manifests with tableName: null,
+ * getAllSchemas() should still merge them into the parent table instead of
+ * creating separate tables.
+ *
+ * Root cause: getSTIBase() relied on tableName matching between child and parent.
+ * When registerFromManifest() derives a tableName from class name (due to null
+ * in manifest), the child's tableName ('meetings') doesn't match parent's
+ * tableName ('events'), so getSTIBase() fails to find the parent.
+ *
+ * Fix: getSTIBase() now finds the STI base by looking for the oldest ancestor
+ * with explicit tableStrategy: 'sti', without requiring tableName matching.
+ *
+ * Related: https://github.com/happyvertical/smrt/issues/703
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { ObjectRegistry } from '../registry';
+
+describe('Issue #703: STI with null tableName from external manifest', () => {
+  // Store original registry state to restore after tests
+  const originalClasses = new Map(ObjectRegistry.classes);
+  const originalClassNameMap = new Map(
+    (ObjectRegistry as any).classNameMap || new Map(),
+  );
+
+  beforeAll(() => {
+    // Register STI base class with explicit tableStrategy and tableName
+    ObjectRegistry.registerFromManifest(
+      'Issue703Event',
+      {
+        className: 'Issue703Event',
+        extends: 'SmrtObject',
+        decoratorConfig: {
+          tableStrategy: 'sti',
+          tableName: 'issue703_events',
+        },
+        fields: {
+          title: { type: 'text', default: '' },
+          eventDate: { type: 'datetime' },
+        },
+        schema: {
+          tableName: 'issue703_events',
+          ddl: 'CREATE TABLE IF NOT EXISTS "issue703_events" ("id" TEXT PRIMARY KEY, "title" TEXT, "event_date" DATETIME, "_meta_type" TEXT, "_meta_data" TEXT)',
+          columns: {
+            id: { type: 'TEXT', primaryKey: true },
+            title: { type: 'TEXT' },
+            event_date: { type: 'DATETIME' },
+            _meta_type: { type: 'TEXT' },
+            _meta_data: { type: 'TEXT' },
+          },
+          indexes: [],
+        },
+      },
+      'test-package',
+    );
+
+    // Register STI child class with null tableName (simulating external manifest)
+    // This is the key scenario: the manifest has tableName: null, which causes
+    // registerFromManifest() to derive 'issue703meetings' from class name
+    ObjectRegistry.registerFromManifest(
+      'Issue703Meeting',
+      {
+        className: 'Issue703Meeting',
+        extends: 'Issue703Event',
+        decoratorConfig: {
+          // tableName is intentionally omitted to simulate null in manifest
+          // registerFromManifest will derive 'issue703meetings' from class name
+        },
+        fields: {
+          councilId: { type: 'text', default: '' },
+          agendaUrl: { type: 'text', default: '' },
+        },
+        // No schema provided - simulating external manifest scenario
+      },
+      'test-package',
+    );
+
+    // Register another STI child with different tableName (explicit mismatch)
+    ObjectRegistry.registerFromManifest(
+      'Issue703WeatherForecast',
+      {
+        className: 'Issue703WeatherForecast',
+        extends: 'Issue703Event',
+        decoratorConfig: {
+          // Explicitly different tableName to test mismatch handling
+          tableName: 'issue703_forecasts',
+        },
+        fields: {
+          temperatureHigh: { type: 'decimal', default: 0.0 },
+          temperatureLow: { type: 'decimal', default: 0.0 },
+        },
+      },
+      'test-package',
+    );
+  });
+
+  afterAll(() => {
+    // Restore original registry state
+    ObjectRegistry.classes.clear();
+    for (const [key, value] of originalClasses) {
+      ObjectRegistry.classes.set(key, value);
+    }
+    const classNameMap = (ObjectRegistry as any).classNameMap;
+    if (classNameMap) {
+      classNameMap.clear();
+      for (const [key, value] of originalClassNameMap) {
+        classNameMap.set(key, value);
+      }
+    }
+  });
+
+  describe('getSTIBase()', () => {
+    it('should return STI base class for the base class itself', () => {
+      const stiBase = ObjectRegistry.getSTIBase('Issue703Event');
+      expect(stiBase).toBe('Issue703Event');
+    });
+
+    it('should find STI base for child class even when tableName is derived (null in manifest)', () => {
+      // This is the key fix for Issue #703
+      // Before fix: getSTIBase('Issue703Meeting') would return 'Issue703Meeting'
+      //             because its derived tableName 'issue703meetings' doesn't match
+      //             parent's tableName 'issue703_events'
+      // After fix: getSTIBase('Issue703Meeting') returns 'Issue703Event'
+      //            because we find the oldest ancestor with explicit tableStrategy: 'sti'
+      const stiBase = ObjectRegistry.getSTIBase('Issue703Meeting');
+      expect(stiBase).toBe('Issue703Event');
+    });
+
+    it('should find STI base for child class even when tableName explicitly differs', () => {
+      // Even with explicitly different tableName, the STI base should be found
+      // because STI inheritance is determined by tableStrategy, not tableName
+      const stiBase = ObjectRegistry.getSTIBase('Issue703WeatherForecast');
+      expect(stiBase).toBe('Issue703Event');
+    });
+
+    it('should return null for CTI classes', () => {
+      // Register a CTI class for comparison
+      ObjectRegistry.registerFromManifest(
+        'Issue703CTIClass',
+        {
+          className: 'Issue703CTIClass',
+          extends: 'SmrtObject',
+          decoratorConfig: {
+            tableStrategy: 'cti',
+            tableName: 'issue703_cti',
+          },
+          fields: {},
+        },
+        'test-package',
+      );
+
+      const stiBase = ObjectRegistry.getSTIBase('Issue703CTIClass');
+      expect(stiBase).toBeNull();
+    });
+  });
+
+  describe('getTableStrategy()', () => {
+    it('should return sti for base class', () => {
+      const strategy = ObjectRegistry.getTableStrategy('Issue703Event');
+      expect(strategy).toBe('sti');
+    });
+
+    it('should return sti for child class (inherited)', () => {
+      const strategy = ObjectRegistry.getTableStrategy('Issue703Meeting');
+      expect(strategy).toBe('sti');
+    });
+
+    it('should return sti for another child class (inherited)', () => {
+      const strategy = ObjectRegistry.getTableStrategy(
+        'Issue703WeatherForecast',
+      );
+      expect(strategy).toBe('sti');
+    });
+  });
+
+  describe('getAllSchemas()', () => {
+    it('should merge STI child columns into parent table schema', () => {
+      const schemas = ObjectRegistry.getAllSchemas();
+
+      // The parent table should exist with ALL columns merged
+      const eventsSchema = schemas.issue703_events;
+      expect(eventsSchema).toBeDefined();
+      expect(eventsSchema.tableName).toBe('issue703_events');
+
+      // DDL should include base class columns
+      expect(eventsSchema.ddl).toContain('"title"');
+      expect(eventsSchema.ddl).toContain('"event_date"');
+
+      // DDL should include Meeting subclass columns (Issue #703 fix)
+      expect(eventsSchema.ddl).toContain('"council_id"');
+      expect(eventsSchema.ddl).toContain('"agenda_url"');
+
+      // DDL should include WeatherForecast subclass columns (Issue #703 fix)
+      expect(eventsSchema.ddl).toContain('"temperature_high"');
+      expect(eventsSchema.ddl).toContain('"temperature_low"');
+
+      // STI meta columns should be present
+      expect(eventsSchema.ddl).toContain('"_meta_type"');
+      expect(eventsSchema.ddl).toContain('"_meta_data"');
+    });
+
+    it('should NOT create separate tables for STI subclasses', () => {
+      const schemas = ObjectRegistry.getAllSchemas();
+
+      // Subclass tables should NOT exist (columns merged into parent)
+      // The derived tableName 'issue703meetings' should NOT appear
+      expect(schemas.issue703meetings).toBeUndefined();
+      expect(schemas.issue703_meetings).toBeUndefined();
+
+      // The explicit different tableName 'issue703_forecasts' should also NOT appear
+      // because STI subclasses share the parent table regardless of their declared tableName
+      expect(schemas.issue703_forecasts).toBeUndefined();
+      expect(schemas.issue703forecasts).toBeUndefined();
+    });
+
+    it('should only produce ONE table for the entire STI hierarchy', () => {
+      const schemas = ObjectRegistry.getAllSchemas();
+
+      // Count tables that match the issue703 prefix
+      const issue703Tables = Object.keys(schemas).filter((name) =>
+        name.startsWith('issue703'),
+      );
+
+      // There should be exactly ONE table for the entire STI hierarchy
+      expect(issue703Tables).toEqual(['issue703_events']);
+    });
+  });
+});

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -2439,6 +2439,37 @@ export class ObjectRegistry {
         continue;
       }
 
+      // Issue #703: Handle STI subclasses with null tableName from external manifests
+      // When loaded from external manifests, tableName may be null, causing
+      // registerFromManifest() to derive a tableName from class name.
+      // For STI subclasses, we need to use the STI base's tableName instead.
+      if (!registered.schema?.tableName && registered.extends) {
+        const tableStrategy = ObjectRegistry.getTableStrategy(_className);
+        if (tableStrategy === 'sti') {
+          const stiBaseName = ObjectRegistry.getSTIBase(_className);
+          if (stiBaseName && stiBaseName !== _className) {
+            const stiBaseClass = ObjectRegistry.findClass(stiBaseName);
+            if (stiBaseClass?.schema?.tableName) {
+              // Ensure we have a schema object to modify
+              if (!registered.schema) {
+                registered.schema = {
+                  tableName: '',
+                  ddl: '',
+                  columns: {},
+                  indexes: [],
+                  triggers: [],
+                  foreignKeys: [],
+                  dependencies: [],
+                  version: '',
+                };
+              }
+              // Set tableName from STI base so the following block processes this class
+              registered.schema.tableName = stiBaseClass.schema.tableName;
+            }
+          }
+        }
+      }
+
       if (registered.schema?.tableName) {
         // For STI subclasses, use the STI base class's tableName
         // This ensures all STI subclass columns are merged into the parent table
@@ -3580,40 +3611,35 @@ export class ObjectRegistry {
       return null; // Not using STI
     }
 
-    // Find the OLDEST/ROOT class in the chain with tableStrategy: 'sti'
-    // that shares the same table name as the target class.
+    // Find the OLDEST/ROOT class in the chain with explicit tableStrategy: 'sti'
+    // (Issue #703 fix: don't rely on tableName matching)
     //
     // In multi-level STI hierarchies (e.g., Council → Organization → Profile),
     // we need to return the oldest ancestor (Profile), not the first one found (Organization)
-    const registered = ObjectRegistry.findClass(className);
-    if (!registered) {
-      return null;
-    }
-
-    // Get this class's table name for matching
-    const targetTableName =
-      registered.config?.tableName || registered.schema?.tableName;
-
-    // Walk up the chain to find the OLDEST STI base with matching table
-    // The chain is ordered [root, ..., className], so the first match is the oldest
+    //
+    // IMPORTANT: Don't rely on tableName matching because:
+    // 1. STI subclasses loaded from external manifests may have tableName: null
+    // 2. registerFromManifest() derives a tableName from class name when null
+    // 3. This causes tableName mismatch ('meetings' vs 'events')
+    // 4. Instead, find the oldest ancestor with EXPLICIT tableStrategy: 'sti'
     const chain = ObjectRegistry.getInheritanceChain(className);
+
+    // Walk the chain (ordered [root, ..., className]) to find oldest STI base
     for (const ancestorName of chain) {
       const ancestor = ObjectRegistry.findClass(ancestorName);
       if (!ancestor) continue;
-      // Use getTableStrategy() to properly detect inherited STI strategy
-      // (not ancestor.config.tableStrategy which only shows explicit config)
-      if (ObjectRegistry.getTableStrategy(ancestorName) === 'sti') {
-        // Check if this ancestor shares the same table
-        const ancestorTableName =
-          ancestor.config?.tableName || ancestor.schema?.tableName;
-        if (ancestorTableName === targetTableName) {
-          // Found the OLDEST STI ancestor with same table - this is the base
-          return ancestorName;
-        }
+
+      // Check if this ancestor EXPLICITLY declares tableStrategy: 'sti'
+      // (not inherited via getTableStrategy(), but set directly in config)
+      if (ancestor.config?.tableStrategy === 'sti') {
+        // Found the OLDEST ancestor with explicit STI - this is the base
+        // All descendants inherit from this table regardless of their tableName
+        return ancestorName;
       }
     }
 
-    // If no matching ancestor found, this class is its own STI base
+    // If no explicit STI ancestor found but we detected STI strategy,
+    // this class is its own STI base (it must have declared tableStrategy: 'sti')
     return className;
   }
 


### PR DESCRIPTION
## Summary

Fixes #703 - STI db:migrate creates separate tables when tableName is null

When STI subclasses are loaded from external manifests with `tableName: null`, `registerFromManifest()` derives a tableName from the class name (e.g., `meetings` from `Meeting`). This caused:

1. `getSTIBase()` to fail finding the parent class because it compared tableNames (`meetings` !== `events`)
2. `getAllSchemas()` to create separate tables for each STI subclass instead of merging columns into the parent table

## Changes

- **`getSTIBase()`**: Now finds the oldest ancestor with explicit `tableStrategy: 'sti'` in config, without requiring tableName matching
- **`getAllSchemas()`**: Handles STI subclasses with null tableName by deriving the tableName from the STI base before processing

## Test plan

- [x] Added `issue-703-sti-null-tablename.test.ts` with 10 test cases covering:
  - `getSTIBase()` finding parent with tableName mismatch
  - `getSTIBase()` finding parent with explicit tableName mismatch  
  - `getAllSchemas()` merging columns into single table
  - `getAllSchemas()` not creating separate tables for STI subclasses
- [x] All existing STI tests pass (issues #690, #693, registry tests)