### PR TITLE
fix(core): rename test Secret class to avoid collision with smrt-secrets

### DIFF
--- a/packages/core/src/vite-plugin/cli-module.test.ts
+++ b/packages/core/src/vite-plugin/cli-module.test.ts
@@ -40,10 +40,11 @@ class CliModuleTestDocument extends SmrtObject {
 }
 
 // Test class with CLI excluded
+// Named "CliTestSecret" to avoid collision with @happyvertical/smrt-secrets Secret class
 @smrt({
   cli: false,
 })
-class Secret extends SmrtObject {
+class CliTestSecret extends SmrtObject {
   value = '';
 
   constructor(options: any) {
@@ -93,10 +94,10 @@ describe('@happyvertical/smrt-virt-cli virtual module generation', () => {
   });
 
   it('should exclude objects with cli: false', () => {
-    const secretClass = ObjectRegistry.getClass('Secret');
+    const secretClass = ObjectRegistry.getClass('CliTestSecret');
     expect(secretClass).toBeDefined();
 
-    const config = ObjectRegistry.getConfig('Secret');
+    const config = ObjectRegistry.getConfig('CliTestSecret');
     expect(config.cli).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

Renames the test `Secret` class in `cli-module.test.ts` to `CliTestSecret` to avoid name collision with `@happyvertical/smrt-secrets` Secret class.

## Problem

The test class named "Secret" collides with the real Secret class from smrt-secrets when external package discovery is enabled (PR #710).

When smrt-secrets builds with the OXC scanner and discovers smrt-core as a dependency, the manifest-loader loads smrt-core's `.smrt/manifest.json` which includes the test Secret class. This causes a "SMRT Class Name Collision Detected" error.

## Solution

Renamed the test class to `CliTestSecret` - a more descriptive name that clearly indicates its purpose (testing CLI exclusion with `cli: false`).

## Test Plan

- [x] Run `cli-module.test.ts` - all 7 tests pass
- [ ] CI validation

## Related

- Fixes #711
- Unblocks #710