### PR TITLE
fix: resolve TypeScript errors caught by publish workflow

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,6 +57,7 @@
     "yaml": "^2.8.2"
   },
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "generate": "node scripts/generate-manifest.js",
     "generate:test": "node scripts/generate-test-manifest.js",
     "test": "(command -v smrt >/dev/null 2>&1 && smrt test) || (node scripts/generate-test-manifest.js && npx vitest run)",

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -72,7 +72,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
    * Populated during create() to avoid async getFields() calls on every query.
    * @private
    */
-  private _cachedFields: Map<string, any> | null = null;
+  private _cachedFields: Record<string, any> | null = null;
 
   /**
    * Convert WHERE clause field names from camelCase to snake_case while preserving operators.
@@ -509,7 +509,9 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
    * @param filter - String ID/slug, Field instance, or object with filter conditions
    * @returns Promise resolving to the object or null if not found
    */
-  public async get(filter: string | Record<string, any>) {
+  public async get(
+    filter: string | Record<string, any>,
+  ): Promise<ModelType | null> {
     // Schema already initialized in Collection.create() static factory
 
     // Ensure manifest is loaded for external packages before validating WHERE clause
@@ -563,7 +565,8 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
 
     if (!rows?.[0]) {
       // Execute afterGet with null result
-      return await GlobalInterceptors.executeAfterGet(
+      // Explicitly specify type parameter since TypeScript can't infer from null
+      return await GlobalInterceptors.executeAfterGet<ModelType>(
         this._itemClass.name,
         null,
         interceptorContext,
@@ -573,7 +576,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     const fields = await this.getFields();
     const formattedData = formatDataJs(rows[0], fields);
 
-    let instance: T;
+    let instance: ModelType;
     if (isSTI && formattedData._meta_type) {
       instance = await this.createPolymorphic(
         formattedData._meta_type,
@@ -581,7 +584,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       );
     } else {
       // CTI: Use collection's item class
-      instance = this.create(formattedData);
+      instance = await this.create(formattedData);
     }
 
     // Execute afterGet interceptors (e.g., tenant validation)

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -55,6 +55,7 @@ import type {
   ColumnDefinition,
   IndexDefinition,
   SchemaDefinition,
+  SQLDataType,
 } from './schema/types.js';
 import { classnameToTablename, tableNameFromClass, toSnakeCase } from './utils';
 import { LRUCache } from './utils/lru-cache';
@@ -72,6 +73,12 @@ import { createQualifiedName } from './utils/qualified-names.js';
  *
  * @see https://github.com/happyvertical/smrt/issues/543
  */
+/**
+ * Type for any constructor function that extends SmrtObject.
+ * Used for WeakMap keys where we need to accept any subclass constructor.
+ */
+type SmrtObjectConstructor = new (...args: any[]) => SmrtObject;
+
 declare global {
   // eslint-disable-next-line no-var
   var __smrtRegistryClasses: Map<string, any> | undefined;
@@ -97,6 +104,14 @@ declare global {
   var __smrtRegistryCollectionTableNames: Map<string, string> | undefined;
   // eslint-disable-next-line no-var
   var __smrtRegistryClassNameMap: Map<string, string> | undefined;
+  // eslint-disable-next-line no-var
+  var __smrtRegistrySchemasInitialized: WeakSet<object> | undefined;
+  // eslint-disable-next-line no-var
+  var __smrtRegistryConstructorIndex:
+    | WeakMap<SmrtObjectConstructor, string>
+    | undefined;
+  // eslint-disable-next-line no-var
+  var __smrtRegistryDiscoveryAttemptCache: Map<string, boolean> | undefined;
 }
 
 /**
@@ -748,10 +763,13 @@ export class ObjectRegistry {
    * Maps constructor → registered class name for fast reverse lookups
    * Uses WeakMap so classes can be garbage collected if unregistered
    */
-  private static get constructorIndex(): WeakMap<typeof SmrtObject, string> {
+  private static get constructorIndex(): WeakMap<
+    SmrtObjectConstructor,
+    string
+  > {
     if (!globalThis.__smrtRegistryConstructorIndex) {
       globalThis.__smrtRegistryConstructorIndex = new WeakMap<
-        typeof SmrtObject,
+        SmrtObjectConstructor,
         string
       >();
     }
@@ -1843,7 +1861,7 @@ export class ObjectRegistry {
    * ```
    */
   static getClassByConstructor(
-    ctor: typeof SmrtObject,
+    ctor: SmrtObjectConstructor,
   ): RegisteredClass | undefined {
     // Use WeakMap index for O(1) lookup
     const registeredName = ObjectRegistry.constructorIndex.get(ctor);
@@ -3371,7 +3389,9 @@ export class ObjectRegistry {
    * Map field type to SQL data type
    * @private
    */
-  private static mapFieldTypeToSQL(fieldType: FieldDefinition['type']): string {
+  private static mapFieldTypeToSQL(
+    fieldType: FieldDefinition['type'],
+  ): SQLDataType {
     switch (fieldType) {
       case 'text':
         return 'TEXT';

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -10,5 +10,9 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "src/vite-plugin/templates/**"
+  ]
 }

--- a/packages/scanner/src/manifest-adapter.ts
+++ b/packages/scanner/src/manifest-adapter.ts
@@ -17,6 +17,12 @@ import type {
 // smrt-core compatible types (copied to avoid circular dependency)
 // ============================================================================
 
+/**
+ * Qualified class name format: "@package/name:ClassName"
+ * Uniquely identifies classes across packages.
+ */
+type QualifiedClassName = `${string}:${string}`;
+
 interface FieldDefinition {
   type:
     | 'text'
@@ -78,7 +84,7 @@ interface SmartObjectConfig {
 interface SmartObjectDefinition {
   name: string;
   className: string;
-  qualifiedName?: string; // NEW: @package/name:ClassName for namespace isolation (Issue #713)
+  qualifiedName?: QualifiedClassName; // NEW: @package/name:ClassName for namespace isolation (Issue #713)
   collection: string;
   filePath: string;
   packageName?: string;
@@ -112,8 +118,11 @@ interface SmartObjectManifest {
  * Create a qualified name for a class (namespace isolation - Issue #713)
  * Format: @package/name:ClassName
  */
-function createQualifiedName(packageName: string, className: string): string {
-  return `${packageName}:${className}`;
+function createQualifiedName(
+  packageName: string,
+  className: string,
+): QualifiedClassName {
+  return `${packageName}:${className}` as QualifiedClassName;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes TypeScript errors that were masked by turbo caching in regular builds
- Adds `typecheck` script to core package to ensure CI catches these errors

## Root Cause
The publish workflow's clean build (via `prepack` → `build:fresh`) catches TypeScript errors that regular cached builds miss. The errors were pre-existing but only surfaced during the publish workflow.

## Changes
- **collection.ts**: Fix `_cachedFields` type (Record not Map), add `await` to async `create()` call, add explicit return type to `get()` method, add type parameter to `GlobalInterceptors.executeAfterGet()`
- **registry.ts**: Add `SmrtObjectConstructor` type alias, add missing `globalThis` declarations, fix `mapFieldTypeToSQL` return type
- **scanner/manifest-adapter.ts**: Add `QualifiedClassName` type, update `qualifiedName` field and `createQualifiedName` function to use it
- **tsconfig.json**: Exclude `vite-plugin/templates` from typecheck (browser code with virtual modules)
- **package.json**: Add `typecheck` script to ensure CI catches these errors going forward

## Test plan
- [x] Clean build passes (`npm run clean && npm run build`)
- [x] TypeScript check passes (`pnpm run typecheck` in core package)
- [x] Tests pass (`pnpm turbo run typecheck lint test --filter=@happyvertical/smrt-core`)

Fixes the publish workflow failure in run #21149202815.