### PR TITLE
fix: pass export query params variadically

### DIFF
--- a/.changeset/fix-export-postgres-params.md
+++ b/.changeset/fix-export-postgres-params.md
@@ -1,0 +1,5 @@
+---
+'@happyvertical/smrt-cli': patch
+---
+
+Fix static-site export queries on Postgres by passing raw SQL parameters to the database adapter as variadic arguments instead of a single wrapped array.

--- a/packages/cli/src/commands/__tests__/export.test.ts
+++ b/packages/cli/src/commands/__tests__/export.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { formatProjectedRecords, queryWithProjection } from '../export.js';
 
 describe('export command helpers', () => {
-  it('passes query params as a single array to the database adapter', async () => {
+  it('passes query params as variadic database adapter arguments', async () => {
     const query = vi.fn().mockResolvedValue({
       rows: [{ title: 'Bridge update' }],
     });
@@ -19,7 +19,8 @@ describe('export command helpers', () => {
 
     expect(query).toHaveBeenCalledWith(
       expect.stringContaining('FROM contents'),
-      ['%:Article', 'published'],
+      '%:Article',
+      'published',
     );
   });
 

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -259,7 +259,7 @@ export async function queryWithProjection(
   }
 
   try {
-    const result = await db.query(sql, whereValues);
+    const result = await db.query(sql, ...whereValues);
     return Array.isArray(result) ? result : (result?.rows ?? []);
   } catch (error) {
     // If query fails (missing column, etc.), return empty


### PR DESCRIPTION
## Summary
- pass `smrt export` query parameters to the database adapter as variadic arguments instead of a wrapped array
- update the export helper regression test to match the Postgres adapter contract
- add a changeset so the fix can publish

## Verification
- `pnpm turbo run build --filter=@happyvertical/smrt-core --filter=@happyvertical/smrt-config --filter=@happyvertical/smrt-cli^...`
- `pnpm --dir packages/cli exec vitest run src/commands/__tests__/export.test.ts`

## Production context
This fixes static-site exports on Postgres. The old call shape caused `smrt export` to log `Query failed for contents/events/...` and silently emit zero-record JSON files.
