### PR TITLE
fix(ci): use mounted pnpm store on ARC runners

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -99,9 +99,9 @@ runs:
         NODE_OPTIONS: --disable-warning=DEP0169
         NPM_TOKEN: ${{ inputs.auth-token }}
       run: |
-        store_root="${PNPM_STORE_DIR:-/home/runner/.local/share/pnpm/store}"
+        store_root="${PNPM_STORE_DIR:-$HOME/.local/share/pnpm/store}"
         mkdir -p "$store_root"
-        pnpm config set store-dir "$store_root" --location=user
+        pnpm config set store-dir "$store_root" --location=global
 
     - name: Get pnpm store directory
       id: pnpm-store


### PR DESCRIPTION
## Summary
- configure pnpm to use the mounted ARC tmpfs store before resolving the cache path
- keep dependency installs on the shared RAM-backed cache exposed by arc-happyvertical

## Why
Live arc-happyvertical runners expose the persistent pnpm cache at `/home/runner/.local/share/pnpm/store`, but pnpm defaults to `/home/runner/.pnpm-store/v10` unless `store-dir` is set explicitly. That means workflow installs miss the shared tmpfs cache and rebuild more work than necessary.