### PR TITLE
fix(content): invoke content list add callback

### DIFF
--- a/packages/content/src/svelte/components/ContentList.svelte
+++ b/packages/content/src/svelte/components/ContentList.svelte
@@ -169,7 +169,7 @@ function handleDeleteContent(content: any) {
         </button>
       </div>
       
-      <button class="add-button" onclick={onAdd}>
+      <button class="add-button" type="button" onclick={() => onAdd()}>
         <svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none">
           <line x1="12" y1="5" x2="12" y2="19"></line>
           <line x1="5" y1="12" x2="19" y2="12"></line>


### PR DESCRIPTION
## Summary
- wrap `ContentList`'s add button callback so it invokes the supplied handler explicitly
- mark the add button as `type="button"` so it does not submit when embedded in a form context

## Why
While adopting `ContentList` in `anytown.ai` on `smrt-content@0.21.14`, the list rendered and its internal filtering worked, and edit navigation worked, but the `Add Content` button did not fire navigation. The add button was the only action wired directly as `onclick={onAdd}` instead of an inline callback.

## Verification
- `pnpm -C packages/content check`
- browser repro from `anytown.ai` against `http://127.0.0.1:4173/bentleyalberta/content`
  - before: `Add Content` did not navigate, `Edit` did
  - after this change, downstream can consume the fix once published
