### PR TITLE
fix(jobs): resolve broken types.js import in Svelte component dist

### DIFF
--- a/packages/jobs/src/svelte/components/JobActions.svelte
+++ b/packages/jobs/src/svelte/components/JobActions.svelte
@@ -4,7 +4,7 @@
  */
 
 import { Button } from '@happyvertical/smrt-svelte/ui';
-import type { JobData } from '../types.js';
+import type { JobData } from './types.js';
 
 export interface Props {
   /** Job to perform actions on */

--- a/packages/jobs/src/svelte/components/JobDashboard.svelte
+++ b/packages/jobs/src/svelte/components/JobDashboard.svelte
@@ -4,9 +4,9 @@
  */
 
 import { Card } from '@happyvertical/smrt-svelte/ui';
-import type { JobData, JobStats, QueueStats } from '../types.js';
 import JobList from './JobList.svelte';
 import JobStatsSummary from './JobStats.svelte';
+import type { JobData, JobStats, QueueStats } from './types.js';
 
 export interface Props {
   /** Statistics data */

--- a/packages/jobs/src/svelte/components/JobDetail.svelte
+++ b/packages/jobs/src/svelte/components/JobDetail.svelte
@@ -4,14 +4,14 @@
  */
 
 import { Card } from '@happyvertical/smrt-svelte/ui';
-import type { JobData } from '../types.js';
+import JobActions from './JobActions.svelte';
+import JobStatusBadge from './JobStatusBadge.svelte';
+import type { JobData } from './types.js';
 import {
   formatDuration,
   formatRelativeTime,
   getPriorityLabel,
-} from '../types.js';
-import JobActions from './JobActions.svelte';
-import JobStatusBadge from './JobStatusBadge.svelte';
+} from './types.js';
 
 export interface Props {
   /** Job to display */

--- a/packages/jobs/src/svelte/components/JobList.svelte
+++ b/packages/jobs/src/svelte/components/JobList.svelte
@@ -3,10 +3,10 @@
  * JobList - Display a filterable, sortable list of background jobs
  */
 import type { Snippet } from 'svelte';
-import type { JobData, JobFilter, JobSort } from '../types.js';
-import { formatRelativeTime, getPriorityLabel } from '../types.js';
 import JobActions from './JobActions.svelte';
 import JobStatusBadge from './JobStatusBadge.svelte';
+import type { JobData, JobFilter, JobSort } from './types.js';
+import { formatRelativeTime, getPriorityLabel } from './types.js';
 
 export interface Props {
   /** Jobs to display */

--- a/packages/jobs/src/svelte/components/JobStats.svelte
+++ b/packages/jobs/src/svelte/components/JobStats.svelte
@@ -4,8 +4,8 @@
  */
 
 import { Card } from '@happyvertical/smrt-svelte/ui';
-import type { JobStats, QueueStats } from '../types.js';
-import { formatDuration } from '../types.js';
+import type { JobStats, QueueStats } from './types.js';
+import { formatDuration } from './types.js';
 
 export interface Props {
   /** Statistics data */

--- a/packages/jobs/src/svelte/components/JobStatusBadge.svelte
+++ b/packages/jobs/src/svelte/components/JobStatusBadge.svelte
@@ -4,8 +4,8 @@
  */
 
 import { Badge } from '@happyvertical/smrt-svelte/ui';
-import type { JobStatus } from '../types.js';
-import { getStatusVariant } from '../types.js';
+import type { JobStatus } from './types.js';
+import { getStatusVariant } from './types.js';
 
 export interface Props {
   status: JobStatus;

--- a/packages/jobs/src/svelte/components/types.ts
+++ b/packages/jobs/src/svelte/components/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Re-export types for co-located component imports.
+ *
+ * svelte-package rewrites '../types.js' → './types.js' when building
+ * components in a subdirectory. This barrel file ensures the rewritten
+ * path resolves correctly in the dist output.
+ */
+export {
+  formatDuration,
+  formatRelativeTime,
+  getPriorityClass,
+  getPriorityLabel,
+  getStatusVariant,
+  type JobData,
+  type JobFilter,
+  type JobPriority,
+  type JobSort,
+  type JobStats,
+  type JobStatus,
+  type QueueStats,
+  type TimeoutBehavior,
+} from '../types.js';


### PR DESCRIPTION
## Summary

- `svelte-package` rewrites `../types.js` → `./types.js` when building components in the `components/` subdirectory, breaking all 6 Svelte components at runtime
- Added a co-located re-export barrel at `components/types.ts` and updated component imports to use `./types.js` so the path resolves correctly in both source and dist

## Test plan

- [x] `pnpm build` in `packages/jobs` succeeds
- [x] `dist/svelte/components/types.js` exists and re-exports from `../types.js`
- [x] All component `.svelte` files in dist import `from './types.js'` (unchanged, now valid)
- [ ] Dashboard dev server no longer shows `Could not resolve "./types.js"` errors after consuming the published fix