### PR TITLE
fix(cli): support CTI-safe static exports

### DIFF
--- a/packages/cli/src/commands/__tests__/export.test.ts
+++ b/packages/cli/src/commands/__tests__/export.test.ts
@@ -30,7 +30,55 @@ vi.mock('@happyvertical/smrt-core', () => ({
         baseFields.set('meetingId', { type: 'foreignKey' });
       }
 
+      if (typeName === 'Council') {
+        return new Map([
+          ['id', { type: 'text', _meta: { __smrtSystemField: true } }],
+          ['slug', { type: 'text', _meta: { __smrtSystemField: true } }],
+          ['context', { type: 'text', _meta: { __smrtSystemField: true } }],
+          ['tenantId', { type: 'foreignKey' }],
+          ['organizationId', { type: 'foreignKey' }],
+          ['name', { type: 'string' }],
+          ['meetingsUrl', { type: 'string' }],
+          ['timezone', { type: 'string' }],
+          ['logoUrl', { type: 'string' }],
+        ]);
+      }
+
       return baseFields;
+    }),
+    getTableStrategy: vi.fn((typeName: string) =>
+      typeName === 'Council' ? 'cti' : 'sti',
+    ),
+    getSchema: vi.fn((typeName: string) => {
+      if (typeName === 'Council') {
+        return {
+          tableName: 'councils',
+          columns: {
+            id: { type: 'TEXT' },
+            slug: { type: 'TEXT' },
+            tenant_id: { type: 'TEXT' },
+            organization_id: { type: 'TEXT' },
+            name: { type: 'TEXT' },
+            meetings_url: { type: 'TEXT' },
+            timezone: { type: 'TEXT' },
+            logo_url: { type: 'TEXT' },
+          },
+        };
+      }
+
+      return {
+        tableName: 'contents',
+        columns: {
+          id: { type: 'TEXT' },
+          slug: { type: 'TEXT' },
+          _meta_type: { type: 'TEXT' },
+          _meta_data: { type: 'JSON' },
+          title: { type: 'TEXT' },
+          body: { type: 'TEXT' },
+          status: { type: 'TEXT' },
+          publish_date: { type: 'DATE' },
+        },
+      };
     }),
   },
 }));
@@ -82,6 +130,18 @@ describe('export command helpers', () => {
     expect(fields).not.toContain('context');
     expect(fields).not.toContain('created_at');
     expect(fields).not.toContain('updated_at');
+  });
+
+  it('does not inject STI meta columns into CTI exports', async () => {
+    const fields = await getCommonFields(
+      ['Council'],
+      { types: ['Council'] },
+      true,
+    );
+
+    expect(fields).toEqual(expect.arrayContaining(['id', 'slug', 'name']));
+    expect(fields).not.toContain('_meta_type');
+    expect(fields).not.toContain('_meta_data');
   });
 
   it('formats export records using requested field names', () => {
@@ -165,5 +225,26 @@ describe('export command helpers', () => {
         'publishDate',
       ),
     ).rejects.toMatchObject({ cause: sourceError });
+  });
+
+  it('does not apply STI filters when exporting CTI tables', async () => {
+    const query = vi.fn().mockResolvedValue({
+      rows: [{ id: 'council-1', slug: 'bentley', name: 'Bentley Council' }],
+    });
+
+    await queryWithProjection(
+      { query },
+      'councils',
+      ['Council'],
+      ['id', 'slug', 'name'],
+      {},
+      'name',
+      10,
+    );
+
+    expect(query).toHaveBeenCalledWith(
+      expect.not.stringContaining('_meta_type LIKE ?'),
+    );
+    expect(query.mock.calls[0]?.slice(1)).toEqual([]);
   });
 });

--- a/packages/cli/src/commands/__tests__/export.test.ts
+++ b/packages/cli/src/commands/__tests__/export.test.ts
@@ -30,6 +30,10 @@ vi.mock('@happyvertical/smrt-core', () => ({
         baseFields.set('meetingId', { type: 'foreignKey' });
       }
 
+      if (typeName === 'SparseMeetingRecap') {
+        baseFields.set('meetingId', { type: 'foreignKey' });
+      }
+
       if (typeName === 'Council') {
         return new Map([
           ['id', { type: 'text', _meta: { __smrtSystemField: true } }],
@@ -49,6 +53,12 @@ vi.mock('@happyvertical/smrt-core', () => ({
     getTableStrategy: vi.fn((typeName: string) =>
       typeName === 'Council' ? 'cti' : 'sti',
     ),
+    getSTIBase: vi.fn((typeName: string) => {
+      if (typeName === 'SparseMeetingRecap') return 'Content';
+      if (typeName === 'MeetingRecap' || typeName === 'MeetingAnnouncement')
+        return 'Content';
+      return typeName === 'Council' ? null : typeName;
+    }),
     getSchema: vi.fn((typeName: string) => {
       if (typeName === 'Council') {
         return {
@@ -62,6 +72,27 @@ vi.mock('@happyvertical/smrt-core', () => ({
             meetings_url: { type: 'TEXT' },
             timezone: { type: 'TEXT' },
             logo_url: { type: 'TEXT' },
+          },
+        };
+      }
+
+      if (typeName === 'SparseMeetingRecap') {
+        return {
+          tableName: 'contents',
+          columns: {
+            meeting_id: { type: 'TEXT' },
+          },
+        };
+      }
+
+      if (typeName === 'Content') {
+        return {
+          tableName: 'contents',
+          columns: {
+            id: { type: 'TEXT' },
+            slug: { type: 'TEXT' },
+            _meta_type: { type: 'TEXT' },
+            _meta_data: { type: 'JSON' },
           },
         };
       }
@@ -130,6 +161,18 @@ describe('export command helpers', () => {
     expect(fields).not.toContain('context');
     expect(fields).not.toContain('created_at');
     expect(fields).not.toContain('updated_at');
+  });
+
+  it('keeps shared STI standard fields for sparse subclass schemas', async () => {
+    const fields = await getCommonFields(
+      ['SparseMeetingRecap'],
+      { types: ['SparseMeetingRecap'] },
+      true,
+    );
+
+    expect(fields).toEqual(
+      expect.arrayContaining(['id', 'slug', '_meta_type', '_meta_data']),
+    );
   });
 
   it('does not inject STI meta columns into CTI exports', async () => {

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -52,6 +52,30 @@ function toSafeTableName(tableName: string): string {
   return assertSafeIdentifier(tableName, 'table name');
 }
 
+type ExportProjectionCapabilities = {
+  includeMetaType: boolean;
+  includeMetaData: boolean;
+  schemaColumns: Set<string>;
+};
+
+async function getProjectionCapabilities(
+  typeName: string,
+): Promise<ExportProjectionCapabilities> {
+  const { ObjectRegistry } = await import('@happyvertical/smrt-core');
+
+  const schema = ObjectRegistry.getSchema(typeName) as
+    | { columns?: Record<string, unknown> }
+    | undefined;
+  const schemaColumns = new Set(Object.keys(schema?.columns ?? {}));
+  const tableStrategy = ObjectRegistry.getTableStrategy(typeName);
+
+  return {
+    includeMetaType: tableStrategy === 'sti' || schemaColumns.has('_meta_type'),
+    includeMetaData: schemaColumns.has('_meta_data'),
+    schemaColumns,
+  };
+}
+
 /**
  * Get fields that should be exported for a given type
  */
@@ -61,6 +85,7 @@ async function getExportableFields(
   fieldExportDefault: boolean,
 ): Promise<string[]> {
   const { ObjectRegistry } = await import('@happyvertical/smrt-core');
+  const projection = await getProjectionCapabilities(typeName);
 
   // Export needs inherited STI/CTI fields as well as direct fields.
   const fields = await ObjectRegistry.getAllFields(typeName);
@@ -72,7 +97,12 @@ async function getExportableFields(
   // If include whitelist is specified, use only those fields
   if (fileConfig.include && fileConfig.include.length > 0) {
     return fileConfig.include.filter(
-      (f) => fields.has(f) || f === '_meta_type',
+      (f) =>
+        fields.has(f) ||
+        (f === '_meta_type' && projection.includeMetaType) ||
+        (f === '_meta_data' && projection.includeMetaData) ||
+        (f === 'id' && projection.schemaColumns.has('id')) ||
+        (f === 'slug' && projection.schemaColumns.has('slug')),
     );
   }
 
@@ -108,12 +138,17 @@ async function getExportableFields(
   const excluded = new Set(fileConfig.exclude || []);
   const result = exportableFields.filter((f) => !excluded.has(f));
 
-  // Always include _meta_type for STI discrimination
-  if (!result.includes('_meta_type')) {
+  if (projection.includeMetaType && !result.includes('_meta_type')) {
     result.push('_meta_type');
   }
 
-  for (const standardField of ['id', 'slug', '_meta_data']) {
+  const standardFields = [
+    projection.schemaColumns.has('id') ? 'id' : null,
+    projection.schemaColumns.has('slug') ? 'slug' : null,
+    projection.includeMetaData ? '_meta_data' : null,
+  ].filter((field): field is string => field !== null);
+
+  for (const standardField of standardFields) {
     if (!result.includes(standardField)) {
       result.push(standardField);
     }
@@ -174,6 +209,15 @@ export async function queryWithProjection(
   orderBy?: string,
   limit?: number,
 ): Promise<any[]> {
+  const projection =
+    types.length > 0
+      ? await getProjectionCapabilities(types[0])
+      : {
+          includeMetaType: false,
+          includeMetaData: false,
+          schemaColumns: new Set<string>(),
+        };
+
   // Build SELECT clause with only exportable fields
   const fieldColumns = fields.map((field) => ({
     field,
@@ -186,7 +230,7 @@ export async function queryWithProjection(
   const whereValues: any[] = [];
 
   // Filter by _meta_type if specified types
-  if (types.length > 0) {
+  if (types.length > 0 && projection.includeMetaType) {
     // Map type names to qualified names or just use as-is
     const typePatterns = types.map((t) => `%:${t}`);
     if (typePatterns.length === 1) {
@@ -364,11 +408,6 @@ export async function getCommonFields(
   const commonFields = [...fieldSets[0]].filter((field) =>
     fieldSets.every((set) => set.has(field)),
   );
-
-  // Add _meta_type if not present (needed for STI discrimination)
-  if (!commonFields.includes('_meta_type')) {
-    commonFields.push('_meta_type');
-  }
 
   return commonFields;
 }

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -63,11 +63,15 @@ async function getProjectionCapabilities(
 ): Promise<ExportProjectionCapabilities> {
   const { ObjectRegistry } = await import('@happyvertical/smrt-core');
 
-  const schema = ObjectRegistry.getSchema(typeName) as
+  const tableStrategy = ObjectRegistry.getTableStrategy(typeName);
+  const schemaOwner =
+    tableStrategy === 'sti'
+      ? ObjectRegistry.getSTIBase(typeName) || typeName
+      : typeName;
+  const schema = ObjectRegistry.getSchema(schemaOwner) as
     | { columns?: Record<string, unknown> }
     | undefined;
   const schemaColumns = new Set(Object.keys(schema?.columns ?? {}));
-  const tableStrategy = ObjectRegistry.getTableStrategy(typeName);
 
   return {
     includeMetaType: tableStrategy === 'sti' || schemaColumns.has('_meta_type'),


### PR DESCRIPTION
## Summary
- stop export from injecting STI meta columns and filters into CTI tables
- keep automatic `_meta_type` / `_meta_data` projection only when the registered schema actually supports them
- add CTI-focused export tests for field projection and query filtering

## Verification
- pnpm --dir packages/cli exec vitest run src/commands/__tests__/export.test.ts
- pnpm --dir packages/cli build

## Downstream proof
- reproduced the Bentley production failure in anytown by widening the Praeco export smoke to include `councils`
- the same downstream smoke fails on released `smrt-cli 0.21.48` with `Export query failed for councils ... _meta_type, _meta_data`
- the same downstream smoke passes when `SMRT_CLI_BIN` points at this patched CLI build