### PR TITLE
fix(core): remove unused ./schema export

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,6 @@
       "default": "./dist/index.js"
     },
     "./utils": "./dist/utils.js",
-    "./schema": "./dist/schema.js",
     "./schema/utils": "./dist/schema/utils.js",
     "./generators": "./dist/generators.js",
     "./generators/rest": "./dist/generators/rest.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,6 +73,8 @@ export * from './registry';
 export { smrt as smrtRegistry } from './registry';
 // Runtime utilities
 export * from './runtime/index';
+// Schema types (for generated code from SchemaCodeGenerator)
+export type { SchemaDefinition } from './schema/types';
 // Universal signaling system
 export * from './signals/index';
 // System tables and types (note-taking, migrations, registry, signals)

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,7 +1,0 @@
-/**
- * Schema generation module
- *
- * Re-exports all schema functionality from the schema/ directory.
- * This file serves as the entry point for @smrt/core/schema exports.
- */
-export * from './schema/index.js';

--- a/packages/core/src/schema/code-generator.ts
+++ b/packages/core/src/schema/code-generator.ts
@@ -36,7 +36,7 @@ export class SchemaCodeGenerator {
    * Generate import statements
    */
   private generateImports(): string {
-    return `import type { SchemaDefinition } from '@happyvertical/smrt-core/schema';`;
+    return `import type { SchemaDefinition } from '@happyvertical/smrt-core';`;
   }
 
   /**


### PR DESCRIPTION
## Summary

Removes the unused `./schema` export that was added in PR #762 and fixed in PR #766.

Analysis confirmed:
- `./schema/utils` is used in the repo (kept)
- `./schema` itself is not imported anywhere in the monorepo
- `SchemaCodeGenerator` only **generates** code that would import from it, but that output isn't used

## Changes

- Remove `./schema` export from package.json
- Delete `src/schema.ts` re-export file (added in #766)
- Update `code-generator.ts` to import `SchemaDefinition` from main package instead

## Test plan

- [x] `npm run build:fresh` passes
- [x] All exports verified