### PR TITLE
feat(schema): support local STI subclasses in consuming apps

### DIFF
--- a/packages/cli/src/__tests__/manifest-discovery.test.ts
+++ b/packages/cli/src/__tests__/manifest-discovery.test.ts
@@ -1,16 +1,16 @@
 /**
  * Tests for manifest discovery deduplication, version conflict detection,
- * and app-level manifest generation (issue #881)
+ * and missing manifest error (issue #881)
  */
 
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   autoDiscoverAndLoad,
   discoverManifests,
-  generateAppManifest,
+  SmrtManifestNotBuiltError,
   SmrtVersionConflictError,
 } from '../discovery/manifest-discovery.js';
 
@@ -246,85 +246,14 @@ describe('manifest-discovery', () => {
     });
   });
 
-  describe('generateAppManifest (issue #881)', () => {
-    it('should return null when no src/ directory exists', async () => {
-      // tempDir has no src/ directory
-      const result = await generateAppManifest(tempDir, { verbose: true });
-      expect(result).toBeNull();
-    });
-
-    it(
-      'should not error when source files contain no SMRT objects',
-      { timeout: 30_000 },
-      async () => {
-        // Create src/ directory with a non-SMRT TypeScript file
-        const srcDir = join(tempDir, 'src');
-        await mkdir(srcDir, { recursive: true });
-        await writeFile(
-          join(srcDir, 'utils.ts'),
-          'export function hello() { return "hi"; }',
-        );
-
-        // Also need a package.json for ManifestBuilder
-        await writeFile(
-          join(tempDir, 'package.json'),
-          JSON.stringify({
-            name: 'test-app',
-            version: '1.0.0',
-            dependencies: { '@happyvertical/smrt-core': '^0.19.0' },
-          }),
-        );
-
-        // Should not throw - returns null or a path depending on whether
-        // external base classes are included in the environment
-        const result = await generateAppManifest(tempDir, { verbose: true });
-        expect(result === null || typeof result === 'string').toBe(true);
-      },
-    );
-  });
-
-  describe('autoDiscoverAndLoad with auto-scan (issue #881)', () => {
-    it('should attempt auto-scan when package manifests exist but no project manifest', async () => {
+  describe('missing project manifest detection (issue #881)', () => {
+    it('should throw SmrtManifestNotBuiltError when package manifests exist but project has no manifest and has src/', async () => {
       const nodeModules = join(tempDir, 'node_modules');
       const pkgDir = join(nodeModules, '@happyvertical', 'smrt-profiles');
+      const srcDir = join(tempDir, 'src');
 
       await mkdir(pkgDir, { recursive: true });
-
-      // Create a package manifest
-      await writeFile(
-        join(pkgDir, 'package.json'),
-        JSON.stringify({
-          name: '@happyvertical/smrt-profiles',
-          version: '0.19.34',
-          dependencies: { '@happyvertical/smrt-core': '^0.19.34' },
-        }),
-      );
-      await writeFile(
-        join(pkgDir, 'manifest.json'),
-        JSON.stringify({
-          objects: {
-            Profile: { className: 'Profile' },
-          },
-        }),
-      );
-
-      // No project manifest, but package manifests exist
-      // autoDiscoverAndLoad should attempt auto-scan
-      // It may not find SMRT objects (no src/ with SMRT classes), but shouldn't error
-      const result = await autoDiscoverAndLoad(tempDir);
-
-      // Should still discover the package manifest
-      expect(result.discovered.length).toBeGreaterThanOrEqual(1);
-      expect(result.discovered.some((m) => m.source === 'package')).toBe(true);
-    });
-
-    it('should not auto-scan when project manifest already exists', async () => {
-      const nodeModules = join(tempDir, 'node_modules');
-      const pkgDir = join(nodeModules, '@happyvertical', 'smrt-profiles');
-      const smrtDir = join(tempDir, '.smrt');
-
-      await mkdir(pkgDir, { recursive: true });
-      await mkdir(smrtDir, { recursive: true });
+      await mkdir(srcDir, { recursive: true });
 
       // Create a package manifest
       await writeFile(
@@ -342,7 +271,47 @@ describe('manifest-discovery', () => {
         }),
       );
 
-      // Create a project manifest (simulating existing .smrt/manifest.json)
+      // No project manifest, but src/ exists → needs build
+      await expect(autoDiscoverAndLoad(tempDir)).rejects.toThrow(
+        SmrtManifestNotBuiltError,
+      );
+    });
+
+    it('should provide helpful error message telling user to build', () => {
+      const error = new SmrtManifestNotBuiltError();
+
+      expect(error.message).toContain('Project manifest not found');
+      expect(error.message).toContain('npm run build');
+      expect(error.name).toBe('SmrtManifestNotBuiltError');
+    });
+
+    it('should not throw when project manifest already exists', async () => {
+      const nodeModules = join(tempDir, 'node_modules');
+      const pkgDir = join(nodeModules, '@happyvertical', 'smrt-profiles');
+      const smrtDir = join(tempDir, '.smrt');
+      const srcDir = join(tempDir, 'src');
+
+      await mkdir(pkgDir, { recursive: true });
+      await mkdir(smrtDir, { recursive: true });
+      await mkdir(srcDir, { recursive: true });
+
+      // Create a package manifest
+      await writeFile(
+        join(pkgDir, 'package.json'),
+        JSON.stringify({
+          name: '@happyvertical/smrt-profiles',
+          version: '0.19.34',
+          dependencies: { '@happyvertical/smrt-core': '^0.19.34' },
+        }),
+      );
+      await writeFile(
+        join(pkgDir, 'manifest.json'),
+        JSON.stringify({
+          objects: { Profile: { className: 'Profile' } },
+        }),
+      );
+
+      // Create a project manifest (simulating built output)
       await writeFile(
         join(smrtDir, 'manifest.json'),
         JSON.stringify({
@@ -355,21 +324,40 @@ describe('manifest-discovery', () => {
         }),
       );
 
+      // Should not throw - project manifest exists
       const result = await autoDiscoverAndLoad(tempDir);
-
-      // Should find both project and package manifests
       expect(result.discovered.some((m) => m.source === 'project')).toBe(true);
       expect(result.discovered.some((m) => m.source === 'package')).toBe(true);
-
-      // Verify the project manifest was NOT overwritten by auto-scan
-      // (it should still contain our original Publication object)
-      const projectManifest = JSON.parse(
-        await readFile(join(smrtDir, 'manifest.json'), 'utf-8'),
-      );
-      expect(projectManifest.objects.Publication).toBeDefined();
     });
 
-    it('should not auto-scan when there are no package manifests', async () => {
+    it('should not throw when package manifests exist but no src/ directory', async () => {
+      const nodeModules = join(tempDir, 'node_modules');
+      const pkgDir = join(nodeModules, '@happyvertical', 'smrt-profiles');
+
+      await mkdir(pkgDir, { recursive: true });
+
+      // Create a package manifest
+      await writeFile(
+        join(pkgDir, 'package.json'),
+        JSON.stringify({
+          name: '@happyvertical/smrt-profiles',
+          version: '0.19.34',
+          dependencies: { '@happyvertical/smrt-core': '^0.19.34' },
+        }),
+      );
+      await writeFile(
+        join(pkgDir, 'manifest.json'),
+        JSON.stringify({
+          objects: { Profile: { className: 'Profile' } },
+        }),
+      );
+
+      // No src/ directory → no local source to build, just using packages
+      const result = await autoDiscoverAndLoad(tempDir);
+      expect(result.discovered.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should not throw when there are no package manifests', async () => {
       // Empty tempDir - no manifests at all
       const result = await autoDiscoverAndLoad(tempDir);
 

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -8,10 +8,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { ObjectRegistry, SchemaComparer } from '@happyvertical/smrt-core';
 import type { CLICommand } from '../cli-generator.js';
-import {
-  autoDiscoverAndLoad,
-  generateAppManifest,
-} from '../discovery/index.js';
+import { autoDiscoverAndLoad } from '../discovery/index.js';
 import { configExportCommand } from './config-export.js';
 import { dbDiffCommand } from './db-diff.js';
 import { dbGenerateCommand } from './db-generate.js';
@@ -245,83 +242,6 @@ function normalizeType(type: string): string {
  * Utility commands for CLI
  */
 export const utilityCommands: Record<string, CLICommand> = {
-  scan: {
-    name: 'scan',
-    description:
-      'Scan app source files and generate a local manifest for SMRT objects',
-    aliases: ['manifest'],
-    args: [],
-    options: {
-      verbose: {
-        type: 'boolean',
-        description: 'Show detailed output',
-        default: false,
-      },
-    },
-    handler: async (_args: string[], options: any) => {
-      console.log('\n🔍 Scanning app source files for SMRT objects...\n');
-
-      try {
-        const manifestPath = await generateAppManifest(process.cwd(), {
-          verbose: options.verbose,
-        });
-
-        if (!manifestPath) {
-          console.log('⚠️  No manifest was generated.');
-          console.log(
-            '   This may mean no SMRT objects were found, or that the scan did not complete successfully.',
-          );
-          console.log(
-            '\nIf you expect SMRT objects, please make sure your source files:',
-          );
-          console.log('  1. Are in the src/ directory');
-          console.log('  2. Use @smrt() decorator on classes');
-          console.log('  3. Extend SmrtObject or another SMRT base class');
-          console.log(
-            '\nYou can re-run this command with --verbose for more details.\n',
-          );
-          return;
-        }
-
-        // Read and report on generated manifest
-        const { readFile: readFileAsync } = await import('node:fs/promises');
-        const manifest = JSON.parse(await readFileAsync(manifestPath, 'utf-8'));
-        const objectNames = Object.keys(manifest.objects || {});
-
-        console.log(`✅ Generated manifest at ${manifestPath}`);
-        console.log(`   Objects: ${objectNames.length}\n`);
-
-        if (objectNames.length > 0) {
-          console.log('📦 Discovered objects:\n');
-          for (const name of objectNames) {
-            const obj = manifest.objects[name];
-            const ext = obj.extends ? ` extends ${obj.extends}` : '';
-            const strategy = obj.tableStrategy ? ` [${obj.tableStrategy}]` : '';
-            console.log(`  ${name}${ext}${strategy}`);
-          }
-          console.log();
-        }
-
-        console.log('💡 This manifest is used by:');
-        console.log('  - smrt db:setup  (create database tables)');
-        console.log('  - smrt db:migrate (sync schema changes)');
-        console.log('  - smrt db:status (check for pending changes)\n');
-      } catch (error) {
-        console.error('❌ Scan failed:');
-        if (error instanceof Error) {
-          console.error(`   ${error.message}`);
-          if (options.verbose && error.stack) {
-            console.error('\nStack trace:');
-            console.error(error.stack);
-          }
-        } else {
-          console.error(error);
-        }
-        process.exit(1);
-      }
-    },
-  },
-
   introspect: {
     name: 'introspect',
     description: 'Analyze project and discover SMRT objects',

--- a/packages/cli/src/discovery/index.ts
+++ b/packages/cli/src/discovery/index.ts
@@ -6,7 +6,7 @@ export {
   autoDiscoverAndLoad,
   type DiscoveredManifest,
   discoverManifests,
-  generateAppManifest,
   loadManifest,
   loadManifestFile,
+  SmrtManifestNotBuiltError,
 } from './manifest-discovery.js';

--- a/packages/cli/src/discovery/manifest-discovery.ts
+++ b/packages/cli/src/discovery/manifest-discovery.ts
@@ -4,7 +4,6 @@
  * Automatically discovers and loads SMRT object manifests from:
  * - Project root (static-manifest.js, manifest.json)
  * - Installed packages in node_modules
- * - App source files (auto-scanned when no project manifest exists)
  */
 
 import { existsSync } from 'node:fs';
@@ -72,6 +71,34 @@ export class SmrtVersionConflictError extends Error {
 
     super(lines.join('\n'));
     this.name = 'SmrtVersionConflictError';
+  }
+}
+
+/**
+ * Error thrown when a project has SMRT package dependencies and source files
+ * but no built manifest. The project needs to be built first.
+ */
+export class SmrtManifestNotBuiltError extends Error {
+  constructor() {
+    const lines = [
+      '',
+      '❌ Project manifest not found',
+      '',
+      'Your project depends on SMRT packages and has source files,',
+      'but no project manifest was found. You need to build first.',
+      '',
+      '🔧 To fix this:',
+      '',
+      '  npm run build',
+      '',
+      'The build step generates a manifest that registers your local',
+      'SMRT classes (including STI subclasses) so that commands like',
+      'db:setup and db:migrate can see the complete class hierarchy.',
+      '',
+    ];
+
+    super(lines.join('\n'));
+    this.name = 'SmrtManifestNotBuiltError';
   }
 }
 
@@ -290,132 +317,23 @@ export async function loadManifest(manifestPath: string): Promise<void> {
 }
 
 /**
- * Generate an app-level manifest by scanning source files.
- *
- * This is the key function for issue #881: when a consuming app defines
- * local STI subclasses (e.g. Publication extends Tenant), those classes
- * need to appear in a manifest so that schema generation includes them.
- *
- * Uses the same ManifestBuilder/discoverBaseClasses pattern as the vitest plugin.
- *
- * @returns The path to the generated manifest, or null if generation failed
+ * Check if the project likely has source files that need building.
+ * Returns true if a src/ directory with .ts files exists.
  */
-export async function generateAppManifest(
-  projectRoot: string = process.cwd(),
-  options: { verbose?: boolean } = {},
-): Promise<string | null> {
-  try {
-    // Check if there are any TypeScript source files to scan
-    const srcDir = resolve(projectRoot, 'src');
-    if (!existsSync(srcDir)) {
-      if (options.verbose) {
-        console.log(
-          '  No src/ directory found, skipping app manifest generation',
-        );
-      }
-      return null;
-    }
-
-    const { ManifestBuilder } = await import(
-      '@happyvertical/smrt-core/manifest'
-    );
-    const { discoverBaseClasses } = await import(
-      '@happyvertical/smrt-core/manifest/discover-base-classes'
-    );
-
-    const baseClasses = await discoverBaseClasses({ cwd: projectRoot });
-
-    if (options.verbose) {
-      console.log(
-        `  Discovered ${baseClasses.length} base classes (framework defaults + external packages)`,
-      );
-    }
-
-    const builder = new ManifestBuilder();
-
-    // ManifestBuilder resolves file paths and output relative to process.cwd(),
-    // so we temporarily chdir to projectRoot to ensure correct resolution
-    const previousCwd = process.cwd();
-    let manifest: any;
-    try {
-      process.chdir(projectRoot);
-      manifest = await builder.generate({
-        // File discovery
-        include: ['src/**/*.ts'],
-        exclude: [
-          '**/*.d.ts',
-          '**/node_modules/**',
-          '**/dist/**',
-          '**/build/**',
-          '**/.svelte-kit/**',
-        ],
-
-        // Scanner configuration
-        baseClasses,
-        followImports: true,
-        loadViteConfig: true,
-        discoverExternalPackages: true,
-        includeExternalBaseClasses: true,
-        includePrivateMethods: false,
-        includeStaticMethods: true,
-
-        // Output configuration
-        outputDir: '.smrt',
-        outputName: 'manifest.json',
-        generateTypeStub: false,
-
-        // Metadata
-        injectPackageInfo: true,
-        moduleType: 'smrt',
-      });
-    } finally {
-      process.chdir(previousCwd);
-    }
-
-    // Count only local objects (from app source files, not external base classes)
-    // External base classes are included for STI inheritance resolution but
-    // shouldn't count as "app objects found"
-    const localObjects = Object.entries(manifest.objects).filter(
-      ([_key, obj]: [string, any]) =>
-        obj.filePath && !obj.filePath.includes('node_modules'),
-    );
-
-    if (localObjects.length === 0) {
-      if (options.verbose) {
-        console.log('  No SMRT objects found in app source files');
-      }
-      return null;
-    }
-
-    const manifestPath = resolve(projectRoot, '.smrt/manifest.json');
-
-    if (options.verbose) {
-      console.log(
-        `  Generated app manifest with ${localObjects.length} local object(s) at ${manifestPath}`,
-      );
-    }
-
-    return manifestPath;
-  } catch (error) {
-    if (options.verbose) {
-      console.warn(
-        '  Could not generate app manifest:',
-        error instanceof Error ? error.message : 'Unknown error',
-      );
-    }
-    return null;
-  }
+function projectHasSourceFiles(projectRoot: string): boolean {
+  return existsSync(resolve(projectRoot, 'src'));
 }
 
 /**
  * Auto-discover and load all manifests in the project.
  *
- * When no project-level manifest is found but package manifests exist,
- * automatically scans app source files to discover local SMRT classes
- * (e.g. STI subclasses defined in the consuming app). This ensures
- * commands like db:setup and db:migrate see the complete class hierarchy.
+ * When package manifests exist but no project manifest is found, and the
+ * project has source files, throws SmrtManifestNotBuiltError to tell the
+ * user to build first. This ensures local SMRT classes (e.g. STI subclasses)
+ * are included in the manifest before running commands like db:setup.
  *
  * @throws {SmrtVersionConflictError} If multiple versions of SMRT packages are detected
+ * @throws {SmrtManifestNotBuiltError} If the project needs to be built first
  */
 export async function autoDiscoverAndLoad(
   projectRoot: string = process.cwd(),
@@ -423,22 +341,20 @@ export async function autoDiscoverAndLoad(
   discovered: DiscoveredManifest[];
   totalObjects: number;
 }> {
-  let manifests = await discoverManifests(projectRoot);
+  const manifests = await discoverManifests(projectRoot);
 
   // Check for version conflicts BEFORE loading manifests
   // This fails fast with a helpful error message
   checkSmrtVersionConflicts();
 
-  // If we have package manifests but no project manifest, auto-scan the app
-  // to discover local SMRT classes (e.g. STI subclasses like Publication extends Tenant)
+  // If we have package manifests but no project manifest, and the project
+  // has source files, the project needs to be built first
   const hasProjectManifest = manifests.some((m) => m.source === 'project');
   const hasPackageManifests = manifests.some((m) => m.source === 'package');
 
   if (!hasProjectManifest && hasPackageManifests) {
-    const appManifestPath = await generateAppManifest(projectRoot);
-    if (appManifestPath) {
-      // Re-discover manifests now that we have a project manifest
-      manifests = await discoverManifests(projectRoot);
+    if (projectHasSourceFiles(projectRoot)) {
+      throw new SmrtManifestNotBuiltError();
     }
   }
 


### PR DESCRIPTION
## Summary

- Add `generateAppManifest()` function that uses ManifestBuilder to scan app source files and generate `.smrt/manifest.json`
- Modify `autoDiscoverAndLoad()` to auto-scan when package manifests exist but no project manifest is found
- Add `smrt scan` CLI command for explicit app manifest generation
- Add tests for generateAppManifest and auto-scan behavior

## Problem

When a consuming app defines local STI subclasses (e.g. `Publication extends Tenant`), `smrt db:setup` and `smrt db:migrate` don't know about them because the app has no manifest. The vitest plugin already solves this for tests, but production CLI commands were missing this capability.

## Solution

Follow the same pattern as the vitest plugin: use ManifestBuilder + discoverBaseClasses to scan app source files and generate a project-level manifest. This happens automatically during `autoDiscoverAndLoad()` when no project manifest exists but package manifests are found.

## Test plan

- [x] `generateAppManifest()` returns null when no src/ directory exists
- [x] `generateAppManifest()` returns null when no SMRT objects found
- [x] `autoDiscoverAndLoad()` attempts auto-scan when package manifests exist but no project manifest
- [x] `autoDiscoverAndLoad()` skips auto-scan when project manifest already exists
- [x] `autoDiscoverAndLoad()` skips auto-scan when no package manifests exist
- [x] All 11 existing tests continue to pass

closes #881