### PR TITLE
fix(core): allow pnpm duplicate copies in case-insensitive collision check

### DIFF
--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -60,7 +60,10 @@ import type {
 } from './schema/types.js';
 import { classnameToTablename, tableNameFromClass, toSnakeCase } from './utils';
 import { LRUCache } from './utils/lru-cache';
-import { createQualifiedName } from './utils/qualified-names.js';
+import {
+  createQualifiedName,
+  isQualifiedName,
+} from './utils/qualified-names.js';
 
 /**
  * Cached verbose flag evaluated once at module load time.
@@ -1223,9 +1226,47 @@ export class ObjectRegistry {
           return; // Same class, skip silently
         }
 
+        // Same package, different pnpm store copy — harmless duplicate
+        // This happens when pnpm installs multiple physical copies of the same package
+        // due to different peer dependency resolutions. Each copy has a distinct constructor
+        // but they are semantically the same class.
+        // Requirements: existing entry has a qualified key, same package, AND same class name
+        // (case-sensitive). A case-insensitive-only match with different exact names indicates
+        // genuinely different classes, not pnpm duplicates.
+        const newPackageName = getPackageName(ctor, true);
+        if (
+          isQualifiedName(existingKey) &&
+          newPackageName &&
+          existing.packageName &&
+          newPackageName === existing.packageName &&
+          name === existing.name
+        ) {
+          existing.constructor = ctor;
+          existing.config = { ...existing.config, ...config };
+          ObjectRegistry.constructorIndex.set(ctor, existingKey);
+          return;
+        }
+
         // Check if this is the same class being re-registered from module re-evaluation
         // (Issue #555: Test isolation - class name collision during vitest collection)
         const newSourceFile = getSourceFileFromStack();
+
+        // Bundled context: source file is in a build output directory
+        // Mirrors the exact-match bundled context check above
+        const isBundledContext =
+          newSourceFile &&
+          (newSourceFile.includes('.svelte-kit/output/') ||
+            newSourceFile.includes('/dist/') ||
+            newSourceFile.includes('/build/') ||
+            newSourceFile.includes('.next/') ||
+            newSourceFile.includes('.nuxt/'));
+
+        if (isBundledContext && existing.packageName?.startsWith('@')) {
+          existing.constructor = ctor;
+          existing.config = { ...existing.config, ...config };
+          ObjectRegistry.constructorIndex.set(ctor, existingKey);
+          return;
+        }
 
         // Allow re-registration if:
         // 1. Both source files are defined and match (same file being re-evaluated)


### PR DESCRIPTION
## Summary

- The case-insensitive collision loop in `ObjectRegistry.register()` was missing two bypass conditions that exist in the exact-match section, causing false "Class Name Collision" errors (e.g., `AgentConfig`) when pnpm installs multiple physical copies of the same package due to different peer dependency resolutions
- Adds **same-package pnpm duplicate bypass**: when the existing entry has a qualified key, both entries share the same package name, and the class name matches exactly (case-sensitive), the constructor is silently updated
- Adds **bundled-context bypass**: when the new registration comes from a build output directory (`.svelte-kit/output/`, `/dist/`, `/build/`, `.next/`, `.nuxt/`) and the existing entry has a scoped package name, it mirrors the exact-match bundled context check

## Context

Downstream Blindman Press sites broke after upgrading to smrt 0.20.26 because pnpm resolved two physical copies of `@happyvertical/smrt-agents` (via different peer deps from praeco/caelus). The `AgentConfig` class was registered twice with distinct constructors — the exact-match section correctly identified this as a pnpm duplicate and allowed it, but the case-insensitive loop (which runs separately) lacked these bypasses and threw a collision error.

Workaround: pnpm overrides forcing all transitive smrt deps to the same version. This fix eliminates the need for that workaround.

## Test plan

- [x] All 1370 existing tests pass
- [x] Existing collision test (`issue-531`, "should throw on case-insensitive collision with non-stub class") still correctly detects genuine collisions between different classes
- [x] Build succeeds