### PR TITLE
fix(jobs,messages): fix Svelte component import paths and event handler

### DIFF
--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-jobs",
-  "version": "0.20.10",
+  "version": "0.20.13",
   "description": "Background job processing for SMRT objects with persistence and scheduling",
   "author": "Will Griffin <willgriffin@gmail.com>",
   "type": "module",

--- a/packages/jobs/src/svelte/components/JobActions.svelte
+++ b/packages/jobs/src/svelte/components/JobActions.svelte
@@ -4,7 +4,7 @@
  */
 
 import { Button } from '@happyvertical/smrt-svelte/ui';
-import type { JobData } from './types.js';
+import type { JobData } from '../types.js';
 
 export interface Props {
   /** Job to perform actions on */

--- a/packages/jobs/src/svelte/components/JobDashboard.svelte
+++ b/packages/jobs/src/svelte/components/JobDashboard.svelte
@@ -4,9 +4,9 @@
  */
 
 import { Card } from '@happyvertical/smrt-svelte/ui';
+import type { JobData, JobStats, QueueStats } from '../types.js';
 import JobList from './JobList.svelte';
 import JobStatsSummary from './JobStats.svelte';
-import type { JobData, JobStats, QueueStats } from './types.js';
 
 export interface Props {
   /** Statistics data */

--- a/packages/jobs/src/svelte/components/JobDetail.svelte
+++ b/packages/jobs/src/svelte/components/JobDetail.svelte
@@ -4,14 +4,14 @@
  */
 
 import { Card } from '@happyvertical/smrt-svelte/ui';
-import JobActions from './JobActions.svelte';
-import JobStatusBadge from './JobStatusBadge.svelte';
-import type { JobData } from './types.js';
+import type { JobData } from '../types.js';
 import {
   formatDuration,
   formatRelativeTime,
   getPriorityLabel,
-} from './types.js';
+} from '../types.js';
+import JobActions from './JobActions.svelte';
+import JobStatusBadge from './JobStatusBadge.svelte';
 
 export interface Props {
   /** Job to display */

--- a/packages/jobs/src/svelte/components/JobList.svelte
+++ b/packages/jobs/src/svelte/components/JobList.svelte
@@ -3,10 +3,10 @@
  * JobList - Display a filterable, sortable list of background jobs
  */
 import type { Snippet } from 'svelte';
+import type { JobData, JobFilter, JobSort } from '../types.js';
+import { formatRelativeTime, getPriorityLabel } from '../types.js';
 import JobActions from './JobActions.svelte';
 import JobStatusBadge from './JobStatusBadge.svelte';
-import type { JobData, JobFilter, JobSort } from './types.js';
-import { formatRelativeTime, getPriorityLabel } from './types.js';
 
 export interface Props {
   /** Jobs to display */

--- a/packages/jobs/src/svelte/components/JobStats.svelte
+++ b/packages/jobs/src/svelte/components/JobStats.svelte
@@ -4,8 +4,8 @@
  */
 
 import { Card } from '@happyvertical/smrt-svelte/ui';
-import type { JobStats, QueueStats } from './types.js';
-import { formatDuration } from './types.js';
+import type { JobStats, QueueStats } from '../types.js';
+import { formatDuration } from '../types.js';
 
 export interface Props {
   /** Statistics data */

--- a/packages/jobs/src/svelte/components/JobStatusBadge.svelte
+++ b/packages/jobs/src/svelte/components/JobStatusBadge.svelte
@@ -4,8 +4,8 @@
  */
 
 import { Badge } from '@happyvertical/smrt-svelte/ui';
-import type { JobStatus } from './types.js';
-import { getStatusVariant } from './types.js';
+import type { JobStatus } from '../types.js';
+import { getStatusVariant } from '../types.js';
 
 export interface Props {
   status: JobStatus;

--- a/packages/messages/src/svelte/components/ComposeForm.svelte
+++ b/packages/messages/src/svelte/components/ComposeForm.svelte
@@ -67,7 +67,7 @@ export interface Props {
   }
 </script>
 
-<form class="compose-form" onsubmit|preventDefault={handleSend}>
+<form class="compose-form" onsubmit={(e) => { e.preventDefault(); handleSend(); }}>
   {#if accounts.length > 1}
     <div class="field">
       <label class="field-label" for="compose-account">From</label>


### PR DESCRIPTION
## Summary

- Fix all smrt-jobs Svelte components: `./types.js` → `../types.js` (`types.ts` lives at `svelte/types.ts`, not `svelte/components/types.ts`)
- Fix ComposeForm `onsubmit` handler syntax for Svelte 5 compatibility
- Version bumped to 0.20.13 (already published to GitHub Packages)

## Test plan
- [x] `pnpm build` succeeds in jobs package
- [x] Published 0.20.13 resolves build failures in downstream consumers (blindmanpress.com)