### PR TITLE
fix(agents): use package.json exports check for admin detection

### DIFF
--- a/packages/agents/src/vite-plugin.test.ts
+++ b/packages/agents/src/vite-plugin.test.ts
@@ -2,7 +2,10 @@
  * Tests for vitePluginAgentRoutes virtual module generation.
  */
 
-import { describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { vitePluginAgentRoutes } from './vite-plugin.js';
 
 describe('vitePluginAgentRoutes', () => {
@@ -35,5 +38,106 @@ describe('vitePluginAgentRoutes', () => {
   it('should not load non-virtual module IDs', () => {
     const plugin = vitePluginAgentRoutes();
     expect(plugin.load('some-other-module')).toBeUndefined();
+  });
+
+  describe('admin export detection', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'smrt-vite-test-'));
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function setupFakePackage(opts: {
+      name: string;
+      hasAdminExport: boolean;
+      agentClassName: string;
+    }) {
+      const pkgDir = join(tmpDir, 'node_modules', ...opts.name.split('/'));
+      const distDir = join(pkgDir, 'dist');
+      mkdirSync(distDir, { recursive: true });
+
+      const exports: Record<string, unknown> = {
+        '.': { import: './dist/index.js' },
+        './manifest': './dist/manifest.json',
+      };
+      if (opts.hasAdminExport) {
+        exports['./admin'] = {
+          svelte: './dist/ui/admin/index.js',
+          import: './dist/ui/admin/index.js',
+        };
+      }
+
+      writeFileSync(
+        join(pkgDir, 'package.json'),
+        JSON.stringify({ name: opts.name, exports }),
+      );
+      writeFileSync(join(distDir, 'index.js'), 'export default {};\n');
+      writeFileSync(
+        join(distDir, 'manifest.json'),
+        JSON.stringify({
+          objects: {
+            [opts.agentClassName]: {
+              className: opts.agentClassName,
+              agent: {
+                name: opts.agentClassName,
+                slug: opts.agentClassName.toLowerCase(),
+                tier: 'core',
+                uiSlots: {},
+              },
+            },
+          },
+        }),
+      );
+
+      // Project-level package.json so createRequire can resolve from it
+      writeFileSync(
+        join(tmpDir, 'package.json'),
+        JSON.stringify({ name: 'test-project' }),
+      );
+
+      // smrt.config.js with the agent
+      writeFileSync(
+        join(tmpDir, 'smrt.config.js'),
+        `export default { agents: ['${opts.name}'] };`,
+      );
+    }
+
+    it('should emit admin import when package has ./admin export', () => {
+      setupFakePackage({
+        name: '@test/with-admin',
+        hasAdminExport: true,
+        agentClassName: 'TestAgent',
+      });
+
+      const plugin = vitePluginAgentRoutes({
+        configPath: join(tmpDir, 'smrt.config.js'),
+      });
+      plugin.configResolved?.({ root: tmpDir });
+
+      const code = plugin.load('\0virtual:smrt-agent-registrations');
+      expect(code).toContain("import '@test/with-admin/admin';");
+      expect(code).not.toContain('not available');
+    });
+
+    it('should emit "not available" comment when package lacks ./admin export', () => {
+      setupFakePackage({
+        name: '@test/no-admin',
+        hasAdminExport: false,
+        agentClassName: 'NoAdminAgent',
+      });
+
+      const plugin = vitePluginAgentRoutes({
+        configPath: join(tmpDir, 'smrt.config.js'),
+      });
+      plugin.configResolved?.({ root: tmpDir });
+
+      const code = plugin.load('\0virtual:smrt-agent-registrations');
+      expect(code).toContain('@test/no-admin/admin — not available');
+      expect(code).not.toContain("import '@test/no-admin/admin';");
+    });
   });
 });

--- a/packages/agents/src/vite-plugin.ts
+++ b/packages/agents/src/vite-plugin.ts
@@ -205,18 +205,19 @@ export function vitePluginAgentRoutes(options: AgentRoutesPluginOptions = {}): {
         let hasAdmin = false;
         try {
           let pkgDir = dirname(manifestPath!);
-          while (
-            pkgDir !== '/' &&
-            !existsSync(resolve(pkgDir, 'package.json'))
-          ) {
-            pkgDir = dirname(pkgDir);
+          while (!existsSync(resolve(pkgDir, 'package.json'))) {
+            const parent = dirname(pkgDir);
+            if (parent === pkgDir) {
+              break;
+            }
+            pkgDir = parent;
           }
           const pkgJson = JSON.parse(
             readFileSync(resolve(pkgDir, 'package.json'), 'utf-8'),
           );
           hasAdmin = !!pkgJson.exports?.['./admin'];
         } catch {
-          // Package not found
+          // Failed to read package.json or parse exports — treat as no admin export
         }
 
         registrations.push({


### PR DESCRIPTION
## Summary

- Replace `createRequire().resolve()` with a `package.json` exports field check in the vite plugin's admin detection logic
- CJS resolution only recognises `default`/`require`/`node` conditions, so packages with `./admin` exports using only `svelte`/`import` conditions (like histrio) were never detected
- The virtual module was emitting `// not available` instead of the admin import, causing panel components to never load

## Test plan

- [ ] Build smrt-agents package
- [ ] Verify histrio's `./admin` export is detected (`hasAdmin = true`) in a dashboard dev build
- [ ] Verify virtual module output includes `import '@happyvertical/histrio/admin';`