### PR TITLE
fix(core): add JSON type handling to SchemaGenerator.formatDefaultValue()

### DIFF
--- a/packages/core/src/schema/generator.ts
+++ b/packages/core/src/schema/generator.ts
@@ -1293,6 +1293,39 @@ export class SchemaGenerator {
       return 'current_timestamp';
     }
 
+    if (type === 'JSON') {
+      // Handle null/undefined
+      if (value === null || value === undefined) {
+        return "'null'";
+      }
+
+      // Handle string inputs - need to validate they're valid JSON
+      if (typeof value === 'string') {
+        // Empty string is not valid JSON
+        if (value === '') {
+          return "'null'";
+        }
+        // '[object Object]' is a common bug from accidental toString()
+        if (value === '[object Object]') {
+          return "'{}'";
+        }
+        // Try to parse as JSON to validate
+        try {
+          JSON.parse(value);
+          // It's valid JSON, use it as-is (escaped for SQL)
+          return `'${value.replace(/'/g, "''")}'`;
+        } catch {
+          // Not valid JSON - encode the string as a JSON string
+          const json = JSON.stringify(value);
+          return `'${json.replace(/'/g, "''")}'`;
+        }
+      }
+
+      // Objects and arrays - stringify them
+      const json = JSON.stringify(value);
+      return `'${json.replace(/'/g, "''")}'`;
+    }
+
     // Fallback for other types
     return `'${String(value).replace(/'/g, "''")}'`;
   }


### PR DESCRIPTION
## Problem

SchemaGenerator.formatDefaultValue() was missing handling for JSON type columns, causing object defaults like `{}` to be converted to the string `'[object Object]'` via String() coercion in the fallback case.

This resulted in CREATE TABLE statements with invalid JSON defaults:
```sql
CREATE TABLE "builds" (
  ...
  "metadata" JSON DEFAULT '[object Object]',
  ...
);
```

Which caused database errors:
```
invalid input syntax for type json, code=22P02, detail=Token "object" is invalid.
```

## Root Cause

There are two `formatDefaultValue` implementations in SMRT:
1. **SchemaGenerator.formatDefaultValue()** (generator.ts:1251) - Missing JSON handling ❌
2. **BaseDDLStrategy.formatDefaultValue()** (base-strategy.ts:242) - Has JSON handling via formatJSONDefault() ✅

The test database setup uses SchemaGenerator.generateSQL() which calls the buggy version.

## Solution

Add JSON type handling to SchemaGenerator.formatDefaultValue() that matches the logic from BaseDDLStrategy.formatJSONDefault():

- Handles `null`/`undefined` → `'null'`
- Handles empty string → `'null'`  
- Handles `'[object Object]'` bug → `'{}'`
- Validates string inputs as JSON
- Stringifies objects/arrays

## Testing

This fix unblocks test failures in @dumm/models where fields like:
```typescript
metadata: Record<string, any> = {}
```

Were generating invalid SQL defaults.

## Related

- Issue #735 documented similar JSON default issues
- BaseDDLStrategy already has this logic (base-strategy.ts:320-351)