### PR TITLE
fix(cli): correctly parse and access hyphenated CLI options

### DIFF
--- a/packages/cli/src/cli-generator.ts
+++ b/packages/cli/src/cli-generator.ts
@@ -912,8 +912,14 @@ export class CLIGenerator {
         return;
       }
 
+      // Re-parse options for built-in command since they weren't in initial parse
+      // The initial parseCliArgs only has object commands, not built-in commands
+      const reParsed = parseCliArgs(process.argv, [], {
+        [parsed.command]: builtInCommand,
+      });
+
       try {
-        await builtInCommand.handler(parsed.args, parsed.options);
+        await builtInCommand.handler(parsed.args, reParsed.options);
         return;
       } catch (error) {
         this.exitWithError(

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -556,7 +556,7 @@ export default testManifest;
         }
 
         // 5. Dry-run mode: Show SQL without executing
-        if (options.dryRun) {
+        if (options['dry-run']) {
           console.log('📋 SQL Preview (not executed):\n');
 
           const { generateSchema } = await import(
@@ -1128,14 +1128,14 @@ export default testManifest;
 
         const tracker = new MigrationTracker({
           db,
-          useConcurrentIndexes: options.postgresSafe ?? false,
+          useConcurrentIndexes: options['postgres-safe'] ?? false,
         });
         await tracker.initialize();
 
         if (options.verbose) {
           const engine = tracker.getEngine();
           console.log(`Migration tracker initialized (engine: ${engine})`);
-          if (options.postgresSafe && engine === 'postgres') {
+          if (options['postgres-safe'] && engine === 'postgres') {
             console.log(
               'PostgreSQL-safe mode enabled (CONCURRENTLY, lock_timeout)',
             );
@@ -1279,7 +1279,7 @@ export default testManifest;
 
         // 10. Handle no migrations needed
         // Only return early if there are no migrations AND --upgrade-sti is not requested (Issue #749)
-        if (migrations.length === 0 && !options.upgradeSti) {
+        if (migrations.length === 0 && !options['upgrade-sti']) {
           console.log(
             '✅ Database schema is up to date - no migrations needed\n',
           );
@@ -1287,7 +1287,7 @@ export default testManifest;
         }
 
         // If no schema migrations but upgrade-sti is requested, skip to upgrade-sti section
-        if (migrations.length === 0 && options.upgradeSti) {
+        if (migrations.length === 0 && options['upgrade-sti']) {
           console.log(
             '✅ Database schema is up to date - no migrations needed\n',
           );
@@ -1296,7 +1296,7 @@ export default testManifest;
 
         // 11. Preview or execute migrations
         // Note: SQL statements come from SchemaComparer via change.sql
-        if (options.dryRun) {
+        if (options['dry-run']) {
           console.log('📋 Migration Preview (not executed):\n');
 
           const columnMigrations = migrations.filter(
@@ -1332,7 +1332,7 @@ export default testManifest;
           }
           console.log();
 
-          if (!options.upgradeSti) {
+          if (!options['upgrade-sti']) {
             console.log('✅ Dry-run complete (no changes made)');
             console.log('   Run without --dry-run to apply migrations\n');
             return;
@@ -1384,7 +1384,7 @@ export default testManifest;
 
             // Apply migration - tracker handles checksum validation and idempotency
             const result = await tracker.apply(migrationDef, {
-              postgresSafe: options.postgresSafe ?? false,
+              postgresSafe: options['postgres-safe'] ?? false,
               force: options.force ?? false,
             });
 
@@ -1428,7 +1428,7 @@ export default testManifest;
         }
 
         // 13.5 Handle --upgrade-sti flag for STI discriminator migration
-        if (options.upgradeSti) {
+        if (options['upgrade-sti']) {
           console.log(
             '\n🔄 Upgrading STI discriminators to qualified names...\n',
           );
@@ -1508,10 +1508,10 @@ export default testManifest;
                   continue;
                 }
 
-                // Generate UPDATE statement
+                // Generate UPDATE statement (? placeholders are converted to $1, $2 by sql package)
                 const updateSql = `UPDATE ${quoteIdentifier(tableName)} SET ${quoteIdentifier('_meta_type')} = ? WHERE ${quoteIdentifier('_meta_type')} = ?`;
 
-                if (options.dryRun) {
+                if (options['dry-run']) {
                   console.log(`  [DRY RUN] ${updateSql}`);
                   console.log(
                     `            params: ['${qualifiedName}', '${metaType}']`,
@@ -1521,20 +1521,22 @@ export default testManifest;
                 }
 
                 try {
-                  const updateResult = await db.query(updateSql, [
+                  const updateResult = await db.query(
+                    updateSql,
                     qualifiedName,
                     metaType,
-                  ]);
+                  );
                   const rowsAffected = updateResult.rowCount || 0;
                   console.log(
                     `  ✓ ${tableName}: "${metaType}" → "${qualifiedName}" (${rowsAffected} row(s))`,
                   );
                   stiSuccessCount++;
-                } catch (error) {
+                } catch (error: any) {
                   const errorMsg =
                     error instanceof Error ? error.message : String(error);
+                  const originalError = error?.context?.originalError;
                   console.error(
-                    `  ✗ ${tableName}: "${metaType}" → "${qualifiedName}" failed: ${errorMsg}`,
+                    `  ✗ ${tableName}: "${metaType}" → "${qualifiedName}" failed: ${originalError || errorMsg}`,
                   );
                   stiErrorCount++;
                 }


### PR DESCRIPTION
## Summary

Fixes #749 - The `db:migrate --upgrade-sti` command was not working because:

1. **Built-in commands were not getting their options parsed** - The initial `parseCliArgs` call only included object commands, not built-in commands, so options like `--upgrade-sti` were never captured.

2. **Hyphenated option names vs camelCase access** - Node.js `util.parseArgs` returns option names as-is (hyphenated), but the code was accessing them with camelCase (`options.upgradeSti` instead of `options['upgrade-sti']`).

3. **Rest params vs array params** - The `db.query` call was passing parameters as an array `[qualifiedName, metaType]`, but the function signature uses rest params `...values`.

## Changes

- `cli-generator.ts`: Re-parse CLI args for built-in commands to capture their options
- `utilities.ts`: Use bracket notation for hyphenated options (`options['upgrade-sti']`, `options['dry-run']`, `options['postgres-safe']`)
- `utilities.ts`: Fix `db.query` call to spread params instead of passing array

## Test Plan

- [x] All 71 integration tests pass in bentleyalberta.com test suite
- [x] `pnpm smrt db:migrate --upgrade-sti` correctly upgrades STI discriminators
- [x] `pnpm smrt db:migrate --dry-run` shows changes without applying