### PR TITLE
[codex] repair live schema drift reconciliation

### DIFF
--- a/packages/cli/src/commands/__tests__/db-migrate-actions.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-actions.test.ts
@@ -3,7 +3,7 @@ import { partitionSchemaChanges } from '../db-migrate-actions.js';
 
 describe('partitionSchemaChanges', () => {
   it('keeps type upgrades in the executable migration set', () => {
-    const { migrations, typeMismatches } = partitionSchemaChanges(
+    const { migrations, manualInterventions } = partitionSchemaChanges(
       [
         {
           type: 'type_upgrade',
@@ -22,7 +22,7 @@ describe('partitionSchemaChanges', () => {
       (tableName) => `${tableName}:Class`,
     );
 
-    expect(typeMismatches).toEqual([]);
+    expect(manualInterventions).toEqual([]);
     expect(migrations).toEqual([
       {
         type: 'type_upgrade',
@@ -45,8 +45,75 @@ describe('partitionSchemaChanges', () => {
     ]);
   });
 
+  it('keeps comment-only SQLite type upgrades in the manual intervention set', () => {
+    const { migrations, manualInterventions } = partitionSchemaChanges(
+      [
+        {
+          type: 'type_upgrade',
+          table: 'contents',
+          name: 'metadata',
+          column: {
+            type: 'JSON',
+          },
+          mismatch: {
+            expected: 'JSON',
+            actual: 'BLOB',
+          },
+          sql: '-- SQLite: Type upgrade for "metadata" requires table recreation',
+        },
+      ],
+      () => 'Content',
+    );
+
+    expect(migrations).toEqual([]);
+    expect(manualInterventions).toEqual([
+      {
+        type: 'type_upgrade',
+        tableName: 'contents',
+        className: 'Content',
+        column: {
+          name: 'metadata',
+          type: 'JSON',
+          notNull: undefined,
+          defaultValue: undefined,
+          unique: undefined,
+        },
+        mismatch: {
+          column: 'metadata',
+          expected: 'JSON',
+          actual: 'BLOB',
+        },
+        sql: '-- SQLite: Type upgrade for "metadata" requires table recreation',
+      },
+    ]);
+  });
+
+  it('drops no-op type upgrades from the action lists', () => {
+    const { migrations, manualInterventions } = partitionSchemaChanges(
+      [
+        {
+          type: 'type_upgrade',
+          table: 'contents',
+          name: 'metadata',
+          column: {
+            type: 'JSON',
+          },
+          mismatch: {
+            expected: 'JSON',
+            actual: 'TEXT',
+          },
+          sql: '-- SQLite: "metadata" already stores JSON as TEXT (no change needed)',
+        },
+      ],
+      () => 'Content',
+    );
+
+    expect(migrations).toEqual([]);
+    expect(manualInterventions).toEqual([]);
+  });
+
   it('separates incompatible type mismatches from executable repairs', () => {
-    const { migrations, typeMismatches } = partitionSchemaChanges(
+    const { migrations, manualInterventions } = partitionSchemaChanges(
       [
         {
           type: 'type_mismatch',
@@ -62,7 +129,7 @@ describe('partitionSchemaChanges', () => {
     );
 
     expect(migrations).toEqual([]);
-    expect(typeMismatches).toEqual([
+    expect(manualInterventions).toEqual([
       {
         type: 'type_mismatch',
         tableName: 'contents',

--- a/packages/cli/src/commands/__tests__/db-migrate-actions.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-actions.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { partitionSchemaChanges } from '../db-migrate-actions.js';
+
+describe('partitionSchemaChanges', () => {
+  it('keeps type upgrades in the executable migration set', () => {
+    const { migrations, typeMismatches } = partitionSchemaChanges(
+      [
+        {
+          type: 'type_upgrade',
+          table: 'contents',
+          name: 'published_at',
+          column: {
+            type: 'TIMESTAMP',
+          },
+          mismatch: {
+            expected: 'TIMESTAMP',
+            actual: 'TEXT',
+          },
+          sql: 'ALTER TABLE "contents" ALTER COLUMN "published_at" TYPE TIMESTAMP',
+        },
+      ],
+      (tableName) => `${tableName}:Class`,
+    );
+
+    expect(typeMismatches).toEqual([]);
+    expect(migrations).toEqual([
+      {
+        type: 'type_upgrade',
+        tableName: 'contents',
+        className: 'contents:Class',
+        column: {
+          name: 'published_at',
+          type: 'TIMESTAMP',
+          notNull: undefined,
+          defaultValue: undefined,
+          unique: undefined,
+        },
+        mismatch: {
+          column: 'published_at',
+          expected: 'TIMESTAMP',
+          actual: 'TEXT',
+        },
+        sql: 'ALTER TABLE "contents" ALTER COLUMN "published_at" TYPE TIMESTAMP',
+      },
+    ]);
+  });
+
+  it('separates incompatible type mismatches from executable repairs', () => {
+    const { migrations, typeMismatches } = partitionSchemaChanges(
+      [
+        {
+          type: 'type_mismatch',
+          table: 'contents',
+          name: 'video_asset_id',
+          mismatch: {
+            expected: 'TEXT',
+            actual: 'INTEGER',
+          },
+        },
+      ],
+      () => 'Content',
+    );
+
+    expect(migrations).toEqual([]);
+    expect(typeMismatches).toEqual([
+      {
+        type: 'type_mismatch',
+        tableName: 'contents',
+        className: 'Content',
+        mismatch: {
+          column: 'video_asset_id',
+          expected: 'TEXT',
+          actual: 'INTEGER',
+        },
+      },
+    ]);
+  });
+});

--- a/packages/cli/src/commands/__tests__/db-status.test.ts
+++ b/packages/cli/src/commands/__tests__/db-status.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  autoDiscoverAndLoadMock,
+  getPackageConfigMock,
+  getDatabaseMock,
+  getAllSchemasAsDefinitionsMock,
+  compareMock,
+  initializeMock,
+  getAppliedMigrationsMock,
+  getEngineMock,
+  SchemaComparerMock,
+  MigrationTrackerMock,
+} = vi.hoisted(() => {
+  const compare = vi.fn();
+  const initialize = vi.fn();
+  const getAppliedMigrations = vi.fn();
+  const getEngine = vi.fn();
+
+  class MockSchemaComparer {
+    compare = compare;
+  }
+
+  class MockMigrationTracker {
+    initialize = initialize;
+    getAppliedMigrations = getAppliedMigrations;
+    getEngine = getEngine;
+  }
+
+  return {
+    autoDiscoverAndLoadMock: vi.fn(),
+    getPackageConfigMock: vi.fn(),
+    getDatabaseMock: vi.fn(),
+    getAllSchemasAsDefinitionsMock: vi.fn(),
+    compareMock: compare,
+    initializeMock: initialize,
+    getAppliedMigrationsMock: getAppliedMigrations,
+    getEngineMock: getEngine,
+    SchemaComparerMock: MockSchemaComparer,
+    MigrationTrackerMock: MockMigrationTracker,
+  };
+});
+
+vi.mock('../../discovery/index.js', () => ({
+  autoDiscoverAndLoad: autoDiscoverAndLoadMock,
+}));
+
+vi.mock('@happyvertical/smrt-config', () => ({
+  getPackageConfig: getPackageConfigMock,
+}));
+
+vi.mock('@happyvertical/sql', () => ({
+  getDatabase: getDatabaseMock,
+}));
+
+vi.mock('@happyvertical/smrt-core', () => ({
+  ObjectRegistry: {
+    getAllSchemasAsDefinitions: getAllSchemasAsDefinitionsMock,
+  },
+  SchemaComparer: SchemaComparerMock,
+}));
+
+vi.mock('@happyvertical/smrt-core/migrations', () => ({
+  MigrationTracker: MigrationTrackerMock,
+}));
+
+import { dbStatusCommand, summarizeSchemaDiff } from '../db-status.js';
+
+describe('db:status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    getPackageConfigMock.mockReturnValue({
+      database: {
+        type: 'postgres',
+        url: 'postgresql://test:test@localhost:5432/test_db',
+      },
+    });
+
+    getDatabaseMock.mockResolvedValue({
+      url: 'postgresql://test:test@localhost:5432/test_db',
+      getTableSchema: vi.fn(),
+    });
+
+    autoDiscoverAndLoadMock.mockResolvedValue({
+      discovered: [{ path: '/fake/manifest.json' }],
+      totalObjects: 3,
+    });
+
+    getAllSchemasAsDefinitionsMock.mockReturnValue({
+      contents: {
+        tableName: 'contents',
+      },
+    });
+
+    initializeMock.mockResolvedValue(undefined);
+    getAppliedMigrationsMock.mockResolvedValue([]);
+    getEngineMock.mockReturnValue('postgres');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('summarizes live schema drift into actionable status entries', () => {
+    expect(
+      summarizeSchemaDiff({
+        added_tables: [{ tableName: 'contents' }],
+        changes: [
+          {
+            type: 'add_column',
+            table: 'contents',
+            name: 'script_text',
+          },
+          {
+            type: 'type_mismatch',
+            table: 'contents',
+            name: 'published_at',
+            mismatch: {
+              expected: 'TIMESTAMP',
+              actual: 'TEXT',
+            },
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        name: 'contents',
+        type: 'missing_table',
+        recommendation:
+          'Run `smrt db:migrate` to create the missing table in the live database.',
+      },
+      {
+        name: 'contents.script_text',
+        type: 'missing_column',
+        recommendation:
+          'Run `smrt db:migrate` to add the missing column before application writes hit this table.',
+      },
+      {
+        name: 'contents.published_at',
+        type: 'type_mismatch',
+        recommendation:
+          'Manual intervention required: expected TIMESTAMP, found TEXT.',
+      },
+    ]);
+  });
+
+  it('reports live drift in JSON output instead of only migration history', async () => {
+    compareMock.mockResolvedValue({
+      added_tables: [],
+      dropped_tables: [],
+      has_changes: true,
+      changes: [
+        {
+          type: 'add_column',
+          table: 'contents',
+          name: 'script_text',
+        },
+        {
+          type: 'add_index',
+          table: 'contents',
+          name: 'idx_contents_published_at',
+        },
+      ],
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await dbStatusCommand.handler([], { json: true });
+
+    expect(compareMock).toHaveBeenCalledWith({
+      contents: {
+        tableName: 'contents',
+      },
+    });
+
+    const output = logSpy.mock.calls.map((call) => call.join('')).join('\n');
+    const parsed = JSON.parse(output);
+
+    expect(parsed.manifests.objects).toBe(3);
+    expect(parsed.drift).toEqual([
+      {
+        name: 'contents.script_text',
+        type: 'missing_column',
+        recommendation:
+          'Run `smrt db:migrate` to add the missing column before application writes hit this table.',
+      },
+      {
+        name: 'contents.idx_contents_published_at',
+        type: 'missing_index',
+        recommendation:
+          'Run `smrt db:migrate` to add the missing index and reconcile the live schema.',
+      },
+    ]);
+  });
+});

--- a/packages/cli/src/commands/__tests__/db-status.test.ts
+++ b/packages/cli/src/commands/__tests__/db-status.test.ts
@@ -113,12 +113,18 @@ describe('db:status', () => {
             name: 'script_text',
           },
           {
-            type: 'type_mismatch',
+            type: 'type_upgrade',
             table: 'contents',
             name: 'published_at',
+            sql: '-- SQLite: Type upgrade for "published_at" requires table recreation',
+          },
+          {
+            type: 'type_mismatch',
+            table: 'contents',
+            name: 'video_asset_id',
             mismatch: {
-              expected: 'TIMESTAMP',
-              actual: 'TEXT',
+              expected: 'TEXT',
+              actual: 'INTEGER',
             },
           },
         ],
@@ -138,9 +144,15 @@ describe('db:status', () => {
       },
       {
         name: 'contents.published_at',
+        type: 'type_upgrade',
+        recommendation:
+          'Manual intervention required: this live column needs a type upgrade that the current database engine cannot auto-apply.',
+      },
+      {
+        name: 'contents.video_asset_id',
         type: 'type_mismatch',
         recommendation:
-          'Manual intervention required: expected TIMESTAMP, found TEXT.',
+          'Manual intervention required: expected TEXT, found INTEGER.',
       },
     ]);
   });
@@ -192,5 +204,21 @@ describe('db:status', () => {
           'Run `smrt db:migrate` to add the missing index and reconcile the live schema.',
       },
     ]);
+  });
+
+  it('omits no-op type upgrades from drift output', () => {
+    expect(
+      summarizeSchemaDiff({
+        added_tables: [],
+        changes: [
+          {
+            type: 'type_upgrade',
+            table: 'contents',
+            name: 'metadata',
+            sql: '-- SQLite: "metadata" already stores JSON as TEXT (no change needed)',
+          },
+        ],
+      }),
+    ).toEqual([]);
   });
 });

--- a/packages/cli/src/commands/db-migrate-actions.ts
+++ b/packages/cli/src/commands/db-migrate-actions.ts
@@ -44,15 +44,38 @@ export interface SchemaChangeLike {
   sql?: string;
 }
 
+export type TypeUpgradeExecutionKind = 'executable' | 'manual' | 'noop';
+
+export function classifyTypeUpgradeSql(sql?: string): TypeUpgradeExecutionKind {
+  const trimmed = sql?.trim();
+
+  if (!trimmed) {
+    return 'manual';
+  }
+
+  if (!trimmed.startsWith('--')) {
+    return 'executable';
+  }
+
+  if (
+    /no change needed/i.test(trimmed) ||
+    /already stores .* as /i.test(trimmed)
+  ) {
+    return 'noop';
+  }
+
+  return 'manual';
+}
+
 export function partitionSchemaChanges(
   changes: SchemaChangeLike[],
   getClassForTable: (tableName: string) => string,
 ): {
   migrations: MigrationAction[];
-  typeMismatches: MigrationAction[];
+  manualInterventions: MigrationAction[];
 } {
   const migrations: MigrationAction[] = [];
-  const typeMismatches: MigrationAction[] = [];
+  const manualInterventions: MigrationAction[] = [];
 
   for (const change of changes) {
     const className = getClassForTable(change.table);
@@ -97,7 +120,7 @@ export function partitionSchemaChanges(
       case 'type_mismatch': {
         const mm = change.mismatch;
         if (!change.name || !mm) continue;
-        typeMismatches.push({
+        manualInterventions.push({
           type: 'type_mismatch',
           tableName: change.table,
           className,
@@ -114,7 +137,7 @@ export function partitionSchemaChanges(
         const mm = change.mismatch;
         const col = change.column;
         if (!change.name || !mm || !col) continue;
-        migrations.push({
+        const action: MigrationAction = {
           type: 'type_upgrade',
           tableName: change.table,
           className,
@@ -131,11 +154,18 @@ export function partitionSchemaChanges(
             actual: mm.actual,
           },
           sql: change.sql,
-        });
+        };
+        const executionKind = classifyTypeUpgradeSql(change.sql);
+
+        if (executionKind === 'executable') {
+          migrations.push(action);
+        } else if (executionKind === 'manual') {
+          manualInterventions.push(action);
+        }
         break;
       }
     }
   }
 
-  return { migrations, typeMismatches };
+  return { migrations, manualInterventions };
 }

--- a/packages/cli/src/commands/db-migrate-actions.ts
+++ b/packages/cli/src/commands/db-migrate-actions.ts
@@ -1,0 +1,141 @@
+export interface MigrationAction {
+  type: 'add_column' | 'add_index' | 'type_mismatch' | 'type_upgrade';
+  tableName: string;
+  className: string;
+  column?: {
+    name: string;
+    type: string;
+    notNull?: boolean;
+    defaultValue?: unknown;
+    unique?: boolean;
+  };
+  index?: {
+    name: string;
+    columns: string[];
+    unique?: boolean;
+  };
+  mismatch?: {
+    column: string;
+    expected: string;
+    actual: string;
+  };
+  sql?: string;
+}
+
+export interface SchemaChangeLike {
+  type: 'add_column' | 'add_index' | 'type_mismatch' | 'type_upgrade';
+  table: string;
+  name?: string;
+  column?: {
+    type: string;
+    notNull?: boolean;
+    defaultValue?: unknown;
+    unique?: boolean;
+  };
+  index?: {
+    name: string;
+    columns: string[];
+    unique?: boolean;
+  };
+  mismatch?: {
+    expected: string;
+    actual: string;
+  };
+  sql?: string;
+}
+
+export function partitionSchemaChanges(
+  changes: SchemaChangeLike[],
+  getClassForTable: (tableName: string) => string,
+): {
+  migrations: MigrationAction[];
+  typeMismatches: MigrationAction[];
+} {
+  const migrations: MigrationAction[] = [];
+  const typeMismatches: MigrationAction[] = [];
+
+  for (const change of changes) {
+    const className = getClassForTable(change.table);
+
+    switch (change.type) {
+      case 'add_column': {
+        const col = change.column;
+        if (!change.name || !col) continue;
+        migrations.push({
+          type: 'add_column',
+          tableName: change.table,
+          className,
+          column: {
+            name: change.name,
+            type: col.type,
+            notNull: col.notNull,
+            defaultValue: col.defaultValue,
+            unique: col.unique,
+          },
+          sql: change.sql,
+        });
+        break;
+      }
+
+      case 'add_index': {
+        const idx = change.index;
+        if (!idx) continue;
+        migrations.push({
+          type: 'add_index',
+          tableName: change.table,
+          className,
+          index: {
+            name: idx.name,
+            columns: idx.columns,
+            unique: idx.unique,
+          },
+          sql: change.sql,
+        });
+        break;
+      }
+
+      case 'type_mismatch': {
+        const mm = change.mismatch;
+        if (!change.name || !mm) continue;
+        typeMismatches.push({
+          type: 'type_mismatch',
+          tableName: change.table,
+          className,
+          mismatch: {
+            column: change.name,
+            expected: mm.expected,
+            actual: mm.actual,
+          },
+        });
+        break;
+      }
+
+      case 'type_upgrade': {
+        const mm = change.mismatch;
+        const col = change.column;
+        if (!change.name || !mm || !col) continue;
+        migrations.push({
+          type: 'type_upgrade',
+          tableName: change.table,
+          className,
+          column: {
+            name: change.name,
+            type: col.type,
+            notNull: col.notNull,
+            defaultValue: col.defaultValue,
+            unique: col.unique,
+          },
+          mismatch: {
+            column: change.name,
+            expected: mm.expected,
+            actual: mm.actual,
+          },
+          sql: change.sql,
+        });
+        break;
+      }
+    }
+  }
+
+  return { migrations, typeMismatches };
+}

--- a/packages/cli/src/commands/db-status.ts
+++ b/packages/cli/src/commands/db-status.ts
@@ -7,8 +7,82 @@
  * - Drift detection warnings
  */
 
+import { ObjectRegistry, SchemaComparer } from '@happyvertical/smrt-core';
 import type { CLICommand } from '../cli-generator.js';
 import { autoDiscoverAndLoad } from '../discovery/index.js';
+
+type StatusDrift = {
+  name: string;
+  type: string;
+  recommendation: string;
+};
+
+export function summarizeSchemaDiff(diff: {
+  added_tables: Array<{ tableName: string }>;
+  changes: Array<{
+    type: string;
+    table: string;
+    name?: string;
+    mismatch?: {
+      expected: string;
+      actual: string;
+    };
+  }>;
+}): StatusDrift[] {
+  const drift: StatusDrift[] = [];
+
+  for (const schema of diff.added_tables) {
+    drift.push({
+      name: schema.tableName,
+      type: 'missing_table',
+      recommendation:
+        'Run `smrt db:migrate` to create the missing table in the live database.',
+    });
+  }
+
+  for (const change of diff.changes) {
+    switch (change.type) {
+      case 'add_column':
+        drift.push({
+          name: `${change.table}.${change.name ?? '(unknown)'}`,
+          type: 'missing_column',
+          recommendation:
+            'Run `smrt db:migrate` to add the missing column before application writes hit this table.',
+        });
+        break;
+
+      case 'add_index':
+        drift.push({
+          name: `${change.table}.${change.name ?? '(unknown)'}`,
+          type: 'missing_index',
+          recommendation:
+            'Run `smrt db:migrate` to add the missing index and reconcile the live schema.',
+        });
+        break;
+
+      case 'type_upgrade':
+        drift.push({
+          name: `${change.table}.${change.name ?? '(unknown)'}`,
+          type: 'type_upgrade',
+          recommendation:
+            'Run `smrt db:migrate` to apply the compatible type upgrade for this live column.',
+        });
+        break;
+
+      case 'type_mismatch':
+        drift.push({
+          name: `${change.table}.${change.name ?? '(unknown)'}`,
+          type: 'type_mismatch',
+          recommendation: change.mismatch
+            ? `Manual intervention required: expected ${change.mismatch.expected}, found ${change.mismatch.actual}.`
+            : 'Manual intervention required to reconcile this incompatible live column type.',
+        });
+        break;
+    }
+  }
+
+  return drift;
+}
 
 export const dbStatusCommand: CLICommand = {
   name: 'db:status',
@@ -99,12 +173,18 @@ export const dbStatusCommand: CLICommand = {
             checksum: m.checksum.substring(0, 8),
           })),
         },
-        drift: [] as { name: string; type: string; recommendation: string }[],
+        drift: [] as StatusDrift[],
       };
 
-      // 8. Check for drift (if we have migration definitions)
-      // Note: In dynamic mode, we don't have file-based definitions yet
-      // This will be more useful when file-based migrations are implemented
+      // 8. Compare the current manifest schema against the live database.
+      // This keeps db:status useful for shared Postgres databases where the
+      // migration history alone is not enough to prove the schema is current.
+      if (typeof db.getTableSchema === 'function') {
+        const manifestSchemas = ObjectRegistry.getAllSchemasAsDefinitions();
+        const comparer = new SchemaComparer(db);
+        const diff = await comparer.compare(manifestSchemas);
+        status.drift = summarizeSchemaDiff(diff);
+      }
 
       // 9. Output results
       if (options.json) {
@@ -176,6 +256,9 @@ export const dbStatusCommand: CLICommand = {
             console.log(`     ${d.recommendation}`);
           }
         }
+        console.log();
+      } else {
+        console.log('✅ Live schema matches current manifests');
         console.log();
       }
 

--- a/packages/cli/src/commands/db-status.ts
+++ b/packages/cli/src/commands/db-status.ts
@@ -10,6 +10,7 @@
 import { ObjectRegistry, SchemaComparer } from '@happyvertical/smrt-core';
 import type { CLICommand } from '../cli-generator.js';
 import { autoDiscoverAndLoad } from '../discovery/index.js';
+import { classifyTypeUpgradeSql } from './db-migrate-actions.js';
 
 type StatusDrift = {
   name: string;
@@ -27,6 +28,7 @@ export function summarizeSchemaDiff(diff: {
       expected: string;
       actual: string;
     };
+    sql?: string;
   }>;
 }): StatusDrift[] {
   const drift: StatusDrift[] = [];
@@ -61,12 +63,28 @@ export function summarizeSchemaDiff(diff: {
         break;
 
       case 'type_upgrade':
-        drift.push({
-          name: `${change.table}.${change.name ?? '(unknown)'}`,
-          type: 'type_upgrade',
-          recommendation:
-            'Run `smrt db:migrate` to apply the compatible type upgrade for this live column.',
-        });
+        switch (classifyTypeUpgradeSql(change.sql)) {
+          case 'executable':
+            drift.push({
+              name: `${change.table}.${change.name ?? '(unknown)'}`,
+              type: 'type_upgrade',
+              recommendation:
+                'Run `smrt db:migrate` to apply the compatible type upgrade for this live column.',
+            });
+            break;
+
+          case 'manual':
+            drift.push({
+              name: `${change.table}.${change.name ?? '(unknown)'}`,
+              type: 'type_upgrade',
+              recommendation:
+                'Manual intervention required: this live column needs a type upgrade that the current database engine cannot auto-apply.',
+            });
+            break;
+
+          case 'noop':
+            break;
+        }
         break;
 
       case 'type_mismatch':

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -1194,7 +1194,7 @@ export default testManifest;
         // 8. Compare schemas using SchemaComparer
         // This uses the same comparison logic as core (including equivalent index detection)
         const migrations: MigrationAction[] = [];
-        const typeMismatches: MigrationAction[] = [];
+        const manualInterventions: MigrationAction[] = [];
 
         console.log('🔍 Comparing schemas...\n');
 
@@ -1282,31 +1282,37 @@ export default testManifest;
           getClassForTable,
         );
         migrations.push(...partitionedChanges.migrations);
-        typeMismatches.push(...partitionedChanges.typeMismatches);
+        manualInterventions.push(...partitionedChanges.manualInterventions);
 
         console.log();
 
-        // 9. Report type mismatches (these require manual intervention)
-        if (typeMismatches.length > 0) {
+        // 9. Report non-executable drift that still needs manual intervention
+        if (manualInterventions.length > 0) {
           console.log(
-            '⚠️  Type mismatches detected (require manual intervention):\n',
+            '⚠️  Schema drift detected that requires manual intervention:\n',
           );
-          for (const mm of typeMismatches) {
-            if (mm.mismatch) {
-              console.log(
-                `   ${mm.tableName}.${mm.mismatch.column}: expected ${mm.mismatch.expected}, found ${mm.mismatch.actual}`,
-              );
-            }
+          for (const change of manualInterventions) {
+            if (!change.mismatch) continue;
+
+            const detail =
+              change.type === 'type_upgrade'
+                ? `${change.tableName}.${change.mismatch.column}: expected ${change.mismatch.expected}, found ${change.mismatch.actual} (cannot auto-apply on this database engine)`
+                : `${change.tableName}.${change.mismatch.column}: expected ${change.mismatch.expected}, found ${change.mismatch.actual}`;
+
+            console.log(`   ${detail}`);
           }
           console.log();
           console.log(
-            '   Type changes require manual migration (backup, recreate, restore).\n',
+            '   Manual migration required (backup, recreate, restore as needed).\n',
           );
         }
 
         // 10. Handle no migrations needed
         const tablesCreated = diff.added_tables.length > 0;
-        const schemaUpToDate = migrations.length === 0 && !tablesCreated;
+        const schemaUpToDate =
+          migrations.length === 0 &&
+          manualInterventions.length === 0 &&
+          !tablesCreated;
 
         // 11. Preview or execute migrations
         // Note: SQL statements come from SchemaComparer via change.sql

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -20,6 +20,11 @@ import { configExportCommand } from './config-export.js';
 import { dbDiffCommand } from './db-diff.js';
 import { dbGenerateCommand } from './db-generate.js';
 import { dbHistoryCommand } from './db-history.js';
+import {
+  type MigrationAction,
+  partitionSchemaChanges,
+  type SchemaChangeLike,
+} from './db-migrate-actions.js';
 import { dbRollbackCommand } from './db-rollback.js';
 import { dbStatusCommand } from './db-status.js';
 import { exportCommand } from './export.js';
@@ -1188,30 +1193,6 @@ export default testManifest;
 
         // 8. Compare schemas using SchemaComparer
         // This uses the same comparison logic as core (including equivalent index detection)
-        type MigrationAction = {
-          type: 'add_column' | 'add_index' | 'type_mismatch';
-          tableName: string;
-          className: string;
-          column?: {
-            name: string;
-            type: string;
-            notNull?: boolean;
-            defaultValue?: any;
-            unique?: boolean;
-          };
-          index?: {
-            name: string;
-            columns: string[];
-            unique?: boolean;
-          };
-          mismatch?: {
-            column: string;
-            expected: string;
-            actual: string;
-          };
-          sql?: string;
-        };
-
         const migrations: MigrationAction[] = [];
         const typeMismatches: MigrationAction[] = [];
 
@@ -1295,67 +1276,13 @@ export default testManifest;
           console.log();
         }
 
-        // Convert SchemaDiff changes to CLI MigrationAction format
-        for (const change of diff.changes) {
-          const className = getClassForTable(change.table);
-
-          switch (change.type) {
-            case 'add_column': {
-              // Type guard: add_column changes always have name and column
-              const col = change.column;
-              if (!change.name || !col) continue;
-              migrations.push({
-                type: 'add_column',
-                tableName: change.table,
-                className,
-                column: {
-                  name: change.name,
-                  type: col.type,
-                  notNull: col.notNull,
-                  defaultValue: col.defaultValue,
-                  unique: col.unique,
-                },
-                sql: change.sql,
-              });
-              break;
-            }
-
-            case 'add_index': {
-              // Type guard: add_index changes always have index
-              const idx = change.index;
-              if (!idx) continue;
-              migrations.push({
-                type: 'add_index',
-                tableName: change.table,
-                className,
-                index: {
-                  name: idx.name,
-                  columns: idx.columns,
-                  unique: idx.unique,
-                },
-                sql: change.sql,
-              });
-              break;
-            }
-
-            case 'type_mismatch': {
-              // Type guard: type_mismatch changes always have name and mismatch
-              const mm = change.mismatch;
-              if (!change.name || !mm) continue;
-              typeMismatches.push({
-                type: 'type_mismatch',
-                tableName: change.table,
-                className,
-                mismatch: {
-                  column: change.name,
-                  expected: mm.expected,
-                  actual: mm.actual,
-                },
-              });
-              break;
-            }
-          }
-        }
+        // Convert SchemaDiff changes to CLI MigrationAction format.
+        const partitionedChanges = partitionSchemaChanges(
+          diff.changes as SchemaChangeLike[],
+          getClassForTable,
+        );
+        migrations.push(...partitionedChanges.migrations);
+        typeMismatches.push(...partitionedChanges.typeMismatches);
 
         console.log();
 
@@ -1456,6 +1383,10 @@ export default testManifest;
               migrationName = `add_column_${migration.tableName}_${migration.column.name}`;
               migrationSql = migration.sql || '';
               actionDesc = `Added column ${migration.tableName}.${migration.column.name}`;
+            } else if (migration.type === 'type_upgrade' && migration.column) {
+              migrationName = `type_upgrade_${migration.tableName}_${migration.column.name}`;
+              migrationSql = migration.sql || '';
+              actionDesc = `Upgraded column ${migration.tableName}.${migration.column.name} from ${migration.mismatch?.actual} to ${migration.mismatch?.expected}`;
             } else if (migration.type === 'add_index' && migration.index) {
               migrationName = `add_index_${migration.index.name}`;
               migrationSql = migration.sql || '';
@@ -1470,7 +1401,9 @@ export default testManifest;
               description:
                 migration.type === 'add_column'
                   ? `Add column ${migration.column?.name} to ${migration.tableName}`
-                  : `Add index ${migration.index?.name} on ${migration.tableName}`,
+                  : migration.type === 'type_upgrade'
+                    ? `Upgrade column ${migration.column?.name} on ${migration.tableName} from ${migration.mismatch?.actual} to ${migration.mismatch?.expected}`
+                    : `Add index ${migration.index?.name} on ${migration.tableName}`,
               version: '1.0.0',
               up: [migrationSql],
               down: [], // Auto-migrations don't have rollback by default
@@ -1480,6 +1413,10 @@ export default testManifest;
             const result = await tracker.apply(migrationDef, {
               postgresSafe: options['postgres-safe'] ?? false,
               force: options.force ?? false,
+              // The diff was computed from the live schema moments earlier, so
+              // missing columns/indexes must be repaired even if a previous
+              // synthetic migration record says "completed".
+              reconcile: true,
             });
 
             if (result.success) {

--- a/packages/core/src/__tests__/issue-1115-live-schema-drift-repair.test.ts
+++ b/packages/core/src/__tests__/issue-1115-live-schema-drift-repair.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Issue #1115: live schema drift must be repairable even when a previous
+ * synthetic migration record already says "completed".
+ *
+ * This reproduces the shared-table failure mode from production:
+ * - a live table exists but is missing a newer STI/shared column
+ * - _smrt_schema_migrations already contains the synthetic add_column record
+ * - the repair flow must still execute because the live schema is authoritative
+ */
+
+import { randomUUID } from 'node:crypto';
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { computeChecksum } from '../migrations/checksum.js';
+import { SchemaComparer } from '../migrations/differ.js';
+import { MigrationTracker } from '../migrations/tracker.js';
+
+describe('Issue #1115: live schema drift repair', () => {
+  let db: Awaited<ReturnType<typeof getDatabase>>;
+  let tracker: MigrationTracker;
+
+  beforeEach(async () => {
+    db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+    tracker = new MigrationTracker({ db });
+    await tracker.initialize();
+  });
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') {
+      await db.close();
+    }
+  });
+
+  it('repairs a missing shared-table column even when the migration record already exists', async () => {
+    await db.query('CREATE TABLE contents (id TEXT PRIMARY KEY)');
+
+    const manifest = {
+      contents: {
+        tableName: 'contents',
+        ddl: 'CREATE TABLE contents (id TEXT PRIMARY KEY, script_text TEXT);',
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          script_text: { type: 'TEXT' },
+        },
+        indexes: [],
+        triggers: [],
+        foreignKeys: [],
+        dependencies: [],
+        version: '1.0.0',
+      },
+    };
+
+    const comparer = new SchemaComparer(db as any);
+    const diff = await comparer.compare(manifest as any);
+    const addColumnChange = diff.changes.find(
+      (change) =>
+        change.type === 'add_column' &&
+        change.table === 'contents' &&
+        change.name === 'script_text',
+    );
+
+    expect(addColumnChange?.sql).toBeDefined();
+
+    const migration = {
+      id: 'add_column_contents_script_text',
+      description: 'Add column script_text to contents',
+      version: '1.0.0',
+      up: [addColumnChange?.sql ?? ''],
+      down: [],
+    };
+
+    await db.query(
+      `INSERT INTO _smrt_schema_migrations
+       (id, name, version, checksum, applied_checksum, status, attempts, is_reversible, batch)
+       VALUES (?, ?, ?, ?, ?, 'completed', 1, 0, 1)`,
+      randomUUID(),
+      migration.id,
+      migration.version,
+      computeChecksum(migration.up),
+      computeChecksum(migration.up),
+    );
+
+    const result = await tracker.apply(migration, { reconcile: true });
+
+    expect(result.success).toBe(true);
+    expect(result.applied).toBe(true);
+
+    const schema = await db.getTableSchema?.('contents');
+    expect(schema?.columns.script_text).toBeDefined();
+  });
+});

--- a/packages/core/src/__tests__/issue-625-error-message.test.ts
+++ b/packages/core/src/__tests__/issue-625-error-message.test.ts
@@ -64,4 +64,36 @@ describe('Issue #625: DatabaseError.queryFailed() root cause message', () => {
     // The cause should be preserved for debugging
     expect(error.cause).toBe(rootCause);
   });
+
+  it('should surface the deepest nested database cause message when available', () => {
+    const pgError = new Error(
+      'column "script_text" of relation "contents" does not exist',
+    );
+    const adapterError = new Error('Failed SQL execution');
+    (
+      adapterError as Error & {
+        context?: { originalError?: unknown };
+        cause?: unknown;
+      }
+    ).context = {
+      originalError: 'Database query failed: UPSERT INTO contents',
+    };
+    (adapterError as Error & { cause?: unknown }).cause = pgError;
+
+    const error = DatabaseError.queryFailed(
+      'UPSERT INTO contents',
+      adapterError,
+    );
+
+    expect(error.message).toContain(
+      'column "script_text" of relation "contents" does not exist',
+    );
+    expect(error.details?.causeMessage).toBe(
+      'column "script_text" of relation "contents" does not exist',
+    );
+    expect(error.details?.causeMessages).toContain('Failed SQL execution');
+    expect(error.details?.causeMessages).toContain(
+      'Database query failed: UPSERT INTO contents',
+    );
+  });
 });

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -85,6 +85,74 @@ export abstract class SmrtError extends Error {
   }
 }
 
+type ErrorLikeWithContext = Error & {
+  cause?: unknown;
+  context?: {
+    originalError?: unknown;
+  };
+};
+
+function collectErrorMessages(
+  value: unknown,
+  messages: string[],
+  visited: Set<unknown>,
+  depth = 0,
+): void {
+  if (!value || visited.has(value) || depth > 10) {
+    return;
+  }
+
+  visited.add(value);
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed) {
+      messages.push(trimmed);
+    }
+    return;
+  }
+
+  if (!(value instanceof Error)) {
+    return;
+  }
+
+  const message = value.message?.trim();
+  if (message) {
+    messages.push(message);
+  }
+
+  const errorWithContext = value as ErrorLikeWithContext;
+  collectErrorMessages(
+    errorWithContext.context?.originalError,
+    messages,
+    visited,
+    depth + 1,
+  );
+  collectErrorMessages(errorWithContext.cause, messages, visited, depth + 1);
+}
+
+function getPrimaryCauseMessage(cause?: Error): {
+  message?: string;
+  messages?: string[];
+} {
+  if (!cause) {
+    return {};
+  }
+
+  const collected: string[] = [];
+  collectErrorMessages(cause, collected, new Set<unknown>());
+
+  const uniqueMessages = [...new Set(collected.filter(Boolean))];
+  if (uniqueMessages.length === 0) {
+    return {};
+  }
+
+  return {
+    message: uniqueMessages[uniqueMessages.length - 1],
+    messages: uniqueMessages,
+  };
+}
+
 /**
  * Errors originating from database operations.
  *
@@ -119,12 +187,17 @@ export class DatabaseError extends SmrtError {
   }
 
   static queryFailed(query: string, cause?: Error): DatabaseError {
-    // Include root cause message for better debugging (issue #625)
-    const causeMsg = cause?.message ? `\nCause: ${cause.message}` : '';
+    // Include the deepest actionable cause message for better debugging.
+    const causeInfo = getPrimaryCauseMessage(cause);
+    const causeMsg = causeInfo.message ? `\nCause: ${causeInfo.message}` : '';
     return new DatabaseError(
       `Database query failed: ${query.substring(0, 100)}${query.length > 100 ? '...' : ''}${causeMsg}`,
       'DB_QUERY_FAILED',
-      { query, causeMessage: cause?.message },
+      {
+        query,
+        causeMessage: causeInfo.message,
+        causeMessages: causeInfo.messages,
+      },
       cause,
     );
   }

--- a/packages/core/src/migrations/__tests__/tracker.test.ts
+++ b/packages/core/src/migrations/__tests__/tracker.test.ts
@@ -159,6 +159,58 @@ describe('MigrationTracker', () => {
       expect(result.error).toContain('checksum mismatch');
     });
 
+    it('should still block checksum mismatches during reconcile', async () => {
+      const migration1: MigrationDefinition = {
+        id: '0001_create_users',
+        description: 'Create users table',
+        version: '1.0.0',
+        up: ['CREATE TABLE users (id TEXT PRIMARY KEY);'],
+        down: ['DROP TABLE users;'],
+      };
+
+      await tracker.apply(migration1);
+
+      const migration2: MigrationDefinition = {
+        id: '0001_create_users',
+        description: 'Create users table',
+        version: '1.0.0',
+        up: ['CREATE TABLE users (id TEXT PRIMARY KEY, name TEXT);'],
+        down: ['DROP TABLE users;'],
+      };
+
+      const result = await tracker.apply(migration2, { reconcile: true });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('checksum mismatch');
+    });
+
+    it('should allow reconcile to re-run a completed checksum-matching migration', async () => {
+      const migration: MigrationDefinition = {
+        id: '0001_reconcile',
+        description: 'Reconcile test',
+        version: '1.0.0',
+        up: [
+          'CREATE TABLE IF NOT EXISTS reconcile_test (id TEXT PRIMARY KEY);',
+        ],
+        down: ['DROP TABLE reconcile_test;'],
+      };
+
+      const first = await tracker.apply(migration);
+      expect(first.success).toBe(true);
+      expect(first.applied).toBe(true);
+
+      const second = await tracker.apply(migration, { reconcile: true });
+
+      expect(second.success).toBe(true);
+      expect(second.applied).toBe(true);
+      expect(second.skipped).toBe(false);
+
+      const history = await tracker.getHistory();
+      expect(history).toHaveLength(1);
+      expect(history[0].attempts).toBe(2);
+      expect(history[0].status).toBe('completed');
+    });
+
     it('should record migration with correct metadata', async () => {
       const migration: MigrationDefinition = {
         id: '0001_create_users',
@@ -254,6 +306,24 @@ describe('MigrationTracker', () => {
       expect(result.error).toContain('--force');
     });
 
+    it('should still block failed migrations during reconcile without --force', async () => {
+      const migration: MigrationDefinition = {
+        id: '0001_bad_sql',
+        description: 'Bad SQL',
+        version: '1.0.0',
+        up: ['THIS IS NOT VALID SQL;'],
+        down: [],
+      };
+
+      await tracker.apply(migration);
+
+      const result = await tracker.apply(migration, { reconcile: true });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('previously failed');
+      expect(result.error).toContain('--force');
+    });
+
     it('should allow retry of failed migration with --force', async () => {
       // First, create a migration that will fail
       const badMigration: MigrationDefinition = {
@@ -311,6 +381,27 @@ describe('MigrationTracker', () => {
       };
 
       const result = await tracker.apply(migration);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('currently running or was interrupted');
+      expect(result.error).toContain('--force');
+    });
+
+    it('should still block running migrations during reconcile without --force', async () => {
+      await db.query(
+        `INSERT INTO _smrt_schema_migrations (id, name, version, checksum, status, attempts, is_reversible, batch)
+         VALUES ('stuck-id', '0001_stuck', '1.0.0', 'abc123', 'running', 1, 0, 1)`,
+      );
+
+      const migration: MigrationDefinition = {
+        id: '0001_stuck',
+        description: 'Stuck migration',
+        version: '1.0.0',
+        up: ['SELECT 1;'],
+        down: [],
+      };
+
+      const result = await tracker.apply(migration, { reconcile: true });
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('currently running or was interrupted');

--- a/packages/core/src/migrations/tracker.ts
+++ b/packages/core/src/migrations/tracker.ts
@@ -240,13 +240,14 @@ export class MigrationTracker {
       );
 
       if (!verification.valid) {
+        const driftType = verification.drift ?? 'db_modified';
         reports.push({
           migration_name: record.name,
           expected_checksum: record.checksum,
           actual_checksum: currentChecksum,
-          drift_type: verification.drift!,
+          drift_type: driftType,
           recommendation:
-            verification.drift === 'file_modified'
+            driftType === 'file_modified'
               ? 'Migration file was modified after application. Create a new migration instead.'
               : 'Database schema was modified outside of migrations. Review and reconcile manually.',
         });

--- a/packages/core/src/migrations/tracker.ts
+++ b/packages/core/src/migrations/tracker.ts
@@ -274,7 +274,7 @@ export class MigrationTracker {
       // Handle based on existing status
       switch (existing.status) {
         case 'completed':
-          if (!options.force) {
+          if (!options.force && !options.reconcile) {
             // Verify checksum matches
             if (existing.checksum !== checksum) {
               return {
@@ -300,7 +300,7 @@ export class MigrationTracker {
           break;
 
         case 'failed':
-          if (!options.force) {
+          if (!options.force && !options.reconcile) {
             return {
               success: false,
               applied: false,
@@ -315,7 +315,7 @@ export class MigrationTracker {
           break;
 
         case 'running':
-          if (!options.force) {
+          if (!options.force && !options.reconcile) {
             return {
               success: false,
               applied: false,

--- a/packages/core/src/migrations/tracker.ts
+++ b/packages/core/src/migrations/tracker.ts
@@ -275,19 +275,19 @@ export class MigrationTracker {
       // Handle based on existing status
       switch (existing.status) {
         case 'completed':
+          if (!options.force && existing.checksum !== checksum) {
+            return {
+              success: false,
+              applied: false,
+              skipped: false,
+              name: definition.id,
+              checksum,
+              execution_time_ms: 0,
+              error: `Migration ${definition.id} checksum mismatch. Was already applied with different checksum. Use --force to override.`,
+            };
+          }
+
           if (!options.force && !options.reconcile) {
-            // Verify checksum matches
-            if (existing.checksum !== checksum) {
-              return {
-                success: false,
-                applied: false,
-                skipped: false,
-                name: definition.id,
-                checksum,
-                execution_time_ms: 0,
-                error: `Migration ${definition.id} checksum mismatch. Was already applied with different checksum. Use --force to override.`,
-              };
-            }
             // Already applied, skip
             return {
               success: true,
@@ -301,7 +301,7 @@ export class MigrationTracker {
           break;
 
         case 'failed':
-          if (!options.force && !options.reconcile) {
+          if (!options.force) {
             return {
               success: false,
               applied: false,
@@ -316,7 +316,7 @@ export class MigrationTracker {
           break;
 
         case 'running':
-          if (!options.force && !options.reconcile) {
+          if (!options.force) {
             return {
               success: false,
               applied: false,

--- a/packages/core/src/migrations/types.ts
+++ b/packages/core/src/migrations/types.ts
@@ -125,9 +125,11 @@ export interface ApplyMigrationsOptions {
   /**
    * Reconcile migration history with live schema drift.
    *
-   * When true, the tracker will re-run a recorded migration if the caller has
-   * already independently determined the change is still required. This keeps
-   * live schema state authoritative for repair flows such as `db:migrate`.
+   * When true, the tracker may re-run a completed migration with the same
+   * checksum if the caller has already independently determined the change is
+   * still required. This keeps live schema state authoritative for repair
+   * flows such as `db:migrate` without bypassing checksum, failed, or running
+   * migration safeguards.
    */
   reconcile?: boolean;
   /** Use PostgreSQL-safe operations (CONCURRENTLY, lock timeout) */

--- a/packages/core/src/migrations/types.ts
+++ b/packages/core/src/migrations/types.ts
@@ -122,6 +122,14 @@ export interface ApplyMigrationsOptions {
   dryRun?: boolean;
   /** Force application even if checksums don't match */
   force?: boolean;
+  /**
+   * Reconcile migration history with live schema drift.
+   *
+   * When true, the tracker will re-run a recorded migration if the caller has
+   * already independently determined the change is still required. This keeps
+   * live schema state authoritative for repair flows such as `db:migrate`.
+   */
+  reconcile?: boolean;
   /** Use PostgreSQL-safe operations (CONCURRENTLY, lock timeout) */
   postgresSafe?: boolean;
 }


### PR DESCRIPTION
## Summary
- make `smrt db:migrate` reconcile live schema drift even when a prior synthetic migration record already says `completed`
- teach `db:status` to compare current manifests against the live database instead of only reporting migration history
- improve nested database error surfacing and add regression coverage around drift repair and status reporting

## Root Cause
`db:migrate` correctly computed live schema diffs, but execution still deferred to `_smrt_schema_migrations` idempotency records. That meant a drifted shared table could remain missing columns in a live database if the synthetic `add_column_*` migration had already been recorded in the past.

During review I found one additional contract gap and fixed it before opening this PR: `db:status` was reporting `type_upgrade` drift as something `db:migrate` could fix, while `db:migrate` was still only executing missing-column and missing-index repairs. The migration action mapping is now extracted and unit-tested so `type_upgrade` repairs stay in the executable path.

## Impact
- downstream CI can use `db:status` as a real live-schema signal instead of a migration-history proxy
- production rollouts get a supported repair path for drifted shared/STI tables
- write-path failures now preserve the deepest actionable database cause more reliably

## Validation
- `pnpm --filter @happyvertical/smrt-cli exec vitest run src/commands/__tests__/db-status.test.ts src/commands/__tests__/db-migrate-actions.test.ts`
- `pnpm --filter @happyvertical/smrt-core exec vitest run src/__tests__/issue-1115-live-schema-drift-repair.test.ts src/__tests__/issue-625-error-message.test.ts src/migrations/__tests__/tracker.test.ts`
- pre-push hooks: `format-check`, `validate-all-workflows`
