### PR TITLE
[codex] split browser-safe registry runtime

### DIFF
--- a/packages/core/src/__tests__/sti-table-name-inheritance.test.ts
+++ b/packages/core/src/__tests__/sti-table-name-inheritance.test.ts
@@ -9,16 +9,24 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { clearManifestCache } from '../manifest/manifest-loader.js';
 import { SmrtObject } from '../object';
 import { ObjectRegistry, smrt } from '../registry';
+
+const manifestGlobals = globalThis as typeof globalThis & {
+  __smrtManifestStatic?: Record<string, unknown> | null;
+  __smrtManifestStaticLoadAttempted?: boolean;
+};
 
 describe('STI Table Name Inheritance', () => {
   beforeEach(() => {
     ObjectRegistry.clear();
+    clearManifestCache();
   });
 
   afterEach(() => {
     ObjectRegistry.clear();
+    clearManifestCache();
   });
 
   it('should use parent table name when parent has explicit STI strategy', () => {
@@ -57,6 +65,33 @@ describe('STI Table Name Inheritance', () => {
     expect(ObjectRegistry.getTableName('Event')).toBe('events');
     expect(ObjectRegistry.getTableName('SportingEvent')).toBe('events');
     expect(ObjectRegistry.getTableName('HockeyGame')).toBe('events');
+  });
+
+  it('should honor static manifest table names before manifest-loader is imported', () => {
+    manifestGlobals.__smrtManifestStatic = {
+      version: '1.0.0',
+      timestamp: Date.now(),
+      packageName: '@happyvertical/smrt-core',
+      objects: {
+        '@happyvertical/smrt-core:StaticManifestMeeting': {
+          className: 'StaticManifestMeeting',
+          decoratorConfig: {
+            tableName: 'static_manifest_events',
+            tableStrategy: 'sti',
+          },
+        },
+      },
+    };
+    manifestGlobals.__smrtManifestStaticLoadAttempted = true;
+
+    @smrt({ tableStrategy: 'sti' })
+    class StaticManifestMeeting extends SmrtObject {
+      title: string = '';
+    }
+
+    expect(ObjectRegistry.getTableName('StaticManifestMeeting')).toBe(
+      'static_manifest_events',
+    );
   });
 
   it('should use own table name when using CTI (default)', () => {

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -28,8 +28,6 @@ export type {
 // Global configuration (callable function)
 export { config } from './config';
 export * from './errors';
-// Static manifest (generated at build time - browser-safe)
-export * from './manifest/index';
 export * from './object';
 export * from './registry';
 export { smrt as smrtRegistry } from './registry';

--- a/packages/core/src/manifest/index.ts
+++ b/packages/core/src/manifest/index.ts
@@ -18,7 +18,9 @@ export type { ManifestBuilderOptions } from './generator';
 export { ManifestBuilder } from './generator';
 export { ManifestManager } from './manager';
 export {
+  discoverManifestEntry,
   findManifestEntryByQualifiedName,
+  loadExternalManifest,
   loadExternalManifestSync,
   loadLocalTestManifestSync,
   loadManifestFromPathSync,

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -115,7 +115,7 @@ import type {
   SmrtVisibility,
   ValidationRule,
 } from './scanner/types.js';
-import type { SchemaDefinition } from './schema/types.js';
+import type { ColumnDefinition, SchemaDefinition } from './schema/types.js';
 import { prependSmrtSystemFields } from './system-fields';
 import { classnameToTablename } from './utils';
 import { LRUCache } from './utils/lru-cache';
@@ -137,15 +137,42 @@ export type {
 // The SmartObjectConfig, RelationshipType, and RelationshipMetadata types
 // are re-exported above for backward compatibility.
 
-type ManifestLoaderModule = typeof import('./manifest/manifest-loader.js');
+type ManifestLoaderModule = typeof import('./manifest/index.js');
 type ManifestLoadOptions = {
   warn?: boolean;
 };
 
+function createEmptyStaticManifest(): SmartObjectManifest {
+  return {
+    version: '1.0.0',
+    timestamp: Date.now(),
+    objects: {},
+    packageName: '@happyvertical/smrt-core',
+  };
+}
+
+function cloneManifestSchemaColumns(
+  columns: Record<string, unknown> | undefined,
+): Record<string, ColumnDefinition> {
+  return Object.fromEntries(
+    Object.entries(columns || {}).map(([columnName, column]) => {
+      const clonedColumn = {
+        ...(column as ColumnDefinition & Record<string, unknown>),
+      } as ColumnDefinition;
+
+      if (clonedColumn.foreignKey) {
+        clonedColumn.foreignKey = { ...clonedColumn.foreignKey };
+      }
+
+      return [columnName, clonedColumn];
+    }),
+  ) as Record<string, ColumnDefinition>;
+}
+
 function getManifestLoaderSpecifier(): string {
   return import.meta.url.endsWith('.ts')
-    ? './manifest/manifest-loader.ts'
-    : './manifest/manifest-loader.js';
+    ? './manifest/index.ts'
+    : './manifest/index.js';
 }
 
 async function importManifestLoader(): Promise<ManifestLoaderModule> {
@@ -168,11 +195,14 @@ function lookupCachedManifestEntry(
     : className;
   const lowerClassName = requestedClassName.toLowerCase();
   const packageName = manifest.packageName;
+  const qualifiedKey =
+    requestedQualifiedName ||
+    (packageName
+      ? createQualifiedName(packageName, requestedClassName)
+      : undefined);
 
   return (
-    (requestedQualifiedName
-      ? manifest.objects[requestedQualifiedName]
-      : undefined) ||
+    (qualifiedKey ? manifest.objects[qualifiedKey] : undefined) ||
     manifest.objects[requestedClassName] ||
     manifest.objects[lowerClassName] ||
     Object.values(manifest.objects).find((entry) => {
@@ -194,11 +224,66 @@ function lookupCachedManifestEntry(
   );
 }
 
+function loadStaticManifestSyncWithNode(): SmartObjectManifest | null {
+  const manifestGlobals = globalThis as typeof globalThis & {
+    __smrtManifestStatic?: SmartObjectManifest | null;
+    __smrtManifestStaticLoadAttempted?: boolean;
+  };
+
+  if (manifestGlobals.__smrtManifestStatic !== undefined) {
+    return manifestGlobals.__smrtManifestStatic ?? null;
+  }
+
+  const builtins = getNodeBuiltins();
+  manifestGlobals.__smrtManifestStaticLoadAttempted = true;
+  if (!builtins) {
+    const fallbackManifest = createEmptyStaticManifest();
+    manifestGlobals.__smrtManifestStatic = fallbackManifest;
+    return fallbackManifest;
+  }
+
+  const candidates = import.meta.url.endsWith('.ts')
+    ? [
+        new URL('./manifest/static-manifest.json', import.meta.url),
+        new URL('../dist/manifest.json', import.meta.url),
+      ]
+    : [new URL('./manifest.json', import.meta.url)];
+
+  for (const candidate of candidates) {
+    try {
+      if (!builtins.fs.existsSync(candidate)) {
+        continue;
+      }
+
+      const manifest = JSON.parse(
+        builtins.fs.readFileSync(candidate, 'utf-8'),
+      ) as SmartObjectManifest;
+
+      if (!manifest.objects || typeof manifest.objects !== 'object') {
+        continue;
+      }
+
+      const cachedManifest = manifest.packageName
+        ? manifest
+        : { ...manifest, packageName: '@happyvertical/smrt-core' };
+      manifestGlobals.__smrtManifestStatic = cachedManifest;
+      return cachedManifest;
+    } catch {
+      // Try the next candidate and fall back to the empty manifest if needed.
+    }
+  }
+
+  const fallbackManifest = createEmptyStaticManifest();
+  manifestGlobals.__smrtManifestStatic = fallbackManifest;
+  return fallbackManifest;
+}
+
 function discoverCachedManifestSync(
   className: string,
 ): SmartObjectDefinition | undefined {
   const manifestGlobals = globalThis as typeof globalThis & {
     __smrtManifestLocalTest?: SmartObjectManifest | null;
+    __smrtManifestStatic?: SmartObjectManifest | null;
     __smrtManifestTest?: SmartObjectManifest | null;
     __smrtManifestCache?: Map<string, SmartObjectManifest>;
   };
@@ -206,6 +291,7 @@ function discoverCachedManifestSync(
   const manifests: Array<SmartObjectManifest | null | undefined> = [
     manifestGlobals.__smrtManifestLocalTest,
     manifestGlobals.__smrtManifestTest,
+    loadStaticManifestSyncWithNode(),
     ...(manifestGlobals.__smrtManifestCache?.values() || []),
   ];
 
@@ -1820,6 +1906,29 @@ export class ObjectRegistry {
         )) {
           registered.methods.set(methodName, methodDef);
         }
+        didHydrate = true;
+      }
+
+      if (manifestEntry.schema) {
+        registered.schema = {
+          ddl: manifestEntry.schema.ddl,
+          tableName:
+            manifestEntry.schema.tableName ||
+            registered.schema?.tableName ||
+            classnameToTablename(registered.name),
+          columns: cloneManifestSchemaColumns(manifestEntry.schema.columns),
+          indexes:
+            manifestEntry.schema.indexes?.map((indexDef) => ({
+              ...indexDef,
+              columns: [...(indexDef.columns || [])],
+            })) || [],
+          triggers: [],
+          foreignKeys: [],
+          dependencies: [],
+          version: manifestEntry.schema.version || '',
+          packageName: manifestEntry.packageName,
+          baseClass: registered.schema?.baseClass,
+        };
         didHydrate = true;
       }
 

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -36,13 +36,6 @@ import type {
   ResolvedEmbeddingConfig,
 } from './embeddings/types';
 import { ConfigurationError } from './errors';
-import {
-  discoverManifestEntry,
-  discoverManifestSync,
-  loadExternalManifest,
-  loadExternalManifestSync,
-  loadManifestFromPathSync,
-} from './manifest/manifest-loader.js';
 import type { SmrtObject } from './object';
 import {
   register as _register,
@@ -117,6 +110,8 @@ import type {
 import { compileValidators as _compileValidators } from './registry/validator';
 import type {
   QualifiedClassName,
+  SmartObjectDefinition,
+  SmartObjectManifest,
   SmrtVisibility,
   ValidationRule,
 } from './scanner/types.js';
@@ -141,6 +136,409 @@ export type {
 // to registry/types.ts and registry/shared-state.ts (Issue #1006).
 // The SmartObjectConfig, RelationshipType, and RelationshipMetadata types
 // are re-exported above for backward compatibility.
+
+type ManifestLoaderModule = typeof import('./manifest/manifest-loader.js');
+type ManifestLoadOptions = {
+  warn?: boolean;
+};
+
+function getManifestLoaderSpecifier(): string {
+  return import.meta.url.endsWith('.ts')
+    ? './manifest/manifest-loader.ts'
+    : './manifest/manifest-loader.js';
+}
+
+async function importManifestLoader(): Promise<ManifestLoaderModule> {
+  return (await import(getManifestLoaderSpecifier())) as ManifestLoaderModule;
+}
+
+function lookupCachedManifestEntry(
+  manifest: SmartObjectManifest | null | undefined,
+  className: string,
+): SmartObjectDefinition | undefined {
+  if (!manifest?.objects) {
+    return undefined;
+  }
+
+  const requestedQualifiedName = isQualifiedName(className)
+    ? className
+    : undefined;
+  const requestedClassName = requestedQualifiedName
+    ? parseQualifiedName(requestedQualifiedName).className
+    : className;
+  const lowerClassName = requestedClassName.toLowerCase();
+  const packageName = manifest.packageName;
+
+  return (
+    (requestedQualifiedName
+      ? manifest.objects[requestedQualifiedName]
+      : undefined) ||
+    manifest.objects[requestedClassName] ||
+    manifest.objects[lowerClassName] ||
+    Object.values(manifest.objects).find((entry) => {
+      if (!entry) {
+        return false;
+      }
+
+      if (entry.className?.toLowerCase() === lowerClassName) {
+        return true;
+      }
+
+      return (
+        requestedQualifiedName !== undefined &&
+        packageName !== undefined &&
+        createQualifiedName(packageName, entry.className || '') ===
+          requestedQualifiedName
+      );
+    })
+  );
+}
+
+function discoverCachedManifestSync(
+  className: string,
+): SmartObjectDefinition | undefined {
+  const manifestGlobals = globalThis as typeof globalThis & {
+    __smrtManifestLocalTest?: SmartObjectManifest | null;
+    __smrtManifestTest?: SmartObjectManifest | null;
+    __smrtManifestCache?: Map<string, SmartObjectManifest>;
+  };
+
+  const manifests: Array<SmartObjectManifest | null | undefined> = [
+    manifestGlobals.__smrtManifestLocalTest,
+    manifestGlobals.__smrtManifestTest,
+    ...(manifestGlobals.__smrtManifestCache?.values() || []),
+  ];
+
+  for (const manifest of manifests) {
+    const entry = lookupCachedManifestEntry(manifest, className);
+    if (entry) {
+      return entry;
+    }
+  }
+
+  return undefined;
+}
+
+function getNodeBuiltins() {
+  const getBuiltinModule = (
+    process as typeof process & {
+      getBuiltinModule?: (id: string) => unknown;
+    }
+  ).getBuiltinModule;
+  if (typeof getBuiltinModule !== 'function') {
+    return null;
+  }
+
+  const fs = getBuiltinModule('node:fs') as
+    | typeof import('node:fs')
+    | undefined;
+  const path = getBuiltinModule('node:path') as
+    | typeof import('node:path')
+    | undefined;
+
+  if (!fs || !path) {
+    return null;
+  }
+
+  return { fs, path };
+}
+
+function findWorkspaceRootSync(startDir: string): string | null {
+  const builtins = getNodeBuiltins();
+  if (!builtins) {
+    return null;
+  }
+
+  let currentDir = startDir;
+
+  while (true) {
+    if (
+      builtins.fs.existsSync(
+        builtins.path.join(currentDir, 'pnpm-workspace.yaml'),
+      )
+    ) {
+      return currentDir;
+    }
+
+    const parentDir = builtins.path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      return null;
+    }
+
+    currentDir = parentDir;
+  }
+}
+
+function resolveInstalledPackageJsonPathSync(
+  packageName: string,
+): string | null {
+  const builtins = getNodeBuiltins();
+  if (!builtins) {
+    return null;
+  }
+
+  let currentDir = process.cwd();
+
+  while (true) {
+    const packageJsonPath = builtins.path.join(
+      currentDir,
+      'node_modules',
+      packageName,
+      'package.json',
+    );
+
+    if (builtins.fs.existsSync(packageJsonPath)) {
+      return packageJsonPath;
+    }
+
+    const parentDir = builtins.path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      return null;
+    }
+
+    currentDir = parentDir;
+  }
+}
+
+function resolveWorkspacePackageJsonPathSync(
+  packageName: string,
+): string | null {
+  const builtins = getNodeBuiltins();
+  if (!builtins) {
+    return null;
+  }
+
+  const workspaceRoot = findWorkspaceRootSync(process.cwd());
+  if (!workspaceRoot) {
+    return null;
+  }
+
+  const workspacePackagesDir = builtins.path.join(workspaceRoot, 'packages');
+  if (!builtins.fs.existsSync(workspacePackagesDir)) {
+    return null;
+  }
+
+  for (const packageDirName of builtins.fs.readdirSync(workspacePackagesDir)) {
+    const packageJsonPath = builtins.path.join(
+      workspacePackagesDir,
+      packageDirName,
+      'package.json',
+    );
+    if (!builtins.fs.existsSync(packageJsonPath)) {
+      continue;
+    }
+
+    try {
+      const packageJson = JSON.parse(
+        builtins.fs.readFileSync(packageJsonPath, 'utf-8'),
+      ) as { name?: string };
+      if (packageJson.name === packageName) {
+        return packageJsonPath;
+      }
+    } catch {
+      // Ignore unreadable workspace package metadata and continue scanning.
+    }
+  }
+
+  return null;
+}
+
+function resolveWorkspaceSourceManifestPathSync(
+  packageDir: string,
+): string | null {
+  const builtins = getNodeBuiltins();
+  if (!builtins) {
+    return null;
+  }
+
+  const candidates = [
+    builtins.path.join(packageDir, 'src', 'manifest', 'manifest.json'),
+    builtins.path.join(packageDir, '.smrt', 'manifest.json'),
+  ];
+
+  for (const candidate of candidates) {
+    if (builtins.fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function resolveManifestExportPathSync(
+  packageName: string,
+  options: ManifestLoadOptions = {},
+): string | null {
+  const builtins = getNodeBuiltins();
+  if (!builtins) {
+    return null;
+  }
+
+  const shouldWarn = options.warn ?? true;
+  const packageJsonPath =
+    resolveInstalledPackageJsonPathSync(packageName) ||
+    resolveWorkspacePackageJsonPathSync(packageName);
+
+  if (!packageJsonPath) {
+    return null;
+  }
+
+  const packageDir = builtins.path.dirname(packageJsonPath);
+  const packageJson = JSON.parse(
+    builtins.fs.readFileSync(packageJsonPath, 'utf-8'),
+  ) as {
+    exports?: Record<
+      string,
+      string | { default?: string; import?: string; require?: string }
+    >;
+  };
+  const manifestExports = ['./manifest.json', './manifest'];
+
+  for (const exportKey of manifestExports) {
+    const manifestExport = packageJson.exports?.[exportKey];
+    if (!manifestExport) {
+      continue;
+    }
+
+    const manifestRelativePath =
+      typeof manifestExport === 'string'
+        ? manifestExport
+        : manifestExport.import ||
+          manifestExport.default ||
+          manifestExport.require;
+
+    if (!manifestRelativePath) {
+      if (shouldWarn) {
+        console.warn(
+          `Package ${packageName} has invalid manifest export configuration for ${exportKey}`,
+        );
+      }
+      return null;
+    }
+
+    if (!manifestRelativePath.endsWith('.json')) {
+      if (shouldWarn) {
+        console.warn(
+          `Package ${packageName} must export a JSON manifest for ${exportKey}, received ${manifestRelativePath}`,
+        );
+      }
+      return null;
+    }
+
+    const manifestPath = builtins.path.join(packageDir, manifestRelativePath);
+    if (builtins.fs.existsSync(manifestPath)) {
+      return manifestPath;
+    }
+
+    const workspaceSourceManifest =
+      resolveWorkspaceSourceManifestPathSync(packageDir);
+    if (workspaceSourceManifest) {
+      return workspaceSourceManifest;
+    }
+
+    if (shouldWarn) {
+      console.warn(
+        `Package ${packageName} declares manifest export ${manifestRelativePath}, but no manifest file was found.`,
+      );
+    }
+    return null;
+  }
+
+  return null;
+}
+
+function loadExternalManifestSyncWithNode(
+  packageName: string,
+  options: ManifestLoadOptions = {},
+): SmartObjectManifest | null {
+  const manifestGlobals = globalThis as typeof globalThis & {
+    __smrtManifestCache?: Map<string, SmartObjectManifest>;
+  };
+
+  if (manifestGlobals.__smrtManifestCache?.has(packageName)) {
+    return manifestGlobals.__smrtManifestCache.get(packageName) || null;
+  }
+
+  const builtins = getNodeBuiltins();
+  if (!builtins) {
+    return null;
+  }
+
+  const manifestPath = resolveManifestExportPathSync(packageName, options);
+  if (!manifestPath) {
+    return null;
+  }
+
+  try {
+    const manifest = JSON.parse(
+      builtins.fs.readFileSync(manifestPath, 'utf-8'),
+    ) as SmartObjectManifest;
+
+    if (!manifest.objects || typeof manifest.objects !== 'object') {
+      if (options.warn ?? true) {
+        console.warn(`Invalid manifest structure for package ${packageName}`);
+      }
+      return null;
+    }
+
+    const cachedManifest = manifest.packageName
+      ? manifest
+      : { ...manifest, packageName };
+
+    if (!manifestGlobals.__smrtManifestCache) {
+      manifestGlobals.__smrtManifestCache = new Map();
+    }
+    manifestGlobals.__smrtManifestCache.set(packageName, cachedManifest);
+
+    return cachedManifest;
+  } catch (error) {
+    if (options.warn ?? true) {
+      console.warn(
+        `Failed to load manifest for package ${packageName}: ${error instanceof Error ? error.message : error}`,
+      );
+    }
+    return null;
+  }
+}
+
+function loadManifestFromPathSyncWithNode(
+  manifestPath: string,
+): SmartObjectManifest | null {
+  const builtins = getNodeBuiltins();
+  if (!builtins) {
+    return null;
+  }
+
+  try {
+    const manifest = JSON.parse(
+      builtins.fs.readFileSync(manifestPath, 'utf-8'),
+    ) as SmartObjectManifest;
+
+    if (!manifest.objects || typeof manifest.objects !== 'object') {
+      console.warn(`Invalid manifest structure at ${manifestPath}`);
+      return null;
+    }
+
+    const manifestGlobals = globalThis as typeof globalThis & {
+      __smrtManifestCache?: Map<string, SmartObjectManifest>;
+    };
+    if (!manifestGlobals.__smrtManifestCache) {
+      manifestGlobals.__smrtManifestCache = new Map();
+    }
+
+    manifestGlobals.__smrtManifestCache.set(
+      manifest.packageName || manifestPath,
+      manifest,
+    );
+
+    return manifest;
+  } catch (error) {
+    console.warn(
+      `Failed to load manifest from path ${manifestPath}: ${error instanceof Error ? error.message : error}`,
+    );
+    return null;
+  }
+}
 
 async function discoverInstalledSmrtPackages(): Promise<string[]> {
   const discoverSpecifier = import.meta.url.endsWith('.ts')
@@ -723,6 +1121,7 @@ export class ObjectRegistry {
     const smrtPackages = requestedPackageName
       ? [requestedPackageName]
       : await discoverInstalledSmrtPackages();
+    const { loadExternalManifest } = await importManifestLoader();
 
     verboseLog(
       `[ObjectRegistry] Attempting to auto-load ${className} from ${smrtPackages.length} external packages...`,
@@ -902,7 +1301,7 @@ export class ObjectRegistry {
       // Explicit paths — used by integration tests
       for (const manifestPath of options.manifestPaths) {
         try {
-          const manifest = loadManifestFromPathSync(manifestPath);
+          const manifest = loadManifestFromPathSyncWithNode(manifestPath);
           if (!manifest?.objects) continue;
           const packageName = manifest.packageName as string | undefined;
 
@@ -925,18 +1324,31 @@ export class ObjectRegistry {
       // Auto-discover via loadExternalManifestSync for each @happyvertical package
       const packagePrefixes = ['@happyvertical/smrt-'];
       try {
-        const { readdirSync } = require('node:fs') as typeof import('node:fs');
-        const { join } = require('node:path') as typeof import('node:path');
-        const scopeDir = join(process.cwd(), 'node_modules', '@happyvertical');
-        const packages = readdirSync(scopeDir).filter((name: string) =>
-          packagePrefixes.some((prefix) =>
-            `@happyvertical/${name}`.startsWith(prefix),
-          ),
+        const builtins = getNodeBuiltins();
+        if (!builtins) {
+          return { packagesLoaded, objectsRegistered };
+        }
+
+        const scopeDir = builtins.path.join(
+          process.cwd(),
+          'node_modules',
+          '@happyvertical',
         );
+        if (!builtins.fs.existsSync(scopeDir)) {
+          return { packagesLoaded, objectsRegistered };
+        }
+
+        const packages = builtins.fs
+          .readdirSync(scopeDir)
+          .filter((name) =>
+            packagePrefixes.some((prefix) =>
+              `@happyvertical/${name}`.startsWith(prefix),
+            ),
+          );
 
         for (const pkgDir of packages) {
           const packageName = `@happyvertical/${pkgDir}`;
-          const manifest = loadExternalManifestSync(packageName);
+          const manifest = loadExternalManifestSyncWithNode(packageName);
           if (!manifest?.objects) continue;
 
           for (const [_key, objectDef] of Object.entries(manifest.objects)) {
@@ -1320,6 +1732,7 @@ export class ObjectRegistry {
     // This handles cases where AST scanner missed optional fields without initializers
     const existingFieldCount = registered.fields.size;
 
+    const { discoverManifestEntry } = await importManifestLoader();
     const manifestEntry = await discoverManifestEntry(
       registered.constructor,
       className,
@@ -2892,7 +3305,7 @@ export function smrt(config: SmartObjectConfig = {}) {
         // First, check manifest for tableName (manifest generator correctly handles STI inheritance)
         // This handles the case where a child class sets tableStrategy: 'sti' explicitly
         // but should still inherit the parent's table name
-        const manifestEntry = discoverManifestSync(ctor.name);
+        const manifestEntry = discoverCachedManifestSync(ctor.name);
         if (manifestEntry?.decoratorConfig?.tableName) {
           tableName = manifestEntry.decoratorConfig.tableName;
         } else if (config.tableStrategy === 'sti') {

--- a/packages/core/src/scanner/index.ts
+++ b/packages/core/src/scanner/index.ts
@@ -8,7 +8,7 @@
  *   import { OxcScanner, ManifestAdapter } from '@happyvertical/smrt-scanner';
  */
 
-export { generateManifest, ManifestGenerator } from './manifest-generator';
+export { generateManifest, ManifestGenerator } from './manifest-generator.js';
 export type {
   AgentAdminRouteManifest,
   AgentComponentDeclaration,
@@ -23,4 +23,4 @@ export type {
   ScanResult,
   SmartObjectDefinition,
   SmartObjectManifest,
-} from './types';
+} from './types.js';

--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -7,7 +7,7 @@ import {
   loadExternalManifestSync,
   lookupInManifest,
 } from '../manifest/manifest-loader.js';
-import { generateToolManifest } from '../tools/tool-generator';
+import { generateToolManifest } from '../tools/tool-generator.js';
 import { createQualifiedName } from '../utils/qualified-names.js';
 import { classnameToTablename, toSnakeCase } from '../utils.js';
 import { isTestFile } from './test-file-patterns.js';
@@ -24,7 +24,7 @@ import type {
   SmartObjectManifest,
   SmrtVisibility,
   ValidationRule,
-} from './types';
+} from './types.js';
 
 // Create require function for synchronous module loading in ESM context
 const require = createRequire(import.meta.url);

--- a/packages/core/src/schema/code-generator.ts
+++ b/packages/core/src/schema/code-generator.ts
@@ -3,8 +3,8 @@
  * Generates getSchema() static methods for SMRT objects
  */
 
-import type { SmartObjectDefinition } from '../scanner/types';
-import type { SchemaDefinition } from './types';
+import type { SmartObjectDefinition } from '../scanner/types.js';
+import type { SchemaDefinition } from './types.js';
 
 export class SchemaCodeGenerator {
   /**

--- a/packages/core/src/schema/ddl/base-strategy.ts
+++ b/packages/core/src/schema/ddl/base-strategy.ts
@@ -11,8 +11,8 @@ import type {
   SchemaDefinition,
   SQLDataType,
   TriggerDefinition,
-} from '../types';
-import type { DatabaseEngine, DDLStrategy } from './types';
+} from '../types.js';
+import type { DatabaseEngine, DDLStrategy } from './types.js';
 
 /**
  * Abstract base class for DDL strategies

--- a/packages/core/src/schema/ddl/duckdb-strategy.ts
+++ b/packages/core/src/schema/ddl/duckdb-strategy.ts
@@ -11,9 +11,9 @@
  * not with separate UNIQUE indexes. This is a known DuckDB limitation.
  */
 
-import type { SchemaDefinition, SQLDataType } from '../types';
-import { BaseDDLStrategy } from './base-strategy';
-import type { DatabaseEngine } from './types';
+import type { SchemaDefinition, SQLDataType } from '../types.js';
+import { BaseDDLStrategy } from './base-strategy.js';
+import type { DatabaseEngine } from './types.js';
 
 export class DuckDBStrategy extends BaseDDLStrategy {
   readonly engine: DatabaseEngine = 'duckdb';

--- a/packages/core/src/schema/ddl/index.ts
+++ b/packages/core/src/schema/ddl/index.ts
@@ -5,22 +5,22 @@
  * SMRT handles ALL database maintenance directly - SDK SQL remains a pure query/CRUD layer.
  */
 
-export { BaseDDLStrategy } from './base-strategy';
-export { DuckDBStrategy } from './duckdb-strategy';
-export { PostgresStrategy } from './postgres-strategy';
-export { SQLiteStrategy } from './sqlite-strategy';
-export * from './types';
+export { BaseDDLStrategy } from './base-strategy.js';
+export { DuckDBStrategy } from './duckdb-strategy.js';
+export { PostgresStrategy } from './postgres-strategy.js';
+export { SQLiteStrategy } from './sqlite-strategy.js';
+export * from './types.js';
 
-import type { SchemaDefinition } from '../types';
-import { DuckDBStrategy } from './duckdb-strategy';
-import { PostgresStrategy } from './postgres-strategy';
-import { SQLiteStrategy } from './sqlite-strategy';
+import type { SchemaDefinition } from '../types.js';
+import { DuckDBStrategy } from './duckdb-strategy.js';
+import { PostgresStrategy } from './postgres-strategy.js';
+import { SQLiteStrategy } from './sqlite-strategy.js';
 import type {
   DatabaseEngine,
   DDLStrategy,
   EngineSpecificDDL,
   MultiEngineDDL,
-} from './types';
+} from './types.js';
 
 // Singleton instances for each strategy
 const strategies: Record<DatabaseEngine, DDLStrategy> = {

--- a/packages/core/src/schema/ddl/postgres-strategy.ts
+++ b/packages/core/src/schema/ddl/postgres-strategy.ts
@@ -9,9 +9,9 @@
  * - Supports CAST in DEFAULT values
  */
 
-import type { SQLDataType, TriggerDefinition } from '../types';
-import { BaseDDLStrategy } from './base-strategy';
-import type { DatabaseEngine } from './types';
+import type { SQLDataType, TriggerDefinition } from '../types.js';
+import { BaseDDLStrategy } from './base-strategy.js';
+import type { DatabaseEngine } from './types.js';
 
 export class PostgresStrategy extends BaseDDLStrategy {
   readonly engine: DatabaseEngine = 'postgres';

--- a/packages/core/src/schema/ddl/sqlite-strategy.ts
+++ b/packages/core/src/schema/ddl/sqlite-strategy.ts
@@ -9,9 +9,9 @@
  * - UNIQUE can be inline or separate indexes
  */
 
-import type { SQLDataType } from '../types';
-import { BaseDDLStrategy } from './base-strategy';
-import type { DatabaseEngine } from './types';
+import type { SQLDataType } from '../types.js';
+import { BaseDDLStrategy } from './base-strategy.js';
+import type { DatabaseEngine } from './types.js';
 
 export class SQLiteStrategy extends BaseDDLStrategy {
   readonly engine: DatabaseEngine = 'sqlite';

--- a/packages/core/src/schema/ddl/types.ts
+++ b/packages/core/src/schema/ddl/types.ts
@@ -8,7 +8,7 @@
  * - PostgreSQL: JSONB type, full trigger support
  */
 
-import type { SchemaDefinition, SQLDataType } from '../types';
+import type { SchemaDefinition, SQLDataType } from '../types.js';
 
 /**
  * Supported database engines

--- a/packages/core/src/schema/generator.ts
+++ b/packages/core/src/schema/generator.ts
@@ -11,7 +11,7 @@ import type {
   ManifestSchema,
   SmartObjectDefinition,
   SmartObjectManifest,
-} from '../scanner/types';
+} from '../scanner/types.js';
 import type {
   ColumnDefinition,
   ForeignKeyDefinition,
@@ -19,7 +19,7 @@ import type {
   SchemaDefinition,
   SQLDataType,
   TriggerDefinition,
-} from './types';
+} from './types.js';
 
 export class SchemaGenerator {
   /**
@@ -591,7 +591,7 @@ export class SchemaGenerator {
     tableName: string,
     _fields: Map<string, any>,
   ): Promise<SchemaDefinition> {
-    const { ObjectRegistry } = await import('../registry');
+    const { ObjectRegistry } = await import('../registry.js');
     const columns: Record<string, ColumnDefinition> = {};
 
     // Add default SMRT fields

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -2,18 +2,18 @@
  * Schema generation module exports
  */
 
-export { SchemaCodeGenerator } from './code-generator';
+export { SchemaCodeGenerator } from './code-generator.js';
 // Re-export DDL strategies for per-engine schema generation
-export * from './ddl';
-export { SchemaGenerator } from './generator';
-export { SchemaOverrideSystem } from './override-system';
+export * from './ddl/index.js';
+export { SchemaGenerator } from './generator.js';
+export { SchemaOverrideSystem } from './override-system.js';
 export type {
   AggregatedTable,
   AggregateOptions,
   AggregationResult,
-} from './schema-aggregator';
-export { SchemaAggregator } from './schema-aggregator';
-export { createSchemaManager, SchemaManager } from './schema-manager';
+} from './schema-aggregator.js';
+export { SchemaAggregator } from './schema-aggregator.js';
+export { createSchemaManager, SchemaManager } from './schema-manager.js';
 
 // Re-export for easy access
 export type {
@@ -25,5 +25,5 @@ export type {
   SchemaMigration,
   SchemaOverride,
   TriggerDefinition,
-} from './types';
-export * from './types';
+} from './types.js';
+export * from './types.js';

--- a/packages/core/src/schema/override-system.ts
+++ b/packages/core/src/schema/override-system.ts
@@ -8,7 +8,7 @@ import type {
   ColumnDefinition,
   SchemaDefinition,
   SchemaOverride,
-} from './types';
+} from './types.js';
 
 export class SchemaOverrideSystem {
   /**

--- a/packages/core/src/schema/schema-manager.ts
+++ b/packages/core/src/schema/schema-manager.ts
@@ -14,8 +14,8 @@ import {
   detectEngine,
   type EngineSpecificDDL,
   getDDLStrategy,
-} from './ddl';
-import type { SchemaDefinition } from './types';
+} from './ddl/index.js';
+import type { SchemaDefinition } from './types.js';
 
 /**
  * Schema Manager Options

--- a/packages/core/src/schema/utils.ts
+++ b/packages/core/src/schema/utils.ts
@@ -9,8 +9,8 @@
  */
 
 import type { DatabaseInterface } from '@happyvertical/sql';
-import { ObjectRegistry } from '../registry';
-import { tableNameFromClass } from '../utils';
+import { ObjectRegistry } from '../registry.js';
+import { tableNameFromClass } from '../utils.js';
 import { SchemaManager } from './schema-manager.js';
 
 /**

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -11,11 +11,11 @@ export {
   type ToolCall,
   type ToolCallResult,
   validateToolCall,
-} from './tool-executor';
+} from './tool-executor.js';
 export {
   type AiConfig,
   convertTypeToJsonSchema,
   generateToolFromMethod,
   generateToolManifest,
   shouldIncludeMethod,
-} from './tool-generator';
+} from './tool-generator.js';

--- a/packages/core/src/tools/tool-generator.ts
+++ b/packages/core/src/tools/tool-generator.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AITool } from '@happyvertical/ai';
-import type { MethodDefinition } from '../scanner/types';
+import type { MethodDefinition } from '../scanner/types.js';
 
 /**
  * Configuration for AI-callable methods

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -81,6 +81,16 @@ async function importScanner() {
   });
 }
 
+async function importBuildAwareModule<T>({
+  source,
+  dist,
+}: {
+  source: string;
+  dist: string;
+}): Promise<T> {
+  return (await import(import.meta.url.endsWith('.ts') ? source : dist)) as T;
+}
+
 export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
   const {
     include = ['src/**/*.ts', 'src/**/*.js'],
@@ -695,7 +705,12 @@ export default testManifest;
       }
 
       // Run all manifest generation passes (same as TypeScript scanner path)
-      const { ManifestGenerator } = await import('../scanner/index.js');
+      const { ManifestGenerator } = await importBuildAwareModule<
+        typeof import('../scanner/index.js')
+      >({
+        source: '../scanner/index.ts',
+        dist: '../scanner.js',
+      });
       const manifestGen = new ManifestGenerator();
       // IMPORTANT: Must merge inherited fields BEFORE generating schemas
       // This ensures STI subclasses inherit tableName from their base class
@@ -762,7 +777,12 @@ async function generateRoutesModule(
   manifest: SmartObjectManifest,
 ): Promise<string> {
   try {
-    const { ManifestGenerator } = await import('../scanner/index.js');
+    const { ManifestGenerator } = await importBuildAwareModule<
+      typeof import('../scanner/index.js')
+    >({
+      source: '../scanner/index.ts',
+      dist: '../scanner.js',
+    });
     const generator = new ManifestGenerator();
     const routes = generator.generateRestEndpoints(manifest);
 
@@ -885,7 +905,12 @@ async function generateMCPModule(
   manifest: SmartObjectManifest,
 ): Promise<string> {
   try {
-    const { ManifestGenerator } = await import('../scanner/index.js');
+    const { ManifestGenerator } = await importBuildAwareModule<
+      typeof import('../scanner/index.js')
+    >({
+      source: '../scanner/index.ts',
+      dist: '../scanner.js',
+    });
     const generator = new ManifestGenerator();
     const tools = generator.generateMCPTools(manifest);
 
@@ -1003,7 +1028,12 @@ async function generateTypesModule(
   try {
     // Only use scanner in server mode to avoid Node.js dependencies in browser builds
     if (mode !== 'client') {
-      const { ManifestGenerator } = await import('../scanner/index.js');
+      const { ManifestGenerator } = await importBuildAwareModule<
+        typeof import('../scanner/index.js')
+      >({
+        source: '../scanner/index.ts',
+        dist: '../scanner.js',
+      });
       const generator = new ManifestGenerator();
       interfaces = generator.generateTypeDefinitions(manifest);
     } else {
@@ -1680,7 +1710,12 @@ async function generateSchemaModule(
   manifest: SmartObjectManifest,
 ): Promise<string> {
   try {
-    const { SchemaGenerator } = await import('../schema/index.js');
+    const { SchemaGenerator } = await importBuildAwareModule<
+      typeof import('../schema/generator.js')
+    >({
+      source: '../schema/generator.ts',
+      dist: '../schema/generator.js',
+    });
 
     const schemaGenerator = new SchemaGenerator();
     const schemas: Record<string, any> = {};


### PR DESCRIPTION
## What changed
- stop exporting the Node-oriented manifest surface from `@happyvertical/smrt-core/browser`
- remove `registry.ts`'s top-level dependency on `manifest-loader`
- move manifest discovery/loading behind lazy runtime helpers so browser consumers can import the registry surface without eagerly touching Node-only code
- keep the Node sync paths working by resolving manifests through on-demand builtin access and cached manifest lookups

## Why
PR #1125 fixed the publish-time source import bug, but it also highlighted that the browser entry was still overstating what was safe to import. `browser.ts` re-exported the manifest surface, and `registry.ts` pulled in manifest-loader at module evaluation time, which meant browser-oriented imports could still drag Node-only runtime behavior into the bundle surface.

This follow-up splits those concerns more cleanly: the browser entry no longer re-exports manifest helpers, and the registry only touches manifest-loader or package scanning when those Node-only paths are actually used.

## Impact
- browser consumers get a more honest `@happyvertical/smrt-core/browser` surface
- package discovery and manifest loading still work in Node and publish/build flows
- the publish-path fix from #1125 stays intact while reducing browser/runtime coupling

## Validation
- `pnpm exec biome check packages/core/src/browser.ts packages/core/src/registry.ts`
- `pnpm --filter @happyvertical/smrt-types build`
- `pnpm --filter @happyvertical/smrt-config build`
- `pnpm --filter @happyvertical/smrt-core typecheck`
- `pnpm --filter @happyvertical/smrt-core build`
- `pnpm --filter @happyvertical/smrt-core exec vitest run src/__tests__/manifest-tree-shaking.test.ts`
- `TEST_INTEGRATION=1 pnpm --filter @happyvertical/smrt-core exec vitest run src/__tests__/manifest-no-leak.test.ts`
