### PR TITLE
fix(core): hydrate external runtime STI classes

### DIFF
--- a/.changeset/friendly-tips-carry.md
+++ b/.changeset/friendly-tips-carry.md
@@ -1,3 +1,4 @@
+---
 "@happyvertical/smrt-agents": patch
 "@happyvertical/smrt-core": patch
 "@happyvertical/smrt-jobs": patch

--- a/.changeset/friendly-tips-carry.md
+++ b/.changeset/friendly-tips-carry.md
@@ -1,0 +1,10 @@
+"@happyvertical/smrt-agents": patch
+"@happyvertical/smrt-core": patch
+"@happyvertical/smrt-jobs": patch
+---
+
+Improve bundled runtime behavior and operator guidance for background jobs.
+
+- fix `ObjectRegistry.ensureManifestLoaded()` and STI polymorphic hydration so installed external classes can be loaded on demand by qualified name
+- clarify stale-heartbeat recovery errors for long-running blocking jobs
+- document bundled runtime manifest loading, heartbeat-safe job execution, and the distinction between automatic scheduled work and manual operator actions such as forage/backfill flows

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -70,7 +70,7 @@ jobs:
     name: Typecheck
     needs: build
     runs-on: arc-happyvertical
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository
@@ -131,7 +131,7 @@ jobs:
     name: Test Core (${{ matrix.shard }})
     needs: build
     runs-on: arc-happyvertical
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -207,7 +207,7 @@ jobs:
     name: Test Packages
     needs: build
     runs-on: arc-happyvertical
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -59,6 +59,19 @@ If you are running a single-agent CLI or script and want built-in
 constructor. Multi-agent hosts should leave that off and coordinate process
 shutdown themselves.
 
+## Scheduled Methods Vs Operator Actions
+
+Use scheduled agent methods for the regular, repeatable maintenance path: the
+work that should happen automatically every time the schedule fires. Keep those
+methods idempotent and safe to rerun.
+
+When operators need a composite catch-up or repair flow, expose that as an
+explicit method such as `forage()`, `backfill()`, or `rebuildIndex()` instead of
+overloading `run()` with manual-only behavior. Those operator actions can still
+be enqueued through `@happyvertical/smrt-jobs`, but they should remain distinct
+from the normal scheduled loop so it stays obvious which work is automatic and
+which work is an intentional intervention.
+
 ## API
 
 ### Main Export (`@happyvertical/smrt-agents`)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -50,6 +50,27 @@ const isExpensive = await product.is('costs more than the average product');
 const description = await product.do('Write a short marketing description');
 ```
 
+### Bundled Runtimes And External Manifests
+
+Long-lived bundled runtimes such as SvelteKit servers, background workers, and
+CLI entrypoints should ship two things together:
+
+1. The generated `smrt-register` runtime entrypoint for local class
+   registration.
+2. The `manifest.json` exports for any installed external `@happyvertical/smrt-*`
+   packages the runtime needs to hydrate at query time.
+
+`ObjectRegistry.ensureManifestLoaded()` can now auto-load installed external
+classes by either simple name (`'EventType'`) or qualified name
+(`'@happyvertical/smrt-events:EventType'`). `SmrtCollection.list()` and
+`SmrtCollection.get()` use that path when they encounter STI discriminators from
+external packages, so bundled runtimes do not need to import every child class
+eagerly just to hydrate rows correctly.
+
+If you want to avoid on-demand manifest discovery in a long-lived process, call
+`ObjectRegistry.loadAllManifests()` during startup after your local registration
+file has run.
+
 ## API
 
 ### Core Classes

--- a/packages/core/src/__tests__/external-runtime-hydration.test.ts
+++ b/packages/core/src/__tests__/external-runtime-hydration.test.ts
@@ -220,6 +220,47 @@ describe('external runtime field hydration', () => {
     ).resolves.toEqual([]);
   });
 
+  it('auto-loads unregistered external classes by qualified name', async () => {
+    const packageName = '@happyvertical/smrt-runtime-fixture-event-types';
+    const qualifiedClassName = createQualifiedName(
+      packageName,
+      'FixtureRuntimeEventType',
+    );
+
+    writeScopedPackage(
+      appDir,
+      packageName,
+      fixtureManifest(packageName, {
+        FixtureRuntimeEventType: {
+          decoratorConfig: {
+            tableStrategy: 'sti',
+            tableName: 'fixture_runtime_event_types',
+            api: false,
+            cli: false,
+            mcp: false,
+          },
+          fields: {
+            label: { type: 'text' },
+            priority: { type: 'number' },
+          },
+        },
+      }),
+    );
+
+    await ObjectRegistry.ensureManifestLoaded(qualifiedClassName);
+
+    const registered =
+      ObjectRegistry.getClassByQualifiedName(qualifiedClassName);
+    expect(registered).toBeDefined();
+    expect(registered?.name).toBe('FixtureRuntimeEventType');
+    expect(ObjectRegistry.getFields(qualifiedClassName).has('label')).toBe(
+      true,
+    );
+    expect(ObjectRegistry.getFields(qualifiedClassName).has('priority')).toBe(
+      true,
+    );
+  });
+
   it('hydrates manifest metadata even when runtime field counts and types already match', async () => {
     const packageName = '@happyvertical/smrt-runtime-fixture-metadata';
 
@@ -931,5 +972,98 @@ describe('external runtime field hydration', () => {
       `${packageName}:FixtureEmailAccount`,
     );
     await expect(collection.count()).resolves.toBe(1);
+  });
+
+  it('hydrates STI rows whose child discriminator is only available from an installed manifest', async () => {
+    const packageName = '@happyvertical/smrt-runtime-fixture-polymorphic';
+    const childQualifiedName = createQualifiedName(
+      packageName,
+      'FixtureRuntimeMeeting',
+    );
+
+    writeScopedPackage(
+      appDir,
+      packageName,
+      fixtureManifest(packageName, {
+        FixtureRuntimeEvent: {
+          decoratorConfig: {
+            tableStrategy: 'sti',
+            tableName: 'fixture_runtime_events',
+            api: false,
+            cli: false,
+            mcp: false,
+          },
+          fields: {
+            title: { type: 'text' },
+          },
+        },
+        FixtureRuntimeMeeting: {
+          extends: 'FixtureRuntimeEvent',
+          decoratorConfig: {
+            tableStrategy: 'sti',
+            tableName: 'fixture_runtime_events',
+            api: false,
+            cli: false,
+            mcp: false,
+          },
+          fields: {
+            location: { type: 'text' },
+          },
+        },
+      }),
+    );
+
+    @smrt({
+      tableStrategy: 'sti',
+      tableName: 'fixture_runtime_events',
+      api: false,
+      cli: false,
+      mcp: false,
+    })
+    class FixtureRuntimeEvent extends SmrtObject {
+      @field()
+      title: string = '';
+    }
+
+    stripPackageIdentity('FixtureRuntimeEvent');
+
+    const db = await getTestDatabase({
+      classes: ['FixtureRuntimeEvent'],
+    });
+
+    await db.query(
+      `INSERT INTO fixture_runtime_events (
+        id,
+        slug,
+        context,
+        created_at,
+        updated_at,
+        _meta_type,
+        title
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      'event-1',
+      'event-1',
+      '',
+      '2026-04-11T20:00:00.000Z',
+      '2026-04-11T20:00:00.000Z',
+      childQualifiedName,
+      'Budget meeting',
+    );
+
+    const collection = await ObjectRegistry.getCollection(
+      'FixtureRuntimeEvent',
+      {
+        db,
+      },
+    );
+
+    const items = await collection.list({});
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.constructor.name).toBe('FixtureRuntimeMeeting');
+    expect((items[0] as any)._meta_type).toBe(childQualifiedName);
+    expect(
+      ObjectRegistry.getClassByQualifiedName(childQualifiedName),
+    ).toBeDefined();
   });
 });

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -1270,9 +1270,17 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     }
 
     if (!registeredClass) {
+      await ObjectRegistry.ensureManifestLoaded(className);
+      registeredClass = ObjectRegistry.getClassByQualifiedName(className);
+      if (!registeredClass) {
+        registeredClass = ObjectRegistry.getClass(className);
+      }
+    }
+
+    if (!registeredClass) {
       throw new Error(
         `STI polymorphic query failed: Class '${className}' not found in ObjectRegistry. ` +
-          `Ensure the class is registered with @smrt() decorator.`,
+          `Ensure the class is registered with @smrt() decorator or available via an installed SMRT manifest.`,
       );
     }
 

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1284,7 +1284,14 @@ export class ObjectRegistry {
    * ```
    */
   static async ensureManifestLoaded(className: string): Promise<void> {
-    const registered = ObjectRegistry.findClass(className);
+    let registered = ObjectRegistry.findClass(className);
+    if (!registered) {
+      const loaded = await ObjectRegistry.tryLoadFromExternalPackage(className);
+      if (loaded) {
+        registered = ObjectRegistry.findClass(className);
+      }
+    }
+
     if (!registered) {
       // Detect if running in test environment
       const isTestEnv =

--- a/packages/jobs/README.md
+++ b/packages/jobs/README.md
@@ -58,6 +58,27 @@ runner.on('job:failed', (job, error) => { /* ... */ });
 process.on('SIGTERM', () => runner.stop());
 ```
 
+### Heartbeat-safe job execution
+
+`TaskRunner` keeps jobs alive with a heartbeat timer. If your job blocks the
+Node.js event loop for longer than the effective stale-job threshold, the runner
+will recover that work as stale and mark it failed.
+
+Common causes:
+
+- `execSync`, `spawnSync`, or other synchronous subprocess APIs
+- long CPU-bound loops in the job method itself
+- large synchronous filesystem work
+
+Prefer async subprocess APIs (`spawn`, `execFile`, streamed stdio) for long
+exports/builds/uploads, or move CPU-heavy work into a separate process or
+worker thread. If a job is intentionally long-running, tune
+`heartbeatInterval` and `staleJobThresholdMs` together so the stale threshold
+comfortably exceeds the longest gap between heartbeats.
+
+`ScheduleRunner` uses the same stale-heartbeat recovery rules when reconciling
+scheduled jobs.
+
 ### Schedule recurring jobs with ScheduleRunner
 
 The `ScheduleRunner` polls the `_smrt_agent_schedules` table for due cron entries and creates `SmrtJob` records for the `TaskRunner` to execute. Wire them together via events:

--- a/packages/jobs/src/runner.ts
+++ b/packages/jobs/src/runner.ts
@@ -421,7 +421,9 @@ export class TaskRunner extends EventEmitter {
 
     const placeholders = staleJobIds.map(() => '?').join(', ');
     const recoveredAt = new Date();
-    const errorMessage = `Recovered stale running job after ${effectiveStaleThresholdMs}ms without a heartbeat`;
+    const errorMessage =
+      `Recovered stale running job after ${effectiveStaleThresholdMs}ms without a heartbeat. ` +
+      `Long synchronous work can block heartbeats; prefer async subprocess APIs or raise the stale threshold for intentionally long jobs.`;
 
     await this.db.query(
       `UPDATE _smrt_jobs

--- a/packages/jobs/src/schedule-runner.ts
+++ b/packages/jobs/src/schedule-runner.ts
@@ -358,7 +358,8 @@ export class ScheduleRunner extends EventEmitter {
           WHERE status = 'running'
             AND id IN (${placeholders})`,
         now,
-        `Recovered stale scheduled job after ${effectiveStaleThresholdMs}ms without a heartbeat`,
+        `Recovered stale scheduled job after ${effectiveStaleThresholdMs}ms without a heartbeat. ` +
+          `Long synchronous work can block heartbeats; prefer async subprocess APIs or raise the stale threshold for intentionally long jobs.`,
         ...staleJobIds,
       );
     }


### PR DESCRIPTION
## Summary
- auto-load installed external SMRT classes when `ensureManifestLoaded()` is called for an unregistered simple or qualified name
- retry STI polymorphic hydration after manifest loading so bundled runtimes can hydrate external child rows instead of failing early
- make stale heartbeat recovery errors point operators toward the real failure mode and document bundled runtime, heartbeat-safe job, and operator-action guidance

## Why
This bundles the upstream gaps we hit while debugging Anytown production:
- bundled workers could still fail on external STI child discriminators like `@happyvertical/smrt-events:EventType`
- stale-job recovery messages did not explain that blocking synchronous work can starve heartbeats
- the docs did not clearly explain the line between automatic scheduled work and manual operator flows like `forage()`

## Testing
- `pnpm turbo build --filter=@happyvertical/smrt-core^... --filter=@happyvertical/smrt-core --filter=@happyvertical/smrt-jobs^... --filter=@happyvertical/smrt-jobs`
- `pnpm --filter @happyvertical/smrt-jobs test -- src/__tests__/job-tenancy.test.ts`
- `pnpm --filter @happyvertical/smrt-core test -- src/__tests__/external-runtime-hydration.test.ts src/__tests__/issue-131-external-manifests.test.ts`

Note: the `@happyvertical/smrt-core` package test script currently runs the full core suite after generating manifests; it passed in full on this branch (`148` files, `1502` tests passed, `2` skipped).