### PR TITLE
[codex] Add code-first feature flags package

### DIFF
--- a/packages/core/src/__tests__/external-runtime-hydration.test.ts
+++ b/packages/core/src/__tests__/external-runtime-hydration.test.ts
@@ -330,6 +330,68 @@ describe('external runtime field hydration', () => {
     expect(hydratedField?._meta?.description).toBe('Fallback hydrated status');
   });
 
+  it('hydrates feature decorator metadata from installed manifests', async () => {
+    const packageName = '@happyvertical/smrt-runtime-fixture-features';
+
+    writeScopedPackage(
+      appDir,
+      packageName,
+      fixtureManifest(packageName, {
+        FixtureFeaturefulAccount: {
+          decoratorConfig: {
+            tableStrategy: 'sti',
+            tableName: 'fixture_featureful_accounts',
+            api: false,
+            cli: false,
+            mcp: false,
+            features: {
+              newEditor: {
+                defaultEnabled: false,
+                label: 'New Editor',
+                description: 'Gradual editor rollout',
+                metadata: {
+                  audience: 'staff',
+                },
+              },
+            },
+          },
+          fields: {
+            name: { type: 'text' },
+          },
+        },
+      }),
+    );
+
+    @smrt({
+      tableStrategy: 'sti',
+      tableName: 'fixture_featureful_accounts',
+      api: false,
+      cli: false,
+      mcp: false,
+    })
+    class FixtureFeaturefulAccount extends SmrtObject {
+      @field()
+      name: string = '';
+    }
+
+    stripPackageIdentity('FixtureFeaturefulAccount');
+
+    await ObjectRegistry.ensureManifestLoaded('FixtureFeaturefulAccount');
+
+    expect(
+      ObjectRegistry.getConfig('FixtureFeaturefulAccount').features,
+    ).toEqual({
+      newEditor: {
+        defaultEnabled: false,
+        label: 'New Editor',
+        description: 'Gradual editor rollout',
+        metadata: {
+          audience: 'staff',
+        },
+      },
+    });
+  });
+
   it('includes parent manifest fields when a local STI class extends a sparse external parent', async () => {
     const packageName = '@happyvertical/smrt-runtime-fixture-analytics';
 

--- a/packages/core/src/__tests__/issue-176-transient-fields.test.ts
+++ b/packages/core/src/__tests__/issue-176-transient-fields.test.ts
@@ -59,7 +59,7 @@ describe('Issue #176: Transient fields', () => {
   beforeEach(async () => {
     dbPath = join(tmpdir(), `test-transient-${randomUUID().slice(0, 8)}.db`);
     db = await getTestDatabase({ type: 'sqlite', url: dbPath });
-  });
+  }, 120000);
 
   afterEach(async () => {
     if (db && typeof db.close === 'function') {

--- a/packages/core/src/generators/rest.ts
+++ b/packages/core/src/generators/rest.ts
@@ -223,7 +223,13 @@ export class APIGenerator {
       }
 
       // Use registered collection directly
-      return await this.executeCrudOperation(req, collection, objectId, url);
+      return await this.executeCrudOperation(
+        req,
+        collection,
+        objectId,
+        url,
+        this.getCollectionObjectName(collection) || objectType,
+      );
     }
 
     // Fall back to auto-discovery via ObjectRegistry
@@ -264,7 +270,13 @@ export class APIGenerator {
     // Get or create collection
     const collection = this.getCollection(classInfo);
 
-    return await this.executeCrudOperation(req, collection, objectId, url);
+    return await this.executeCrudOperation(
+      req,
+      collection,
+      objectId,
+      url,
+      classInfo.name,
+    );
   }
 
   /**
@@ -275,8 +287,14 @@ export class APIGenerator {
     collection: SmrtCollection<any>,
     objectId: string | undefined,
     url: URL,
+    objectName?: string,
   ): Promise<Response> {
     try {
+      const action = this.getCrudAction(req.method, objectId);
+      if (action && !this.isApiActionEnabled(objectName, action)) {
+        return this.createErrorResponse(405, 'Method not allowed');
+      }
+
       // Handle special /count endpoint
       if (objectId === 'count' && req.method === 'GET') {
         return await this.handleCount(collection, url.searchParams);
@@ -318,6 +336,63 @@ export class APIGenerator {
       console.error('API Error:', error);
       return this.createErrorResponse(500, 'Internal server error');
     }
+  }
+
+  private getCrudAction(
+    method: string,
+    objectId: string | undefined,
+  ): 'list' | 'get' | 'create' | 'update' | 'delete' | null {
+    switch (method) {
+      case 'GET':
+        return objectId && objectId !== 'count' ? 'get' : 'list';
+      case 'POST':
+        return 'create';
+      case 'PUT':
+      case 'PATCH':
+        return 'update';
+      case 'DELETE':
+        return 'delete';
+      default:
+        return null;
+    }
+  }
+
+  private isApiActionEnabled(
+    objectName: string | undefined,
+    action: 'list' | 'get' | 'create' | 'update' | 'delete',
+  ): boolean {
+    if (!objectName) {
+      return true;
+    }
+
+    const config = ObjectRegistry.getConfig(objectName);
+    const apiConfig = config.api;
+
+    if (apiConfig === false) {
+      return false;
+    }
+
+    if (apiConfig && typeof apiConfig === 'object') {
+      if (apiConfig.include && !apiConfig.include.includes(action)) {
+        return false;
+      }
+
+      if (apiConfig.exclude?.includes(action)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private getCollectionObjectName(
+    collection: SmrtCollection<any>,
+  ): string | undefined {
+    const itemClass =
+      (collection as any)._itemClass ||
+      (collection.constructor as any)?._itemClass;
+
+    return itemClass?.name;
   }
 
   /**

--- a/packages/core/src/generators/rest.ts
+++ b/packages/core/src/generators/rest.ts
@@ -392,7 +392,12 @@ export class APIGenerator {
       (collection as any)._itemClass ||
       (collection.constructor as any)?._itemClass;
 
-    return itemClass?.name;
+    if (!itemClass) {
+      return undefined;
+    }
+
+    const registered = ObjectRegistry.getClassByConstructor(itemClass);
+    return registered?.qualifiedName || registered?.name || itemClass.name;
   }
 
   /**

--- a/packages/core/src/registry.test.ts
+++ b/packages/core/src/registry.test.ts
@@ -1088,6 +1088,66 @@ describe('ObjectRegistry', () => {
         ObjectRegistry.getAllSchemas().external_tenant_scoped_secrets?.ddl,
       ).toContain('"tenant_id"');
     });
+
+    it('should preserve feature declarations from external decorator config', () => {
+      class ExternalFeaturefulSecret extends SmrtObject {
+        name: string = '';
+      }
+
+      Object.defineProperty(ExternalFeaturefulSecret, 'name', {
+        value: 'ExternalFeaturefulSecret',
+        configurable: true,
+      });
+
+      ObjectRegistry.register(ExternalFeaturefulSecret as any, {
+        name: 'ExternalFeaturefulSecret',
+        packageName: '@test/pkg',
+        _manifest: {
+          objects: {
+            ExternalFeaturefulSecret: {
+              className: 'ExternalFeaturefulSecret',
+              fields: {
+                name: { type: 'text' },
+              },
+              decoratorConfig: {
+                features: {
+                  newDashboard: {
+                    defaultEnabled: false,
+                    label: 'New Dashboard',
+                    description: 'Roll out the new dashboard experience',
+                    metadata: {
+                      tier: 'premium',
+                    },
+                  },
+                },
+              },
+              schema: {
+                tableName: 'external_featureful_secrets',
+                ddl: '',
+                columns: {},
+                indexes: [],
+                version: 'test',
+              },
+            },
+          },
+        } as any,
+      });
+
+      const registered = ObjectRegistry.getClassByConstructor(
+        ExternalFeaturefulSecret as any,
+      );
+
+      expect(registered?.config.features).toEqual({
+        newDashboard: {
+          defaultEnabled: false,
+          label: 'New Dashboard',
+          description: 'Roll out the new dashboard experience',
+          metadata: {
+            tier: 'premium',
+          },
+        },
+      });
+    });
   });
 
   describe('Mixed Field helpers and primitives (Issue #102, #103)', () => {

--- a/packages/core/src/registry/types.ts
+++ b/packages/core/src/registry/types.ts
@@ -424,6 +424,41 @@ export interface SmartObjectConfig {
       };
 
   /**
+   * Code-owned feature toggle declarations for this class.
+   *
+   * Feature definitions live in code and can be synced into runtime metadata
+   * stores by downstream packages (for example `@happyvertical/smrt-features`).
+   * Each feature is identified by a class-local key that becomes part of the
+   * canonical feature key `<qualifiedClassName>#<localId>`.
+   *
+   * V1 supports boolean flags only.
+   */
+  features?: Record<
+    string,
+    {
+      /**
+       * Default enabled state before runtime overrides are applied.
+       */
+      defaultEnabled: boolean;
+
+      /**
+       * Human-friendly label for admin UIs and generated docs.
+       */
+      label?: string;
+
+      /**
+       * Optional description explaining what the feature does.
+       */
+      description?: string;
+
+      /**
+       * Additional code-owned metadata for applications.
+       */
+      metadata?: Record<string, unknown>;
+    }
+  >;
+
+  /**
    * Agent metadata configuration
    *
    * Only relevant for classes extending Agent. Provides metadata

--- a/packages/features/CHANGELOG.md
+++ b/packages/features/CHANGELOG.md
@@ -1,0 +1,3 @@
+# @happyvertical/smrt-features
+
+Initial development version in this workspace.

--- a/packages/features/CLAUDE.md
+++ b/packages/features/CLAUDE.md
@@ -1,0 +1,5 @@
+# smrt-features
+
+- Feature definitions are code-owned and mirrored into `_smrt_feature_definitions`.
+- Runtime override state lives in `_smrt_feature_overrides`.
+- Tenant hierarchy support is optional and resolved via `@happyvertical/smrt-users` when available.

--- a/packages/features/README.md
+++ b/packages/features/README.md
@@ -1,0 +1,3 @@
+# @happyvertical/smrt-features
+
+Code-first feature flags for SMRT with global overrides, tenant overrides, and optional tenant-hierarchy resolution through `@happyvertical/smrt-users`.

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@happyvertical/smrt-features",
+  "version": "0.21.39",
+  "description": "Code-first feature flags and tenant-aware overrides for the SMRT framework",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "CLAUDE.md"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./manifest": "./dist/manifest.json",
+    "./manifest.json": "./dist/manifest.json"
+  },
+  "scripts": {
+    "build": "vite build --mode library",
+    "build:watch": "vite build --mode library --watch",
+    "clean": "rm -rf dist",
+    "dev": "vite dev",
+    "prepack": "npm run build && npm run verify:pack",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
+  },
+  "dependencies": {
+    "@happyvertical/smrt-core": "workspace:*"
+  },
+  "peerDependencies": {
+    "@happyvertical/smrt-users": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@happyvertical/smrt-users": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@happyvertical/smrt-cli": "workspace:*",
+    "@happyvertical/smrt-users": "workspace:*",
+    "@happyvertical/smrt-vitest": "workspace:*",
+    "@types/node": "25.0.9",
+    "typescript": "^5.9.3",
+    "vite": "^7.3.1",
+    "vitest": "^4.0.17"
+  },
+  "keywords": [
+    "smrt",
+    "feature-flags",
+    "feature-toggles",
+    "multi-tenant",
+    "rollout"
+  ],
+  "author": "HAVE Team",
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  }
+}

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -42,7 +42,7 @@
     "@happyvertical/smrt-cli": "workspace:*",
     "@happyvertical/smrt-users": "workspace:*",
     "@happyvertical/smrt-vitest": "workspace:*",
-    "@types/node": "25.0.9",
+    "@types/node": "24.10.9",
     "typescript": "^5.9.3",
     "vite": "^7.3.1",
     "vitest": "^4.0.17"

--- a/packages/features/src/feature-definition.ts
+++ b/packages/features/src/feature-definition.ts
@@ -1,0 +1,54 @@
+import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import type { FeatureDefinitionOptions, FeatureMetadata } from './types.js';
+import { parseFeatureMetadata, serializeFeatureMetadata } from './utils.js';
+
+@smrt({
+  tableName: '_smrt_feature_definitions',
+  api: { include: ['list', 'get'] },
+  cli: { include: ['list', 'get'], exclude: ['getMetadata', 'setMetadata'] },
+  mcp: { include: ['list', 'get'], exclude: ['getMetadata', 'setMetadata'] },
+  conflictColumns: ['feature_key'],
+})
+export class FeatureDefinition extends SmrtObject {
+  featureKey: string = '';
+  packageName: string = '';
+  qualifiedClassName: string = '';
+  className: string = '';
+  localId: string = '';
+  defaultEnabled: boolean = false;
+  label: string = '';
+  description: string = '';
+  metadata: string = '';
+  visibility: string = 'public';
+
+  constructor(options: FeatureDefinitionOptions = {}) {
+    super(options);
+
+    if (options.featureKey !== undefined) this.featureKey = options.featureKey;
+    if (options.packageName !== undefined)
+      this.packageName = options.packageName;
+    if (options.qualifiedClassName !== undefined) {
+      this.qualifiedClassName = options.qualifiedClassName;
+    }
+    if (options.className !== undefined) this.className = options.className;
+    if (options.localId !== undefined) this.localId = options.localId;
+    if (options.defaultEnabled !== undefined) {
+      this.defaultEnabled = options.defaultEnabled;
+    }
+    if (options.label !== undefined) this.label = options.label;
+    if (options.description !== undefined)
+      this.description = options.description;
+    if (options.visibility !== undefined) this.visibility = options.visibility;
+    if (options.metadata !== undefined) {
+      this.metadata = serializeFeatureMetadata(options.metadata);
+    }
+  }
+
+  getMetadata(): FeatureMetadata {
+    return parseFeatureMetadata(this.metadata);
+  }
+
+  setMetadata(metadata: FeatureMetadata | null): void {
+    this.metadata = serializeFeatureMetadata(metadata);
+  }
+}

--- a/packages/features/src/feature-definitions.ts
+++ b/packages/features/src/feature-definitions.ts
@@ -37,7 +37,7 @@ export class FeatureDefinitionCollection extends SmrtCollection<FeatureDefinitio
       return { definition: created, status: 'created' };
     }
 
-    const nextMetadata = seed.metadata ? JSON.stringify(seed.metadata) : '';
+    const nextMetadata = serializeFeatureMetadata(seed.metadata);
     const changed =
       existing.packageName !== seed.packageName ||
       existing.qualifiedClassName !== seed.qualifiedClassName ||

--- a/packages/features/src/feature-definitions.ts
+++ b/packages/features/src/feature-definitions.ts
@@ -1,0 +1,69 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { FeatureDefinition } from './feature-definition.js';
+import type { FeatureDefinitionSeed } from './types.js';
+import { serializeFeatureMetadata } from './utils.js';
+
+export class FeatureDefinitionCollection extends SmrtCollection<FeatureDefinition> {
+  static readonly _itemClass = FeatureDefinition;
+
+  async findByFeatureKey(
+    featureKey: string,
+  ): Promise<FeatureDefinition | null> {
+    const results = await this.list({
+      where: { featureKey },
+      limit: 1,
+    });
+    return results[0] ?? null;
+  }
+
+  async findByPackageName(packageName: string): Promise<FeatureDefinition[]> {
+    return this.list({
+      where: { packageName },
+    });
+  }
+
+  async upsertDefinition(seed: FeatureDefinitionSeed): Promise<{
+    definition: FeatureDefinition;
+    status: 'created' | 'updated' | 'unchanged';
+  }> {
+    const existing = await this.findByFeatureKey(seed.featureKey);
+
+    if (!existing) {
+      const created = await this.create({
+        ...seed,
+        metadata: serializeFeatureMetadata(seed.metadata),
+      });
+      await created.save();
+      return { definition: created, status: 'created' };
+    }
+
+    const nextMetadata = seed.metadata ? JSON.stringify(seed.metadata) : '';
+    const changed =
+      existing.packageName !== seed.packageName ||
+      existing.qualifiedClassName !== seed.qualifiedClassName ||
+      existing.className !== seed.className ||
+      existing.localId !== seed.localId ||
+      existing.defaultEnabled !== seed.defaultEnabled ||
+      existing.label !== (seed.label ?? '') ||
+      existing.description !== (seed.description ?? '') ||
+      existing.metadata !== nextMetadata ||
+      existing.visibility !== (seed.visibility ?? 'public');
+
+    if (!changed) {
+      return { definition: existing, status: 'unchanged' };
+    }
+
+    existing.packageName = seed.packageName;
+    existing.qualifiedClassName = seed.qualifiedClassName;
+    existing.className = seed.className;
+    existing.localId = seed.localId;
+    existing.defaultEnabled = seed.defaultEnabled;
+    existing.label = seed.label ?? '';
+    existing.description = seed.description ?? '';
+    existing.metadata = nextMetadata;
+    existing.visibility = seed.visibility ?? 'public';
+    await existing.save();
+
+    return { definition: existing, status: 'updated' };
+  }
+}

--- a/packages/features/src/feature-override.ts
+++ b/packages/features/src/feature-override.ts
@@ -1,0 +1,46 @@
+import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  FeatureOverrideEffect,
+  type FeatureOverrideOptions,
+  type FeatureScopeType,
+  GLOBAL_FEATURE_SCOPE_ID,
+} from './types.js';
+
+@smrt({
+  tableName: '_smrt_feature_overrides',
+  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  cli: {
+    exclude: ['isInherit', 'isEnabled', 'isDisabled'],
+  },
+  mcp: {
+    exclude: ['isInherit', 'isEnabled', 'isDisabled'],
+  },
+  conflictColumns: ['feature_key', 'scope_type', 'scope_id'],
+})
+export class FeatureOverride extends SmrtObject {
+  featureKey: string = '';
+  scopeType: FeatureScopeType = 'global';
+  scopeId: string = GLOBAL_FEATURE_SCOPE_ID;
+  effect: FeatureOverrideEffect = FeatureOverrideEffect.INHERIT;
+
+  constructor(options: FeatureOverrideOptions = {}) {
+    super(options);
+
+    if (options.featureKey !== undefined) this.featureKey = options.featureKey;
+    if (options.scopeType !== undefined) this.scopeType = options.scopeType;
+    if (options.scopeId !== undefined) this.scopeId = options.scopeId;
+    if (options.effect !== undefined) this.effect = options.effect;
+  }
+
+  isInherit(): boolean {
+    return this.effect === FeatureOverrideEffect.INHERIT;
+  }
+
+  isEnabled(): boolean {
+    return this.effect === FeatureOverrideEffect.ENABLE;
+  }
+
+  isDisabled(): boolean {
+    return this.effect === FeatureOverrideEffect.DISABLE;
+  }
+}

--- a/packages/features/src/feature-overrides.ts
+++ b/packages/features/src/feature-overrides.ts
@@ -1,0 +1,132 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { FeatureOverride } from './feature-override.js';
+import {
+  type FeatureOverrideEffect,
+  type FeatureScopeType,
+  GLOBAL_FEATURE_SCOPE_ID,
+} from './types.js';
+
+export class FeatureOverrideCollection extends SmrtCollection<FeatureOverride> {
+  static readonly _itemClass = FeatureOverride;
+
+  async findByFeatureKey(featureKey: string): Promise<FeatureOverride[]> {
+    return this.list({
+      where: { featureKey },
+    });
+  }
+
+  async findByFeatureAndScope(
+    featureKey: string,
+    scopeType: FeatureScopeType,
+    scopeId: string,
+  ): Promise<FeatureOverride | null> {
+    const results = await this.list({
+      where: { featureKey, scopeType, scopeId },
+      limit: 1,
+    });
+    return results[0] ?? null;
+  }
+
+  async getGlobalOverride(featureKey: string): Promise<FeatureOverride | null> {
+    return this.findByFeatureAndScope(
+      featureKey,
+      'global',
+      GLOBAL_FEATURE_SCOPE_ID,
+    );
+  }
+
+  async getTenantOverride(
+    featureKey: string,
+    tenantId: string,
+  ): Promise<FeatureOverride | null> {
+    return this.findByFeatureAndScope(featureKey, 'tenant', tenantId);
+  }
+
+  async getOverrideMap(
+    featureKey: string,
+    scopeType: FeatureScopeType,
+    scopeIds: string[],
+  ): Promise<Map<string, FeatureOverride>> {
+    const result = new Map<string, FeatureOverride>();
+    if (scopeIds.length === 0) {
+      return result;
+    }
+
+    const overrides = await this.list({
+      where: { featureKey, scopeType, scopeId: scopeIds },
+    });
+
+    for (const override of overrides) {
+      result.set(override.scopeId, override);
+    }
+
+    return result;
+  }
+
+  async setOverride(
+    featureKey: string,
+    scopeType: FeatureScopeType,
+    scopeId: string,
+    effect: FeatureOverrideEffect,
+  ): Promise<FeatureOverride> {
+    const existing = await this.findByFeatureAndScope(
+      featureKey,
+      scopeType,
+      scopeId,
+    );
+
+    if (existing) {
+      existing.effect = effect;
+      await existing.save();
+      return existing;
+    }
+
+    const created = await this.create({
+      featureKey,
+      scopeType,
+      scopeId,
+      effect,
+    });
+    await created.save();
+    return created;
+  }
+
+  async setGlobalOverride(
+    featureKey: string,
+    effect: FeatureOverrideEffect,
+  ): Promise<FeatureOverride> {
+    return this.setOverride(
+      featureKey,
+      'global',
+      GLOBAL_FEATURE_SCOPE_ID,
+      effect,
+    );
+  }
+
+  async setTenantOverride(
+    featureKey: string,
+    tenantId: string,
+    effect: FeatureOverrideEffect,
+  ): Promise<FeatureOverride> {
+    return this.setOverride(featureKey, 'tenant', tenantId, effect);
+  }
+
+  async removeOverride(
+    featureKey: string,
+    scopeType: FeatureScopeType,
+    scopeId: string,
+  ): Promise<boolean> {
+    const existing = await this.findByFeatureAndScope(
+      featureKey,
+      scopeType,
+      scopeId,
+    );
+
+    if (!existing) {
+      return false;
+    }
+
+    await existing.delete();
+    return true;
+  }
+}

--- a/packages/features/src/feature-resolver.test.ts
+++ b/packages/features/src/feature-resolver.test.ts
@@ -1,0 +1,170 @@
+import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { getTestDatabase } from '@happyvertical/smrt-core/testing';
+import { afterEach, describe, expect, it } from 'vitest';
+import { TenantCollection } from '../../users/src/index.js';
+import { FeatureOverrideCollection } from './feature-overrides.js';
+import { FeatureResolver } from './feature-resolver.js';
+import { FeatureOverrideEffect } from './types.js';
+import { resolveFeatureKeyForTarget } from './utils.js';
+
+@smrt({
+  packageName: '@test/smrt-feature-resolver',
+  visibility: 'internal',
+  api: false,
+  cli: false,
+  mcp: false,
+  features: {
+    newEditor: {
+      defaultEnabled: false,
+      label: 'New Editor',
+    },
+    reports: {
+      defaultEnabled: true,
+    },
+  },
+})
+class FeatureResolverFixture extends SmrtObject {}
+
+describe('FeatureResolver', () => {
+  const closers = new Set<() => Promise<void>>();
+
+  afterEach(async () => {
+    for (const close of closers) {
+      await close();
+    }
+    closers.clear();
+  });
+
+  it('builds canonical feature keys from qualified class names', () => {
+    const resolved = resolveFeatureKeyForTarget(
+      FeatureResolverFixture,
+      'newEditor',
+    );
+
+    expect(resolved).toEqual({
+      featureKey:
+        '@test/smrt-feature-resolver:FeatureResolverFixture#newEditor',
+      defaultEnabled: false,
+    });
+  });
+
+  it('applies a global override over the decorator default', async () => {
+    const db = await getTestDatabase({
+      classes: ['FeatureDefinition', 'FeatureOverride'],
+    });
+    closers.add(async () => {
+      if (typeof (db as any).close === 'function') {
+        await (db as any).close();
+      }
+    });
+
+    const overrides = await (FeatureOverrideCollection as any).create({ db });
+    await overrides.setGlobalOverride(
+      '@test/smrt-feature-resolver:FeatureResolverFixture#newEditor',
+      FeatureOverrideEffect.ENABLE,
+    );
+
+    const resolver = new FeatureResolver(
+      { db },
+      { tenantHierarchyLoader: async () => null },
+    );
+
+    await expect(
+      resolver.isEnabledFor(FeatureResolverFixture, 'newEditor'),
+    ).resolves.toBe(true);
+  });
+
+  it('applies direct tenant overrides when smrt-users is unavailable', async () => {
+    const db = await getTestDatabase({
+      classes: ['FeatureDefinition', 'FeatureOverride'],
+    });
+    closers.add(async () => {
+      if (typeof (db as any).close === 'function') {
+        await (db as any).close();
+      }
+    });
+
+    const overrides = await (FeatureOverrideCollection as any).create({ db });
+    await overrides.setTenantOverride(
+      '@test/smrt-feature-resolver:FeatureResolverFixture#reports',
+      'tenant-direct',
+      FeatureOverrideEffect.DISABLE,
+    );
+
+    const resolver = new FeatureResolver(
+      { db },
+      { tenantHierarchyLoader: async () => null },
+    );
+
+    await expect(
+      resolver.isEnabledFor(FeatureResolverFixture, 'reports', {
+        tenantId: 'tenant-direct',
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it('treats explicit INHERIT as a fallback to the current baseline', async () => {
+    const db = await getTestDatabase({
+      classes: ['FeatureDefinition', 'FeatureOverride'],
+    });
+    closers.add(async () => {
+      if (typeof (db as any).close === 'function') {
+        await (db as any).close();
+      }
+    });
+
+    const overrides = await (FeatureOverrideCollection as any).create({ db });
+    const featureKey =
+      '@test/smrt-feature-resolver:FeatureResolverFixture#newEditor';
+
+    await overrides.setGlobalOverride(featureKey, FeatureOverrideEffect.ENABLE);
+    await overrides.setTenantOverride(
+      featureKey,
+      'tenant-inherit',
+      FeatureOverrideEffect.INHERIT,
+    );
+
+    const resolver = new FeatureResolver(
+      { db },
+      { tenantHierarchyLoader: async () => null },
+    );
+
+    await expect(
+      resolver.isEnabled(featureKey, { tenantId: 'tenant-inherit' }),
+    ).resolves.toBe(true);
+  });
+
+  it('uses smrt-users tenant hierarchy when available', async () => {
+    const db = await getTestDatabase({
+      classes: ['FeatureDefinition', 'FeatureOverride', 'Tenant'],
+    });
+    closers.add(async () => {
+      if (typeof (db as any).close === 'function') {
+        await (db as any).close();
+      }
+    });
+
+    const tenants = await (TenantCollection as any).create({ db });
+    const root = await tenants.create({ name: 'Root Tenant' });
+    await root.save();
+    const child = await tenants.createChild(root.id, {
+      name: 'Child Tenant',
+      inheritPermissions: true,
+    });
+
+    const overrides = await (FeatureOverrideCollection as any).create({ db });
+    await overrides.setTenantOverride(
+      '@test/smrt-feature-resolver:FeatureResolverFixture#newEditor',
+      root.id,
+      FeatureOverrideEffect.ENABLE,
+    );
+
+    const resolver = new FeatureResolver({ db });
+
+    await expect(
+      resolver.isEnabledFor(FeatureResolverFixture, 'newEditor', {
+        tenantId: child.id,
+      }),
+    ).resolves.toBe(true);
+  });
+});

--- a/packages/features/src/feature-resolver.ts
+++ b/packages/features/src/feature-resolver.ts
@@ -1,0 +1,207 @@
+import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+import { importWorkspaceModule } from '@happyvertical/smrt-core/utils/import-workspace-module';
+import { FeatureDefinitionCollection } from './feature-definitions.js';
+import { FeatureOverrideCollection } from './feature-overrides.js';
+import {
+  FeatureOverrideEffect,
+  type FeatureResolutionContext,
+  type FeatureResolverOptions,
+  type FeatureTenantHierarchyProvider,
+  type FeatureTenantNode,
+  type FeatureUsersModule,
+} from './types.js';
+import {
+  findFeatureDefaultInRegistry,
+  resolveFeatureKeyForTarget,
+} from './utils.js';
+
+export class FeatureResolver {
+  private readonly options: SmrtClassOptions;
+  private readonly resolverOptions: FeatureResolverOptions;
+  private featureDefinitions!: FeatureDefinitionCollection;
+  private featureOverrides!: FeatureOverrideCollection;
+  private initializationPromise: Promise<void> | null = null;
+  private tenantHierarchyPromise: Promise<FeatureTenantHierarchyProvider | null> | null =
+    null;
+
+  constructor(
+    options: SmrtClassOptions = {},
+    resolverOptions: FeatureResolverOptions = {},
+  ) {
+    this.options = options;
+    this.resolverOptions = resolverOptions;
+  }
+
+  async isEnabled(
+    featureKey: string,
+    context: FeatureResolutionContext = {},
+  ): Promise<boolean> {
+    await this.ensureInitialized();
+
+    const baseState = await this.resolveBaseState(featureKey);
+    const globalOverride =
+      await this.featureOverrides.getGlobalOverride(featureKey);
+    const globalState = this.applyOverride(baseState, globalOverride?.effect);
+
+    if (!context.tenantId) {
+      return globalState;
+    }
+
+    const tenantHierarchy = await this.getTenantHierarchy();
+    if (!tenantHierarchy) {
+      const directOverride = await this.featureOverrides.getTenantOverride(
+        featureKey,
+        context.tenantId,
+      );
+      return this.applyOverride(globalState, directOverride?.effect);
+    }
+
+    const chain = await tenantHierarchy.getChain(context.tenantId);
+    if (chain.length === 0) {
+      const directOverride = await this.featureOverrides.getTenantOverride(
+        featureKey,
+        context.tenantId,
+      );
+      return this.applyOverride(globalState, directOverride?.effect);
+    }
+
+    const overrides = await this.featureOverrides.getOverrideMap(
+      featureKey,
+      'tenant',
+      chain.map((node) => node.id),
+    );
+
+    let inheritedState = globalState;
+
+    for (let index = 0; index < chain.length; index++) {
+      const current = chain[index];
+      const previous = index > 0 ? chain[index - 1] : null;
+      const shouldInherit =
+        index === 0 ||
+        (!!previous?.cascadePermissions && current.inheritPermissions);
+
+      const baseline = shouldInherit ? inheritedState : globalState;
+      const override = overrides.get(current.id);
+      inheritedState = this.applyOverride(baseline, override?.effect);
+    }
+
+    return inheritedState;
+  }
+
+  async isEnabledFor(
+    classOrInstance: object | (new (...args: any[]) => any),
+    localId: string,
+    context: FeatureResolutionContext = {},
+  ): Promise<boolean> {
+    const { featureKey } = resolveFeatureKeyForTarget(classOrInstance, localId);
+    return this.isEnabled(featureKey, context);
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (!this.initializationPromise) {
+      this.initializationPromise = (async () => {
+        this.featureDefinitions = await (
+          FeatureDefinitionCollection as any
+        ).create(this.options);
+        this.featureOverrides = await (FeatureOverrideCollection as any).create(
+          this.options,
+        );
+      })();
+    }
+
+    await this.initializationPromise;
+  }
+
+  private async resolveBaseState(featureKey: string): Promise<boolean> {
+    const registryDefault = findFeatureDefaultInRegistry(featureKey);
+    if (registryDefault !== undefined) {
+      return registryDefault;
+    }
+
+    const definition =
+      await this.featureDefinitions.findByFeatureKey(featureKey);
+    if (!definition) {
+      throw new Error(
+        `Feature "${featureKey}" is not declared in the registry or synced feature definitions.`,
+      );
+    }
+
+    return definition.defaultEnabled;
+  }
+
+  private applyOverride(
+    currentState: boolean,
+    effect: FeatureOverrideEffect | undefined,
+  ): boolean {
+    switch (effect) {
+      case FeatureOverrideEffect.ENABLE:
+        return true;
+      case FeatureOverrideEffect.DISABLE:
+        return false;
+      default:
+        return currentState;
+    }
+  }
+
+  private async getTenantHierarchy(): Promise<FeatureTenantHierarchyProvider | null> {
+    if (!this.tenantHierarchyPromise) {
+      const loader =
+        this.resolverOptions.tenantHierarchyLoader ||
+        defaultTenantHierarchyLoader;
+      this.tenantHierarchyPromise = loader(this.options);
+    }
+
+    return this.tenantHierarchyPromise;
+  }
+}
+
+async function defaultTenantHierarchyLoader(
+  options: SmrtClassOptions,
+): Promise<FeatureTenantHierarchyProvider | null> {
+  try {
+    const usersModule = await importWorkspaceModule<FeatureUsersModule>({
+      packageName: '@happyvertical/smrt-users',
+      sourceEntry: 'packages/users/src/index.ts',
+      purpose: 'tenant-aware feature flag resolution',
+    });
+
+    const tenantCollection = await usersModule.TenantCollection.create(options);
+    return {
+      async getChain(tenantId: string): Promise<FeatureTenantNode[]> {
+        const tenant = await tenantCollection.get({ id: tenantId });
+        if (!tenant) {
+          return [];
+        }
+
+        const ancestors = await tenantCollection.getAncestorsFromRoot(tenantId);
+        return [...ancestors, tenant].map((node: any) => ({
+          id: String(node.id),
+          inheritPermissions: Boolean(node.inheritPermissions),
+          cascadePermissions: Boolean(node.cascadePermissions),
+        }));
+      },
+    };
+  } catch (error) {
+    if (isMissingUsersDependency(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function isMissingUsersDependency(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const causeMessage =
+    error.cause instanceof Error ? ` ${error.cause.message}` : '';
+  const text = `${error.message}${causeMessage}`;
+
+  return (
+    text.includes('@happyvertical/smrt-users') &&
+    (text.includes('Cannot find module') ||
+      text.includes('Failed to load') ||
+      text.includes('could not find'))
+  );
+}

--- a/packages/features/src/feature-sync.test.ts
+++ b/packages/features/src/feature-sync.test.ts
@@ -1,0 +1,239 @@
+import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import type { SmartObjectManifest } from '@happyvertical/smrt-core/manifest';
+import { getTestDatabase } from '@happyvertical/smrt-core/testing';
+import { afterEach, describe, expect, it } from 'vitest';
+import { FeatureDefinitionCollection } from './feature-definitions.js';
+import { FeatureSyncService } from './feature-sync.js';
+
+@smrt({
+  packageName: '@test/smrt-feature-sync',
+  visibility: 'internal',
+  api: false,
+  cli: false,
+  mcp: false,
+  features: {
+    alphaRollout: {
+      defaultEnabled: false,
+      label: 'Alpha Rollout',
+      description: 'First stage rollout',
+    },
+    staffReports: {
+      defaultEnabled: true,
+      metadata: {
+        audience: 'staff',
+      },
+    },
+  },
+})
+class FeatureSyncFixture extends SmrtObject {}
+
+describe('FeatureSyncService', () => {
+  const closers = new Set<() => Promise<void>>();
+
+  afterEach(async () => {
+    for (const close of closers) {
+      await close();
+    }
+    closers.clear();
+  });
+
+  it('syncs decorator-defined features into _smrt_feature_definitions and is idempotent', async () => {
+    const db = await getTestDatabase({
+      classes: ['FeatureDefinition'],
+    });
+    closers.add(async () => {
+      if (typeof (db as any).close === 'function') {
+        await (db as any).close();
+      }
+    });
+
+    const syncService = new FeatureSyncService({ db });
+
+    const first = await syncService.syncDefinitions({
+      classNames: ['FeatureSyncFixture'],
+    });
+    const second = await syncService.syncDefinitions({
+      classNames: ['FeatureSyncFixture'],
+    });
+
+    const definitions = await (FeatureDefinitionCollection as any).create({
+      db,
+    });
+    const alpha = await definitions.findByFeatureKey(
+      '@test/smrt-feature-sync:FeatureSyncFixture#alphaRollout',
+    );
+    const staff = await definitions.findByFeatureKey(
+      '@test/smrt-feature-sync:FeatureSyncFixture#staffReports',
+    );
+
+    expect(first).toMatchObject({
+      total: 2,
+      created: 2,
+      updated: 0,
+      unchanged: 0,
+      deleted: 0,
+    });
+    expect(second).toMatchObject({
+      total: 2,
+      created: 0,
+      updated: 0,
+      unchanged: 2,
+      deleted: 0,
+    });
+    expect(alpha?.defaultEnabled).toBe(false);
+    expect(alpha?.label).toBe('Alpha Rollout');
+    expect(staff?.defaultEnabled).toBe(true);
+    expect(staff?.getMetadata()).toEqual({ audience: 'staff' });
+  });
+
+  it('prunes stale synced definitions within the touched package when syncing a manifest', async () => {
+    const db = await getTestDatabase({
+      classes: ['FeatureDefinition'],
+    });
+    closers.add(async () => {
+      if (typeof (db as any).close === 'function') {
+        await (db as any).close();
+      }
+    });
+
+    const syncService = new FeatureSyncService({ db });
+    const definitions = await (FeatureDefinitionCollection as any).create({
+      db,
+    });
+
+    const firstManifest: SmartObjectManifest = {
+      version: '1.0.0',
+      timestamp: Date.now(),
+      packageName: '@test/smrt-feature-manifest',
+      objects: {
+        '@test/smrt-feature-manifest:ManifestFixture': {
+          className: 'ManifestFixture',
+          qualifiedName: '@test/smrt-feature-manifest:ManifestFixture',
+          collection: 'manifestfixtures',
+          filePath: '/tmp/ManifestFixture.ts',
+          fields: {},
+          methods: {},
+          decoratorConfig: {
+            features: {
+              alpha: {
+                defaultEnabled: false,
+              },
+              beta: {
+                defaultEnabled: true,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const secondManifest: SmartObjectManifest = {
+      ...firstManifest,
+      timestamp: Date.now() + 1,
+      objects: {
+        '@test/smrt-feature-manifest:ManifestFixture': {
+          ...firstManifest.objects[
+            '@test/smrt-feature-manifest:ManifestFixture'
+          ],
+          decoratorConfig: {
+            features: {
+              beta: {
+                defaultEnabled: false,
+                label: 'Beta',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    await syncService.syncManifest(firstManifest);
+    const result = await syncService.syncManifest(secondManifest);
+
+    const alpha = await definitions.findByFeatureKey(
+      '@test/smrt-feature-manifest:ManifestFixture#alpha',
+    );
+    const beta = await definitions.findByFeatureKey(
+      '@test/smrt-feature-manifest:ManifestFixture#beta',
+    );
+
+    expect(result).toMatchObject({
+      total: 1,
+      created: 0,
+      updated: 1,
+      unchanged: 0,
+      deleted: 1,
+    });
+    expect(alpha).toBeNull();
+    expect(beta?.defaultEnabled).toBe(false);
+    expect(beta?.label).toBe('Beta');
+  });
+
+  it('prunes stale definitions when a touched package removes its last feature', async () => {
+    const db = await getTestDatabase({
+      classes: ['FeatureDefinition'],
+    });
+    closers.add(async () => {
+      if (typeof (db as any).close === 'function') {
+        await (db as any).close();
+      }
+    });
+
+    const syncService = new FeatureSyncService({ db });
+    const definitions = await (FeatureDefinitionCollection as any).create({
+      db,
+    });
+
+    const firstManifest: SmartObjectManifest = {
+      version: '1.0.0',
+      timestamp: Date.now(),
+      packageName: '@test/smrt-feature-empty-manifest',
+      objects: {
+        '@test/smrt-feature-empty-manifest:ManifestFixture': {
+          className: 'ManifestFixture',
+          qualifiedName: '@test/smrt-feature-empty-manifest:ManifestFixture',
+          collection: 'manifestfixtures',
+          filePath: '/tmp/ManifestFixture.ts',
+          fields: {},
+          methods: {},
+          decoratorConfig: {
+            features: {
+              alpha: {
+                defaultEnabled: false,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const secondManifest: SmartObjectManifest = {
+      ...firstManifest,
+      timestamp: Date.now() + 1,
+      objects: {
+        '@test/smrt-feature-empty-manifest:ManifestFixture': {
+          ...firstManifest.objects[
+            '@test/smrt-feature-empty-manifest:ManifestFixture'
+          ],
+          decoratorConfig: {},
+        },
+      },
+    };
+
+    await syncService.syncManifest(firstManifest);
+    const result = await syncService.syncManifest(secondManifest);
+
+    const alpha = await definitions.findByFeatureKey(
+      '@test/smrt-feature-empty-manifest:ManifestFixture#alpha',
+    );
+
+    expect(result).toMatchObject({
+      total: 0,
+      created: 0,
+      updated: 0,
+      unchanged: 0,
+      deleted: 1,
+    });
+    expect(alpha).toBeNull();
+  });
+});

--- a/packages/features/src/feature-sync.test.ts
+++ b/packages/features/src/feature-sync.test.ts
@@ -27,6 +27,20 @@ import { FeatureSyncService } from './feature-sync.js';
 })
 class FeatureSyncFixture extends SmrtObject {}
 
+@smrt({
+  packageName: '@test/smrt-feature-sync',
+  visibility: 'internal',
+  api: false,
+  cli: false,
+  mcp: false,
+  features: {
+    siblingRollout: {
+      defaultEnabled: true,
+    },
+  },
+})
+class FeatureSyncSiblingFixture extends SmrtObject {}
+
 describe('FeatureSyncService', () => {
   const closers = new Set<() => Promise<void>>();
 
@@ -235,5 +249,44 @@ describe('FeatureSyncService', () => {
       deleted: 1,
     });
     expect(alpha).toBeNull();
+  });
+
+  it('does not prune sibling definitions during filtered syncs', async () => {
+    const db = await getTestDatabase({
+      classes: ['FeatureDefinition'],
+    });
+    closers.add(async () => {
+      if (typeof (db as any).close === 'function') {
+        await (db as any).close();
+      }
+    });
+
+    const syncService = new FeatureSyncService({ db });
+    const definitions = await (FeatureDefinitionCollection as any).create({
+      db,
+    });
+
+    await syncService.syncDefinitions({
+      classNames: ['FeatureSyncFixture', 'FeatureSyncSiblingFixture'],
+    });
+
+    const result = await syncService.syncDefinitions({
+      classNames: ['FeatureSyncFixture'],
+      pruneStale: true,
+    });
+
+    const sibling = await definitions.findByFeatureKey(
+      '@test/smrt-feature-sync:FeatureSyncSiblingFixture#siblingRollout',
+    );
+
+    expect(result).toMatchObject({
+      total: 2,
+      created: 0,
+      updated: 0,
+      unchanged: 2,
+      deleted: 0,
+    });
+    expect(sibling).not.toBeNull();
+    expect(sibling?.defaultEnabled).toBe(true);
   });
 });

--- a/packages/features/src/feature-sync.ts
+++ b/packages/features/src/feature-sync.ts
@@ -37,11 +37,9 @@ export class FeatureSyncService {
     const isFilteredSync =
       Boolean(options.classNames?.length) ||
       Boolean(options.constructors?.length);
-    return this.applyDefinitions(
-      definitions,
-      touchedPackages,
-      options.pruneStale ?? !isFilteredSync,
-    );
+    const pruneStale = isFilteredSync ? false : (options.pruneStale ?? true);
+
+    return this.applyDefinitions(definitions, touchedPackages, pruneStale);
   }
 
   async syncManifest(
@@ -143,29 +141,38 @@ export class FeatureSyncService {
     let unchanged = 0;
     let deleted = 0;
 
-    const currentKeys = new Set<string>();
-    for (const definition of deduped.values()) {
-      currentKeys.add(definition.featureKey);
-
-      const result = await this.featureDefinitions.upsertDefinition(definition);
+    const dedupedDefinitions = Array.from(deduped.values());
+    const currentKeys = new Set(
+      dedupedDefinitions.map((definition) => definition.featureKey),
+    );
+    const upsertResults = await Promise.all(
+      dedupedDefinitions.map((definition) =>
+        this.featureDefinitions.upsertDefinition(definition),
+      ),
+    );
+    for (const result of upsertResults) {
       if (result.status === 'created') created++;
       if (result.status === 'updated') updated++;
       if (result.status === 'unchanged') unchanged++;
     }
 
     if (pruneStale) {
-      for (const packageName of touchedPackages) {
-        const existing =
-          await this.featureDefinitions.findByPackageName(packageName);
-        for (const definition of existing) {
-          if (currentKeys.has(definition.featureKey)) {
-            continue;
-          }
+      const existingByPackage = await Promise.all(
+        Array.from(touchedPackages, (packageName) =>
+          this.featureDefinitions.findByPackageName(packageName),
+        ),
+      );
 
-          await definition.delete();
-          deleted++;
-        }
-      }
+      const staleDefinitions = existingByPackage.flatMap((existing) =>
+        existing.filter(
+          (definition) => !currentKeys.has(definition.featureKey),
+        ),
+      );
+
+      await Promise.all(
+        staleDefinitions.map((definition) => definition.delete()),
+      );
+      deleted = staleDefinitions.length;
     }
 
     return {

--- a/packages/features/src/feature-sync.ts
+++ b/packages/features/src/feature-sync.ts
@@ -1,0 +1,180 @@
+import {
+  ObjectRegistry,
+  type SmrtClassOptions,
+} from '@happyvertical/smrt-core';
+import type { SmartObjectManifest } from '@happyvertical/smrt-core/manifest';
+import { FeatureDefinitionCollection } from './feature-definitions.js';
+import type {
+  FeatureDefinitionSeed,
+  FeatureSyncResult,
+  SyncDefinitionsOptions,
+  SyncManifestOptions,
+} from './types.js';
+import {
+  extractFeatureSeedsFromManifest,
+  extractFeatureSeedsFromRegistryEntry,
+  extractTouchedPackagesFromManifest,
+  getPackageNameFromRegistry,
+} from './utils.js';
+
+export class FeatureSyncService {
+  private readonly options: SmrtClassOptions;
+  private featureDefinitions!: FeatureDefinitionCollection;
+  private initializationPromise: Promise<void> | null = null;
+
+  constructor(options: SmrtClassOptions = {}) {
+    this.options = options;
+  }
+
+  async syncDefinitions(
+    options: SyncDefinitionsOptions = {},
+  ): Promise<FeatureSyncResult> {
+    await this.ensureInitialized();
+    const registrations = this.collectRegistrations(options);
+    const definitions = this.collectDefinitionsFromRegistrations(registrations);
+    const touchedPackages =
+      this.collectTouchedPackagesFromRegistrations(registrations);
+    const isFilteredSync =
+      Boolean(options.classNames?.length) ||
+      Boolean(options.constructors?.length);
+    return this.applyDefinitions(
+      definitions,
+      touchedPackages,
+      options.pruneStale ?? !isFilteredSync,
+    );
+  }
+
+  async syncManifest(
+    manifest: SmartObjectManifest,
+    options: SyncManifestOptions = {},
+  ): Promise<FeatureSyncResult> {
+    await this.ensureInitialized();
+    const definitions = extractFeatureSeedsFromManifest(manifest);
+    const touchedPackages = extractTouchedPackagesFromManifest(manifest);
+    return this.applyDefinitions(
+      definitions,
+      touchedPackages,
+      options.pruneStale ?? true,
+    );
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (!this.initializationPromise) {
+      this.initializationPromise = (async () => {
+        this.featureDefinitions = await (
+          FeatureDefinitionCollection as any
+        ).create(this.options);
+      })();
+    }
+
+    await this.initializationPromise;
+  }
+
+  private collectDefinitionsFromRegistrations(
+    registrations: Array<any>,
+  ): FeatureDefinitionSeed[] {
+    const definitions: FeatureDefinitionSeed[] = [];
+
+    for (const registration of registrations) {
+      definitions.push(...extractFeatureSeedsFromRegistryEntry(registration));
+    }
+
+    return definitions;
+  }
+
+  private collectTouchedPackagesFromRegistrations(
+    registrations: Array<any>,
+  ): Set<string> {
+    const packages = new Set<string>();
+
+    for (const registration of registrations) {
+      if (registration.visibility === 'test') {
+        continue;
+      }
+
+      const packageName = getPackageNameFromRegistry(registration);
+      if (packageName) {
+        packages.add(packageName);
+      }
+    }
+
+    return packages;
+  }
+
+  private collectRegistrations(options: SyncDefinitionsOptions): Array<any> {
+    if (options.classNames?.length) {
+      return options.classNames
+        .map((name) => ObjectRegistry.getClass(name))
+        .filter((value): value is NonNullable<typeof value> => !!value);
+    }
+
+    if (options.constructors?.length) {
+      return options.constructors
+        .map((ctor) => ObjectRegistry.getClassByConstructor(ctor as any))
+        .filter((value): value is NonNullable<typeof value> => !!value);
+    }
+
+    const registrations: any[] = [];
+    const seen = new Set<any>();
+
+    for (const registration of ObjectRegistry.getAllClasses().values()) {
+      if (seen.has(registration)) {
+        continue;
+      }
+      seen.add(registration);
+      registrations.push(registration);
+    }
+
+    return registrations;
+  }
+
+  private async applyDefinitions(
+    definitions: FeatureDefinitionSeed[],
+    touchedPackages: Set<string>,
+    pruneStale: boolean,
+  ): Promise<FeatureSyncResult> {
+    const deduped = new Map<string, FeatureDefinitionSeed>();
+    for (const definition of definitions) {
+      deduped.set(definition.featureKey, definition);
+    }
+
+    let created = 0;
+    let updated = 0;
+    let unchanged = 0;
+    let deleted = 0;
+
+    const currentKeys = new Set<string>();
+    for (const definition of deduped.values()) {
+      currentKeys.add(definition.featureKey);
+
+      const result = await this.featureDefinitions.upsertDefinition(definition);
+      if (result.status === 'created') created++;
+      if (result.status === 'updated') updated++;
+      if (result.status === 'unchanged') unchanged++;
+    }
+
+    if (pruneStale) {
+      for (const packageName of touchedPackages) {
+        const existing =
+          await this.featureDefinitions.findByPackageName(packageName);
+        for (const definition of existing) {
+          if (currentKeys.has(definition.featureKey)) {
+            continue;
+          }
+
+          await definition.delete();
+          deleted++;
+        }
+      }
+    }
+
+    return {
+      total: deduped.size,
+      created,
+      updated,
+      unchanged,
+      deleted,
+      featureKeys: Array.from(currentKeys).sort(),
+    };
+  }
+}

--- a/packages/features/src/generated-surfaces.test.ts
+++ b/packages/features/src/generated-surfaces.test.ts
@@ -26,6 +26,40 @@ class ListOnlyRestFixtureCollection extends SmrtCollection<ListOnlyRestFixture> 
   static readonly _itemClass = ListOnlyRestFixture;
 }
 
+const GetOnlyCollisionRestFixture = (() => {
+  @smrt({
+    packageName: '@test/smrt-features-collision-a',
+    api: { include: ['get'] },
+    cli: false,
+    mcp: false,
+  })
+  class CollisionRestFixture extends SmrtObject {
+    name: string = '';
+  }
+
+  return CollisionRestFixture;
+})();
+
+const ListOnlyCollisionRestFixture = (() => {
+  @smrt({
+    packageName: '@test/smrt-features-collision-b',
+    api: { include: ['list'] },
+    cli: false,
+    mcp: false,
+  })
+  class CollisionRestFixture extends SmrtObject {
+    name: string = '';
+  }
+
+  return CollisionRestFixture;
+})();
+
+class CollisionRestFixtureCollection extends SmrtCollection<
+  InstanceType<typeof ListOnlyCollisionRestFixture>
+> {
+  static readonly _itemClass = ListOnlyCollisionRestFixture;
+}
+
 describe('smrt-features generated surfaces', () => {
   const closers = new Set<() => Promise<void>>();
 
@@ -173,6 +207,37 @@ describe('smrt-features generated surfaces', () => {
     );
     const getResponse = await handler(
       new Request('http://localhost/api/v1/listonlyrestfixture/some-id'),
+    );
+
+    expect(countResponse.status).toBe(200);
+    expect(await countResponse.json()).toEqual({ count: 0 });
+    expect(getResponse.status).toBe(405);
+  });
+
+  it('uses the collection constructor registration when same-named classes exist in multiple packages', async () => {
+    void GetOnlyCollisionRestFixture;
+
+    const db = await getTestDatabase({
+      classes: ['@test/smrt-features-collision-b:CollisionRestFixture'],
+    });
+    closers.add(async () => {
+      if (typeof (db as any).close === 'function') {
+        await (db as any).close();
+      }
+    });
+
+    const collection = await (CollisionRestFixtureCollection as any).create({
+      db,
+    });
+    const api = new APIGenerator({}, { db });
+    api.registerCollection('collisionrestfixture', collection);
+    const handler = api.generateHandler();
+
+    const countResponse = await handler(
+      new Request('http://localhost/api/v1/collisionrestfixture/count'),
+    );
+    const getResponse = await handler(
+      new Request('http://localhost/api/v1/collisionrestfixture/some-id'),
     );
 
     expect(countResponse.status).toBe(200);

--- a/packages/features/src/generated-surfaces.test.ts
+++ b/packages/features/src/generated-surfaces.test.ts
@@ -1,0 +1,182 @@
+import {
+  APIGenerator,
+  MCPGenerator,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { getTestDatabase } from '@happyvertical/smrt-core/testing';
+import { afterEach, describe, expect, it } from 'vitest';
+import { CLIGenerator } from '../../cli/src/cli-generator.js';
+import { FeatureDefinitionCollection } from './feature-definitions.js';
+import { FeatureOverrideCollection } from './feature-overrides.js';
+import { FeatureOverrideEffect } from './types.js';
+
+@smrt({
+  packageName: '@test/smrt-features',
+  api: { include: ['list'] },
+  cli: false,
+  mcp: false,
+})
+class ListOnlyRestFixture extends SmrtObject {
+  name: string = '';
+}
+
+class ListOnlyRestFixtureCollection extends SmrtCollection<ListOnlyRestFixture> {
+  static readonly _itemClass = ListOnlyRestFixture;
+}
+
+describe('smrt-features generated surfaces', () => {
+  const closers = new Set<() => Promise<void>>();
+
+  afterEach(async () => {
+    for (const close of closers) {
+      await close();
+    }
+    closers.clear();
+  });
+
+  it('exposes definitions as read-only and overrides as full CRUD across REST, CLI, and MCP', async () => {
+    const db = await getTestDatabase({
+      classes: ['FeatureDefinition', 'FeatureOverride'],
+    });
+    closers.add(async () => {
+      if (typeof (db as any).close === 'function') {
+        await (db as any).close();
+      }
+    });
+
+    const definitions = await (FeatureDefinitionCollection as any).create({
+      db,
+    });
+    const definition = await definitions.create({
+      featureKey: '@test/pkg:Demo#newEditor',
+      packageName: '@test/pkg',
+      qualifiedClassName: '@test/pkg:Demo',
+      className: 'Demo',
+      localId: 'newEditor',
+      defaultEnabled: false,
+    });
+    await definition.save();
+
+    const overrides = await (FeatureOverrideCollection as any).create({ db });
+    const override = await overrides.create({
+      featureKey: '@test/pkg:Demo#newEditor',
+      scopeType: 'tenant',
+      scopeId: 'tenant-1',
+      effect: FeatureOverrideEffect.ENABLE,
+    });
+    await override.save();
+
+    const api = new APIGenerator({}, { db });
+    api.registerCollection('featuredefinition', definitions);
+    api.registerCollection('featureoverride', overrides);
+    const handler = api.generateHandler();
+
+    const listDefinitions = await handler(
+      new Request('http://localhost/api/v1/featuredefinition'),
+    );
+    const createDefinition = await handler(
+      new Request('http://localhost/api/v1/featuredefinition', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          featureKey: '@test/pkg:Demo#beta',
+          packageName: '@test/pkg',
+          qualifiedClassName: '@test/pkg:Demo',
+          className: 'Demo',
+          localId: 'beta',
+          defaultEnabled: false,
+        }),
+      }),
+    );
+    const getOverride = await handler(
+      new Request(`http://localhost/api/v1/featureoverride/${override.id}`),
+    );
+    const createOverride = await handler(
+      new Request('http://localhost/api/v1/featureoverride', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          featureKey: '@test/pkg:Demo#newEditor',
+          scopeType: 'tenant',
+          scopeId: 'tenant-2',
+          effect: FeatureOverrideEffect.DISABLE,
+        }),
+      }),
+    );
+
+    expect(listDefinitions.status).toBe(200);
+    expect(createDefinition.status).toBe(405);
+    expect(getOverride.status).toBe(200);
+    expect(createOverride.status).toBe(201);
+
+    const cli = new CLIGenerator({ prompt: false }, { db });
+    const definitionCommands = await (cli as any).generateObjectCommands(
+      'FeatureDefinition',
+      {},
+    );
+    const overrideCommands = await (cli as any).generateObjectCommands(
+      'FeatureOverride',
+      {},
+    );
+
+    expect(definitionCommands.map((command: any) => command.name)).toEqual([
+      'featuredefinition:list',
+      'featuredefinition:get',
+    ]);
+    expect(overrideCommands.map((command: any) => command.name)).toEqual([
+      'featureoverride:list',
+      'featureoverride:get',
+      'featureoverride:create',
+      'featureoverride:update',
+      'featureoverride:delete',
+    ]);
+
+    const mcp = new MCPGenerator({}, { db });
+    const toolNames = (await mcp.generateTools()).map((tool) => tool.name);
+
+    expect(toolNames).toContain('featuredefinition_list');
+    expect(toolNames).toContain('featuredefinition_get');
+    expect(toolNames).not.toContain('featuredefinition_create');
+    expect(toolNames).not.toContain('featuredefinition_getmetadata');
+    expect(toolNames).not.toContain('featuredefinition_setmetadata');
+    expect(toolNames).toContain('featureoverride_list');
+    expect(toolNames).toContain('featureoverride_get');
+    expect(toolNames).toContain('featureoverride_create');
+    expect(toolNames).toContain('featureoverride_update');
+    expect(toolNames).toContain('featureoverride_delete');
+    expect(toolNames).not.toContain('featureoverride_isinherit');
+    expect(toolNames).not.toContain('featureoverride_isenabled');
+    expect(toolNames).not.toContain('featureoverride_isdisabled');
+  });
+
+  it('keeps the /count route available for list-only REST surfaces', async () => {
+    const db = await getTestDatabase({
+      classes: ['ListOnlyRestFixture'],
+    });
+    closers.add(async () => {
+      if (typeof (db as any).close === 'function') {
+        await (db as any).close();
+      }
+    });
+
+    const collection = await (ListOnlyRestFixtureCollection as any).create({
+      db,
+    });
+    const api = new APIGenerator({}, { db });
+    api.registerCollection('listonlyrestfixture', collection);
+    const handler = api.generateHandler();
+
+    const countResponse = await handler(
+      new Request('http://localhost/api/v1/listonlyrestfixture/count'),
+    );
+    const getResponse = await handler(
+      new Request('http://localhost/api/v1/listonlyrestfixture/some-id'),
+    );
+
+    expect(countResponse.status).toBe(200);
+    expect(await countResponse.json()).toEqual({ count: 0 });
+    expect(getResponse.status).toBe(405);
+  });
+});

--- a/packages/features/src/index.ts
+++ b/packages/features/src/index.ts
@@ -1,0 +1,40 @@
+/**
+ * @happyvertical/smrt-features
+ *
+ * Code-first feature flags for the SMRT framework.
+ *
+ * @packageDocumentation
+ */
+
+export { FeatureDefinition } from './feature-definition.js';
+export { FeatureDefinitionCollection } from './feature-definitions.js';
+export { FeatureOverride } from './feature-override.js';
+export { FeatureOverrideCollection } from './feature-overrides.js';
+export { FeatureResolver } from './feature-resolver.js';
+export { FeatureSyncService } from './feature-sync.js';
+
+export {
+  type FeatureDefinitionOptions,
+  type FeatureDefinitionSeed,
+  type FeatureMetadata,
+  FeatureOverrideEffect,
+  type FeatureOverrideOptions,
+  type FeatureResolutionContext,
+  type FeatureResolverOptions,
+  type FeatureScopeType,
+  type FeatureSyncResult,
+  type FeatureTenantHierarchyLoader,
+  type FeatureTenantHierarchyProvider,
+  type FeatureTenantNode,
+  type FeatureUsersModule,
+  GLOBAL_FEATURE_SCOPE_ID,
+  type SyncDefinitionsOptions,
+  type SyncManifestOptions,
+} from './types.js';
+
+export {
+  createFeatureKey,
+  findFeatureDefaultInRegistry,
+  parseFeatureKey,
+  resolveFeatureKeyForTarget,
+} from './utils.js';

--- a/packages/features/src/types.ts
+++ b/packages/features/src/types.ts
@@ -1,0 +1,109 @@
+import type {
+  SmartObjectManifest,
+  SmrtClassOptions,
+} from '@happyvertical/smrt-core';
+
+export const GLOBAL_FEATURE_SCOPE_ID = '*';
+
+export type FeatureScopeType = 'global' | 'tenant';
+
+export enum FeatureOverrideEffect {
+  INHERIT = 'inherit',
+  ENABLE = 'enable',
+  DISABLE = 'disable',
+}
+
+export interface FeatureMetadata {
+  [key: string]: unknown;
+}
+
+export interface FeatureDefinitionOptions {
+  id?: string;
+  featureKey?: string;
+  packageName?: string;
+  qualifiedClassName?: string;
+  className?: string;
+  localId?: string;
+  defaultEnabled?: boolean;
+  label?: string;
+  description?: string;
+  metadata?: FeatureMetadata | string | null;
+  visibility?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface FeatureOverrideOptions {
+  id?: string;
+  featureKey?: string;
+  scopeType?: FeatureScopeType;
+  scopeId?: string;
+  effect?: FeatureOverrideEffect;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface FeatureDefinitionSeed {
+  featureKey: string;
+  packageName: string;
+  qualifiedClassName: string;
+  className: string;
+  localId: string;
+  defaultEnabled: boolean;
+  label?: string;
+  description?: string;
+  metadata?: FeatureMetadata;
+  visibility?: string;
+}
+
+export interface SyncDefinitionsOptions {
+  classNames?: string[];
+  constructors?: Array<new (...args: any[]) => any>;
+  pruneStale?: boolean;
+}
+
+export interface SyncManifestOptions {
+  pruneStale?: boolean;
+}
+
+export interface FeatureSyncResult {
+  total: number;
+  created: number;
+  updated: number;
+  unchanged: number;
+  deleted: number;
+  featureKeys: string[];
+}
+
+export interface FeatureResolutionContext {
+  tenantId?: string;
+}
+
+export interface FeatureTenantNode {
+  id: string;
+  inheritPermissions: boolean;
+  cascadePermissions: boolean;
+}
+
+export interface FeatureTenantHierarchyProvider {
+  getChain(tenantId: string): Promise<FeatureTenantNode[]>;
+}
+
+export type FeatureTenantHierarchyLoader = (
+  options: SmrtClassOptions,
+) => Promise<FeatureTenantHierarchyProvider | null>;
+
+export interface FeatureResolverOptions {
+  tenantHierarchyLoader?: FeatureTenantHierarchyLoader;
+}
+
+export interface FeatureUsersModule {
+  TenantCollection: {
+    create(options: SmrtClassOptions): Promise<{
+      get(criteria: { id: string }): Promise<any>;
+      getAncestorsFromRoot(tenantId: string): Promise<any[]>;
+    }>;
+  };
+}
+
+export type { SmrtClassOptions, SmartObjectManifest };

--- a/packages/features/src/utils.test.ts
+++ b/packages/features/src/utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { parseFeatureMetadata, serializeFeatureMetadata } from './utils.js';
+
+describe('feature metadata helpers', () => {
+  it('round-trips plain object metadata', () => {
+    const serialized = serializeFeatureMetadata({
+      audience: 'staff',
+      rollout: 'alpha',
+    });
+
+    expect(parseFeatureMetadata(serialized)).toEqual({
+      audience: 'staff',
+      rollout: 'alpha',
+    });
+  });
+
+  it('normalizes JSON object strings before storing them', () => {
+    const serialized = serializeFeatureMetadata(
+      '{"audience":"staff","rollout":"alpha"}',
+    );
+
+    expect(serialized).toBe('{"audience":"staff","rollout":"alpha"}');
+    expect(parseFeatureMetadata(serialized)).toEqual({
+      audience: 'staff',
+      rollout: 'alpha',
+    });
+  });
+
+  it('rejects non-object metadata strings during serialization', () => {
+    expect(() => serializeFeatureMetadata('not-json')).toThrow(/plain object/);
+    expect(() => serializeFeatureMetadata('["staff"]')).toThrow(/plain object/);
+  });
+
+  it('gracefully falls back for invalid stored metadata', () => {
+    expect(parseFeatureMetadata('not-json')).toEqual({});
+    expect(parseFeatureMetadata('["staff"]')).toEqual({});
+  });
+});

--- a/packages/features/src/utils.ts
+++ b/packages/features/src/utils.ts
@@ -1,0 +1,318 @@
+import {
+  createQualifiedName,
+  isQualifiedName,
+  ObjectRegistry,
+  parseQualifiedName,
+  type SmartObjectConfig,
+} from '@happyvertical/smrt-core';
+import type {
+  SmartObjectDefinition,
+  SmartObjectManifest,
+} from '@happyvertical/smrt-core/manifest';
+import type { FeatureDefinitionSeed, FeatureMetadata } from './types.js';
+
+type RegistryEntryLike = {
+  name: string;
+  qualifiedName?: string;
+  packageName?: string;
+  config: SmartObjectConfig;
+  visibility?: string;
+};
+
+export function createFeatureKey(
+  qualifiedClassName: string,
+  localId: string,
+): string {
+  if (!isQualifiedName(qualifiedClassName)) {
+    throw new Error(
+      `Feature keys require a qualified class name. Received "${qualifiedClassName}".`,
+    );
+  }
+
+  if (!localId) {
+    throw new Error('Feature localId is required.');
+  }
+
+  if (localId.includes('#')) {
+    throw new Error(
+      `Feature localId "${localId}" cannot contain "#". This character is reserved for canonical feature keys.`,
+    );
+  }
+
+  return `${qualifiedClassName}#${localId}`;
+}
+
+export function parseFeatureKey(featureKey: string): {
+  qualifiedClassName: string;
+  localId: string;
+} {
+  const separatorIndex = featureKey.lastIndexOf('#');
+  if (separatorIndex <= 0 || separatorIndex === featureKey.length - 1) {
+    throw new Error(
+      `Invalid feature key "${featureKey}". Expected format "<qualifiedClassName>#<localId>".`,
+    );
+  }
+
+  const qualifiedClassName = featureKey.slice(0, separatorIndex);
+  const localId = featureKey.slice(separatorIndex + 1);
+
+  if (!isQualifiedName(qualifiedClassName)) {
+    throw new Error(
+      `Invalid feature key "${featureKey}". "${qualifiedClassName}" is not a qualified class name.`,
+    );
+  }
+
+  return { qualifiedClassName, localId };
+}
+
+export function serializeFeatureMetadata(
+  metadata: FeatureMetadata | string | null | undefined,
+): string {
+  if (!metadata) {
+    return '';
+  }
+
+  if (typeof metadata === 'string') {
+    return metadata;
+  }
+
+  return JSON.stringify(metadata);
+}
+
+export function parseFeatureMetadata(
+  metadata: string | null | undefined,
+): FeatureMetadata {
+  if (!metadata) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(metadata);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function getQualifiedClassNameFromRegistry(
+  registration: RegistryEntryLike,
+): string | null {
+  if (
+    registration.qualifiedName &&
+    isQualifiedName(registration.qualifiedName)
+  ) {
+    return registration.qualifiedName;
+  }
+
+  if (registration.packageName) {
+    return createQualifiedName(registration.packageName, registration.name);
+  }
+
+  return null;
+}
+
+export function getPackageNameFromRegistry(
+  registration: RegistryEntryLike,
+): string | null {
+  if (registration.packageName) {
+    return registration.packageName;
+  }
+
+  const qualifiedClassName = getQualifiedClassNameFromRegistry(registration);
+  if (!qualifiedClassName) {
+    return null;
+  }
+
+  return parseQualifiedName(qualifiedClassName).packageName;
+}
+
+export function extractFeatureSeedsFromRegistryEntry(
+  registration: RegistryEntryLike,
+): FeatureDefinitionSeed[] {
+  if (registration.visibility === 'test') {
+    return [];
+  }
+
+  const qualifiedClassName = getQualifiedClassNameFromRegistry(registration);
+  if (!qualifiedClassName) {
+    return [];
+  }
+
+  const featureConfig = registration.config.features;
+  if (!featureConfig) {
+    return [];
+  }
+
+  const packageName =
+    registration.packageName ||
+    parseQualifiedName(qualifiedClassName).packageName;
+
+  return Object.entries(featureConfig).map(([localId, feature]) => ({
+    featureKey: createFeatureKey(qualifiedClassName, localId),
+    packageName,
+    qualifiedClassName,
+    className: registration.name,
+    localId,
+    defaultEnabled: feature.defaultEnabled,
+    label: feature.label,
+    description: feature.description,
+    metadata: feature.metadata,
+    visibility: registration.visibility,
+  }));
+}
+
+export function extractFeatureSeedsFromManifest(
+  manifest: SmartObjectManifest,
+): FeatureDefinitionSeed[] {
+  const seeds: FeatureDefinitionSeed[] = [];
+
+  for (const [objectKey, objectDef] of Object.entries(manifest.objects)) {
+    seeds.push(...extractFeatureSeedsFromManifestObject(objectKey, objectDef));
+  }
+
+  return seeds;
+}
+
+export function extractTouchedPackagesFromManifest(
+  manifest: SmartObjectManifest,
+): Set<string> {
+  const packages = new Set<string>();
+
+  if (manifest.packageName) {
+    packages.add(manifest.packageName);
+  }
+
+  for (const [objectKey, objectDef] of Object.entries(manifest.objects)) {
+    if (objectDef.visibility === 'test') {
+      continue;
+    }
+
+    if (objectDef.packageName) {
+      packages.add(objectDef.packageName);
+      continue;
+    }
+
+    const qualifiedClassName = resolveManifestQualifiedClassName(
+      objectKey,
+      objectDef,
+    );
+    if (qualifiedClassName) {
+      packages.add(parseQualifiedName(qualifiedClassName).packageName);
+    }
+  }
+
+  return packages;
+}
+
+function extractFeatureSeedsFromManifestObject(
+  objectKey: string,
+  objectDef: SmartObjectDefinition,
+): FeatureDefinitionSeed[] {
+  if (objectDef.visibility === 'test') {
+    return [];
+  }
+
+  const features = objectDef.decoratorConfig.features;
+  if (!features) {
+    return [];
+  }
+
+  const qualifiedClassName = resolveManifestQualifiedClassName(
+    objectKey,
+    objectDef,
+  );
+  if (!qualifiedClassName) {
+    return [];
+  }
+
+  const packageName =
+    objectDef.packageName || parseQualifiedName(qualifiedClassName).packageName;
+
+  return Object.entries(features).map(([localId, feature]) => ({
+    featureKey: createFeatureKey(qualifiedClassName, localId),
+    packageName,
+    qualifiedClassName,
+    className: objectDef.className,
+    localId,
+    defaultEnabled: feature.defaultEnabled,
+    label: feature.label,
+    description: feature.description,
+    metadata:
+      feature.metadata && typeof feature.metadata === 'object'
+        ? (feature.metadata as FeatureMetadata)
+        : undefined,
+    visibility: objectDef.visibility,
+  }));
+}
+
+function resolveManifestQualifiedClassName(
+  objectKey: string,
+  objectDef: SmartObjectDefinition,
+): string | null {
+  if (objectDef.qualifiedName && isQualifiedName(objectDef.qualifiedName)) {
+    return objectDef.qualifiedName;
+  }
+
+  if (isQualifiedName(objectKey)) {
+    return objectKey;
+  }
+
+  if (objectDef.packageName) {
+    return createQualifiedName(objectDef.packageName, objectDef.className);
+  }
+
+  return null;
+}
+
+export function resolveFeatureKeyForTarget(
+  classOrInstance: object | (new (...args: any[]) => any),
+  localId: string,
+): {
+  featureKey: string;
+  defaultEnabled: boolean;
+} {
+  const ctor =
+    typeof classOrInstance === 'function'
+      ? (classOrInstance as new (
+          ...args: any[]
+        ) => any)
+      : (classOrInstance as any).constructor;
+
+  const registration = ObjectRegistry.getClassByConstructor(ctor);
+  if (!registration) {
+    throw new Error(
+      `Cannot resolve feature "${localId}" because ${ctor?.name || 'the target class'} is not registered with @smrt().`,
+    );
+  }
+
+  const qualifiedClassName = getQualifiedClassNameFromRegistry(registration);
+  if (!qualifiedClassName) {
+    throw new Error(
+      `Cannot resolve feature "${localId}" for ${registration.name} because the class has no qualified package identity.`,
+    );
+  }
+
+  const feature = registration.config.features?.[localId];
+  if (!feature) {
+    throw new Error(
+      `Feature "${localId}" is not declared on ${qualifiedClassName}.`,
+    );
+  }
+
+  return {
+    featureKey: createFeatureKey(qualifiedClassName, localId),
+    defaultEnabled: feature.defaultEnabled,
+  };
+}
+
+export function findFeatureDefaultInRegistry(
+  featureKey: string,
+): boolean | undefined {
+  const { qualifiedClassName, localId } = parseFeatureKey(featureKey);
+  const registration =
+    ObjectRegistry.getClassByQualifiedName(qualifiedClassName) ||
+    ObjectRegistry.getClass(qualifiedClassName);
+
+  const feature = registration?.config.features?.[localId];
+  return feature?.defaultEnabled;
+}

--- a/packages/features/src/utils.ts
+++ b/packages/features/src/utils.ts
@@ -73,7 +73,14 @@ export function serializeFeatureMetadata(
   }
 
   if (typeof metadata === 'string') {
-    return metadata;
+    const parsed = parseFeatureMetadataString(metadata);
+    return JSON.stringify(parsed);
+  }
+
+  if (!isFeatureMetadataRecord(metadata)) {
+    throw new Error(
+      'Feature metadata must be a plain object or a JSON string representing a plain object.',
+    );
   }
 
   return JSON.stringify(metadata);
@@ -87,11 +94,40 @@ export function parseFeatureMetadata(
   }
 
   try {
-    const parsed = JSON.parse(metadata);
-    return parsed && typeof parsed === 'object' ? parsed : {};
+    return parseFeatureMetadataString(metadata);
   } catch {
     return {};
   }
+}
+
+function parseFeatureMetadataString(metadata: string): FeatureMetadata {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(metadata);
+  } catch (error) {
+    throw new Error(
+      'Feature metadata must be a plain object or a JSON string representing a plain object.',
+      { cause: error },
+    );
+  }
+
+  if (!isFeatureMetadataRecord(parsed)) {
+    throw new Error(
+      'Feature metadata must be a plain object or a JSON string representing a plain object.',
+    );
+  }
+
+  return parsed;
+}
+
+function isFeatureMetadataRecord(value: unknown): value is FeatureMetadata {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }
 
 export function getQualifiedClassNameFromRegistry(

--- a/packages/features/tsconfig.json
+++ b/packages/features/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "types": ["node"],
+    "lib": ["ES2023"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/features/vite.config.ts
+++ b/packages/features/vite.config.ts
@@ -1,0 +1,3 @@
+import { createPackageConfig } from '../../vite.config.base.js';
+
+export default createPackageConfig('features');

--- a/packages/features/vitest.config.ts
+++ b/packages/features/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+import { smrtVitestPlugin } from '@happyvertical/smrt-vitest';
+
+export default defineConfig({
+  plugins: [smrtVitestPlugin({ verbose: true })],
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    testTimeout: 60000,
+    fileParallelism: false,
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
+  },
+});

--- a/packages/ledgers/src/__tests__/account.test.ts
+++ b/packages/ledgers/src/__tests__/account.test.ts
@@ -10,6 +10,7 @@
 import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AccountCollection } from '../collections/Accounts';
 
@@ -24,7 +25,23 @@ describe('Account', () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    const databases: DatabaseInterface[] = [];
+
+    if (accounts) {
+      databases.push(accounts.db);
+    }
+
+    for (const db of databases) {
+      if (typeof db.close === 'function') {
+        try {
+          await db.close();
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+    }
+
     if (existsSync(dbPath)) {
       try {
         rmSync(dbPath, { force: true });

--- a/packages/ledgers/src/__tests__/double-entry.test.ts
+++ b/packages/ledgers/src/__tests__/double-entry.test.ts
@@ -10,6 +10,7 @@
 import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AccountCollection } from '../collections/Accounts';
 import { JournalEntryCollection } from '../collections/JournalEntries';
@@ -102,7 +103,29 @@ describe('Double-Entry Accounting', () => {
     await cogsExpense.save();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    const databases = new Set<DatabaseInterface>();
+
+    if (accounts) {
+      databases.add(accounts.db);
+    }
+    if (journals) {
+      databases.add(journals.db);
+    }
+    if (entries) {
+      databases.add(entries.db);
+    }
+
+    for (const db of databases) {
+      if (typeof db.close === 'function') {
+        try {
+          await db.close();
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+    }
+
     if (existsSync(dbPath)) {
       try {
         rmSync(dbPath, { force: true });

--- a/packages/ledgers/src/__tests__/journal.test.ts
+++ b/packages/ledgers/src/__tests__/journal.test.ts
@@ -10,6 +10,7 @@
 import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AccountCollection } from '../collections/Accounts';
 import { JournalEntryCollection } from '../collections/JournalEntries';
@@ -52,7 +53,29 @@ describe('Journal', () => {
     await revenueAccount.save();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    const databases = new Set<DatabaseInterface>();
+
+    if (accounts) {
+      databases.add(accounts.db);
+    }
+    if (journals) {
+      databases.add(journals.db);
+    }
+    if (entries) {
+      databases.add(entries.db);
+    }
+
+    for (const db of databases) {
+      if (typeof db.close === 'function') {
+        try {
+          await db.close();
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+    }
+
     if (existsSync(dbPath)) {
       try {
         rmSync(dbPath, { force: true });

--- a/packages/ledgers/vitest.config.ts
+++ b/packages/ledgers/vitest.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts'],
-    testTimeout: 30000,
+    testTimeout: 60000,
+    hookTimeout: 60000,
     // Run test files sequentially to avoid SQLite locking issues
     fileParallelism: false,
     // Use single-threaded pool to avoid database contention

--- a/packages/scanner/src/__tests__/oxc-parser.test.ts
+++ b/packages/scanner/src/__tests__/oxc-parser.test.ts
@@ -100,6 +100,36 @@ describe('OXC Parser', () => {
       expect(config?.cli).toBe(true);
     });
 
+    it('should extract code-first feature declarations from decorator config', () => {
+      const source = `
+        @smrt({
+          features: {
+            newEditor: {
+              defaultEnabled: false,
+              label: 'New Editor',
+              description: 'Progressive editor rollout',
+              metadata: { audience: 'staff' }
+            }
+          }
+        })
+        class FeaturefulDocument extends SmrtObject {
+          title: string = '';
+        }
+      `;
+
+      const result = parseSource(source);
+      const config = result.classes[0].decoratorConfig;
+
+      expect(config?.features).toEqual({
+        newEditor: {
+          defaultEnabled: false,
+          label: 'New Editor',
+          description: 'Progressive editor rollout',
+          metadata: { audience: 'staff' },
+        },
+      });
+    });
+
     it('should extract method definitions', () => {
       const source = `
         @smrt()

--- a/packages/scanner/src/manifest-adapter.ts
+++ b/packages/scanner/src/manifest-adapter.ts
@@ -80,6 +80,15 @@ interface MethodDefinition {
 
 interface SmartObjectConfig {
   tableStrategy?: 'sti' | 'cti';
+  features?: Record<
+    string,
+    {
+      defaultEnabled: boolean;
+      label?: string;
+      description?: string;
+      metadata?: Record<string, unknown>;
+    }
+  >;
   api?: {
     include?: string[];
     exclude?: string[];

--- a/packages/scanner/src/types.ts
+++ b/packages/scanner/src/types.ts
@@ -54,6 +54,17 @@ export interface RawDecoratorConfig {
   /** Table strategy: 'sti' | 'cti' */
   tableStrategy?: 'sti' | 'cti';
 
+  /** Code-owned feature toggle declarations */
+  features?: Record<
+    string,
+    {
+      defaultEnabled: boolean;
+      label?: string;
+      description?: string;
+      metadata?: Record<string, unknown>;
+    }
+  >;
+
   /** API configuration */
   api?: {
     include?: string[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -834,6 +834,34 @@ importers:
         specifier: ^4.0.17
         version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/features:
+    dependencies:
+      '@happyvertical/smrt-core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@happyvertical/smrt-cli':
+        specifier: workspace:*
+        version: link:../cli
+      '@happyvertical/smrt-users':
+        specifier: workspace:*
+        version: link:../users
+      '@happyvertical/smrt-vitest':
+        specifier: workspace:*
+        version: link:../vitest
+      '@types/node':
+        specifier: 24.10.9
+        version: 24.10.9
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: ^4.0.17
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@24.10.9)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(tsx@4.21.0)(yaml@2.8.2)
+
   packages/gnode:
     dependencies:
       '@happyvertical/ai':


### PR DESCRIPTION
## Summary

Adds code-first feature flags to SMRT with a new `@happyvertical/smrt-features` package, while keeping feature metadata transport in core/scanner and leaving runtime resolution and override storage outside `smrt-core`.

## What Changed

- adds `features` support to `@smrt()` typing plus registry/scanner/manifest serialization and hydration
- introduces `@happyvertical/smrt-features` with:
  - code-owned feature definitions synced into `_smrt_feature_definitions`
  - mutable global and tenant overrides in `_smrt_feature_overrides`
  - a `FeatureResolver` that evaluates decorator defaults, global overrides, and tenant overrides with optional tenant hierarchy support from `smrt-users`
  - generated REST/CLI/MCP surfaces with read-only definitions and CRUD overrides
- fixes REST runtime action gating so generated `api.include` and `api.exclude` rules are enforced consistently, including `/count` for list-only surfaces
- adds tests covering manifest flow, canonical key generation, resolver behavior, sync idempotency, stale-definition pruning, and generated surfaces

## Architecture Notes

- definitions are decorator/code-first and not admin-editable in v1
- runtime override state lives in `_smrt_` tables rather than decorator config
- tenant integration is optional and uses plain string scope ids instead of cross-package foreign keys
- billing/package entitlement mapping is intentionally deferred to application code or a future package

## Validation

- `pnpm --filter @happyvertical/smrt-features test`
- `pnpm exec tsc -p packages/features/tsconfig.json --noEmit`
- `pnpm --filter @happyvertical/smrt-features build`
- `pnpm --filter @happyvertical/smrt-core exec vitest run src/registry.test.ts src/__tests__/external-runtime-hydration.test.ts`
- `pnpm --filter @happyvertical/smrt-scanner test -- src/__tests__/oxc-parser.test.ts`
- `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
- `pnpm exec tsc -p packages/scanner/tsconfig.json --noEmit`
- `npm run build`
- `npm test`

## Review Notes

A local review pass surfaced and fixed two edge cases before opening this PR:

- stale definitions were not pruned when a touched package removed its last feature
- REST action gating could incorrectly block or allow `/count` on list-only surfaces
