### PR TITLE
fix(release): support squash merge titles

### DIFF
--- a/CHANGESETS.md
+++ b/CHANGESETS.md
@@ -8,7 +8,7 @@ This project uses [Changesets](https://github.com/changesets/changesets) for ver
 
 No selective commit types, no manual changeset creation needed. The workflow is:
 
-1. Create PR with conventional commits
+1. Create PR with conventional commits when possible
 2. Tests pass, merge to main
 3. Version bumps automatically (patch, or minor for breaking changes)
 4. Packages published to GitHub Packages
@@ -37,7 +37,7 @@ BREAKING CHANGE: method signature changed"
 
 ## Commit Format
 
-Use conventional commits:
+Use conventional commits when possible:
 
 ```
 type(scope): description
@@ -58,6 +58,10 @@ feat(core)!: breaking change
 - `svelte`, `tags`, `dev-mcp`, `docs-mcp`
 
 **No scope** = affects all packages
+
+Squash-merge PR titles like `smrt#1069: normalize video owned asset models (#1071)`
+or `Follow up smrt#1063 owned asset helper refactor (#1072)` also trigger a
+patch release when they land on `main`.
 
 ## What Happens When You Merge?
 
@@ -100,9 +104,10 @@ node scripts/check-version-limit.js
 
 ### "No conventional commits found"
 
-The auto-changeset script requires at least one commit following conventional format.
-
-**Fix**: Ensure commits use format `type(scope): description`
+The auto-changeset script prefers conventional commits, but squash-merge PR
+titles also count as releasable patch changes. If a merge still doesn't
+release, check that the commit subject isn't empty and that it landed after
+the latest release tag.
 
 ### Version check fails
 

--- a/scripts/auto-changeset.ts
+++ b/scripts/auto-changeset.ts
@@ -22,6 +22,7 @@ interface ParsedCommit {
   message: string;
   body?: string;
   hash: string;
+  source: 'conventional' | 'fallback';
 }
 
 function exec(command: string): string {
@@ -72,8 +73,18 @@ function parseConventionalCommit(commitLine: string): ParsedCommit | null {
   const match = subject.match(/^(\w+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/);
 
   if (!match) {
-    console.log(`Skipping non-conventional commit: ${subject}`);
-    return null;
+    const message = normalizeFallbackMessage(subject);
+    console.log(
+      `Treating non-conventional commit as patch release input: ${subject}`,
+    );
+    return {
+      type: 'fallback',
+      breaking: false,
+      message,
+      body,
+      hash: hash.substring(0, 7),
+      source: 'fallback',
+    };
   }
 
   const [, type, scope, breaking, message] = match;
@@ -88,7 +99,15 @@ function parseConventionalCommit(commitLine: string): ParsedCommit | null {
     message: message.trim(),
     body,
     hash: hash.substring(0, 7),
+    source: 'conventional',
   };
+}
+
+function normalizeFallbackMessage(subject: string): string {
+  return subject
+    .replace(/\s+\(#\d+\)\s*$/, '')
+    .replace(/^[a-z0-9_-]+#\d+:\s*/i, '')
+    .trim();
 }
 
 function determineVersionBump(
@@ -111,8 +130,13 @@ function generateChangesetContent(
   const features = commits.filter((c) => c.type === 'feat' && !c.breaking);
   const fixes = commits.filter((c) => c.type === 'fix' && !c.breaking);
   const other = commits.filter(
-    (c) => !c.breaking && c.type !== 'feat' && c.type !== 'fix',
+    (c) =>
+      !c.breaking &&
+      c.type !== 'feat' &&
+      c.type !== 'fix' &&
+      c.type !== 'fallback',
   );
+  const fallback = commits.filter((c) => c.type === 'fallback');
 
   let content = `---\n`;
   // Use @happyvertical/smrt-core as representative package (all packages in fixed group will bump together)
@@ -147,6 +171,14 @@ function generateChangesetContent(
     content += `### Other Changes\n\n`;
     other.forEach((c) => {
       content += `- ${c.type}: ${c.message}${c.scope ? ` (${c.scope})` : ''}\n`;
+    });
+    content += `\n`;
+  }
+
+  if (fallback.length > 0) {
+    content += `### Merged Changes\n\n`;
+    fallback.forEach((c) => {
+      content += `- ${c.message}\n`;
     });
   }
 
@@ -186,17 +218,19 @@ function main() {
     .filter((c): c is ParsedCommit => c !== null);
 
   if (parsedCommits.length === 0) {
-    console.log('ℹ️  No conventional commits found');
+    console.log('ℹ️  No releasable commits found');
     return;
   }
 
   const bump = determineVersionBump(parsedCommits);
+  const fallbackCommits = parsedCommits.filter((c) => c.source === 'fallback');
 
   console.log(`📦 Version bump: ${bump}`);
-  console.log(`   - ${parsedCommits.length} conventional commits`);
+  console.log(`   - ${parsedCommits.length} releasable commits`);
   console.log(
     `   - ${parsedCommits.filter((c) => c.breaking).length} breaking changes`,
   );
+  console.log(`   - ${fallbackCommits.length} fallback patch commits`);
 
   // Generate changeset
   const changesetId = randomBytes(8).toString('hex');


### PR DESCRIPTION
## Summary
- treat non-conventional squash merge titles as fallback patch release inputs instead of skipping them
- keep conventional commits as the source of breaking-change detection
- document that squash-merge PR titles like smrt#1069: ... also trigger releases

## Testing
- git diff --check
- did not run package tests locally