### PR TITLE
fix(core): handle self-referencing foreignKey in dependency graph

### DIFF
--- a/packages/core/src/registry.test.ts
+++ b/packages/core/src/registry.test.ts
@@ -801,6 +801,32 @@ describe('ObjectRegistry', () => {
       expect(productIndex).toBeLessThan(orderIndex);
       expect(customerIndex).toBeLessThan(orderIndex);
     });
+
+    it('should handle self-referencing classes (Issue #728)', () => {
+      // Self-referencing class like Tenant with parentTenantId -> Tenant
+      class SelfRefClass extends SmrtObject {
+        name: string = '';
+        parentId?: string;
+      }
+
+      const fields = new Map();
+      fields.set('name', new Field('text', { required: true }));
+      fields.set(
+        'parentId',
+        new Field('foreignKey', { related: 'SelfRefClass', nullable: true }),
+      );
+      registerTestClass(SelfRefClass, fields);
+
+      // Should NOT throw circular dependency error
+      const order = ObjectRegistry.getInitializationOrder();
+
+      // Self-referencing class should be in the order
+      expect(order).toContain('SelfRefClass');
+
+      // Verify dependency graph excludes self-reference
+      const graph = ObjectRegistry.getDependencyGraph();
+      expect(graph.get('SelfRefClass')).toEqual([]);
+    });
   });
 
   describe('Table Name Capture (Issue #9 - Phase 1)', () => {

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -3142,8 +3142,12 @@ export class ObjectRegistry {
       for (const [_fieldName, field] of registered.fields) {
         if (field.type === 'foreignKey' && field.related) {
           const relatedClass = field.related;
-          // Only add if the related class is registered
-          if (ObjectRegistry.classes.has(relatedClass)) {
+          // Skip self-references (table can reference itself after creation)
+          // Only add if the related class is registered and not self
+          if (
+            relatedClass !== className &&
+            ObjectRegistry.classes.has(relatedClass)
+          ) {
             dependencies.push(relatedClass);
           }
         }


### PR DESCRIPTION
## Summary

Fixes #728 - `smrt db:migrate` fails with "Circular dependency detected involving class: Tenant" error.

### Root Cause

The `getDependencyGraph()` method was including self-references in the dependency list. When a class like `Tenant` has a self-referential `foreignKey` field (e.g., `parentTenantId` -> `Tenant` for hierarchical tenants), the topological sort in `getInitializationOrder()` would detect this as a circular dependency and throw an error.

### Solution

Self-references don't create ordering constraints because:
- The table must exist before any rows can be inserted
- A foreign key constraint to the same table is valid once the table is created
- No ordering conflict exists - the table is created before any data

The fix simply skips self-references when building the dependency graph:

```typescript
// Skip self-references (table can reference itself after creation)
if (relatedClass !== className && ObjectRegistry.classes.has(relatedClass)) {
  dependencies.push(relatedClass);
}
```

## Test plan

- [x] Added test case for self-referencing classes (Issue #728)
- [x] All 1212 tests pass
- [x] Build succeeds