### PR TITLE
fix(jobs): pass agent config to constructor, separate from method args

### DIFF
--- a/packages/jobs/src/runner.ts
+++ b/packages/jobs/src/runner.ts
@@ -265,24 +265,28 @@ export class TaskRunner extends EventEmitter {
     }
 
     // Get the constructor from the registry entry
-    const ObjectClass =
-      registeredClass.constructor as unknown as new (options: {
-        db: DatabaseInterface | null;
-      }) => SmrtObject;
+    const ObjectClass = registeredClass.constructor as unknown as new (
+      options: Record<string, unknown>,
+    ) => SmrtObject;
+
+    // Extract internal keys from args before passing to constructor/method
+    const rawArgs = (job.args ?? {}) as Record<string, unknown>;
+    const agentConfig = (rawArgs._agentConfig ?? {}) as Record<string, unknown>;
+    const { _agentConfig: _, _scheduleId: __, ...methodArgs } = rawArgs;
 
     // Create or load the object instance
     let instance: SmrtObject;
 
     if (job.objectId) {
       // Load existing object
-      instance = new ObjectClass({ db: this.db });
+      instance = new ObjectClass({ db: this.db, ...agentConfig });
       await instance.initialize();
       await (
         instance as SmrtObject & { loadFromId(id: string): Promise<void> }
       ).loadFromId(job.objectId);
     } else {
       // Create new instance for static-like methods
-      instance = new ObjectClass({ db: this.db });
+      instance = new ObjectClass({ db: this.db, ...agentConfig });
       await instance.initialize();
     }
 
@@ -306,7 +310,7 @@ export class TaskRunner extends EventEmitter {
     // Log job start
     contextLogger.info(`Starting job: ${job.getDescription()}`);
 
-    // Invoke the method
+    // Invoke the method with cleaned args (no internal keys)
     const method = (
       instance as unknown as Record<string, (args: unknown) => Promise<unknown>>
     )[job.method];
@@ -314,7 +318,7 @@ export class TaskRunner extends EventEmitter {
       throw new Error(`Method not found: ${job.objectType}.${job.method}`);
     }
 
-    const result = await method.call(instance, job.args);
+    const result = await method.call(instance, methodArgs);
 
     return { result };
   }

--- a/packages/jobs/src/schedule-runner.ts
+++ b/packages/jobs/src/schedule-runner.ts
@@ -302,16 +302,22 @@ export class ScheduleRunner extends EventEmitter {
       );
 
       // Create a job for this schedule
+      // Nest agent_config under _agentConfig so TaskRunner can pass it
+      // to the agent constructor separately from method args
+      const args: Record<string, unknown> = {
+        ...methodArgs,
+        _scheduleId: schedule.id,
+      };
+      if (Object.keys(agentConfig).length > 0) {
+        args._agentConfig = agentConfig;
+      }
+
       const job = await this.jobCollection.create({
         queue: 'agents',
         objectType: schedule.agent_type as string,
         objectId: schedule.agent_id as string | null,
         method: (schedule.method as string) || 'run',
-        args: {
-          ...methodArgs,
-          ...agentConfig,
-          _scheduleId: schedule.id,
-        },
+        args,
         priority: 75, // High priority for scheduled agents
         maxAttempts: 3,
         timeout: (schedule.timeout as number) || 3600000,


### PR DESCRIPTION
## Summary

- TaskRunner extracts `_agentConfig` from job args and spreads it into the agent constructor, so agents receive location/provider/tenant-db config
- Internal keys (`_agentConfig`, `_scheduleId`) are stripped before passing args to the agent method
- ScheduleRunner nests `agent_config` under `_agentConfig` key instead of flat-spreading alongside method args
- Constructor type widened from `{ db: DatabaseInterface | null }` to `Record<string, unknown>`

## Test plan

- [x] `pnpm build` passes in packages/jobs
- [x] `pnpm test` — all 10 existing tests pass
- [ ] Manual: trigger a scheduled job with agent_config → agent receives config in constructor, method gets clean args