### PR TITLE
fix(core): increase timeout for LRU cache eviction test

### DIFF
--- a/packages/core/src/__tests__/issue-117-memory-leak-prevention.test.ts
+++ b/packages/core/src/__tests__/issue-117-memory-leak-prevention.test.ts
@@ -137,7 +137,7 @@ describe('Issue #117: Memory Leak Prevention', () => {
         },
       );
       expect(collection1).not.toBe(collections[1]);
-    }, 10000); // 10 second timeout (creates 100 SQLite databases)
+    }, 30000); // 30 second timeout (creates 100 SQLite databases - slow in CI)
 
     it('should handle cache clear correctly', async () => {
       // Create a collection


### PR DESCRIPTION
## Summary
Increase timeout for the LRU cache eviction test from 10s to 30s.

The test creates 100 SQLite databases which can be slow in CI, causing flaky timeouts.

## Test plan
- [x] Local test passes
- [ ] CI passes