### PR TITLE
fix(cli): show underlying database error in migration failures

### DIFF
--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -1444,6 +1444,16 @@ export default testManifest;
             const errorMsg =
               error instanceof Error ? error.message : String(error);
             console.error(`  ✗ ${migration.type} failed: ${errorMsg}`);
+            // Show underlying database error if available
+            if (
+              error instanceof Error &&
+              'context' in error &&
+              (error as any).context?.originalError
+            ) {
+              console.error(
+                `     Cause: ${(error as any).context.originalError}`,
+              );
+            }
             if (options.verbose && error instanceof Error && error.stack) {
               console.error(`\n${error.stack}\n`);
             }


### PR DESCRIPTION
## Summary
- Shows the underlying PostgreSQL error when migrations fail with 'Failed to execute raw query'
- Helps diagnose why db:migrate is failing for bentleyalberta.com

Previously, only the generic message was shown. Now the actual database error is displayed.

## Related
Debugging bentleyalberta.com workflow failures where 198 migrations are detected and all fail with 'Failed to execute raw query' without showing the actual cause.