### PR TITLE
fix(core): skip collection classes in SvelteKit route generator

### DIFF
--- a/packages/core/src/vite-plugin/sveltekit-generator.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.test.ts
@@ -944,4 +944,115 @@ describe('SvelteKit Route Generator', () => {
       consoleSpy.mockRestore();
     });
   });
+
+  describe('Collection Class Filtering', () => {
+    it('should skip collection classes and only generate routes for item classes', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const manifest: SmartObjectManifest = {
+        objects: {
+          Invitation: {
+            className: 'Invitation',
+            collection: 'invitations',
+            fields: {},
+            methods: {
+              canBeRedeemed: {
+                isPublic: true,
+                parameters: [],
+              },
+            },
+            decoratorConfig: { api: true },
+            filePath: '/test/project/src/lib/models/Invitation.ts',
+          },
+          InvitationCollection: {
+            className: 'InvitationCollection',
+            collection: 'invitations', // Same as Invitation (inherited by manifest-generator)
+            fields: {},
+            methods: {
+              findByToken: {
+                isPublic: true,
+                parameters: [{ name: 'token', type: 'string' }],
+              },
+            },
+            decoratorConfig: { api: true },
+            extends: 'SmrtCollection',
+            extendsTypeArg: 'Invitation',
+            filePath: '/test/project/src/lib/models/InvitationCollection.ts',
+          },
+        },
+      };
+
+      await generateSvelteKitRoutes(projectRoot, manifest, {
+        enabled: true,
+        routesDir: 'src/routes/api',
+        objectsDir: 'src/lib/objects',
+      });
+
+      // Should log that collection class was skipped
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[smrt] Skipping InvitationCollection - collection class (routes handled by item class)',
+      );
+
+      // Should report 1 generated + 1 skipped
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[smrt] Generated routes for 1 SMRT objects (skipped 1 collection classes)',
+      );
+
+      // Should generate routes for Invitation (item class)
+      const writeFileCalls = vi
+        .mocked(writeFileSync)
+        .mock.calls.map(([path]) => path as string);
+      const invitationRoutes = writeFileCalls.filter((p) =>
+        p.includes('invitations'),
+      );
+
+      // Should have collection route, item route, and canBeRedeemed action route
+      expect(invitationRoutes).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('invitations/+server.ts'),
+          expect.stringContaining('invitations/[id]/+server.ts'),
+          expect.stringContaining('invitations/[id]/canBeRedeemed/+server.ts'),
+        ]),
+      );
+
+      // Should NOT have findByToken route (that's on the collection class which was skipped)
+      const findByTokenRoutes = writeFileCalls.filter((p) =>
+        p.includes('findByToken'),
+      );
+      expect(findByTokenRoutes).toHaveLength(0);
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should not skip non-collection classes that happen to have extends set', async () => {
+      const manifest: SmartObjectManifest = {
+        objects: {
+          Meeting: {
+            className: 'Meeting',
+            collection: 'meetings',
+            fields: {},
+            methods: {},
+            decoratorConfig: { api: true },
+            extends: 'Event', // STI: extends Event, NOT SmrtCollection
+            filePath: '/test/project/src/lib/models/Meeting.ts',
+          },
+        },
+      };
+
+      await generateSvelteKitRoutes(projectRoot, manifest, {
+        enabled: true,
+        routesDir: 'src/routes/api',
+        objectsDir: 'src/lib/objects',
+      });
+
+      // Should generate routes for Meeting (it's an STI child, not a collection)
+      const writeFileCalls = vi
+        .mocked(writeFileSync)
+        .mock.calls.map(([path]) => path as string);
+      const meetingRoutes = writeFileCalls.filter((p) =>
+        p.includes('meetings'),
+      );
+      expect(meetingRoutes.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -37,6 +37,15 @@ function extractSimpleClassName(qualifiedName: string): string {
 }
 
 /**
+ * Check if an object definition represents a SmrtCollection class.
+ * Collection classes share route paths with their item class (via inherited `collection` field),
+ * so generating routes for both would cause file collisions.
+ */
+function isCollectionClass(objectDef: SmartObjectDefinition): boolean {
+  return objectDef.extends === 'SmrtCollection';
+}
+
+/**
  * Generates SvelteKit API routes from manifest
  */
 export async function generateSvelteKitRoutes(
@@ -51,15 +60,29 @@ export async function generateSvelteKitRoutes(
   // Generate centralized configuration file first (if it doesn't exist)
   await generateSmrtConfigFile(projectRoot, manifest, options);
 
+  let generatedCount = 0;
+  let skippedCollections = 0;
   for (const [className, objectDef] of Object.entries(manifest.objects)) {
+    if (isCollectionClass(objectDef)) {
+      console.log(
+        `[smrt] Skipping ${className} - collection class (routes handled by item class)`,
+      );
+      skippedCollections++;
+      continue;
+    }
     await generateRoutesForObject(projectRoot, className, objectDef, options);
+    generatedCount++;
   }
 
   // Update .gitignore to exclude generated routes
   updateGitignore(projectRoot, options);
 
+  const skippedMsg =
+    skippedCollections > 0
+      ? ` (skipped ${skippedCollections} collection classes)`
+      : '';
   console.log(
-    `[smrt] Generated routes for ${Object.keys(manifest.objects).length} SMRT objects`,
+    `[smrt] Generated routes for ${generatedCount} SMRT objects${skippedMsg}`,
   );
 }
 


### PR DESCRIPTION
## Summary

- Collection classes (extending `SmrtCollection`) inherit their item class's `collection` property from manifest-generator, causing both to generate routes at the same path
- The second file overwrites the first, losing typed imports and custom action routes (e.g., `canBeRedeemed`, `isPending`)
- Added `isCollectionClass()` check to skip collection classes during route generation — their item class's routes handle all REST operations
- Improved log output to report both generated and skipped counts

## Test plan

- [x] Added test: collection classes are skipped, only item class routes generated
- [x] Added test: STI child classes (extending Event, etc.) are NOT skipped
- [x] All 21 tests pass

Closes #982