### PR TITLE
fix(vite-plugin): add smrtDependencies discovery to OXC scanner path

### DIFF
--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -534,6 +534,20 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
       // Add moduleType identifier
       newManifest.moduleType = 'smrt';
 
+      // Discover external SMRT packages for cross-package STI inheritance
+      // (Issue #690: Without this, STI child classes from external packages
+      // get separate tables instead of merging into parent)
+      const { discoverSmrtPackages } = await import(
+        '../manifest/discover-smrt-packages.js'
+      );
+      const smrtDependencies = discoverSmrtPackages();
+      if (smrtDependencies.length > 0) {
+        newManifest.smrtDependencies = smrtDependencies;
+        console.log(
+          `[smrt] Found ${smrtDependencies.length} SMRT dependencies: ${smrtDependencies.join(', ')}`,
+        );
+      }
+
       // Generate pre-computed schemas for each object (same as TypeScript scanner path)
       const { ManifestGenerator } = await import('../scanner/index.js');
       const manifestGen = new ManifestGenerator();


### PR DESCRIPTION
## Summary

Add `smrtDependencies` discovery to the OXC scanner path, matching the TypeScript scanner path behavior from PR #707.

## Problem

The vite plugin has two scanner paths:
1. **TypeScript scanner** - Has `discoverExternalPackages: true` (PR #707)
2. **OXC scanner** (experimental) - Was **missing** smrtDependencies discovery

Packages using the OXC scanner (like caelus) had `smrtDependencies: null` in their manifests, breaking cross-package STI detection.

**Example:** WeatherForecast (caelus) extends Event (smrt-events). Event has `tableStrategy: 'sti'`, but without smrtDependencies, the runtime couldn't trace this relationship and generated a separate `weather_forecasts` table instead of merging into `events`.

## Changes

Added `discoverSmrtPackages()` call to `scanWithOxc()` function, populating `smrtDependencies` in the manifest.

## Verification

Tested with caelus rebuild - manifest now shows:
```json
{
  "smrtDependencies": [
    "@happyvertical/smrt-agents",
    "@happyvertical/smrt-core",
    "@happyvertical/smrt-events",
    "@happyvertical/smrt-places",
    "@happyvertical/smrt-profiles"
  ]
}
```

All 1173 tests pass.

Fixes #690