### PR TITLE
feat(core): add isType() and resolveType() helpers for STI name resolution

### DIFF
--- a/packages/core/src/__tests__/qualified-names.test.ts
+++ b/packages/core/src/__tests__/qualified-names.test.ts
@@ -14,6 +14,7 @@ import {
   getPackageFromQualifiedName,
   isFromPackage,
   isQualifiedName,
+  isType,
   parseQualifiedName,
   qualifiedNamesEqual,
 } from '../utils/qualified-names';
@@ -256,6 +257,62 @@ describe('qualified-names utilities', () => {
           '@HAPPYVERTICAL/smrt-core',
         ),
       ).toBe(false);
+    });
+  });
+
+  describe('isType', () => {
+    it('should return true when qualified name matches short name', () => {
+      expect(isType('@happyvertical/praeco:MeetingRecap', 'MeetingRecap')).toBe(
+        true,
+      );
+      expect(isType('@happyvertical/smrt-events:Event', 'Event')).toBe(true);
+    });
+
+    it('should return false when class names do not match', () => {
+      expect(isType('@happyvertical/praeco:MeetingRecap', 'Article')).toBe(
+        false,
+      );
+      expect(isType('@happyvertical/smrt-events:Event', 'Meeting')).toBe(false);
+    });
+
+    it('should work with simple names (passthrough)', () => {
+      expect(isType('MeetingRecap', 'MeetingRecap')).toBe(true);
+      expect(isType('MeetingRecap', 'Article')).toBe(false);
+    });
+
+    it('should return false for null or undefined', () => {
+      expect(isType(null, 'MeetingRecap')).toBe(false);
+      expect(isType(undefined, 'MeetingRecap')).toBe(false);
+    });
+
+    it('should return false for empty string', () => {
+      expect(isType('', 'MeetingRecap')).toBe(false);
+    });
+
+    it('should be case-sensitive', () => {
+      expect(isType('@happyvertical/praeco:MeetingRecap', 'meetingrecap')).toBe(
+        false,
+      );
+      expect(isType('@happyvertical/praeco:MeetingRecap', 'MEETINGRECAP')).toBe(
+        false,
+      );
+    });
+
+    it('should work for STI filtering use case', () => {
+      // Simulating filtering events by _meta_type
+      const events = [
+        {
+          _meta_type: '@happyvertical/praeco:Meeting',
+          name: 'Council Meeting',
+        },
+        { _meta_type: '@happyvertical/smrt-events:Event', name: 'Holiday' },
+        { _meta_type: '@happyvertical/praeco:Meeting', name: 'Budget Meeting' },
+      ];
+
+      const meetings = events.filter((e) => isType(e._meta_type, 'Meeting'));
+      expect(meetings).toHaveLength(2);
+      expect(meetings[0].name).toBe('Council Meeting');
+      expect(meetings[1].name).toBe('Budget Meeting');
     });
   });
 

--- a/packages/core/src/__tests__/sti-registry.test.ts
+++ b/packages/core/src/__tests__/sti-registry.test.ts
@@ -363,4 +363,88 @@ describe('STI Registry Methods', () => {
       expect(ObjectRegistry.getDescendants('Event')).toEqual(['Meeting']);
     });
   });
+
+  describe('resolveType()', () => {
+    it('should resolve unambiguous short name to qualified name', () => {
+      @smrt({ tableStrategy: 'sti' })
+      class Event extends SmrtObject {
+        title: string = '';
+      }
+
+      @smrt()
+      class Meeting extends Event {
+        roomNumber: string = '';
+      }
+
+      const qualified = ObjectRegistry.resolveType('Meeting');
+      expect(qualified).toMatch(/^@[^:]+:Meeting$/);
+    });
+
+    it('should pass through already qualified names', () => {
+      @smrt({ tableStrategy: 'sti' })
+      class Event extends SmrtObject {
+        title: string = '';
+      }
+
+      // Get the actual qualified name
+      const registered = ObjectRegistry.findClass('Event');
+      const qualifiedName = registered?.qualifiedName;
+
+      // Should pass through unchanged
+      const result = ObjectRegistry.resolveType(qualifiedName!);
+      expect(result).toBe(qualifiedName);
+    });
+
+    it('should throw for unregistered class names', () => {
+      expect(() => ObjectRegistry.resolveType('NonExistentClass')).toThrow(
+        'is not registered',
+      );
+    });
+
+    it('should throw for ambiguous names when multiple packages define same class', () => {
+      // Register two classes with the same short name but different packages
+      // We simulate this by registering directly with different qualified names
+
+      @smrt()
+      class Product extends SmrtObject {
+        name: string = '';
+      }
+
+      // Get the first product's qualified name
+      const product1 = ObjectRegistry.findClass('Product');
+
+      // Manually register another "Product" from a different package
+      // This simulates what happens when two packages define the same class name
+      ObjectRegistry.classes.set('Product2', {
+        name: 'Product',
+        qualifiedName: '@other/package:Product',
+        constructor: class OtherProduct extends SmrtObject {},
+        collectionConstructor: undefined,
+        config: {},
+        fields: new Map(),
+        methods: new Map(),
+        schema: undefined,
+        validators: [],
+        packageName: '@other/package',
+        extends: 'SmrtObject',
+      } as any);
+
+      // Now resolveType should throw because "Product" is ambiguous
+      expect(() => ObjectRegistry.resolveType('Product')).toThrow('ambiguous');
+      expect(() => ObjectRegistry.resolveType('Product')).toThrow(
+        'multiple packages',
+      );
+    });
+
+    it('should be case-insensitive for lookup', () => {
+      @smrt()
+      class MyClass extends SmrtObject {
+        value: string = '';
+      }
+
+      // Should find the class regardless of case
+      const qualified = ObjectRegistry.resolveType('myclass');
+      expect(qualified).toMatch(/MyClass$/);
+    });
+  });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -103,6 +103,7 @@ export {
   getPackageFromQualifiedName,
   isFromPackage,
   isQualifiedName,
+  isType,
   type ParsedQualifiedName,
   parseQualifiedName,
   qualifiedNamesEqual,

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1948,6 +1948,71 @@ export class ObjectRegistry {
   }
 
   /**
+   * Resolve a short class name to its qualified name.
+   * Throws an error if the name is ambiguous (multiple packages define the same class name).
+   *
+   * @param shortName - The simple class name to resolve (e.g., 'MeetingRecap')
+   * @returns The qualified class name (e.g., '@happyvertical/praeco:MeetingRecap')
+   * @throws {Error} If no class with that name is registered
+   * @throws {Error} If multiple classes with that name exist (ambiguous)
+   *
+   * @example
+   * ```typescript
+   * // Unambiguous resolution
+   * const qualified = ObjectRegistry.resolveType('MeetingRecap');
+   * // Returns: '@happyvertical/praeco:MeetingRecap'
+   *
+   * // Already qualified names pass through
+   * const same = ObjectRegistry.resolveType('@happyvertical/praeco:MeetingRecap');
+   * // Returns: '@happyvertical/praeco:MeetingRecap'
+   *
+   * // Ambiguous names throw
+   * ObjectRegistry.resolveType('Event');
+   * // Error: "Event" is ambiguous. Found in multiple packages:
+   * //   - @happyvertical/smrt-events:Event
+   * //   - @happyvertical/calendar:Event
+   * // Use the fully qualified name instead.
+   * ```
+   */
+  static resolveType(shortName: string): QualifiedClassName {
+    // If already qualified, validate and return
+    if (shortName.includes(':') && shortName.startsWith('@')) {
+      const registered = ObjectRegistry.getClassByQualifiedName(
+        shortName as QualifiedClassName,
+      );
+      if (!registered) {
+        throw new Error(
+          `Class "${shortName}" is not registered. ` +
+            `Make sure the package is installed and the class is decorated with @smrt().`,
+        );
+      }
+      return shortName as QualifiedClassName;
+    }
+
+    // Find all classes with this short name
+    const matches = ObjectRegistry.findClassesByName(shortName);
+
+    if (matches.length === 0) {
+      throw new Error(
+        `Class "${shortName}" is not registered. ` +
+          `Make sure the package is installed and the class is decorated with @smrt().`,
+      );
+    }
+
+    if (matches.length > 1) {
+      const packageList = matches
+        .map((m) => `  - ${m.qualifiedName}`)
+        .join('\n');
+      throw new Error(
+        `"${shortName}" is ambiguous. Found in multiple packages:\n${packageList}\n` +
+          `Use the fully qualified name instead.`,
+      );
+    }
+
+    return matches[0].qualifiedName as QualifiedClassName;
+  }
+
+  /**
    * Get all registered classes from a specific package.
    *
    * @param packageName - The package name to filter by

--- a/packages/core/src/utils/qualified-names.ts
+++ b/packages/core/src/utils/qualified-names.ts
@@ -195,3 +195,33 @@ export function isFromPackage(
   const parsed = parseQualifiedName(qualifiedName);
   return parsed.packageName === packageName;
 }
+
+/**
+ * Checks if a qualified name (like `_meta_type`) matches a short class name.
+ * This is useful for STI filtering where the database stores qualified names
+ * but code often uses short names for comparisons.
+ *
+ * @param qualifiedName - The qualified name or simple name to check (e.g., from `_meta_type`)
+ * @param shortName - The short class name to match against
+ * @returns true if the class name portion matches
+ *
+ * @example
+ * ```typescript
+ * // Filtering STI records by type
+ * const meetings = events.filter(e => isType(e._meta_type, 'Meeting'));
+ *
+ * // Works with both qualified and simple names
+ * isType('@happyvertical/praeco:MeetingRecap', 'MeetingRecap') // true
+ * isType('@happyvertical/praeco:MeetingRecap', 'Article') // false
+ * isType('MeetingRecap', 'MeetingRecap') // true (simple name passthrough)
+ * ```
+ */
+export function isType(
+  qualifiedName: string | null | undefined,
+  shortName: string,
+): boolean {
+  if (!qualifiedName) {
+    return false;
+  }
+  return getClassName(qualifiedName) === shortName;
+}


### PR DESCRIPTION
## Summary

Addresses #755 - Allow short name resolution for `_meta_type` in STI.

Adds two helper functions for working with qualified class names in STI scenarios:

### `isType(qualifiedName, shortName)` - Pure comparison helper

Compares a qualified `_meta_type` value against a short class name. This is safe for filtering STI records without needing fully qualified names in code.

```typescript
import { isType } from '@happyvertical/smrt-core';

// Filter STI records by type
const meetings = events.filter(e => isType(e._meta_type, 'Meeting'));

// Works with both qualified and simple names
isType('@happyvertical/praeco:MeetingRecap', 'MeetingRecap') // true
isType('@happyvertical/praeco:MeetingRecap', 'Article') // false
isType('MeetingRecap', 'MeetingRecap') // true (passthrough)
```

### `ObjectRegistry.resolveType(shortName)` - Registry lookup with ambiguity detection

Resolves a short class name to its fully qualified name. **Throws an error if ambiguous** (multiple packages define the same class name) - this helps catch configuration issues early.

```typescript
// Unambiguous resolution
const qualified = ObjectRegistry.resolveType('MeetingRecap');
// Returns: '@happyvertical/praeco:MeetingRecap'

// Ambiguous names throw with helpful error
ObjectRegistry.resolveType('Event');
// Error: "Event" is ambiguous. Found in multiple packages:
//   - @happyvertical/smrt-events:Event
//   - @happyvertical/calendar:Event
// Use the fully qualified name instead.
```

## Test plan

- [x] Added 7 tests for `isType()` in qualified-names.test.ts
- [x] Added 4 tests for `resolveType()` in sti-registry.test.ts
- [x] All existing tests pass