### PR TITLE
fix(tenancy): detect field descriptors as unset for tenant auto-population

### DIFF
--- a/packages/tenancy/src/__tests__/tenancy.test.ts
+++ b/packages/tenancy/src/__tests__/tenancy.test.ts
@@ -491,6 +491,33 @@ describe('TenantInterceptor', () => {
       });
     });
 
+    it('should auto-populate when tenantId is a field descriptor (issue #829)', async () => {
+      // When a model uses `tenantId = tenantId({ nullable: true })` as a class property,
+      // the field descriptor object remains on the instance if the constructor doesn't
+      // explicitly set a value. The interceptor should treat this as "not set".
+      registerTenantScopedClass('Contract');
+      const interceptor = createTenantInterceptor();
+
+      // Simulate a class property with the field descriptor object
+      const fieldDescriptor = tenantId({ nullable: true });
+      const instance = { tenantId: fieldDescriptor } as any;
+
+      await withTenant({ tenantId: 'tenant-123' }, async () => {
+        // Before: tenantId is a field descriptor object (truthy, but not a value)
+        expect(isTenantIdField(instance.tenantId)).toBe(true);
+
+        interceptor.beforeSave?.(instance, {
+          className: 'Contract',
+          operation: 'save',
+          timestamp: new Date(),
+        });
+
+        // After: tenantId should be auto-populated with the actual tenant ID
+        expect(instance.tenantId).toBe('tenant-123');
+        expect(isTenantIdField(instance.tenantId)).toBe(false);
+      });
+    });
+
     it('should throw on tenant mismatch', async () => {
       registerTenantScopedClass('Document');
       const interceptor = createTenantInterceptor();
@@ -507,6 +534,51 @@ describe('TenantInterceptor', () => {
             timestamp: new Date(),
           }),
         ).toThrow(TenantIsolationError);
+      });
+    });
+
+    it('should not throw for field descriptor with different context (issue #829)', async () => {
+      // A field descriptor should not trigger a tenant mismatch error
+      // because it's not an actual tenant ID value
+      registerTenantScopedClass('Contract');
+      const interceptor = createTenantInterceptor();
+
+      const fieldDescriptor = tenantId({ nullable: true });
+      const instance = { tenantId: fieldDescriptor } as any;
+
+      await withTenant({ tenantId: 'tenant-123' }, async () => {
+        // Should NOT throw - the field descriptor should be replaced, not validated
+        expect(() =>
+          interceptor.beforeSave?.(instance, {
+            className: 'Contract',
+            operation: 'save',
+            timestamp: new Date(),
+          }),
+        ).not.toThrow();
+
+        expect(instance.tenantId).toBe('tenant-123');
+      });
+    });
+  });
+
+  describe('beforeDelete', () => {
+    it('should not throw for field descriptor with different context (issue #829)', async () => {
+      // A field descriptor should not trigger a tenant mismatch error on delete
+      registerTenantScopedClass('Contract');
+      const interceptor = createTenantInterceptor();
+
+      const fieldDescriptor = tenantId({ nullable: true });
+      const instance = { tenantId: fieldDescriptor } as any;
+
+      await withTenant({ tenantId: 'tenant-123' }, async () => {
+        // Should NOT throw - field descriptors are ignored for validation
+        expect(() =>
+          interceptor.beforeDelete?.(instance, {
+            className: 'Contract',
+            operation: 'delete',
+            timestamp: new Date(),
+          }),
+        ).not.toThrow();
       });
     });
   });

--- a/packages/tenancy/src/interceptor.ts
+++ b/packages/tenancy/src/interceptor.ts
@@ -24,6 +24,7 @@ import {
   TenantContextError,
   TenantIsolationError,
 } from './context.js';
+import { isTenantIdField } from './fields.js';
 import { getTenantScopedConfig, isTenantScopedClass } from './registry.js';
 
 /**
@@ -307,14 +308,21 @@ export function createTenantInterceptor(
         return; // Mode is 'optional'
       }
 
-      // Auto-populate tenant ID if not set
-      if (!instanceTenantId && config?.autoPopulate !== false) {
+      // Auto-populate tenant ID if not set (or if it's a field descriptor, not a value)
+      if (
+        (!instanceTenantId || isTenantIdField(instanceTenantId)) &&
+        config?.autoPopulate !== false
+      ) {
         (instance as any)[tenantField] = tenantContext.tenantId;
         return;
       }
 
-      // Validate tenant ID matches context
-      if (instanceTenantId && instanceTenantId !== tenantContext.tenantId) {
+      // Validate tenant ID matches context (skip validation for field descriptors)
+      if (
+        instanceTenantId &&
+        !isTenantIdField(instanceTenantId) &&
+        instanceTenantId !== tenantContext.tenantId
+      ) {
         opts.onIsolationViolation?.(
           className,
           tenantContext.tenantId,
@@ -364,8 +372,12 @@ export function createTenantInterceptor(
         return;
       }
 
-      // Validate tenant ID matches
-      if (instanceTenantId && instanceTenantId !== tenantContext.tenantId) {
+      // Validate tenant ID matches (skip validation for field descriptors)
+      if (
+        instanceTenantId &&
+        !isTenantIdField(instanceTenantId) &&
+        instanceTenantId !== tenantContext.tenantId
+      ) {
         opts.onIsolationViolation?.(
           className,
           tenantContext.tenantId,


### PR DESCRIPTION
## Summary

- Fix tenant ID auto-population when `tenantId` is a field descriptor object instead of a value
- Use existing `isTenantIdField()` helper to detect field descriptors in `beforeSave` and `beforeDelete` hooks
- Treat field descriptors as "not set" for auto-population purposes

## Root Cause

When models use `tenantId = tenantId({ nullable: true })` as a class property, the field descriptor object remains on the instance if the constructor doesn't explicitly set a value. The interceptor was checking `!instanceTenantId` which evaluates to `false` for truthy objects, causing:

1. **Auto-population skipped**: Field descriptor is truthy, so auto-populate code never ran
2. **Database corruption**: Field descriptor objects were serialized to the database
3. **Incorrect validation**: Could trigger false tenant mismatch errors

## Changes

1. **Import `isTenantIdField`** from `fields.ts` into `interceptor.ts`
2. **beforeSave auto-populate** (line 311): Check `!instanceTenantId || isTenantIdField(instanceTenantId)`
3. **beforeSave validation** (line 317): Skip validation when `isTenantIdField(instanceTenantId)`
4. **beforeDelete validation** (line 368): Skip validation when `isTenantIdField(instanceTenantId)`

## Test plan

- [x] Added test: "should auto-populate when tenantId is a field descriptor (issue #829)"
- [x] Added test: "should not throw for field descriptor with different context (issue #829)" for beforeSave
- [x] Added test: "should not throw for field descriptor with different context (issue #829)" for beforeDelete
- [x] All 43 tenancy tests pass

Closes #829