### PR TITLE
fix(cli): deduplicate imports in generate-register

### DIFF
--- a/packages/cli/src/commands/__tests__/generate-register.test.ts
+++ b/packages/cli/src/commands/__tests__/generate-register.test.ts
@@ -304,4 +304,78 @@ describe('generate-register', () => {
     const widgetImports = content.match(/import \{[^}]*Widget[^}]*\}/g);
     expect(widgetImports).toHaveLength(1);
   });
+
+  it('registers both objects when they share a collectionExportName', async () => {
+    // Two different objects share the same collectionExportName.
+    // Both objects should be registered; only the first gets collection registration.
+    mockedAutoDiscover.mockResolvedValue({
+      discovered: [
+        {
+          path: '/fake/pkg-a/manifest.json',
+          source: 'package',
+          packageName: '@happyvertical/pkg-a',
+        },
+        {
+          path: '/fake/pkg-b/manifest.json',
+          source: 'package',
+          packageName: '@happyvertical/pkg-b',
+        },
+      ],
+    } as any);
+
+    mockedLoadManifest.mockImplementation(async (path: string) => {
+      if (path.includes('pkg-a')) {
+        return {
+          objects: {
+            Widget: {
+              className: 'Widget',
+              exportName: 'Widget',
+              packageName: '@happyvertical/pkg-a',
+              qualifiedName: '@happyvertical/pkg-a:Widget',
+              hasCollection: true,
+              collectionExportName: 'ItemCollection',
+              collection: 'widgets',
+              visibility: 'public',
+            },
+          },
+        };
+      }
+      if (path.includes('pkg-b')) {
+        return {
+          objects: {
+            Gadget: {
+              className: 'Gadget',
+              exportName: 'Gadget',
+              packageName: '@happyvertical/pkg-b',
+              qualifiedName: '@happyvertical/pkg-b:Gadget',
+              hasCollection: true,
+              collectionExportName: 'ItemCollection',
+              collection: 'gadgets',
+              visibility: 'public',
+            },
+          },
+        };
+      }
+      return null;
+    });
+
+    await handler([], { 'output-path': outputPath });
+
+    const content = await readFile(outputPath, 'utf-8');
+
+    // Both objects should be imported
+    expect(content).toContain(
+      "import { Widget, ItemCollection } from '@happyvertical/pkg-a'",
+    );
+    expect(content).toContain("import { Gadget } from '@happyvertical/pkg-b'");
+
+    // Both objects should be registered
+    expect(content).toContain('ObjectRegistry.register(Widget');
+    expect(content).toContain('ObjectRegistry.register(Gadget');
+
+    // ItemCollection should only appear once (from Widget's package)
+    const collectionImports = content.match(/ItemCollection/g);
+    // 1 in import, 1 in registerCollection
+    expect(collectionImports).toHaveLength(2);
+  });
 });

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -385,15 +385,18 @@ export const generateCommands: Record<string, CLICommand> = {
             if (seenExportNames.has(exportName)) continue;
             seenExportNames.add(exportName);
 
+            // Check if collection export name is already taken by another object.
+            // Only skip collection registration, not the object itself.
             const collectionExportName = def.collectionExportName;
-            if (collectionExportName) {
-              if (seenExportNames.has(collectionExportName)) continue;
+            const skipCollection =
+              collectionExportName && seenExportNames.has(collectionExportName);
+            if (collectionExportName && !skipCollection) {
               seenExportNames.add(collectionExportName);
             }
 
             // Import from the object's canonical package, not the current manifest package
             const importPath = def.importPath || def.packageName || packageName;
-            const hasCollection = def.hasCollection;
+            const hasCollection = def.hasCollection && !skipCollection;
             const tableName = def.collection || objectName.toLowerCase();
 
             // Generate import statement


### PR DESCRIPTION
## Summary

- Deduplicates objects across package manifests in `generate-register` by `qualifiedName` and `exportName`, preventing `Identifier 'X' has already been declared` errors when packages re-export classes from dependencies (via `enrichManifest` merging)
- Imports from the object's canonical `packageName` instead of the manifest's package, so `Profile` always imports from `smrt-profiles` regardless of which manifest it appears in
- Filters out `visibility: 'test'` objects (e.g., `PerfTestUser`, `Issue144TestProfile`) from the generated register file

Closes #965

## Test plan

- [x] Added 4 unit tests covering: cross-package deduplication, test-visibility filtering, canonical import paths, and exportName collision prevention
- [x] All 14 existing CLI test files continue to pass
- [ ] Manual verification: run `smrt generate-register` in a downstream project and confirm no duplicate imports in `.smrt/register.js`