### PR TITLE
feat(users): add tableStrategy 'sti' to Tenant model

### DIFF
--- a/packages/users/src/models/Tenant.ts
+++ b/packages/users/src/models/Tenant.ts
@@ -62,6 +62,7 @@ export const MAX_TENANT_HIERARCHY_DEPTH = 10;
  * ```
  */
 @smrt({
+  tableStrategy: 'sti',
   api: { include: ['list', 'get', 'create', 'update'] },
   mcp: { include: ['list', 'get'] },
   cli: true,


### PR DESCRIPTION
## Summary
- Adds `tableStrategy: 'sti'` to `Tenant`'s `@smrt()` decorator in smrt-users
- Enables downstream apps to define STI subclasses of Tenant (e.g., `Publication extends Tenant`)
- Without this, the schema generator creates separate tables instead of merging into `tenants` with `_meta_type` discrimination

## Test plan
- [x] smrt-users tests pass (84/84)
- [x] Manifest now includes `_meta_type` and `_meta_data` columns on `tenants` table
- [ ] Dashboard builds with `Publication` using `tableStrategy: 'sti'` (after linking)

Closes #881