### PR TITLE
ci: split test jobs and use turbo remote cache

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -44,6 +44,11 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           auth-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Restore build from cache
+        run: pnpm run build
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run typecheck
         run: pnpm turbo run typecheck
         env:
@@ -66,6 +71,11 @@ jobs:
           install-deps: 'true'
           registry-url: 'https://npm.pkg.github.com'
           auth-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Restore build from cache
+        run: pnpm run build
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run lint
         run: pnpm turbo run lint
@@ -92,6 +102,11 @@ jobs:
           install-deps: 'true'
           registry-url: 'https://npm.pkg.github.com'
           auth-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Restore build from cache
+        run: pnpm run build
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests
         run: pnpm turbo run test


### PR DESCRIPTION
## Summary

- Split monolithic test job into parallel build/typecheck/lint/test jobs
- Remove GitHub Actions cache steps (turbo remote cache handles caching now)
- Remove postgres services block (use local postgres on runner)

## Changes

**Before:** Single job running sequentially (~4 min)
```
build → typecheck → lint → test
```

**After:** Parallel jobs after shared build (~1-2 min)
```
        ┌→ typecheck
build ──┼→ lint
        └→ test
```

## Infrastructure Dependencies

- [x] iac#286 - Turbo remote cache deployed
- [x] iac#287 - Local PostgreSQL configured on runner

## Expected Impact

| Metric | Before | After |
|--------|--------|-------|
| Total CI time | ~4 min | ~1-2 min |
| Longest job | 4 min | ~1 min (test) |

Closes #774