### PR TITLE
perf(core): reduce console noise by making registry logs conditional

### DIFF
--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -62,6 +62,27 @@ import { LRUCache } from './utils/lru-cache';
 import { createQualifiedName } from './utils/qualified-names.js';
 
 /**
+ * Cached verbose flag evaluated once at module load time.
+ * Checks SMRT_VERBOSE=true or DEBUG containing 'smrt'.
+ * Avoids repeated env var parsing on every log statement.
+ * @see https://github.com/happyvertical/smrt/issues/782
+ */
+const VERBOSE_ENABLED =
+  process.env.SMRT_VERBOSE === 'true' ||
+  (process.env.DEBUG?.includes('smrt') ?? false);
+
+/**
+ * Log a message only when verbose mode is enabled.
+ * Used throughout registry.ts to reduce noise during normal operation.
+ * @param args - Arguments to pass to console.log
+ */
+function verboseLog(...args: unknown[]): void {
+  if (VERBOSE_ENABLED) {
+    console.log(...args);
+  }
+}
+
+/**
  * Extend globalThis to include ObjectRegistry state.
  * Using globalThis ensures all module instances share the same registry,
  * which is critical in monorepos where the same package can be loaded
@@ -951,7 +972,7 @@ export class ObjectRegistry {
         existing.config = { ...existing.config, ...config };
         // Index constructor for O(1) reverse lookups (Issue #713)
         ObjectRegistry.constructorIndex.set(ctor, name);
-        console.log(
+        verboseLog(
           `[registry] Replaced manifest stub with real class: ${name}`,
         );
         return;
@@ -1057,7 +1078,7 @@ export class ObjectRegistry {
           ObjectRegistry.classNameMap.set(name.toLowerCase(), name);
           // Index constructor for O(1) reverse lookups (Issue #713)
           ObjectRegistry.constructorIndex.set(ctor, name);
-          console.log(
+          verboseLog(
             `[registry] Replaced manifest stub '${existingKey}' with real class '${name}'`,
           );
           return;
@@ -1142,12 +1163,12 @@ export class ObjectRegistry {
     const methods = new Map<string, any>();
     let packageName: string | undefined;
 
-    console.log(
+    verboseLog(
       `[registry] Registering ${name}: manifestEntry =`,
       manifestEntry ? 'found' : 'not found',
     );
     if (manifestEntry?.fields) {
-      console.log(
+      verboseLog(
         `[registry] Manifest has ${Object.keys(manifestEntry.fields).length} fields:`,
         Object.keys(manifestEntry.fields),
       );
@@ -1199,7 +1220,7 @@ export class ObjectRegistry {
         fields.set(fieldName, field);
       }
 
-      console.log(
+      verboseLog(
         `[registry] ✅ Loaded ${fields.size} fields for ${name} from manifest`,
       );
 
@@ -1212,7 +1233,7 @@ export class ObjectRegistry {
     } else {
       // No manifest found yet - use package name from stack trace
       // This will be used later by ensureManifestLoaded() to load the external manifest
-      console.log(
+      verboseLog(
         `[registry] ⚠️  No manifest entry for ${name} - fields will be loaded later`,
       );
       packageName = packageNameFromStack;
@@ -1222,7 +1243,7 @@ export class ObjectRegistry {
     // Decorators take priority over AST-scanned types (Issue #316)
     const decorators = ObjectRegistry.fieldDecorators.get(name);
     if (decorators && decorators.size > 0) {
-      console.log(
+      verboseLog(
         `[registry] Applying ${decorators.size} field decorators for ${name}`,
       );
 
@@ -1272,7 +1293,7 @@ export class ObjectRegistry {
           }
 
           fields.set(fieldName, mergedField);
-          console.log(
+          verboseLog(
             `[registry]   ✅ Merged decorator for ${fieldName}: type=${mergedField.type}`,
           );
         } else {
@@ -1302,7 +1323,7 @@ export class ObjectRegistry {
           }
 
           fields.set(fieldName, newField);
-          console.log(
+          verboseLog(
             `[registry]   ✅ Added field ${fieldName} from decorator: type=${decoratorOptions.type || 'text'}`,
           );
         }
@@ -1340,7 +1361,7 @@ export class ObjectRegistry {
             },
           },
         });
-        console.log(
+        verboseLog(
           `[registry] ✅ Injected ${fieldName} field for tenant-scoped class ${name}`,
         );
       }
@@ -1363,7 +1384,7 @@ export class ObjectRegistry {
       )) {
         methods.set(methodName, methodDef);
       }
-      console.log(
+      verboseLog(
         `[registry] Loaded ${methods.size} methods for ${name} from _manifestMethods`,
       );
     }
@@ -1436,7 +1457,7 @@ export class ObjectRegistry {
         version: manifestEntry.schema.version || '',
         packageName: manifestEntry.packageName,
       };
-      console.log(
+      verboseLog(
         `[registry] Loaded pre-generated schema for ${name} (${Object.keys(manifestEntry.schema.columns || {}).length} columns)`,
       );
     } else {
@@ -1515,7 +1536,7 @@ export class ObjectRegistry {
     // Index constructor for O(1) reverse lookups (Issue #713: constructor-based lookup)
     ObjectRegistry.constructorIndex.set(ctor, name);
 
-    console.log(
+    verboseLog(
       `🎯 Registered smrt object: ${name} with schema for ${schema.tableName} and ${validators.length} validators`,
     );
 
@@ -1532,7 +1553,7 @@ export class ObjectRegistry {
       // Mark this collection as processed to prevent infinite recursion
       ObjectRegistry.stiSiblingsLoaded.add(collection);
 
-      console.log(
+      verboseLog(
         `[registry] Checking for STI siblings for collection: ${collection}`,
       );
 
@@ -1550,13 +1571,13 @@ export class ObjectRegistry {
             packageName &&
             sibling.packageName === packageName
           ) {
-            console.log(
+            verboseLog(
               `[registry] Skipping STI sibling ${sibling.className} from same package: ${packageName}`,
             );
             continue;
           }
 
-          console.log(
+          verboseLog(
             `[registry] Auto-loading STI sibling: ${sibling.className} for collection: ${collection}`,
           );
           ObjectRegistry.registerFromManifest(
@@ -1695,7 +1716,7 @@ export class ObjectRegistry {
         version: objectDef.schema.version || '',
         packageName: packageName,
       };
-      console.log(
+      verboseLog(
         `[registry] Loaded pre-generated schema for ${name} (${Object.keys(objectDef.schema.columns || {}).length} columns)`,
       );
     } else {
@@ -1743,7 +1764,7 @@ export class ObjectRegistry {
       visibility, // New: Visibility control for manifest filtering
     });
 
-    console.log(
+    verboseLog(
       `📦 Registered ${name} from manifest (${fields.size} fields, ${methods.size} methods)`,
     );
 
@@ -1760,7 +1781,7 @@ export class ObjectRegistry {
       // Mark this collection as processed to prevent infinite recursion
       ObjectRegistry.stiSiblingsLoaded.add(collection);
 
-      console.log(
+      verboseLog(
         `[registry] Checking for STI siblings for collection: ${collection}`,
       );
 
@@ -1778,13 +1799,13 @@ export class ObjectRegistry {
             packageName &&
             sibling.packageName === packageName
           ) {
-            console.log(
+            verboseLog(
               `[registry] Skipping STI sibling ${sibling.className} from same package: ${packageName}`,
             );
             continue;
           }
 
-          console.log(
+          verboseLog(
             `[registry] Auto-loading STI sibling: ${sibling.className} for collection: ${collection}`,
           );
           ObjectRegistry.registerFromManifest(
@@ -2170,7 +2191,7 @@ export class ObjectRegistry {
 
     const smrtPackages = discoverSmrtPackages();
 
-    console.log(
+    verboseLog(
       `[ObjectRegistry] Attempting to auto-load ${className} from ${smrtPackages.length} external packages...`,
     );
 
@@ -2206,7 +2227,7 @@ export class ObjectRegistry {
         continue;
       }
 
-      console.log(
+      verboseLog(
         `[ObjectRegistry] ✅ Found ${className} in ${packageName} manifest`,
       );
 
@@ -2238,7 +2259,7 @@ export class ObjectRegistry {
         }
 
         if (parentDef && !ObjectRegistry.hasClass(objectDef.extends)) {
-          console.log(
+          verboseLog(
             `[ObjectRegistry] Also registering parent class ${objectDef.extends} for STI`,
           );
           ObjectRegistry.registerFromManifest(
@@ -2250,13 +2271,13 @@ export class ObjectRegistry {
 
         // Merge inherited fields from parent into child
         // This ensures STI child classes get all parent fields
-        console.log(
+        verboseLog(
           `[ObjectRegistry] Merging inherited fields for ${className}...`,
         );
         await ObjectRegistry.getAllFields(className);
         const registered = ObjectRegistry.findClass(className);
         if (registered?.inheritedFields) {
-          console.log(
+          verboseLog(
             `[ObjectRegistry] ✅ ${className} now has ${registered.inheritedFields.size} total fields (including inherited)`,
           );
         }
@@ -2265,7 +2286,7 @@ export class ObjectRegistry {
       return true;
     }
 
-    console.log(
+    verboseLog(
       `[ObjectRegistry] ❌ Could not find ${className} in any SMRT package`,
     );
     return false;
@@ -2825,7 +2846,7 @@ export class ObjectRegistry {
         registered.extends = manifestEntry.extends;
       }
 
-      console.log(
+      verboseLog(
         `📦 Loaded manifest for external package class: ${className} (${registered.fields.size} fields, ${registered.methods.size} methods)`,
       );
     } else {


### PR DESCRIPTION
## Summary

- Replace unconditional console.log statements in ObjectRegistry with conditional verboseLog helper
- Logs are now only printed when `SMRT_VERBOSE=true` or `DEBUG` contains 'smrt'
- This reduces startup noise and I/O overhead for downstream projects with many (50+) SMRT objects

## Context

Relates to #782 - CLI startup performance issue where object registration is extremely slow.

While this PR doesn't address the core performance bottleneck (which is the time to load and register 58+ objects), it eliminates unnecessary console I/O during normal operation, which:
1. Reduces noise in logs
2. Avoids I/O syscalls on every object registration
3. Makes the CLI output cleaner for end users

## Changes

- Add `VERBOSE_ENABLED` constant evaluated once at module load time
- Add `verboseLog()` helper function that only logs when verbose mode is enabled
- Replace 25+ console.log calls with verboseLog in:
  - `register()` - manifest stub replacement logs
  - `registerFromManifest()` - schema loading, field merging, STI sibling discovery
  - `ensureManifestLoaded()` - auto-loading from external packages

## Test plan

- [x] Build passes
- [x] TypeScript type-check passes
- [x] Pre-commit hooks pass (format, commitlint)

## How to enable verbose logging

Users who want the detailed logging can set:
```bash
SMRT_VERBOSE=true smrt <command>
# or
DEBUG=smrt smrt <command>
```