### PR TITLE
fix(cli): deduplicate manifest discovery to prevent OOM

### DIFF
--- a/packages/cli/src/__tests__/manifest-discovery.test.ts
+++ b/packages/cli/src/__tests__/manifest-discovery.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests for manifest discovery deduplication and version conflict detection
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  autoDiscoverAndLoad,
+  discoverManifests,
+  SmrtVersionConflictError,
+} from '../discovery/manifest-discovery.js';
+
+describe('manifest-discovery', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'smrt-discovery-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('deduplication', () => {
+    it('should deduplicate packages with same name@version but different paths', async () => {
+      const nodeModules = join(tempDir, 'node_modules');
+
+      // Create two package locations with the same name@version
+      // Simulating pnpm's flat .pnpm structure (package.json at root of .pnpm/pkg@version/)
+      const pkg1Dir = join(nodeModules, '@happyvertical', 'smrt-profiles-1');
+      const pkg2Dir = join(nodeModules, '@happyvertical', 'smrt-profiles-2');
+
+      await mkdir(pkg1Dir, { recursive: true });
+      await mkdir(pkg2Dir, { recursive: true });
+
+      // Both have the same name and version in package.json
+      const pkgJson = JSON.stringify({
+        name: '@happyvertical/smrt-profiles',
+        version: '0.19.34',
+        dependencies: {
+          '@happyvertical/smrt-core': '^0.19.34',
+        },
+      });
+
+      await writeFile(join(pkg1Dir, 'package.json'), pkgJson);
+      await writeFile(join(pkg2Dir, 'package.json'), pkgJson);
+
+      // Both have manifest files
+      const manifestContent = JSON.stringify({
+        objects: {
+          Profile: { className: 'Profile' },
+        },
+      });
+
+      await writeFile(join(pkg1Dir, 'manifest.json'), manifestContent);
+      await writeFile(join(pkg2Dir, 'manifest.json'), manifestContent);
+
+      const discovered = await discoverManifests(tempDir);
+
+      // Should only load one manifest despite two copies existing
+      const profileManifests = discovered.filter(
+        (m) => m.packageName === '@happyvertical/smrt-profiles',
+      );
+      expect(profileManifests).toHaveLength(1);
+    });
+
+    it('should load different versions of the same package separately', async () => {
+      const nodeModules = join(tempDir, 'node_modules');
+
+      // Two different versions of the same package
+      const pkg1Dir = join(nodeModules, '@happyvertical', 'smrt-profiles-v1');
+      const pkg2Dir = join(nodeModules, '@happyvertical', 'smrt-profiles-v2');
+
+      await mkdir(pkg1Dir, { recursive: true });
+      await mkdir(pkg2Dir, { recursive: true });
+
+      await writeFile(
+        join(pkg1Dir, 'package.json'),
+        JSON.stringify({
+          name: '@happyvertical/smrt-profiles',
+          version: '0.19.33',
+          dependencies: { '@happyvertical/smrt-core': '^0.19.33' },
+        }),
+      );
+
+      await writeFile(
+        join(pkg2Dir, 'package.json'),
+        JSON.stringify({
+          name: '@happyvertical/smrt-profiles',
+          version: '0.19.34',
+          dependencies: { '@happyvertical/smrt-core': '^0.19.34' },
+        }),
+      );
+
+      // Different manifest content for different versions
+      await writeFile(
+        join(pkg1Dir, 'manifest.json'),
+        JSON.stringify({ objects: { ProfileV1: { className: 'ProfileV1' } } }),
+      );
+      await writeFile(
+        join(pkg2Dir, 'manifest.json'),
+        JSON.stringify({ objects: { ProfileV2: { className: 'ProfileV2' } } }),
+      );
+
+      const discovered = await discoverManifests(tempDir);
+
+      // Should load both versions (they're different)
+      const profileManifests = discovered.filter(
+        (m) => m.packageName === '@happyvertical/smrt-profiles',
+      );
+      expect(profileManifests).toHaveLength(2);
+    });
+
+    it('should skip packages without manifests', async () => {
+      const nodeModules = join(tempDir, 'node_modules');
+      const pkgDir = join(nodeModules, '@happyvertical', 'smrt-profiles');
+
+      await mkdir(pkgDir, { recursive: true });
+
+      await writeFile(
+        join(pkgDir, 'package.json'),
+        JSON.stringify({
+          name: '@happyvertical/smrt-profiles',
+          version: '0.19.34',
+          dependencies: { '@happyvertical/smrt-core': '^0.19.34' },
+        }),
+      );
+
+      // No manifest file
+
+      const discovered = await discoverManifests(tempDir);
+
+      const profileManifests = discovered.filter(
+        (m) => m.packageName === '@happyvertical/smrt-profiles',
+      );
+      expect(profileManifests).toHaveLength(0);
+    });
+  });
+
+  describe('version conflict detection', () => {
+    it('should throw SmrtVersionConflictError when multiple smrt package versions are found', async () => {
+      const nodeModules = join(tempDir, 'node_modules');
+
+      // Create packages with conflicting smrt-core versions
+      const pkg1Dir = join(nodeModules, '@happyvertical', 'smrt-core-v1');
+      const pkg2Dir = join(nodeModules, '@happyvertical', 'smrt-core-v2');
+
+      await mkdir(pkg1Dir, { recursive: true });
+      await mkdir(pkg2Dir, { recursive: true });
+
+      await writeFile(
+        join(pkg1Dir, 'package.json'),
+        JSON.stringify({
+          name: '@happyvertical/smrt-core',
+          version: '0.19.33',
+          dependencies: { smrt: '^0.19.33' },
+        }),
+      );
+
+      await writeFile(
+        join(pkg2Dir, 'package.json'),
+        JSON.stringify({
+          name: '@happyvertical/smrt-core',
+          version: '0.19.34',
+          dependencies: { smrt: '^0.19.34' },
+        }),
+      );
+
+      // Add manifests so they're discovered
+      await writeFile(
+        join(pkg1Dir, 'manifest.json'),
+        JSON.stringify({ objects: { CoreV1: {} } }),
+      );
+      await writeFile(
+        join(pkg2Dir, 'manifest.json'),
+        JSON.stringify({ objects: { CoreV2: {} } }),
+      );
+
+      await expect(autoDiscoverAndLoad(tempDir)).rejects.toThrow(
+        SmrtVersionConflictError,
+      );
+    });
+
+    it('should provide helpful error message with fix instructions', () => {
+      const conflicts = new Map<string, Set<string>>();
+      conflicts.set(
+        '@happyvertical/smrt-core',
+        new Set(['0.19.33', '0.19.34']),
+      );
+
+      const error = new SmrtVersionConflictError(conflicts);
+
+      expect(error.message).toContain('SMRT Version Conflict Detected');
+      expect(error.message).toContain('@happyvertical/smrt-core');
+      expect(error.message).toContain('0.19.33');
+      expect(error.message).toContain('0.19.34');
+      expect(error.message).toContain('pnpm why');
+      expect(error.message).toContain('overrides');
+      expect(error.message).toContain('pnpm store prune');
+    });
+
+    it('should not throw when all smrt packages have consistent versions', async () => {
+      const nodeModules = join(tempDir, 'node_modules');
+
+      // Create packages with consistent versions
+      const coreDir = join(nodeModules, '@happyvertical', 'smrt-core');
+      const profilesDir = join(nodeModules, '@happyvertical', 'smrt-profiles');
+
+      await mkdir(coreDir, { recursive: true });
+      await mkdir(profilesDir, { recursive: true });
+
+      await writeFile(
+        join(coreDir, 'package.json'),
+        JSON.stringify({
+          name: '@happyvertical/smrt-core',
+          version: '0.19.34',
+          dependencies: { smrt: '^0.19.34' },
+        }),
+      );
+
+      await writeFile(
+        join(profilesDir, 'package.json'),
+        JSON.stringify({
+          name: '@happyvertical/smrt-profiles',
+          version: '0.19.34',
+          dependencies: { '@happyvertical/smrt-core': '^0.19.34' },
+        }),
+      );
+
+      await writeFile(
+        join(coreDir, 'manifest.json'),
+        JSON.stringify({ objects: { Core: {} } }),
+      );
+      await writeFile(
+        join(profilesDir, 'manifest.json'),
+        JSON.stringify({ objects: { Profile: {} } }),
+      );
+
+      // Should not throw
+      const result = await autoDiscoverAndLoad(tempDir);
+      expect(result.discovered).toHaveLength(2);
+    });
+  });
+});

--- a/packages/cli/src/discovery/manifest-discovery.ts
+++ b/packages/cli/src/discovery/manifest-discovery.ts
@@ -15,7 +15,62 @@ export interface DiscoveredManifest {
   path: string;
   source: 'project' | 'package';
   packageName?: string;
+  packageVersion?: string;
   objectCount: number;
+}
+
+/**
+ * Tracks all versions found for each @happyvertical/smrt-* package.
+ * Used to detect version conflicts that could cause runtime issues.
+ */
+const smrtPackageVersions = new Map<string, Set<string>>();
+
+/**
+ * Error thrown when multiple versions of SMRT packages are detected
+ */
+export class SmrtVersionConflictError extends Error {
+  constructor(conflicts: Map<string, Set<string>>) {
+    const lines = [
+      '',
+      '❌ SMRT Version Conflict Detected',
+      '',
+      'Multiple versions of SMRT packages found in your project:',
+      '',
+    ];
+
+    for (const [pkg, versions] of conflicts) {
+      lines.push(`  ${pkg}: ${[...versions].join(', ')}`);
+    }
+
+    lines.push(
+      '',
+      'All SMRT packages must use the same version to ensure consistent behavior.',
+      '',
+      '🔧 To fix this:',
+      '',
+      '  1. Run: pnpm why <package-name>',
+      '     to find which dependencies are pulling in different versions',
+      '',
+      '  2. Update your dependencies to use consistent versions:',
+      '     pnpm update @happyvertical/smrt-core@latest',
+      '',
+      '  3. If transitive deps are the issue, add overrides to package.json:',
+      '     {',
+      '       "pnpm": {',
+      '         "overrides": {',
+      '           "@happyvertical/smrt-*": "^0.19.34"',
+      '         }',
+      '       }',
+      '     }',
+      '',
+      '  4. Clean stale packages:',
+      '     pnpm store prune && rm -rf node_modules && pnpm install',
+      '',
+    );
+
+    super(lines.join('\n'));
+    this.name = 'SmrtVersionConflictError';
+  }
 }
 
 /**
@@ -76,12 +131,27 @@ async function findProjectManifests(
 
 /**
  * Find manifests in installed packages
+ *
+ * Note: pnpm creates multiple copies of packages with different dependency hashes
+ * (e.g., @happyvertical/smrt-profiles@0.19.34_...hash1..., ...hash2..., etc.)
+ * We deduplicate by package name to avoid loading the same manifest hundreds of times,
+ * which would cause memory exhaustion. See issue #771.
  */
 async function findPackageManifests(
   projectRoot: string,
 ): Promise<DiscoveredManifest[]> {
   const discovered: DiscoveredManifest[] = [];
   const nodeModulesPath = resolve(projectRoot, 'node_modules');
+
+  // Track packages we've already processed to avoid duplicates from pnpm's
+  // content-addressable storage (same package version with different dependency hashes).
+  // We use name@version as the key because:
+  // - Same version with different hashes = identical manifest (safe to dedupe)
+  // - Different versions = potentially different manifest (must not dedupe)
+  const seenPackages = new Set<string>();
+
+  // Clear version tracking for this discovery run
+  smrtPackageVersions.clear();
 
   try {
     // Find all package.json files that might contain SMRT packages
@@ -95,6 +165,20 @@ async function findPackageManifests(
       try {
         const pkgContent = await readFile(pkgPath, 'utf-8');
         const pkg = JSON.parse(pkgContent);
+
+        // Track all versions of @happyvertical/smrt-* packages for conflict detection
+        if (pkg.name?.startsWith('@happyvertical/smrt-')) {
+          if (!smrtPackageVersions.has(pkg.name)) {
+            smrtPackageVersions.set(pkg.name, new Set());
+          }
+          smrtPackageVersions.get(pkg.name)?.add(pkg.version);
+        }
+
+        // Skip if we've already processed this package name@version
+        const packageKey = `${pkg.name}@${pkg.version}`;
+        if (seenPackages.has(packageKey)) {
+          continue;
+        }
 
         // Check if package has @happyvertical/smrt in dependencies
         const deps = {
@@ -120,10 +204,13 @@ async function findPackageManifests(
             try {
               const manifest = await loadManifestFile(manifestPath);
               if (manifest?.objects) {
+                // Mark this package as seen AFTER we successfully load a manifest
+                seenPackages.add(packageKey);
                 discovered.push({
                   path: manifestPath,
                   source: 'package',
                   packageName: pkg.name,
+                  packageVersion: pkg.version,
                   objectCount: Object.keys(manifest.objects).length,
                 });
                 break; // Use first found manifest for this package
@@ -142,6 +229,24 @@ async function findPackageManifests(
   }
 
   return discovered;
+}
+
+/**
+ * Check for SMRT package version conflicts and throw if any found.
+ * This ensures all @happyvertical/smrt-* packages use the same version.
+ */
+function checkSmrtVersionConflicts(): void {
+  const conflicts = new Map<string, Set<string>>();
+
+  for (const [pkg, versions] of smrtPackageVersions) {
+    if (versions.size > 1) {
+      conflicts.set(pkg, versions);
+    }
+  }
+
+  if (conflicts.size > 0) {
+    throw new SmrtVersionConflictError(conflicts);
+  }
 }
 
 /**
@@ -183,7 +288,9 @@ export async function loadManifest(manifestPath: string): Promise<void> {
 }
 
 /**
- * Auto-discover and load all manifests in the project
+ * Auto-discover and load all manifests in the project.
+ *
+ * @throws {SmrtVersionConflictError} If multiple versions of SMRT packages are detected
  */
 export async function autoDiscoverAndLoad(
   projectRoot: string = process.cwd(),
@@ -192,6 +299,11 @@ export async function autoDiscoverAndLoad(
   totalObjects: number;
 }> {
   const manifests = await discoverManifests(projectRoot);
+
+  // Check for version conflicts BEFORE loading manifests
+  // This fails fast with a helpful error message
+  checkSmrtVersionConflicts();
+
   let totalObjects = 0;
 
   // Load each discovered manifest

--- a/turbo.json
+++ b/turbo.json
@@ -81,7 +81,7 @@
       "cache": true
     },
     "typecheck": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "generate:test"],
       "inputs": ["src/**", "test/**", "**/*.ts", "tsconfig.json"],
       "cache": true
     },


### PR DESCRIPTION
## Summary

- Fixes memory exhaustion during `smrt db:setup` and other CLI commands that use manifest discovery
- Deduplicates package manifests by `name@version` to handle pnpm's content-addressable storage
- **Adds version conflict detection** to fail early with helpful error messages when multiple SMRT package versions are detected

## Problem

pnpm creates multiple copies of packages with different dependency hashes:
```
node_modules/.pnpm/@happyvertical+smrt-profiles@0.19.34_...hash1.../
node_modules/.pnpm/@happyvertical+smrt-profiles@0.19.34_...hash2.../
... (20+ copies)
```

The manifest discovery was loading **ALL** of them:
- 303 manifest files (17MB on disk)
- Parsed into 50-100MB+ of heap
- Caused OOM with default Node memory limits

Additionally, having multiple versions of SMRT packages in a project can cause subtle runtime issues that are hard to debug.

## Solution

1. **Deduplicate by `name@version`**: Track which package versions have been processed and skip duplicates. Same version with different dependency hashes = identical manifest.

2. **Version conflict detection**: Track all `@happyvertical/smrt-*` package versions during discovery and throw `SmrtVersionConflictError` if multiple versions are found. The error provides clear fix instructions:
   - How to diagnose with `pnpm why`
   - How to update dependencies
   - How to use pnpm overrides for transitive deps
   - How to clean stale packages

## Test plan

- [x] CLI tests pass
- [x] Verify `smrt db:setup` works with 512MB memory limit in bentleyalberta.com
- [ ] Test version conflict error by intentionally installing mismatched versions

Fixes #771