### PR TITLE
fix(users): use in-memory filter for json override effects to fix postgres 500s

### DIFF
--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-users",
-  "version": "0.20.54",
+  "version": "0.20.55",
   "description": "Multi-tenant user management for the SMRT framework - users, tenants, roles, permissions, groups",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/users/src/collections/MembershipOverrideCollection.ts
+++ b/packages/users/src/collections/MembershipOverrideCollection.ts
@@ -23,21 +23,26 @@ export class MembershipOverrideCollection extends SmrtCollection<MembershipOverr
   }
 
   /**
-   * Find grant overrides for a membership
+   * Find grant overrides for a membership.
+   *
+   * Filters in memory because the `effect` column is JSON-typed and
+   * Postgres rejects bare `json = text` comparisons.  A single
+   * `findByMembership` call is reused for both grant and deny lookups
+   * within the same request (see `_overridesByMembership` cache).
    */
   async findGrants(membershipId: string): Promise<MembershipOverride[]> {
-    return await this.list({
-      where: { membershipId, effect: OverrideEffect.GRANT },
-    });
+    const all = await this.findByMembership(membershipId);
+    return all.filter((o) => o.effect === OverrideEffect.GRANT);
   }
 
   /**
-   * Find deny overrides for a membership
+   * Find deny overrides for a membership.
+   *
+   * See `findGrants` for rationale on in-memory filtering.
    */
   async findDenies(membershipId: string): Promise<MembershipOverride[]> {
-    return await this.list({
-      where: { membershipId, effect: OverrideEffect.DENY },
-    });
+    const all = await this.findByMembership(membershipId);
+    return all.filter((o) => o.effect === OverrideEffect.DENY);
   }
 
   /**

--- a/packages/users/src/collections/TenantPermissionOverrideCollection.ts
+++ b/packages/users/src/collections/TenantPermissionOverrideCollection.ts
@@ -38,30 +38,35 @@ export class TenantPermissionOverrideCollection extends SmrtCollection<TenantPer
   }
 
   /**
-   * Find grant overrides for a tenant
+   * Find grant overrides for a tenant.
+   *
+   * Filters in memory because the `effect` column is JSON-typed and
+   * Postgres rejects bare `json = text` comparisons.  A single
+   * `findByTenant` call is reused for grant, deny, and inherit lookups.
    */
   async findGrants(tenantId: string): Promise<TenantPermissionOverride[]> {
-    return await this.list({
-      where: { tenantId, effect: TenantPermissionEffect.GRANT },
-    });
+    const all = await this.findByTenant(tenantId);
+    return all.filter((o) => o.effect === TenantPermissionEffect.GRANT);
   }
 
   /**
-   * Find deny overrides for a tenant
+   * Find deny overrides for a tenant.
+   *
+   * See `findGrants` for rationale on in-memory filtering.
    */
   async findDenies(tenantId: string): Promise<TenantPermissionOverride[]> {
-    return await this.list({
-      where: { tenantId, effect: TenantPermissionEffect.DENY },
-    });
+    const all = await this.findByTenant(tenantId);
+    return all.filter((o) => o.effect === TenantPermissionEffect.DENY);
   }
 
   /**
-   * Find inherit overrides for a tenant
+   * Find inherit overrides for a tenant.
+   *
+   * See `findGrants` for rationale on in-memory filtering.
    */
   async findInherits(tenantId: string): Promise<TenantPermissionOverride[]> {
-    return await this.list({
-      where: { tenantId, effect: TenantPermissionEffect.INHERIT },
-    });
+    const all = await this.findByTenant(tenantId);
+    return all.filter((o) => o.effect === TenantPermissionEffect.INHERIT);
   }
 
   /**


### PR DESCRIPTION
Fixes a 500 error in Postgres when trying to cast JSON to unknown type during override effect filtering. This moves the `effect` filter to memory for both `MembershipOverrideCollection` and `TenantPermissionOverrideCollection`.