### PR TITLE
fix(core): handle class registration collision in bundled contexts

### DIFF
--- a/.changeset/fix-bundler-collision.md
+++ b/.changeset/fix-bundler-collision.md
@@ -1,0 +1,13 @@
+---
+"@happyvertical/smrt-core": patch
+---
+
+Fix class name collision in bundled contexts (Vite/SvelteKit)
+
+When bundlers like Vite duplicate module code into multiple chunks, the same class
+can be registered multiple times with different source file paths (e.g., different
+chunk files). This caused false collision errors for legitimate re-registrations.
+
+The fix detects bundled contexts by checking if the source file is in a build
+output directory (.svelte-kit/output, dist, build, .next, .nuxt) and allows
+re-registration if the existing entry came from a known package manifest.

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -933,6 +933,25 @@ export class ObjectRegistry {
       // (Issue #555: Test isolation - class name collision during vitest collection)
       const newSourceFile = getSourceFileFromStack();
 
+      // Detect bundled context: source file is in a build output directory
+      // Bundlers (Vite, webpack, etc.) can duplicate module code into multiple chunks,
+      // causing the same class to be registered multiple times with different source paths
+      const isBundledContext =
+        newSourceFile &&
+        (newSourceFile.includes('.svelte-kit/output/') ||
+          newSourceFile.includes('/dist/') ||
+          newSourceFile.includes('/build/') ||
+          newSourceFile.includes('.next/') ||
+          newSourceFile.includes('.nuxt/'));
+
+      // In bundled contexts, allow re-registration if the existing entry came from a manifest
+      // (which means it's a known package class that the bundler duplicated)
+      if (isBundledContext && existing.packageName?.startsWith('@')) {
+        existing.constructor = ctor;
+        existing.config = { ...existing.config, ...config };
+        return;
+      }
+
       // Allow re-registration if:
       // 1. Both source files are defined and match (same file being re-evaluated)
       // 2. Either source file is unavailable (can't do proper comparison, allow as fallback)


### PR DESCRIPTION
## Summary

When bundlers like Vite/SvelteKit duplicate module code into multiple chunks, the same class can be registered multiple times with different source file paths. This caused false collision errors for legitimate re-registrations.

## Changes

- Detect bundled contexts by checking if the source file is in a build output directory (`.svelte-kit/output`, `dist`, `build`, `.next`, `.nuxt`)
- Allow re-registration if the existing entry came from a known package manifest
- This fixes Asset class collision errors when building SvelteKit apps that use multiple smrt packages

## Test plan

- [x] All 1250 existing tests pass
- [ ] Manual test: Build blindmanpress.com dashboard after this fix is published