### PR TITLE
[codex] align schedule schema and migration failure reporting

### DIFF
--- a/.changeset/fix-schedule-schema-status.md
+++ b/.changeset/fix-schedule-schema-status.md
@@ -1,0 +1,7 @@
+---
+"@happyvertical/smrt-core": patch
+"@happyvertical/smrt-agents": patch
+"@happyvertical/smrt-cli": patch
+---
+
+Align `AgentSchedule` manifest schema output with the runtime storage contract for `agentConfig` and `methodArgs`, and improve migration status/history reporting so superseded failed generated migrations are distinguished from active schema drift.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ npm run format                  # Biome
 - **STI discriminator**: qualified names — `@happyvertical/smrt-content:Article`
 - **Tenant scoping**: most domain models use `@TenantScoped({ mode: 'optional' })` + nullable tenantId
 - **JSON fields**: store as string, provide `getX()`/`setX()` helpers with graceful parse error handling
+- **No private reach-ins**: do not cast into underscored internals like `_db`, `_tableName`, or registry-private state from outside the owning class. If a public API is missing, add one upstream instead of reaching through a private implementation detail.
 - **Changesets**: auto-generated on merge to main. Don't run `npx changeset` manually
 
 ## SDK Dependencies

--- a/packages/agents/src/config.test.ts
+++ b/packages/agents/src/config.test.ts
@@ -70,6 +70,14 @@ describe('agent model runtime field registration', () => {
     expect(fields.get('enabled')?.type).toBe('boolean');
     expect(fields.get('nextRun')?.type).toBe('datetime');
     expect(fields.get('runningCount')?.type).toBe('integer');
+
+    const schemas = ObjectRegistry.getAllSchemasAsDefinitions();
+    expect(schemas._smrt_agent_schedules?.columns.agent_config?.type).toBe(
+      'TEXT',
+    );
+    expect(schemas._smrt_agent_schedules?.columns.method_args?.type).toBe(
+      'TEXT',
+    );
   });
 
   it('registers TenantAgent JSON and text fields when loaded directly', async () => {

--- a/packages/agents/src/schedule.ts
+++ b/packages/agents/src/schedule.ts
@@ -60,7 +60,7 @@ export class AgentSchedule extends SmrtObject {
   agentId: string | null = null;
 
   /** Agent configuration to pass when running */
-  @field({ type: 'json' })
+  @field({ type: 'json', sqlType: 'TEXT' })
   agentConfig: Record<string, unknown> = {};
 
   /** Cron expression (e.g., '0 2 * * *' for 2 AM daily) */
@@ -124,7 +124,7 @@ export class AgentSchedule extends SmrtObject {
   method: string = 'run';
 
   /** Arguments to pass to the method */
-  @field({ type: 'json' })
+  @field({ type: 'json', sqlType: 'TEXT' })
   methodArgs: Record<string, unknown> = {};
 
   /**

--- a/packages/cli/CLAUDE.md
+++ b/packages/cli/CLAUDE.md
@@ -39,4 +39,4 @@ smrt dispatch:*              # Dispatch management (list/process/retry/cleanup)
 
 - **Test mode detection**: checks `NODE_ENV=test`, `VITEST=true`, `global.it`/`describe` — could conflict with other test runners
 - **External package load failures silenced**: one package failing doesn't prevent others from loading
-- **Schema history nuance**: `db:status` / `db:history` should distinguish active live drift from superseded failed additive migrations instead of treating all failed rows as current blockers
+- **Schema history nuance**: `db:status` / `db:history` should distinguish active live drift from superseded failed generated schema repairs instead of treating all failed rows as current blockers

--- a/packages/cli/CLAUDE.md
+++ b/packages/cli/CLAUDE.md
@@ -6,7 +6,7 @@ Developer CLI with lazy-loaded commands, manifest discovery, and class introspec
 
 ```
 smrt introspect              # Discover SMRT objects in project
-smrt db:status               # Pending schema changes
+smrt db:status               # Pending schema changes + failed migration classification
 smrt db:migrate              # Apply migrations
 smrt db:diff --generate      # Generate migration from changes
 smrt db:rollback             # Rollback migrations
@@ -39,3 +39,4 @@ smrt dispatch:*              # Dispatch management (list/process/retry/cleanup)
 
 - **Test mode detection**: checks `NODE_ENV=test`, `VITEST=true`, `global.it`/`describe` — could conflict with other test runners
 - **External package load failures silenced**: one package failing doesn't prevent others from loading
+- **Schema history nuance**: `db:status` / `db:history` should distinguish active live drift from superseded failed additive migrations instead of treating all failed rows as current blockers

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -24,11 +24,11 @@ pnpm add -D @happyvertical/smrt-cli
 
 | Command | Description |
 |---------|------------|
-| `smrt db:status` | Show pending schema changes |
+| `smrt db:status` | Show pending schema changes and classify failed migration history |
 | `smrt db:migrate` | Apply pending migrations |
 | `smrt db:diff --generate` | Generate migration from schema changes |
 | `smrt db:rollback` | Rollback last migration |
-| `smrt db:history` | Show migration history |
+| `smrt db:history` | Show migration history with active-vs-superseded failure classification |
 
 ### Code Generation
 

--- a/packages/cli/src/commands/__tests__/db-history.test.ts
+++ b/packages/cli/src/commands/__tests__/db-history.test.ts
@@ -201,19 +201,20 @@ describe('db:history', () => {
         name: 'add_column_contents_script_text',
         classification: 'unresolved',
         recommendation:
-          'Run `smrt db:migrate` to reconcile the live schema, then confirm this failed additive migration no longer appears as unresolved.',
+          'Run `smrt db:migrate` to reconcile the live schema, then confirm this failed generated schema repair no longer appears as unresolved.',
       }),
       expect.objectContaining({
         name: 'add_index_idx_contents_published_at',
         classification: 'superseded',
         recommendation:
-          'No current live-schema drift maps to this failed additive migration. Keep the row for audit history, but it no longer blocks the current schema.',
+          'No current live-schema drift maps to this failed generated schema repair. Keep the row for audit history, but it no longer blocks the current schema.',
       }),
       expect.objectContaining({
         name: 'type_upgrade_contents_status',
-        classification: 'other',
+        classification: 'superseded',
         recommendation:
-          'Inspect this failed migration directly. It is not a superseded additive repair and may still need manual attention.',
+          'No current live-schema drift maps to this failed generated schema repair. Keep the row for audit history, but it no longer blocks the current schema.',
+        resolution: 'superseded',
       }),
       expect.objectContaining({
         name: 'baseline_schema',

--- a/packages/cli/src/commands/__tests__/db-history.test.ts
+++ b/packages/cli/src/commands/__tests__/db-history.test.ts
@@ -223,4 +223,24 @@ describe('db:history', () => {
       }),
     ]);
   });
+
+  it('counts manual-review failures when schema comparison is unavailable', async () => {
+    getDatabaseMock.mockResolvedValue({
+      url: 'postgresql://test:test@localhost:5432/test_db',
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await dbHistoryCommand.handler([], {});
+
+    const output = logSpy.mock.calls.map((call) => call.join('')).join('\n');
+
+    expect(autoDiscoverAndLoadMock).not.toHaveBeenCalled();
+    expect(output).toContain(
+      'Summary: 1 completed, 3 failed (0 unresolved, 0 superseded, 3 other), 0 rolled back',
+    );
+    expect(output).toContain(
+      '0 failed still require action, 0 are superseded history, 3 need manual review',
+    );
+  });
 });

--- a/packages/cli/src/commands/__tests__/db-migrate-actions.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-actions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
-  getUnresolvedAdditiveMigrationNames,
+  getUnresolvedGeneratedMigrationNames,
   partitionSchemaChanges,
   summarizeFailedMigrations,
 } from '../db-migrate-actions.js';
@@ -149,13 +149,19 @@ describe('partitionSchemaChanges', () => {
 });
 
 describe('failed migration classification', () => {
-  it('tracks current unresolved additive repairs separately from superseded failures', () => {
-    const unresolvedNames = getUnresolvedAdditiveMigrationNames([
+  it('tracks current unresolved generated repairs separately from superseded failures', () => {
+    const unresolvedNames = getUnresolvedGeneratedMigrationNames([
       {
         type: 'add_column',
         table: 'contents',
         name: 'script_text',
         column: { type: 'TEXT' },
+      },
+      {
+        type: 'type_upgrade',
+        table: 'contents',
+        name: 'status',
+        sql: 'ALTER TABLE contents ALTER COLUMN status TYPE JSONB USING status::jsonb',
       },
     ]);
 
@@ -183,8 +189,15 @@ describe('failed migration classification', () => {
           name: 'add_column_contents_script_text',
           classification: 'unresolved',
           recommendation:
-            'Run `smrt db:migrate` to reconcile the live schema, then confirm this failed additive migration no longer appears as unresolved.',
+            'Run `smrt db:migrate` to reconcile the live schema, then confirm this failed generated schema repair no longer appears as unresolved.',
           errorMessage: 'column missing',
+        },
+        {
+          name: 'type_upgrade_contents_status',
+          classification: 'unresolved',
+          recommendation:
+            'Run `smrt db:migrate` to reconcile the live schema, then confirm this failed generated schema repair no longer appears as unresolved.',
+          errorMessage: 'cannot cast',
         },
       ],
       superseded: [
@@ -192,19 +205,11 @@ describe('failed migration classification', () => {
           name: 'add_index_idx_contents_published_at',
           classification: 'superseded',
           recommendation:
-            'No current live-schema drift maps to this failed additive migration. Keep the row for audit history, but it no longer blocks the current schema.',
+            'No current live-schema drift maps to this failed generated schema repair. Keep the row for audit history, but it no longer blocks the current schema.',
           errorMessage: 'index already exists',
         },
       ],
-      other: [
-        {
-          name: 'type_upgrade_contents_status',
-          classification: 'other',
-          recommendation:
-            'Inspect this failed migration directly. It is not a superseded additive repair and may still need manual attention.',
-          errorMessage: 'cannot cast',
-        },
-      ],
+      other: [],
     });
   });
 

--- a/packages/cli/src/commands/__tests__/db-status.test.ts
+++ b/packages/cli/src/commands/__tests__/db-status.test.ts
@@ -348,6 +348,12 @@ describe('db:status', () => {
           name: 'script_text',
           column: { type: 'TEXT' },
         },
+        {
+          type: 'type_upgrade',
+          table: 'contents',
+          name: 'status',
+          sql: 'ALTER TABLE contents ALTER COLUMN status TYPE JSONB USING status::jsonb',
+        },
       ],
     });
     getHistoryMock.mockResolvedValue([
@@ -378,8 +384,15 @@ describe('db:status', () => {
           name: 'add_column_contents_script_text',
           classification: 'unresolved',
           recommendation:
-            'Run `smrt db:migrate` to reconcile the live schema, then confirm this failed additive migration no longer appears as unresolved.',
+            'Run `smrt db:migrate` to reconcile the live schema, then confirm this failed generated schema repair no longer appears as unresolved.',
           errorMessage: 'column missing',
+        },
+        {
+          name: 'type_upgrade_contents_status',
+          classification: 'unresolved',
+          recommendation:
+            'Run `smrt db:migrate` to reconcile the live schema, then confirm this failed generated schema repair no longer appears as unresolved.',
+          errorMessage: 'cannot cast',
         },
       ],
       superseded: [
@@ -387,19 +400,11 @@ describe('db:status', () => {
           name: 'add_index_idx_contents_published_at',
           classification: 'superseded',
           recommendation:
-            'No current live-schema drift maps to this failed additive migration. Keep the row for audit history, but it no longer blocks the current schema.',
+            'No current live-schema drift maps to this failed generated schema repair. Keep the row for audit history, but it no longer blocks the current schema.',
           errorMessage: 'index already exists',
         },
       ],
-      other: [
-        {
-          name: 'type_upgrade_contents_status',
-          classification: 'other',
-          recommendation:
-            'Inspect this failed migration directly. It is not a superseded additive repair and may still need manual attention.',
-          errorMessage: 'cannot cast',
-        },
-      ],
+      other: [],
     });
   });
 });

--- a/packages/cli/src/commands/__tests__/db-status.test.ts
+++ b/packages/cli/src/commands/__tests__/db-status.test.ts
@@ -216,6 +216,110 @@ describe('db:status', () => {
     });
   });
 
+  it('classifies failed additive migrations as superseded history when live drift is gone', async () => {
+    compareMock.mockResolvedValue({
+      added_tables: [],
+      dropped_tables: [],
+      has_changes: false,
+      changes: [],
+    });
+    getHistoryMock.mockResolvedValue([
+      {
+        id: 'failed-1',
+        name: 'add_column_contents_script_text',
+        version: '1.0.0',
+        checksum: 'abc',
+        applied_checksum: null,
+        applied_at: new Date('2026-04-12T10:00:00Z'),
+        execution_time_ms: 1,
+        package_name: null,
+        source_file: null,
+        status: 'failed',
+        error_message: 'must be owner of table contents',
+        attempts: 1,
+        is_reversible: false,
+        rolled_back_at: null,
+        applied_by: null,
+        batch: 1,
+      },
+    ]);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await dbStatusCommand.handler([], { json: true });
+
+    const parsed = JSON.parse(
+      logSpy.mock.calls.map((call) => call.join('')).join('\n'),
+    );
+    expect(parsed.migrations.failed).toEqual({
+      total: 1,
+      actionRequired: 0,
+      superseded: 1,
+      manualReview: 0,
+      details: [
+        {
+          name: 'add_column_contents_script_text',
+          resolution: 'superseded',
+          kind: 'add_column',
+          reason:
+            'Current manifests no longer require this generated schema change, so the failed row is retained history rather than active drift.',
+          errorMessage: 'must be owner of table contents',
+        },
+      ],
+    });
+  });
+
+  it('keeps failed migrations actionable when the live diff still requires them', async () => {
+    compareMock.mockResolvedValue({
+      added_tables: [],
+      dropped_tables: [],
+      has_changes: true,
+      changes: [
+        {
+          type: 'type_upgrade',
+          table: '_smrt_agent_schedules',
+          name: 'agent_config',
+          sql: 'ALTER TABLE _smrt_agent_schedules ALTER COLUMN agent_config TYPE JSONB USING agent_config::jsonb',
+        },
+      ],
+    });
+    getHistoryMock.mockResolvedValue([
+      {
+        id: 'failed-2',
+        name: 'type_upgrade__smrt_agent_schedules_agent_config',
+        version: '1.0.0',
+        checksum: 'def',
+        applied_checksum: null,
+        applied_at: new Date('2026-04-12T10:00:00Z'),
+        execution_time_ms: 1,
+        package_name: null,
+        source_file: null,
+        status: 'failed',
+        error_message:
+          'default for column "agent_config" cannot be cast automatically to type jsonb',
+        attempts: 1,
+        is_reversible: false,
+        rolled_back_at: null,
+        applied_by: null,
+        batch: 1,
+      },
+    ]);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await dbStatusCommand.handler([], { json: true });
+
+    const parsed = JSON.parse(
+      logSpy.mock.calls.map((call) => call.join('')).join('\n'),
+    );
+    expect(parsed.migrations.failed.actionRequired).toBe(1);
+    expect(parsed.migrations.failed.details[0]).toMatchObject({
+      name: 'type_upgrade__smrt_agent_schedules_agent_config',
+      resolution: 'action_required',
+      kind: 'type_upgrade',
+    });
+  });
+
   it('omits no-op type upgrades from drift output', () => {
     expect(
       summarizeSchemaDiff({

--- a/packages/cli/src/commands/db-history.ts
+++ b/packages/cli/src/commands/db-history.ts
@@ -9,12 +9,13 @@ import type { MigrationStatus } from '@happyvertical/smrt-core/migrations';
 import type { CLICommand } from '../cli-generator.js';
 import { autoDiscoverAndLoad } from '../discovery/index.js';
 import {
-  classifyFailedMigration,
   type FailedMigrationClassification,
   getFailedMigrationRecommendation,
-  getUnresolvedGeneratedMigrationNames,
 } from './db-migrate-actions.js';
-import { assessFailedMigrations } from './migration-failure-analysis.js';
+import {
+  assessFailedMigrations,
+  type FailedMigrationAssessment,
+} from './migration-failure-analysis.js';
 
 type AnnotatedHistoryEntry = {
   id: string;
@@ -36,6 +37,19 @@ type AnnotatedHistoryEntry = {
   classification: FailedMigrationClassification | null;
   recommendation: string | null;
 };
+
+function getLegacyFailedMigrationClassification(
+  assessment: FailedMigrationAssessment,
+): FailedMigrationClassification {
+  switch (assessment.resolution) {
+    case 'action_required':
+      return 'unresolved';
+    case 'superseded':
+      return 'superseded';
+    default:
+      return 'other';
+  }
+}
 
 export const dbHistoryCommand: CLICommand = {
   name: 'db:history',
@@ -135,39 +149,28 @@ export const dbHistoryCommand: CLICommand = {
 
       // 6. Get history
       const history = await tracker.getHistory(queryOptions);
-      let unresolvedSyntheticMigrationNames: Set<string> | null = null;
-      let failedAssessmentsByName = new Map<
-        string,
-        ReturnType<typeof assessFailedMigrations>[number]
-      >();
+      const failedHistory = history.filter(
+        (migration) => migration.status === 'failed',
+      );
+      let liveSchemaCompared = false;
+      let failedAssessments = assessFailedMigrations(failedHistory, null);
 
-      if (
-        history.some((migration) => migration.status === 'failed') &&
-        typeof db.getTableSchema === 'function'
-      ) {
+      if (failedHistory.length > 0 && typeof db.getTableSchema === 'function') {
         try {
           await autoDiscoverAndLoad();
           const manifestSchemas = ObjectRegistry.getAllSchemasAsDefinitions();
           const comparer = new SchemaComparer(db);
           const diff = await comparer.compare(manifestSchemas);
-          unresolvedSyntheticMigrationNames =
-            getUnresolvedGeneratedMigrationNames(diff.changes);
-          failedAssessmentsByName = new Map(
-            assessFailedMigrations(
-              history.filter((migration) => migration.status === 'failed'),
-              diff,
-            ).map((item) => [item.name, item]),
-          );
+          liveSchemaCompared = true;
+          failedAssessments = assessFailedMigrations(failedHistory, diff);
         } catch {
-          unresolvedSyntheticMigrationNames = null;
-          failedAssessmentsByName = new Map(
-            assessFailedMigrations(
-              history.filter((migration) => migration.status === 'failed'),
-              null,
-            ).map((item) => [item.name, item]),
-          );
+          liveSchemaCompared = false;
+          failedAssessments = assessFailedMigrations(failedHistory, null);
         }
       }
+      const failedAssessmentsByName = new Map(
+        failedAssessments.map((item) => [item.name, item]),
+      );
 
       const annotatedHistory: AnnotatedHistoryEntry[] = history.map((m) => {
         if (m.status !== 'failed') {
@@ -178,8 +181,9 @@ export const dbHistoryCommand: CLICommand = {
           };
         }
 
-        const classification = unresolvedSyntheticMigrationNames
-          ? classifyFailedMigration(m.name, unresolvedSyntheticMigrationNames)
+        const failedAssessment = failedAssessmentsByName.get(m.name);
+        const classification = failedAssessment
+          ? getLegacyFailedMigrationClassification(failedAssessment)
           : 'other';
 
         return {
@@ -187,7 +191,7 @@ export const dbHistoryCommand: CLICommand = {
           classification,
           recommendation: getFailedMigrationRecommendation(
             classification,
-            unresolvedSyntheticMigrationNames !== null,
+            liveSchemaCompared,
           ),
         };
       });
@@ -327,22 +331,15 @@ export const dbHistoryCommand: CLICommand = {
       const rolledBack = annotatedHistory.filter(
         (m) => m.status === 'rolled_back',
       ).length;
-      const actionRequired = history.filter(
-        (m) =>
-          m.status === 'failed' &&
-          failedAssessmentsByName.get(m.name)?.resolution === 'action_required',
+      const actionRequired = failedAssessments.filter(
+        (item) => item.resolution === 'action_required',
       ).length;
-      const superseded = history.filter(
-        (m) =>
-          m.status === 'failed' &&
-          failedAssessmentsByName.get(m.name)?.resolution === 'superseded',
+      const superseded = failedAssessments.filter(
+        (item) => item.resolution === 'superseded',
       ).length;
-      const manualReview = history.filter(
-        (m) =>
-          m.status === 'failed' &&
-          failedAssessmentsByName.get(m.name)?.resolution === 'manual_review',
+      const manualReview = failedAssessments.filter(
+        (item) => item.resolution === 'manual_review',
       ).length;
-
       console.log('━'.repeat(50));
       console.log(
         `Summary: ${completed} completed, ${failed} failed (${failedUnresolved} unresolved, ${failedSuperseded} superseded, ${failedOther} other), ${rolledBack} rolled back`,

--- a/packages/cli/src/commands/db-history.ts
+++ b/packages/cli/src/commands/db-history.ts
@@ -14,6 +14,7 @@ import {
   getFailedMigrationRecommendation,
   getUnresolvedAdditiveMigrationNames,
 } from './db-migrate-actions.js';
+import { assessFailedMigrations } from './migration-failure-analysis.js';
 
 type AnnotatedHistoryEntry = {
   id: string;
@@ -135,6 +136,10 @@ export const dbHistoryCommand: CLICommand = {
       // 6. Get history
       const history = await tracker.getHistory(queryOptions);
       let unresolvedSyntheticMigrationNames: Set<string> | null = null;
+      let failedAssessmentsByName = new Map<
+        string,
+        ReturnType<typeof assessFailedMigrations>[number]
+      >();
 
       if (
         history.some((migration) => migration.status === 'failed') &&
@@ -147,8 +152,20 @@ export const dbHistoryCommand: CLICommand = {
           const diff = await comparer.compare(manifestSchemas);
           unresolvedSyntheticMigrationNames =
             getUnresolvedAdditiveMigrationNames(diff.changes);
+          failedAssessmentsByName = new Map(
+            assessFailedMigrations(
+              history.filter((migration) => migration.status === 'failed'),
+              diff,
+            ).map((item) => [item.name, item]),
+          );
         } catch {
           unresolvedSyntheticMigrationNames = null;
+          failedAssessmentsByName = new Map(
+            assessFailedMigrations(
+              history.filter((migration) => migration.status === 'failed'),
+              null,
+            ).map((item) => [item.name, item]),
+          );
         }
       }
 
@@ -196,6 +213,16 @@ export const dbHistoryCommand: CLICommand = {
           sourceFile: m.source_file,
           classification: m.classification,
           recommendation: m.recommendation,
+          resolution:
+            m.status === 'failed'
+              ? (failedAssessmentsByName.get(m.name)?.resolution ??
+                'manual_review')
+              : null,
+          resolutionReason:
+            m.status === 'failed'
+              ? (failedAssessmentsByName.get(m.name)?.reason ??
+                'Review the failed migration directly.')
+              : null,
         }));
         console.log(JSON.stringify(jsonOutput, null, 2));
         return;
@@ -215,8 +242,13 @@ export const dbHistoryCommand: CLICommand = {
       for (const m of annotatedHistory) {
         const statusIcon = getStatusIcon(m.status);
         const timeStr = formatDateTime(m.applied_at);
+        const failedAssessment =
+          m.status === 'failed' ? failedAssessmentsByName.get(m.name) : null;
+        const resolutionSuffix = failedAssessment
+          ? ` [${failedAssessment.resolution.replace('_', ' ')}]`
+          : '';
 
-        console.log(`${statusIcon} ${m.name}`);
+        console.log(`${statusIcon} ${m.name}${resolutionSuffix}`);
         console.log(`   Applied: ${timeStr}`);
 
         if (options.verbose) {
@@ -244,6 +276,9 @@ export const dbHistoryCommand: CLICommand = {
             console.log(`   Failed state: ${m.classification}`);
             console.log(`   Recommendation: ${m.recommendation}`);
           }
+          if (failedAssessment) {
+            console.log(`   Resolution: ${failedAssessment.reason}`);
+          }
           if (m.rolled_back_at) {
             console.log(`   Rolled back: ${formatDateTime(m.rolled_back_at)}`);
           }
@@ -261,6 +296,9 @@ export const dbHistoryCommand: CLICommand = {
           }
           if (m.classification) {
             parts.push(m.classification);
+          }
+          if (failedAssessment) {
+            parts.push(failedAssessment.resolution.replace('_', ' '));
           }
           if (parts.length > 0) {
             console.log(`   ${parts.join(' | ')}`);
@@ -289,11 +327,31 @@ export const dbHistoryCommand: CLICommand = {
       const rolledBack = annotatedHistory.filter(
         (m) => m.status === 'rolled_back',
       ).length;
+      const actionRequired = history.filter(
+        (m) =>
+          m.status === 'failed' &&
+          failedAssessmentsByName.get(m.name)?.resolution === 'action_required',
+      ).length;
+      const superseded = history.filter(
+        (m) =>
+          m.status === 'failed' &&
+          failedAssessmentsByName.get(m.name)?.resolution === 'superseded',
+      ).length;
+      const manualReview = history.filter(
+        (m) =>
+          m.status === 'failed' &&
+          failedAssessmentsByName.get(m.name)?.resolution === 'manual_review',
+      ).length;
 
       console.log('━'.repeat(50));
       console.log(
         `Summary: ${completed} completed, ${failed} failed (${failedUnresolved} unresolved, ${failedSuperseded} superseded, ${failedOther} other), ${rolledBack} rolled back`,
       );
+      if (failed > 0) {
+        console.log(
+          `         ${actionRequired} failed still require action, ${superseded} are superseded history, ${manualReview} need manual review`,
+        );
+      }
       console.log();
 
       console.log('💡 Commands:');

--- a/packages/cli/src/commands/db-history.ts
+++ b/packages/cli/src/commands/db-history.ts
@@ -12,7 +12,7 @@ import {
   classifyFailedMigration,
   type FailedMigrationClassification,
   getFailedMigrationRecommendation,
-  getUnresolvedAdditiveMigrationNames,
+  getUnresolvedGeneratedMigrationNames,
 } from './db-migrate-actions.js';
 import { assessFailedMigrations } from './migration-failure-analysis.js';
 
@@ -151,7 +151,7 @@ export const dbHistoryCommand: CLICommand = {
           const comparer = new SchemaComparer(db);
           const diff = await comparer.compare(manifestSchemas);
           unresolvedSyntheticMigrationNames =
-            getUnresolvedAdditiveMigrationNames(diff.changes);
+            getUnresolvedGeneratedMigrationNames(diff.changes);
           failedAssessmentsByName = new Map(
             assessFailedMigrations(
               history.filter((migration) => migration.status === 'failed'),

--- a/packages/cli/src/commands/db-migrate-actions.ts
+++ b/packages/cli/src/commands/db-migrate-actions.ts
@@ -144,7 +144,8 @@ export function classifyFailedMigration(
 ): FailedMigrationClassification {
   if (
     !migrationName.startsWith('add_column_') &&
-    !migrationName.startsWith('add_index_')
+    !migrationName.startsWith('add_index_') &&
+    !migrationName.startsWith('type_upgrade_')
   ) {
     return 'other';
   }
@@ -154,13 +155,24 @@ export function classifyFailedMigration(
     : 'superseded';
 }
 
-export function getUnresolvedAdditiveMigrationNames(
+export function getUnresolvedGeneratedMigrationNames(
   changes: SchemaChangeLike[],
 ): Set<string> {
   const names = new Set<string>();
 
   for (const change of changes) {
-    if (change.type !== 'add_column' && change.type !== 'add_index') {
+    if (
+      change.type !== 'add_column' &&
+      change.type !== 'add_index' &&
+      change.type !== 'type_upgrade'
+    ) {
+      continue;
+    }
+
+    if (
+      change.type === 'type_upgrade' &&
+      classifyTypeUpgradeSql(change.sql) === 'noop'
+    ) {
       continue;
     }
 
@@ -173,18 +185,21 @@ export function getUnresolvedAdditiveMigrationNames(
   return names;
 }
 
+export const getUnresolvedAdditiveMigrationNames =
+  getUnresolvedGeneratedMigrationNames;
+
 export function getFailedMigrationRecommendation(
   classification: FailedMigrationClassification,
   liveSchemaCompared: boolean = true,
 ): string {
   switch (classification) {
     case 'unresolved':
-      return 'Run `smrt db:migrate` to reconcile the live schema, then confirm this failed additive migration no longer appears as unresolved.';
+      return 'Run `smrt db:migrate` to reconcile the live schema, then confirm this failed generated schema repair no longer appears as unresolved.';
     case 'superseded':
-      return 'No current live-schema drift maps to this failed additive migration. Keep the row for audit history, but it no longer blocks the current schema.';
+      return 'No current live-schema drift maps to this failed generated schema repair. Keep the row for audit history, but it no longer blocks the current schema.';
     default:
       return liveSchemaCompared
-        ? 'Inspect this failed migration directly. It is not a superseded additive repair and may still need manual attention.'
+        ? 'Inspect this failed migration directly. It is not a superseded generated schema repair and may still need manual attention.'
         : 'Inspect this failed migration directly. Live schema comparison was unavailable, so SMRT could not determine whether it has been superseded.';
   }
 }

--- a/packages/cli/src/commands/db-status.ts
+++ b/packages/cli/src/commands/db-status.ts
@@ -13,7 +13,7 @@ import type { CLICommand } from '../cli-generator.js';
 import { autoDiscoverAndLoad } from '../discovery/index.js';
 import {
   classifyTypeUpgradeSql,
-  getUnresolvedAdditiveMigrationNames,
+  getUnresolvedGeneratedMigrationNames,
   summarizeFailedMigrations,
 } from './db-migrate-actions.js';
 import { assessFailedMigrations } from './migration-failure-analysis.js';
@@ -241,7 +241,7 @@ export const dbStatusCommand: CLICommand = {
         status.drift = summarizeSchemaDiff(diff);
         status.failedMigrations = summarizeFailedMigrations(
           failed,
-          getUnresolvedAdditiveMigrationNames(diff.changes),
+          getUnresolvedGeneratedMigrationNames(diff.changes),
         );
       }
 
@@ -350,7 +350,7 @@ export const dbStatusCommand: CLICommand = {
         options.verbose,
       );
       printFailedMigrationGroup(
-        'ℹ️  Historical failed additive migrations already superseded by the live schema:',
+        'ℹ️  Historical failed generated schema repairs already superseded by the live schema:',
         status.failedMigrations.superseded,
         options.verbose,
       );

--- a/packages/cli/src/commands/db-status.ts
+++ b/packages/cli/src/commands/db-status.ts
@@ -8,21 +8,37 @@
  */
 
 import { ObjectRegistry, SchemaComparer } from '@happyvertical/smrt-core';
+import type { SchemaDiff } from '@happyvertical/smrt-core/migrations';
 import type { CLICommand } from '../cli-generator.js';
 import { autoDiscoverAndLoad } from '../discovery/index.js';
 import {
   classifyTypeUpgradeSql,
-  type FailedMigrationBuckets,
-  type FailedMigrationSummaryItem,
   getUnresolvedAdditiveMigrationNames,
   summarizeFailedMigrations,
 } from './db-migrate-actions.js';
+import { assessFailedMigrations } from './migration-failure-analysis.js';
 
 type StatusDrift = {
   name: string;
   type: string;
   recommendation: string;
 };
+
+type FailedMigrationSummary = {
+  total: number;
+  actionRequired: number;
+  superseded: number;
+  manualReview: number;
+  details: Array<{
+    name: string;
+    resolution: 'action_required' | 'superseded' | 'manual_review';
+    kind: 'add_column' | 'add_index' | 'type_upgrade' | 'other';
+    reason: string;
+    errorMessage: string | null;
+  }>;
+};
+
+type FailedMigrationBuckets = ReturnType<typeof summarizeFailedMigrations>;
 
 export function summarizeSchemaDiff(diff: {
   added_tables: Array<{ tableName: string }>;
@@ -170,6 +186,7 @@ export const dbStatusCommand: CLICommand = {
 
       // 5. Get applied migrations
       const applied = await tracker.getAppliedMigrations();
+      const failed = await tracker.getHistory({ status: 'failed' });
 
       // 6. Auto-discover manifests to get current definitions
       const { discovered, totalObjects } = await autoDiscoverAndLoad();
@@ -187,6 +204,13 @@ export const dbStatusCommand: CLICommand = {
         },
         migrations: {
           applied: applied.length,
+          failed: {
+            total: failed.length,
+            actionRequired: 0,
+            superseded: 0,
+            manualReview: 0,
+            details: [],
+          } as FailedMigrationSummary,
           details: applied.map((m) => ({
             name: m.name,
             version: m.version,
@@ -198,15 +222,14 @@ export const dbStatusCommand: CLICommand = {
           })),
         },
         drift: [] as StatusDrift[],
-        failedMigrations: {
-          unresolved: [],
-          superseded: [],
-          other: [],
-        } as FailedMigrationBuckets,
+        failedMigrations: summarizeFailedMigrations(failed, null),
       };
-
-      const failedHistory = await tracker.getHistory({ status: 'failed' });
-      status.failedMigrations = summarizeFailedMigrations(failedHistory, null);
+      let diff: SchemaDiff = {
+        added_tables: [],
+        dropped_tables: [],
+        changes: [],
+        has_changes: false,
+      };
 
       // 8. Compare the current manifest schema against the live database.
       // This keeps db:status useful for shared Postgres databases where the
@@ -214,13 +237,31 @@ export const dbStatusCommand: CLICommand = {
       if (typeof db.getTableSchema === 'function') {
         const manifestSchemas = ObjectRegistry.getAllSchemasAsDefinitions();
         const comparer = new SchemaComparer(db);
-        const diff = await comparer.compare(manifestSchemas);
+        diff = await comparer.compare(manifestSchemas);
         status.drift = summarizeSchemaDiff(diff);
         status.failedMigrations = summarizeFailedMigrations(
-          failedHistory,
+          failed,
           getUnresolvedAdditiveMigrationNames(diff.changes),
         );
       }
+
+      const failedAssessments = assessFailedMigrations(
+        failed,
+        typeof db.getTableSchema === 'function' ? diff : null,
+      );
+      status.migrations.failed = {
+        total: failedAssessments.length,
+        actionRequired: failedAssessments.filter(
+          (item) => item.resolution === 'action_required',
+        ).length,
+        superseded: failedAssessments.filter(
+          (item) => item.resolution === 'superseded',
+        ).length,
+        manualReview: failedAssessments.filter(
+          (item) => item.resolution === 'manual_review',
+        ).length,
+        details: failedAssessments,
+      };
 
       // 9. Output results
       if (options.json) {
@@ -314,6 +355,22 @@ export const dbStatusCommand: CLICommand = {
         options.verbose,
       );
 
+      if (failedAssessments.length > 0) {
+        console.log(
+          `🧾 Failed migration history: ${status.migrations.failed.actionRequired} action required, ${status.migrations.failed.superseded} superseded, ${status.migrations.failed.manualReview} manual review`,
+        );
+        if (options.verbose) {
+          for (const item of failedAssessments) {
+            console.log(`   • ${item.name}: ${item.resolution}`);
+            console.log(`     ${item.reason}`);
+            if (item.errorMessage) {
+              console.log(`     Last error: ${item.errorMessage}`);
+            }
+          }
+        }
+        console.log();
+      }
+
       console.log('💡 Commands:');
       console.log('   smrt db:migrate   - Apply pending changes');
       console.log('   smrt db:history   - View migration history');
@@ -353,7 +410,11 @@ function getTimeAgo(date: Date): string {
 
 function printFailedMigrationGroup(
   title: string,
-  migrations: FailedMigrationSummaryItem[],
+  migrations: Array<{
+    name: string;
+    recommendation: string;
+    errorMessage: string | null;
+  }>,
   verbose: boolean,
 ): void {
   if (migrations.length === 0) {

--- a/packages/cli/src/commands/migration-failure-analysis.ts
+++ b/packages/cli/src/commands/migration-failure-analysis.ts
@@ -3,7 +3,10 @@ import type {
   SchemaDiff,
   SchemaMigrationRecord,
 } from '@happyvertical/smrt-core/migrations';
-import { classifyTypeUpgradeSql } from './db-migrate-actions.js';
+import {
+  classifyTypeUpgradeSql,
+  getSyntheticMigrationNameForChange,
+} from './db-migrate-actions.js';
 
 export type FailedMigrationResolution =
   | 'action_required'
@@ -18,24 +21,16 @@ export interface FailedMigrationAssessment {
   errorMessage: string | null;
 }
 
-function getGeneratedMigrationName(change: SchemaChange): string | null {
-  if (change.type === 'add_column' && change.name) {
-    return `add_column_${change.table}_${change.name}`;
-  }
-
-  if (change.type === 'add_index') {
-    const indexName = change.index?.name || change.name;
-    return indexName ? `add_index_${indexName}` : null;
-  }
-
+function getActionableGeneratedMigrationName(
+  change: SchemaChange,
+): string | null {
   if (change.type === 'type_upgrade' && change.name) {
     if (classifyTypeUpgradeSql(change.sql) === 'noop') {
       return null;
     }
-    return `type_upgrade_${change.table}_${change.name}`;
   }
 
-  return null;
+  return getSyntheticMigrationNameForChange(change);
 }
 
 export function getActionableFailedMigrationNames(
@@ -44,7 +39,7 @@ export function getActionableFailedMigrationNames(
   const names = new Set<string>();
 
   for (const change of diff.changes) {
-    const name = getGeneratedMigrationName(change);
+    const name = getActionableGeneratedMigrationName(change);
     if (name) {
       names.add(name);
     }

--- a/packages/cli/src/commands/migration-failure-analysis.ts
+++ b/packages/cli/src/commands/migration-failure-analysis.ts
@@ -1,0 +1,114 @@
+import type {
+  SchemaChange,
+  SchemaDiff,
+  SchemaMigrationRecord,
+} from '@happyvertical/smrt-core/migrations';
+import { classifyTypeUpgradeSql } from './db-migrate-actions.js';
+
+export type FailedMigrationResolution =
+  | 'action_required'
+  | 'superseded'
+  | 'manual_review';
+
+export interface FailedMigrationAssessment {
+  name: string;
+  resolution: FailedMigrationResolution;
+  kind: 'add_column' | 'add_index' | 'type_upgrade' | 'other';
+  reason: string;
+  errorMessage: string | null;
+}
+
+function getGeneratedMigrationName(change: SchemaChange): string | null {
+  if (change.type === 'add_column' && change.name) {
+    return `add_column_${change.table}_${change.name}`;
+  }
+
+  if (change.type === 'add_index') {
+    const indexName = change.index?.name || change.name;
+    return indexName ? `add_index_${indexName}` : null;
+  }
+
+  if (change.type === 'type_upgrade' && change.name) {
+    if (classifyTypeUpgradeSql(change.sql) === 'noop') {
+      return null;
+    }
+    return `type_upgrade_${change.table}_${change.name}`;
+  }
+
+  return null;
+}
+
+export function getActionableFailedMigrationNames(
+  diff: SchemaDiff,
+): Set<string> {
+  const names = new Set<string>();
+
+  for (const change of diff.changes) {
+    const name = getGeneratedMigrationName(change);
+    if (name) {
+      names.add(name);
+    }
+  }
+
+  return names;
+}
+
+function classifyKind(name: string): FailedMigrationAssessment['kind'] {
+  if (name.startsWith('add_column_')) return 'add_column';
+  if (name.startsWith('add_index_')) return 'add_index';
+  if (name.startsWith('type_upgrade_')) return 'type_upgrade';
+  return 'other';
+}
+
+export function assessFailedMigrations(
+  failedMigrations: SchemaMigrationRecord[],
+  diff: SchemaDiff | null,
+): FailedMigrationAssessment[] {
+  const actionableNames = diff ? getActionableFailedMigrationNames(diff) : null;
+
+  return failedMigrations.map((migration) => {
+    const kind = classifyKind(migration.name);
+
+    if (actionableNames?.has(migration.name)) {
+      return {
+        name: migration.name,
+        resolution: 'action_required',
+        kind,
+        reason:
+          'Current manifests still require this schema change in the live database.',
+        errorMessage: migration.error_message,
+      };
+    }
+
+    if (!actionableNames) {
+      return {
+        name: migration.name,
+        resolution: 'manual_review',
+        kind,
+        reason:
+          'Live schema comparison was unavailable, so SMRT could not determine whether this failed migration is still required.',
+        errorMessage: migration.error_message,
+      };
+    }
+
+    if (kind !== 'other') {
+      return {
+        name: migration.name,
+        resolution: 'superseded',
+        kind,
+        reason:
+          'Current manifests no longer require this generated schema change, so the failed row is retained history rather than active drift.',
+        errorMessage: migration.error_message,
+      };
+    }
+
+    return {
+      name: migration.name,
+      resolution: 'manual_review',
+      kind,
+      reason:
+        'This failed migration is not a generated additive schema change. Review it directly before clearing or retrying it.',
+      errorMessage: migration.error_message,
+    };
+  });
+}

--- a/packages/core/src/__tests__/issue-1120-preserve-fk-actions.test.ts
+++ b/packages/core/src/__tests__/issue-1120-preserve-fk-actions.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ObjectRegistry } from '../registry.js';
+import { snapshotObjectRegistryState } from '../test-utils.js';
+
+describe('Issue #1120 - runtime schema rebuild preserves manifest FK actions', () => {
+  let restoreRegistry: () => void;
+
+  beforeEach(() => {
+    restoreRegistry = snapshotObjectRegistryState();
+  });
+
+  afterEach(() => {
+    restoreRegistry();
+  });
+
+  it('does not overwrite manifest foreign key actions when runtime fields are merged', () => {
+    ObjectRegistry.registerFromManifest(
+      '@test/pkg:RestrictiveChild',
+      {
+        className: 'RestrictiveChild',
+        fields: {
+          parentId: {
+            type: 'foreignKey',
+            related: 'Parent.id',
+            nullable: false,
+          },
+        },
+        methods: {},
+        decoratorConfig: {
+          tableName: 'restrictive_children',
+        },
+        schema: {
+          tableName: 'restrictive_children',
+          ddl: '',
+          columns: {
+            parent_id: {
+              type: 'TEXT',
+              notNull: true,
+              foreignKey: {
+                table: 'parents',
+                column: 'id',
+                onDelete: 'RESTRICT',
+                onUpdate: 'CASCADE',
+              },
+            },
+          },
+          indexes: [],
+          triggers: [],
+          foreignKeys: [],
+          dependencies: [],
+          version: 'test-version',
+        },
+      },
+      '@test/pkg',
+    );
+
+    ObjectRegistry.registerFieldDecorator('RestrictiveChild', 'parentId', {
+      type: 'foreignKey',
+      related: 'Parent.id',
+      required: true,
+    });
+
+    const definitions = ObjectRegistry.getAllSchemasAsDefinitions();
+
+    expect(
+      definitions.restrictive_children?.columns.parent_id?.foreignKey,
+    ).toEqual({
+      table: 'parents',
+      column: 'id',
+      onDelete: 'RESTRICT',
+      onUpdate: 'CASCADE',
+    });
+  });
+});

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { ObjectRegistry } from '../registry.js';
+import type { SQLDataType } from '../schema/types.js';
 import {
   type CompatiblePropertyDecorator,
   type CompatiblePropertyDecoratorContext,
@@ -59,14 +60,7 @@ export interface FieldOptions {
   /** Explicit field type for runtime-only registration paths */
   type?: FieldType;
   /** Explicit SQL storage type when runtime and persistence contracts differ */
-  sqlType?:
-    | 'TEXT'
-    | 'INTEGER'
-    | 'REAL'
-    | 'BLOB'
-    | 'BOOLEAN'
-    | 'JSON'
-    | 'TIMESTAMP';
+  sqlType?: SQLDataType;
   /** Whether the field is required */
   required?: boolean;
   /** Default value for the field */

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -58,6 +58,15 @@ export type FieldType =
 export interface FieldOptions {
   /** Explicit field type for runtime-only registration paths */
   type?: FieldType;
+  /** Explicit SQL storage type when runtime and persistence contracts differ */
+  sqlType?:
+    | 'TEXT'
+    | 'INTEGER'
+    | 'REAL'
+    | 'BLOB'
+    | 'BOOLEAN'
+    | 'JSON'
+    | 'TIMESTAMP';
   /** Whether the field is required */
   required?: boolean;
   /** Default value for the field */

--- a/packages/core/src/registry/class-registration.ts
+++ b/packages/core/src/registry/class-registration.ts
@@ -18,7 +18,7 @@ import {
 import { SmrtObject } from '../object';
 import type { QualifiedClassName, SmrtVisibility } from '../scanner/types.js';
 import type { ColumnDefinition, SchemaDefinition } from '../schema/types.js';
-import { tableNameFromClass } from '../utils';
+import { tableNameFromClass, toSnakeCase } from '../utils';
 import {
   createQualifiedName,
   isQualifiedName,
@@ -732,6 +732,25 @@ export function register(
       version: '',
       packageName: undefined,
     };
+  }
+
+  if (schema.columns && decorators && decorators.size > 0) {
+    for (const [fieldName, decoratorOptions] of decorators) {
+      if (!decoratorOptions?.sqlType) {
+        continue;
+      }
+
+      const columnName = toSnakeCase(fieldName);
+      const existingColumn = schema.columns[columnName];
+      if (!existingColumn) {
+        continue;
+      }
+
+      schema.columns[columnName] = {
+        ...existingColumn,
+        type: decoratorOptions.sqlType,
+      };
+    }
   }
 
   // Use pre-computed validation rules from manifest if available (Issue #782)

--- a/packages/core/src/registry/schema-builder.ts
+++ b/packages/core/src/registry/schema-builder.ts
@@ -16,6 +16,35 @@ import { classnameToTablename, toSnakeCase } from '../utils';
 import { findClass } from './name-resolver';
 import { getClasses, getCollectionTableNames } from './shared-state';
 
+function applyDecoratorSqlTypeOverrides(
+  className: string,
+  columns: Record<string, ColumnDefinition>,
+): Record<string, ColumnDefinition> {
+  const decorators = ObjectRegistry.getFieldDecorators(className);
+  if (!decorators.size) {
+    return columns;
+  }
+
+  for (const [fieldName, options] of decorators) {
+    if (!options?.sqlType) {
+      continue;
+    }
+
+    const columnName = toSnakeCase(fieldName);
+    const existing = columns[columnName];
+    if (!existing) {
+      continue;
+    }
+
+    columns[columnName] = {
+      ...existing,
+      type: options.sqlType,
+    };
+  }
+
+  return columns;
+}
+
 /**
  * Get cached schema definition for a registered class
  *
@@ -167,16 +196,15 @@ export function getAllSchemas(): Record<
 
       // Start with manifest columns, then merge in any field-derived columns that
       // were added or repaired at runtime (for example tenantScoped injections
-      // from external decorator config).
+      // or explicit sqlType overrides from decorator config).
       const columnsToUse = { ...(registered.schema.columns || {}) };
       if (registered.fields.size > 0) {
         const fieldColumns = fieldsToColumns(registered.fields);
         for (const [columnName, columnDef] of Object.entries(fieldColumns)) {
-          if (!columnsToUse[columnName]) {
-            columnsToUse[columnName] = columnDef;
-          }
+          columnsToUse[columnName] = columnDef;
         }
       }
+      applyDecoratorSqlTypeOverrides(simpleName, columnsToUse);
 
       if (!tableSchemas[tableName]) {
         // First class for this table - initialize with base columns
@@ -357,16 +385,16 @@ export function getAllSchemasAsDefinitions(): Record<string, SchemaDefinition> {
         }
       }
 
-      // Get columns from schema, or generate from fields if empty
+      // Get columns from schema, then repair/override them from runtime field
+      // metadata when decorators carry more precise storage intent.
       const columnsToUse = { ...(registered.schema.columns || {}) };
       if (registered.fields.size > 0) {
         const fieldColumns = fieldsToColumns(registered.fields);
         for (const [columnName, columnDef] of Object.entries(fieldColumns)) {
-          if (!columnsToUse[columnName]) {
-            columnsToUse[columnName] = columnDef;
-          }
+          columnsToUse[columnName] = columnDef;
         }
       }
+      applyDecoratorSqlTypeOverrides(simpleName, columnsToUse);
 
       if (!tableSchemas[tableName]) {
         // First class for this table - initialize with base columns
@@ -622,7 +650,7 @@ export function fieldsToColumns(
     }
 
     // Map field type to SQL type
-    const sqlType = mapFieldTypeToSQL(fieldDef.type);
+    const sqlType = fieldDef._meta?.sqlType || mapFieldTypeToSQL(fieldDef.type);
 
     const column: ColumnDefinition = {
       type: sqlType,

--- a/packages/core/src/registry/schema-builder.ts
+++ b/packages/core/src/registry/schema-builder.ts
@@ -45,6 +45,26 @@ function applyDecoratorSqlTypeOverrides(
   return columns;
 }
 
+function mergeRuntimeFieldColumns(
+  className: string,
+  schemaColumns: Record<string, ColumnDefinition> | undefined,
+  fields: Map<string, FieldDefinition>,
+): Record<string, ColumnDefinition> {
+  const columnsToUse = { ...(schemaColumns || {}) };
+
+  if (fields.size > 0) {
+    const fieldColumns = fieldsToColumns(fields);
+    for (const [columnName, columnDef] of Object.entries(fieldColumns)) {
+      if (!columnsToUse[columnName]) {
+        columnsToUse[columnName] = columnDef;
+      }
+    }
+  }
+
+  applyDecoratorSqlTypeOverrides(className, columnsToUse);
+  return columnsToUse;
+}
+
 /**
  * Get cached schema definition for a registered class
  *
@@ -194,17 +214,16 @@ export function getAllSchemas(): Record<
         }
       }
 
-      // Start with manifest columns, then merge in any field-derived columns that
-      // were added or repaired at runtime (for example tenantScoped injections
-      // or explicit sqlType overrides from decorator config).
-      const columnsToUse = { ...(registered.schema.columns || {}) };
-      if (registered.fields.size > 0) {
-        const fieldColumns = fieldsToColumns(registered.fields);
-        for (const [columnName, columnDef] of Object.entries(fieldColumns)) {
-          columnsToUse[columnName] = columnDef;
-        }
-      }
-      applyDecoratorSqlTypeOverrides(simpleName, columnsToUse);
+      // Start with manifest columns, then backfill any columns that only exist
+      // in runtime field metadata (for example tenantScoped injections). We do
+      // not replace existing manifest column metadata here, because the manifest
+      // is authoritative for foreign keys, defaults, and other schema details.
+      // Explicit decorator sqlType overrides are patched onto the merged column.
+      const columnsToUse = mergeRuntimeFieldColumns(
+        simpleName,
+        registered.schema.columns,
+        registered.fields,
+      );
 
       if (!tableSchemas[tableName]) {
         // First class for this table - initialize with base columns
@@ -385,16 +404,14 @@ export function getAllSchemasAsDefinitions(): Record<string, SchemaDefinition> {
         }
       }
 
-      // Get columns from schema, then repair/override them from runtime field
-      // metadata when decorators carry more precise storage intent.
-      const columnsToUse = { ...(registered.schema.columns || {}) };
-      if (registered.fields.size > 0) {
-        const fieldColumns = fieldsToColumns(registered.fields);
-        for (const [columnName, columnDef] of Object.entries(fieldColumns)) {
-          columnsToUse[columnName] = columnDef;
-        }
-      }
-      applyDecoratorSqlTypeOverrides(simpleName, columnsToUse);
+      // Manifest schema remains authoritative for existing columns. Runtime
+      // field metadata can backfill missing columns and apply explicit sqlType
+      // overrides without erasing richer manifest metadata.
+      const columnsToUse = mergeRuntimeFieldColumns(
+        simpleName,
+        registered.schema.columns,
+        registered.fields,
+      );
 
       if (!tableSchemas[tableName]) {
         // First class for this table - initialize with base columns
@@ -670,8 +687,16 @@ export function fieldsToColumns(
       column.foreignKey = {
         table: classnameToTablename(table),
         column: columnName,
-        onDelete: 'CASCADE',
-        onUpdate: 'CASCADE',
+        onDelete:
+          ((
+            fieldDef._meta as { onDelete?: 'CASCADE' | 'SET NULL' | 'RESTRICT' }
+          )?.onDelete as ColumnDefinition['foreignKey']['onDelete']) ||
+          'CASCADE',
+        onUpdate:
+          ((
+            fieldDef._meta as { onUpdate?: 'CASCADE' | 'SET NULL' | 'RESTRICT' }
+          )?.onUpdate as ColumnDefinition['foreignKey']['onUpdate']) ||
+          'CASCADE',
       };
     }
 

--- a/packages/core/src/registry/schema-builder.ts
+++ b/packages/core/src/registry/schema-builder.ts
@@ -16,6 +16,10 @@ import { classnameToTablename, toSnakeCase } from '../utils';
 import { findClass } from './name-resolver';
 import { getClasses, getCollectionTableNames } from './shared-state';
 
+type ForeignKeyAction = NonNullable<
+  NonNullable<ColumnDefinition['foreignKey']>['onDelete']
+>;
+
 function applyDecoratorSqlTypeOverrides(
   className: string,
   columns: Record<string, ColumnDefinition>,
@@ -684,19 +688,17 @@ export function fieldsToColumns(
     // Handle foreign keys
     if (fieldDef.type === 'foreignKey' && fieldDef.related) {
       const [table, columnName = 'id'] = fieldDef.related.split('.');
+      const fieldMeta = fieldDef._meta as
+        | {
+            onDelete?: ForeignKeyAction;
+            onUpdate?: ForeignKeyAction;
+          }
+        | undefined;
       column.foreignKey = {
         table: classnameToTablename(table),
         column: columnName,
-        onDelete:
-          ((
-            fieldDef._meta as { onDelete?: 'CASCADE' | 'SET NULL' | 'RESTRICT' }
-          )?.onDelete as ColumnDefinition['foreignKey']['onDelete']) ||
-          'CASCADE',
-        onUpdate:
-          ((
-            fieldDef._meta as { onUpdate?: 'CASCADE' | 'SET NULL' | 'RESTRICT' }
-          )?.onUpdate as ColumnDefinition['foreignKey']['onUpdate']) ||
-          'CASCADE',
+        onDelete: fieldMeta?.onDelete ?? 'CASCADE',
+        onUpdate: fieldMeta?.onUpdate ?? 'CASCADE',
       };
     }
 

--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -9,7 +9,7 @@ import {
 } from '../manifest/manifest-loader.js';
 import { generateToolManifest } from '../tools/tool-generator';
 import { createQualifiedName } from '../utils/qualified-names.js';
-import { classnameToTablename } from '../utils.js';
+import { classnameToTablename, toSnakeCase } from '../utils.js';
 import { isTestFile } from './test-file-patterns.js';
 import type {
   AgentAdminRouteManifest,
@@ -337,13 +337,13 @@ export class ManifestGenerator {
    */
   generateSchemas(manifest: SmartObjectManifest): void {
     // Import SchemaGenerator synchronously (using createRequire for ESM compatibility)
-    // Try .js first (built output), fall back to .ts (source for tests)
+    // In Vitest/source runs, prefer the TypeScript source so tests exercise the
+    // current branch instead of stale built artifacts.
     let SchemaGenerator: any;
     try {
-      SchemaGenerator = require('../schema/generator.js').SchemaGenerator;
-    } catch {
-      // Fallback for when running tests directly on source files
       SchemaGenerator = require('../schema/generator.ts').SchemaGenerator;
+    } catch {
+      SchemaGenerator = require('../schema/generator.js').SchemaGenerator;
     }
     const generator = new SchemaGenerator();
 
@@ -383,6 +383,7 @@ export class ManifestGenerator {
           obj.fields,
           aggregatedManifest,
         );
+        this.applySqlTypeOverrides(obj);
       } else if (this.isSTIChildClass(obj, manifest)) {
         // This is an STI child class - check if base is LOCAL or EXTERNAL
         const stiBase = this.findSTIBaseInfo(obj, manifest);
@@ -410,6 +411,7 @@ export class ManifestGenerator {
             obj.fields,
             aggregatedManifest,
           );
+          this.applySqlTypeOverrides(obj);
         }
       } else {
         // CTI class - generate individual table schema
@@ -423,7 +425,31 @@ export class ManifestGenerator {
           obj.fields,
           obj.decoratorConfig,
         );
+        this.applySqlTypeOverrides(obj);
       }
+    }
+  }
+
+  private applySqlTypeOverrides(obj: SmartObjectDefinition): void {
+    if (!obj.schema?.columns) {
+      return;
+    }
+
+    for (const [fieldName, field] of Object.entries(obj.fields || {})) {
+      const sqlType = field?._meta?.sqlType;
+      if (!sqlType) {
+        continue;
+      }
+
+      const columnName = toSnakeCase(fieldName);
+      if (!obj.schema.columns[columnName]) {
+        continue;
+      }
+
+      obj.schema.columns[columnName] = {
+        ...obj.schema.columns[columnName],
+        type: sqlType,
+      };
     }
   }
 

--- a/packages/core/src/schema/generator.ts
+++ b/packages/core/src/schema/generator.ts
@@ -134,7 +134,7 @@ export class SchemaGenerator {
       }
 
       const column: ColumnDefinition = {
-        type: this.mapFieldTypeToSQL(fieldDef.type),
+        type: fieldDef._meta?.sqlType || this.mapFieldTypeToSQL(fieldDef.type),
         // If _meta.nullable is true, the field can be null regardless of required
         // This handles field helpers like text({ required: true, nullable: true })
         notNull: fieldDef._meta?.nullable ? false : fieldDef.required || false,
@@ -433,7 +433,8 @@ export class SchemaGenerator {
         continue;
       }
 
-      const sqlType = this.mapFieldTypeToSQL(field.type);
+      const sqlType =
+        field._meta?.sqlType || this.mapFieldTypeToSQL(field.type);
 
       const columnDef: ColumnDefinition = {
         type: sqlType,
@@ -700,7 +701,8 @@ export class SchemaGenerator {
           continue;
         }
 
-        const sqlType = this.mapFieldTypeToSQL(field.type);
+        const sqlType =
+          field._meta?.sqlType || this.mapFieldTypeToSQL(field.type);
 
         const columnDef: ColumnDefinition = {
           type: sqlType,
@@ -923,7 +925,8 @@ export class SchemaGenerator {
           continue;
         }
 
-        const sqlType = this.mapFieldTypeToSQL(field.type);
+        const sqlType =
+          field._meta?.sqlType || this.mapFieldTypeToSQL(field.type);
 
         const columnDef: ManifestColumnDefinition = {
           type: sqlType,
@@ -1078,7 +1081,8 @@ export class SchemaGenerator {
       }
 
       const columnName = this.toSnakeCase(fieldName);
-      const sqlType = this.mapFieldTypeToSQL(field.type);
+      const sqlType =
+        field._meta?.sqlType || this.mapFieldTypeToSQL(field.type);
 
       const columnDef: ManifestColumnDefinition = {
         type: sqlType,


### PR DESCRIPTION
## What changed
- add `sqlType` decorator support to schema generation and manifest registration paths in `smrt-core`
- set `AgentSchedule.agentConfig` and `methodArgs` to keep JSON runtime semantics while publishing `TEXT` storage columns in `smrt-agents`
- add richer failed-migration analysis in `smrt-cli` so `db:status` and `db:history` can distinguish active schema drift from superseded failed generated migrations
- add a changeset for `smrt-core`, `smrt-agents`, and `smrt-cli`

## Why
`v0.21.46` narrowed the shared-schema drift problem, but two upstream gaps remained:
1. `AgentSchedule.agentConfig` / `methodArgs` were still emitted as `JSON` in generated schemas even though the live/runtime storage contract is `TEXT`
2. `db:status` / `db:history` still treated old failed generated migrations like live blockers, which made it hard to tell real action from superseded history

## Impact
- generated manifests and runtime schema definitions now agree on `TEXT` storage for the schedule config fields
- downstream apps can run `smrt db:migrate` / `smrt db:status` against drifted shared databases without seeing those schedule fields as a false-positive type upgrade
- migration history output is much more actionable when a database has old failed additive migrations hanging around

## Root cause
The field decorator metadata already knew about the storage override, but schema/manifest generation was still defaulting to field type mapping in a few places. Separately, failed migration history had no comparison against the current manifest diff, so stale additive failures looked indistinguishable from active unresolved drift.

## Validation
- `pnpm --dir packages/cli exec vitest run src/commands/__tests__/db-status.test.ts src/commands/__tests__/db-history.test.ts`
- `pnpm --dir packages/agents exec vitest run src/config.test.ts`
- `pnpm --dir packages/core build`
- `pnpm --dir packages/agents build`