### PR TITLE
docs(facts): CLAUDE.md and SPEC.md for smrt-facts

### DIFF
--- a/packages/facts/CLAUDE.md
+++ b/packages/facts/CLAUDE.md
@@ -1,0 +1,117 @@
+# @happyvertical/smrt-facts
+
+Distributed memory and knowledge management with provenance tracking, semantic deduplication, and evolution chains.
+
+## Architecture
+
+```
+src/
+  index.ts                  # Export barrel
+  types.ts                  # FactType, FactStatus, EvolutionType, SubjectRole, options interfaces
+  utils.ts                  # calculateConfidence(), normalizeText()
+  fact.ts                   # Fact model (STI base, embeddings)
+  fact-source.ts            # FactSource model (provenance)
+  fact-subject.ts           # FactSubject model (polymorphic entity linking)
+  fact-content.ts           # FactContent model (content join table)
+  fact-tag.ts               # FactTag model (tag join table)
+  facts.ts                  # FactCollection (reconcile, evolution, confidence)
+  fact-sources.ts           # FactSourceCollection
+  fact-subjects.ts          # FactSubjectCollection
+  fact-contents.ts          # FactContentCollection
+  fact-tags.ts              # FactTagCollection
+```
+
+## Models
+
+### Fact
+
+STI base model with embedding support. Represents an atomic unit of knowledge.
+
+**Properties**: `textRefined`, `textRaw`, `type` (FactType), `status` (FactStatus), `domain`, `parentId`, `evolutionType`, `sourceCount`, `confidence`, `metadata` (JSON)
+
+**Embeddings**: Auto-generated on `textRefined` with combined field template `{textRefined}\n\nType: {type}\nDomain: {domain}`
+
+**Methods**:
+- Status: `isActive()`, `isSuperseded()`
+- Hierarchy: `hasParent()`, `getParent()`, `getChildren()`
+- Metadata: `getMetadata()`, `setMetadata()`, `updateMetadata()`
+
+### FactSource
+
+Provenance tracking for facts. Links a fact to its information source.
+
+**Properties**: `factId`, `sourceType`, `sourceUrl`, `sourceTitle`, `credibility` (0-1), `extractedAt`, `metadata`
+
+**Conflict columns**: none (multiple sources per fact allowed)
+
+### FactSubject
+
+Polymorphic entity linking. Links any entity to a fact with a role.
+
+**Properties**: `factId`, `entityType`, `entityId`, `role` (SubjectRole), `metadata`
+
+**Conflict columns**: `['fact_id', 'entity_type', 'entity_id']` — one link per entity-fact pair
+
+### FactContent
+
+Join table between facts and content items.
+
+**Properties**: `factId`, `contentId`, `relationship` (FactContentRelationship), `metadata`
+
+**Conflict columns**: `['fact_id', 'content_id', 'relationship']` — allows multiple relationship types per pair
+
+### FactTag
+
+Join table between facts and tags.
+
+**Properties**: `factId`, `tagSlug`, `metadata`
+
+**Conflict columns**: `['fact_id', 'tag_slug']`
+
+## Collections
+
+### FactCollection
+
+Core collection with reconcile, evolution, and confidence methods.
+
+**Query methods**: `getActive()`, `getPending()`, `getByType()`, `getByDomain()`, `getByStatus()`, `getChildren()`
+
+**Reconcile**: `reconcile(options)` — Semantic search + AI disambiguation to create, merge, or branch facts
+
+**Evolution**: `branch()`, `getEvolutionChain()`, `getLatestInChain()`, `getEvolutionTree()`
+
+**Confidence**: `recalculateConfidence(factId)` — Weighted formula from source count, credibility, recency, corroboration
+
+**Entity**: `getEntityBriefing(entityType, entityId)` — Summary of all facts about an entity
+
+### FactSourceCollection
+
+`getForFact()`, `countForFact()`, `getByType()`, `getHighCredibility()`, `getAverageCredibility()`
+
+### FactSubjectCollection
+
+`linkEntity()`, `unlinkEntity()`, `getForFact()`, `getForEntity()`, `getByRole()`, `countForFact()`
+
+### FactContentCollection
+
+`link()`, `unlink()`, `getForFact()`, `getForContent()`, `getByRelationship()`
+
+### FactTagCollection
+
+`addTag()`, `removeTag()`, `getForFact()`, `getForTag()`, `getTagSlugs()`
+
+## Key Patterns
+
+- **Metadata as JSON string**: All models store metadata as `string = ''`, with `getMetadata()`/`setMetadata()`/`updateMetadata()` helpers that handle JSON parsing. The `getMetadata()` method handles both string and object inputs (objects may arrive from `create()` without going through the constructor's JSON.stringify).
+- **Cycle detection**: Evolution chain/tree traversals use visited-ID Sets to prevent infinite loops from circular parentId references.
+- **Tenancy optional**: All models use `@TenantScoped({ mode: 'optional' })` with `@tenantId({ nullable: true })`.
+- **STI**: All models use `tableStrategy: 'sti'` for single-table inheritance.
+
+## Key Exports
+
+`Fact`, `FactCollection`, `FactSource`, `FactSourceCollection`, `FactSubject`, `FactSubjectCollection`, `FactContent`, `FactContentCollection`, `FactTag`, `FactTagCollection`, `calculateConfidence`, `normalizeText`
+
+## Dependencies
+
+- `@happyvertical/smrt-core`, `@happyvertical/smrt-tenancy`
+- `@happyvertical/ai`, `@happyvertical/sql`, `@happyvertical/files`, `@happyvertical/utils`, `@happyvertical/logger`

--- a/packages/facts/SPEC.md
+++ b/packages/facts/SPEC.md
@@ -1,0 +1,134 @@
+# @happyvertical/smrt-facts — Specification
+
+## Reconcile Algorithm
+
+The `reconcile()` method is the primary entry point for ingesting new knowledge. It determines whether incoming text represents a new fact, corroborates an existing one, or contradicts it.
+
+### Input
+
+```typescript
+interface ReconcileOptions {
+  rawInput: string;                    // Text to reconcile
+  similarityThreshold?: number;        // Auto-merge threshold (default: 0.85)
+  conflictThreshold?: number;          // Minimum similarity to consider (default: 0.60)
+  type?: FactType;                     // Classification (default: 'assertion')
+  domain?: string;                     // Domain scope
+  source?: {                           // Optional provenance
+    sourceType?: string;
+    sourceUrl?: string;
+    sourceTitle?: string;
+    credibility?: number;
+  };
+}
+```
+
+### Decision Flow
+
+```
+semanticSearch(rawInput, limit=5, minSimilarity=conflictThreshold)
+  │
+  ├─ No match above conflictThreshold (0.60)
+  │  └─ CREATE new fact (status: active)
+  │
+  ├─ Top match >= similarityThreshold (0.85)
+  │  └─ MERGE: increment sourceCount, update textRaw
+  │
+  └─ Ambiguous zone (0.60 - 0.85)
+     └─ AI disambiguation via _disambiguateWithAI()
+        ├─ AI says "merge" → MERGE
+        └─ AI says "branch" → BRANCH: create child fact, mark parent superseded
+```
+
+After the action, if source metadata was provided, a `FactSource` record is created. On merge with a source, `recalculateConfidence()` is called to update the fact's confidence score.
+
+### Output
+
+```typescript
+interface ReconcileResult {
+  action: 'created' | 'merged' | 'branched';
+  fact: Fact;                          // The resulting fact
+  source?: FactSource;                 // Created source record
+  similarity?: number;                 // Best match similarity
+  matchedFact?: Fact;                  // Existing fact that was matched
+}
+```
+
+## Confidence Formula
+
+Version 1 uses a simple weighted sum clamped to [0, 1]:
+
+```
+confidence = base + sourceBoost + credibilityBoost + recencyBoost + corroborationBoost
+
+Where:
+  base                = 0.5
+  sourceBoost         = min(sourceCount / 10, 0.3)
+  credibilityBoost    = avgSourceCredibility * 0.2
+  recencyBoost        = max(0, 0.1 - daysSinceLastSource * 0.01)
+  corroborationBoost  = corroborationScore * 0.1
+
+Result: max(0, min(1, confidence))
+```
+
+**Defaults** (when no sources exist): `avgSourceCredibility = 0.5`, `daysSinceLastSource = 0`, `corroborationScore = 0` — yielding a baseline confidence of 0.7.
+
+The `recalculateConfidence()` method loads all FactSource records, computes averages, and saves the updated confidence and sourceCount to the fact.
+
+## Evolution Semantics
+
+Facts form directed acyclic graphs via `parentId`. Each child has an `evolutionType`:
+
+| Type | Meaning | Parent status change |
+|------|---------|---------------------|
+| `original` | Root fact, no parent | — |
+| `correction` | Fixes an error in parent | Parent → `superseded` |
+| `refinement` | Improves wording/precision | No change |
+| `contradiction` | Directly contradicts parent | Parent → `superseded` |
+| `extension` | Adds new information to parent | No change |
+| `merge` | Combines multiple facts | No change |
+
+### Evolution Methods
+
+- **`getEvolutionChain(factId)`**: Walk up via `parentId` to root. Returns `[root, ..., factId]`. Uses visited-ID Set for cycle safety.
+- **`getLatestInChain(factId)`**: Walk down children, always picking highest confidence. Returns the leaf. Uses visited-ID Set for cycle safety.
+- **`getEvolutionTree(factId)`**: Find root via `getEvolutionChain`, then BFS all descendants. Returns flat array of entire tree.
+- **`branch(parentId, data, evolutionType)`**: Create child fact, generate embeddings, and if evolution type is `correction` or `contradiction`, mark parent as `superseded`.
+
+## Entity Briefing
+
+`getEntityBriefing(entityType, entityId)` aggregates all facts linked to an entity via FactSubject:
+
+```typescript
+interface EntityBriefing {
+  entityType: string;
+  entityId: string;
+  facts: Fact[];
+  totalCount: number;
+  byType: Record<string, number>;    // e.g., { assertion: 5, observation: 2 }
+  byStatus: Record<string, number>;  // e.g., { active: 6, superseded: 1 }
+}
+```
+
+## Type Reference
+
+### FactType
+`assertion` | `observation` | `measurement` | `definition` | `relationship` | `event` | `opinion` | `prediction`
+
+### FactStatus
+`pending` | `active` | `disputed` | `superseded` | `archived` | `retracted`
+
+### EvolutionType
+`original` | `correction` | `refinement` | `contradiction` | `extension` | `merge`
+
+### SubjectRole
+`subject` | `object` | `source` | `location` | `participant` | `related`
+
+### FactContentRelationship
+`extracted_from` | `referenced_in` | `supports` | `contradicts` | `related`
+
+## Future Work
+
+- **DispatchBus events**: Emit `fact.discovered` events from reconcile() for reactive pipelines
+- **interesting() integration**: Use confidence + source count + recency to determine if a fact is noteworthy
+- **Cross-gnode federation**: Share facts between gnodes with provenance chains
+- **Batch reconcile**: Process multiple inputs in a single call with shared semantic search


### PR DESCRIPTION
## Summary
- Adds `packages/facts/CLAUDE.md` — architecture overview, model reference, collection API, key patterns, and dependencies
- Adds `packages/facts/SPEC.md` — reconcile algorithm specification, confidence formula, evolution semantics, entity briefing, and type reference

Refs: #954

## Test plan
- [ ] Documentation is accurate against current implementation
- [ ] No code changes, documentation only