### PR TITLE
fix(core): add schema.ts re-export file for build compatibility

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
       "default": "./dist/index.js"
     },
     "./utils": "./dist/utils.js",
-    "./schema": "./dist/schema/index.js",
+    "./schema": "./dist/schema.js",
     "./schema/utils": "./dist/schema/utils.js",
     "./generators": "./dist/generators.js",
     "./generators/rest": "./dist/generators/rest.js",

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,0 +1,7 @@
+/**
+ * Schema generation module
+ *
+ * Re-exports all schema functionality from the schema/ directory.
+ * This file serves as the entry point for @smrt/core/schema exports.
+ */
+export * from './schema/index.js';


### PR DESCRIPTION
## Summary
- Add `src/schema.ts` re-export file to match the pattern used by `generators.ts` and `manifest.ts`
- Update package.json export to use `./dist/schema.js` instead of `./dist/schema/index.js`

## Problem
The on-merge-main workflow was failing because the publish process couldn't find `./dist/schema/index.js`. The build process uses the package.json exports to determine entry points, and the conversion from `./dist/schema/index.js` to `src/schema/index.ts` was correct, but the output file name is `dist/schema.js`, not `dist/schema/index.js`.

## Solution
Following the established pattern in the codebase:
- `generators.ts` → re-exports from `./generators/index.js`
- `manifest.ts` → re-exports from `./manifest/index.js`  
- **NEW**: `schema.ts` → re-exports from `./schema/index.js`

## Test plan
- [x] Local `npm run build:fresh` passes
- [x] All exports verified (`verify:exports` script)
- [ ] CI passes