### PR TITLE
feat(scanner): support agent manifests in OXC scanner path

### DIFF
--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -522,14 +522,16 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
 
       // Read package.json for metadata BEFORE creating manifest (Issue #713)
       // This ensures qualified names are generated correctly for namespace isolation
+      // packageJson is also needed for agent manifest generation (component discovery)
       let packageName: string | undefined;
       let packageVersion: string | undefined;
+      let packageJson: any;
       try {
         const { readFileSync } = await import('node:fs');
         const { join } = await import('node:path');
         const pkgPath = join(rootDir, 'package.json');
         const pkgContent = readFileSync(pkgPath, 'utf-8');
-        const packageJson = JSON.parse(pkgContent);
+        packageJson = JSON.parse(pkgContent);
         packageName = packageJson.name || undefined;
         packageVersion = packageJson.version || undefined;
       } catch {
@@ -561,13 +563,17 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
         );
       }
 
-      // Merge inherited fields and generate pre-computed schemas (same as TypeScript scanner path)
+      // Run all manifest generation passes (same as TypeScript scanner path)
       const { ManifestGenerator } = await import('../scanner/index.js');
       const manifestGen = new ManifestGenerator();
       // IMPORTANT: Must merge inherited fields BEFORE generating schemas
       // This ensures STI subclasses inherit tableName from their base class
       manifestGen.mergeInheritedFields(newManifest);
+      manifestGen.generateValidationRules(newManifest);
       manifestGen.generateSchemas(newManifest);
+      // Fifth pass: Generate agent manifests for Agent subclasses
+      // Derives permissions, features, menuItems, and components from code
+      manifestGen.generateAgentManifests(newManifest, packageName, packageJson);
 
       const elapsed = performance.now() - startTime;
 

--- a/packages/scanner/src/__tests__/scanner.test.ts
+++ b/packages/scanner/src/__tests__/scanner.test.ts
@@ -56,6 +56,49 @@ describe('OxcScanner', () => {
     `,
     );
 
+    // Create agent test file with static uiSlots and agent decorator
+    writeFileSync(
+      join(tempDir, 'agent.ts'),
+      `
+      import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+
+      @smrt({
+        agent: {
+          icon: 'newspaper',
+          tier: 'standard',
+          description: 'Test agent',
+        },
+        cli: { include: ['discover', 'analyze'] },
+        mcp: { include: ['analyze', 'report'] },
+      })
+      export class TestAgent extends SmrtObject {
+        static uiSlots = {
+          sources: {
+            id: 'sources',
+            label: 'Data Sources',
+            description: 'Configure data sources',
+            icon: 'database',
+            order: 1,
+          },
+          settings: {
+            id: 'settings',
+            label: 'Agent Settings',
+            description: 'Configure defaults',
+            icon: 'settings',
+            order: 2,
+          },
+        };
+
+        name: string = '';
+        source: string = '';
+
+        async discover(): Promise<any> { return {}; }
+        async analyze(): Promise<any> { return {}; }
+        async report(): Promise<any> { return {}; }
+      }
+    `,
+    );
+
     // Create subdirectory with STI example
     const stiDir = join(tempDir, 'events');
     const mkdirSync = require('node:fs').mkdirSync;
@@ -114,19 +157,20 @@ describe('OxcScanner', () => {
 
       const results = await scanner.scan();
 
-      // Should find Product, Category, Event, Meeting, Conference
+      // Should find Product, Category, TestAgent, Event, Meeting, Conference
       // Helper should be found but not as a SMRT class
       const smrtClasses = results.files
         .flatMap((f) => f.classes)
         .filter((c) => c.hasSmartDecorator);
 
-      expect(smrtClasses.length).toBe(5);
+      expect(smrtClasses.length).toBe(6);
       expect(smrtClasses.map((c) => c.className).sort()).toEqual([
         'Category',
         'Conference',
         'Event',
         'Meeting',
         'Product',
+        'TestAgent',
       ]);
     });
 
@@ -215,6 +259,76 @@ describe('OxcScanner', () => {
     });
   });
 
+  describe('static properties and agent manifests', () => {
+    it('should extract static uiSlots into manifest staticProperties', async () => {
+      const scanner = new OxcScanner({
+        cwd: tempDir,
+        include: ['**/*.ts'],
+      });
+
+      const { resolved } = await scanner.scanAndResolve();
+
+      // Convert to manifest
+      const { ManifestAdapter } = await import('../manifest-adapter.js');
+      const adapter = new ManifestAdapter();
+      const manifest = adapter.toManifest(resolved, {
+        packageName: '@test/agent-pkg',
+      });
+
+      const agentKey = '@test/agent-pkg:TestAgent';
+      const agentDef = manifest.objects[agentKey];
+      expect(agentDef).toBeDefined();
+
+      // Should have staticProperties with uiSlots
+      expect(agentDef.staticProperties).toBeDefined();
+      expect(agentDef.staticProperties?.uiSlots).toBeDefined();
+      expect(agentDef.staticProperties?.uiSlots.sources).toMatchObject({
+        id: 'sources',
+        label: 'Data Sources',
+        icon: 'database',
+        order: 1,
+      });
+      expect(agentDef.staticProperties?.uiSlots.settings).toMatchObject({
+        id: 'settings',
+        label: 'Agent Settings',
+        icon: 'settings',
+        order: 2,
+      });
+
+      // uiSlots should NOT appear as a regular field
+      expect(agentDef.fields.uiSlots).toBeUndefined();
+
+      // Regular instance fields should still be present
+      expect(agentDef.fields.name).toBeDefined();
+      expect(agentDef.fields.source).toBeDefined();
+    });
+
+    it('should have decoratorConfig.agent for agent classes', async () => {
+      const scanner = new OxcScanner({
+        cwd: tempDir,
+        include: ['**/*.ts'],
+      });
+
+      const { resolved } = await scanner.scanAndResolve();
+      const { ManifestAdapter } = await import('../manifest-adapter.js');
+      const adapter = new ManifestAdapter();
+      const manifest = adapter.toManifest(resolved, {
+        packageName: '@test/agent-pkg',
+      });
+
+      const agentDef = manifest.objects['@test/agent-pkg:TestAgent'];
+      expect(agentDef.decoratorConfig.agent).toMatchObject({
+        icon: 'newspaper',
+        tier: 'standard',
+        description: 'Test agent',
+      });
+
+      // Non-agent class should NOT have agent config
+      const productDef = manifest.objects['@test/agent-pkg:Product'];
+      expect(productDef.decoratorConfig.agent).toBeUndefined();
+    });
+  });
+
   describe('getStats', () => {
     it('should return scan statistics', async () => {
       const scanner = new OxcScanner({
@@ -227,7 +341,7 @@ describe('OxcScanner', () => {
 
       expect(stats.fileCount).toBeGreaterThan(0);
       expect(stats.totalClasses).toBeGreaterThan(0);
-      expect(stats.smrtClasses).toBe(5); // Product, Category, Event, Meeting, Conference
+      expect(stats.smrtClasses).toBe(6); // Product, Category, TestAgent, Event, Meeting, Conference
       expect(stats.stiClasses).toBe(3); // Event, Meeting, Conference
       expect(stats.parseTimeMs).toBeGreaterThanOrEqual(0);
     });

--- a/packages/scanner/src/manifest-adapter.ts
+++ b/packages/scanner/src/manifest-adapter.ts
@@ -98,6 +98,7 @@ interface SmartObjectDefinition {
   decoratorConfig: SmartObjectConfig;
   extends?: string;
   extendsTypeArg?: string;
+  staticProperties?: Record<string, any>;
 }
 
 interface SmartObjectManifest {
@@ -108,6 +109,30 @@ interface SmartObjectManifest {
   objects: Record<string, SmartObjectDefinition>;
   moduleType?: string;
   smrtDependencies?: string[];
+}
+
+// ============================================================================
+// Utilities
+// ============================================================================
+
+/**
+ * Parse a JavaScript object literal string into a plain object.
+ * Uses Function constructor to safely evaluate object literal syntax
+ * (single quotes, computed keys, nested objects, etc.)
+ *
+ * Only used at build time for parsing static property initializers
+ * from source code (e.g., `static uiSlots = { ... }`).
+ */
+function parseObjectLiteral(source: string): Record<string, any> | null {
+  if (!source || !source.trim().startsWith('{')) return null;
+  try {
+    // Use indirect eval via Function to parse the object literal
+    // This runs at build time only, on source code we already trust
+    // eslint-disable-next-line no-new-func
+    return new Function(`return (${source})`)() as Record<string, any>;
+  } catch {
+    return null;
+  }
 }
 
 // ============================================================================
@@ -176,9 +201,25 @@ export class ManifestAdapter {
     classDef: ResolvedClassDefinition,
     options: { packageName?: string; packageVersion?: string } = {},
   ): SmartObjectDefinition {
-    // Convert fields
+    // Extract static properties (e.g., uiSlots on Agent subclasses)
+    let staticProperties: Record<string, any> | undefined;
+    for (const field of classDef.allFields) {
+      if (field.isStatic && field.name === 'uiSlots' && field.initializer) {
+        try {
+          const parsed = parseObjectLiteral(field.initializer);
+          if (parsed) {
+            staticProperties = { uiSlots: parsed };
+          }
+        } catch {
+          // Failed to parse uiSlots initializer — skip
+        }
+      }
+    }
+
+    // Convert fields (skip static fields — they're not database columns)
     const fields: Record<string, FieldDefinition> = {};
     for (const field of classDef.allFields) {
+      if (field.isStatic) continue;
       const converted = this.convertField(field);
       if (converted) {
         fields[field.name] = converted;
@@ -220,6 +261,7 @@ export class ManifestAdapter {
       extendsTypeArg: classDef.extendsTypeArg || undefined,
       exportName: classDef.className,
       collectionExportName: `${classDef.className}Collection`,
+      staticProperties,
     };
   }
 

--- a/packages/scanner/src/oxc-parser.ts
+++ b/packages/scanner/src/oxc-parser.ts
@@ -838,6 +838,19 @@ function reconstructObjectExpression(
       let value = '';
       if (prop.value.range) {
         value = sourceText.slice(prop.value.range[0], prop.value.range[1]);
+      } else if (prop.value.type === 'ObjectExpression') {
+        // Recursively reconstruct nested objects (e.g., uiSlots.sources)
+        value =
+          reconstructObjectExpression(
+            prop.value as ObjectExpression,
+            sourceText,
+          ) || '';
+      } else if (prop.value.type === 'ArrayExpression') {
+        value =
+          reconstructArrayExpression(
+            prop.value as ArrayExpression,
+            sourceText,
+          ) || '';
       } else if (prop.value.type === 'Identifier') {
         value = prop.value.name;
       } else if (prop.value.type === 'Literal') {
@@ -1018,6 +1031,12 @@ function extractPropertyDefinition(
     } else if (node.value.type === 'ArrayExpression') {
       // Reconstruct array expression
       initializer = reconstructArrayExpression(node.value, sourceText);
+    } else if (node.value.type === 'ObjectExpression') {
+      // Reconstruct object expression (e.g., static uiSlots = { ... })
+      initializer = reconstructObjectExpression(
+        node.value as ObjectExpression,
+        sourceText,
+      );
     }
   }
 
@@ -1040,6 +1059,7 @@ function extractPropertyDefinition(
     numericValue,
     decorators,
     optional: node.optional || false,
+    isStatic: node.static || false,
     readonly: node.readonly || false,
     accessibility: node.accessibility || 'public',
     line: node.loc?.start.line || 0,

--- a/packages/scanner/src/types.ts
+++ b/packages/scanner/src/types.ts
@@ -103,6 +103,9 @@ export interface RawFieldDefinition {
   /** Whether field is optional (has ?) */
   optional: boolean;
 
+  /** Whether field is static */
+  isStatic: boolean;
+
   /** Whether field is readonly */
   readonly: boolean;
 


### PR DESCRIPTION
## Summary

- OXC scanner now extracts `static uiSlots` into `staticProperties` on manifest definitions
- `reconstructObjectExpression` handles nested `ObjectExpression`/`ArrayExpression` values recursively
- Vite plugin's `scanWithOxc()` now runs all 5 manifest generation passes (was missing `generateValidationRules()` and `generateAgentManifests()`)
- Adds `isStatic` field to `RawFieldDefinition` type in scanner

## Context

The OXC fast scanner path (`experimentalFastScanner = true`, the default) was missing the agent manifest generation that the TypeScript AST scanner path has. This meant agent packages built with the OXC path produced manifests with `decoratorConfig.agent` but no auto-generated `agent` section with permissions, features, menuItems, and components.

## Test plan

- [x] All 81 turbo tasks pass (1364+ tests in smrt-core, 54 in smrt-scanner)
- [x] New tests verify static uiSlots extraction and decoratorConfig.agent presence
- [x] Verified end-to-end with debug script that nested object literals are fully reconstructed