### PR TITLE
fix(core): add type annotations for parse() calls

### DIFF
--- a/packages/core/src/manifest/discover-smrt-packages.ts
+++ b/packages/core/src/manifest/discover-smrt-packages.ts
@@ -201,7 +201,9 @@ function hasManifestExport(packageName: string): boolean {
     }
 
     // Load and validate manifest
-    const manifest = parse(readFileSync(manifestPath, 'utf-8'));
+    const manifest = parse<{ moduleType?: string }>(
+      readFileSync(manifestPath, 'utf-8'),
+    );
 
     // Validate moduleType
     if (manifest.moduleType !== 'smrt') {
@@ -319,10 +321,10 @@ export function discoverSmrtPackages(options: DiscoveryOptions = {}): string[] {
   const cacheDisabled =
     options.noCache || process.env.SMRT_DISABLE_DISCOVERY_CACHE === 'true';
 
-  const verbose =
-    options.verbose ||
+  const verbose: boolean =
+    options.verbose === true ||
     process.env.SMRT_VERBOSE === 'true' ||
-    process.env.DEBUG?.includes('smrt');
+    !!process.env.DEBUG?.includes('smrt');
 
   if (cacheDisabled) {
     if (verbose) {

--- a/packages/core/src/manifest/manifest-loader.ts
+++ b/packages/core/src/manifest/manifest-loader.ts
@@ -529,7 +529,9 @@ export function getPackageName(
               const pkgPath = join(dir, 'package.json');
               try {
                 if (existsSync(pkgPath)) {
-                  const pkg = parse(readFileSync(pkgPath, 'utf-8'));
+                  const pkg = parse<{ name?: string }>(
+                    readFileSync(pkgPath, 'utf-8'),
+                  );
                   if (pkg.name?.startsWith('@')) {
                     return pkg.name;
                   }
@@ -615,7 +617,7 @@ export function loadExternalManifestSync(packageName: string): Manifest | null {
       const testPath = join(dir, 'package.json');
       try {
         const content = readFileSync(testPath, 'utf-8');
-        const json = parse(content);
+        const json = parse<{ name?: string }>(content);
         if (json.name === packageName) {
           pkgPath = testPath;
           break;
@@ -641,7 +643,7 @@ export function loadExternalManifestSync(packageName: string): Manifest | null {
     try {
       if (existsSync(nodeModulesPkgPath)) {
         const content = readFileSync(nodeModulesPkgPath, 'utf-8');
-        const json = parse(content);
+        const json = parse<{ name?: string }>(content);
         if (json.name === packageName) {
           pkgPath = nodeModulesPkgPath;
         }
@@ -678,7 +680,7 @@ export function loadExternalManifestSync(packageName: string): Manifest | null {
       try {
         if (existsSync(workspacePkgPath)) {
           const content = readFileSync(workspacePkgPath, 'utf-8');
-          const json = parse(content);
+          const json = parse<{ name?: string }>(content);
           if (json.name === packageName) {
             pkgPath = workspacePkgPath;
             debugLog(
@@ -726,7 +728,9 @@ export function loadExternalManifestSync(packageName: string): Manifest | null {
     }
 
     // Fallback: Try package.json exports (for published packages without .smrt/)
-    const pkgJson = parse(readFileSync(pkgPath, 'utf-8'));
+    const pkgJson = parse<{
+      exports?: Record<string, string | { default?: string; import?: string }>;
+    }>(readFileSync(pkgPath, 'utf-8'));
     let manifestExport = pkgJson.exports?.['./manifest.json'];
 
     if (!manifestExport) {
@@ -1476,7 +1480,7 @@ export function discoverSTISiblingsSync(
         if (existsSync(manifestPath)) {
           try {
             const manifestContent = readFileSync(manifestPath, 'utf-8');
-            const manifest = parse(manifestContent);
+            const manifest = parse<SmartObjectManifest>(manifestContent);
             // Cache it
             getManifestCacheMap().set(fullPackageName, manifest);
             addFromManifest(manifest, `nodeModules:${fullPackageName}`);


### PR DESCRIPTION
## Summary
Fix TypeScript errors introduced by PR #784 where `parse()` from `@happyvertical/json` returns `unknown` instead of `any`.

## Changes
- Add explicit type parameters to `parse<T>()` calls in discover-smrt-packages.ts
- Add explicit type parameters to `parse<T>()` calls in manifest-loader.ts
- Fix `verbose` variable to be `boolean` instead of `boolean | undefined`

## Test plan
- [x] `pnpm run typecheck` passes locally
- [ ] CI typecheck passes