### PR TITLE
fix(cli): correct URL logging in db:setup and db:migrate

### DIFF
--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -601,7 +601,9 @@ export default testManifest;
         const { getDatabase } = await import('@happyvertical/sql');
         const db = await getDatabase({ type: dbType, url: dbUrl });
 
-        console.log(`✓ Connected to ${dbType}://${dbUrl}\n`);
+        // Mask password in URL for logging
+        const maskedUrl = dbUrl.replace(/:([^:@]+)@/, ':***@');
+        console.log(`✓ Connected to ${maskedUrl}\n`);
 
         // 7. Drop tables if requested
         if (options.drop) {
@@ -1114,7 +1116,9 @@ export default testManifest;
           process.exit(1);
         }
 
-        console.log(`✓ Connected to ${dbType}://${dbUrl}\n`);
+        // Mask password in URL for logging
+        const maskedUrl = dbUrl.replace(/:([^:@]+)@/, ':***@');
+        console.log(`✓ Connected to ${maskedUrl}\n`);
 
         // 7.5. Initialize MigrationTracker for tracking applied migrations
         const { MigrationTracker, shortChecksum } = await import(


### PR DESCRIPTION
## Summary
- Fixes malformed URL logging in `smrt db:setup` and `smrt db:migrate` commands
- URLs were being logged as `postgres://postgresql://...` (double protocol)
- Also masks passwords in logged URLs for security

## Changes
- Modified `packages/cli/src/commands/utilities.ts` to log the URL directly without prepending protocol
- Added password masking with regex replacement

## Test
```bash
smrt db:setup
# Before: ✓ Connected to postgres://postgresql://user:password@localhost:5432/db
# After:  ✓ Connected to postgresql://user:***@localhost:5432/db
```