### PR TITLE
fix(core): write local manifest for non-library builds

### DIFF
--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -97,6 +97,34 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
   let projectRoot: string = process.cwd();
   let config: any = null; // Store resolved config for closeBundle hook
 
+  /**
+   * Write manifest to .smrt/manifest.json for CLI discovery.
+   * This ensures `smrt db:migrate`, `smrt db:status`, etc. can find
+   * locally-defined SMRT objects in non-library builds (Issue #963).
+   */
+  async function writeLocalManifest(
+    m: SmartObjectManifest,
+    rootDir: string,
+  ): Promise<void> {
+    try {
+      const { writeFileSync, mkdirSync } = await import('node:fs');
+      const { resolve } = await import('node:path');
+
+      const smrtDir = resolve(rootDir, '.smrt');
+      mkdirSync(smrtDir, { recursive: true });
+
+      const manifestPath = resolve(smrtDir, 'manifest.json');
+      writeFileSync(manifestPath, JSON.stringify(m, null, 2), 'utf-8');
+
+      const objectCount = Object.keys(m.objects).length;
+      console.log(
+        `[smrt] Wrote local manifest with ${objectCount} objects to .smrt/manifest.json`,
+      );
+    } catch (error) {
+      console.error('[smrt] Error writing local manifest:', error);
+    }
+  }
+
   return {
     name: 'smrt-auto-service',
 
@@ -137,6 +165,11 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
       // Scan files and generate initial manifest in all modes
       manifest = await scanAndGenerateManifest(projectRoot);
 
+      // Write local manifest for CLI discovery (Issue #963)
+      if (manifest) {
+        await writeLocalManifest(manifest, projectRoot);
+      }
+
       // Generate SvelteKit routes if enabled
       if (svelteKit.enabled && manifest) {
         await generateSvelteKitRoutes(resolvedConfig.root, manifest, {
@@ -152,6 +185,11 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
     async buildStart() {
       // Rescan files on build start in all modes
       manifest = await scanAndGenerateManifest(projectRoot);
+
+      // Write local manifest for CLI discovery (Issue #963)
+      if (manifest) {
+        await writeLocalManifest(manifest, projectRoot);
+      }
     },
 
     configureServer(devServer) {
@@ -206,6 +244,11 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
             console.log(`[smrt] Rescanning due to change in ${file}`);
             manifest = await scanAndGenerateManifest(projectRoot);
 
+            // Write local manifest for CLI discovery (Issue #963)
+            if (manifest) {
+              await writeLocalManifest(manifest, projectRoot);
+            }
+
             // Generate SvelteKit routes if enabled
             if (svelteKit.enabled && manifest && server) {
               await generateSvelteKitRoutes(server.config.root, manifest, {
@@ -231,6 +274,11 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
           if (await shouldRescan(file)) {
             console.log(`[smrt] Rescanning due to new file ${file}`);
             manifest = await scanAndGenerateManifest(projectRoot);
+
+            // Write local manifest for CLI discovery (Issue #963)
+            if (manifest) {
+              await writeLocalManifest(manifest, projectRoot);
+            }
           }
         });
       }

--- a/packages/core/src/vite-plugin/local-manifest.test.ts
+++ b/packages/core/src/vite-plugin/local-manifest.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for local manifest writing (Issue #963)
+ *
+ * Verifies that smrtPlugin writes .smrt/manifest.json for CLI discovery
+ * in non-library builds (SvelteKit apps, standalone Vite apps, etc.).
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { smrtPlugin } from './index';
+
+describe('smrtPlugin local manifest writing (Issue #963)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    // Create a temporary project directory
+    tmpDir = resolve(
+      import.meta.dirname,
+      `__test-local-manifest-${Date.now()}`,
+    );
+    mkdirSync(join(tmpDir, 'src'), { recursive: true });
+
+    // Create a minimal package.json
+    writeFileSync(
+      join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: 'test-app',
+        version: '1.0.0',
+        dependencies: {
+          '@happyvertical/smrt-core': '*',
+        },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should write .smrt/manifest.json during configResolved', async () => {
+    const plugin = smrtPlugin({
+      include: ['src/**/*.ts'],
+      generateTypes: false,
+    });
+
+    // Simulate Vite's configResolved hook (non-library build)
+    const mockConfig = {
+      root: tmpDir,
+      build: {},
+      plugins: [],
+    };
+
+    await (plugin as any).configResolved(mockConfig);
+
+    // Verify .smrt/manifest.json was written
+    const manifestPath = join(tmpDir, '.smrt', 'manifest.json');
+    expect(existsSync(manifestPath)).toBe(true);
+
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+    expect(manifest).toHaveProperty('version');
+    expect(manifest).toHaveProperty('objects');
+  });
+
+  it('should write .smrt/manifest.json during buildStart', async () => {
+    const plugin = smrtPlugin({
+      include: ['src/**/*.ts'],
+      generateTypes: false,
+    });
+
+    // configResolved must be called first to set projectRoot
+    await (plugin as any).configResolved({
+      root: tmpDir,
+      build: {},
+      plugins: [],
+    });
+
+    // Remove the manifest written by configResolved
+    const manifestPath = join(tmpDir, '.smrt', 'manifest.json');
+    if (existsSync(manifestPath)) {
+      rmSync(manifestPath);
+    }
+
+    // Now call buildStart
+    await (plugin as any).buildStart();
+
+    // Verify .smrt/manifest.json was written again
+    expect(existsSync(manifestPath)).toBe(true);
+  });
+
+  it('should still write dist/manifest.json during closeBundle for library builds', async () => {
+    const plugin = smrtPlugin({
+      include: ['src/**/*.ts'],
+      generateTypes: false,
+    });
+
+    // configResolved with library build config
+    await (plugin as any).configResolved({
+      root: tmpDir,
+      build: {
+        lib: { entry: 'src/index.ts' },
+        outDir: 'dist',
+      },
+      plugins: [],
+    });
+
+    // closeBundle should write dist/manifest.json for library builds
+    await (plugin as any).closeBundle();
+
+    const distManifestPath = join(tmpDir, 'dist', 'manifest.json');
+    expect(existsSync(distManifestPath)).toBe(true);
+
+    // .smrt/manifest.json should also exist (written during configResolved)
+    const localManifestPath = join(tmpDir, '.smrt', 'manifest.json');
+    expect(existsSync(localManifestPath)).toBe(true);
+  });
+
+  it('should not write dist/manifest.json during closeBundle for non-library builds', async () => {
+    const plugin = smrtPlugin({
+      include: ['src/**/*.ts'],
+      generateTypes: false,
+    });
+
+    // configResolved without library build config
+    await (plugin as any).configResolved({
+      root: tmpDir,
+      build: {},
+      plugins: [],
+    });
+
+    // closeBundle should NOT write dist/manifest.json for non-library builds
+    await (plugin as any).closeBundle();
+
+    const distManifestPath = join(tmpDir, 'dist', 'manifest.json');
+    expect(existsSync(distManifestPath)).toBe(false);
+
+    // But .smrt/manifest.json should exist (written during configResolved)
+    const localManifestPath = join(tmpDir, '.smrt', 'manifest.json');
+    expect(existsSync(localManifestPath)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- `smrtPlugin` now writes `.smrt/manifest.json` after every manifest generation (during `configResolved`, `buildStart`, and HMR file changes)
- Previously, manifests were only written to disk for library builds (`config.build?.lib`), leaving application projects (SvelteKit apps, standalone Vite apps) without a persisted manifest
- CLI tools like `smrt db:migrate`, `smrt db:status`, and `smrt db:diff` can now discover locally-defined `@smrt()` classes in non-library projects

closes #963

## Test plan

- [x] New tests verify `.smrt/manifest.json` is written during `configResolved` and `buildStart`
- [x] New tests verify `dist/manifest.json` is still written for library builds in `closeBundle`
- [x] New tests verify `dist/manifest.json` is NOT written for non-library builds in `closeBundle`
- [x] All existing vite-plugin tests pass (27 tests across 3 files)