### PR TITLE
fix(cli): fail loud on incomplete exports

### DIFF
--- a/.changeset/fix-export-inherited-fields.md
+++ b/.changeset/fix-export-inherited-fields.md
@@ -1,0 +1,5 @@
+---
+'@happyvertical/smrt-cli': patch
+---
+
+Fix static export to include inherited STI fields and fail loudly when projected export queries error instead of silently writing incomplete payloads.

--- a/packages/cli/src/commands/__tests__/export.test.ts
+++ b/packages/cli/src/commands/__tests__/export.test.ts
@@ -9,6 +9,17 @@ vi.mock('@happyvertical/smrt-core', () => ({
   ObjectRegistry: {
     getAllFields: vi.fn((typeName: string) => {
       const baseFields = new Map([
+        ['id', { type: 'text', _meta: { __smrtSystemField: true } }],
+        ['slug', { type: 'text', _meta: { __smrtSystemField: true } }],
+        ['context', { type: 'text', _meta: { __smrtSystemField: true } }],
+        [
+          'created_at',
+          { type: 'datetime', _meta: { __smrtSystemField: true } },
+        ],
+        [
+          'updated_at',
+          { type: 'datetime', _meta: { __smrtSystemField: true } },
+        ],
         ['title', { type: 'string' }],
         ['body', { type: 'string' }],
         ['status', { type: 'string' }],
@@ -54,7 +65,7 @@ describe('export command helpers', () => {
   it('uses inherited registry fields when computing shared export columns', async () => {
     const fields = await getCommonFields(
       ['MeetingRecap', 'MeetingAnnouncement'],
-      {},
+      { types: ['MeetingRecap', 'MeetingAnnouncement'] },
       true,
     );
 
@@ -68,6 +79,9 @@ describe('export command helpers', () => {
         '_meta_type',
       ]),
     );
+    expect(fields).not.toContain('context');
+    expect(fields).not.toContain('created_at');
+    expect(fields).not.toContain('updated_at');
   });
 
   it('formats export records using requested field names', () => {
@@ -122,12 +136,12 @@ describe('export command helpers', () => {
   });
 
   it('fails loudly when the projected export query fails', async () => {
+    const sourceError = new Error('column "video_url" does not exist');
+
     await expect(
       queryWithProjection(
         {
-          query: vi
-            .fn()
-            .mockRejectedValue(new Error('column "video_url" does not exist')),
+          query: vi.fn().mockRejectedValue(sourceError),
         },
         'contents',
         ['MeetingRecap'],
@@ -138,5 +152,18 @@ describe('export command helpers', () => {
     ).rejects.toThrow(
       'Export query failed for contents (columns: title): column "video_url" does not exist',
     );
+
+    await expect(
+      queryWithProjection(
+        {
+          query: vi.fn().mockRejectedValue(sourceError),
+        },
+        'contents',
+        ['MeetingRecap'],
+        ['title'],
+        { status: 'published' },
+        'publishDate',
+      ),
+    ).rejects.toMatchObject({ cause: sourceError });
   });
 });

--- a/packages/cli/src/commands/__tests__/export.test.ts
+++ b/packages/cli/src/commands/__tests__/export.test.ts
@@ -1,7 +1,34 @@
-import { describe, expect, it, vi } from 'vitest';
-import { formatProjectedRecords, queryWithProjection } from '../export.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  formatProjectedRecords,
+  getCommonFields,
+  queryWithProjection,
+} from '../export.js';
+
+vi.mock('@happyvertical/smrt-core', () => ({
+  ObjectRegistry: {
+    getAllFields: vi.fn((typeName: string) => {
+      const baseFields = new Map([
+        ['title', { type: 'string' }],
+        ['body', { type: 'string' }],
+        ['status', { type: 'string' }],
+        ['publishDate', { type: 'date' }],
+      ]);
+
+      if (typeName === 'MeetingRecap' || typeName === 'MeetingAnnouncement') {
+        baseFields.set('meetingId', { type: 'foreignKey' });
+      }
+
+      return baseFields;
+    }),
+  },
+}));
 
 describe('export command helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('passes query params as variadic database adapter arguments', async () => {
     const query = vi.fn().mockResolvedValue({
       rows: [{ title: 'Bridge update' }],
@@ -21,6 +48,25 @@ describe('export command helpers', () => {
       expect.stringContaining('FROM contents'),
       '%:Article',
       'published',
+    );
+  });
+
+  it('uses inherited registry fields when computing shared export columns', async () => {
+    const fields = await getCommonFields(
+      ['MeetingRecap', 'MeetingAnnouncement'],
+      {},
+      true,
+    );
+
+    expect(fields).toEqual(
+      expect.arrayContaining([
+        'title',
+        'body',
+        'status',
+        'publishDate',
+        'meetingId',
+        '_meta_type',
+      ]),
     );
   });
 
@@ -73,5 +119,24 @@ describe('export command helpers', () => {
         10,
       ),
     ).rejects.toThrow('Invalid filter field');
+  });
+
+  it('fails loudly when the projected export query fails', async () => {
+    await expect(
+      queryWithProjection(
+        {
+          query: vi
+            .fn()
+            .mockRejectedValue(new Error('column "video_url" does not exist')),
+        },
+        'contents',
+        ['MeetingRecap'],
+        ['title'],
+        { status: 'published' },
+        'publishDate',
+      ),
+    ).rejects.toThrow(
+      'Export query failed for contents (columns: title): column "video_url" does not exist',
+    );
   });
 });

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -79,6 +79,8 @@ async function getExportableFields(
   const exportableFields: string[] = [];
 
   for (const [fieldName, fieldDef] of fields) {
+    if ((fieldDef as any)._meta?.__smrtSystemField === true) continue;
+
     // Skip transient and relationship fields
     if (fieldDef.transient) continue;
     if (fieldDef.type === 'oneToMany' || fieldDef.type === 'manyToMany')
@@ -262,10 +264,12 @@ export async function queryWithProjection(
     const result = await db.query(sql, ...whereValues);
     return Array.isArray(result) ? result : (result?.rows ?? []);
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(
-      `Export query failed for ${tableName} (columns: ${selectFields}): ${message}`,
-    );
+    const contextMessage = `Export query failed for ${tableName} (columns: ${selectFields})`;
+    if (error instanceof Error) {
+      throw new Error(`${contextMessage}: ${error.message}`, { cause: error });
+    }
+
+    throw new Error(`${contextMessage}: ${String(error)}`);
   }
 }
 

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -62,8 +62,8 @@ async function getExportableFields(
 ): Promise<string[]> {
   const { ObjectRegistry } = await import('@happyvertical/smrt-core');
 
-  // Get fields from registry
-  const fields = ObjectRegistry.getFields(typeName);
+  // Export needs inherited STI/CTI fields as well as direct fields.
+  const fields = await ObjectRegistry.getAllFields(typeName);
   if (fields.size === 0) {
     console.warn(`⚠️  No fields found for type: ${typeName}`);
     return [];
@@ -262,11 +262,10 @@ export async function queryWithProjection(
     const result = await db.query(sql, ...whereValues);
     return Array.isArray(result) ? result : (result?.rows ?? []);
   } catch (error) {
-    // If query fails (missing column, etc.), return empty
-    console.warn(
-      `⚠️  Query failed for ${tableName}: ${error instanceof Error ? error.message : error}`,
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Export query failed for ${tableName} (columns: ${selectFields}): ${message}`,
     );
-    return [];
   }
 }
 
@@ -339,7 +338,7 @@ async function resolveTableName(types: string[]): Promise<string> {
 /**
  * Get common fields across all types for an export file
  */
-async function getCommonFields(
+export async function getCommonFields(
   types: string[],
   fileConfig: ExportFileConfig,
   fieldExportDefault: boolean,


### PR DESCRIPTION
## Summary
- include inherited STI fields when computing export projections
- fail export queries loudly instead of silently writing incomplete payloads
- cover the regression with focused export command tests

## Why
Anytown site exports can currently write article-less payloads even when the recap rows exist in Postgres. The root cause is that `smrt export` only looks at direct fields for a type, so inherited content fields like `title`, `body`, `status`, and `publishDate` can drop out of the projection. On top of that, raw query failures are logged as warnings and the command still emits empty JSON files.

## Verification
- `pnpm --dir packages/cli exec vitest run src/commands/__tests__/export.test.ts`
- `pnpm --dir packages/cli build`