### PR TITLE
feat(cli): add unified smrt export command for static site generation

### DIFF
--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -1,0 +1,565 @@
+/**
+ * export Command
+ *
+ * Unified export command for static site generation.
+ * Exports data from database to JSON files based on smrt.config.js export configuration.
+ *
+ * This replaces per-agent export commands (praeco export, caelus export, etc.)
+ * with a single, schema-driven export that respects field-level export annotations.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type {
+  ExportFileConfig,
+  ExportFilterValue,
+} from '@happyvertical/smrt-config';
+import type { CLICommand } from '../cli-generator.js';
+
+/**
+ * Get fields that should be exported for a given type
+ */
+async function getExportableFields(
+  typeName: string,
+  fileConfig: ExportFileConfig,
+  fieldExportDefault: boolean,
+): Promise<string[]> {
+  const { ObjectRegistry } = await import('@happyvertical/smrt-core');
+
+  // Get fields from registry
+  const fields = ObjectRegistry.getFields(typeName);
+  if (fields.size === 0) {
+    console.warn(`⚠️  No fields found for type: ${typeName}`);
+    return [];
+  }
+
+  // If include whitelist is specified, use only those fields
+  if (fileConfig.include && fileConfig.include.length > 0) {
+    return fileConfig.include.filter(
+      (f) => fields.has(f) || f === '_meta_type',
+    );
+  }
+
+  const exportableFields: string[] = [];
+
+  for (const [fieldName, fieldDef] of fields) {
+    // Skip transient and relationship fields
+    if (fieldDef.transient) continue;
+    if (fieldDef.type === 'oneToMany' || fieldDef.type === 'manyToMany')
+      continue;
+
+    // Check field-level export annotation (from @field({ exported: ... }))
+    const exportedAnnotation = (fieldDef as any).exported;
+
+    // exported: false means never export (cannot be overridden)
+    if (exportedAnnotation === false) continue;
+
+    // exported: true means always export
+    if (exportedAnnotation === true) {
+      exportableFields.push(fieldName);
+      continue;
+    }
+
+    // No annotation - use site's fieldExportDefault
+    if (fieldExportDefault) {
+      exportableFields.push(fieldName);
+    }
+  }
+
+  // Apply exclude blacklist
+  const excluded = new Set(fileConfig.exclude || []);
+  const result = exportableFields.filter((f) => !excluded.has(f));
+
+  // Always include _meta_type for STI discrimination
+  if (!result.includes('_meta_type')) {
+    result.push('_meta_type');
+  }
+
+  return result;
+}
+
+/**
+ * Build WHERE clause from filter config
+ */
+function buildWhereClause(
+  filters: Record<string, string[] | number[] | ExportFilterValue> | undefined,
+): Record<string, any> {
+  if (!filters) return {};
+
+  const where: Record<string, any> = {};
+
+  for (const [field, value] of Object.entries(filters)) {
+    if (Array.isArray(value)) {
+      // Shorthand: field: ['a', 'b'] means IN clause
+      where[field] = value;
+    } else if (typeof value === 'object') {
+      // Full filter object
+      const filterValue = value as ExportFilterValue;
+      if (filterValue.eq !== undefined) where[field] = filterValue.eq;
+      else if (filterValue.in !== undefined) where[field] = filterValue.in;
+      else if (filterValue.gte !== undefined)
+        where[`${field}__gte`] = filterValue.gte;
+      else if (filterValue.lte !== undefined)
+        where[`${field}__lte`] = filterValue.lte;
+      else if (filterValue.gt !== undefined)
+        where[`${field}__gt`] = filterValue.gt;
+      else if (filterValue.lt !== undefined)
+        where[`${field}__lt`] = filterValue.lt;
+      else if (filterValue.ne !== undefined)
+        where[`${field}__ne`] = filterValue.ne;
+      else if (filterValue.contains !== undefined)
+        where[`${field}__contains`] = filterValue.contains;
+    } else {
+      // Simple value
+      where[field] = value;
+    }
+  }
+
+  return where;
+}
+
+/**
+ * Query records with field projection
+ */
+async function queryWithProjection(
+  db: any,
+  tableName: string,
+  types: string[],
+  fields: string[],
+  filters: Record<string, any>,
+  orderBy?: string,
+  limit?: number,
+): Promise<any[]> {
+  // Build SELECT clause with only exportable fields
+  const selectFields = fields.join(', ');
+
+  // Build WHERE clause
+  const whereClauses: string[] = [];
+  const whereValues: any[] = [];
+
+  // Filter by _meta_type if specified types
+  if (types.length > 0) {
+    // Map type names to qualified names or just use as-is
+    const typePatterns = types.map((t) => `%:${t}`);
+    if (typePatterns.length === 1) {
+      whereClauses.push('_meta_type LIKE ?');
+      whereValues.push(typePatterns[0]);
+    } else {
+      whereClauses.push(
+        `(${typePatterns.map(() => '_meta_type LIKE ?').join(' OR ')})`,
+      );
+      whereValues.push(...typePatterns);
+    }
+  }
+
+  // Apply custom filters
+  for (const [field, value] of Object.entries(filters)) {
+    if (field.endsWith('__gte')) {
+      whereClauses.push(`${field.replace('__gte', '')} >= ?`);
+      whereValues.push(value);
+    } else if (field.endsWith('__lte')) {
+      whereClauses.push(`${field.replace('__lte', '')} <= ?`);
+      whereValues.push(value);
+    } else if (field.endsWith('__gt')) {
+      whereClauses.push(`${field.replace('__gt', '')} > ?`);
+      whereValues.push(value);
+    } else if (field.endsWith('__lt')) {
+      whereClauses.push(`${field.replace('__lt', '')} < ?`);
+      whereValues.push(value);
+    } else if (field.endsWith('__ne')) {
+      whereClauses.push(`${field.replace('__ne', '')} != ?`);
+      whereValues.push(value);
+    } else if (field.endsWith('__contains')) {
+      whereClauses.push(`${field.replace('__contains', '')} LIKE ?`);
+      whereValues.push(`%${value}%`);
+    } else if (Array.isArray(value)) {
+      whereClauses.push(`${field} IN (${value.map(() => '?').join(', ')})`);
+      whereValues.push(...value);
+    } else {
+      whereClauses.push(`${field} = ?`);
+      whereValues.push(value);
+    }
+  }
+
+  // Build query
+  let sql = `SELECT ${selectFields} FROM ${tableName}`;
+  if (whereClauses.length > 0) {
+    sql += ` WHERE ${whereClauses.join(' AND ')}`;
+  }
+  if (orderBy) {
+    const desc = orderBy.startsWith('-');
+    const column = desc ? orderBy.slice(1) : orderBy;
+    sql += ` ORDER BY ${column} ${desc ? 'DESC' : 'ASC'}`;
+  }
+  if (limit) {
+    sql += ` LIMIT ${limit}`;
+  }
+
+  try {
+    const rows = await db.query(sql, whereValues);
+    return rows;
+  } catch (error) {
+    // If query fails (missing column, etc.), return empty
+    console.warn(
+      `⚠️  Query failed for ${tableName}: ${error instanceof Error ? error.message : error}`,
+    );
+    return [];
+  }
+}
+
+/**
+ * Resolve table name for given types
+ */
+async function resolveTableName(types: string[]): Promise<string> {
+  const { ObjectRegistry } = await import('@happyvertical/smrt-core');
+
+  // Get table from first type's config
+  for (const typeName of types) {
+    const config = ObjectRegistry.getConfig(typeName);
+    if (config?.tableName) {
+      return config.tableName;
+    }
+
+    // Check manifest for table info
+    const manifest = ObjectRegistry.getManifest(typeName);
+    if (manifest?.schema?.tableName) {
+      return manifest.schema.tableName;
+    }
+  }
+
+  // Default to 'events' or 'contents' based on common patterns
+  const typeNames = types.map((t) => t.toLowerCase());
+  if (
+    typeNames.some((t) =>
+      ['meeting', 'game', 'forecast', 'weatherforecast', 'event'].includes(t),
+    )
+  ) {
+    return 'events';
+  }
+  if (
+    typeNames.some((t) =>
+      ['article', 'meetingrecap', 'meetingannouncement', 'content'].includes(t),
+    )
+  ) {
+    return 'contents';
+  }
+
+  return 'events'; // Default fallback
+}
+
+/**
+ * Get common fields across all types for an export file
+ */
+async function getCommonFields(
+  types: string[],
+  fileConfig: ExportFileConfig,
+  fieldExportDefault: boolean,
+): Promise<string[]> {
+  const fieldSets: Set<string>[] = [];
+
+  for (const typeName of types) {
+    const fields = await getExportableFields(
+      typeName,
+      fileConfig,
+      fieldExportDefault,
+    );
+    fieldSets.push(new Set(fields));
+  }
+
+  if (fieldSets.length === 0) return [];
+
+  // Find intersection of all field sets
+  const commonFields = [...fieldSets[0]].filter((field) =>
+    fieldSets.every((set) => set.has(field)),
+  );
+
+  // Add _meta_type if not present (needed for STI discrimination)
+  if (!commonFields.includes('_meta_type')) {
+    commonFields.push('_meta_type');
+  }
+
+  return commonFields;
+}
+
+export const exportCommand: CLICommand = {
+  name: 'export',
+  description:
+    'Export data from database to JSON files for static site generation',
+  aliases: ['dump'],
+  args: [],
+  options: {
+    output: {
+      type: 'string',
+      description: 'Output directory (default: ./data)',
+      default: './data',
+      short: 'o',
+    },
+    file: {
+      type: 'string',
+      description: 'Export only a specific file (e.g., contents, events)',
+      short: 'f',
+    },
+    'show-drafts': {
+      type: 'boolean',
+      description:
+        'Include draft/review status content (reads PUBLIC_SHOW_DRAFTS env)',
+      default: false,
+    },
+    'dry-run': {
+      type: 'boolean',
+      description: 'Show what would be exported without writing files',
+      default: false,
+    },
+    json: {
+      type: 'boolean',
+      description: 'Output summary as JSON',
+      default: false,
+    },
+    verbose: {
+      type: 'boolean',
+      description: 'Show detailed output',
+      short: 'v',
+      default: false,
+    },
+  },
+  handler: async (_args: string[], options: any) => {
+    try {
+      // 1. Load config
+      const { getConfig, getPackageConfig } = await import(
+        '@happyvertical/smrt-config'
+      );
+      const { DEFAULT_CLI_CONFIG } = await import('../config.js');
+
+      const smrtConfig = getConfig();
+      const cliConfig = getPackageConfig('cli', DEFAULT_CLI_CONFIG);
+
+      // Check for export configuration
+      const exportConfig = smrtConfig.export;
+      if (!exportConfig || Object.keys(exportConfig).length === 0) {
+        if (!options.json) {
+          console.error('\n❌ No export configuration found');
+          console.error('\nPlease add an `export` section to smrt.config.js');
+          console.error('\nExample:');
+          console.error(`
+  export: {
+    fieldExportDefault: true,
+    contents: {
+      types: ['MeetingRecap', 'MeetingAnnouncement'],
+      filters: { status: ['published'] },
+    },
+    events: {
+      types: ['Meeting', 'Game', 'WeatherForecast'],
+    },
+  },
+`);
+        } else {
+          console.log(
+            JSON.stringify({ error: 'No export configuration found' }),
+          );
+        }
+        process.exit(1);
+      }
+
+      // 2. Validate database configuration
+      if (!cliConfig.database?.url || cliConfig.database.url === ':memory:') {
+        if (options.json) {
+          console.log(JSON.stringify({ error: 'Database not configured' }));
+        } else {
+          console.error('\n❌ Database configuration required');
+          console.error(
+            '\nPlease configure database in smrt.config.js packages.cli.database\n',
+          );
+        }
+        process.exit(1);
+      }
+
+      if (!options.json) {
+        console.log('\n📦 Exporting Data for Static Site\n');
+      }
+
+      // 3. Connect to database
+      const { getDatabase } = await import('@happyvertical/sql');
+      const db = await getDatabase({
+        type: cliConfig.database.type || 'sqlite',
+        url: cliConfig.database.url,
+      });
+
+      // 4. Load manifest for field information
+      const { ObjectRegistry } = await import('@happyvertical/smrt-core');
+      await ObjectRegistry.loadExternalManifests();
+
+      // 5. Get export defaults
+      const fieldExportDefault = exportConfig.fieldExportDefault !== false; // Default: true
+      const defaultFormat = exportConfig.format || 'json';
+
+      // Determine if we should show drafts
+      const showDrafts =
+        options['show-drafts'] || process.env.PUBLIC_SHOW_DRAFTS === 'true';
+
+      // 6. Process each export file
+      const outputDir = path.resolve(process.cwd(), options.output);
+      const summary: Record<string, any> = {};
+      const onlyFile = options.file;
+
+      // Ensure output directory exists
+      if (!options['dry-run'] && !fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true });
+      }
+
+      // Extract file configs (skip reserved keys)
+      const reservedKeys = new Set(['fieldExportDefault', 'format']);
+      const fileConfigs = Object.entries(exportConfig).filter(
+        ([key, value]) =>
+          !reservedKeys.has(key) && typeof value === 'object' && value !== null,
+      ) as [string, ExportFileConfig][];
+
+      for (const [filename, fileConfig] of fileConfigs) {
+        // Skip if only exporting specific file
+        if (onlyFile && filename !== onlyFile) continue;
+
+        if (options.verbose && !options.json) {
+          console.log(`Processing: ${filename}`);
+        }
+
+        // Get types and resolve table
+        const types = fileConfig.types || [];
+        if (types.length === 0) {
+          console.warn(`⚠️  No types specified for ${filename}, skipping`);
+          continue;
+        }
+
+        // Get fields to export (union of all type fields)
+        const fields = await getCommonFields(
+          types,
+          fileConfig,
+          fieldExportDefault,
+        );
+        if (fields.length === 0) {
+          console.warn(`⚠️  No exportable fields for ${filename}, skipping`);
+          continue;
+        }
+
+        // Resolve table name from first type
+        const tableName = await resolveTableName(types);
+
+        // Build filters
+        const filters = buildWhereClause(fileConfig.filters);
+
+        // Add status filter if not showing drafts
+        if (!showDrafts && fields.includes('status')) {
+          if (!filters.status) {
+            filters.status = ['published'];
+          }
+        }
+
+        // Query records
+        const records = await queryWithProjection(
+          db,
+          tableName,
+          types,
+          fields,
+          filters,
+          fileConfig.orderBy,
+          fileConfig.limit,
+        );
+
+        // Format records (parse JSON fields, etc.)
+        const formattedRecords = records.map((row: any) => {
+          const record: Record<string, any> = {};
+          for (const field of fields) {
+            let value = row[field];
+            // Try to parse JSON fields
+            if (
+              typeof value === 'string' &&
+              (value.startsWith('{') || value.startsWith('['))
+            ) {
+              try {
+                value = JSON.parse(value);
+              } catch {
+                // Keep as string
+              }
+            }
+            record[field] = value;
+          }
+          return record;
+        });
+
+        // Write file
+        const format = fileConfig.format || defaultFormat;
+        const extension =
+          format === 'ndjson' ? 'ndjson' : format === 'csv' ? 'csv' : 'json';
+        const outputPath = path.join(outputDir, `${filename}.${extension}`);
+
+        if (!options['dry-run']) {
+          let content: string;
+          if (format === 'ndjson') {
+            content = formattedRecords
+              .map((r: any) => JSON.stringify(r))
+              .join('\n');
+          } else if (format === 'csv') {
+            // Simple CSV (headers + rows)
+            if (formattedRecords.length > 0) {
+              const headers = Object.keys(formattedRecords[0]);
+              const rows = formattedRecords.map((r: any) =>
+                headers.map((h) => JSON.stringify(r[h] ?? '')).join(','),
+              );
+              content = [headers.join(','), ...rows].join('\n');
+            } else {
+              content = '';
+            }
+          } else {
+            content = JSON.stringify(formattedRecords, null, 2);
+          }
+
+          fs.writeFileSync(outputPath, content, 'utf-8');
+        }
+
+        summary[filename] = {
+          types,
+          records: formattedRecords.length,
+          fields: fields.length,
+          path: outputPath,
+        };
+
+        if (!options.json) {
+          const dryRunNote = options['dry-run'] ? ' (dry-run)' : '';
+          console.log(
+            `  ✓ ${filename}.${extension}: ${formattedRecords.length} records${dryRunNote}`,
+          );
+        }
+      }
+
+      // 7. Output summary
+      if (options.json) {
+        console.log(JSON.stringify(summary, null, 2));
+      } else {
+        console.log('\n✅ Export complete');
+        console.log(`   Output: ${outputDir}`);
+        console.log(`   Files: ${Object.keys(summary).length}`);
+        console.log(
+          `   Records: ${Object.values(summary).reduce((acc, s: any) => acc + s.records, 0)}`,
+        );
+        if (showDrafts) {
+          console.log('   Mode: Including drafts');
+        }
+      }
+    } catch (error) {
+      if (options.json) {
+        console.log(
+          JSON.stringify({
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        );
+      } else {
+        console.error('\n❌ Export failed:');
+        if (error instanceof Error) {
+          console.error(`   ${error.message}`);
+          if (options.verbose) {
+            console.error(error.stack);
+          }
+        }
+      }
+      process.exit(1);
+    }
+  },
+};

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -12,6 +12,8 @@ export { dbRollbackCommand } from './db-rollback.js';
 export { dbStatusCommand } from './db-status.js';
 export { dispatchCommands } from './dispatch.js';
 export { docsCommands } from './docs-claude.js';
+// Data export command
+export { exportCommand } from './export.js';
 export { generateCommands } from './generate.js';
 export { gitCommands } from './git.js';
 export { gnodeCommands } from './gnode.js';

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -15,6 +15,7 @@ import { dbGenerateCommand } from './db-generate.js';
 import { dbHistoryCommand } from './db-history.js';
 import { dbRollbackCommand } from './db-rollback.js';
 import { dbStatusCommand } from './db-status.js';
+import { exportCommand } from './export.js';
 
 /**
  * Column definition type for migration comparison
@@ -1944,4 +1945,7 @@ export default testManifest;
 
   // Configuration commands
   'config:export': configExportCommand,
+
+  // Data export command (for static site generation)
+  export: exportCommand,
 };

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -21,6 +21,10 @@ export type {
   // CLI and migrations configuration types
   CliConfig,
   DatabaseConfig,
+  // Export configuration types
+  ExportConfig,
+  ExportFileConfig,
+  ExportFilterValue,
   LoadConfigOptions,
   MigrationsConfig,
   MigrationsPostgresConfig,

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -350,6 +350,121 @@ export interface SiteConfig {
 }
 
 // ============================================================================
+// Export Configuration Types
+// ============================================================================
+
+/**
+ * Filter operators for export queries
+ */
+export interface ExportFilterValue {
+  /** Equals (shorthand: just the value) */
+  eq?: string | number | boolean;
+  /** Not equals */
+  ne?: string | number | boolean;
+  /** Greater than */
+  gt?: string | number;
+  /** Greater than or equal */
+  gte?: string | number;
+  /** Less than */
+  lt?: string | number;
+  /** Less than or equal */
+  lte?: string | number;
+  /** In array */
+  in?: (string | number)[];
+  /** Contains (text) */
+  contains?: string;
+}
+
+/**
+ * Configuration for a single export file
+ */
+export interface ExportFileConfig {
+  /**
+   * SMRT object types to include in this export
+   * Uses className (e.g., 'MeetingRecap', 'Game')
+   */
+  types: string[];
+
+  /**
+   * Field whitelist - only export these fields
+   * If specified, overrides exclude and fieldExportDefault
+   */
+  include?: string[];
+
+  /**
+   * Field blacklist - exclude these fields
+   * Applied after schema-level exported: false check
+   */
+  exclude?: string[];
+
+  /**
+   * Filters to apply when querying records
+   * Keys are field names, values are filter conditions
+   *
+   * @example
+   * filters: {
+   *   status: ['published'],  // shorthand for status IN ('published')
+   *   publish_date: { gte: '2025-01-01' },
+   *   council_slug: ['town-of-bentley'],
+   * }
+   */
+  filters?: Record<string, string[] | number[] | ExportFilterValue>;
+
+  /**
+   * Output format for this file
+   * @default 'json'
+   */
+  format?: 'json' | 'ndjson' | 'csv' | 'sqlite';
+
+  /**
+   * Field to order by
+   * Prefix with '-' for descending (e.g., '-publish_date')
+   */
+  orderBy?: string;
+
+  /**
+   * Maximum records per file
+   * If exceeded, creates paginated files (e.g., contents-1.json, contents-2.json)
+   */
+  limit?: number;
+
+  /**
+   * Create separate files per unique value of this field
+   * e.g., shardBy: 'year' creates contents-2024.json, contents-2025.json
+   */
+  shardBy?: string;
+}
+
+/**
+ * Export configuration for static site generation
+ *
+ * Controls how data is exported from database to JSON files for build.
+ */
+export interface ExportConfig {
+  /**
+   * Default export behavior for fields without explicit `exported` annotation
+   *
+   * - true: Export all fields by default (simpler, for most sites)
+   * - false: Only export fields with explicit `exported: true`
+   *
+   * @default true
+   */
+  fieldExportDefault?: boolean;
+
+  /**
+   * Default output format for all exports
+   * @default 'json'
+   */
+  format?: 'json' | 'ndjson' | 'csv' | 'sqlite';
+
+  /**
+   * Export file configurations
+   * Keys become filenames (e.g., 'contents' -> 'contents.json')
+   */
+  [filename: string]: ExportFileConfig | boolean | string | undefined;
+}
+
+// ============================================================================
 // Main Configuration
 // ============================================================================
 
@@ -362,6 +477,9 @@ export interface SmrtConfig {
 
   // Site identity and configuration (for site templates)
   site?: SiteConfig;
+
+  // Export configuration for static site generation
+  export?: ExportConfig;
 
   // Module-scoped configurations
   modules?: {

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -47,6 +47,13 @@ export interface FieldOptions {
   transient?: boolean;
   /** Field description */
   description?: string;
+  /**
+   * Controls whether the field is included in JSON exports.
+   * - `true`: Always exported (unless site explicitly excludes it)
+   * - `false`: Never exported (cannot be overridden by site config)
+   * - `undefined`: Uses site's fieldExportDefault setting
+   */
+  exported?: boolean;
 }
 
 /**

--- a/packages/core/src/scanner/types.ts
+++ b/packages/core/src/scanner/types.ts
@@ -40,6 +40,13 @@ export interface FieldDefinition {
   description?: string;
   _meta?: Record<string, any>;
   transient?: boolean; // Field not persisted to database
+  /**
+   * Controls whether the field is included in JSON exports.
+   * - `true`: Always exported (unless site explicitly excludes it)
+   * - `false`: Never exported (cannot be overridden by site config)
+   * - `undefined`: Uses site's fieldExportDefault setting
+   */
+  exported?: boolean;
 }
 
 export interface MethodDefinition {


### PR DESCRIPTION
## Summary

This adds a schema-driven export system that replaces per-agent export commands (`praeco export`, `caelus export`, `ludis export`) with a single unified `smrt export` command.

### Changes (7 files)

**smrt-core:**
- Add `exported?: boolean` field option to control JSON export visibility
- Fields with `exported: false` are never exported (cannot be overridden)
- Fields with `exported: true` are always exported
- Undefined uses site's `fieldExportDefault` setting

**smrt-config:**
- Add `ExportConfig`, `ExportFileConfig`, `ExportFilterValue` types
- Support per-file type filtering, field whitelists/blacklists
- Support filters (status, date ranges, etc.)

**smrt-cli:**
- Add `smrt export` command that reads export config from smrt.config.js
- Supports `--output`, `--file`, `--show-drafts`, `--dry-run`, `--verbose` flags
- Projects only allowed fields based on schema annotations and site config
- Fresh dump every time (no merge logic)

### Usage

```bash
smrt export --output ./data
```

### Config example

```javascript
export: {
  fieldExportDefault: true,
  contents: {
    types: ['MeetingRecap', 'MeetingAnnouncement'],
    filters: { status: ['published'] },
  },
  events: {
    types: ['Meeting', 'Game', 'WeatherForecast'],
  },
}
```

## Test plan

- [ ] Verify `smrt export --help` shows the new command
- [ ] Test with a site that has export configuration
- [ ] Verify `--dry-run` works without writing files
- [ ] Verify field-level `exported: false` prevents export