### PR TITLE
Fix manifest upgrades and failed migration drift reporting

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,7 @@
     "dev": "npm run build:watch",
     "test": "vitest run",
     "test:watch": "vitest",
+    "typecheck": "tsc -p tsconfig.typecheck.json",
     "cli": "tsx src/index.ts"
   },
   "dependencies": {

--- a/packages/cli/src/commands/__tests__/db-history.test.ts
+++ b/packages/cli/src/commands/__tests__/db-history.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  autoDiscoverAndLoadMock,
+  getPackageConfigMock,
+  getDatabaseMock,
+  getAllSchemasAsDefinitionsMock,
+  compareMock,
+  initializeMock,
+  getHistoryMock,
+  SchemaComparerMock,
+  MigrationTrackerMock,
+} = vi.hoisted(() => {
+  const compare = vi.fn();
+  const initialize = vi.fn();
+  const getHistory = vi.fn();
+
+  class MockSchemaComparer {
+    compare = compare;
+  }
+
+  class MockMigrationTracker {
+    initialize = initialize;
+    getHistory = getHistory;
+  }
+
+  return {
+    autoDiscoverAndLoadMock: vi.fn(),
+    getPackageConfigMock: vi.fn(),
+    getDatabaseMock: vi.fn(),
+    getAllSchemasAsDefinitionsMock: vi.fn(),
+    compareMock: compare,
+    initializeMock: initialize,
+    getHistoryMock: getHistory,
+    SchemaComparerMock: MockSchemaComparer,
+    MigrationTrackerMock: MockMigrationTracker,
+  };
+});
+
+vi.mock('../../discovery/index.js', () => ({
+  autoDiscoverAndLoad: autoDiscoverAndLoadMock,
+}));
+
+vi.mock('@happyvertical/smrt-config', () => ({
+  getPackageConfig: getPackageConfigMock,
+}));
+
+vi.mock('@happyvertical/sql', () => ({
+  getDatabase: getDatabaseMock,
+}));
+
+vi.mock('@happyvertical/smrt-core', () => ({
+  ObjectRegistry: {
+    getAllSchemasAsDefinitions: getAllSchemasAsDefinitionsMock,
+  },
+  SchemaComparer: SchemaComparerMock,
+}));
+
+vi.mock('@happyvertical/smrt-core/migrations', () => ({
+  MigrationTracker: MigrationTrackerMock,
+}));
+
+import { dbHistoryCommand } from '../db-history.js';
+
+describe('db:history', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    getPackageConfigMock.mockReturnValue({
+      database: {
+        type: 'postgres',
+        url: 'postgresql://test:test@localhost:5432/test_db',
+      },
+    });
+
+    getDatabaseMock.mockResolvedValue({
+      url: 'postgresql://test:test@localhost:5432/test_db',
+      getTableSchema: vi.fn(),
+    });
+
+    autoDiscoverAndLoadMock.mockResolvedValue({
+      discovered: [{ path: '/fake/manifest.json' }],
+      totalObjects: 3,
+    });
+
+    getAllSchemasAsDefinitionsMock.mockReturnValue({
+      contents: {
+        tableName: 'contents',
+      },
+    });
+
+    initializeMock.mockResolvedValue(undefined);
+    compareMock.mockResolvedValue({
+      added_tables: [],
+      dropped_tables: [],
+      has_changes: true,
+      changes: [
+        {
+          type: 'add_column',
+          table: 'contents',
+          name: 'script_text',
+          column: { type: 'TEXT' },
+        },
+      ],
+    });
+    getHistoryMock.mockResolvedValue([
+      {
+        id: '1',
+        name: 'add_column_contents_script_text',
+        version: '0.21.45',
+        checksum: 'a'.repeat(64),
+        applied_checksum: null,
+        applied_at: new Date('2026-04-10T00:00:00Z'),
+        execution_time_ms: 12,
+        status: 'failed',
+        error_message: 'column missing',
+        attempts: 1,
+        is_reversible: false,
+        rolled_back_at: null,
+        applied_by: 'ci',
+        batch: 1,
+        package_name: '@happyvertical/smrt-cli',
+        source_file: null,
+      },
+      {
+        id: '2',
+        name: 'add_index_idx_contents_published_at',
+        version: '0.21.44',
+        checksum: 'b'.repeat(64),
+        applied_checksum: null,
+        applied_at: new Date('2026-04-09T00:00:00Z'),
+        execution_time_ms: 10,
+        status: 'failed',
+        error_message: 'index already exists',
+        attempts: 1,
+        is_reversible: false,
+        rolled_back_at: null,
+        applied_by: 'ci',
+        batch: 1,
+        package_name: '@happyvertical/smrt-cli',
+        source_file: null,
+      },
+      {
+        id: '3',
+        name: 'type_upgrade_contents_status',
+        version: '0.21.45',
+        checksum: 'c'.repeat(64),
+        applied_checksum: null,
+        applied_at: new Date('2026-04-08T00:00:00Z'),
+        execution_time_ms: 8,
+        status: 'failed',
+        error_message: 'cannot cast',
+        attempts: 1,
+        is_reversible: false,
+        rolled_back_at: null,
+        applied_by: 'ci',
+        batch: 1,
+        package_name: '@happyvertical/smrt-cli',
+        source_file: null,
+      },
+      {
+        id: '4',
+        name: 'baseline_schema',
+        version: '0.21.45',
+        checksum: 'd'.repeat(64),
+        applied_checksum: 'd'.repeat(64),
+        applied_at: new Date('2026-04-07T00:00:00Z'),
+        execution_time_ms: 50,
+        status: 'completed',
+        error_message: null,
+        attempts: 1,
+        is_reversible: true,
+        rolled_back_at: null,
+        applied_by: 'ci',
+        batch: 1,
+        package_name: '@happyvertical/smrt-core',
+        source_file: null,
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('annotates failed migrations with live-schema classification in JSON output', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await dbHistoryCommand.handler([], { json: true });
+
+    const output = logSpy.mock.calls.map((call) => call.join('')).join('\n');
+    const parsed = JSON.parse(output);
+
+    expect(compareMock).toHaveBeenCalledWith({
+      contents: {
+        tableName: 'contents',
+      },
+    });
+    expect(parsed).toEqual([
+      expect.objectContaining({
+        name: 'add_column_contents_script_text',
+        classification: 'unresolved',
+        recommendation:
+          'Run `smrt db:migrate` to reconcile the live schema, then confirm this failed additive migration no longer appears as unresolved.',
+      }),
+      expect.objectContaining({
+        name: 'add_index_idx_contents_published_at',
+        classification: 'superseded',
+        recommendation:
+          'No current live-schema drift maps to this failed additive migration. Keep the row for audit history, but it no longer blocks the current schema.',
+      }),
+      expect.objectContaining({
+        name: 'type_upgrade_contents_status',
+        classification: 'other',
+        recommendation:
+          'Inspect this failed migration directly. It is not a superseded additive repair and may still need manual attention.',
+      }),
+      expect.objectContaining({
+        name: 'baseline_schema',
+        classification: null,
+        recommendation: null,
+      }),
+    ]);
+  });
+});

--- a/packages/cli/src/commands/__tests__/db-migrate-actions.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-actions.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { partitionSchemaChanges } from '../db-migrate-actions.js';
+import {
+  getUnresolvedAdditiveMigrationNames,
+  partitionSchemaChanges,
+  summarizeFailedMigrations,
+} from '../db-migrate-actions.js';
 
 describe('partitionSchemaChanges', () => {
   it('keeps type upgrades in the executable migration set', () => {
@@ -141,5 +145,87 @@ describe('partitionSchemaChanges', () => {
         },
       },
     ]);
+  });
+});
+
+describe('failed migration classification', () => {
+  it('tracks current unresolved additive repairs separately from superseded failures', () => {
+    const unresolvedNames = getUnresolvedAdditiveMigrationNames([
+      {
+        type: 'add_column',
+        table: 'contents',
+        name: 'script_text',
+        column: { type: 'TEXT' },
+      },
+    ]);
+
+    expect(
+      summarizeFailedMigrations(
+        [
+          {
+            name: 'add_column_contents_script_text',
+            error_message: 'column missing',
+          },
+          {
+            name: 'add_index_idx_contents_published_at',
+            error_message: 'index already exists',
+          },
+          {
+            name: 'type_upgrade_contents_status',
+            error_message: 'cannot cast',
+          },
+        ],
+        unresolvedNames,
+      ),
+    ).toEqual({
+      unresolved: [
+        {
+          name: 'add_column_contents_script_text',
+          classification: 'unresolved',
+          recommendation:
+            'Run `smrt db:migrate` to reconcile the live schema, then confirm this failed additive migration no longer appears as unresolved.',
+          errorMessage: 'column missing',
+        },
+      ],
+      superseded: [
+        {
+          name: 'add_index_idx_contents_published_at',
+          classification: 'superseded',
+          recommendation:
+            'No current live-schema drift maps to this failed additive migration. Keep the row for audit history, but it no longer blocks the current schema.',
+          errorMessage: 'index already exists',
+        },
+      ],
+      other: [
+        {
+          name: 'type_upgrade_contents_status',
+          classification: 'other',
+          recommendation:
+            'Inspect this failed migration directly. It is not a superseded additive repair and may still need manual attention.',
+          errorMessage: 'cannot cast',
+        },
+      ],
+    });
+  });
+
+  it('falls back to direct-review classification when live drift comparison is unavailable', () => {
+    expect(
+      summarizeFailedMigrations(
+        [{ name: 'add_column_contents_script_text', error_message: null }],
+        null,
+      ),
+    ).toEqual({
+      unresolved: [],
+      superseded: [],
+      other: [
+        {
+          name: 'add_column_contents_script_text',
+          classification: 'other',
+          recommendation:
+            'Inspect this failed migration directly. Live schema comparison was unavailable, so SMRT could not determine whether it has been superseded.',
+          errorMessage: null,
+        },
+      ],
+    });
   });
 });

--- a/packages/cli/src/commands/__tests__/db-status.test.ts
+++ b/packages/cli/src/commands/__tests__/db-status.test.ts
@@ -8,6 +8,7 @@ const {
   compareMock,
   initializeMock,
   getAppliedMigrationsMock,
+  getHistoryMock,
   getEngineMock,
   SchemaComparerMock,
   MigrationTrackerMock,
@@ -15,6 +16,7 @@ const {
   const compare = vi.fn();
   const initialize = vi.fn();
   const getAppliedMigrations = vi.fn();
+  const getHistory = vi.fn();
   const getEngine = vi.fn();
 
   class MockSchemaComparer {
@@ -24,6 +26,7 @@ const {
   class MockMigrationTracker {
     initialize = initialize;
     getAppliedMigrations = getAppliedMigrations;
+    getHistory = getHistory;
     getEngine = getEngine;
   }
 
@@ -35,6 +38,7 @@ const {
     compareMock: compare,
     initializeMock: initialize,
     getAppliedMigrationsMock: getAppliedMigrations,
+    getHistoryMock: getHistory,
     getEngineMock: getEngine,
     SchemaComparerMock: MockSchemaComparer,
     MigrationTrackerMock: MockMigrationTracker,
@@ -95,6 +99,7 @@ describe('db:status', () => {
 
     initializeMock.mockResolvedValue(undefined);
     getAppliedMigrationsMock.mockResolvedValue([]);
+    getHistoryMock.mockResolvedValue([]);
     getEngineMock.mockReturnValue('postgres');
   });
 
@@ -204,6 +209,11 @@ describe('db:status', () => {
           'Run `smrt db:migrate` to add the missing index and reconcile the live schema.',
       },
     ]);
+    expect(parsed.failedMigrations).toEqual({
+      unresolved: [],
+      superseded: [],
+      other: [],
+    });
   });
 
   it('omits no-op type upgrades from drift output', () => {
@@ -220,5 +230,72 @@ describe('db:status', () => {
         ],
       }),
     ).toEqual([]);
+  });
+
+  it('classifies failed additive migrations against current live drift', async () => {
+    compareMock.mockResolvedValue({
+      added_tables: [],
+      dropped_tables: [],
+      has_changes: true,
+      changes: [
+        {
+          type: 'add_column',
+          table: 'contents',
+          name: 'script_text',
+          column: { type: 'TEXT' },
+        },
+      ],
+    });
+    getHistoryMock.mockResolvedValue([
+      {
+        name: 'add_column_contents_script_text',
+        error_message: 'column missing',
+      },
+      {
+        name: 'add_index_idx_contents_published_at',
+        error_message: 'index already exists',
+      },
+      {
+        name: 'type_upgrade_contents_status',
+        error_message: 'cannot cast',
+      },
+    ]);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await dbStatusCommand.handler([], { json: true });
+
+    const output = logSpy.mock.calls.map((call) => call.join('')).join('\n');
+    const parsed = JSON.parse(output);
+
+    expect(parsed.failedMigrations).toEqual({
+      unresolved: [
+        {
+          name: 'add_column_contents_script_text',
+          classification: 'unresolved',
+          recommendation:
+            'Run `smrt db:migrate` to reconcile the live schema, then confirm this failed additive migration no longer appears as unresolved.',
+          errorMessage: 'column missing',
+        },
+      ],
+      superseded: [
+        {
+          name: 'add_index_idx_contents_published_at',
+          classification: 'superseded',
+          recommendation:
+            'No current live-schema drift maps to this failed additive migration. Keep the row for audit history, but it no longer blocks the current schema.',
+          errorMessage: 'index already exists',
+        },
+      ],
+      other: [
+        {
+          name: 'type_upgrade_contents_status',
+          classification: 'other',
+          recommendation:
+            'Inspect this failed migration directly. It is not a superseded additive repair and may still need manual attention.',
+          errorMessage: 'cannot cast',
+        },
+      ],
+    });
   });
 });

--- a/packages/cli/src/commands/db-history.ts
+++ b/packages/cli/src/commands/db-history.ts
@@ -4,8 +4,37 @@
  * Shows detailed migration history with filtering options.
  */
 
+import { ObjectRegistry, SchemaComparer } from '@happyvertical/smrt-core';
 import type { MigrationStatus } from '@happyvertical/smrt-core/migrations';
 import type { CLICommand } from '../cli-generator.js';
+import { autoDiscoverAndLoad } from '../discovery/index.js';
+import {
+  classifyFailedMigration,
+  type FailedMigrationClassification,
+  getFailedMigrationRecommendation,
+  getUnresolvedAdditiveMigrationNames,
+} from './db-migrate-actions.js';
+
+type AnnotatedHistoryEntry = {
+  id: string;
+  name: string;
+  version: string;
+  checksum: string;
+  applied_checksum: string | null;
+  applied_at: Date;
+  execution_time_ms: number | null;
+  status: MigrationStatus;
+  error_message: string | null;
+  attempts: number;
+  is_reversible: boolean;
+  rolled_back_at: Date | null;
+  applied_by: string | null;
+  batch: number | null;
+  package_name: string | null;
+  source_file: string | null;
+  classification: FailedMigrationClassification | null;
+  recommendation: string | null;
+};
 
 export const dbHistoryCommand: CLICommand = {
   name: 'db:history',
@@ -105,10 +134,50 @@ export const dbHistoryCommand: CLICommand = {
 
       // 6. Get history
       const history = await tracker.getHistory(queryOptions);
+      let unresolvedSyntheticMigrationNames: Set<string> | null = null;
+
+      if (
+        history.some((migration) => migration.status === 'failed') &&
+        typeof db.getTableSchema === 'function'
+      ) {
+        try {
+          await autoDiscoverAndLoad();
+          const manifestSchemas = ObjectRegistry.getAllSchemasAsDefinitions();
+          const comparer = new SchemaComparer(db);
+          const diff = await comparer.compare(manifestSchemas);
+          unresolvedSyntheticMigrationNames =
+            getUnresolvedAdditiveMigrationNames(diff.changes);
+        } catch {
+          unresolvedSyntheticMigrationNames = null;
+        }
+      }
+
+      const annotatedHistory: AnnotatedHistoryEntry[] = history.map((m) => {
+        if (m.status !== 'failed') {
+          return {
+            ...m,
+            classification: null,
+            recommendation: null,
+          };
+        }
+
+        const classification = unresolvedSyntheticMigrationNames
+          ? classifyFailedMigration(m.name, unresolvedSyntheticMigrationNames)
+          : 'other';
+
+        return {
+          ...m,
+          classification,
+          recommendation: getFailedMigrationRecommendation(
+            classification,
+            unresolvedSyntheticMigrationNames !== null,
+          ),
+        };
+      });
 
       // 7. Output results
       if (options.json) {
-        const jsonOutput = history.map((m) => ({
+        const jsonOutput = annotatedHistory.map((m) => ({
           id: m.id,
           name: m.name,
           version: m.version,
@@ -125,13 +194,15 @@ export const dbHistoryCommand: CLICommand = {
           batch: m.batch,
           packageName: m.package_name,
           sourceFile: m.source_file,
+          classification: m.classification,
+          recommendation: m.recommendation,
         }));
         console.log(JSON.stringify(jsonOutput, null, 2));
         return;
       }
 
       // Human-readable output
-      if (history.length === 0) {
+      if (annotatedHistory.length === 0) {
         console.log('No migrations found matching criteria.');
         console.log();
         console.log('💡 Run `smrt db:migrate` to apply schema changes');
@@ -139,9 +210,9 @@ export const dbHistoryCommand: CLICommand = {
         return;
       }
 
-      console.log(`Showing ${history.length} migration(s):\n`);
+      console.log(`Showing ${annotatedHistory.length} migration(s):\n`);
 
-      for (const m of history) {
+      for (const m of annotatedHistory) {
         const statusIcon = getStatusIcon(m.status);
         const timeStr = formatDateTime(m.applied_at);
 
@@ -169,6 +240,10 @@ export const dbHistoryCommand: CLICommand = {
           if (m.error_message) {
             console.log(`   Error: ${m.error_message}`);
           }
+          if (m.classification) {
+            console.log(`   Failed state: ${m.classification}`);
+            console.log(`   Recommendation: ${m.recommendation}`);
+          }
           if (m.rolled_back_at) {
             console.log(`   Rolled back: ${formatDateTime(m.rolled_back_at)}`);
           }
@@ -184,6 +259,9 @@ export const dbHistoryCommand: CLICommand = {
           if (m.error_message) {
             parts.push(`error: ${m.error_message.substring(0, 50)}`);
           }
+          if (m.classification) {
+            parts.push(m.classification);
+          }
           if (parts.length > 0) {
             console.log(`   ${parts.join(' | ')}`);
           }
@@ -193,15 +271,28 @@ export const dbHistoryCommand: CLICommand = {
       }
 
       // Summary
-      const completed = history.filter((m) => m.status === 'completed').length;
-      const failed = history.filter((m) => m.status === 'failed').length;
-      const rolledBack = history.filter(
+      const completed = annotatedHistory.filter(
+        (m) => m.status === 'completed',
+      ).length;
+      const failed = annotatedHistory.filter(
+        (m) => m.status === 'failed',
+      ).length;
+      const failedUnresolved = annotatedHistory.filter(
+        (m) => m.classification === 'unresolved',
+      ).length;
+      const failedSuperseded = annotatedHistory.filter(
+        (m) => m.classification === 'superseded',
+      ).length;
+      const failedOther = annotatedHistory.filter(
+        (m) => m.classification === 'other',
+      ).length;
+      const rolledBack = annotatedHistory.filter(
         (m) => m.status === 'rolled_back',
       ).length;
 
       console.log('━'.repeat(50));
       console.log(
-        `Summary: ${completed} completed, ${failed} failed, ${rolledBack} rolled back`,
+        `Summary: ${completed} completed, ${failed} failed (${failedUnresolved} unresolved, ${failedSuperseded} superseded, ${failedOther} other), ${rolledBack} rolled back`,
       );
       console.log();
 

--- a/packages/cli/src/commands/db-migrate-actions.ts
+++ b/packages/cli/src/commands/db-migrate-actions.ts
@@ -45,6 +45,27 @@ export interface SchemaChangeLike {
 }
 
 export type TypeUpgradeExecutionKind = 'executable' | 'manual' | 'noop';
+export type FailedMigrationClassification =
+  | 'unresolved'
+  | 'superseded'
+  | 'other';
+export interface FailedMigrationLike {
+  name: string;
+  error_message?: string | null;
+}
+
+export interface FailedMigrationSummaryItem {
+  name: string;
+  classification: FailedMigrationClassification;
+  recommendation: string;
+  errorMessage: string | null;
+}
+
+export interface FailedMigrationBuckets {
+  unresolved: FailedMigrationSummaryItem[];
+  superseded: FailedMigrationSummaryItem[];
+  other: FailedMigrationSummaryItem[];
+}
 
 export function classifyTypeUpgradeSql(sql?: string): TypeUpgradeExecutionKind {
   const trimmed = sql?.trim();
@@ -65,6 +86,133 @@ export function classifyTypeUpgradeSql(sql?: string): TypeUpgradeExecutionKind {
   }
 
   return 'manual';
+}
+
+export function getSyntheticMigrationNameForAction(
+  action: MigrationAction,
+): string | null {
+  switch (action.type) {
+    case 'add_column':
+      return action.column
+        ? `add_column_${action.tableName}_${action.column.name}`
+        : null;
+
+    case 'add_index':
+      return action.index ? `add_index_${action.index.name}` : null;
+
+    case 'type_upgrade':
+      return action.column
+        ? `type_upgrade_${action.tableName}_${action.column.name}`
+        : null;
+
+    default:
+      return null;
+  }
+}
+
+export function getSyntheticMigrationNameForChange(
+  change: SchemaChangeLike,
+): string | null {
+  switch (change.type) {
+    case 'add_column':
+      return change.name ? `add_column_${change.table}_${change.name}` : null;
+
+    case 'add_index': {
+      const indexName = change.index?.name ?? change.name;
+      return indexName ? `add_index_${indexName}` : null;
+    }
+
+    case 'type_upgrade':
+      return change.name ? `type_upgrade_${change.table}_${change.name}` : null;
+
+    default:
+      return null;
+  }
+}
+
+export function classifyFailedMigration(
+  migrationName: string,
+  unresolvedSyntheticMigrationNames: Set<string>,
+): FailedMigrationClassification {
+  if (
+    !migrationName.startsWith('add_column_') &&
+    !migrationName.startsWith('add_index_')
+  ) {
+    return 'other';
+  }
+
+  return unresolvedSyntheticMigrationNames.has(migrationName)
+    ? 'unresolved'
+    : 'superseded';
+}
+
+export function getUnresolvedAdditiveMigrationNames(
+  changes: SchemaChangeLike[],
+): Set<string> {
+  const names = new Set<string>();
+
+  for (const change of changes) {
+    if (change.type !== 'add_column' && change.type !== 'add_index') {
+      continue;
+    }
+
+    const migrationName = getSyntheticMigrationNameForChange(change);
+    if (migrationName) {
+      names.add(migrationName);
+    }
+  }
+
+  return names;
+}
+
+export function getFailedMigrationRecommendation(
+  classification: FailedMigrationClassification,
+  liveSchemaCompared: boolean = true,
+): string {
+  switch (classification) {
+    case 'unresolved':
+      return 'Run `smrt db:migrate` to reconcile the live schema, then confirm this failed additive migration no longer appears as unresolved.';
+    case 'superseded':
+      return 'No current live-schema drift maps to this failed additive migration. Keep the row for audit history, but it no longer blocks the current schema.';
+    default:
+      return liveSchemaCompared
+        ? 'Inspect this failed migration directly. It is not a superseded additive repair and may still need manual attention.'
+        : 'Inspect this failed migration directly. Live schema comparison was unavailable, so SMRT could not determine whether it has been superseded.';
+  }
+}
+
+export function summarizeFailedMigrations(
+  failedMigrations: FailedMigrationLike[],
+  unresolvedSyntheticMigrationNames: Set<string> | null,
+): FailedMigrationBuckets {
+  const liveSchemaCompared = unresolvedSyntheticMigrationNames !== null;
+  const buckets: FailedMigrationBuckets = {
+    unresolved: [],
+    superseded: [],
+    other: [],
+  };
+
+  for (const migration of failedMigrations) {
+    const classification = unresolvedSyntheticMigrationNames
+      ? classifyFailedMigration(
+          migration.name,
+          unresolvedSyntheticMigrationNames,
+        )
+      : 'other';
+    const summary: FailedMigrationSummaryItem = {
+      name: migration.name,
+      classification,
+      recommendation: getFailedMigrationRecommendation(
+        classification,
+        liveSchemaCompared,
+      ),
+      errorMessage: migration.error_message ?? null,
+    };
+
+    buckets[classification].push(summary);
+  }
+
+  return buckets;
 }
 
 export function partitionSchemaChanges(

--- a/packages/cli/src/commands/db-migrate-actions.ts
+++ b/packages/cli/src/commands/db-migrate-actions.ts
@@ -23,7 +23,15 @@ export interface MigrationAction {
 }
 
 export interface SchemaChangeLike {
-  type: 'add_column' | 'add_index' | 'type_mismatch' | 'type_upgrade';
+  type:
+    | 'add_table'
+    | 'drop_table'
+    | 'add_column'
+    | 'drop_column'
+    | 'add_index'
+    | 'drop_index'
+    | 'type_mismatch'
+    | 'type_upgrade';
   table: string;
   name?: string;
   column?: {

--- a/packages/cli/src/commands/db-status.ts
+++ b/packages/cli/src/commands/db-status.ts
@@ -10,7 +10,13 @@
 import { ObjectRegistry, SchemaComparer } from '@happyvertical/smrt-core';
 import type { CLICommand } from '../cli-generator.js';
 import { autoDiscoverAndLoad } from '../discovery/index.js';
-import { classifyTypeUpgradeSql } from './db-migrate-actions.js';
+import {
+  classifyTypeUpgradeSql,
+  type FailedMigrationBuckets,
+  type FailedMigrationSummaryItem,
+  getUnresolvedAdditiveMigrationNames,
+  summarizeFailedMigrations,
+} from './db-migrate-actions.js';
 
 type StatusDrift = {
   name: string;
@@ -192,7 +198,15 @@ export const dbStatusCommand: CLICommand = {
           })),
         },
         drift: [] as StatusDrift[],
+        failedMigrations: {
+          unresolved: [],
+          superseded: [],
+          other: [],
+        } as FailedMigrationBuckets,
       };
+
+      const failedHistory = await tracker.getHistory({ status: 'failed' });
+      status.failedMigrations = summarizeFailedMigrations(failedHistory, null);
 
       // 8. Compare the current manifest schema against the live database.
       // This keeps db:status useful for shared Postgres databases where the
@@ -202,6 +216,10 @@ export const dbStatusCommand: CLICommand = {
         const comparer = new SchemaComparer(db);
         const diff = await comparer.compare(manifestSchemas);
         status.drift = summarizeSchemaDiff(diff);
+        status.failedMigrations = summarizeFailedMigrations(
+          failedHistory,
+          getUnresolvedAdditiveMigrationNames(diff.changes),
+        );
       }
 
       // 9. Output results
@@ -280,6 +298,22 @@ export const dbStatusCommand: CLICommand = {
         console.log();
       }
 
+      printFailedMigrationGroup(
+        '⚠️  Failed migrations still map to unresolved live drift:',
+        status.failedMigrations.unresolved,
+        options.verbose,
+      );
+      printFailedMigrationGroup(
+        '⚠️  Failed migrations requiring direct review:',
+        status.failedMigrations.other,
+        options.verbose,
+      );
+      printFailedMigrationGroup(
+        'ℹ️  Historical failed additive migrations already superseded by the live schema:',
+        status.failedMigrations.superseded,
+        options.verbose,
+      );
+
       console.log('💡 Commands:');
       console.log('   smrt db:migrate   - Apply pending changes');
       console.log('   smrt db:history   - View migration history');
@@ -315,4 +349,26 @@ function getTimeAgo(date: Date): string {
   if (seconds < 604800) return `${Math.floor(seconds / 86400)}d ago`;
 
   return date.toLocaleDateString();
+}
+
+function printFailedMigrationGroup(
+  title: string,
+  migrations: FailedMigrationSummaryItem[],
+  verbose: boolean,
+): void {
+  if (migrations.length === 0) {
+    return;
+  }
+
+  console.log(title);
+  for (const migration of migrations) {
+    console.log(`   • ${migration.name}`);
+    if (verbose) {
+      console.log(`     ${migration.recommendation}`);
+      if (migration.errorMessage) {
+        console.log(`     Last error: ${migration.errorMessage}`);
+      }
+    }
+  }
+  console.log();
 }

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -21,6 +21,7 @@ import { dbDiffCommand } from './db-diff.js';
 import { dbGenerateCommand } from './db-generate.js';
 import { dbHistoryCommand } from './db-history.js';
 import {
+  getSyntheticMigrationNameForAction,
   type MigrationAction,
   partitionSchemaChanges,
   type SchemaChangeLike,
@@ -1381,20 +1382,20 @@ export default testManifest;
         for (const migration of migrations) {
           try {
             // Generate a unique migration name based on the action
-            let migrationName: string;
+            const migrationName = getSyntheticMigrationNameForAction(migration);
+            if (!migrationName) {
+              continue;
+            }
             let migrationSql: string;
             let actionDesc: string;
 
             if (migration.type === 'add_column' && migration.column) {
-              migrationName = `add_column_${migration.tableName}_${migration.column.name}`;
               migrationSql = migration.sql || '';
               actionDesc = `Added column ${migration.tableName}.${migration.column.name}`;
             } else if (migration.type === 'type_upgrade' && migration.column) {
-              migrationName = `type_upgrade_${migration.tableName}_${migration.column.name}`;
               migrationSql = migration.sql || '';
               actionDesc = `Upgraded column ${migration.tableName}.${migration.column.name} from ${migration.mismatch?.actual} to ${migration.mismatch?.expected}`;
             } else if (migration.type === 'add_index' && migration.index) {
-              migrationName = `add_index_${migration.index.name}`;
               migrationSql = migration.sql || '';
               actionDesc = `Created index ${migration.index.name} on ${migration.tableName}`;
             } else {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -7,11 +7,11 @@
     "tsBuildInfoFile": "./dist/.tsbuildinfo",
     "types": ["node", "vitest/globals"],
     "paths": {
-      "@happyvertical/smrt-agents": ["packages/agents"],
-      "@happyvertical/smrt-config": ["packages/config"],
-      "@happyvertical/smrt-core": ["packages/core"],
-      "@happyvertical/smrt-playground": ["packages/smrt-playground"],
-      "@happyvertical/smrt-types": ["packages/types"]
+      "@happyvertical/smrt-agents": ["packages/agents/src/index.ts"],
+      "@happyvertical/smrt-config": ["packages/config/src/index.ts"],
+      "@happyvertical/smrt-core": ["packages/core/src/index.ts"],
+      "@happyvertical/smrt-playground": ["packages/smrt-playground/src/index.ts"],
+      "@happyvertical/smrt-types": ["packages/types/src/index.ts"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -5,11 +5,20 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "tsBuildInfoFile": "./dist/.tsbuildinfo",
-    "types": ["node", "vitest/globals"]
+    "types": ["node", "vitest/globals"],
+    "paths": {
+      "@happyvertical/smrt-agents": ["packages/agents"],
+      "@happyvertical/smrt-config": ["packages/config"],
+      "@happyvertical/smrt-core": ["packages/core"],
+      "@happyvertical/smrt-playground": ["packages/smrt-playground"],
+      "@happyvertical/smrt-types": ["packages/types"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"],
   "references": [
+    { "path": "../agents" },
+    { "path": "../config" },
     { "path": "../core" },
     { "path": "../smrt-playground" },
     { "path": "../types" }

--- a/packages/cli/tsconfig.typecheck.json
+++ b/packages/cli/tsconfig.typecheck.json
@@ -1,10 +1,6 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.package-typecheck.json",
   "compilerOptions": {
-    "composite": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "tsBuildInfoFile": "./dist/.tsbuildinfo",
     "types": ["node", "vitest/globals"]
   },
   "include": ["src/**/*"],

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,18 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    pool: 'forks',
+  },
+  resolve: {
+    alias: [
+      {
+        find: /^@happyvertical\/smrt-agents$/,
+        replacement: resolve(__dirname, '../agents/src/index.ts'),
+      },
+    ],
+  },
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,7 +60,7 @@
     "yaml": "^2.8.2"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig.typecheck.json",
     "generate": "node scripts/generate-manifest.js",
     "generate:test": "node scripts/generate-test-manifest.js",
     "test": "node scripts/generate-test-manifest.js && vitest run",

--- a/packages/core/src/migrations/__tests__/differ.test.ts
+++ b/packages/core/src/migrations/__tests__/differ.test.ts
@@ -371,6 +371,49 @@ describe('SchemaComparer engine-specific SQL generation', () => {
     expect(typeUpgrades[0].sql).toContain('::jsonb');
   });
 
+  it('should preserve PostgreSQL JSON defaults during TEXT→JSON upgrades', async () => {
+    const mockPostgresDb = {
+      url: 'postgresql://localhost/test',
+      query: async () => ({ rows: [{ table_name: 'documents' }] }),
+      getTableSchema: async () => ({
+        columns: {
+          id: { type: 'TEXT', notnull: true },
+          metadata: { type: 'TEXT', notnull: false },
+        },
+        indexes: [],
+      }),
+    };
+
+    const pgComparer = new SchemaComparer(mockPostgresDb as any, {
+      ignoreTypeMismatches: false,
+    });
+
+    const manifest: Record<string, SchemaDefinition> = {
+      documents: {
+        tableName: 'documents',
+        ddl: "CREATE TABLE documents (id TEXT PRIMARY KEY, metadata JSON DEFAULT '{}');",
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          metadata: { type: 'JSON', defaultValue: '{}' },
+        },
+        indexes: [],
+        triggers: [],
+        foreignKeys: [],
+        dependencies: [],
+        version: '1.0.0',
+      },
+    };
+
+    const diff = await pgComparer.compare(manifest);
+
+    const typeUpgrades = diff.changes.filter((c) => c.type === 'type_upgrade');
+    expect(typeUpgrades).toHaveLength(1);
+    expect(typeUpgrades[0].sql).toContain('DROP DEFAULT');
+    expect(typeUpgrades[0].sql).toContain('TYPE JSONB');
+    expect(typeUpgrades[0].sql).toContain('USING "metadata"::jsonb');
+    expect(typeUpgrades[0].sql).toContain("SET DEFAULT '{}'::jsonb");
+  });
+
   it('should generate DuckDB ALTER COLUMN TYPE for TEXT→JSON', async () => {
     // Create a mock database interface that identifies as DuckDB
     const mockDuckDb = {

--- a/packages/core/src/migrations/differ.ts
+++ b/packages/core/src/migrations/differ.ts
@@ -199,7 +199,7 @@ export class SchemaComparer {
             const sql = this.generateTypeUpgradeSQL(
               tableName,
               colName,
-              colDef.type,
+              colDef,
               dbCol.type,
             );
             changes.push({
@@ -444,11 +444,12 @@ export class SchemaComparer {
   private generateTypeUpgradeSQL(
     tableName: string,
     colName: string,
-    manifestType: string,
+    colDef: ColumnDefinition,
     dbType: string,
   ): string {
     const quotedTable = this.quoteIdentifier(tableName);
     const quotedCol = this.quoteIdentifier(colName);
+    const manifestType = colDef.type;
 
     // Validate manifestType before mapping
     const validatedType: SQLDataType = isValidSQLDataType(manifestType)
@@ -469,30 +470,40 @@ export class SchemaComparer {
         // For other type upgrades, SQLite requires recreating the table
         return `-- SQLite: Type upgrade for ${quotedCol} requires table recreation`;
 
-      case 'postgres':
-        // PostgreSQL requires explicit ALTER COLUMN with USING clause
-        if (
-          this.normalizeType(manifestType) === 'JSON' &&
-          this.normalizeType(dbType) === 'TEXT'
-        ) {
-          // TEXT → JSONB: cast text to jsonb
-          return `ALTER TABLE ${quotedTable} ALTER COLUMN ${quotedCol} TYPE ${targetType} USING ${quotedCol}::${targetType.toLowerCase()}`;
+      case 'postgres': {
+        // PostgreSQL defaults must be dropped/reset around some type changes
+        // so drift repairs can succeed even when an existing default cannot
+        // be cast automatically to the target type.
+        const manifestNormalized = this.normalizeType(manifestType);
+        const dbNormalized = this.normalizeType(dbType);
+        const clauses: string[] = [];
+
+        if (colDef.defaultValue !== undefined) {
+          clauses.push(`ALTER COLUMN ${quotedCol} DROP DEFAULT`);
         }
-        if (
-          this.normalizeType(manifestType) === 'TEXT' &&
-          this.normalizeType(dbType) === 'JSON'
-        ) {
-          // JSONB → TEXT: cast jsonb to text
-          return `ALTER TABLE ${quotedTable} ALTER COLUMN ${quotedCol} TYPE TEXT USING ${quotedCol}::text`;
+
+        let typeClause = `ALTER COLUMN ${quotedCol} TYPE ${targetType}`;
+        if (manifestNormalized === 'JSON' && dbNormalized === 'TEXT') {
+          typeClause += ` USING ${quotedCol}::${targetType.toLowerCase()}`;
+        } else if (manifestNormalized === 'TEXT' && dbNormalized === 'JSON') {
+          typeClause += ` USING ${quotedCol}::text`;
         }
-        if (
-          this.normalizeType(manifestType) === 'REAL' &&
-          this.normalizeType(dbType) === 'INTEGER'
-        ) {
-          // INTEGER → DOUBLE PRECISION
-          return `ALTER TABLE ${quotedTable} ALTER COLUMN ${quotedCol} TYPE ${targetType}`;
+        clauses.push(typeClause);
+
+        if (colDef.defaultValue !== undefined) {
+          const formattedDefault = this.ddlStrategy.formatDefaultValue(
+            colDef.defaultValue,
+            validatedType,
+          );
+          const defaultSql =
+            manifestNormalized === 'JSON'
+              ? `${formattedDefault}::${targetType.toLowerCase()}`
+              : formattedDefault;
+          clauses.push(`ALTER COLUMN ${quotedCol} SET DEFAULT ${defaultSql}`);
         }
-        return `ALTER TABLE ${quotedTable} ALTER COLUMN ${quotedCol} TYPE ${targetType}`;
+
+        return `ALTER TABLE ${quotedTable} ${clauses.join(', ')}`;
+      }
 
       case 'duckdb':
         // DuckDB supports ALTER COLUMN TYPE for type conversions

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -9,9 +9,9 @@
     "emitDecoratorMetadata": true,
     "types": ["node"],
     "paths": {
-      "@happyvertical/smrt-config": ["packages/config"],
-      "@happyvertical/smrt-scanner": ["packages/scanner"],
-      "@happyvertical/smrt-types": ["packages/types"]
+      "@happyvertical/smrt-config": ["packages/config/src/index.ts"],
+      "@happyvertical/smrt-scanner": ["packages/scanner/src/index.ts"],
+      "@happyvertical/smrt-types": ["packages/types/src/index.ts"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -7,12 +7,22 @@
     "tsBuildInfoFile": "./dist/.tsbuildinfo",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "types": ["node"]
+    "types": ["node"],
+    "paths": {
+      "@happyvertical/smrt-config": ["packages/config"],
+      "@happyvertical/smrt-scanner": ["packages/scanner"],
+      "@happyvertical/smrt-types": ["packages/types"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": [
     "**/*.test.ts",
     "**/*.spec.ts",
     "src/vite-plugin/templates/**"
+  ],
+  "references": [
+    { "path": "../config" },
+    { "path": "../scanner" },
+    { "path": "../types" }
   ]
 }

--- a/packages/core/tsconfig.typecheck.json
+++ b/packages/core/tsconfig.typecheck.json
@@ -1,13 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.package-typecheck.json",
   "compilerOptions": {
-    "composite": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "types": ["node"],
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
-    "types": ["node"]
+    "emitDecoratorMetadata": true
   },
   "include": ["src/**/*"],
   "exclude": [

--- a/packages/scanner/src/__tests__/manifest-adapter.test.ts
+++ b/packages/scanner/src/__tests__/manifest-adapter.test.ts
@@ -238,6 +238,54 @@ describe('ManifestAdapter', () => {
         expect(result.type).toBe('text');
       });
 
+      it('should treat string unions with null and undefined as optional text', () => {
+        const field: RawFieldDefinition = {
+          name: 'tenantId',
+          accessibility: 'public',
+          typeAnnotation: 'string | null | undefined',
+          initializer: null,
+          optional: false,
+          hasDecimalPoint: false,
+          numericValue: null,
+          decorators: [],
+          isStatic: false,
+          readonly: false,
+          line: 1,
+        };
+
+        const adapterWithAliases = new ManifestAdapter();
+        adapterWithAliases.toManifest([], { typeAliases: {} });
+
+        const result = adapterWithAliases.inferFieldType(field);
+        expect(result.type).toBe('text');
+        expect(result.required).toBe(false);
+        expect(result.source).toBe('annotation');
+      });
+
+      it('should treat imported enum-member initializers as text', () => {
+        const field: RawFieldDefinition = {
+          name: 'status',
+          accessibility: 'public',
+          typeAnnotation: 'UserStatus',
+          initializer: 'UserStatus.ACTIVE',
+          optional: false,
+          hasDecimalPoint: false,
+          numericValue: null,
+          decorators: [],
+          isStatic: false,
+          readonly: false,
+          line: 1,
+        };
+
+        const adapterWithAliases = new ManifestAdapter();
+        adapterWithAliases.toManifest([], { typeAliases: {} });
+
+        const result = adapterWithAliases.inferFieldType(field);
+        expect(result.type).toBe('text');
+        expect(result.required).toBe(false);
+        expect(result.source).toBe('heuristic');
+      });
+
       it('should use string initializer heuristic as fallback', () => {
         const field: RawFieldDefinition = {
           name: 'status',

--- a/packages/scanner/src/__tests__/manifest-adapter.test.ts
+++ b/packages/scanner/src/__tests__/manifest-adapter.test.ts
@@ -262,7 +262,7 @@ describe('ManifestAdapter', () => {
         expect(result.source).toBe('annotation');
       });
 
-      it('should treat imported enum-member initializers as text', () => {
+      it('should not guess text from unresolved enum-member initializers', () => {
         const field: RawFieldDefinition = {
           name: 'status',
           accessibility: 'public',
@@ -281,9 +281,37 @@ describe('ManifestAdapter', () => {
         adapterWithAliases.toManifest([], { typeAliases: {} });
 
         const result = adapterWithAliases.inferFieldType(field);
-        expect(result.type).toBe('text');
+        expect(result.type).toBe('json');
         expect(result.required).toBe(false);
-        expect(result.source).toBe('heuristic');
+        expect(result.source).toBe('default');
+      });
+
+      it('should let @field({ type: text }) override unresolved enum-member initializers', () => {
+        const field: RawFieldDefinition = {
+          name: 'status',
+          accessibility: 'public',
+          typeAnnotation: 'UserStatus',
+          initializer: 'UserStatus.ACTIVE',
+          optional: false,
+          hasDecimalPoint: false,
+          numericValue: null,
+          decorators: [
+            {
+              name: 'field',
+              arguments: ["{ type: 'text' }"],
+            },
+          ],
+          isStatic: false,
+          readonly: false,
+          line: 1,
+        };
+
+        const adapterWithAliases = new ManifestAdapter();
+        adapterWithAliases.toManifest([], { typeAliases: {} });
+
+        const result = adapterWithAliases.convertField(field);
+        expect(result?.type).toBe('text');
+        expect(result?.required).toBe(false);
       });
 
       it('should use string initializer heuristic as fallback', () => {

--- a/packages/scanner/src/__tests__/scanner.test.ts
+++ b/packages/scanner/src/__tests__/scanner.test.ts
@@ -408,6 +408,39 @@ describe('OxcScanner', () => {
       expect(widgetDef.fields.visibility.type).toBe('text');
       expect(widgetDef.fields.visibility.default).toBe('public');
     });
+
+    it('should preserve explicit text fields for external enum imports', async () => {
+      writeFileSync(
+        join(tempDir, 'external-enum.ts'),
+        `
+        import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+        import { UserStatus } from '@happyvertical/smrt-types';
+
+        @smrt()
+        export class ExternalEnumUser extends SmrtObject {
+          @field({ type: 'text' })
+          status: UserStatus = UserStatus.ACTIVE;
+        }
+        `,
+      );
+
+      const scanner = new OxcScanner({
+        cwd: tempDir,
+        include: ['external-enum.ts'],
+      });
+
+      const { results, resolved } = await scanner.scanAndResolve();
+
+      const { ManifestAdapter } = await import('../manifest-adapter.js');
+      const adapter = new ManifestAdapter();
+      const manifest = adapter.toManifest(resolved, {
+        packageName: '@test/widget-pkg',
+        typeAliases: results.typeAliases,
+      });
+
+      const userDef = manifest.objects['@test/widget-pkg:ExternalEnumUser'];
+      expect(userDef.fields.status.type).toBe('text');
+    });
   });
 
   describe('getStats', () => {
@@ -422,7 +455,7 @@ describe('OxcScanner', () => {
 
       expect(stats.fileCount).toBeGreaterThan(0);
       expect(stats.totalClasses).toBeGreaterThan(0);
-      expect(stats.smrtClasses).toBe(8); // Product, Category, TestAgent, Event, Meeting, Conference, Performer, Widget
+      expect(stats.smrtClasses).toBe(9); // Product, Category, TestAgent, Event, Meeting, Conference, Performer, Widget, ExternalEnumUser
       expect(stats.stiClasses).toBe(3); // Event, Meeting, Conference
       expect(stats.parseTimeMs).toBeGreaterThanOrEqual(0);
     });

--- a/packages/scanner/src/manifest-adapter.ts
+++ b/packages/scanner/src/manifest-adapter.ts
@@ -865,9 +865,19 @@ export class ManifestAdapter {
       };
     }
 
-    // Union types with null → nullable
-    if (type?.includes(' | null') || type?.includes('null | ')) {
-      const baseType = type.replace(/\s*\|\s*null/g, '').trim();
+    // Union types with null/undefined → nullable or optional
+    if (
+      type?.includes(' | null') ||
+      type?.includes('null | ') ||
+      type?.includes(' | undefined') ||
+      type?.includes('undefined | ')
+    ) {
+      const baseType = type
+        .replace(/\s*\|\s*null/g, '')
+        .replace(/\s*\|\s*undefined/g, '')
+        .replace(/\bnull\s*\|\s*/g, '')
+        .replace(/\bundefined\s*\|\s*/g, '')
+        .trim();
       const inference = this.inferFromAnnotation({
         ...field,
         typeAnnotation: baseType,
@@ -912,6 +922,20 @@ export class ManifestAdapter {
       } finally {
         this._aliasDepth = (this._aliasDepth ?? 0) - 1;
       }
+    }
+
+    // Imported string enums often arrive as unresolved identifiers like
+    // `UserStatus` with enum-member initializers such as `UserStatus.ACTIVE`.
+    if (
+      type &&
+      /^[A-Za-z_$][\w$]*$/.test(type) &&
+      new RegExp(`^${type}\\.[A-Z0-9_]+$`).test(field.initializer ?? '')
+    ) {
+      return {
+        type: 'text',
+        required: isRequired,
+        source: 'heuristic',
+      };
     }
 
     // String initializer heuristic: if initializer is a quoted string, infer text

--- a/packages/scanner/src/manifest-adapter.ts
+++ b/packages/scanner/src/manifest-adapter.ts
@@ -924,20 +924,6 @@ export class ManifestAdapter {
       }
     }
 
-    // Imported string enums often arrive as unresolved identifiers like
-    // `UserStatus` with enum-member initializers such as `UserStatus.ACTIVE`.
-    if (
-      type &&
-      /^[A-Za-z_$][\w$]*$/.test(type) &&
-      new RegExp(`^${type}\\.[A-Z0-9_]+$`).test(field.initializer ?? '')
-    ) {
-      return {
-        type: 'text',
-        required: isRequired,
-        source: 'heuristic',
-      };
-    }
-
     // String initializer heuristic: if initializer is a quoted string, infer text
     if (field.initializer?.match(/^(['"]).*\1$/)) {
       return {

--- a/packages/smrt-playground/tsconfig.json
+++ b/packages/smrt-playground/tsconfig.json
@@ -1,10 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
     "types": ["node", "svelte"],
     "lib": ["ES2023", "DOM"],
     "strict": true,
     "skipLibCheck": true
   },
+  "include": ["src/**/*"],
   "exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.spec.ts"]
 }

--- a/packages/users/src/models/Membership.ts
+++ b/packages/users/src/models/Membership.ts
@@ -3,7 +3,7 @@
  * @packageDocumentation
  */
 
-import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { field, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { MembershipStatus } from '../types/index.js';
 
 /**
@@ -50,6 +50,7 @@ export class Membership extends SmrtObject {
   /**
    * Membership status
    */
+  @field({ type: 'text' })
   status: MembershipStatus = MembershipStatus.ACTIVE;
 
   constructor(options: any = {}) {

--- a/packages/users/src/models/MembershipOverride.ts
+++ b/packages/users/src/models/MembershipOverride.ts
@@ -3,7 +3,7 @@
  * @packageDocumentation
  */
 
-import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { field, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { OverrideEffect } from '../types/index.js';
 
 /**
@@ -50,6 +50,7 @@ export class MembershipOverride extends SmrtObject {
   /**
    * Effect of the override: grant or deny
    */
+  @field({ type: 'text' })
   effect: OverrideEffect = OverrideEffect.GRANT;
 
   constructor(options: any = {}) {

--- a/packages/users/src/models/Session.ts
+++ b/packages/users/src/models/Session.ts
@@ -3,7 +3,7 @@
  * @packageDocumentation
  */
 
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { SessionStatus } from '../types/index.js';
 
 /**
@@ -58,6 +58,7 @@ export class Session extends SmrtObject {
   /**
    * Session status
    */
+  @field({ type: 'text' })
   status: SessionStatus = SessionStatus.ACTIVE;
 
   /**

--- a/packages/users/src/models/Tenant.ts
+++ b/packages/users/src/models/Tenant.ts
@@ -3,7 +3,7 @@
  * @packageDocumentation
  */
 
-import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { field, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantStatus } from '../types/index.js';
 
 /**
@@ -76,6 +76,7 @@ export class Tenant extends SmrtObject {
   /**
    * Tenant status
    */
+  @field({ type: 'text' })
   status: TenantStatus = TenantStatus.ACTIVE;
 
   /**

--- a/packages/users/src/models/TenantPermissionOverride.ts
+++ b/packages/users/src/models/TenantPermissionOverride.ts
@@ -3,7 +3,7 @@
  * @packageDocumentation
  */
 
-import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { field, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantPermissionEffect } from '../types/index.js';
 
 /**
@@ -66,6 +66,7 @@ export class TenantPermissionOverride extends SmrtObject {
   /**
    * Effect of the override: inherit, grant, or deny
    */
+  @field({ type: 'text' })
   effect: TenantPermissionEffect = TenantPermissionEffect.INHERIT;
 
   constructor(options: any = {}) {

--- a/packages/users/src/models/User.ts
+++ b/packages/users/src/models/User.ts
@@ -3,7 +3,7 @@
  * @packageDocumentation
  */
 
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { UserStatus } from '../types/index.js';
 
 /**
@@ -68,6 +68,7 @@ export class User extends SmrtObject {
   /**
    * User account status
    */
+  @field({ type: 'text' })
   status: UserStatus = UserStatus.ACTIVE;
 
   /**

--- a/turbo.json
+++ b/turbo.json
@@ -82,7 +82,7 @@
     },
     "typecheck": {
       "dependsOn": ["^build", "generate:test"],
-      "inputs": ["src/**", "test/**", "**/*.ts", "tsconfig.json"],
+      "inputs": ["src/**", "test/**", "**/*.ts", "tsconfig*.json"],
       "cache": true
     },
     "dev": {


### PR DESCRIPTION
## Summary
- fix manifest inference for nullable tenant IDs and imported enum-backed text fields so runtime contracts stop drifting into `type_upgrade` repairs
- preserve PostgreSQL defaults when reconciling `TEXT -> JSONB` upgrades so live shared databases can apply the repair safely
- teach `db:status` and `db:history` to distinguish unresolved failed additive migrations from superseded historical failures

## Testing
- `pnpm --filter @happyvertical/smrt-scanner exec vitest run src/__tests__/manifest-adapter.test.ts`
- `pnpm --filter @happyvertical/smrt-core exec vitest run src/migrations/__tests__/differ.test.ts`
- `pnpm --filter @happyvertical/smrt-cli exec vitest run src/commands/__tests__/db-migrate-actions.test.ts src/commands/__tests__/db-status.test.ts src/commands/__tests__/db-history.test.ts src/commands/__tests__/sti-upgrade.test.ts src/commands/__tests__/utilities-runtime-check.test.ts`

Closes #1117
Closes #1118