### PR TITLE
fix(vitest): merge DDL columns across STI subclasses in test DB

### DIFF
--- a/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
+++ b/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
@@ -368,6 +368,143 @@ describe('createIsolatedTestDbFromManifest', () => {
         await cleanup();
       }
     });
+
+    it('should merge columns from STI subclasses that add extra fields', async () => {
+      const manifestPath = join(testDir, 'sti-merge-test.json');
+      const manifest = {
+        objects: {
+          // Base class with core columns
+          Tenant: {
+            className: 'Tenant',
+            schema: {
+              tableName: 'sti_tenants',
+              ddl: 'CREATE TABLE IF NOT EXISTS "sti_tenants" ("id" TEXT PRIMARY KEY NOT NULL, "_meta_type" TEXT NOT NULL, "name" TEXT DEFAULT \'\', "status" TEXT);',
+              indexes: [
+                { name: 'sti_tenants_meta_type_idx', columns: ['_meta_type'] },
+              ],
+            },
+          },
+          // STI subclass adding timezone and editorial_email
+          Publication: {
+            className: 'Publication',
+            schema: {
+              tableName: 'sti_tenants',
+              ddl: 'CREATE TABLE IF NOT EXISTS "sti_tenants" ("id" TEXT PRIMARY KEY NOT NULL, "_meta_type" TEXT NOT NULL, "name" TEXT DEFAULT \'\', "status" TEXT, "timezone" TEXT DEFAULT \'UTC\', "editorial_email" TEXT DEFAULT \'\');',
+              indexes: [
+                { name: 'sti_tenants_meta_type_idx', columns: ['_meta_type'] },
+                { name: 'sti_tenants_timezone_idx', columns: ['timezone'] },
+              ],
+            },
+          },
+          // Another STI subclass adding repo_template and github_org
+          Network: {
+            className: 'Network',
+            schema: {
+              tableName: 'sti_tenants',
+              ddl: 'CREATE TABLE IF NOT EXISTS "sti_tenants" ("id" TEXT PRIMARY KEY NOT NULL, "_meta_type" TEXT NOT NULL, "name" TEXT DEFAULT \'\', "status" TEXT, "repo_template" TEXT DEFAULT \'\', "github_org" TEXT DEFAULT \'\');',
+              indexes: [
+                { name: 'sti_tenants_meta_type_idx', columns: ['_meta_type'] },
+              ],
+            },
+          },
+        },
+      };
+
+      writeFileSync(manifestPath, JSON.stringify(manifest));
+
+      const { db, cleanup } = await createIsolatedTestDbFromManifest({
+        manifestPath,
+      });
+
+      try {
+        // Should be able to insert with ALL columns from ALL subclasses
+        await db.insert('sti_tenants', {
+          id: 'tenant-1',
+          _meta_type: 'Tenant',
+          name: 'Base Tenant',
+          status: 'active',
+        });
+
+        await db.insert('sti_tenants', {
+          id: 'pub-1',
+          _meta_type: 'Publication',
+          name: 'My Publication',
+          status: 'active',
+          timezone: 'America/Edmonton',
+          editorial_email: 'editor@example.com',
+        });
+
+        await db.insert('sti_tenants', {
+          id: 'net-1',
+          _meta_type: 'Network',
+          name: 'My Network',
+          status: 'active',
+          repo_template: 'template-repo',
+          github_org: 'my-org',
+        });
+
+        const all = await db.list('sti_tenants', {});
+        expect(all).toHaveLength(3);
+
+        // Verify Publication columns exist
+        const pub = await db.get('sti_tenants', { id: 'pub-1' });
+        expect(pub?.timezone).toBe('America/Edmonton');
+        expect(pub?.editorial_email).toBe('editor@example.com');
+
+        // Verify Network columns exist
+        const net = await db.get('sti_tenants', { id: 'net-1' });
+        expect(net?.repo_template).toBe('template-repo');
+        expect(net?.github_org).toBe('my-org');
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it('should merge indexes from STI subclasses', async () => {
+      const manifestPath = join(testDir, 'sti-index-merge-test.json');
+      const manifest = {
+        objects: {
+          BaseEvent: {
+            className: 'BaseEvent',
+            schema: {
+              tableName: 'sti_events',
+              ddl: 'CREATE TABLE IF NOT EXISTS "sti_events" ("id" TEXT PRIMARY KEY NOT NULL, "_meta_type" TEXT NOT NULL, "title" TEXT);',
+              indexes: [
+                { name: 'sti_events_meta_type_idx', columns: ['_meta_type'] },
+              ],
+            },
+          },
+          SpecialEvent: {
+            className: 'SpecialEvent',
+            schema: {
+              tableName: 'sti_events',
+              ddl: 'CREATE TABLE IF NOT EXISTS "sti_events" ("id" TEXT PRIMARY KEY NOT NULL, "_meta_type" TEXT NOT NULL, "title" TEXT, "venue" TEXT);',
+              indexes: [
+                { name: 'sti_events_meta_type_idx', columns: ['_meta_type'] },
+                { name: 'sti_events_venue_idx', columns: ['venue'] },
+              ],
+            },
+          },
+        },
+      };
+
+      writeFileSync(manifestPath, JSON.stringify(manifest));
+
+      const { db, cleanup } = await createIsolatedTestDbFromManifest({
+        manifestPath,
+      });
+
+      try {
+        // Both indexes should exist
+        const indexes =
+          await db.many`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='sti_events'`;
+        const indexNames = indexes.map((i: any) => i.name);
+        expect(indexNames).toContain('sti_events_meta_type_idx');
+        expect(indexNames).toContain('sti_events_venue_idx');
+      } finally {
+        await cleanup();
+      }
+    });
   });
 
   describe('foreign key dependency ordering', () => {

--- a/packages/vitest/src/test-db.ts
+++ b/packages/vitest/src/test-db.ts
@@ -487,9 +487,60 @@ function extractForeignKeyDependencies(ddl: string): string[] {
 }
 
 /**
+ * Tokenize CREATE TABLE body into individual column/constraint definitions.
+ *
+ * Splits on top-level commas (not inside parentheses or quotes) so it works
+ * for both multi-line and single-line DDL strings.
+ */
+function tokenizeDDLBody(body: string): string[] {
+  const segments: string[] = [];
+  let current = '';
+  let parenDepth = 0;
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+  let prevChar = '';
+
+  for (const ch of body) {
+    if (ch === "'" && !inDoubleQuote && prevChar !== '\\') {
+      inSingleQuote = !inSingleQuote;
+    } else if (ch === '"' && !inSingleQuote && prevChar !== '\\') {
+      inDoubleQuote = !inDoubleQuote;
+    } else if (!inSingleQuote && !inDoubleQuote) {
+      if (ch === '(') parenDepth += 1;
+      else if (ch === ')' && parenDepth > 0) parenDepth -= 1;
+    }
+
+    if (ch === ',' && parenDepth === 0 && !inSingleQuote && !inDoubleQuote) {
+      const trimmed = current.trim();
+      if (trimmed) segments.push(trimmed);
+      current = '';
+    } else {
+      current += ch;
+    }
+
+    prevChar = ch;
+  }
+
+  const last = current.trim();
+  if (last) segments.push(last);
+
+  return segments;
+}
+
+/** Keywords that indicate a table-level constraint, not a column definition */
+const CONSTRAINT_KEYWORDS = new Set([
+  'CONSTRAINT',
+  'PRIMARY',
+  'FOREIGN',
+  'UNIQUE',
+  'CHECK',
+]);
+
+/**
  * Parse column definitions from a CREATE TABLE DDL statement
  *
  * Returns a Map of column name → full column definition line.
+ * Skips table-level constraints (FOREIGN KEY, PRIMARY KEY, etc.).
  */
 function parseColumnsFromDDL(ddl: string): Map<string, string> {
   const columns = new Map<string, string>();
@@ -499,19 +550,17 @@ function parseColumnsFromDDL(ddl: string): Map<string, string> {
   );
   if (!bodyMatch) return columns;
 
-  const body = bodyMatch[1];
-  // Split on commas that are followed by a newline + optional whitespace + quote (column start)
-  const lines = body
-    .split(/,\s*\n/)
-    .map((l) => l.trim())
-    .filter(Boolean);
+  const segments = tokenizeDDLBody(bodyMatch[1]);
 
-  for (const line of lines) {
-    // Extract column name (first quoted or unquoted identifier)
-    const colMatch = line.match(/^"?([a-zA-Z_][a-zA-Z0-9_]*)"?\s+/);
-    if (colMatch) {
-      columns.set(colMatch[1], line);
-    }
+  for (const segment of segments) {
+    // Extract first identifier and check if it's a constraint keyword
+    const colMatch = segment.match(/^"?([a-zA-Z_][a-zA-Z0-9_]*)"?\s+/);
+    if (!colMatch) continue;
+
+    const firstToken = colMatch[1].toUpperCase();
+    if (CONSTRAINT_KEYWORDS.has(firstToken)) continue;
+
+    columns.set(colMatch[1], segment);
   }
 
   return columns;


### PR DESCRIPTION
## Summary

- `createIsolatedTestDbFromManifest` used first-wins deduplication when multiple STI classes share a table — only the first class's columns were included in the CREATE TABLE DDL
- This caused `SQLITE_ERROR: table tenants has no column named repo_template` when saving objects whose STI subclasses add columns (e.g., Tenant + Publication + Network all on the `tenants` table)
- Now merges DDL columns, indexes, and FK dependencies from all STI subclasses sharing the same `tableName`

## Test plan

- [x] Verified in blindmanpress.com dashboard: all 281 tests pass (was 10 failures in tenant.test.ts)
- [ ] CI passes