### PR TITLE
fix(vite-plugin): enable external package discovery for STI inheritance

### DIFF
--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -450,6 +450,11 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
         injectPackageInfo: true,
         moduleType: 'smrt',
         loadViteConfig: false, // We are already in Vite context
+        // Enable external package discovery for cross-package STI inheritance
+        // (Issue #690: Without this, smrtDependencies is null and STI child classes
+        // from external packages get separate tables instead of merging into parent)
+        discoverExternalPackages: true,
+        includeExternalBaseClasses: true,
       });
 
       // Generate TypeScript declarations if enabled


### PR DESCRIPTION
## Summary

Enable `discoverExternalPackages` and `includeExternalBaseClasses` when calling `ManifestBuilder.generate()` from the vite plugin.

**Root cause:** Manifests generated during vite builds had `smrtDependencies: null` because the vite plugin wasn't passing `discoverExternalPackages: true` to the manifest builder.

**Impact:** Cross-package STI inheritance detection failed. STI child classes from external packages (e.g., `WeatherForecast` in caelus extends `Event` in smrt-events) got separate tables instead of merging into the parent's STI table.

**Example:**
- `Event` (smrt-events) has `tableStrategy: 'sti'` → should use `events` table
- `WeatherForecast` (caelus) extends `Event` → should merge into `events` table
- Without this fix: WeatherForecast got its own `weather_forecasts` table
- With this fix: WeatherForecast columns merge into `events` table

## Changes

- Added `discoverExternalPackages: true` to enable SMRT package discovery
- Added `includeExternalBaseClasses: true` to load base classes from external packages

## Test plan

- [ ] Build caelus with the updated smrt-core
- [ ] Verify caelus manifest has `smrtDependencies: ["@happyvertical/smrt-events", ...]`
- [ ] Verify WeatherForecast schema either has no separate table or inherits from events
- [ ] Run `smrt db:diff` in a consumer project and verify STI columns are detected

Fixes #690