### PR TITLE
fix(scanner): resolve TSTypeLiteral to object for json field inference

### DIFF
--- a/packages/scanner/src/__tests__/manifest-adapter.test.ts
+++ b/packages/scanner/src/__tests__/manifest-adapter.test.ts
@@ -223,6 +223,29 @@ describe('ManifestAdapter', () => {
         const result = adapterWithAliases.inferFieldType(field);
         expect(result.type).toBe('json');
       });
+
+      it('should infer json for inline object type literal (TSTypeLiteral)', () => {
+        const field: RawFieldDefinition = {
+          name: 'regexPatterns',
+          accessibility: 'public',
+          typeAnnotation: 'object',
+          initializer: '{}',
+          optional: false,
+          hasDecimalPoint: false,
+          numericValue: null,
+          decorators: [],
+          isStatic: false,
+          readonly: false,
+          line: 1,
+        };
+
+        const adapter = new ManifestAdapter();
+        adapter.toManifest([], { typeAliases: {} });
+
+        const result = adapter.inferFieldType(field);
+        expect(result.type).toBe('json');
+        expect(result.required).toBe(false);
+      });
     });
 
     describe('@oneToMany and @manyToMany decorators', () => {

--- a/packages/scanner/src/__tests__/oxc-parser.test.ts
+++ b/packages/scanner/src/__tests__/oxc-parser.test.ts
@@ -532,14 +532,14 @@ describe('OXC Parser', () => {
       expect(result.typeAliases.Direction).toBeUndefined();
     });
 
-    it('should skip complex type aliases that cannot be resolved', () => {
+    it('should resolve inline object type aliases to object', () => {
       const source = `
         type Config = { key: string; value: number };
       `;
 
       const result = parseSource(source);
-      // TSTypeLiteral (object shape) returns null from extractTypeName
-      expect(result.typeAliases.Config).toBeUndefined();
+      // TSTypeLiteral (object shape) resolves to 'object' for json storage
+      expect(result.typeAliases.Config).toBe('object');
     });
   });
 

--- a/packages/scanner/src/oxc-parser.ts
+++ b/packages/scanner/src/oxc-parser.ts
@@ -1218,6 +1218,10 @@ function extractTypeName(type: TSType): string | null {
       return types.join(' | ');
     }
 
+    // Inline object type literal: { subject?: string; from?: string; body?: string }
+    // Maps to 'object' which the ManifestAdapter resolves as json
+    case 'TSTypeLiteral':
+      return 'object';
     case 'TSFunctionType':
       return 'Function';
   }


### PR DESCRIPTION
## Summary
- Adds `TSTypeLiteral` case to `extractTypeName()` in the OXC parser, returning `'object'`
- This allows the ManifestAdapter to correctly infer `json` type for fields with inline object type annotations like `{ subject?: string; from?: string; body?: string }`
- Previously, `extractTypeName` returned `null` for `TSTypeLiteral`, causing `inferFieldType` to skip the annotation branch and default to `text` instead of `json`

## Root cause
Discovered via nunitus `RoutingRule.regexPatterns` field regression after upgrading to smrt 0.20.36. The field uses an inline object type:
```ts
regexPatterns: {
  subject?: string;
  from?: string;
  body?: string;
} = {};
```
On 0.20.10, the scanner correctly inferred `json` type. On 0.20.36, it fell through to `text`, breaking JSON round-trip serialization (objects stored as strings, retrieved without parsing).

## Test plan
- [x] Updated existing test: `should resolve inline object type aliases to object` (was `should skip complex type aliases`)
- [x] Added new test: `should infer json for inline object type literal (TSTypeLiteral)`
- [x] All 83 scanner tests pass