### PR TITLE
fix(core): use shared pluralize function in manifest generator

### DIFF
--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -9,6 +9,7 @@ import {
 } from '../manifest/manifest-loader.js';
 import { generateToolManifest } from '../tools/tool-generator';
 import { createQualifiedName } from '../utils/qualified-names.js';
+import { classnameToTablename } from '../utils.js';
 import { isTestFile } from './test-file-patterns.js';
 import type {
   ScanResult,
@@ -582,11 +583,9 @@ export class ManifestGenerator {
    * to ensure manifest-generated table names match runtime-derived names.
    */
   private classNameToTableName(className: string): string {
-    return className
-      .replace(/([a-z])([A-Z])/g, '$1_$2') // Only add underscore between lowercase→uppercase
-      .toLowerCase()
-      .replace(/([^s])$/, '$1s') // Add 's' if doesn't end with 's'
-      .replace(/y$/, 'ies'); // Handle words ending in 'y'
+    // Use the shared pluralization function that handles English plurals correctly
+    // (e.g., 'Currency' → 'currencies', 'JournalEntry' → 'journal_entries')
+    return classnameToTablename(className);
   }
 
   /**


### PR DESCRIPTION
## Summary

The manifest generator had its own buggy `classNameToTableName` implementation that produced incorrect English plurals:

| Class | Before (buggy) | After (correct) |
|-------|----------------|-----------------|
| Currency | currencys | currencies |
| JournalEntry | journal_entrys | journal_entries |
| StatementBatch | statement_batchs | statement_batches |
| ExpenseCategory | expense_categorys | expense_categories |

The bug was in the regex logic:
```typescript
.replace(/([^s])$/, '$1s')  // Adds 's' first → 'currencys'
.replace(/y$/, 'ies');       // Then looks for 'y$' but it's now 'ys'!
```

This fix imports and uses the shared `classnameToTablename()` function from `utils.ts` which uses the `pluralize` library for correct English pluralization.

## Test plan

- [x] Verified fix works with magnateos.com project - table names now correctly pluralized
- [ ] Run existing test suite (`pnpm test`)

Closes #839