### PR TITLE
feat(smrt-images): extract Image into new package

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -34,7 +34,10 @@
       "@happyvertical/smrt-users",
       "@happyvertical/smrt-vitest",
       "@happyvertical/smrt-svelte",
-      "@happyvertical/smrt-scanner"
+      "@happyvertical/smrt-scanner",
+      "@happyvertical/smrt-social",
+      "@happyvertical/smrt-video",
+      "@happyvertical/smrt-voice"
     ]
   ],
   "linked": [],

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-social",
-  "version": "0.0.39",
+  "version": "0.20.8",
   "type": "module",
   "description": "Social media account management for multi-platform publishing in the SMRT ecosystem",
   "author": "HappyVertical",

--- a/packages/video/package.json
+++ b/packages/video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-video",
-  "version": "0.0.39",
+  "version": "0.20.8",
   "type": "module",
   "description": "Video content management for AI-powered video production in the SMRT ecosystem",
   "author": "HappyVertical",

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-voice",
-  "version": "0.0.39",
+  "version": "0.20.8",
   "type": "module",
   "description": "Voice profile management for AI-powered voice synthesis and cloning in the SMRT ecosystem",
   "author": "HappyVertical",


### PR DESCRIPTION
## Summary
- Extract `Image` and `ImageCollection` from `smrt-assets` into a new `@happyvertical/smrt-images` package with image-specific utilities (categorizer, deriver, editor, metadata, search, upstream)
- Enhance `smrt-assets` with `AssetAssociation`, `Folder`/`FolderCollection`, and expanded `AssetStore` capabilities
- Sync `smrt-video`, `smrt-voice`, and `smrt-social` versions from `0.0.38` to `0.20.7` and add them to the changeset fixed group

## Test plan
- [ ] Verify `smrt-images` builds successfully
- [ ] Verify existing `smrt-assets` tests still pass
- [ ] Verify image adapter parity tests pass in new location
- [ ] Confirm all three version-synced packages appear in changeset fixed group