### PR TITLE
fix(release): add missing packages to changeset config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,6 +5,7 @@
   "fixed": [
     [
       "@happyvertical/smrt-ads",
+      "@happyvertical/smrt-affiliates",
       "@happyvertical/smrt-agents",
       "@happyvertical/smrt-analytics",
       "@happyvertical/smrt-assets",
@@ -28,6 +29,7 @@
       "@happyvertical/smrt-projects",
       "@happyvertical/smrt-properties",
       "@happyvertical/smrt-secrets",
+      "@happyvertical/smrt-sites",
       "@happyvertical/smrt-tags",
       "@happyvertical/smrt-tenancy",
       "@happyvertical/smrt-template-site-static-json",


### PR DESCRIPTION
## Summary
- Adds `@happyvertical/smrt-affiliates` and `@happyvertical/smrt-sites` to the changeset `fixed` array
- Both packages were created in feature PRs but never added to the config, causing them to stay at 0.20.34 while all other packages advanced to 0.20.37

## Test plan
- [ ] Next release publishes all packages at the same version