### PR TITLE
fix(core): include base columns and STI meta columns in getAllSchemas() DDL (#690)

### DIFF
--- a/packages/core/src/__tests__/issue-703-sti-null-tablename.test.ts
+++ b/packages/core/src/__tests__/issue-703-sti-null-tablename.test.ts
@@ -219,13 +219,14 @@ describe('Issue #703: STI with null tableName from external manifest', () => {
     it('should only produce ONE table for the entire STI hierarchy', () => {
       const schemas = ObjectRegistry.getAllSchemas();
 
-      // Count tables that match the issue703 prefix
-      const issue703Tables = Object.keys(schemas).filter((name) =>
-        name.startsWith('issue703'),
+      // Count STI tables that match the issue703 prefix
+      // (exclude the CTI table 'issue703_cti' which was registered for getSTIBase comparison)
+      const issue703STITables = Object.keys(schemas).filter(
+        (name) => name.startsWith('issue703') && name !== 'issue703_cti',
       );
 
       // There should be exactly ONE table for the entire STI hierarchy
-      expect(issue703Tables).toEqual(['issue703_events']);
+      expect(issue703STITables).toEqual(['issue703_events']);
     });
   });
 });

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -2429,6 +2429,7 @@ export class ObjectRegistry {
         columns: Record<string, ColumnDefinition>;
         indexes: Array<{ name: string; columns: string[]; unique?: boolean }>;
         ddl: string;
+        isSTI: boolean;
       }
     > = {};
 
@@ -2499,12 +2500,30 @@ export class ObjectRegistry {
         }
 
         if (!tableSchemas[tableName]) {
-          // First class for this table - initialize
+          // First class for this table - initialize with base columns
+          // These are required for all tables but are skipped by fieldsToColumns()
+          const baseColumns: Record<string, ColumnDefinition> = {
+            id: { type: 'TEXT', primaryKey: true },
+            slug: { type: 'TEXT', notNull: true },
+            context: { type: 'TEXT' },
+            created_at: { type: 'TIMESTAMP' },
+            updated_at: { type: 'TIMESTAMP' },
+          };
+
+          // For STI tables, add discriminator and data columns
+          // (Issue #690: db:diff needs these columns to detect schema changes)
+          const isSTI = tableStrategy === 'sti';
+          if (isSTI) {
+            baseColumns._meta_type = { type: 'TEXT', notNull: true };
+            baseColumns._meta_data = { type: 'TEXT' };
+          }
+
           tableSchemas[tableName] = {
             tableName,
-            columns: { ...columnsToUse },
+            columns: { ...baseColumns, ...columnsToUse },
             indexes: [],
             ddl: registered.schema.ddl || '',
+            isSTI,
           };
         } else {
           // Additional class sharing this table (STI scenario)
@@ -2558,6 +2577,7 @@ export class ObjectRegistry {
         ddl = ObjectRegistry.generateDDLFromColumns(
           tableName,
           tableSchema.columns,
+          tableSchema.isSTI,
         );
       }
 
@@ -2594,6 +2614,7 @@ export class ObjectRegistry {
   private static generateDDLFromColumns(
     tableName: string,
     columns: Record<string, ColumnDefinition>,
+    isSTI = false,
   ): string {
     let sql = `CREATE TABLE IF NOT EXISTS "${tableName}" (\n`;
 
@@ -2632,6 +2653,18 @@ export class ObjectRegistry {
     }
 
     sql += columnLines.join(',\n');
+
+    // Add UNIQUE constraint for UPSERT operations
+    // For STI tables: UNIQUE(slug, context, _meta_type) - different types can have same slug+context
+    // For non-STI tables: UNIQUE(slug, context)
+    if (columns.slug && columns.context) {
+      if (isSTI && columns._meta_type) {
+        sql += ',\n  UNIQUE(slug, context, _meta_type)';
+      } else {
+        sql += ',\n  UNIQUE(slug, context)';
+      }
+    }
+
     sql += '\n);';
 
     return sql;


### PR DESCRIPTION
## Summary

Fixes #690

When `getAllSchemas()` regenerates DDL from merged columns for STI tables, it was missing:
- Base columns: `id`, `slug`, `context`, `created_at`, `updated_at`  
- STI meta columns: `_meta_type`, `_meta_data`

This caused `db:diff` to not detect missing STI subclass columns because the generated DDL was incomplete.

## Changes

- Add base columns when initializing table schema in `getAllSchemas()`
- Add `_meta_type` and `_meta_data` columns for STI tables
- Add `UNIQUE(slug, context)` constraint for non-STI tables
- Add `UNIQUE(slug, context, _meta_type)` constraint for STI tables (required for UPSERT operations)
- Fix issue-703 test that incorrectly counted CTI tables as STI tables

## Test plan

- [x] `issue-690-sti-migrate-columns.test.ts` passes - verifies STI subclass columns are detected in DDL
- [x] `issue-703-sti-null-tablename.test.ts` passes - verifies STI inheritance works with null tableName
- [x] All STI tests pass (143 tests in sti-*.test.ts files)