### PR TITLE
fix(core): use $lib paths for local objects with packageName set

### DIFF
--- a/packages/core/src/vite-plugin/sveltekit-generator.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.test.ts
@@ -470,6 +470,62 @@ describe('SvelteKit Route Generator', () => {
       expect(actionContent).toContain("getCollection<Meeting>('Meeting')");
     });
 
+    it('should use $lib path for local objects even when packageName is set', async () => {
+      const manifest: SmartObjectManifest = {
+        objects: {
+          '@myapp/dashboard:Invitation': {
+            className: 'Invitation',
+            collection: 'invitations',
+            packageName: '@myapp/dashboard',
+            filePath: '/test/project/src/lib/models/Invitation.ts',
+            fields: {},
+            methods: {
+              canBeRedeemed: {
+                name: 'canBeRedeemed',
+                parameters: [],
+                returnType: 'boolean',
+                isPublic: true,
+              },
+            },
+            decoratorConfig: {
+              api: {
+                include: ['get', 'canBeRedeemed'],
+              },
+            },
+          },
+        },
+      };
+
+      await generateSvelteKitRoutes(projectRoot, manifest, {
+        enabled: true,
+        routesDir: 'src/routes/api',
+        objectsDir: 'src/lib/models',
+      });
+
+      // Action route should use $lib path, NOT the packageName
+      const actionRoute = vi
+        .mocked(writeFileSync)
+        .mock.calls.find((call) =>
+          call[0]
+            .toString()
+            .includes('invitations/[id]/canBeRedeemed/+server.ts'),
+        );
+
+      expect(actionRoute).toBeDefined();
+      const content = actionRoute?.[1] as string;
+
+      // Should import via $lib, not from '@myapp/dashboard'
+      expect(content).toContain(
+        "import type { Invitation } from '$lib/models/Invitation'",
+      );
+      expect(content).not.toContain("from '@myapp/dashboard'");
+
+      // Should still use typed getCollection with qualified registry key
+      expect(content).toContain(
+        "getCollection<Invitation>('@myapp/dashboard:Invitation')",
+      );
+    });
+
     it('should extract simple class name from qualified names', async () => {
       const manifest: SmartObjectManifest = {
         objects: {

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -455,8 +455,24 @@ function getSvelteKitImportPath(
 }
 
 /**
+ * Check if an object's source file is local to the project (not in node_modules).
+ * The scanner sets packageName for all objects (including local ones from the
+ * project's own package.json), so we check the filePath to distinguish.
+ */
+function isLocalObject(
+  projectRoot: string,
+  objectDef: SmartObjectDefinition,
+): boolean {
+  if (!objectDef.filePath) return false;
+  return (
+    objectDef.filePath.startsWith(projectRoot) &&
+    !objectDef.filePath.includes('/node_modules/')
+  );
+}
+
+/**
  * Resolve the import statement for a SMRT model class.
- * External packages import from the package name, local objects use $lib paths.
+ * Local objects use $lib paths, external packages use the package/import path.
  */
 function resolveModelImport(
   projectRoot: string,
@@ -466,6 +482,21 @@ function resolveModelImport(
 ): { simpleClassName: string; importStatement: string } {
   const simpleClassName = extractSimpleClassName(className);
 
+  // Local objects (source files in the project, not node_modules) use $lib paths
+  if (isLocalObject(projectRoot, objectDef)) {
+    const importPath = getSvelteKitImportPath(
+      projectRoot,
+      objectDef.filePath,
+      options.objectsDir,
+      simpleClassName,
+    );
+    return {
+      simpleClassName,
+      importStatement: `import type { ${simpleClassName} } from '${importPath}';`,
+    };
+  }
+
+  // External packages: prefer importPath (subpath export) over packageName (root)
   const externalImportSource = objectDef.importPath ?? objectDef.packageName;
   if (externalImportSource) {
     return {
@@ -474,6 +505,7 @@ function resolveModelImport(
     };
   }
 
+  // Fallback: use $lib path from filePath
   const importPath = getSvelteKitImportPath(
     projectRoot,
     objectDef.filePath,


### PR DESCRIPTION
## Summary

Follow-up to #980. The manifest scanner sets `packageName` for all objects, including local ones from the project's own `package.json`. This caused the generated routes to import from the app's own package name (e.g., `from '@blindmanpress/dashboard'`) instead of using `$lib` paths — resulting in "Cannot find module" errors.

### Before
```typescript
// Generated for a local model — broken import
import type { Invitation } from '@blindmanpress/dashboard';
```

### After
```typescript
// Generated for a local model — correct $lib path
import type { Invitation } from '$lib/models/Invitation';
```

Added `isLocalObject()` helper that checks if `filePath` is inside `projectRoot` and outside `node_modules/` to distinguish local from external objects.

## Test plan

- [x] All 19 tests pass (18 existing + 1 new)
- [x] New test: local object with `packageName` set generates `$lib` import, not package import