### PR TITLE
feat(sites): add smrt-sites package for site lifecycle management

### DIFF
--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@happyvertical/smrt-sites",
+  "version": "0.19.73",
+  "description": "Site lifecycle management for multi-tenant SMRT networks",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./manifest": "./dist/manifest.json",
+    "./manifest.json": "./dist/manifest.json"
+  },
+  "scripts": {
+    "build": "vite build --mode library && node ../../scripts/generate-stub-from-manifest.js",
+    "build:watch": "vite build --mode library --watch",
+    "clean": "rm -rf dist",
+    "dev": "vite dev",
+    "test": "npx vitest run --passWithNoTests",
+    "test:watch": "npx vitest"
+  },
+  "dependencies": {
+    "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-tenancy": "workspace:*"
+  },
+  "peerDependencies": {
+    "@happyvertical/smrt-agents": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@happyvertical/smrt-agents": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@happyvertical/smrt-cli": "workspace:*",
+    "@happyvertical/smrt-vitest": "workspace:*",
+    "@happyvertical/sql": "^0.67.7",
+    "@types/node": "25.0.9",
+    "fast-glob": "3.3.3",
+    "typescript": "^5.9.3",
+    "vite": "^7.3.1",
+    "vitest": "^4.0.17"
+  },
+  "keywords": [
+    "ai",
+    "smrt",
+    "sites",
+    "multi-tenant",
+    "site-management"
+  ],
+  "author": "HAVE Team",
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  }
+}

--- a/packages/sites/src/__tests__/site-agent-binding-collection.test.ts
+++ b/packages/sites/src/__tests__/site-agent-binding-collection.test.ts
@@ -1,0 +1,156 @@
+/**
+ * SiteAgentBindingCollection tests
+ *
+ * Tests for collection query methods:
+ * 1. findBySite
+ * 2. findByAgent
+ * 3. findEnabled
+ * 4. findBySiteAndAgent
+ */
+
+import { existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SiteAgentBindingCollection } from '../collections/SiteAgentBindingCollection';
+
+describe('SiteAgentBindingCollection', () => {
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = join(tmpdir(), `smrt-binding-collection-test-${Date.now()}.db`);
+  });
+
+  afterEach(() => {
+    if (existsSync(dbPath)) {
+      try {
+        rmSync(dbPath, { force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  it('should find bindings by site', async () => {
+    const bindings = await SiteAgentBindingCollection.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+
+    await (
+      await bindings.create({
+        tenantId: 'tenant-1',
+        siteId: 'site-1',
+        agentClass: 'Praeco',
+      })
+    ).save();
+    await (
+      await bindings.create({
+        tenantId: 'tenant-1',
+        siteId: 'site-1',
+        agentClass: 'Caelus',
+      })
+    ).save();
+    await (
+      await bindings.create({
+        tenantId: 'tenant-1',
+        siteId: 'site-2',
+        agentClass: 'Praeco',
+      })
+    ).save();
+
+    const site1Bindings = await bindings.findBySite('site-1');
+    expect(site1Bindings).toHaveLength(2);
+  });
+
+  it('should find bindings by agent class', async () => {
+    const bindings = await SiteAgentBindingCollection.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+
+    await (
+      await bindings.create({
+        tenantId: 'tenant-1',
+        siteId: 'site-1',
+        agentClass: 'Praeco',
+      })
+    ).save();
+    await (
+      await bindings.create({
+        tenantId: 'tenant-1',
+        siteId: 'site-2',
+        agentClass: 'Praeco',
+      })
+    ).save();
+    await (
+      await bindings.create({
+        tenantId: 'tenant-1',
+        siteId: 'site-3',
+        agentClass: 'Caelus',
+      })
+    ).save();
+
+    const praecoBindings = await bindings.findByAgent('Praeco');
+    expect(praecoBindings).toHaveLength(2);
+  });
+
+  it('should find enabled bindings for a site', async () => {
+    const bindings = await SiteAgentBindingCollection.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+
+    await (
+      await bindings.create({
+        tenantId: 'tenant-1',
+        siteId: 'site-1',
+        agentClass: 'Praeco',
+        enabled: true,
+        priority: 10,
+      })
+    ).save();
+    await (
+      await bindings.create({
+        tenantId: 'tenant-1',
+        siteId: 'site-1',
+        agentClass: 'Caelus',
+        enabled: false,
+        priority: 5,
+      })
+    ).save();
+    await (
+      await bindings.create({
+        tenantId: 'tenant-1',
+        siteId: 'site-1',
+        agentClass: 'Ludis',
+        enabled: true,
+        priority: 20,
+      })
+    ).save();
+
+    const enabled = await bindings.findEnabled('site-1');
+    expect(enabled).toHaveLength(2);
+    // Should be sorted by priority descending
+    expect(enabled[0].agentClass).toBe('Ludis');
+    expect(enabled[1].agentClass).toBe('Praeco');
+  });
+
+  it('should find specific site-agent binding', async () => {
+    const bindings = await SiteAgentBindingCollection.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+
+    await (
+      await bindings.create({
+        tenantId: 'tenant-1',
+        siteId: 'site-1',
+        agentClass: 'Praeco',
+      })
+    ).save();
+
+    const found = await bindings.findBySiteAndAgent('site-1', 'Praeco');
+    expect(found).toBeDefined();
+    expect(found?.agentClass).toBe('Praeco');
+
+    const notFound = await bindings.findBySiteAndAgent('site-1', 'Nonexistent');
+    expect(notFound).toBeNull();
+  });
+});

--- a/packages/sites/src/__tests__/site-agent-binding.test.ts
+++ b/packages/sites/src/__tests__/site-agent-binding.test.ts
@@ -1,0 +1,128 @@
+/**
+ * SiteAgentBinding model tests
+ *
+ * Tests for:
+ * 1. Binding CRUD operations
+ * 2. Config handling (JSON field)
+ */
+
+import { existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SiteAgentBindingCollection } from '../collections/SiteAgentBindingCollection';
+
+describe('SiteAgentBinding', () => {
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = join(tmpdir(), `smrt-binding-test-${Date.now()}.db`);
+  });
+
+  afterEach(() => {
+    if (existsSync(dbPath)) {
+      try {
+        rmSync(dbPath, { force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  describe('Basic CRUD', () => {
+    it('should create a binding', async () => {
+      const bindings = await SiteAgentBindingCollection.create({
+        db: { type: 'sqlite', url: dbPath },
+      });
+
+      const binding = await bindings.create({
+        tenantId: 'tenant-1',
+        siteId: 'site-1',
+        agentClass: 'Praeco',
+        enabled: true,
+        priority: 10,
+      });
+
+      expect(binding.id).toBeDefined();
+      expect(binding.siteId).toBe('site-1');
+      expect(binding.agentClass).toBe('Praeco');
+      expect(binding.enabled).toBe(true);
+      expect(binding.priority).toBe(10);
+    });
+
+    it('should preserve data through save/load cycle', async () => {
+      const bindings = await SiteAgentBindingCollection.create({
+        db: { type: 'sqlite', url: dbPath },
+      });
+
+      const binding = await bindings.create({
+        tenantId: 'tenant-1',
+        siteId: 'site-2',
+        agentClass: 'Caelus',
+        enabled: false,
+        priority: 5,
+        config: { forecastDays: 7 },
+      });
+      await binding.save();
+
+      const loaded = await bindings.get({ id: binding.id });
+      expect(loaded).toBeDefined();
+      expect(loaded?.siteId).toBe('site-2');
+      expect(loaded?.agentClass).toBe('Caelus');
+      expect(loaded?.enabled).toBe(false);
+      expect(loaded?.priority).toBe(5);
+    });
+
+    it('should delete a binding', async () => {
+      const bindings = await SiteAgentBindingCollection.create({
+        db: { type: 'sqlite', url: dbPath },
+      });
+
+      const binding = await bindings.create({
+        tenantId: 'tenant-1',
+        siteId: 'site-3',
+        agentClass: 'Ludis',
+      });
+      await binding.save();
+
+      await binding.delete();
+
+      const loaded = await bindings.get({ id: binding.id });
+      expect(loaded).toBeNull();
+    });
+  });
+
+  describe('Config handling', () => {
+    it('should store and retrieve config', async () => {
+      const bindings = await SiteAgentBindingCollection.create({
+        db: { type: 'sqlite', url: dbPath },
+      });
+
+      const binding = await bindings.create({
+        tenantId: 'tenant-1',
+        siteId: 'site-4',
+        agentClass: 'Praeco',
+        config: { sources: ['url1', 'url2'], maxArticles: 5 },
+      });
+      await binding.save();
+
+      const loaded = await bindings.get({ id: binding.id });
+      expect(loaded?.config).toBeDefined();
+    });
+
+    it('should handle null config', async () => {
+      const bindings = await SiteAgentBindingCollection.create({
+        db: { type: 'sqlite', url: dbPath },
+      });
+
+      const binding = await bindings.create({
+        tenantId: 'tenant-1',
+        siteId: 'site-5',
+        agentClass: 'Aedile',
+        config: null,
+      });
+
+      expect(binding.config).toBeNull();
+    });
+  });
+});

--- a/packages/sites/src/__tests__/site-collection.test.ts
+++ b/packages/sites/src/__tests__/site-collection.test.ts
@@ -1,0 +1,165 @@
+/**
+ * SiteCollection tests
+ *
+ * Tests for collection query methods:
+ * 1. findByDomain
+ * 2. findByTenant
+ * 3. findByStatus
+ * 4. findActive
+ */
+
+import { existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SiteCollection } from '../collections/SiteCollection';
+
+describe('SiteCollection', () => {
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = join(tmpdir(), `smrt-site-collection-test-${Date.now()}.db`);
+  });
+
+  afterEach(() => {
+    if (existsSync(dbPath)) {
+      try {
+        rmSync(dbPath, { force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  it('should find site by domain', async () => {
+    const sites = await SiteCollection.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+
+    await (
+      await sites.create({
+        tenantId: 'tenant-1',
+        name: 'Site A',
+        domain: 'site-a.com',
+      })
+    ).save();
+    await (
+      await sites.create({
+        tenantId: 'tenant-1',
+        name: 'Site B',
+        domain: 'site-b.com',
+      })
+    ).save();
+
+    const found = await sites.findByDomain('site-a.com');
+    expect(found).toBeDefined();
+    expect(found?.name).toBe('Site A');
+
+    const notFound = await sites.findByDomain('nonexistent.com');
+    expect(notFound).toBeNull();
+  });
+
+  it('should find sites by tenant', async () => {
+    const sites = await SiteCollection.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+
+    await (
+      await sites.create({
+        name: 'T1-A',
+        domain: 't1a.com',
+        tenantId: 'tenant-1',
+      })
+    ).save();
+    await (
+      await sites.create({
+        name: 'T1-B',
+        domain: 't1b.com',
+        tenantId: 'tenant-1',
+      })
+    ).save();
+    await (
+      await sites.create({
+        name: 'T2-A',
+        domain: 't2a.com',
+        tenantId: 'tenant-2',
+      })
+    ).save();
+
+    const t1Sites = await sites.findByTenant('tenant-1');
+    expect(t1Sites).toHaveLength(2);
+    expect(t1Sites.map((s) => s.name).sort()).toEqual(['T1-A', 'T1-B']);
+  });
+
+  it('should find sites by status', async () => {
+    const sites = await SiteCollection.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+
+    await (
+      await sites.create({
+        tenantId: 'tenant-1',
+        name: 'Active 1',
+        domain: 'a1.com',
+        status: 'active',
+      })
+    ).save();
+    await (
+      await sites.create({
+        tenantId: 'tenant-1',
+        name: 'Draft 1',
+        domain: 'd1.com',
+        status: 'draft',
+      })
+    ).save();
+    await (
+      await sites.create({
+        tenantId: 'tenant-1',
+        name: 'Active 2',
+        domain: 'a2.com',
+        status: 'active',
+      })
+    ).save();
+
+    const active = await sites.findByStatus('active');
+    expect(active).toHaveLength(2);
+
+    const drafts = await sites.findByStatus('draft');
+    expect(drafts).toHaveLength(1);
+  });
+
+  it('should find active sites', async () => {
+    const sites = await SiteCollection.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+
+    await (
+      await sites.create({
+        tenantId: 'tenant-1',
+        name: 'Active',
+        domain: 'active.com',
+        status: 'active',
+      })
+    ).save();
+    await (
+      await sites.create({
+        tenantId: 'tenant-1',
+        name: 'Suspended',
+        domain: 'suspended.com',
+        status: 'suspended',
+      })
+    ).save();
+    await (
+      await sites.create({
+        tenantId: 'tenant-1',
+        name: 'Archived',
+        domain: 'archived.com',
+        status: 'archived',
+      })
+    ).save();
+
+    const active = await sites.findActive();
+    expect(active).toHaveLength(1);
+    expect(active[0].name).toBe('Active');
+  });
+});

--- a/packages/sites/src/__tests__/site-service.test.ts
+++ b/packages/sites/src/__tests__/site-service.test.ts
@@ -1,0 +1,197 @@
+/**
+ * SiteService tests
+ *
+ * Tests for service-layer operations:
+ * 1. Site lifecycle (create, activate, suspend, archive)
+ * 2. Provisioning status management
+ * 3. Agent binding management
+ */
+
+import { existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SiteAgentBindingCollection } from '../collections/SiteAgentBindingCollection';
+import { SiteCollection } from '../collections/SiteCollection';
+import { SiteService } from '../services/SiteService';
+
+describe('SiteService', () => {
+  let dbPath: string;
+  let service: SiteService;
+
+  beforeEach(async () => {
+    dbPath = join(tmpdir(), `smrt-site-service-test-${Date.now()}.db`);
+    const dbConfig = { db: { type: 'sqlite' as const, url: dbPath } };
+
+    const sites = await SiteCollection.create(dbConfig);
+    const bindings = await SiteAgentBindingCollection.create(dbConfig);
+    service = new SiteService({ sites, bindings });
+  });
+
+  afterEach(() => {
+    if (existsSync(dbPath)) {
+      try {
+        rmSync(dbPath, { force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  describe('Site lifecycle', () => {
+    it('should create a site in draft status', async () => {
+      const site = await service.createSite('tenant-1', {
+        name: 'New Site',
+        domain: 'newsite.com',
+      });
+
+      expect(site.status).toBe('draft');
+      expect(site.provisioningStatus).toBe('pending');
+      expect(site.name).toBe('New Site');
+      expect(site.domain).toBe('newsite.com');
+      expect(site.tenantId).toBe('tenant-1');
+    });
+
+    it('should activate a site', async () => {
+      const site = await service.createSite('tenant-1', {
+        name: 'Activate Me',
+        domain: 'activate.com',
+      });
+
+      const activated = await service.activateSite(site.id!);
+      expect(activated.status).toBe('active');
+    });
+
+    it('should reject activation without required fields', async () => {
+      const site = await service.createSite('tenant-1', {
+        name: '',
+        domain: 'no-name.com',
+      });
+
+      await expect(service.activateSite(site.id!)).rejects.toThrow(
+        'name is required',
+      );
+    });
+
+    it('should suspend a site', async () => {
+      const site = await service.createSite('tenant-1', {
+        name: 'Suspend Me',
+        domain: 'suspend.com',
+      });
+
+      const suspended = await service.suspendSite(site.id!);
+      expect(suspended.status).toBe('suspended');
+    });
+
+    it('should archive a site', async () => {
+      const site = await service.createSite('tenant-1', {
+        name: 'Archive Me',
+        domain: 'archive.com',
+      });
+
+      const archived = await service.archiveSite(site.id!);
+      expect(archived.status).toBe('archived');
+    });
+
+    it('should throw for nonexistent site', async () => {
+      await expect(service.activateSite('nonexistent')).rejects.toThrow(
+        "Site 'nonexistent' not found",
+      );
+    });
+  });
+
+  describe('Provisioning', () => {
+    it('should mark site as provisioned', async () => {
+      const site = await service.createSite('tenant-1', {
+        name: 'Provision Me',
+        domain: 'provision.com',
+      });
+
+      const provisioned = await service.markProvisioned(site.id!);
+      expect(provisioned.provisioningStatus).toBe('ready');
+      expect(provisioned.provisionedAt).toBeDefined();
+      expect(provisioned.provisioningError).toBe('');
+    });
+
+    it('should mark provisioning as failed', async () => {
+      const site = await service.createSite('tenant-1', {
+        name: 'Fail Me',
+        domain: 'fail.com',
+      });
+
+      const failed = await service.markProvisioningFailed(
+        site.id!,
+        'DNS configuration failed',
+      );
+      expect(failed.provisioningStatus).toBe('failed');
+      expect(failed.provisioningError).toBe('DNS configuration failed');
+    });
+  });
+
+  describe('Agent bindings', () => {
+    it('should bind an agent to a site', async () => {
+      const site = await service.createSite('tenant-1', {
+        name: 'Agent Site',
+        domain: 'agent.com',
+      });
+
+      const binding = await service.bindAgent(site.id!, 'Praeco', {
+        sources: ['url1'],
+      });
+      expect(binding.siteId).toBe(site.id);
+      expect(binding.agentClass).toBe('Praeco');
+      expect(binding.enabled).toBe(true);
+    });
+
+    it('should re-enable existing binding on rebind', async () => {
+      const site = await service.createSite('tenant-1', {
+        name: 'Rebind Site',
+        domain: 'rebind.com',
+      });
+
+      const first = await service.bindAgent(site.id!, 'Praeco');
+      const second = await service.bindAgent(site.id!, 'Praeco', {
+        newConfig: true,
+      });
+
+      expect(second.id).toBe(first.id);
+      expect(second.enabled).toBe(true);
+    });
+
+    it('should unbind an agent from a site', async () => {
+      const site = await service.createSite('tenant-1', {
+        name: 'Unbind Site',
+        domain: 'unbind.com',
+      });
+
+      await service.bindAgent(site.id!, 'Praeco');
+      await service.unbindAgent(site.id!, 'Praeco');
+
+      const enabled = await service.getEnabledAgents(site.id!);
+      expect(enabled).toHaveLength(0);
+    });
+
+    it('should get enabled agents for a site', async () => {
+      const site = await service.createSite('tenant-1', {
+        name: 'Multi Agent',
+        domain: 'multi.com',
+      });
+
+      await service.bindAgent(site.id!, 'Praeco');
+      await service.bindAgent(site.id!, 'Caelus');
+
+      const enabled = await service.getEnabledAgents(site.id!);
+      expect(enabled).toHaveLength(2);
+    });
+
+    it('should handle unbind of nonexistent binding gracefully', async () => {
+      const site = await service.createSite('tenant-1', {
+        name: 'No Binding',
+        domain: 'nobinding.com',
+      });
+
+      // Should not throw
+      await service.unbindAgent(site.id!, 'Nonexistent');
+    });
+  });
+});

--- a/packages/sites/src/__tests__/site.test.ts
+++ b/packages/sites/src/__tests__/site.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Site model tests
+ *
+ * Tests for:
+ * 1. Site CRUD operations
+ * 2. Site status management
+ * 3. JSON field handling (portalConfig, metadata)
+ */
+
+import { existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SiteCollection } from '../collections/SiteCollection';
+
+describe('Site', () => {
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = join(tmpdir(), `smrt-site-test-${Date.now()}.db`);
+  });
+
+  afterEach(() => {
+    if (existsSync(dbPath)) {
+      try {
+        rmSync(dbPath, { force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  describe('Basic CRUD Operations', () => {
+    it('should create a site', async () => {
+      const sites = await SiteCollection.create({
+        db: { type: 'sqlite', url: dbPath },
+      });
+
+      const site = await sites.create({
+        tenantId: 'tenant-1',
+        name: 'Bentley Alberta',
+        domain: 'bentleyalberta.com',
+        status: 'active',
+        tier: 'standard',
+      });
+
+      expect(site.id).toBeDefined();
+      expect(site.name).toBe('Bentley Alberta');
+      expect(site.domain).toBe('bentleyalberta.com');
+      expect(site.status).toBe('active');
+      expect(site.tier).toBe('standard');
+    });
+
+    it('should preserve data through save/load cycle', async () => {
+      const sites = await SiteCollection.create({
+        db: { type: 'sqlite', url: dbPath },
+      });
+
+      const site = await sites.create({
+        tenantId: 'tenant-1',
+        name: 'Test Site',
+        domain: 'test.com',
+        tier: 'premium',
+        databaseUrl: 'file:./data/test.db',
+        databaseType: 'sqlite',
+        repositoryUrl: 'https://github.com/org/test',
+        templateName: 'default',
+      });
+      await site.save();
+
+      const loaded = await sites.get({ id: site.id });
+      expect(loaded).toBeDefined();
+      expect(loaded?.name).toBe('Test Site');
+      expect(loaded?.domain).toBe('test.com');
+      expect(loaded?.tier).toBe('premium');
+      expect(loaded?.databaseUrl).toBe('file:./data/test.db');
+      expect(loaded?.databaseType).toBe('sqlite');
+      expect(loaded?.repositoryUrl).toBe('https://github.com/org/test');
+      expect(loaded?.templateName).toBe('default');
+    });
+
+    it('should update site fields', async () => {
+      const sites = await SiteCollection.create({
+        db: { type: 'sqlite', url: dbPath },
+      });
+
+      const site = await sites.create({
+        tenantId: 'tenant-1',
+        name: 'Original',
+        domain: 'original.com',
+      });
+      await site.save();
+
+      site.name = 'Updated';
+      site.status = 'suspended';
+      await site.save();
+
+      const loaded = await sites.get({ id: site.id });
+      expect(loaded?.name).toBe('Updated');
+      expect(loaded?.status).toBe('suspended');
+    });
+
+    it('should delete a site', async () => {
+      const sites = await SiteCollection.create({
+        db: { type: 'sqlite', url: dbPath },
+      });
+
+      const site = await sites.create({
+        tenantId: 'tenant-1',
+        name: 'Deletable',
+        domain: 'delete.me',
+      });
+      await site.save();
+
+      await site.delete();
+
+      const loaded = await sites.get({ id: site.id });
+      expect(loaded).toBeNull();
+    });
+  });
+
+  describe('Status helpers', () => {
+    it('should check if site is active', async () => {
+      const sites = await SiteCollection.create({
+        db: { type: 'sqlite', url: dbPath },
+      });
+
+      const active = await sites.create({
+        tenantId: 'tenant-1',
+        name: 'Active',
+        domain: 'active.com',
+        status: 'active',
+      });
+
+      const draft = await sites.create({
+        tenantId: 'tenant-1',
+        name: 'Draft',
+        domain: 'draft.com',
+        status: 'draft',
+      });
+
+      expect(active.isActive()).toBe(true);
+      expect(draft.isActive()).toBe(false);
+    });
+
+    it('should check if site is ready', async () => {
+      const sites = await SiteCollection.create({
+        db: { type: 'sqlite', url: dbPath },
+      });
+
+      const ready = await sites.create({
+        tenantId: 'tenant-1',
+        name: 'Ready',
+        domain: 'ready.com',
+        provisioningStatus: 'ready',
+      });
+
+      const pending = await sites.create({
+        tenantId: 'tenant-1',
+        name: 'Pending',
+        domain: 'pending.com',
+        provisioningStatus: 'pending',
+      });
+
+      expect(ready.isReady()).toBe(true);
+      expect(pending.isReady()).toBe(false);
+    });
+  });
+
+  describe('JSON fields', () => {
+    it('should store and retrieve portalConfig', async () => {
+      const sites = await SiteCollection.create({
+        db: { type: 'sqlite', url: dbPath },
+      });
+
+      const site = await sites.create({
+        tenantId: 'tenant-1',
+        name: 'Themed Site',
+        domain: 'themed.com',
+        portalConfig: {
+          theme: 'dark',
+          branding: { logo: '/logo.png' },
+          navigation: [{ label: 'Home', path: '/' }],
+        },
+      });
+      await site.save();
+
+      const loaded = await sites.get({ id: site.id });
+      const config = loaded?.getPortalConfig();
+      expect(config?.theme).toBe('dark');
+      expect(config?.branding?.logo).toBe('/logo.png');
+      expect(config?.navigation).toHaveLength(1);
+    });
+
+    it('should store and retrieve metadata', async () => {
+      const sites = await SiteCollection.create({
+        db: { type: 'sqlite', url: dbPath },
+      });
+
+      const site = await sites.create({
+        tenantId: 'tenant-1',
+        name: 'Meta Site',
+        domain: 'meta.com',
+        metadata: {
+          analyticsId: 'UA-12345',
+          features: ['ads', 'newsletter'],
+        },
+      });
+      await site.save();
+
+      const loaded = await sites.get({ id: site.id });
+      const meta = loaded?.getMetadata();
+      expect(meta?.analyticsId).toBe('UA-12345');
+      expect(meta?.features).toEqual(['ads', 'newsletter']);
+    });
+
+    it('should merge metadata updates', async () => {
+      const sites = await SiteCollection.create({
+        db: { type: 'sqlite', url: dbPath },
+      });
+
+      const site = await sites.create({
+        tenantId: 'tenant-1',
+        name: 'Merge Site',
+        domain: 'merge.com',
+        metadata: { a: 1, b: 2 },
+      });
+      await site.save();
+
+      // Reload to get the persisted state
+      const loaded = await sites.get({ id: site.id });
+      expect(loaded).toBeDefined();
+
+      loaded?.updateMetadata({ b: 3, c: 4 });
+      expect(loaded?.getMetadata()).toEqual({ a: 1, b: 3, c: 4 });
+    });
+  });
+});

--- a/packages/sites/src/collections/SiteAgentBindingCollection.ts
+++ b/packages/sites/src/collections/SiteAgentBindingCollection.ts
@@ -1,0 +1,49 @@
+/**
+ * SiteAgentBindingCollection - Collection manager for SiteAgentBinding objects
+ *
+ * Provides queries for agent bindings by site, agent class, and enabled state.
+ */
+
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { SiteAgentBinding } from '../models/SiteAgentBinding';
+
+export class SiteAgentBindingCollection extends SmrtCollection<SiteAgentBinding> {
+  static readonly _itemClass = SiteAgentBinding;
+
+  /**
+   * Find all agent bindings for a site
+   */
+  async findBySite(siteId: string): Promise<SiteAgentBinding[]> {
+    return this.list({ where: { siteId } });
+  }
+
+  /**
+   * Find all sites using a specific agent class
+   */
+  async findByAgent(agentClass: string): Promise<SiteAgentBinding[]> {
+    return this.list({ where: { agentClass } });
+  }
+
+  /**
+   * Find enabled bindings for a site, ordered by priority descending
+   */
+  async findEnabled(siteId: string): Promise<SiteAgentBinding[]> {
+    const bindings = await this.list({
+      where: { siteId, enabled: true },
+    });
+    return bindings.sort((a, b) => b.priority - a.priority);
+  }
+
+  /**
+   * Find a specific site-agent binding
+   */
+  async findBySiteAndAgent(
+    siteId: string,
+    agentClass: string,
+  ): Promise<SiteAgentBinding | null> {
+    const results = await this.list({
+      where: { siteId, agentClass },
+    });
+    return results[0] ?? null;
+  }
+}

--- a/packages/sites/src/collections/SiteCollection.ts
+++ b/packages/sites/src/collections/SiteCollection.ts
@@ -1,0 +1,42 @@
+/**
+ * SiteCollection - Collection manager for Site objects
+ *
+ * Provides domain lookup, tenant filtering, and status queries.
+ */
+
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { Site } from '../models/Site';
+import type { SiteStatus } from '../types';
+
+export class SiteCollection extends SmrtCollection<Site> {
+  static readonly _itemClass = Site;
+
+  /**
+   * Find a site by its primary domain
+   */
+  async findByDomain(domain: string): Promise<Site | null> {
+    const results = await this.list({ where: { domain } });
+    return results[0] ?? null;
+  }
+
+  /**
+   * Find all sites belonging to a tenant
+   */
+  async findByTenant(tenantId: string): Promise<Site[]> {
+    return this.list({ where: { tenantId } });
+  }
+
+  /**
+   * Find sites by lifecycle status
+   */
+  async findByStatus(status: SiteStatus): Promise<Site[]> {
+    return this.list({ where: { status } });
+  }
+
+  /**
+   * Find all active sites
+   */
+  async findActive(): Promise<Site[]> {
+    return this.findByStatus('active');
+  }
+}

--- a/packages/sites/src/index.ts
+++ b/packages/sites/src/index.ts
@@ -1,0 +1,33 @@
+/**
+ * @happyvertical/smrt-sites
+ *
+ * Site lifecycle management for multi-tenant SMRT networks.
+ *
+ * Provides models, collections, and services for managing deployable
+ * websites within a tenant hierarchy, including agent binding and
+ * infrastructure provisioning tracking.
+ *
+ * @packageDocumentation
+ */
+
+// Export collections
+export { SiteAgentBindingCollection } from './collections/SiteAgentBindingCollection';
+export { SiteCollection } from './collections/SiteCollection';
+
+// Export models
+export { Site } from './models/Site';
+export { SiteAgentBinding } from './models/SiteAgentBinding';
+export type { SiteServiceOptions } from './services/SiteService';
+// Export services
+export { SiteService } from './services/SiteService';
+
+// Export types
+export type {
+  CreateSiteData,
+  ProvisioningStatus,
+  SiteAgentBindingOptions,
+  SiteOptions,
+  SitePortalConfig,
+  SiteStatus,
+  SiteTier,
+} from './types';

--- a/packages/sites/src/models/Site.ts
+++ b/packages/sites/src/models/Site.ts
@@ -1,0 +1,179 @@
+/**
+ * Site model - Represents a deployable website within a multi-tenant network
+ *
+ * Manages site lifecycle from draft through active/suspended/archived states,
+ * with infrastructure provisioning tracking and portal configuration.
+ *
+ * Tenancy: Sites are tenant-scoped with required mode — every site
+ * belongs to exactly one tenant.
+ */
+
+import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import type {
+  ProvisioningStatus,
+  SiteOptions,
+  SitePortalConfig,
+  SiteStatus,
+  SiteTier,
+} from '../types';
+
+@TenantScoped({ mode: 'required' })
+@smrt({
+  tableName: 'sites',
+  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  mcp: { include: ['list', 'get', 'create', 'update'] },
+  cli: true,
+  conflictColumns: ['tenant_id', 'domain'],
+})
+export class Site extends SmrtObject {
+  @tenantId()
+  tenantId: string = '';
+
+  /** Display name, e.g. "Bentley Alberta" */
+  name: string = '';
+
+  /** Primary domain, e.g. "bentleyalberta.com" */
+  domain: string = '';
+
+  /** Lifecycle status */
+  status: SiteStatus = 'draft';
+
+  /** Pricing/feature tier */
+  tier: SiteTier = 'free';
+
+  /** Site-specific database connection URL */
+  databaseUrl: string = '';
+
+  /** Database type: sqlite, postgres, libsql */
+  databaseType: string = '';
+
+  /** Theme, branding, navigation settings (JSON) */
+  portalConfig: string = '';
+
+  /** Git repository URL */
+  repositoryUrl: string = '';
+
+  /** Starter template name */
+  templateName: string = '';
+
+  /** Infrastructure provisioning status */
+  provisioningStatus: ProvisioningStatus | '' = '';
+
+  /** When provisioning completed */
+  provisionedAt: Date | null = null;
+
+  /** Last provisioning error message */
+  provisioningError: string = '';
+
+  /** Extensible key-value metadata (JSON) */
+  metadata: string = '';
+
+  createdAt: Date = new Date();
+  updatedAt: Date = new Date();
+
+  constructor(options: SiteOptions = {}) {
+    super(options);
+
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+    if (options.name !== undefined) this.name = options.name;
+    if (options.domain !== undefined) this.domain = options.domain;
+    if (options.status !== undefined) this.status = options.status;
+    if (options.tier !== undefined) this.tier = options.tier;
+    if (options.databaseUrl !== undefined)
+      this.databaseUrl = options.databaseUrl;
+    if (options.databaseType !== undefined)
+      this.databaseType = options.databaseType;
+    if (options.repositoryUrl !== undefined)
+      this.repositoryUrl = options.repositoryUrl;
+    if (options.templateName !== undefined)
+      this.templateName = options.templateName;
+    if (options.provisioningStatus !== undefined)
+      this.provisioningStatus = options.provisioningStatus;
+    if (options.provisionedAt !== undefined)
+      this.provisionedAt = options.provisionedAt;
+    if (options.provisioningError !== undefined)
+      this.provisioningError = options.provisioningError;
+
+    // Handle portalConfig — can be object or JSON string
+    if (options.portalConfig !== undefined) {
+      if (typeof options.portalConfig === 'string') {
+        this.portalConfig = options.portalConfig;
+      } else {
+        this.portalConfig = JSON.stringify(options.portalConfig);
+      }
+    }
+
+    // Handle metadata — can be object or JSON string
+    if (options.metadata !== undefined) {
+      if (typeof options.metadata === 'string') {
+        this.metadata = options.metadata;
+      } else {
+        this.metadata = JSON.stringify(options.metadata);
+      }
+    }
+
+    if (options.createdAt) this.createdAt = options.createdAt;
+    if (options.updatedAt) this.updatedAt = options.updatedAt;
+  }
+
+  /**
+   * Check if the site is active
+   */
+  isActive(): boolean {
+    return this.status === 'active';
+  }
+
+  /**
+   * Check if the site is provisioned and ready
+   */
+  isReady(): boolean {
+    return this.provisioningStatus === 'ready';
+  }
+
+  /**
+   * Get portal config as parsed object
+   */
+  getPortalConfig(): SitePortalConfig {
+    if (!this.portalConfig) return {};
+    try {
+      return JSON.parse(this.portalConfig);
+    } catch {
+      return {};
+    }
+  }
+
+  /**
+   * Set portal config from object
+   */
+  setPortalConfig(config: SitePortalConfig): void {
+    this.portalConfig = JSON.stringify(config);
+  }
+
+  /**
+   * Get metadata as parsed object
+   */
+  getMetadata(): Record<string, unknown> {
+    if (!this.metadata) return {};
+    try {
+      return JSON.parse(this.metadata);
+    } catch {
+      return {};
+    }
+  }
+
+  /**
+   * Set metadata from object
+   */
+  setMetadata(data: Record<string, unknown>): void {
+    this.metadata = JSON.stringify(data);
+  }
+
+  /**
+   * Update metadata by merging with existing values
+   */
+  updateMetadata(updates: Record<string, unknown>): void {
+    const current = this.getMetadata();
+    this.setMetadata({ ...current, ...updates });
+  }
+}

--- a/packages/sites/src/models/SiteAgentBinding.ts
+++ b/packages/sites/src/models/SiteAgentBinding.ts
@@ -1,0 +1,64 @@
+/**
+ * SiteAgentBinding - Junction between sites and agents
+ *
+ * Represents which agents are bound to a specific site,
+ * with optional per-site agent configuration overrides.
+ *
+ * Each row binds an agent class to a site. The absence of a row
+ * means the agent is not enabled for that site.
+ */
+
+import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import type { SiteAgentBindingOptions } from '../types';
+
+@TenantScoped({ mode: 'required' })
+@smrt({
+  tableName: 'site_agent_bindings',
+  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  cli: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
+  conflictColumns: ['site_id', 'agent_class'],
+})
+export class SiteAgentBinding extends SmrtObject {
+  @tenantId()
+  tenantId: string = '';
+
+  /** FK to sites table */
+  siteId: string = '';
+
+  /** Agent class name, e.g. "Praeco" */
+  agentClass: string = '';
+
+  /** Whether this agent is enabled for the site */
+  enabled: boolean = true;
+
+  /** Per-site agent configuration overrides (JSON) */
+  config: Record<string, unknown> | null = null;
+
+  /** Sort priority (higher = first) */
+  priority: number = 0;
+
+  constructor(options: SiteAgentBindingOptions = {}) {
+    super(options);
+
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+    if (options.siteId !== undefined) this.siteId = options.siteId;
+    if (options.agentClass !== undefined) this.agentClass = options.agentClass;
+    if (options.enabled !== undefined) this.enabled = options.enabled;
+    if (options.priority !== undefined) this.priority = options.priority;
+
+    // Handle config — can be object, JSON string, or null
+    if (options.config !== undefined) {
+      if (typeof options.config === 'string') {
+        try {
+          this.config = JSON.parse(options.config);
+        } catch {
+          this.config = null;
+        }
+      } else {
+        this.config = options.config;
+      }
+    }
+  }
+}

--- a/packages/sites/src/services/SiteService.ts
+++ b/packages/sites/src/services/SiteService.ts
@@ -1,0 +1,175 @@
+/**
+ * SiteService - High-level API for site lifecycle management
+ *
+ * Provides stateless operations for creating, activating, suspending,
+ * and archiving sites, as well as managing agent bindings.
+ */
+
+import type { SiteAgentBindingCollection } from '../collections/SiteAgentBindingCollection';
+import type { SiteCollection } from '../collections/SiteCollection';
+import type { Site } from '../models/Site';
+import type { SiteAgentBinding } from '../models/SiteAgentBinding';
+import type { CreateSiteData } from '../types';
+
+/**
+ * Options for creating a SiteService
+ */
+export interface SiteServiceOptions {
+  sites: SiteCollection;
+  bindings: SiteAgentBindingCollection;
+}
+
+export class SiteService {
+  private sites: SiteCollection;
+  private bindings: SiteAgentBindingCollection;
+
+  constructor(options: SiteServiceOptions) {
+    this.sites = options.sites;
+    this.bindings = options.bindings;
+  }
+
+  /**
+   * Create a new site in draft status
+   */
+  async createSite(tenantId: string, data: CreateSiteData): Promise<Site> {
+    const site = await this.sites.create({
+      tenantId,
+      name: data.name,
+      domain: data.domain,
+      status: 'draft',
+      tier: data.tier ?? 'free',
+      databaseUrl: data.databaseUrl ?? '',
+      databaseType: data.databaseType ?? '',
+      portalConfig: data.portalConfig ?? {},
+      repositoryUrl: data.repositoryUrl ?? '',
+      templateName: data.templateName ?? '',
+      provisioningStatus: 'pending',
+      metadata: data.metadata ?? {},
+    });
+    await site.save();
+    return site;
+  }
+
+  /**
+   * Activate a site — validates required fields then sets status to active
+   */
+  async activateSite(siteId: string): Promise<Site> {
+    const site = await this.requireSite(siteId);
+
+    if (!site.name) {
+      throw new Error('Cannot activate site: name is required');
+    }
+    if (!site.domain) {
+      throw new Error('Cannot activate site: domain is required');
+    }
+
+    site.status = 'active';
+    site.updatedAt = new Date();
+    await site.save();
+    return site;
+  }
+
+  /**
+   * Suspend a site
+   */
+  async suspendSite(siteId: string): Promise<Site> {
+    const site = await this.requireSite(siteId);
+    site.status = 'suspended';
+    site.updatedAt = new Date();
+    await site.save();
+    return site;
+  }
+
+  /**
+   * Archive a site
+   */
+  async archiveSite(siteId: string): Promise<Site> {
+    const site = await this.requireSite(siteId);
+    site.status = 'archived';
+    site.updatedAt = new Date();
+    await site.save();
+    return site;
+  }
+
+  /**
+   * Mark site as provisioned and ready
+   */
+  async markProvisioned(siteId: string): Promise<Site> {
+    const site = await this.requireSite(siteId);
+    site.provisioningStatus = 'ready';
+    site.provisionedAt = new Date();
+    site.provisioningError = '';
+    site.updatedAt = new Date();
+    await site.save();
+    return site;
+  }
+
+  /**
+   * Mark site provisioning as failed
+   */
+  async markProvisioningFailed(siteId: string, error: string): Promise<Site> {
+    const site = await this.requireSite(siteId);
+    site.provisioningStatus = 'failed';
+    site.provisioningError = error;
+    site.updatedAt = new Date();
+    await site.save();
+    return site;
+  }
+
+  /**
+   * Bind an agent to a site
+   */
+  async bindAgent(
+    siteId: string,
+    agentClass: string,
+    config?: Record<string, unknown>,
+  ): Promise<SiteAgentBinding> {
+    const site = await this.requireSite(siteId);
+
+    const existing = await this.bindings.findBySiteAndAgent(siteId, agentClass);
+    if (existing) {
+      existing.enabled = true;
+      if (config !== undefined) existing.config = config;
+      await existing.save();
+      return existing;
+    }
+
+    const binding = await this.bindings.create({
+      tenantId: site.tenantId,
+      siteId,
+      agentClass,
+      enabled: true,
+      config: config ?? null,
+    });
+    await binding.save();
+    return binding;
+  }
+
+  /**
+   * Unbind an agent from a site
+   */
+  async unbindAgent(siteId: string, agentClass: string): Promise<void> {
+    const binding = await this.bindings.findBySiteAndAgent(siteId, agentClass);
+    if (binding) {
+      await binding.delete();
+    }
+  }
+
+  /**
+   * Get all enabled agent bindings for a site
+   */
+  async getEnabledAgents(siteId: string): Promise<SiteAgentBinding[]> {
+    return this.bindings.findEnabled(siteId);
+  }
+
+  /**
+   * Load a site by ID, throwing if not found
+   */
+  private async requireSite(siteId: string): Promise<Site> {
+    const site = await this.sites.get({ id: siteId });
+    if (!site) {
+      throw new Error(`Site '${siteId}' not found`);
+    }
+    return site;
+  }
+}

--- a/packages/sites/src/types.ts
+++ b/packages/sites/src/types.ts
@@ -1,0 +1,84 @@
+/**
+ * Types for smrt-sites package
+ */
+
+/**
+ * Site lifecycle status
+ */
+export type SiteStatus = 'draft' | 'active' | 'suspended' | 'archived';
+
+/**
+ * Site pricing/feature tier
+ */
+export type SiteTier = 'free' | 'standard' | 'premium';
+
+/**
+ * Infrastructure provisioning status
+ */
+export type ProvisioningStatus =
+  | 'pending'
+  | 'provisioning'
+  | 'ready'
+  | 'failed';
+
+/**
+ * Portal configuration for theming, branding, and navigation
+ */
+export interface SitePortalConfig {
+  theme?: string;
+  branding?: Record<string, unknown>;
+  navigation?: Array<{ label: string; path: string; icon?: string }>;
+}
+
+/**
+ * Data required to create a new site
+ */
+export interface CreateSiteData {
+  name: string;
+  domain: string;
+  tier?: SiteTier;
+  databaseUrl?: string;
+  databaseType?: string;
+  portalConfig?: SitePortalConfig;
+  repositoryUrl?: string;
+  templateName?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Options for constructing a Site instance
+ */
+export interface SiteOptions {
+  id?: string;
+  tenantId?: string;
+  name?: string;
+  domain?: string;
+  status?: SiteStatus;
+  tier?: SiteTier;
+  databaseUrl?: string;
+  databaseType?: string;
+  portalConfig?: SitePortalConfig | string;
+  repositoryUrl?: string;
+  templateName?: string;
+  provisioningStatus?: ProvisioningStatus;
+  provisionedAt?: Date | null;
+  provisioningError?: string;
+  metadata?: Record<string, unknown> | string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+/**
+ * Options for constructing a SiteAgentBinding instance
+ */
+export interface SiteAgentBindingOptions {
+  id?: string;
+  tenantId?: string;
+  siteId?: string;
+  agentClass?: string;
+  enabled?: boolean;
+  config?: Record<string, unknown> | string | null;
+  priority?: number;
+  createdAt?: Date;
+  updatedAt?: Date;
+}

--- a/packages/sites/tsconfig.json
+++ b/packages/sites/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "types": ["node"],
+    "lib": ["ES2023"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/sites/vite.config.ts
+++ b/packages/sites/vite.config.ts
@@ -1,0 +1,3 @@
+import { createPackageConfig } from '../../vite.config.base.js';
+
+export default createPackageConfig('sites');

--- a/packages/sites/vitest.config.ts
+++ b/packages/sites/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+import { smrtVitestPlugin } from '@happyvertical/smrt-vitest';
+
+export default defineConfig({
+  plugins: [smrtVitestPlugin({ verbose: true })],
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    testTimeout: 30000,
+    fileParallelism: false,
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1139,6 +1139,43 @@ importers:
         specifier: ^4.0.17
         version: 4.0.17(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.3.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/sites:
+    dependencies:
+      '@happyvertical/smrt-agents':
+        specifier: workspace:*
+        version: link:../agents
+      '@happyvertical/smrt-core':
+        specifier: workspace:*
+        version: link:../core
+      '@happyvertical/smrt-tenancy':
+        specifier: workspace:*
+        version: link:../tenancy
+    devDependencies:
+      '@happyvertical/smrt-cli':
+        specifier: workspace:*
+        version: link:../cli
+      '@happyvertical/smrt-vitest':
+        specifier: workspace:*
+        version: link:../vitest
+      '@happyvertical/sql':
+        specifier: ^0.67.7
+        version: 0.67.7
+      '@types/node':
+        specifier: 24.10.9
+        version: 24.10.9
+      fast-glob:
+        specifier: 3.3.3
+        version: 3.3.3
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: ^4.0.17
+        version: 4.0.17(@types/node@24.10.9)(happy-dom@20.3.0)(jiti@2.6.1)(jsdom@27.3.0)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/smrt-dev-mcp:
     dependencies:
       '@happyvertical/ai':
@@ -2751,6 +2788,11 @@ packages:
     peerDependencies:
       jimp: '>=1.6.0'
       sharp: '>=0.34.5'
+    peerDependenciesMeta:
+      jimp:
+        optional: true
+      sharp:
+        optional: true
 
   '@happyvertical/jobs@0.66.9':
     resolution: {integrity: sha512-S//tD2dbiqRq+3vcf+v/VOMkiWn/hOS/bmXswv+TPIQ6dhxDKoMDM1fkIIWhuMUlt2W5AUYX2fLz3JC0VIFdRw==, tarball: https://npm.pkg.github.com/download/@happyvertical/jobs/0.66.9/7710e064fc53cd87cfe4ecc558063ccdfbb909dd}
@@ -2759,6 +2801,15 @@ packages:
       '@google-cloud/tasks': '>=4.0.0'
       bull: '>=4.0.0'
       bullmq: '>=5.0.0'
+    peerDependenciesMeta:
+      '@aws-sdk/client-sqs':
+        optional: true
+      '@google-cloud/tasks':
+        optional: true
+      bull:
+        optional: true
+      bullmq:
+        optional: true
 
   '@happyvertical/json@0.67.4':
     resolution: {integrity: sha512-PcqquSt4OzlD8czqXmc/R8ywCuxki1g8UFZVJX/L72cF+LOTAAO7Z5rdsrHfO/mCxkwZIZ5omyWYBWOXRO7I3Q==, tarball: https://npm.pkg.github.com/download/@happyvertical/json/0.67.4/907604f5a1acac7994d1bcbcdd703c5e58703952}
@@ -7103,7 +7154,6 @@ packages:
 
   libsql@0.5.22:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   linebreak@1.1.0:
@@ -10181,6 +10231,7 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+    optional: true
 
   '@aws-sdk/client-sso@3.956.0':
     dependencies:
@@ -10310,6 +10361,7 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+    optional: true
 
   '@aws-sdk/core@3.956.0':
     dependencies:
@@ -10358,6 +10410,7 @@ snapshots:
       '@smithy/util-middleware': 4.2.8
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/crc64-nvme@3.957.0':
     dependencies:
@@ -10407,6 +10460,7 @@ snapshots:
       '@smithy/property-provider': 4.2.8
       '@smithy/types': 4.12.0
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-http@3.956.0':
     dependencies:
@@ -10446,6 +10500,7 @@ snapshots:
       '@smithy/types': 4.12.0
       '@smithy/util-stream': 4.5.10
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-ini@3.956.0':
     dependencies:
@@ -10503,6 +10558,7 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+    optional: true
 
   '@aws-sdk/credential-provider-login@3.956.0':
     dependencies:
@@ -10542,6 +10598,7 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+    optional: true
 
   '@aws-sdk/credential-provider-node@3.956.0':
     dependencies:
@@ -10593,6 +10650,7 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+    optional: true
 
   '@aws-sdk/credential-provider-process@3.956.0':
     dependencies:
@@ -10620,6 +10678,7 @@ snapshots:
       '@smithy/shared-ini-file-loader': 4.4.3
       '@smithy/types': 4.12.0
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-sso@3.956.0':
     dependencies:
@@ -10659,6 +10718,7 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+    optional: true
 
   '@aws-sdk/credential-provider-web-identity@3.956.0':
     dependencies:
@@ -10695,6 +10755,7 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+    optional: true
 
   '@aws-sdk/credential-providers@3.956.0':
     dependencies:
@@ -10861,6 +10922,7 @@ snapshots:
       '@smithy/protocol-http': 5.3.8
       '@smithy/types': 4.12.0
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/middleware-location-constraint@3.956.0':
     dependencies:
@@ -10891,6 +10953,7 @@ snapshots:
       '@aws-sdk/types': 3.965.0
       '@smithy/types': 4.12.0
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/middleware-recursion-detection@3.956.0':
     dependencies:
@@ -10915,6 +10978,7 @@ snapshots:
       '@smithy/protocol-http': 5.3.8
       '@smithy/types': 4.12.0
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/middleware-sdk-s3@3.956.0':
     dependencies:
@@ -10958,6 +11022,7 @@ snapshots:
       '@smithy/util-hex-encoding': 4.2.0
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/middleware-ssec@3.956.0':
     dependencies:
@@ -11000,6 +11065,7 @@ snapshots:
       '@smithy/protocol-http': 5.3.8
       '@smithy/types': 4.12.0
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/middleware-websocket@3.956.0':
     dependencies:
@@ -11155,6 +11221,7 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+    optional: true
 
   '@aws-sdk/region-config-resolver@3.956.0':
     dependencies:
@@ -11179,6 +11246,7 @@ snapshots:
       '@smithy/node-config-provider': 4.3.8
       '@smithy/types': 4.12.0
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/signature-v4-multi-region@3.956.0':
     dependencies:
@@ -11233,6 +11301,7 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+    optional: true
 
   '@aws-sdk/types@3.956.0':
     dependencies:
@@ -11248,6 +11317,7 @@ snapshots:
     dependencies:
       '@smithy/types': 4.12.0
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/util-arn-parser@3.953.0':
     dependencies:
@@ -11280,6 +11350,7 @@ snapshots:
       '@smithy/url-parser': 4.2.8
       '@smithy/util-endpoints': 3.2.8
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/util-format-url@3.956.0':
     dependencies:
@@ -11319,6 +11390,7 @@ snapshots:
       '@smithy/types': 4.12.0
       bowser: 2.13.1
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/util-user-agent-node@3.956.0':
     dependencies:
@@ -11343,6 +11415,7 @@ snapshots:
       '@smithy/node-config-provider': 4.3.8
       '@smithy/types': 4.12.0
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/xml-builder@3.956.0':
     dependencies:
@@ -11361,6 +11434,7 @@ snapshots:
       '@smithy/types': 4.12.0
       fast-xml-parser: 5.2.5
       tslib: 2.8.1
+    optional: true
 
   '@aws/lambda-invoke-store@0.2.3': {}
 
@@ -12137,6 +12211,7 @@ snapshots:
       google-gax: 5.0.6
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@google/genai@1.34.0(@modelcontextprotocol/sdk@1.25.2(@cfworker/json-schema@4.1.1)(hono@4.11.4)(zod@4.3.5))':
     dependencies:
@@ -12166,7 +12241,7 @@ snapshots:
       agentkeepalive: 4.6.0
       axios: 1.13.2(debug@4.4.3)
       query-string: 7.1.3
-      retry-axios: 2.6.0(axios@1.13.2(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.13.2)
     transitivePeerDependencies:
       - debug
 
@@ -12178,6 +12253,7 @@ snapshots:
     dependencies:
       '@grpc/proto-loader': 0.8.0
       '@js-sdsl/ordered-map': 4.4.2
+    optional: true
 
   '@grpc/proto-loader@0.8.0':
     dependencies:
@@ -12185,6 +12261,7 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.5.4
       yargs: 17.7.2
+    optional: true
 
   '@gutenye/ocr-common@1.4.8':
     dependencies:
@@ -12320,16 +12397,18 @@ snapshots:
   '@happyvertical/images@0.66.9(jimp@1.6.0)(sharp@0.34.5)':
     dependencies:
       '@resvg/resvg-js': 2.6.2
-      jimp: 1.6.0
       satori: 0.18.3
+    optionalDependencies:
+      jimp: 1.6.0
       sharp: 0.34.5
 
   '@happyvertical/jobs@0.66.9(@aws-sdk/client-sqs@3.966.0)(@google-cloud/tasks@6.2.1)(bull@4.16.5)(bullmq@5.66.5)':
     dependencies:
-      '@aws-sdk/client-sqs': 3.966.0
-      '@google-cloud/tasks': 6.2.1
       '@happyvertical/sql': 0.66.9
       '@happyvertical/utils': 0.66.9
+    optionalDependencies:
+      '@aws-sdk/client-sqs': 3.966.0
+      '@google-cloud/tasks': 6.2.1
       bull: 4.16.5
       bullmq: 5.66.5
     transitivePeerDependencies:
@@ -12722,7 +12801,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.0.9
 
-  '@ioredis/commands@1.5.0': {}
+  '@ioredis/commands@1.5.0':
+    optional: true
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -12752,6 +12832,7 @@ snapshots:
       exif-parser: 0.1.12
       file-type: 16.5.4
       mime: 3.0.0
+    optional: true
 
   '@jimp/diff@1.6.0':
     dependencies:
@@ -12759,8 +12840,10 @@ snapshots:
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
       pixelmatch: 5.3.0
+    optional: true
 
-  '@jimp/file-ops@1.6.0': {}
+  '@jimp/file-ops@1.6.0':
+    optional: true
 
   '@jimp/js-bmp@1.6.0':
     dependencies:
@@ -12768,6 +12851,7 @@ snapshots:
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
       bmp-ts: 1.0.9
+    optional: true
 
   '@jimp/js-gif@1.6.0':
     dependencies:
@@ -12775,40 +12859,47 @@ snapshots:
       '@jimp/types': 1.6.0
       gifwrap: 0.10.1
       omggif: 1.0.10
+    optional: true
 
   '@jimp/js-jpeg@1.6.0':
     dependencies:
       '@jimp/core': 1.6.0
       '@jimp/types': 1.6.0
       jpeg-js: 0.4.4
+    optional: true
 
   '@jimp/js-png@1.6.0':
     dependencies:
       '@jimp/core': 1.6.0
       '@jimp/types': 1.6.0
       pngjs: 7.0.0
+    optional: true
 
   '@jimp/js-tiff@1.6.0':
     dependencies:
       '@jimp/core': 1.6.0
       '@jimp/types': 1.6.0
       utif2: 4.1.0
+    optional: true
 
   '@jimp/plugin-blit@1.6.0':
     dependencies:
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-blur@1.6.0':
     dependencies:
       '@jimp/core': 1.6.0
       '@jimp/utils': 1.6.0
+    optional: true
 
   '@jimp/plugin-circle@1.6.0':
     dependencies:
       '@jimp/types': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-color@1.6.0':
     dependencies:
@@ -12817,6 +12908,7 @@ snapshots:
       '@jimp/utils': 1.6.0
       tinycolor2: 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-contain@1.6.0':
     dependencies:
@@ -12826,6 +12918,7 @@ snapshots:
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-cover@1.6.0':
     dependencies:
@@ -12834,6 +12927,7 @@ snapshots:
       '@jimp/plugin-resize': 1.6.0
       '@jimp/types': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-crop@1.6.0':
     dependencies:
@@ -12841,27 +12935,32 @@ snapshots:
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-displace@1.6.0':
     dependencies:
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-dither@1.6.0':
     dependencies:
       '@jimp/types': 1.6.0
+    optional: true
 
   '@jimp/plugin-fisheye@1.6.0':
     dependencies:
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-flip@1.6.0':
     dependencies:
       '@jimp/types': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-hash@1.6.0':
     dependencies:
@@ -12875,11 +12974,13 @@ snapshots:
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
       any-base: 1.1.0
+    optional: true
 
   '@jimp/plugin-mask@1.6.0':
     dependencies:
       '@jimp/types': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-print@1.6.0':
     dependencies:
@@ -12893,17 +12994,20 @@ snapshots:
       parse-bmfont-xml: 1.1.6
       simple-xml-to-json: 1.2.3
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-quantize@1.6.0':
     dependencies:
       image-q: 4.0.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-resize@1.6.0':
     dependencies:
       '@jimp/core': 1.6.0
       '@jimp/types': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-rotate@1.6.0':
     dependencies:
@@ -12913,6 +13017,7 @@ snapshots:
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/plugin-threshold@1.6.0':
     dependencies:
@@ -12922,15 +13027,18 @@ snapshots:
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
       zod: 3.25.76
+    optional: true
 
   '@jimp/types@1.6.0':
     dependencies:
       zod: 3.25.76
+    optional: true
 
   '@jimp/utils@1.6.0':
     dependencies:
       '@jimp/types': 1.6.0
       tinycolor2: 1.6.0
+    optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -12951,7 +13059,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@js-sdsl/ordered-map@4.4.2': {}
+  '@js-sdsl/ordered-map@4.4.2':
+    optional: true
 
   '@keyv/serialize@1.1.1': {}
 
@@ -14379,7 +14488,8 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@tootallnate/once@2.0.0': {}
+  '@tootallnate/once@2.0.0':
+    optional: true
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -14636,6 +14746,7 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   agent-base@7.1.4: {}
 
@@ -14718,7 +14829,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
-  any-base@1.1.0: {}
+  any-base@1.1.0:
+    optional: true
 
   any-promise@1.3.0: {}
 
@@ -14742,7 +14854,8 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
-  await-to-js@3.0.0: {}
+  await-to-js@3.0.0:
+    optional: true
 
   axios@1.13.2(debug@4.4.3):
     dependencies:
@@ -14825,7 +14938,8 @@ snapshots:
 
   bmp-js@0.1.0: {}
 
-  bmp-ts@1.0.9: {}
+  bmp-ts@1.0.9:
+    optional: true
 
   body-parser@2.2.2:
     dependencies:
@@ -14893,6 +15007,7 @@ snapshots:
       uuid: 8.3.2
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   bullmq@5.66.5:
     dependencies:
@@ -14905,6 +15020,7 @@ snapshots:
       uuid: 11.1.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   byte-counter@0.1.0: {}
 
@@ -15231,6 +15347,7 @@ snapshots:
   cron-parser@4.9.0:
     dependencies:
       luxon: 3.7.2
+    optional: true
 
   cross-fetch@4.1.0:
     dependencies:
@@ -15368,7 +15485,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  denque@2.1.0: {}
+  denque@2.1.0:
+    optional: true
 
   depd@2.0.0: {}
 
@@ -15463,6 +15581,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
       stream-shift: 1.0.3
+    optional: true
 
   eastasianwidth@0.2.0: {}
 
@@ -15669,7 +15788,8 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
-  exif-parser@0.1.12: {}
+  exif-parser@0.1.12:
+    optional: true
 
   expand-template@2.0.3: {}
 
@@ -15968,7 +16088,8 @@ snapshots:
       hasown: 2.0.2
       math-intrinsics: 1.1.0
 
-  get-port@5.1.1: {}
+  get-port@5.1.1:
+    optional: true
 
   get-proto@1.0.1:
     dependencies:
@@ -15994,6 +16115,7 @@ snapshots:
     dependencies:
       image-q: 4.0.0
       omggif: 1.0.10
+    optional: true
 
   git-log-parser@1.2.1:
     dependencies:
@@ -16088,6 +16210,7 @@ snapshots:
       rimraf: 5.0.10
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   google-logging-utils@1.1.3: {}
 
@@ -16269,6 +16392,7 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -16288,6 +16412,7 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -16323,7 +16448,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.13.2(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.13.2)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -16357,6 +16482,7 @@ snapshots:
   image-q@4.0.0:
     dependencies:
       '@types/node': 24.10.9
+    optional: true
 
   imapflow@1.2.6:
     dependencies:
@@ -16467,6 +16593,7 @@ snapshots:
       standard-as-callback: 2.1.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   ioredis@5.9.2:
     dependencies:
@@ -16481,6 +16608,7 @@ snapshots:
       standard-as-callback: 2.1.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   ip-address@10.1.0: {}
 
@@ -16604,6 +16732,7 @@ snapshots:
       '@jimp/plugin-threshold': 1.6.0
       '@jimp/types': 1.6.0
       '@jimp/utils': 1.6.0
+    optional: true
 
   jiti@2.6.1: {}
 
@@ -16921,13 +17050,15 @@ snapshots:
 
   lodash.capitalize@4.2.1: {}
 
-  lodash.defaults@4.2.0: {}
+  lodash.defaults@4.2.0:
+    optional: true
 
   lodash.escaperegexp@4.1.2: {}
 
   lodash.includes@4.3.0: {}
 
-  lodash.isarguments@3.1.0: {}
+  lodash.isarguments@3.1.0:
+    optional: true
 
   lodash.isboolean@3.0.3: {}
 
@@ -16984,7 +17115,8 @@ snapshots:
 
   lunr@2.3.9: {}
 
-  luxon@3.7.2: {}
+  luxon@3.7.2:
+    optional: true
 
   magic-string@0.27.0:
     dependencies:
@@ -17078,7 +17210,8 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
-  mime@3.0.0: {}
+  mime@3.0.0:
+    optional: true
 
   mime@4.1.0: {}
 
@@ -17167,10 +17300,12 @@ snapshots:
   msgpackr@1.11.5:
     optionalDependencies:
       msgpackr-extract: 3.0.3
+    optional: true
 
   msgpackr@1.11.8:
     optionalDependencies:
       msgpackr-extract: 3.0.3
+    optional: true
 
   muggle-string@0.4.1: {}
 
@@ -17202,7 +17337,8 @@ snapshots:
     dependencies:
       semver: 7.7.3
 
-  node-abort-controller@3.1.1: {}
+  node-abort-controller@3.1.1:
+    optional: true
 
   node-addon-api@6.1.0: {}
 
@@ -17284,7 +17420,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
-  object-hash@3.0.0: {}
+  object-hash@3.0.0:
+    optional: true
 
   object-inspect@1.13.4: {}
 
@@ -17292,7 +17429,8 @@ snapshots:
 
   obug@2.1.1: {}
 
-  omggif@1.0.10: {}
+  omggif@1.0.10:
+    optional: true
 
   on-exit-leak-free@2.1.2: {}
 
@@ -17551,7 +17689,8 @@ snapshots:
 
   pako@0.2.9: {}
 
-  pako@1.0.11: {}
+  pako@1.0.11:
+    optional: true
 
   parent-module@1.0.1:
     dependencies:
@@ -17559,14 +17698,17 @@ snapshots:
 
   parent-require@1.0.0: {}
 
-  parse-bmfont-ascii@1.0.6: {}
+  parse-bmfont-ascii@1.0.6:
+    optional: true
 
-  parse-bmfont-binary@1.0.6: {}
+  parse-bmfont-binary@1.0.6:
+    optional: true
 
   parse-bmfont-xml@1.1.6:
     dependencies:
       xml-parse-from-string: 1.0.1
       xml2js: 0.5.0
+    optional: true
 
   parse-css-color@0.2.1:
     dependencies:
@@ -17753,6 +17895,7 @@ snapshots:
   pixelmatch@5.3.0:
     dependencies:
       pngjs: 6.0.0
+    optional: true
 
   pkce-challenge@5.0.1: {}
 
@@ -17793,7 +17936,8 @@ snapshots:
 
   pluralize@8.0.0: {}
 
-  pngjs@6.0.0: {}
+  pngjs@6.0.0:
+    optional: true
 
   pngjs@7.0.0: {}
 
@@ -17860,6 +18004,7 @@ snapshots:
   proto3-json-serializer@3.0.4:
     dependencies:
       protobufjs: 7.5.4
+    optional: true
 
   protobufjs@6.11.4:
     dependencies:
@@ -18041,11 +18186,13 @@ snapshots:
     dependencies:
       resolve: 1.22.11
 
-  redis-errors@1.2.0: {}
+  redis-errors@1.2.0:
+    optional: true
 
   redis-parser@3.0.0:
     dependencies:
       redis-errors: 1.2.0
+    optional: true
 
   redis@5.10.0:
     dependencies:
@@ -18096,7 +18243,7 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
-  retry-axios@2.6.0(axios@1.13.2(debug@4.4.3)):
+  retry-axios@2.6.0(axios@1.13.2):
     dependencies:
       axios: 1.13.2(debug@4.4.3)
 
@@ -18106,6 +18253,7 @@ snapshots:
       teeny-request: 10.1.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   retry@0.12.0: {}
 
@@ -18470,7 +18618,8 @@ snapshots:
 
   simple-wcswidth@1.1.2: {}
 
-  simple-xml-to-json@1.2.3: {}
+  simple-xml-to-json@1.2.3:
+    optional: true
 
   sirv@3.0.2:
     dependencies:
@@ -18563,7 +18712,8 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  standard-as-callback@2.1.0: {}
+  standard-as-callback@2.1.0:
+    optional: true
 
   statuses@2.0.2: {}
 
@@ -18583,12 +18733,14 @@ snapshots:
   stream-events@1.0.5:
     dependencies:
       stubs: 3.0.0
+    optional: true
 
   stream-json@1.9.1:
     dependencies:
       stream-chain: 2.2.5
 
-  stream-shift@1.0.3: {}
+  stream-shift@1.0.3:
+    optional: true
 
   streamx@2.23.0:
     dependencies:
@@ -18668,7 +18820,8 @@ snapshots:
       '@tokenizer/token': 0.3.0
       peek-readable: 4.1.0
 
-  stubs@3.0.0: {}
+  stubs@3.0.0:
+    optional: true
 
   super-regex@1.1.0:
     dependencies:
@@ -18810,6 +18963,7 @@ snapshots:
       stream-events: 1.0.5
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   temp-dir@2.0.0: {}
 
@@ -18887,7 +19041,8 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinycolor2@1.6.0: {}
+  tinycolor2@1.6.0:
+    optional: true
 
   tinyexec@1.0.2: {}
 
@@ -19138,16 +19293,19 @@ snapshots:
   utif2@4.1.0:
     dependencies:
       pako: 1.0.11
+    optional: true
 
   util-deprecate@1.0.2: {}
 
   uuid@10.0.0: {}
 
-  uuid@11.1.0: {}
+  uuid@11.1.0:
+    optional: true
 
   uuid@13.0.0: {}
 
-  uuid@8.3.2: {}
+  uuid@8.3.2:
+    optional: true
 
   vali-date@1.0.0: {}
 
@@ -19398,14 +19556,17 @@ snapshots:
 
   xml-name-validator@5.0.0: {}
 
-  xml-parse-from-string@1.0.1: {}
+  xml-parse-from-string@1.0.1:
+    optional: true
 
   xml2js@0.5.0:
     dependencies:
       sax: 1.4.4
       xmlbuilder: 11.0.1
+    optional: true
 
-  xmlbuilder@11.0.1: {}
+  xmlbuilder@11.0.1:
+    optional: true
 
   xmlchars@2.2.0: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -63,6 +63,7 @@
     { "path": "./packages/places" },
     { "path": "./packages/products" },
     { "path": "./packages/profiles" },
+    { "path": "./packages/sites" },
     { "path": "./packages/tags" },
     { "path": "./packages/tenancy" },
     { "path": "./packages/users" },


### PR DESCRIPTION
## Summary

- New `@happyvertical/smrt-sites` package providing tenant-scoped site lifecycle management
- `Site` model with status lifecycle (draft → active → suspended → archived), provisioning tracking, and portal configuration
- `SiteAgentBinding` junction model for binding agents to sites with per-site config overrides
- `SiteCollection` with domain lookup, tenant filtering, and status queries
- `SiteAgentBindingCollection` with site/agent/enabled queries
- `SiteService` for high-level lifecycle operations (create, activate, suspend, archive, bind/unbind agents)
- 35 tests across 5 test files, all passing

## Context

PRD Phase 1 gap analysis — the only missing item was site lifecycle management. All other Phase 1 items (strict tenancy, background jobs, secret management, agent UI registry) were already implemented.

## Test plan

- [x] `pnpm --filter @happyvertical/smrt-sites build` compiles cleanly
- [x] `pnpm --filter @happyvertical/smrt-sites test` — 35/35 tests pass
- [ ] CI builds and tests pass
- [ ] Copilot review addressed