### PR TITLE
feat(content): add 'review' status to Content publication workflow

### DIFF
--- a/packages/content/src/content.ts
+++ b/packages/content/src/content.ts
@@ -64,7 +64,7 @@ export interface ContentOptions extends SmrtObjectOptions {
   /**
    * Publication status
    */
-  status?: 'published' | 'draft' | 'archived' | 'deleted' | null;
+  status?: 'published' | 'draft' | 'review' | 'archived' | 'deleted' | null;
 
   /**
    * Content state flag
@@ -210,7 +210,8 @@ export class Content extends SmrtObject {
   /**
    * Publication status
    */
-  public status: 'published' | 'draft' | 'archived' | 'deleted' = 'draft';
+  public status: 'published' | 'draft' | 'review' | 'archived' | 'deleted' =
+    'draft';
 
   /**
    * Content state flag


### PR DESCRIPTION
## Summary
- Add 'review' as a valid status option for Content objects
- Enables editorial review workflows before publishing

## Changes
- Updated `ContentOptions` interface to include 'review' status
- Updated `Content` class status property to include 'review' option

## Test plan
- [x] TypeScript compiles without errors
- [ ] Existing content operations unaffected