### PR TITLE
feat(core): add conflictColumns support for junction tables

### DIFF
--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -1011,11 +1011,10 @@ export class SmrtObject extends SmrtClass {
         }
       }
 
-      // STI: Include _meta_type in conflict columns
-      const conflictColumns =
-        tableStrategy === 'sti'
-          ? ['slug', 'context', '_meta_type']
-          : ['slug', 'context'];
+      // Get conflict columns from registry (supports custom columns for junction tables)
+      const conflictColumns = ObjectRegistry.getConflictColumns(
+        this.constructor.name,
+      );
 
       await ErrorUtils.withRetry(
         async () => {

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -203,6 +203,25 @@ export interface SmartObjectConfig {
   tableStrategy?: 'cti' | 'sti';
 
   /**
+   * Custom conflict columns for UPSERT operations
+   *
+   * By default, SMRT uses ['slug', 'context'] for CTI tables and
+   * ['slug', 'context', '_meta_type'] for STI tables. Override this
+   * for junction tables or models with different natural keys.
+   *
+   * @example
+   * ```typescript
+   * // Junction table using foreign keys as natural key
+   * @smrt({ conflictColumns: ['event_id', 'profile_id'] })
+   * class EventParticipant extends SmrtObject {
+   *   eventId = '';
+   *   profileId = '';
+   * }
+   * ```
+   */
+  conflictColumns?: string[];
+
+  /**
    * Visibility control for manifest inclusion and cross-package access
    * - 'public': Included in published manifest, available to all consumers (default)
    * - 'internal': Package-only, excluded from published manifest
@@ -3921,6 +3940,45 @@ export class ObjectRegistry {
     }
 
     return 'cti'; // Default strategy
+  }
+
+  /**
+   * Get the conflict columns for UPSERT operations on a class
+   *
+   * Returns custom conflict columns if specified, otherwise defaults based on
+   * table strategy:
+   * - CTI: ['slug', 'context']
+   * - STI: ['slug', 'context', '_meta_type']
+   *
+   * @param className - Name of the class to get conflict columns for
+   * @returns Array of column names to use for conflict detection
+   *
+   * @example
+   * ```typescript
+   * // Junction table with custom conflict columns
+   * @smrt({ conflictColumns: ['event_id', 'profile_id'] })
+   * class EventParticipant extends SmrtObject {}
+   *
+   * ObjectRegistry.getConflictColumns('EventParticipant');
+   * // Returns: ['event_id', 'profile_id']
+   * ```
+   */
+  static getConflictColumns(className: string): string[] {
+    const registered = ObjectRegistry.findClass(className);
+    if (!registered) {
+      return ['slug', 'context']; // Default for unregistered classes
+    }
+
+    // Explicit config wins
+    if (registered.config?.conflictColumns) {
+      return registered.config.conflictColumns;
+    }
+
+    // Fall back to table strategy-based defaults
+    const tableStrategy = ObjectRegistry.getTableStrategy(className);
+    return tableStrategy === 'sti'
+      ? ['slug', 'context', '_meta_type']
+      : ['slug', 'context'];
   }
 
   /**

--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -268,6 +268,7 @@ export class ManifestGenerator {
           name,
           tableName,
           obj.fields,
+          obj.decoratorConfig,
         );
       }
     }

--- a/packages/core/src/schema/generator.ts
+++ b/packages/core/src/schema/generator.ts
@@ -971,6 +971,7 @@ export class SchemaGenerator {
     className: string,
     tableName: string,
     fields: Record<string, FieldDefinition>,
+    config?: { conflictColumns?: string[] },
   ): ManifestSchema {
     const columns: Record<string, ManifestColumnDefinition> = {};
 
@@ -1058,9 +1059,16 @@ export class SchemaGenerator {
       columns: ['id'],
     });
 
+    // Use custom conflict columns if provided, otherwise default to slug+context
+    const conflictColumns = config?.conflictColumns || ['slug', 'context'];
+    const indexName =
+      conflictColumns.length > 2
+        ? `${tableName}_${conflictColumns.slice(0, 2).join('_')}_idx`
+        : `${tableName}_${conflictColumns.join('_')}_idx`;
+
     indexes.push({
-      name: `${tableName}_slug_context_idx`,
-      columns: ['slug', 'context'],
+      name: indexName,
+      columns: conflictColumns,
       unique: true,
     });
 

--- a/packages/events/src/models/EventParticipant.ts
+++ b/packages/events/src/models/EventParticipant.ts
@@ -8,7 +8,9 @@ import { SmrtObject, smrt } from '@happyvertical/smrt-core';
 import type { EventParticipantOptions } from '../types';
 
 @smrt({
-  tableStrategy: 'sti',
+  // Junction table - uses event_id + profile_id + role as natural key
+  // instead of slug-based conflict columns
+  conflictColumns: ['event_id', 'profile_id', 'role'],
   api: { include: ['list', 'get', 'create', 'update', 'delete'] },
   mcp: { include: ['list', 'get', 'create', 'update'] },
   cli: true,


### PR DESCRIPTION
## Summary
Add custom conflict columns support for UPSERT operations to fix issues with junction tables like EventParticipant.

## Changes
- Add `conflictColumns` option to `SmartObjectConfig` 
- Add `ObjectRegistry.getConflictColumns()` method
- Update `save()` to use registry-based conflict columns
- Update schema generator to create matching unique indexes
- Update `EventParticipant` to use `(event_id, profile_id, role)` conflict columns

## Problem
Junction tables like `EventParticipant` don't use slug-based natural keys. They use foreign key combinations (`eventId + profileId`) as their identity. The previous hardcoded conflict columns `['slug', 'context', '_meta_type']` caused UPSERT errors:

```
Database query failed: UPSERT INTO event_participants
```

## Solution
Allow models to specify custom conflict columns via the `@smrt()` decorator:

```typescript
@smrt({
  conflictColumns: ['event_id', 'profile_id', 'role'],
})
export class EventParticipant extends SmrtObject {
  eventId = '';
  profileId = '';
  role = '';
}
```

## Test plan
- [x] Rebuild smrt-core and smrt-events
- [ ] Run praeco discover workflow with PostgreSQL backend
- [ ] Verify EventParticipant records are created without UPSERT errors