### PR TITLE
chore(release): recover v0.20.56 release metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "smrt framework for building vertical AI agents",
   "author": "Will Griffin <willgriffin@gmail.com>",
   "type": "module",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "scripts": {
     "format": "turbo format",
     "format-check": "turbo format-check",

--- a/packages/ads/CHANGELOG.md
+++ b/packages/ads/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-ads
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-assets@0.20.56
+  - @happyvertical/smrt-commerce@0.20.56
+  - @happyvertical/smrt-properties@0.20.56
+  - @happyvertical/smrt-tags@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/ads/package.json
+++ b/packages/ads/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-ads",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Advertising delivery and tracking models for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/affiliates/CHANGELOG.md
+++ b/packages/affiliates/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-affiliates
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-ads@0.20.56
+  - @happyvertical/smrt-commerce@0.20.56
+  - @happyvertical/smrt-profiles@0.20.56
+  - @happyvertical/smrt-properties@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/affiliates/package.json
+++ b/packages/affiliates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-affiliates",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Affiliate partner and commission tracking models for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/CHANGELOG.md
+++ b/packages/agents/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-agents
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+  - @happyvertical/smrt-config@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-agents",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "type": "module",
   "description": "Agent framework for building autonomous actors in the SMRT ecosystem",
   "author": "HappyVertical",

--- a/packages/analytics/CHANGELOG.md
+++ b/packages/analytics/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-analytics
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-analytics",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Analytics integration models for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/assets/CHANGELOG.md
+++ b/packages/assets/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-assets
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-tags@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-assets",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Asset management system with versioning, metadata, and AI-powered operations for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/chat/CHANGELOG.md
+++ b/packages/chat/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-chat
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-agents@0.20.56
+  - @happyvertical/smrt-profiles@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+  - @happyvertical/smrt-svelte@0.20.56
+  - @happyvertical/smrt-types@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-chat",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Chat rooms, DMs, threads, and agent conversations for the SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-cli
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-agents@0.20.56
+  - @happyvertical/smrt-config@0.20.56
+  - @happyvertical/smrt-types@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-cli",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Developer CLI for SMRT framework - introspection, testing, and project management",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/commerce/CHANGELOG.md
+++ b/packages/commerce/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-commerce
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-ledgers@0.20.56
+  - @happyvertical/smrt-profiles@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+  - @happyvertical/smrt-svelte@0.20.56
+  - @happyvertical/smrt-types@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/commerce/package.json
+++ b/packages/commerce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-commerce",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Commerce models for the SMRT framework - contracts, fulfillments, payments",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-config
 
+## 0.20.56
+
 ## 0.20.54
 
 ## 0.20.53

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-config",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "type": "module",
   "description": "Centralized configuration management for SMRT modules",
   "author": "HappyVertical",

--- a/packages/content/CHANGELOG.md
+++ b/packages/content/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-content
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-assets@0.20.56
+  - @happyvertical/smrt-images@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-content",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Content processing module for SMRT framework - handles documents, web content, and media",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @happyvertical/smrt-core
 
+## 0.20.56
+
+### Patch Changes
+
+- ### Features
+
+  - Add UI components and Material Design updates (#1023) (images)
+
+  ### Bug Fixes
+
+  - use in-memory filter for json override effects to fix postgres 500s (#1025) (users)
+  - @happyvertical/smrt-scanner@0.20.56
+  - @happyvertical/smrt-config@0.20.56
+  - @happyvertical/smrt-types@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-core",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Core AI agent framework with standardized collections, object-relational mapping, and code generators",
   "author": "Will Griffin <willgriffin@gmail.com>",
   "type": "module",

--- a/packages/events/CHANGELOG.md
+++ b/packages/events/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-events
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-places@0.20.56
+  - @happyvertical/smrt-profiles@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+  - @happyvertical/smrt-types@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-events",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Hierarchical event management with participant tracking and SMRT framework support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/facts/CHANGELOG.md
+++ b/packages/facts/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-facts
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/facts/package.json
+++ b/packages/facts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-facts",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Distributed memory and knowledge management with provenance tracking for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gnode/CHANGELOG.md
+++ b/packages/gnode/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-gnode
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/gnode/package.json
+++ b/packages/gnode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-gnode",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "SMRT federation library for building federated local knowledge bases (gnodes)",
   "author": "Will Griffin <willgriffin@gmail.com>",
   "type": "module",

--- a/packages/images/CHANGELOG.md
+++ b/packages/images/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-images
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-assets@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/images/package.json
+++ b/packages/images/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-images",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Image asset management with AI-powered categorization, search, editing, and metadata extraction for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/jobs/CHANGELOG.md
+++ b/packages/jobs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-jobs
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-svelte@0.20.56
+  - @happyvertical/smrt-config@0.20.56
+  - @happyvertical/smrt-types@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-jobs",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Background job processing for SMRT objects with persistence and scheduling",
   "author": "Will Griffin <willgriffin@gmail.com>",
   "type": "module",

--- a/packages/ledgers/CHANGELOG.md
+++ b/packages/ledgers/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-ledgers
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/ledgers/package.json
+++ b/packages/ledgers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-ledgers",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Double-entry accounting ledger for the SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/messages/CHANGELOG.md
+++ b/packages/messages/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-messages
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-secrets@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+  - @happyvertical/smrt-svelte@0.20.56
+  - @happyvertical/smrt-types@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-messages",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Unified multi-channel messaging with STI-based hierarchies",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/places/CHANGELOG.md
+++ b/packages/places/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-places
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/places/package.json
+++ b/packages/places/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-places",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Hierarchical place management with geo integration and SMRT framework support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/products/CHANGELOG.md
+++ b/packages/products/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-products
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/products/package.json
+++ b/packages/products/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-products",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "SMRT products module: triple-purpose microservice template for standalone apps, federated modules, and NPM libraries",
   "author": "Will Griffin <willgriffin@gmail.com>",
   "type": "module",

--- a/packages/profiles/CHANGELOG.md
+++ b/packages/profiles/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-profiles
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/profiles/package.json
+++ b/packages/profiles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-profiles",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Profile management system with relationships, metadata, and reciprocal associations for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/projects/CHANGELOG.md
+++ b/packages/projects/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-projects
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+  - @happyvertical/smrt-svelte@0.20.56
+  - @happyvertical/smrt-config@0.20.56
+  - @happyvertical/smrt-types@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/projects/package.json
+++ b/packages/projects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-projects",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Provider-agnostic project management models (Issues, PRs, Repositories, Projects) for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/properties/CHANGELOG.md
+++ b/packages/properties/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-properties
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-profiles@0.20.56
+  - @happyvertical/smrt-projects@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/properties/package.json
+++ b/packages/properties/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-properties",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Digital property and zone management models for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/scanner/CHANGELOG.md
+++ b/packages/scanner/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-scanner
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-scanner",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "High-performance TypeScript scanner using OXC for SMRT manifest generation",
   "author": "Will Griffin <willgriffin@gmail.com>",
   "type": "module",

--- a/packages/secrets/CHANGELOG.md
+++ b/packages/secrets/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-secrets
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/secrets/package.json
+++ b/packages/secrets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-secrets",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Per-tenant secret management with envelope encryption for SMRT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sites/CHANGELOG.md
+++ b/packages/sites/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-sites
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-agents@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-sites",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Site lifecycle management for multi-tenant SMRT networks",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-dev-mcp/CHANGELOG.md
+++ b/packages/smrt-dev-mcp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-dev-mcp
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/smrt-dev-mcp/package.json
+++ b/packages/smrt-dev-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-dev-mcp",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Development MCP server for SMRT framework - Code generation and project introspection",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-svelte/CHANGELOG.md
+++ b/packages/smrt-svelte/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-svelte
 
+## 0.20.56
+
+### Patch Changes
+
+- @happyvertical/smrt-agents@0.20.56
+- @happyvertical/smrt-jobs@0.20.56
+- @happyvertical/smrt-profiles@0.20.56
+- @happyvertical/smrt-users@0.20.56
+- @happyvertical/smrt-types@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-svelte",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Svelte 5 components for SMRT user management - auth, users, tenants, roles, permissions, groups",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/social/CHANGELOG.md
+++ b/packages/social/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-social
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-content@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+  - @happyvertical/smrt-video@0.20.56
+  - @happyvertical/smrt-config@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-social",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "type": "module",
   "description": "Social media account management for multi-platform publishing in the SMRT ecosystem",
   "author": "HappyVertical",

--- a/packages/tags/CHANGELOG.md
+++ b/packages/tags/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-tags
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-tags",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Reusable tagging system with hierarchies, contexts, and multi-language support for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/template-site-static-json/CHANGELOG.md
+++ b/packages/template-site-static-json/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-template-site-static-json
 
+## 0.20.56
+
 ## 0.20.54
 
 ## 0.20.53

--- a/packages/template-site-static-json/package.json
+++ b/packages/template-site-static-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-template-site-static-json",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Static community site template with JSON data storage and SMRT framework",
   "type": "module",
   "main": "index.js",

--- a/packages/template-sveltekit/CHANGELOG.md
+++ b/packages/template-sveltekit/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-template-sveltekit
 
+## 0.20.56
+
 ## 0.20.54
 
 ## 0.20.53

--- a/packages/template-sveltekit/package.json
+++ b/packages/template-sveltekit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-template-sveltekit",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "SvelteKit project template with SMRT framework integration",
   "type": "module",
   "main": "index.js",

--- a/packages/tenancy/CHANGELOG.md
+++ b/packages/tenancy/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-tenancy
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/tenancy/package.json
+++ b/packages/tenancy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-tenancy",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Production-ready multi-tenancy framework for SMRT with automatic tenant isolation and enforcement",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-types
 
+## 0.20.56
+
 ## 0.20.54
 
 ## 0.20.53

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-types",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Shared type definitions for the HAVE SDK",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/users/CHANGELOG.md
+++ b/packages/users/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-users
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-types@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-users",
-  "version": "0.20.55",
+  "version": "0.20.56",
   "description": "Multi-tenant user management for the SMRT framework - users, tenants, roles, permissions, groups",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/video/CHANGELOG.md
+++ b/packages/video/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @happyvertical/smrt-video
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-assets@0.20.56
+  - @happyvertical/smrt-content@0.20.56
+  - @happyvertical/smrt-profiles@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+  - @happyvertical/smrt-voice@0.20.56
+  - @happyvertical/smrt-config@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/video/package.json
+++ b/packages/video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-video",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "type": "module",
   "description": "Video content management for AI-powered video production in the SMRT ecosystem",
   "author": "HappyVertical",

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-vitest
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-vitest",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "description": "Vitest plugin for automatic cross-package manifest loading in SMRT tests",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/voice/CHANGELOG.md
+++ b/packages/voice/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-voice
 
+## 0.20.56
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.20.56
+  - @happyvertical/smrt-assets@0.20.56
+  - @happyvertical/smrt-content@0.20.56
+  - @happyvertical/smrt-tenancy@0.20.56
+  - @happyvertical/smrt-config@0.20.56
+
 ## 0.20.54
 
 ### Patch Changes

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-voice",
-  "version": "0.20.54",
+  "version": "0.20.56",
   "type": "module",
   "description": "Voice profile management for AI-powered voice synthesis and cloning in the SMRT ecosystem",
   "author": "HappyVertical",


### PR DESCRIPTION
This recovers the missing version/changelog commit for v0.20.56 after the publish workflow successfully pushed packages to GitHub Packages but failed before it could push the release commit back to the repository.

What this PR does:
- syncs root and workspace package versions to 0.20.56
- restores the generated changelog entries from changesets
- aligns main with the already-published v0.20.56 packages

Release tag already exists: v0.20.56