### PR TITLE
fix(tenancy): use toJSON() in serializeInstance to avoid circular JSON crash

### DIFF
--- a/packages/tenancy/src/__tests__/tenancy.test.ts
+++ b/packages/tenancy/src/__tests__/tenancy.test.ts
@@ -870,5 +870,94 @@ describe('TenantInterceptor', () => {
       expect(payload.save).toBeUndefined();
       expect(payload.validate).toBeUndefined();
     });
+
+    it('should produce JSON-serializable payload when instance has circular _db handle (issue #946)', async () => {
+      const { bus, emitted } = createMockDispatchBus();
+      const interceptor = createTenantInterceptor({
+        dispatchBus: bus,
+        directoryClasses: ['Membership'],
+      });
+
+      // Simulate a real SmrtObject with a _db handle containing
+      // circular references (connection pool with Timeout objects)
+      const circularPool: Record<string, unknown> = {};
+      const timeout = { _idlePrev: circularPool };
+      circularPool._idleNext = timeout;
+      timeout._idlePrev = circularPool; // circular!
+
+      const instance = {
+        id: 'mem-1',
+        tenantId: 't-1',
+        userId: 'u-1',
+        status: 'active',
+        // Internal framework handles that cause the crash
+        _db: { pool: circularPool },
+        _ai: { client: {} },
+        _fs: { adapter: {} },
+        // toJSON() returns only data fields, like a real SmrtObject
+        toJSON() {
+          return {
+            id: this.id,
+            tenantId: this.tenantId,
+            userId: this.userId,
+            status: this.status,
+          };
+        },
+      } as any;
+
+      const context = {
+        className: 'Membership',
+        operation: 'save' as const,
+        timestamp: new Date(),
+        metadata: { _directoryIsNew: true },
+      };
+
+      await interceptor.afterSave?.(instance, context);
+
+      expect(emitted).toHaveLength(1);
+
+      const payload = emitted[0].payload as Record<string, unknown>;
+      expect(payload.className).toBe('Membership');
+      expect(payload.id).toBe('mem-1');
+      expect(payload.userId).toBe('u-1');
+
+      // The critical assertion: payload must be JSON-serializable
+      // (this is what DispatchBus.emit() does internally)
+      expect(() => JSON.stringify(payload)).not.toThrow();
+
+      // Internal handles must NOT leak into the payload
+      expect(payload._db).toBeUndefined();
+      expect(payload._ai).toBeUndefined();
+      expect(payload._fs).toBeUndefined();
+    });
+
+    it('should fall back to Object.keys when toJSON is not available', async () => {
+      const { bus, emitted } = createMockDispatchBus();
+      const interceptor = createTenantInterceptor({
+        dispatchBus: bus,
+        directoryClasses: ['Tenant'],
+      });
+
+      // Plain object stub without toJSON (backwards compat)
+      const instance = {
+        id: 'tenant-1',
+        name: 'Acme',
+        status: 'active',
+      } as any;
+
+      const context = {
+        className: 'Tenant',
+        operation: 'save' as const,
+        timestamp: new Date(),
+        metadata: { _directoryIsNew: true },
+      };
+
+      await interceptor.afterSave?.(instance, context);
+
+      const payload = emitted[0].payload as Record<string, unknown>;
+      expect(payload.className).toBe('Tenant');
+      expect(payload.id).toBe('tenant-1');
+      expect(payload.name).toBe('Acme');
+    });
   });
 });

--- a/packages/tenancy/src/interceptor.ts
+++ b/packages/tenancy/src/interceptor.ts
@@ -96,12 +96,24 @@ const DEFAULT_OPTIONS: TenantInterceptorOptions = {
 
 /**
  * Extract a plain-object snapshot of an instance for dispatch payloads.
- * Copies own enumerable properties, skipping functions and internal symbols.
+ *
+ * Prefers `toJSON()` when available (all real SmrtObject instances) because
+ * it returns only data fields and excludes internal handles like `_db`, `_ai`,
+ * and `_fs` which may contain circular references (e.g. connection pools with
+ * Timeout objects).
+ *
+ * @see https://github.com/happyvertical/smrt/issues/946
  */
 function serializeInstance(
   instance: SmrtObject,
   className: string,
 ): Record<string, unknown> {
+  if (typeof (instance as any).toJSON === 'function') {
+    return { className, ...(instance as any).toJSON() };
+  }
+
+  // Fallback for plain-object stubs (e.g. in unit tests):
+  // skip functions and framework-internal properties
   const result: Record<string, unknown> = { className };
   for (const key of Object.keys(instance)) {
     const value = (instance as any)[key];


### PR DESCRIPTION
## Summary

- `serializeInstance()` used `Object.keys(instance)` which picked up internal framework handles (`_db`, `_ai`, `_fs`) containing circular references (connection pool `Timeout` objects), causing `DispatchBus.emit()` to crash with `TypeError: Converting circular structure to JSON`
- Now prefers `instance.toJSON()` which only returns serializable data fields, with the old `Object.keys()` logic kept as a fallback for plain-object stubs in tests

closes #946

## Test plan

- [x] Added regression test with mock circular `_db` handle verifying payload is JSON-serializable
- [x] Added test verifying fallback path for plain objects without `toJSON()`
- [x] All 53 tenancy tests pass