### PR TITLE
fix(core): OXC scanner inherits STI fields from parent classes

### DIFF
--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -3,7 +3,10 @@
  */
 
 import { createRequire } from 'node:module';
-import { loadExternalManifestSync } from '../manifest/manifest-loader.js';
+import {
+  loadExternalManifestSync,
+  lookupInManifest,
+} from '../manifest/manifest-loader.js';
 import { generateToolManifest } from '../tools/tool-generator';
 import { createQualifiedName } from '../utils/qualified-names.js';
 import { isTestFile } from './test-file-patterns.js';
@@ -970,14 +973,11 @@ export class ManifestGenerator {
         continue;
       }
 
-      // Search for parent class in external manifest (case-insensitive)
-      const parentKey = Object.keys(externalManifest.objects).find(
-        (key) => key.toLowerCase() === parentClassName.toLowerCase(),
-      );
+      // Use lookupInManifest for O(1) lookup via cached className index
+      // Handles both qualified names and simple class names
+      const parentObj = lookupInManifest(externalManifest, parentClassName);
 
-      if (parentKey) {
-        const parentObj = externalManifest.objects[parentKey];
-
+      if (parentObj) {
         // Cache the loaded parent object for future lookups
         objectsByName.set(parentObj.className, parentObj);
         objectsByName.set(parentObj.className.toLowerCase(), parentObj);

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -561,9 +561,12 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
         );
       }
 
-      // Generate pre-computed schemas for each object (same as TypeScript scanner path)
+      // Merge inherited fields and generate pre-computed schemas (same as TypeScript scanner path)
       const { ManifestGenerator } = await import('../scanner/index.js');
       const manifestGen = new ManifestGenerator();
+      // IMPORTANT: Must merge inherited fields BEFORE generating schemas
+      // This ensures STI subclasses inherit tableName from their base class
+      manifestGen.mergeInheritedFields(newManifest);
       manifestGen.generateSchemas(newManifest);
 
       const elapsed = performance.now() - startTime;


### PR DESCRIPTION
## Summary

Two fixes for STI (Single Table Inheritance) when using the OXC scanner:

1. **vite-plugin**: Call `mergeInheritedFields()` before `generateSchemas()`
   - The TypeScript scanner path already did this, but OXC scanner path was missing this call
   - Without it, STI subclasses like MeetingRecap got their own tableName derived from the class name instead of inheriting from Content

2. **manifest-generator**: Fix parent class lookup with qualified names
   - External manifest keys are qualified (e.g., `@happyvertical/smrt-content:Content`)
   - But the search was comparing against simple names (e.g., `Content`)
   - Now matches both exact key and qualified name suffix

## Problem

praeco's `MeetingRecap` and `MeetingAnnouncement` classes extend `Article` (from smrt-content) which extends `Content`. They should use the `contents` table via STI.

However, with the OXC scanner:
- MeetingRecap was getting `tableName: "meeting_recaps"` 
- Instead of inheriting `tableName: "contents"` from Content

This caused `Collection.list()` to query the wrong table and return empty results.

## Root Cause

The OXC scanner path in `vite-plugin/index.ts` was calling `generateSchemas()` but not `mergeInheritedFields()` first. The TypeScript scanner path correctly called both.

Additionally, `loadParentFromExternalPackage()` was failing to find parent classes because manifest keys now use qualified names like `@happyvertical/smrt-content:Content` but the search was looking for simple names like `Content`.

## Test Plan

- [x] Verified MeetingRecap now loads with `tableName: "contents"` and 28 columns
- [x] Verified praeco export correctly queries the contents table
- [x] Manual test: inserted MeetingRecap into contents table, export found it