### PR TITLE
fix(core): skip default UI for SvelteKit projects

### DIFF
--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -162,7 +162,13 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
       server = devServer;
 
       // Serve default HTML when no index.html exists
+      // Skip for SvelteKit projects (they use src/app.html and handle routing themselves)
       devServer.middlewares.use(async (req, res, next) => {
+        // Skip default UI entirely for SvelteKit projects
+        if (svelteKit.enabled) {
+          return next();
+        }
+
         if (req.url === '/' || req.url === '/index.html') {
           try {
             const { existsSync } = await import('node:fs');


### PR DESCRIPTION
## Summary
- Skip SMRT default UI when `svelteKit.enabled` is true in the vite plugin options
- SvelteKit projects use `src/app.html` and handle their own routing

## Problem
The SMRT vite plugin was serving a default development UI when no `index.html` was found in the project root. SvelteKit projects use `src/app.html` instead, so the plugin was intercepting requests and serving the wrong UI.

## Solution
Check if `svelteKit.enabled` is true in the plugin config and skip the default UI middleware entirely, letting SvelteKit handle all routing.

## Test plan
- [x] Create a SvelteKit project with `svelteKit.enabled: true`
- [x] Verify the default SMRT UI is no longer served
- [x] Verify SvelteKit routes work correctly