### PR TITLE
fix(users): correct sveltekit export path in package.json

### DIFF
--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -12,7 +12,7 @@
     },
     "./sveltekit": {
       "types": "./dist/sveltekit/index.d.ts",
-      "import": "./dist/sveltekit/index.js"
+      "import": "./dist/sveltekit.js"
     },
     "./manifest.json": "./dist/manifest.json"
   },


### PR DESCRIPTION
## Summary
- Fix the sveltekit subpath export to point to the correct build output location

## Problem
The Vite build outputs the sveltekit entry point as `dist/sveltekit.js`, but the package.json export was pointing to `dist/sveltekit/index.js` which doesn't exist.

This caused the following error when importing `@happyvertical/smrt-users/sveltekit`:
```
[vite]: Rollup failed to resolve import "@happyvertical/smrt-users/sveltekit"
```

## Solution
Update the package.json exports to point to the correct file path:
- Before: `./dist/sveltekit/index.js`
- After: `./dist/sveltekit.js`

## Test Plan
- [x] Build passes locally
- [ ] magnateos.com Docker build passes