### PR TITLE
feat(cli): add background job and schedule CLI commands

### DIFF
--- a/packages/agents/src/schedule.test.ts
+++ b/packages/agents/src/schedule.test.ts
@@ -1,0 +1,492 @@
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  AgentSchedule,
+  AgentScheduleCollection,
+  type ScheduleStatus,
+} from './schedule.js';
+
+describe('AgentSchedule', () => {
+  let collection: AgentScheduleCollection;
+  let db: Awaited<ReturnType<typeof getDatabase>>;
+
+  beforeEach(async () => {
+    db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+
+    // Create agent schedules table
+    await db.query(`
+      CREATE TABLE IF NOT EXISTS _smrt_agent_schedules (
+        id TEXT PRIMARY KEY,
+        slug TEXT NOT NULL,
+        context TEXT,
+        agent_type TEXT NOT NULL,
+        agent_id TEXT,
+        agent_config TEXT DEFAULT '{}',
+        cron TEXT NOT NULL,
+        timezone TEXT DEFAULT 'UTC',
+        enabled INTEGER DEFAULT 1,
+        status TEXT DEFAULT 'active',
+        last_run DATETIME,
+        next_run DATETIME,
+        last_status TEXT,
+        last_error TEXT,
+        run_count INTEGER DEFAULT 0,
+        success_count INTEGER DEFAULT 0,
+        failure_count INTEGER DEFAULT 0,
+        max_concurrent INTEGER DEFAULT 1,
+        running_count INTEGER DEFAULT 0,
+        timeout INTEGER DEFAULT 3600000,
+        method TEXT DEFAULT 'run',
+        method_args TEXT DEFAULT '{}',
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(slug, context)
+      )
+    `);
+
+    collection = await AgentScheduleCollection.create({
+      db: { type: 'sqlite', url: ':memory:' },
+    });
+    (collection as unknown as { _db: typeof db })._db = db;
+  });
+
+  afterEach(async () => {
+    // Cleanup
+  });
+
+  describe('create and save', () => {
+    it('should create a schedule with default values', async () => {
+      const schedule = await collection.create({
+        agentType: 'Praeco',
+        cron: '0 2 * * *',
+      });
+      await schedule.save();
+
+      expect(schedule.id).toBeDefined();
+      expect(schedule.enabled).toBe(true);
+      expect(schedule.status).toBe('active');
+      expect(schedule.maxConcurrent).toBe(1);
+      expect(schedule.method).toBe('run');
+    });
+
+    it('should create a schedule with custom values', async () => {
+      const schedule = await collection.create({
+        agentType: 'Praeco',
+        agentId: 'praeco-main',
+        cron: '0 */6 * * *',
+        timezone: 'America/New_York',
+        maxConcurrent: 2,
+        timeout: 7200000,
+        method: 'scrape',
+        methodArgs: { depth: 3 },
+      });
+      await schedule.save();
+
+      expect(schedule.agentType).toBe('Praeco');
+      expect(schedule.agentId).toBe('praeco-main');
+      expect(schedule.cron).toBe('0 */6 * * *');
+      expect(schedule.timezone).toBe('America/New_York');
+      expect(schedule.maxConcurrent).toBe(2);
+      expect(schedule.timeout).toBe(7200000);
+      expect(schedule.method).toBe('scrape');
+      expect(schedule.methodArgs).toEqual({ depth: 3 });
+    });
+  });
+
+  describe('enable() and disable()', () => {
+    it('should enable a disabled schedule', async () => {
+      const schedule = await collection.create({
+        agentType: 'Praeco',
+        cron: '0 2 * * *',
+      });
+      schedule.enabled = false;
+      schedule.status = 'disabled';
+      await schedule.save();
+
+      await schedule.enable();
+
+      expect(schedule.enabled).toBe(true);
+      expect(schedule.status).toBe('active');
+      expect(schedule.nextRun).not.toBeNull();
+    });
+
+    it('should disable an enabled schedule', async () => {
+      const schedule = await collection.create({
+        agentType: 'Praeco',
+        cron: '0 2 * * *',
+      });
+      await schedule.save();
+
+      await schedule.disable();
+
+      expect(schedule.enabled).toBe(false);
+      expect(schedule.status).toBe('disabled');
+    });
+  });
+
+  describe('pause() and resume()', () => {
+    it('should pause a schedule', async () => {
+      const schedule = await collection.create({
+        agentType: 'Praeco',
+        cron: '0 2 * * *',
+      });
+      await schedule.save();
+
+      await schedule.pause();
+
+      expect(schedule.status).toBe('paused');
+    });
+
+    it('should resume a paused schedule', async () => {
+      const schedule = await collection.create({
+        agentType: 'Praeco',
+        cron: '0 2 * * *',
+      });
+      schedule.status = 'paused';
+      await schedule.save();
+
+      await schedule.resume();
+
+      expect(schedule.status).toBe('active');
+    });
+  });
+
+  describe('recordSuccess() and recordFailure()', () => {
+    it('should record a successful run', async () => {
+      const schedule = await collection.create({
+        agentType: 'Praeco',
+        cron: '0 2 * * *',
+      });
+      schedule.runningCount = 1;
+      await schedule.save();
+
+      await schedule.recordSuccess();
+
+      expect(schedule.lastRun).toBeInstanceOf(Date);
+      expect(schedule.lastStatus).toBe('success');
+      expect(schedule.runCount).toBe(1);
+      expect(schedule.successCount).toBe(1);
+      expect(schedule.runningCount).toBe(0);
+    });
+
+    it('should record a failed run', async () => {
+      const schedule = await collection.create({
+        agentType: 'Praeco',
+        cron: '0 2 * * *',
+      });
+      schedule.runningCount = 1;
+      await schedule.save();
+
+      await schedule.recordFailure('Connection timeout');
+
+      expect(schedule.lastRun).toBeInstanceOf(Date);
+      expect(schedule.lastStatus).toBe('failed');
+      expect(schedule.lastError).toBe('Connection timeout');
+      expect(schedule.runCount).toBe(1);
+      expect(schedule.failureCount).toBe(1);
+      expect(schedule.runningCount).toBe(0);
+    });
+  });
+
+  describe('isDue()', () => {
+    it('should return false when disabled', async () => {
+      const schedule = await collection.create({
+        agentType: 'Praeco',
+        cron: '0 2 * * *',
+      });
+      schedule.enabled = false;
+      await schedule.save();
+
+      expect(schedule.isDue()).toBe(false);
+    });
+
+    it('should return false when status is not active', async () => {
+      const schedule = await collection.create({
+        agentType: 'Praeco',
+        cron: '0 2 * * *',
+      });
+      schedule.status = 'paused';
+      await schedule.save();
+
+      expect(schedule.isDue()).toBe(false);
+    });
+
+    it('should return false when no nextRun', async () => {
+      const schedule = await collection.create({
+        agentType: 'Praeco',
+        cron: '0 2 * * *',
+      });
+      schedule.nextRun = null;
+      await schedule.save();
+
+      expect(schedule.isDue()).toBe(false);
+    });
+
+    it('should return false when max concurrent reached', async () => {
+      const schedule = await collection.create({
+        agentType: 'Praeco',
+        cron: '0 2 * * *',
+      });
+      schedule.maxConcurrent = 1;
+      schedule.runningCount = 1;
+      schedule.nextRun = new Date(Date.now() - 60000); // Past due
+      await schedule.save();
+
+      expect(schedule.isDue()).toBe(false);
+    });
+
+    it('should return true when due and available', async () => {
+      const schedule = await collection.create({
+        agentType: 'Praeco',
+        cron: '0 2 * * *',
+      });
+      schedule.nextRun = new Date(Date.now() - 60000); // 1 minute ago
+      await schedule.save();
+
+      expect(schedule.isDue()).toBe(true);
+    });
+  });
+
+  describe('calculateNextRun()', () => {
+    it('should calculate next run from cron expression', async () => {
+      const schedule = await collection.create({
+        agentType: 'Praeco',
+        cron: '* * * * *', // Every minute
+      });
+
+      schedule.calculateNextRun();
+
+      expect(schedule.nextRun).not.toBeNull();
+      expect(schedule.nextRun?.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('should set error status for invalid cron', async () => {
+      const schedule = await collection.create({
+        agentType: 'Praeco',
+        cron: 'invalid cron',
+      });
+
+      schedule.calculateNextRun();
+
+      expect(schedule.nextRun).toBeNull();
+      expect(schedule.status).toBe('error');
+      expect(schedule.lastError).toContain('Invalid cron expression');
+    });
+
+    it('should clear nextRun when disabled', async () => {
+      const schedule = await collection.create({
+        agentType: 'Praeco',
+        cron: '0 2 * * *',
+      });
+      schedule.enabled = false;
+
+      schedule.calculateNextRun();
+
+      expect(schedule.nextRun).toBeNull();
+    });
+  });
+
+  describe('getDescription()', () => {
+    it('should return description with agent ID', async () => {
+      const schedule = await collection.create({
+        agentType: 'Praeco',
+        agentId: 'praeco-main',
+        cron: '0 2 * * *',
+      });
+
+      expect(schedule.getDescription()).toBe(
+        'Praeco#praeco-main.run() @ 0 2 * * *',
+      );
+    });
+
+    it('should return description without agent ID', async () => {
+      const schedule = await collection.create({
+        agentType: 'Praeco',
+        cron: '0 2 * * *',
+      });
+
+      expect(schedule.getDescription()).toBe('Praeco.run() @ 0 2 * * *');
+    });
+
+    it('should include custom method', async () => {
+      const schedule = await collection.create({
+        agentType: 'Praeco',
+        cron: '0 2 * * *',
+        method: 'scrape',
+      });
+
+      expect(schedule.getDescription()).toBe('Praeco.scrape() @ 0 2 * * *');
+    });
+  });
+});
+
+describe('AgentScheduleCollection', () => {
+  let collection: AgentScheduleCollection;
+  let db: Awaited<ReturnType<typeof getDatabase>>;
+
+  beforeEach(async () => {
+    db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+
+    await db.query(`
+      CREATE TABLE IF NOT EXISTS _smrt_agent_schedules (
+        id TEXT PRIMARY KEY,
+        slug TEXT NOT NULL,
+        context TEXT,
+        agent_type TEXT NOT NULL,
+        agent_id TEXT,
+        agent_config TEXT DEFAULT '{}',
+        cron TEXT NOT NULL,
+        timezone TEXT DEFAULT 'UTC',
+        enabled INTEGER DEFAULT 1,
+        status TEXT DEFAULT 'active',
+        last_run DATETIME,
+        next_run DATETIME,
+        last_status TEXT,
+        last_error TEXT,
+        run_count INTEGER DEFAULT 0,
+        success_count INTEGER DEFAULT 0,
+        failure_count INTEGER DEFAULT 0,
+        max_concurrent INTEGER DEFAULT 1,
+        running_count INTEGER DEFAULT 0,
+        timeout INTEGER DEFAULT 3600000,
+        method TEXT DEFAULT 'run',
+        method_args TEXT DEFAULT '{}',
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(slug, context)
+      )
+    `);
+
+    collection = await AgentScheduleCollection.create({
+      db: { type: 'sqlite', url: ':memory:' },
+    });
+    (collection as unknown as { _db: typeof db })._db = db;
+  });
+
+  describe('listByStatus()', () => {
+    it('should list schedules by status', async () => {
+      const s1 = await collection.create({
+        agentType: 'Agent1',
+        cron: '0 * * * *',
+      });
+      s1.status = 'active';
+      await s1.save();
+
+      const s2 = await collection.create({
+        agentType: 'Agent2',
+        cron: '0 * * * *',
+      });
+      s2.status = 'paused';
+      await s2.save();
+
+      const active = await collection.listByStatus('active');
+      expect(active).toHaveLength(1);
+      expect(active[0].agentType).toBe('Agent1');
+    });
+  });
+
+  describe('listDue()', () => {
+    it('should list schedules that are due', async () => {
+      const past = new Date(Date.now() - 60000);
+      const future = new Date(Date.now() + 60000);
+
+      const s1 = await collection.create({
+        agentType: 'Agent1',
+        cron: '0 * * * *',
+      });
+      s1.nextRun = past;
+      await s1.save();
+
+      const s2 = await collection.create({
+        agentType: 'Agent2',
+        cron: '0 * * * *',
+      });
+      s2.nextRun = future;
+      await s2.save();
+
+      const due = await collection.listDue();
+      expect(due).toHaveLength(1);
+      expect(due[0].agentType).toBe('Agent1');
+    });
+  });
+
+  describe('listByAgentType()', () => {
+    it('should list schedules for agent type', async () => {
+      const s1 = await collection.create({
+        agentType: 'Praeco',
+        cron: '0 2 * * *',
+      });
+      await s1.save();
+
+      const s2 = await collection.create({
+        agentType: 'Caelus',
+        cron: '0 4 * * *',
+      });
+      await s2.save();
+
+      const praeco = await collection.listByAgentType('Praeco');
+      expect(praeco).toHaveLength(1);
+      expect(praeco[0].agentType).toBe('Praeco');
+    });
+
+    it('should exclude disabled by default', async () => {
+      const s1 = await collection.create({
+        agentType: 'Praeco',
+        cron: '0 2 * * *',
+      });
+      s1.enabled = false;
+      await s1.save();
+
+      const result = await collection.listByAgentType('Praeco');
+      expect(result).toHaveLength(0);
+    });
+
+    it('should include disabled when requested', async () => {
+      const s1 = await collection.create({
+        agentType: 'Praeco',
+        cron: '0 2 * * *',
+      });
+      s1.enabled = false;
+      await s1.save();
+
+      const result = await collection.listByAgentType('Praeco', {
+        includeDisabled: true,
+      });
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('stats()', () => {
+    it('should return schedule statistics', async () => {
+      const statuses: ScheduleStatus[] = [
+        'active',
+        'active',
+        'paused',
+        'disabled',
+        'error',
+      ];
+
+      for (const status of statuses) {
+        const s = await collection.create({
+          agentType: 'Agent',
+          cron: '0 * * * *',
+        });
+        s.status = status;
+        s.enabled = status !== 'disabled';
+        // For due calculation
+        if (status === 'active') {
+          s.nextRun = new Date(Date.now() - 60000); // Past
+        }
+        await s.save();
+      }
+
+      const stats = await collection.stats();
+      expect(stats.total).toBe(5);
+      expect(stats.active).toBe(2);
+      expect(stats.paused).toBe(1);
+      expect(stats.disabled).toBe(1);
+      expect(stats.error).toBe(1);
+      expect(stats.dueNow).toBe(2); // Both active schedules are due
+    });
+  });
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,7 @@
     "@happyvertical/smrt-agents": "workspace:*",
     "@happyvertical/smrt-config": "workspace:*",
     "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-jobs": "workspace:*",
     "@happyvertical/smrt-types": "workspace:*",
     "@happyvertical/sql": "^0.66.0",
     "@happyvertical/utils": "^0.66.0",

--- a/packages/cli/src/cli-generator.ts
+++ b/packages/cli/src/cli-generator.ts
@@ -47,6 +47,8 @@ let _gitCommands: Record<string, Command> | null = null;
 let _initCommands: Record<string, Command> | null = null;
 let _utilityCommands: Record<string, Command> | null = null;
 let _dispatchCommands: Record<string, Command> | null = null;
+let _jobCommands: Record<string, Command> | null = null;
+let _scheduleCommands: Record<string, Command> | null = null;
 
 async function getGnodeCommands(): Promise<Record<string, Command>> {
   if (!_gnodeCommands) {
@@ -94,6 +96,22 @@ async function getDispatchCommands(): Promise<Record<string, Command>> {
     _dispatchCommands = dispatchCommands;
   }
   return _dispatchCommands;
+}
+
+async function getJobCommands(): Promise<Record<string, Command>> {
+  if (!_jobCommands) {
+    const { jobCommands } = await import('./commands/index.js');
+    _jobCommands = jobCommands;
+  }
+  return _jobCommands;
+}
+
+async function getScheduleCommands(): Promise<Record<string, Command>> {
+  if (!_scheduleCommands) {
+    const { scheduleCommands } = await import('./commands/index.js');
+    _scheduleCommands = scheduleCommands;
+  }
+  return _scheduleCommands;
 }
 
 export interface CLIConfig {
@@ -873,6 +891,8 @@ export class CLIGenerator {
       initCommands,
       utilityCommands,
       dispatchCommands,
+      jobCommands,
+      scheduleCommands,
     ] = await Promise.all([
       getGnodeCommands(),
       getGenerateCommands(),
@@ -880,6 +900,8 @@ export class CLIGenerator {
       getInitCommands(),
       getUtilityCommands(),
       getDispatchCommands(),
+      getJobCommands(),
+      getScheduleCommands(),
     ]);
     const builtInCommands = {
       ...gnodeCommands,
@@ -888,6 +910,8 @@ export class CLIGenerator {
       ...initCommands,
       ...utilityCommands,
       ...dispatchCommands,
+      ...jobCommands,
+      ...scheduleCommands,
     };
 
     const builtInCommand = builtInCommands[parsed.command];
@@ -1209,6 +1233,8 @@ export class CLIGenerator {
       initCommands,
       utilityCommands,
       dispatchCommands,
+      jobCommands,
+      scheduleCommands,
     ] = await Promise.all([
       getGnodeCommands(),
       getGenerateCommands(),
@@ -1216,6 +1242,8 @@ export class CLIGenerator {
       getInitCommands(),
       getUtilityCommands(),
       getDispatchCommands(),
+      getJobCommands(),
+      getScheduleCommands(),
     ]);
 
     console.log('Project Setup:');
@@ -1244,6 +1272,16 @@ export class CLIGenerator {
 
     console.log('Gnode Commands:');
     for (const command of Object.values(gnodeCommands)) {
+      this.showCommandHelp(command);
+    }
+
+    console.log('Background Jobs:');
+    for (const command of Object.values(jobCommands)) {
+      this.showCommandHelp(command);
+    }
+
+    console.log('Agent Scheduling:');
+    for (const command of Object.values(scheduleCommands)) {
       this.showCommandHelp(command);
     }
 

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -15,4 +15,7 @@ export { generateCommands } from './generate.js';
 export { gitCommands } from './git.js';
 export { gnodeCommands } from './gnode.js';
 export { initCommands } from './init.js';
+// Background worker commands
+export { jobCommands } from './jobs.js';
+export { scheduleCommands } from './schedules.js';
 export { utilityCommands } from './utilities.js';

--- a/packages/cli/src/commands/jobs.ts
+++ b/packages/cli/src/commands/jobs.ts
@@ -1,0 +1,527 @@
+/**
+ * Job Commands - CLI tools for background job management
+ *
+ * Commands for managing background jobs and workers.
+ */
+
+import type { CLICommand } from '../cli-generator.js';
+
+/**
+ * Get job collection with database from config
+ */
+async function getJobCollection() {
+  const { SmrtJobCollection } = await import('@happyvertical/smrt-jobs');
+  const { getPackageConfig } = await import('@happyvertical/smrt-config');
+  const { DEFAULT_CLI_CONFIG } = await import('../config.js');
+
+  const config = getPackageConfig('cli', DEFAULT_CLI_CONFIG);
+  const dbConfig = config.database;
+
+  if (!dbConfig?.url) {
+    throw new Error(
+      'Database not configured. Set database.url in smrt.config.ts or use --db option.',
+    );
+  }
+
+  return SmrtJobCollection.create({
+    db: {
+      type: dbConfig.type || 'sqlite',
+      url: dbConfig.url,
+    },
+  });
+}
+
+/**
+ * Get task runner with database from config
+ */
+async function getTaskRunner(options: {
+  concurrency?: number;
+  queues?: string[];
+  pollInterval?: number;
+}) {
+  const { TaskRunner } = await import('@happyvertical/smrt-jobs');
+  const { getPackageConfig } = await import('@happyvertical/smrt-config');
+  const { getDatabase } = await import('@happyvertical/sql');
+  const { DEFAULT_CLI_CONFIG } = await import('../config.js');
+
+  const config = getPackageConfig('cli', DEFAULT_CLI_CONFIG);
+  const dbConfig = config.database;
+
+  if (!dbConfig?.url) {
+    throw new Error(
+      'Database not configured. Set database.url in smrt.config.ts or use --db option.',
+    );
+  }
+
+  const db = await getDatabase({
+    type: dbConfig.type || 'sqlite',
+    url: dbConfig.url,
+  });
+
+  const runner = new TaskRunner({
+    concurrency: options.concurrency || 5,
+    queues: options.queues,
+    pollInterval: options.pollInterval || 5000,
+  });
+
+  await runner.initialize(db);
+  return runner;
+}
+
+/**
+ * Job management commands
+ */
+export const jobCommands: Record<string, CLICommand> = {
+  'job:list': {
+    name: 'job:list',
+    description: 'List background jobs',
+    args: [],
+    options: {
+      status: {
+        type: 'string',
+        description:
+          'Filter by status (pending|running|completed|failed|cancelled)',
+        short: 's',
+      },
+      queue: {
+        type: 'string',
+        description: 'Filter by queue name',
+        short: 'q',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum results (default: 50)',
+        short: 'l',
+        default: 50,
+      },
+      json: {
+        type: 'boolean',
+        description: 'Output as JSON',
+        short: 'j',
+        default: false,
+      },
+    },
+    handler: async (_args: string[], options: any) => {
+      try {
+        const collection = await getJobCollection();
+
+        let jobs: Awaited<ReturnType<typeof collection.list>>;
+        if (options.status) {
+          jobs = await collection.listByStatus(options.status, {
+            queue: options.queue,
+            limit: options.limit || 50,
+          });
+        } else {
+          const where: Record<string, unknown> = {};
+          if (options.queue) {
+            where.queue = options.queue;
+          }
+          jobs = await collection.list({
+            where,
+            orderBy: ['priority DESC', 'run_at ASC'],
+            limit: options.limit || 50,
+          });
+        }
+
+        if (options.json) {
+          console.log(JSON.stringify(jobs, null, 2));
+          return;
+        }
+
+        if (jobs.length === 0) {
+          console.log('No jobs found.');
+          return;
+        }
+
+        console.log(`\nFound ${jobs.length} job(s):\n`);
+        console.log(
+          'ID'.padEnd(12) +
+            'OBJECT'.padEnd(20) +
+            'METHOD'.padEnd(15) +
+            'QUEUE'.padEnd(12) +
+            'STATUS'.padEnd(12) +
+            'ATTEMPTS',
+        );
+        console.log('-'.repeat(83));
+
+        for (const job of jobs) {
+          const object = job.objectId
+            ? `${job.objectType}#${job.objectId.substring(0, 6)}`
+            : job.objectType;
+          const jobId = job.id || '-';
+          console.log(
+            jobId.substring(0, 10).padEnd(12) +
+              object.substring(0, 18).padEnd(20) +
+              job.method.substring(0, 13).padEnd(15) +
+              job.queue.substring(0, 10).padEnd(12) +
+              job.status.padEnd(12) +
+              `${job.attempts}/${job.maxAttempts}`,
+          );
+        }
+        console.log();
+      } catch (error) {
+        console.error(
+          'Error listing jobs:',
+          error instanceof Error ? error.message : error,
+        );
+        process.exit(1);
+      }
+    },
+  },
+
+  'job:get': {
+    name: 'job:get',
+    description: 'Get details of a specific job',
+    args: ['<id>'],
+    options: {
+      json: {
+        type: 'boolean',
+        description: 'Output as JSON',
+        short: 'j',
+        default: false,
+      },
+    },
+    handler: async (args: string[], options: any) => {
+      if (args.length < 1) {
+        console.error('Usage: smrt job:get <id>');
+        process.exit(1);
+      }
+
+      const [id] = args;
+
+      try {
+        const collection = await getJobCollection();
+        const job = await collection.get(id);
+
+        if (!job) {
+          console.error(`Job not found: ${id}`);
+          process.exit(1);
+        }
+
+        if (options.json) {
+          console.log(JSON.stringify(job, null, 2));
+          return;
+        }
+
+        console.log('\nJob Details:');
+        console.log('─'.repeat(50));
+        console.log(`ID:           ${job.id}`);
+        console.log(`Description:  ${job.getDescription()}`);
+        console.log(`Queue:        ${job.queue}`);
+        console.log(`Status:       ${job.status}`);
+        console.log(`Priority:     ${job.priority}`);
+        console.log(`Attempts:     ${job.attempts}/${job.maxAttempts}`);
+        console.log(`Timeout:      ${job.timeout}ms`);
+        console.log(`Run At:       ${job.runAt.toISOString()}`);
+
+        if (job.startedAt) {
+          console.log(`Started At:   ${job.startedAt.toISOString()}`);
+        }
+        if (job.completedAt) {
+          console.log(`Completed At: ${job.completedAt.toISOString()}`);
+        }
+        if (job.lastError) {
+          console.log(`Last Error:   ${job.lastError}`);
+        }
+        if (job.resultPointer) {
+          console.log(`Result:       ${job.resultPointer}`);
+        }
+
+        console.log('\nArguments:');
+        console.log(JSON.stringify(job.args, null, 2));
+        console.log();
+      } catch (error) {
+        console.error(
+          'Error getting job:',
+          error instanceof Error ? error.message : error,
+        );
+        process.exit(1);
+      }
+    },
+  },
+
+  'job:retry': {
+    name: 'job:retry',
+    description: 'Retry a failed or cancelled job',
+    args: ['<id>'],
+    options: {},
+    handler: async (args: string[]) => {
+      if (args.length < 1) {
+        console.error('Usage: smrt job:retry <id>');
+        process.exit(1);
+      }
+
+      const [id] = args;
+
+      try {
+        const collection = await getJobCollection();
+        const job = await collection.get(id);
+
+        if (!job) {
+          console.error(`Job not found: ${id}`);
+          process.exit(1);
+        }
+
+        await job.retry();
+        console.log(`Job ${id} reset to pending and will be retried.`);
+      } catch (error) {
+        console.error(
+          'Error retrying job:',
+          error instanceof Error ? error.message : error,
+        );
+        process.exit(1);
+      }
+    },
+  },
+
+  'job:cancel': {
+    name: 'job:cancel',
+    description: 'Cancel a pending or running job',
+    args: ['<id>'],
+    options: {},
+    handler: async (args: string[]) => {
+      if (args.length < 1) {
+        console.error('Usage: smrt job:cancel <id>');
+        process.exit(1);
+      }
+
+      const [id] = args;
+
+      try {
+        const collection = await getJobCollection();
+        const job = await collection.get(id);
+
+        if (!job) {
+          console.error(`Job not found: ${id}`);
+          process.exit(1);
+        }
+
+        await job.cancel();
+        console.log(`Job ${id} has been cancelled.`);
+      } catch (error) {
+        console.error(
+          'Error cancelling job:',
+          error instanceof Error ? error.message : error,
+        );
+        process.exit(1);
+      }
+    },
+  },
+
+  'job:stats': {
+    name: 'job:stats',
+    description: 'Show job queue statistics',
+    args: [],
+    options: {
+      queue: {
+        type: 'string',
+        description: 'Filter by queue name',
+        short: 'q',
+      },
+      json: {
+        type: 'boolean',
+        description: 'Output as JSON',
+        short: 'j',
+        default: false,
+      },
+    },
+    handler: async (_args: string[], options: any) => {
+      try {
+        const collection = await getJobCollection();
+        const stats = await collection.stats(options.queue);
+
+        if (options.json) {
+          console.log(JSON.stringify(stats, null, 2));
+          return;
+        }
+
+        const queue = options.queue || 'all queues';
+        console.log(`\nJob Statistics (${queue}):`);
+        console.log('─'.repeat(30));
+        console.log(`Pending:     ${stats.pending}`);
+        console.log(`Running:     ${stats.running}`);
+        console.log(`Completed:   ${stats.completed}`);
+        console.log(`Failed:      ${stats.failed}`);
+        console.log(`Cancelled:   ${stats.cancelled}`);
+        console.log('─'.repeat(30));
+        console.log(
+          `Total:       ${stats.pending + stats.running + stats.completed + stats.failed + stats.cancelled}`,
+        );
+        console.log();
+      } catch (error) {
+        console.error(
+          'Error getting stats:',
+          error instanceof Error ? error.message : error,
+        );
+        process.exit(1);
+      }
+    },
+  },
+
+  'job:work': {
+    name: 'job:work',
+    description: 'Start a job worker to process background jobs',
+    args: [],
+    options: {
+      concurrency: {
+        type: 'number',
+        description: 'Number of concurrent jobs (default: 5)',
+        short: 'c',
+        default: 5,
+      },
+      queues: {
+        type: 'string',
+        description: 'Comma-separated list of queues to process',
+        short: 'q',
+      },
+      'poll-interval': {
+        type: 'number',
+        description: 'Poll interval in milliseconds (default: 5000)',
+        short: 'p',
+        default: 5000,
+      },
+    },
+    handler: async (_args: string[], options: any) => {
+      try {
+        const queues = options.queues
+          ? options.queues.split(',').map((q: string) => q.trim())
+          : undefined;
+
+        const runner = await getTaskRunner({
+          concurrency: options.concurrency,
+          queues,
+          pollInterval: options['poll-interval'],
+        });
+
+        console.log('\n🚀 Starting job worker...');
+        console.log(`   Concurrency: ${options.concurrency || 5}`);
+        console.log(`   Queues: ${queues ? queues.join(', ') : 'all'}`);
+        console.log(`   Poll Interval: ${options['poll-interval'] || 5000}ms`);
+        console.log('\nPress Ctrl+C to stop.\n');
+
+        // Handle shutdown signals
+        const shutdown = async (signal: string) => {
+          console.log(`\n${signal} received, shutting down gracefully...`);
+          await runner.stop();
+          console.log('Worker stopped.');
+          process.exit(0);
+        };
+
+        process.on('SIGINT', () => shutdown('SIGINT'));
+        process.on('SIGTERM', () => shutdown('SIGTERM'));
+
+        // Start the runner
+        await runner.start();
+
+        // Keep process alive
+        await new Promise(() => {
+          // This will never resolve, keeping the worker running
+        });
+      } catch (error) {
+        console.error(
+          'Error starting worker:',
+          error instanceof Error ? error.message : error,
+        );
+        process.exit(1);
+      }
+    },
+  },
+
+  'job:cleanup': {
+    name: 'job:cleanup',
+    description: 'Clean up old completed/failed jobs',
+    args: [],
+    options: {
+      'completed-older-than': {
+        type: 'number',
+        description: 'Delete completed jobs older than N days (default: 7)',
+        short: 'c',
+        default: 7,
+      },
+      'failed-older-than': {
+        type: 'number',
+        description: 'Delete failed jobs older than N days',
+        short: 'f',
+      },
+      'cancelled-older-than': {
+        type: 'number',
+        description: 'Delete cancelled jobs older than N days',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum jobs to delete (default: unlimited)',
+        short: 'l',
+      },
+      dry: {
+        type: 'boolean',
+        description: 'Show what would be deleted without executing',
+        default: false,
+      },
+    },
+    handler: async (_args: string[], options: any) => {
+      try {
+        const collection = await getJobCollection();
+
+        if (options.dry) {
+          const stats = await collection.stats();
+          console.log('\nCurrent counts:');
+          console.log(`  Completed: ${stats.completed}`);
+          console.log(`  Failed: ${stats.failed}`);
+          console.log(`  Cancelled: ${stats.cancelled}`);
+          console.log(
+            `\nWould delete completed older than ${options['completed-older-than'] || 7} days`,
+          );
+          if (options['failed-older-than']) {
+            console.log(
+              `Would delete failed older than ${options['failed-older-than']} days`,
+            );
+          }
+          if (options['cancelled-older-than']) {
+            console.log(
+              `Would delete cancelled older than ${options['cancelled-older-than']} days`,
+            );
+          }
+          return;
+        }
+
+        const now = Date.now();
+        const daysToMs = (days: number) => days * 24 * 60 * 60 * 1000;
+
+        const cleanupOptions: {
+          completedBefore?: Date;
+          failedBefore?: Date;
+          cancelledBefore?: Date;
+          limit?: number;
+        } = {};
+
+        if (options['completed-older-than']) {
+          cleanupOptions.completedBefore = new Date(
+            now - daysToMs(options['completed-older-than']),
+          );
+        }
+        if (options['failed-older-than']) {
+          cleanupOptions.failedBefore = new Date(
+            now - daysToMs(options['failed-older-than']),
+          );
+        }
+        if (options['cancelled-older-than']) {
+          cleanupOptions.cancelledBefore = new Date(
+            now - daysToMs(options['cancelled-older-than']),
+          );
+        }
+        if (options.limit) {
+          cleanupOptions.limit = options.limit;
+        }
+
+        const deleted = await collection.cleanup(cleanupOptions);
+        console.log(`Cleaned up ${deleted} job(s).`);
+      } catch (error) {
+        console.error(
+          'Error cleaning up jobs:',
+          error instanceof Error ? error.message : error,
+        );
+        process.exit(1);
+      }
+    },
+  },
+};

--- a/packages/cli/src/commands/schedules.ts
+++ b/packages/cli/src/commands/schedules.ts
@@ -1,0 +1,642 @@
+/**
+ * Schedule Commands - CLI tools for agent scheduling
+ *
+ * Commands for managing scheduled agent executions.
+ */
+
+import type { CLICommand } from '../cli-generator.js';
+
+/**
+ * Get schedule collection with database from config
+ */
+async function getScheduleCollection() {
+  const { AgentScheduleCollection } = await import(
+    '@happyvertical/smrt-agents'
+  );
+  const { getPackageConfig } = await import('@happyvertical/smrt-config');
+  const { DEFAULT_CLI_CONFIG } = await import('../config.js');
+
+  const config = getPackageConfig('cli', DEFAULT_CLI_CONFIG);
+  const dbConfig = config.database;
+
+  if (!dbConfig?.url) {
+    throw new Error(
+      'Database not configured. Set database.url in smrt.config.ts or use --db option.',
+    );
+  }
+
+  return AgentScheduleCollection.create({
+    db: {
+      type: dbConfig.type || 'sqlite',
+      url: dbConfig.url,
+    },
+  });
+}
+
+/**
+ * Get schedule runner with database from config
+ */
+async function getScheduleRunner(options: { pollInterval?: number } = {}) {
+  const { ScheduleRunner } = await import('@happyvertical/smrt-jobs');
+  const { getPackageConfig } = await import('@happyvertical/smrt-config');
+  const { getDatabase } = await import('@happyvertical/sql');
+  const { DEFAULT_CLI_CONFIG } = await import('../config.js');
+
+  const config = getPackageConfig('cli', DEFAULT_CLI_CONFIG);
+  const dbConfig = config.database;
+
+  if (!dbConfig?.url) {
+    throw new Error(
+      'Database not configured. Set database.url in smrt.config.ts or use --db option.',
+    );
+  }
+
+  const db = await getDatabase({
+    type: dbConfig.type || 'sqlite',
+    url: dbConfig.url,
+  });
+
+  const runner = new ScheduleRunner({
+    pollInterval: options.pollInterval || 60000,
+  });
+
+  await runner.initialize(db);
+  return runner;
+}
+
+/**
+ * Schedule management commands
+ */
+export const scheduleCommands: Record<string, CLICommand> = {
+  'schedule:list': {
+    name: 'schedule:list',
+    description: 'List agent schedules',
+    args: [],
+    options: {
+      status: {
+        type: 'string',
+        description: 'Filter by status (active|paused|disabled|error)',
+        short: 's',
+      },
+      agent: {
+        type: 'string',
+        description: 'Filter by agent type',
+        short: 'a',
+      },
+      'include-disabled': {
+        type: 'boolean',
+        description: 'Include disabled schedules',
+        default: false,
+      },
+      json: {
+        type: 'boolean',
+        description: 'Output as JSON',
+        short: 'j',
+        default: false,
+      },
+    },
+    handler: async (_args: string[], options: any) => {
+      try {
+        const collection = await getScheduleCollection();
+
+        let schedules: Awaited<ReturnType<typeof collection.list>>;
+        if (options.status) {
+          schedules = await collection.listByStatus(options.status);
+        } else if (options.agent) {
+          schedules = await collection.listByAgentType(options.agent, {
+            includeDisabled: options['include-disabled'],
+          });
+        } else {
+          schedules = await collection.list({
+            orderBy: 'next_run ASC',
+          });
+        }
+
+        if (options.json) {
+          console.log(JSON.stringify(schedules, null, 2));
+          return;
+        }
+
+        if (schedules.length === 0) {
+          console.log('No schedules found.');
+          return;
+        }
+
+        console.log(`\nFound ${schedules.length} schedule(s):\n`);
+        console.log(
+          'ID'.padEnd(12) +
+            'AGENT'.padEnd(20) +
+            'CRON'.padEnd(18) +
+            'STATUS'.padEnd(10) +
+            'NEXT RUN',
+        );
+        console.log('-'.repeat(78));
+
+        for (const schedule of schedules) {
+          const agent = schedule.agentId
+            ? `${schedule.agentType}#${schedule.agentId.substring(0, 6)}`
+            : schedule.agentType;
+          const nextRun = schedule.nextRun
+            ? schedule.nextRun.toISOString().substring(0, 19)
+            : '-';
+          const scheduleId = schedule.id || '-';
+          console.log(
+            scheduleId.substring(0, 10).padEnd(12) +
+              agent.substring(0, 18).padEnd(20) +
+              schedule.cron.substring(0, 16).padEnd(18) +
+              schedule.status.padEnd(10) +
+              nextRun,
+          );
+        }
+        console.log();
+      } catch (error) {
+        console.error(
+          'Error listing schedules:',
+          error instanceof Error ? error.message : error,
+        );
+        process.exit(1);
+      }
+    },
+  },
+
+  'schedule:get': {
+    name: 'schedule:get',
+    description: 'Get details of a specific schedule',
+    args: ['<id>'],
+    options: {
+      json: {
+        type: 'boolean',
+        description: 'Output as JSON',
+        short: 'j',
+        default: false,
+      },
+    },
+    handler: async (args: string[], options: any) => {
+      if (args.length < 1) {
+        console.error('Usage: smrt schedule:get <id>');
+        process.exit(1);
+      }
+
+      const [id] = args;
+
+      try {
+        const collection = await getScheduleCollection();
+        const schedule = await collection.get(id);
+
+        if (!schedule) {
+          console.error(`Schedule not found: ${id}`);
+          process.exit(1);
+        }
+
+        if (options.json) {
+          console.log(JSON.stringify(schedule, null, 2));
+          return;
+        }
+
+        console.log('\nSchedule Details:');
+        console.log('─'.repeat(50));
+        console.log(`ID:           ${schedule.id}`);
+        console.log(`Description:  ${schedule.getDescription()}`);
+        console.log(`Agent Type:   ${schedule.agentType}`);
+        console.log(`Agent ID:     ${schedule.agentId || '-'}`);
+        console.log(`Cron:         ${schedule.cron}`);
+        console.log(`Timezone:     ${schedule.timezone}`);
+        console.log(`Status:       ${schedule.status}`);
+        console.log(`Enabled:      ${schedule.enabled ? 'yes' : 'no'}`);
+        console.log(`Method:       ${schedule.method}`);
+        console.log(`Max Concurrent: ${schedule.maxConcurrent}`);
+        console.log(`Timeout:      ${schedule.timeout}ms`);
+
+        console.log('\nExecution Stats:');
+        console.log(`  Total Runs:   ${schedule.runCount}`);
+        console.log(`  Successes:    ${schedule.successCount}`);
+        console.log(`  Failures:     ${schedule.failureCount}`);
+        console.log(`  Running Now:  ${schedule.runningCount}`);
+
+        if (schedule.lastRun) {
+          console.log(`\nLast Run:     ${schedule.lastRun.toISOString()}`);
+          console.log(`Last Status:  ${schedule.lastStatus || '-'}`);
+        }
+        if (schedule.lastError) {
+          console.log(`Last Error:   ${schedule.lastError}`);
+        }
+        if (schedule.nextRun) {
+          console.log(`\nNext Run:     ${schedule.nextRun.toISOString()}`);
+        }
+
+        if (Object.keys(schedule.agentConfig).length > 0) {
+          console.log('\nAgent Config:');
+          console.log(JSON.stringify(schedule.agentConfig, null, 2));
+        }
+
+        if (Object.keys(schedule.methodArgs).length > 0) {
+          console.log('\nMethod Args:');
+          console.log(JSON.stringify(schedule.methodArgs, null, 2));
+        }
+        console.log();
+      } catch (error) {
+        console.error(
+          'Error getting schedule:',
+          error instanceof Error ? error.message : error,
+        );
+        process.exit(1);
+      }
+    },
+  },
+
+  'schedule:create': {
+    name: 'schedule:create',
+    description: 'Create a new agent schedule',
+    args: ['<agent-type>'],
+    options: {
+      cron: {
+        type: 'string',
+        description: 'Cron expression (required)',
+        short: 'c',
+      },
+      'agent-id': {
+        type: 'string',
+        description: 'Specific agent instance ID',
+        short: 'i',
+      },
+      timezone: {
+        type: 'string',
+        description: 'Timezone (default: UTC)',
+        short: 't',
+        default: 'UTC',
+      },
+      method: {
+        type: 'string',
+        description: 'Method to call (default: run)',
+        short: 'm',
+        default: 'run',
+      },
+      'max-concurrent': {
+        type: 'number',
+        description: 'Maximum concurrent runs (default: 1)',
+        default: 1,
+      },
+      timeout: {
+        type: 'number',
+        description: 'Timeout in milliseconds (default: 3600000)',
+        default: 3600000,
+      },
+      disabled: {
+        type: 'boolean',
+        description: 'Create in disabled state',
+        default: false,
+      },
+    },
+    handler: async (args: string[], options: any) => {
+      if (args.length < 1) {
+        console.error('Usage: smrt schedule:create <agent-type> --cron "..."');
+        process.exit(1);
+      }
+
+      if (!options.cron) {
+        console.error('Error: --cron option is required');
+        process.exit(1);
+      }
+
+      const [agentType] = args;
+
+      try {
+        const collection = await getScheduleCollection();
+        const schedule = await collection.create({
+          agentType,
+          agentId: options['agent-id'] || null,
+          cron: options.cron,
+          timezone: options.timezone,
+          method: options.method,
+          maxConcurrent: options['max-concurrent'],
+          timeout: options.timeout,
+          enabled: !options.disabled,
+          status: options.disabled ? 'disabled' : 'active',
+        });
+
+        await schedule.save();
+
+        console.log(`\nCreated schedule: ${schedule.id}`);
+        console.log(`Description: ${schedule.getDescription()}`);
+        if (schedule.nextRun) {
+          console.log(`Next run: ${schedule.nextRun.toISOString()}`);
+        }
+        console.log();
+      } catch (error) {
+        console.error(
+          'Error creating schedule:',
+          error instanceof Error ? error.message : error,
+        );
+        process.exit(1);
+      }
+    },
+  },
+
+  'schedule:enable': {
+    name: 'schedule:enable',
+    description: 'Enable a schedule',
+    args: ['<id>'],
+    options: {},
+    handler: async (args: string[]) => {
+      if (args.length < 1) {
+        console.error('Usage: smrt schedule:enable <id>');
+        process.exit(1);
+      }
+
+      const [id] = args;
+
+      try {
+        const collection = await getScheduleCollection();
+        const schedule = await collection.get(id);
+
+        if (!schedule) {
+          console.error(`Schedule not found: ${id}`);
+          process.exit(1);
+        }
+
+        await schedule.enable();
+        console.log(`Schedule ${id} enabled.`);
+        if (schedule.nextRun) {
+          console.log(`Next run: ${schedule.nextRun.toISOString()}`);
+        }
+      } catch (error) {
+        console.error(
+          'Error enabling schedule:',
+          error instanceof Error ? error.message : error,
+        );
+        process.exit(1);
+      }
+    },
+  },
+
+  'schedule:disable': {
+    name: 'schedule:disable',
+    description: 'Disable a schedule',
+    args: ['<id>'],
+    options: {},
+    handler: async (args: string[]) => {
+      if (args.length < 1) {
+        console.error('Usage: smrt schedule:disable <id>');
+        process.exit(1);
+      }
+
+      const [id] = args;
+
+      try {
+        const collection = await getScheduleCollection();
+        const schedule = await collection.get(id);
+
+        if (!schedule) {
+          console.error(`Schedule not found: ${id}`);
+          process.exit(1);
+        }
+
+        await schedule.disable();
+        console.log(`Schedule ${id} disabled.`);
+      } catch (error) {
+        console.error(
+          'Error disabling schedule:',
+          error instanceof Error ? error.message : error,
+        );
+        process.exit(1);
+      }
+    },
+  },
+
+  'schedule:pause': {
+    name: 'schedule:pause',
+    description: 'Temporarily pause a schedule',
+    args: ['<id>'],
+    options: {},
+    handler: async (args: string[]) => {
+      if (args.length < 1) {
+        console.error('Usage: smrt schedule:pause <id>');
+        process.exit(1);
+      }
+
+      const [id] = args;
+
+      try {
+        const collection = await getScheduleCollection();
+        const schedule = await collection.get(id);
+
+        if (!schedule) {
+          console.error(`Schedule not found: ${id}`);
+          process.exit(1);
+        }
+
+        await schedule.pause();
+        console.log(`Schedule ${id} paused.`);
+      } catch (error) {
+        console.error(
+          'Error pausing schedule:',
+          error instanceof Error ? error.message : error,
+        );
+        process.exit(1);
+      }
+    },
+  },
+
+  'schedule:resume': {
+    name: 'schedule:resume',
+    description: 'Resume a paused schedule',
+    args: ['<id>'],
+    options: {},
+    handler: async (args: string[]) => {
+      if (args.length < 1) {
+        console.error('Usage: smrt schedule:resume <id>');
+        process.exit(1);
+      }
+
+      const [id] = args;
+
+      try {
+        const collection = await getScheduleCollection();
+        const schedule = await collection.get(id);
+
+        if (!schedule) {
+          console.error(`Schedule not found: ${id}`);
+          process.exit(1);
+        }
+
+        await schedule.resume();
+        console.log(`Schedule ${id} resumed.`);
+        if (schedule.nextRun) {
+          console.log(`Next run: ${schedule.nextRun.toISOString()}`);
+        }
+      } catch (error) {
+        console.error(
+          'Error resuming schedule:',
+          error instanceof Error ? error.message : error,
+        );
+        process.exit(1);
+      }
+    },
+  },
+
+  'schedule:delete': {
+    name: 'schedule:delete',
+    description: 'Delete a schedule',
+    args: ['<id>'],
+    options: {
+      force: {
+        type: 'boolean',
+        description: 'Skip confirmation',
+        short: 'f',
+        default: false,
+      },
+    },
+    handler: async (args: string[], options: any) => {
+      if (args.length < 1) {
+        console.error('Usage: smrt schedule:delete <id>');
+        process.exit(1);
+      }
+
+      const [id] = args;
+
+      try {
+        const collection = await getScheduleCollection();
+        const schedule = await collection.get(id);
+
+        if (!schedule) {
+          console.error(`Schedule not found: ${id}`);
+          process.exit(1);
+        }
+
+        if (!options.force) {
+          const readline = await import('node:readline');
+          const rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout,
+          });
+
+          const answer = await new Promise<string>((resolve) => {
+            rl.question(
+              `Delete schedule "${schedule.getDescription()}"? [y/N] `,
+              resolve,
+            );
+          });
+          rl.close();
+
+          if (answer.toLowerCase() !== 'y') {
+            console.log('Cancelled.');
+            return;
+          }
+        }
+
+        await schedule.delete();
+        console.log(`Schedule ${id} deleted.`);
+      } catch (error) {
+        console.error(
+          'Error deleting schedule:',
+          error instanceof Error ? error.message : error,
+        );
+        process.exit(1);
+      }
+    },
+  },
+
+  'schedule:stats': {
+    name: 'schedule:stats',
+    description: 'Show schedule statistics',
+    args: [],
+    options: {
+      json: {
+        type: 'boolean',
+        description: 'Output as JSON',
+        short: 'j',
+        default: false,
+      },
+    },
+    handler: async (_args: string[], options: any) => {
+      try {
+        const collection = await getScheduleCollection();
+        const stats = await collection.stats();
+
+        if (options.json) {
+          console.log(JSON.stringify(stats, null, 2));
+          return;
+        }
+
+        console.log('\nSchedule Statistics:');
+        console.log('─'.repeat(30));
+        console.log(`Active:      ${stats.active}`);
+        console.log(`Paused:      ${stats.paused}`);
+        console.log(`Disabled:    ${stats.disabled}`);
+        console.log(`Error:       ${stats.error}`);
+        console.log('─'.repeat(30));
+        console.log(`Total:       ${stats.total}`);
+        console.log(`Due Now:     ${stats.dueNow}`);
+        console.log();
+      } catch (error) {
+        console.error(
+          'Error getting stats:',
+          error instanceof Error ? error.message : error,
+        );
+        process.exit(1);
+      }
+    },
+  },
+
+  'schedule:run': {
+    name: 'schedule:run',
+    description: 'Start the schedule runner to process due schedules',
+    args: [],
+    options: {
+      'poll-interval': {
+        type: 'number',
+        description: 'Poll interval in milliseconds (default: 60000)',
+        short: 'p',
+        default: 60000,
+      },
+      once: {
+        type: 'boolean',
+        description: 'Run once and exit',
+        default: false,
+      },
+    },
+    handler: async (_args: string[], options: any) => {
+      try {
+        const runner = await getScheduleRunner({
+          pollInterval: options['poll-interval'],
+        });
+
+        if (options.once) {
+          console.log('Checking for due schedules...');
+          const processed = await runner.processOnce();
+          console.log(`Processed ${processed} schedule(s).`);
+          return;
+        }
+
+        console.log('\n📅 Starting schedule runner...');
+        console.log(`   Poll Interval: ${options['poll-interval'] || 60000}ms`);
+        console.log('\nPress Ctrl+C to stop.\n');
+
+        // Handle shutdown signals
+        const shutdown = async (signal: string) => {
+          console.log(`\n${signal} received, shutting down gracefully...`);
+          await runner.stop();
+          console.log('Schedule runner stopped.');
+          process.exit(0);
+        };
+
+        process.on('SIGINT', () => shutdown('SIGINT'));
+        process.on('SIGTERM', () => shutdown('SIGTERM'));
+
+        // Start the runner
+        await runner.start();
+
+        // Keep process alive
+        await new Promise(() => {
+          // This will never resolve, keeping the runner running
+        });
+      } catch (error) {
+        console.error(
+          'Error starting schedule runner:',
+          error instanceof Error ? error.message : error,
+        );
+        process.exit(1);
+      }
+    },
+  },
+};

--- a/packages/jobs/src/__tests__/smrt-job.test.ts
+++ b/packages/jobs/src/__tests__/smrt-job.test.ts
@@ -1,0 +1,391 @@
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { type JobStatus, SmrtJob, SmrtJobCollection } from '../smrt-job.js';
+
+describe('SmrtJob', () => {
+  let collection: SmrtJobCollection;
+
+  beforeEach(async () => {
+    const db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+
+    // Create jobs table
+    await db.query(`
+      CREATE TABLE IF NOT EXISTS _smrt_jobs (
+        id TEXT PRIMARY KEY,
+        slug TEXT NOT NULL,
+        context TEXT,
+        queue TEXT DEFAULT 'default',
+        object_type TEXT NOT NULL,
+        object_id TEXT,
+        method TEXT NOT NULL,
+        args TEXT DEFAULT '{}',
+        run_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        priority INTEGER DEFAULT 50,
+        status TEXT DEFAULT 'pending',
+        attempts INTEGER DEFAULT 0,
+        max_attempts INTEGER DEFAULT 3,
+        timeout INTEGER DEFAULT 300000,
+        timeout_behavior TEXT DEFAULT 'fail',
+        started_at DATETIME,
+        completed_at DATETIME,
+        last_error TEXT,
+        result_pointer TEXT,
+        retry_strategy TEXT DEFAULT '{}',
+        worker_id TEXT,
+        worker_heartbeat DATETIME,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(slug, context)
+      )
+    `);
+
+    collection = await SmrtJobCollection.create({
+      db: { type: 'sqlite', url: ':memory:' },
+    });
+    // Override internal db
+    (collection as unknown as { _db: typeof db })._db = db;
+  });
+
+  afterEach(async () => {
+    // Cleanup
+  });
+
+  describe('create and save', () => {
+    it('should create a job with default values', async () => {
+      const job = await collection.create({
+        objectType: 'Document',
+        method: 'generateSummary',
+      });
+      await job.save();
+
+      expect(job.id).toBeDefined();
+      expect(job.queue).toBe('default');
+      expect(job.status).toBe('pending');
+      expect(job.priority).toBe(50);
+      expect(job.maxAttempts).toBe(3);
+    });
+
+    it('should create a job with custom values', async () => {
+      const job = await collection.create({
+        objectType: 'Document',
+        objectId: 'doc-123',
+        method: 'generateSummary',
+        args: { format: 'md' },
+        queue: 'summaries',
+        priority: 75,
+        maxAttempts: 5,
+        timeout: 600000,
+      });
+      await job.save();
+
+      expect(job.objectType).toBe('Document');
+      expect(job.objectId).toBe('doc-123');
+      expect(job.method).toBe('generateSummary');
+      expect(job.args).toEqual({ format: 'md' });
+      expect(job.queue).toBe('summaries');
+      expect(job.priority).toBe(75);
+      expect(job.maxAttempts).toBe(5);
+      expect(job.timeout).toBe(600000);
+    });
+  });
+
+  describe('retry()', () => {
+    it('should reset job for retry', async () => {
+      const job = await collection.create({
+        objectType: 'Document',
+        method: 'process',
+      });
+      job.status = 'failed';
+      job.attempts = 2;
+      job.lastError = 'Network error';
+      job.startedAt = new Date();
+      await job.save();
+
+      await job.retry();
+
+      expect(job.status).toBe('pending');
+      expect(job.attempts).toBe(0);
+      expect(job.lastError).toBeNull();
+      expect(job.startedAt).toBeNull();
+    });
+
+    it('should throw error when retrying completed job', async () => {
+      const job = await collection.create({
+        objectType: 'Document',
+        method: 'process',
+      });
+      job.status = 'completed';
+      await job.save();
+
+      await expect(job.retry()).rejects.toThrow('Cannot retry a completed job');
+    });
+  });
+
+  describe('cancel()', () => {
+    it('should cancel a pending job', async () => {
+      const job = await collection.create({
+        objectType: 'Document',
+        method: 'process',
+      });
+      await job.save();
+
+      await job.cancel();
+
+      expect(job.status).toBe('cancelled');
+      expect(job.completedAt).toBeInstanceOf(Date);
+    });
+
+    it('should throw error when cancelling completed job', async () => {
+      const job = await collection.create({
+        objectType: 'Document',
+        method: 'process',
+      });
+      job.status = 'completed';
+      await job.save();
+
+      await expect(job.cancel()).rejects.toThrow(
+        'Cannot cancel job with status: completed',
+      );
+    });
+  });
+
+  describe('getDescription()', () => {
+    it('should return description with object ID', async () => {
+      const job = await collection.create({
+        objectType: 'Document',
+        objectId: 'doc-123',
+        method: 'generateSummary',
+      });
+
+      expect(job.getDescription()).toBe('Document#doc-123.generateSummary()');
+    });
+
+    it('should return description without object ID', async () => {
+      const job = await collection.create({
+        objectType: 'Document',
+        method: 'generateSummary',
+      });
+
+      expect(job.getDescription()).toBe('Document.generateSummary()');
+    });
+  });
+});
+
+describe('SmrtJobCollection', () => {
+  let collection: SmrtJobCollection;
+  let db: Awaited<ReturnType<typeof getDatabase>>;
+
+  beforeEach(async () => {
+    db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+
+    // Create jobs table
+    await db.query(`
+      CREATE TABLE IF NOT EXISTS _smrt_jobs (
+        id TEXT PRIMARY KEY,
+        slug TEXT NOT NULL,
+        context TEXT,
+        queue TEXT DEFAULT 'default',
+        object_type TEXT NOT NULL,
+        object_id TEXT,
+        method TEXT NOT NULL,
+        args TEXT DEFAULT '{}',
+        run_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        priority INTEGER DEFAULT 50,
+        status TEXT DEFAULT 'pending',
+        attempts INTEGER DEFAULT 0,
+        max_attempts INTEGER DEFAULT 3,
+        timeout INTEGER DEFAULT 300000,
+        timeout_behavior TEXT DEFAULT 'fail',
+        started_at DATETIME,
+        completed_at DATETIME,
+        last_error TEXT,
+        result_pointer TEXT,
+        retry_strategy TEXT DEFAULT '{}',
+        worker_id TEXT,
+        worker_heartbeat DATETIME,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(slug, context)
+      )
+    `);
+
+    collection = await SmrtJobCollection.create({
+      db: { type: 'sqlite', url: ':memory:' },
+    });
+    (collection as unknown as { _db: typeof db })._db = db;
+  });
+
+  describe('listByStatus()', () => {
+    it('should list jobs by single status', async () => {
+      const job1 = await collection.create({
+        objectType: 'Doc',
+        method: 'process',
+      });
+      job1.status = 'pending';
+      await job1.save();
+
+      const job2 = await collection.create({
+        objectType: 'Doc',
+        method: 'process',
+      });
+      job2.status = 'completed';
+      await job2.save();
+
+      const pending = await collection.listByStatus('pending');
+      expect(pending).toHaveLength(1);
+      expect(pending[0].id).toBe(job1.id);
+    });
+
+    it('should list jobs by multiple statuses', async () => {
+      const job1 = await collection.create({
+        objectType: 'Doc',
+        method: 'process',
+      });
+      job1.status = 'pending';
+      await job1.save();
+
+      const job2 = await collection.create({
+        objectType: 'Doc',
+        method: 'process',
+      });
+      job2.status = 'failed';
+      await job2.save();
+
+      const jobs = await collection.listByStatus(['pending', 'failed']);
+      expect(jobs).toHaveLength(2);
+    });
+  });
+
+  describe('listReady()', () => {
+    it('should list pending jobs ready to run', async () => {
+      const now = new Date();
+      const past = new Date(now.getTime() - 60000);
+      const future = new Date(now.getTime() + 60000);
+
+      const job1 = await collection.create({
+        objectType: 'Doc',
+        method: 'process',
+        runAt: past,
+      });
+      await job1.save();
+
+      const job2 = await collection.create({
+        objectType: 'Doc',
+        method: 'process',
+        runAt: future,
+      });
+      await job2.save();
+
+      const ready = await collection.listReady();
+      expect(ready).toHaveLength(1);
+      expect(ready[0].id).toBe(job1.id);
+    });
+
+    it('should filter by queues', async () => {
+      const job1 = await collection.create({
+        objectType: 'Doc',
+        method: 'process',
+        queue: 'high-priority',
+      });
+      await job1.save();
+
+      const job2 = await collection.create({
+        objectType: 'Doc',
+        method: 'process',
+        queue: 'default',
+      });
+      await job2.save();
+
+      const ready = await collection.listReady({
+        queues: ['high-priority'],
+      });
+      expect(ready).toHaveLength(1);
+      expect(ready[0].queue).toBe('high-priority');
+    });
+  });
+
+  describe('stats()', () => {
+    it('should return job statistics', async () => {
+      const statuses: JobStatus[] = [
+        'pending',
+        'pending',
+        'running',
+        'completed',
+        'completed',
+        'completed',
+        'failed',
+      ];
+
+      for (const status of statuses) {
+        const job = await collection.create({
+          objectType: 'Doc',
+          method: 'process',
+        });
+        job.status = status;
+        await job.save();
+      }
+
+      const stats = await collection.stats();
+      expect(stats.pending).toBe(2);
+      expect(stats.running).toBe(1);
+      expect(stats.completed).toBe(3);
+      expect(stats.failed).toBe(1);
+      expect(stats.cancelled).toBe(0);
+    });
+
+    it('should filter by queue', async () => {
+      const job1 = await collection.create({
+        objectType: 'Doc',
+        method: 'process',
+        queue: 'summaries',
+      });
+      job1.status = 'completed';
+      await job1.save();
+
+      const job2 = await collection.create({
+        objectType: 'Doc',
+        method: 'process',
+        queue: 'default',
+      });
+      job2.status = 'pending';
+      await job2.save();
+
+      const stats = await collection.stats('summaries');
+      expect(stats.completed).toBe(1);
+      expect(stats.pending).toBe(0);
+    });
+  });
+
+  describe('cleanup()', () => {
+    it('should delete old completed jobs', async () => {
+      const oldDate = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000); // 8 days ago
+      const recentDate = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000); // 1 day ago
+
+      const oldJob = await collection.create({
+        objectType: 'Doc',
+        method: 'process',
+      });
+      oldJob.status = 'completed';
+      oldJob.completedAt = oldDate;
+      await oldJob.save();
+
+      const recentJob = await collection.create({
+        objectType: 'Doc',
+        method: 'process',
+      });
+      recentJob.status = 'completed';
+      recentJob.completedAt = recentDate;
+      await recentJob.save();
+
+      const deleted = await collection.cleanup({
+        completedBefore: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000), // 7 days ago
+      });
+
+      expect(deleted).toBe(1);
+
+      const remaining = await collection.list({});
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].id).toBe(recentJob.id);
+    });
+  });
+});

--- a/packages/jobs/src/schedule-runner.ts
+++ b/packages/jobs/src/schedule-runner.ts
@@ -164,10 +164,24 @@ export class ScheduleRunner extends EventEmitter {
   }
 
   /**
-   * Poll for due schedules and create jobs
+   * Process due schedules once and return the count
+   * Useful for single-run mode (e.g., CLI --once flag)
    */
-  private async poll(): Promise<void> {
-    if (!this.db || !this.jobCollection) return;
+  async processOnce(): Promise<number> {
+    if (!this.db) {
+      throw new Error(
+        'ScheduleRunner not initialized. Call initialize() first.',
+      );
+    }
+    return this.poll();
+  }
+
+  /**
+   * Poll for due schedules and create jobs
+   * @returns Number of schedules processed
+   */
+  private async poll(): Promise<number> {
+    if (!this.db || !this.jobCollection) return 0;
 
     const now = new Date().toISOString();
 
@@ -186,6 +200,8 @@ export class ScheduleRunner extends EventEmitter {
     for (const row of result.rows) {
       await this.triggerSchedule(row as ScheduleRow);
     }
+
+    return result.rows.length;
   }
 
   /**


### PR DESCRIPTION
## Summary

Add CLI commands for managing background jobs and agent schedules as part of the background workers feature.

**Job commands (`job:*`):**
- `list` - List jobs with status/queue filtering
- `get` - Show job details
- `retry` - Retry failed/cancelled jobs
- `cancel` - Cancel pending/running jobs
- `stats` - Show queue statistics
- `work` - Start a job worker
- `cleanup` - Remove old completed/failed jobs

**Schedule commands (`schedule:*`):**
- `list` - List schedules with status/agent filtering
- `get` - Show schedule details
- `create` - Create new agent schedule
- `enable/disable` - Toggle schedule state
- `pause/resume` - Temporarily pause schedules
- `delete` - Remove schedules
- `stats` - Show schedule statistics
- `run` - Start schedule runner (with `--once` option)

**Also includes:**
- Tests for SmrtJob model (15 tests)
- Tests for AgentSchedule model (25 tests)
- `processOnce()` method to ScheduleRunner for single-run mode

## Test plan

- [ ] Run `smrt test packages/jobs` - verify SmrtJob tests pass
- [ ] Run `smrt test packages/agents` - verify AgentSchedule tests pass
- [ ] Test CLI commands manually:
  - `smrt job:list`
  - `smrt schedule:list`
  - `smrt help` (verify new command sections appear)