### PR TITLE
feat(assets): public asset runtime + generic serving contract (#1128)

### DIFF
--- a/packages/assets/CLAUDE.md
+++ b/packages/assets/CLAUDE.md
@@ -31,8 +31,11 @@ Agents that need asset I/O should accept an `AssetRuntimeLike` in their options 
 
 ## Serving contract
 
-- `serveAsset({ runtime, asset, tenantId?, disposition?, canAccess?, headers? })` → standard Web `Response`.
-  - `404` when the id/tenant mismatch, `403` when `canAccess` denies, `500` on store read errors, `200` otherwise with `Content-Type`, `Content-Length`, and `Content-Disposition` set.
+- `serveAsset({ runtime, asset, tenantId?, disposition?, canAccess?, headers?, remoteMode? })` → standard Web `Response`.
+  - `404` when the id doesn't resolve; `403` when the tenant mismatches or `canAccess` denies; `302` when `remoteMode: 'redirect'` and the asset's `sourceUri` is `http(s)`; `502` when `remoteMode: 'proxy'` and the origin fetch fails; `500` on store read errors or unexpected failures; `200` otherwise with `Content-Type`, `Content-Length`, and `Content-Disposition` set.
+  - Assets whose `sourceUri` is `http(s)` are supported via `remoteMode`: `'proxy'` (default, fetch and return bytes), `'redirect'` (302 to the origin), or `'error'` (treat as misconfiguration). Pass `fetchImpl` to swap the fetch client.
+  - `Content-Disposition` filenames are sanitised (control characters stripped, `"` / `\` / `/` replaced) to prevent header injection on untrusted asset names.
+  - The 500 body is a generic `'Internal error serving asset'`; the underlying error is logged via `console.error` so operators can debug without leaking paths/bucket names to clients.
   - Works in SvelteKit `+server.ts` endpoints, Hono, and any runtime with a global `Response` (Node 18+). Pass `responseCtor` for older runtimes.
 - `resolveAssetForServing(options)` → `{ asset, data, contentType, filename, size }` when callers want to render their own framework response. Throws `AssetServeError(status)` on the same failure modes.
 

--- a/packages/assets/CLAUDE.md
+++ b/packages/assets/CLAUDE.md
@@ -25,7 +25,7 @@ Apps and agents should depend on the public **asset runtime** rather than hand-w
 - `AssetRuntime.storeSourceAsset(name, data, opts)` — create a new source asset (record + bytes).
 - `AssetRuntime.storeDerivedAsset(source, name, data, opts)` — create a derivative with `parentId` set and (by default) a provenance `AssetAssociation` under a chosen role.
 - `AssetRuntime.linkDerivation(source, derivative, { role })` — record provenance without touching bytes.
-- `AssetRuntime.setExtractionStatus(asset, status, { error?, extractedAt? })` — write canonical extraction metadata into the asset's description JSON sidecar.
+- `AssetRuntime.setExtractionStatus(asset, status, { error?, extractedAt? })` — write canonical extraction metadata into the asset's description JSON sidecar. Non-destructive: if `description` is free-form prose or non-object JSON, the original value is preserved under the reserved `text` key instead of being overwritten. Existing JSON objects are merged into.
 
 Agents that need asset I/O should accept an `AssetRuntimeLike` in their options rather than asking callers to pass a store + collection separately.
 

--- a/packages/assets/CLAUDE.md
+++ b/packages/assets/CLAUDE.md
@@ -17,6 +17,41 @@ Provider-agnostic asset management with versioning, type classification, and gen
 - **AssetStore**: abstraction for provider-agnostic file I/O (S3, local, etc.).
 - **Ownership rule**: base/domain-owned asset relationships should live on noun join tables such as `content_assets`, `profile_assets`, `event_assets`, `place_assets`, and `product_assets`; keep `AssetAssociation` for generic/provenance links like image derivation.
 
+## Runtime surface
+
+Apps and agents should depend on the public **asset runtime** rather than hand-wiring a collection + store per-package (#1128).
+
+- `createAssetRuntime({ db, storage })` → `AssetRuntime` bundling `AssetCollection`, `AssetAssociationCollection`, and an initialized `AssetStore`.
+- `AssetRuntime.storeSourceAsset(name, data, opts)` — create a new source asset (record + bytes).
+- `AssetRuntime.storeDerivedAsset(source, name, data, opts)` — create a derivative with `parentId` set and (by default) a provenance `AssetAssociation` under a chosen role.
+- `AssetRuntime.linkDerivation(source, derivative, { role })` — record provenance without touching bytes.
+- `AssetRuntime.setExtractionStatus(asset, status, { error?, extractedAt? })` — write canonical extraction metadata into the asset's description JSON sidecar.
+
+Agents that need asset I/O should accept an `AssetRuntimeLike` in their options rather than asking callers to pass a store + collection separately.
+
+## Serving contract
+
+- `serveAsset({ runtime, asset, tenantId?, disposition?, canAccess?, headers? })` → standard Web `Response`.
+  - `404` when the id/tenant mismatch, `403` when `canAccess` denies, `500` on store read errors, `200` otherwise with `Content-Type`, `Content-Length`, and `Content-Disposition` set.
+  - Works in SvelteKit `+server.ts` endpoints, Hono, and any runtime with a global `Response` (Node 18+). Pass `responseCtor` for older runtimes.
+- `resolveAssetForServing(options)` → `{ asset, data, contentType, filename, size }` when callers want to render their own framework response. Throws `AssetServeError(status)` on the same failure modes.
+
+## Source/derived vocabulary
+
+The following roles are exported as `ASSET_ROLES` and should be preferred over ad-hoc strings when apps want cross-package tooling (serving, UI pickers) to agree on meaning:
+
+| Role | Use |
+|------|-----|
+| `source_document` | original upstream document (agenda PDF, minutes) |
+| `document_image` | page/extracted image derived from a source document |
+| `thumbnail` | preview rendition of another asset |
+| `proof` | non-canonical evidence asset backing a fact |
+| `derivation_source` | "came from" link on generated media |
+| `attachment` | generic owner-join link |
+| `hero` | primary/featured asset on an owner |
+
+Canonical metadata keys are exported as `ASSET_METADATA_KEYS`: `extractionStatus`, `extractionError`, `extractedAt`, `sourceUrl`, `sourceHash`, `pageNumber`. Extraction status values live in `ASSET_EXTRACTION_STATUS` (`pending | running | succeeded | failed`).
+
 ## Gotchas
 
 - **Version history manual**: `findVersions()` chaining required — no ORM shortcut

--- a/packages/assets/src/__tests__/asset-runtime.test.ts
+++ b/packages/assets/src/__tests__/asset-runtime.test.ts
@@ -280,5 +280,57 @@ describe('AssetRuntime', () => {
       const parsed = JSON.parse(source.description);
       expect(parsed.extractionError).toBe('second');
     });
+
+    it('preserves free-form description prose under the text key', async () => {
+      const runtime = await createAssetRuntime({ db, storage: storageDir });
+      const source = await runtime.storeSourceAsset(
+        'agenda.pdf',
+        Buffer.from('PDF'),
+        {
+          mimeType: 'application/pdf',
+          typeSlug: 'document',
+          description: 'City council agenda, regular session, 2026-04-16',
+        },
+      );
+      expect(source.description).toBe(
+        'City council agenda, regular session, 2026-04-16',
+      );
+
+      await runtime.setExtractionStatus(source, 'running');
+
+      const parsed = JSON.parse(source.description);
+      expect(parsed.extractionStatus).toBe('running');
+      expect(parsed.text).toBe(
+        'City council agenda, regular session, 2026-04-16',
+      );
+
+      // A subsequent update should keep the prose around too.
+      await runtime.setExtractionStatus(source, 'succeeded');
+      const afterSuccess = JSON.parse(source.description);
+      expect(afterSuccess.extractionStatus).toBe('succeeded');
+      expect(afterSuccess.text).toBe(
+        'City council agenda, regular session, 2026-04-16',
+      );
+    });
+
+    it('leaves an existing JSON object description intact apart from extraction keys', async () => {
+      const runtime = await createAssetRuntime({ db, storage: storageDir });
+      const source = await runtime.storeSourceAsset(
+        'agenda.pdf',
+        Buffer.from('PDF'),
+        {
+          mimeType: 'application/pdf',
+          typeSlug: 'document',
+          description: JSON.stringify({ author: 'city-clerk', pageCount: 42 }),
+        },
+      );
+
+      await runtime.setExtractionStatus(source, 'succeeded');
+
+      const parsed = JSON.parse(source.description);
+      expect(parsed.author).toBe('city-clerk');
+      expect(parsed.pageCount).toBe(42);
+      expect(parsed.extractionStatus).toBe('succeeded');
+    });
   });
 });

--- a/packages/assets/src/__tests__/asset-runtime.test.ts
+++ b/packages/assets/src/__tests__/asset-runtime.test.ts
@@ -110,6 +110,35 @@ describe('AssetRuntime', () => {
       expect(links).toHaveLength(1);
       expect(links[0].metaId).toBe(derived.id);
       expect(links[0].role).toBe('document_image');
+      // metaType describes the derivative object (target of metaId),
+      // not the source. Default is 'Asset'.
+      expect(links[0].metaType).toBe('Asset');
+    });
+
+    it('records derivativeMetaType on the association for STI subtypes', async () => {
+      const runtime = await createAssetRuntime({ db, storage: storageDir });
+      const source = await runtime.storeSourceAsset(
+        'agenda.pdf',
+        Buffer.from('PDF'),
+        { mimeType: 'application/pdf', typeSlug: 'document' },
+      );
+
+      const derived = await runtime.storeDerivedAsset(
+        source,
+        'agenda-page-1.png',
+        Buffer.from('PNG'),
+        {
+          mimeType: 'image/png',
+          typeSlug: 'image',
+          role: ASSET_ROLES.DOCUMENT_IMAGE,
+          derivativeMetaType: 'Image',
+        },
+      );
+
+      const links = await runtime.associations.getForAsset(source.id!);
+      expect(links).toHaveLength(1);
+      expect(links[0].metaId).toBe(derived.id);
+      expect(links[0].metaType).toBe('Image');
     });
 
     it('skips the association when linkAssociation is false', async () => {
@@ -166,11 +195,13 @@ describe('AssetRuntime', () => {
 
       const link = await runtime.linkDerivation(source, derivative, {
         role: ASSET_ROLES.DOCUMENT_IMAGE,
+        derivativeMetaType: 'Image',
       });
 
       expect(link.assetId).toBe(source.id);
       expect(link.metaId).toBe(derivative.id);
       expect(link.role).toBe('document_image');
+      expect(link.metaType).toBe('Image');
     });
   });
 
@@ -206,6 +237,48 @@ describe('AssetRuntime', () => {
       expect(parsed.extractionStatus).toBe('failed');
       expect(parsed.extractionError).toBe('pdf parse error');
       expect(parsed.extractedAt).toBeUndefined();
+    });
+
+    it('clears a stale extractionError when transitioning out of failed', async () => {
+      const runtime = await createAssetRuntime({ db, storage: storageDir });
+      const source = await runtime.storeSourceAsset(
+        'agenda.pdf',
+        Buffer.from('PDF'),
+        { mimeType: 'application/pdf', typeSlug: 'document' },
+      );
+
+      await runtime.setExtractionStatus(source, 'failed', {
+        error: 'pdf parse error',
+      });
+      expect(JSON.parse(source.description).extractionError).toBe(
+        'pdf parse error',
+      );
+
+      await runtime.setExtractionStatus(source, 'running');
+      const afterRetry = JSON.parse(source.description);
+      expect(afterRetry.extractionStatus).toBe('running');
+      expect(afterRetry.extractionError).toBeUndefined();
+
+      await runtime.setExtractionStatus(source, 'succeeded');
+      const afterSuccess = JSON.parse(source.description);
+      expect(afterSuccess.extractionStatus).toBe('succeeded');
+      expect(afterSuccess.extractionError).toBeUndefined();
+      expect(typeof afterSuccess.extractedAt).toBe('string');
+    });
+
+    it('preserves a caller-provided error on repeated failures', async () => {
+      const runtime = await createAssetRuntime({ db, storage: storageDir });
+      const source = await runtime.storeSourceAsset(
+        'agenda.pdf',
+        Buffer.from('PDF'),
+        { mimeType: 'application/pdf', typeSlug: 'document' },
+      );
+
+      await runtime.setExtractionStatus(source, 'failed', { error: 'first' });
+      await runtime.setExtractionStatus(source, 'failed', { error: 'second' });
+
+      const parsed = JSON.parse(source.description);
+      expect(parsed.extractionError).toBe('second');
     });
   });
 });

--- a/packages/assets/src/__tests__/asset-runtime.test.ts
+++ b/packages/assets/src/__tests__/asset-runtime.test.ts
@@ -1,0 +1,211 @@
+/**
+ * AssetRuntime tests
+ *
+ * Covers the public runtime surface: factory wiring, source/derived
+ * creation, provenance linking, and the extraction-status helper.
+ */
+
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join as pathJoin } from 'node:path';
+import { getTestDatabase } from '@happyvertical/smrt-core/testing';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Asset } from '../asset';
+import { AssetAssociationCollection } from '../asset-associations';
+import { ASSET_ROLES } from '../asset-conventions';
+import { AssetRuntime, createAssetRuntime } from '../asset-runtime';
+import { AssetCollection } from '../assets';
+
+describe('AssetRuntime', () => {
+  let db: DatabaseInterface;
+  let storageDir: string;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    storageDir = mkdtempSync(pathJoin(tmpdir(), 'asset-runtime-'));
+  });
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') {
+      await db.close();
+    }
+    if (storageDir && existsSync(storageDir)) {
+      rmSync(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('createAssetRuntime()', () => {
+    it('wires collection, associations, and an initialized store from a single config', async () => {
+      const runtime = await createAssetRuntime({
+        db,
+        storage: storageDir,
+      });
+
+      expect(runtime).toBeInstanceOf(AssetRuntime);
+      expect(runtime.collection).toBeInstanceOf(AssetCollection);
+      expect(runtime.associations).toBeInstanceOf(AssetAssociationCollection);
+      expect(runtime.store.basePath).toBe(storageDir);
+    });
+
+    it('reuses pre-built collections when provided', async () => {
+      const collection = await AssetCollection.create({ db });
+      const associations = await AssetAssociationCollection.create({ db });
+
+      const runtime = await createAssetRuntime({
+        db,
+        storage: storageDir,
+        collection,
+        associations,
+      });
+
+      expect(runtime.collection).toBe(collection);
+      expect(runtime.associations).toBe(associations);
+    });
+  });
+
+  describe('storeSourceAsset', () => {
+    it('creates a persisted asset with bytes on disk', async () => {
+      const runtime = await createAssetRuntime({ db, storage: storageDir });
+      const bytes = Buffer.from('hello world');
+
+      const asset = await runtime.storeSourceAsset('notes.txt', bytes, {
+        mimeType: 'text/plain',
+        typeSlug: 'document',
+      });
+
+      expect(asset.id).toBeTruthy();
+      expect(asset.sourceUri).toMatch(/^file:\/\//);
+      expect(asset.mimeType).toBe('text/plain');
+
+      const reloaded = await runtime.store.readById(asset.id!);
+      expect(reloaded?.data.toString()).toBe('hello world');
+    });
+  });
+
+  describe('storeDerivedAsset', () => {
+    it('persists a derivative with parentId + provenance association by default', async () => {
+      const runtime = await createAssetRuntime({ db, storage: storageDir });
+
+      const source = await runtime.storeSourceAsset(
+        'agenda.pdf',
+        Buffer.from('PDF BYTES'),
+        { mimeType: 'application/pdf', typeSlug: 'document' },
+      );
+
+      const derived = await runtime.storeDerivedAsset(
+        source,
+        'agenda-page-1.png',
+        Buffer.from('PNG BYTES'),
+        {
+          mimeType: 'image/png',
+          typeSlug: 'image',
+          role: ASSET_ROLES.DOCUMENT_IMAGE,
+        },
+      );
+
+      expect(derived.parentId).toBe(source.id);
+
+      const links = await runtime.associations.getForAsset(source.id!);
+      expect(links).toHaveLength(1);
+      expect(links[0].metaId).toBe(derived.id);
+      expect(links[0].role).toBe('document_image');
+    });
+
+    it('skips the association when linkAssociation is false', async () => {
+      const runtime = await createAssetRuntime({ db, storage: storageDir });
+      const source = await runtime.storeSourceAsset(
+        'agenda.pdf',
+        Buffer.from('PDF'),
+        { mimeType: 'application/pdf', typeSlug: 'document' },
+      );
+
+      const derived = await runtime.storeDerivedAsset(
+        source,
+        'thumb.png',
+        Buffer.from('PNG'),
+        {
+          mimeType: 'image/png',
+          typeSlug: 'image',
+          linkAssociation: false,
+        },
+      );
+
+      expect(derived.parentId).toBe(source.id);
+      const links = await runtime.associations.getForAsset(source.id!);
+      expect(links).toHaveLength(0);
+    });
+
+    it('rejects derivation from an unpersisted source', async () => {
+      const runtime = await createAssetRuntime({ db, storage: storageDir });
+      const ghost = new Asset({ name: 'ghost' });
+
+      await expect(
+        runtime.storeDerivedAsset(ghost, 'x.png', Buffer.from('x'), {
+          mimeType: 'image/png',
+          typeSlug: 'image',
+        }),
+      ).rejects.toThrow(/missing id/);
+    });
+  });
+
+  describe('linkDerivation', () => {
+    it('records an association between existing source + derivative', async () => {
+      const runtime = await createAssetRuntime({ db, storage: storageDir });
+
+      const source = await runtime.storeSourceAsset(
+        'agenda.pdf',
+        Buffer.from('PDF'),
+        { mimeType: 'application/pdf', typeSlug: 'document' },
+      );
+      const derivative = await runtime.storeSourceAsset(
+        'manual-extract.png',
+        Buffer.from('PNG'),
+        { mimeType: 'image/png', typeSlug: 'image' },
+      );
+
+      const link = await runtime.linkDerivation(source, derivative, {
+        role: ASSET_ROLES.DOCUMENT_IMAGE,
+      });
+
+      expect(link.assetId).toBe(source.id);
+      expect(link.metaId).toBe(derivative.id);
+      expect(link.role).toBe('document_image');
+    });
+  });
+
+  describe('setExtractionStatus', () => {
+    it('writes extraction metadata into the asset description sidecar', async () => {
+      const runtime = await createAssetRuntime({ db, storage: storageDir });
+      const source = await runtime.storeSourceAsset(
+        'agenda.pdf',
+        Buffer.from('PDF'),
+        { mimeType: 'application/pdf', typeSlug: 'document' },
+      );
+
+      await runtime.setExtractionStatus(source, 'succeeded');
+
+      const parsed = JSON.parse(source.description);
+      expect(parsed.extractionStatus).toBe('succeeded');
+      expect(typeof parsed.extractedAt).toBe('string');
+    });
+
+    it('records an error when status is failed', async () => {
+      const runtime = await createAssetRuntime({ db, storage: storageDir });
+      const source = await runtime.storeSourceAsset(
+        'agenda.pdf',
+        Buffer.from('PDF'),
+        { mimeType: 'application/pdf', typeSlug: 'document' },
+      );
+
+      await runtime.setExtractionStatus(source, 'failed', {
+        error: 'pdf parse error',
+      });
+
+      const parsed = JSON.parse(source.description);
+      expect(parsed.extractionStatus).toBe('failed');
+      expect(parsed.extractionError).toBe('pdf parse error');
+      expect(parsed.extractedAt).toBeUndefined();
+    });
+  });
+});

--- a/packages/assets/src/__tests__/asset-serving.test.ts
+++ b/packages/assets/src/__tests__/asset-serving.test.ts
@@ -1,0 +1,175 @@
+/**
+ * asset-serving tests
+ *
+ * Exercises the generic serving contract end-to-end with an in-memory
+ * SQLite DB and a real temp-directory asset store.
+ */
+
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join as pathJoin } from 'node:path';
+import { getTestDatabase } from '@happyvertical/smrt-core/testing';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { type AssetRuntime, createAssetRuntime } from '../asset-runtime';
+import {
+  AssetServeError,
+  resolveAssetForServing,
+  serveAsset,
+} from '../asset-serving';
+
+describe('serveAsset', () => {
+  let db: DatabaseInterface;
+  let storageDir: string;
+  let runtime: AssetRuntime;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    storageDir = mkdtempSync(pathJoin(tmpdir(), 'asset-serving-'));
+    runtime = await createAssetRuntime({ db, storage: storageDir });
+  });
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') {
+      await db.close();
+    }
+    if (storageDir && existsSync(storageDir)) {
+      rmSync(storageDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns 200 with bytes, content-type, and content-disposition', async () => {
+    const asset = await runtime.storeSourceAsset(
+      'hello.txt',
+      Buffer.from('hello'),
+      { mimeType: 'text/plain', typeSlug: 'document' },
+    );
+
+    const response = await serveAsset({ runtime, asset: asset.id! });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('text/plain');
+    expect(response.headers.get('content-length')).toBe('5');
+    const disposition = response.headers.get('content-disposition') ?? '';
+    expect(disposition.startsWith('inline;')).toBe(true);
+    expect(disposition).toContain('hello.txt');
+
+    const body = Buffer.from(await response.arrayBuffer());
+    expect(body.toString()).toBe('hello');
+  });
+
+  it('uses attachment disposition when requested', async () => {
+    const asset = await runtime.storeSourceAsset(
+      'report.pdf',
+      Buffer.from('PDF'),
+      { mimeType: 'application/pdf', typeSlug: 'document' },
+    );
+
+    const response = await serveAsset({
+      runtime,
+      asset,
+      disposition: 'attachment',
+    });
+
+    expect(response.headers.get('content-disposition')).toMatch(/^attachment;/);
+  });
+
+  it('returns 404 when the asset id does not resolve', async () => {
+    const response = await serveAsset({ runtime, asset: 'missing-id' });
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 403 when tenantId mismatches', async () => {
+    const asset = await runtime.storeSourceAsset(
+      'secret.txt',
+      Buffer.from('secret'),
+      { mimeType: 'text/plain', typeSlug: 'document' },
+    );
+    asset.tenantId = 'tenant-a';
+    await asset.save();
+
+    const response = await serveAsset({
+      runtime,
+      asset: asset.id!,
+      tenantId: 'tenant-b',
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('allows global (tenantId=null) assets through a tenant check', async () => {
+    const asset = await runtime.storeSourceAsset(
+      'public.txt',
+      Buffer.from('pub'),
+      { mimeType: 'text/plain', typeSlug: 'document' },
+    );
+
+    const response = await serveAsset({
+      runtime,
+      asset: asset.id!,
+      tenantId: 'tenant-a',
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it('runs the custom canAccess hook after tenant checks', async () => {
+    const asset = await runtime.storeSourceAsset(
+      'guarded.txt',
+      Buffer.from('x'),
+      { mimeType: 'text/plain', typeSlug: 'document' },
+    );
+
+    const response = await serveAsset({
+      runtime,
+      asset: asset.id!,
+      canAccess: () => false,
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  describe('resolveAssetForServing', () => {
+    it('throws AssetServeError(404) for unknown ids', async () => {
+      await expect(
+        resolveAssetForServing({ runtime, asset: 'nope' }),
+      ).rejects.toMatchObject({
+        name: 'AssetServeError',
+        status: 404,
+      });
+    });
+
+    it('returns bytes + metadata for authorised callers', async () => {
+      const asset = await runtime.storeSourceAsset(
+        'ok.txt',
+        Buffer.from('ok'),
+        { mimeType: 'text/plain', typeSlug: 'document' },
+      );
+
+      const resolved = await resolveAssetForServing({
+        runtime,
+        asset: asset.id!,
+      });
+
+      expect(resolved.asset.id).toBe(asset.id);
+      expect(resolved.data.toString()).toBe('ok');
+      expect(resolved.contentType).toBe('text/plain');
+      expect(resolved.size).toBe(2);
+    });
+
+    it('surfaces 500 errors from the store as AssetServeError', async () => {
+      const asset = await runtime.storeSourceAsset(
+        'broken.txt',
+        Buffer.from('bytes'),
+        { mimeType: 'text/plain', typeSlug: 'document' },
+      );
+      // Force the store to fail by pointing at a missing file
+      asset.sourceUri = 'file:///definitely/not/real/path.txt';
+      await asset.save();
+
+      await expect(
+        resolveAssetForServing({ runtime, asset: asset.id! }),
+      ).rejects.toBeInstanceOf(AssetServeError);
+    });
+  });
+});

--- a/packages/assets/src/__tests__/asset-serving.test.ts
+++ b/packages/assets/src/__tests__/asset-serving.test.ts
@@ -129,6 +129,159 @@ describe('serveAsset', () => {
     expect(response.status).toBe(403);
   });
 
+  it('does not leak underlying error details in the 500 body', async () => {
+    const asset = await runtime.storeSourceAsset(
+      'broken.txt',
+      Buffer.from('bytes'),
+      { mimeType: 'text/plain', typeSlug: 'document' },
+    );
+    asset.sourceUri = 'file:///definitely/not/real/absolute-path.txt';
+    await asset.save();
+
+    const response = await serveAsset({ runtime, asset: asset.id! });
+
+    expect(response.status).toBe(500);
+    const body = await response.text();
+    expect(body).toBe('Failed to read asset bytes');
+    expect(body).not.toContain('absolute-path');
+  });
+
+  it('sanitises control characters out of Content-Disposition', async () => {
+    const asset = await runtime.storeSourceAsset(
+      'bad\r\nname.txt',
+      Buffer.from('x'),
+      { mimeType: 'text/plain', typeSlug: 'document' },
+    );
+
+    const response = await serveAsset({ runtime, asset: asset.id! });
+
+    expect(response.status).toBe(200);
+    const disposition = response.headers.get('content-disposition') ?? '';
+    // The critical property: no raw control characters (prevents
+    // CRLF header injection and Response-constructor errors).
+    const hasControl = [...disposition].some((ch) => {
+      const code = ch.charCodeAt(0);
+      return code <= 0x1f || code === 0x7f;
+    });
+    expect(hasControl).toBe(false);
+    // The trailing text and extension should survive sanitisation.
+    expect(disposition).toContain('badname.txt');
+  });
+
+  it('replaces quotes and path separators in filename', async () => {
+    const asset = await runtime.storeSourceAsset(
+      'normal.txt',
+      Buffer.from('x'),
+      { mimeType: 'text/plain', typeSlug: 'document' },
+    );
+
+    const response = await serveAsset({
+      runtime,
+      asset: asset.id!,
+      filename: 'a"weird\\/name.txt',
+    });
+
+    expect(response.status).toBe(200);
+    const disposition = response.headers.get('content-disposition') ?? '';
+    expect(disposition).toContain('filename="a_weird__name.txt"');
+    expect(disposition).not.toMatch(/filename="[^"]*["\\/][^"]*"/);
+  });
+
+  describe('remote sourceUri handling', () => {
+    it('proxies bytes from an http(s) origin by default', async () => {
+      const asset = await runtime.storeSourceAsset(
+        'manifest.json',
+        Buffer.from('ignored local'),
+        { mimeType: 'application/json', typeSlug: 'document' },
+      );
+      asset.sourceUri = 'https://example.com/docs/manifest.json';
+      await asset.save();
+
+      const calls: string[] = [];
+      const fetchImpl: typeof fetch = async (input) => {
+        calls.push(String(input));
+        return new Response(
+          Buffer.from('REMOTE BYTES') as unknown as BodyInit,
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        );
+      };
+
+      const response = await serveAsset({
+        runtime,
+        asset: asset.id!,
+        fetchImpl,
+      });
+
+      expect(calls).toEqual(['https://example.com/docs/manifest.json']);
+      expect(response.status).toBe(200);
+      const body = Buffer.from(await response.arrayBuffer());
+      expect(body.toString()).toBe('REMOTE BYTES');
+    });
+
+    it('returns 302 Location when remoteMode is redirect', async () => {
+      const asset = await runtime.storeSourceAsset(
+        'doc.pdf',
+        Buffer.from('ignored'),
+        { mimeType: 'application/pdf', typeSlug: 'document' },
+      );
+      asset.sourceUri = 'https://example.com/agenda.pdf';
+      await asset.save();
+
+      const response = await serveAsset({
+        runtime,
+        asset: asset.id!,
+        remoteMode: 'redirect',
+      });
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get('location')).toBe(
+        'https://example.com/agenda.pdf',
+      );
+    });
+
+    it('returns 502 when the proxied fetch fails', async () => {
+      const asset = await runtime.storeSourceAsset(
+        'bad.json',
+        Buffer.from('ignored'),
+        { mimeType: 'application/json', typeSlug: 'document' },
+      );
+      asset.sourceUri = 'https://example.com/missing.json';
+      await asset.save();
+
+      const fetchImpl: typeof fetch = async () =>
+        new Response('', { status: 404 });
+
+      const response = await serveAsset({
+        runtime,
+        asset: asset.id!,
+        fetchImpl,
+      });
+
+      expect(response.status).toBe(502);
+    });
+
+    it('treats remote URIs as errors when remoteMode is error', async () => {
+      const asset = await runtime.storeSourceAsset(
+        'whatever.bin',
+        Buffer.from('ignored'),
+        { mimeType: 'application/octet-stream', typeSlug: 'document' },
+      );
+      asset.sourceUri = 'https://example.com/thing.bin';
+      await asset.save();
+
+      const response = await serveAsset({
+        runtime,
+        asset: asset.id!,
+        remoteMode: 'error',
+      });
+
+      expect(response.status).toBe(500);
+    });
+  });
+
   describe('resolveAssetForServing', () => {
     it('throws AssetServeError(404) for unknown ids', async () => {
       await expect(

--- a/packages/assets/src/asset-conventions.ts
+++ b/packages/assets/src/asset-conventions.ts
@@ -1,0 +1,81 @@
+/**
+ * Asset conventions
+ *
+ * Shared constants and metadata-key conventions for how apps and agents
+ * describe asset relationships and derivation state on top of `smrt-assets`.
+ *
+ * These are advisory: `AssetAssociation.role` and `Asset` metadata fields
+ * accept any string, but standardising on these values makes cross-agent
+ * serving, filtering, and UI work possible without everybody inventing
+ * their own vocabulary.
+ */
+
+/**
+ * Canonical association roles used with `AssetAssociation` and noun join
+ * tables like `content_assets`.
+ *
+ * - `source_document`: original upstream document (e.g. agenda PDF) that
+ *   later derivatives are extracted from.
+ * - `document_image`: page image or other visual derived from a source
+ *   document.
+ * - `thumbnail`: small preview rendition of another asset.
+ * - `proof`: non-canonical evidence asset (e.g. a screenshot used to
+ *   back a fact).
+ * - `derivation_source`: source side of a derivation link (used when a
+ *   derivative points back to the asset it was produced from).
+ * - `attachment`: generic "this asset belongs to that object" link —
+ *   the default for noun join tables.
+ * - `hero`: primary/featured asset for an owner.
+ */
+export const ASSET_ROLES = {
+  SOURCE_DOCUMENT: 'source_document',
+  DOCUMENT_IMAGE: 'document_image',
+  THUMBNAIL: 'thumbnail',
+  PROOF: 'proof',
+  DERIVATION_SOURCE: 'derivation_source',
+  ATTACHMENT: 'attachment',
+  HERO: 'hero',
+} as const;
+
+export type AssetRole = (typeof ASSET_ROLES)[keyof typeof ASSET_ROLES];
+
+/**
+ * Canonical metadata keys used on `Asset.description`-adjacent metadata
+ * surfaces or stored via `AssetAssociation` sidecars. These keys are the
+ * recommended names for cross-package extraction, provenance, and
+ * content-addressing state.
+ *
+ * Apps are free to add their own keys; using these for the common cases
+ * keeps derived-asset tooling portable.
+ *
+ * - `extractionStatus`: `'pending' | 'running' | 'succeeded' | 'failed'`
+ * - `extractionError`: error string from the last extraction attempt
+ * - `extractedAt`: ISO timestamp of the last successful extraction
+ * - `sourceUrl`: upstream URL the asset was fetched from
+ * - `sourceHash`: content-address hash of the source bytes (e.g. sha256)
+ * - `pageNumber`: 1-based page number within a multi-page source document
+ */
+export const ASSET_METADATA_KEYS = {
+  EXTRACTION_STATUS: 'extractionStatus',
+  EXTRACTION_ERROR: 'extractionError',
+  EXTRACTED_AT: 'extractedAt',
+  SOURCE_URL: 'sourceUrl',
+  SOURCE_HASH: 'sourceHash',
+  PAGE_NUMBER: 'pageNumber',
+} as const;
+
+export type AssetMetadataKey =
+  (typeof ASSET_METADATA_KEYS)[keyof typeof ASSET_METADATA_KEYS];
+
+/**
+ * Known extraction status values for `ASSET_METADATA_KEYS.EXTRACTION_STATUS`.
+ */
+export const ASSET_EXTRACTION_STATUS = {
+  PENDING: 'pending',
+  RUNNING: 'running',
+  SUCCEEDED: 'succeeded',
+  FAILED: 'failed',
+} as const;
+
+export type AssetExtractionStatus =
+  (typeof ASSET_EXTRACTION_STATUS)[keyof typeof ASSET_EXTRACTION_STATUS];

--- a/packages/assets/src/asset-runtime.ts
+++ b/packages/assets/src/asset-runtime.ts
@@ -97,20 +97,25 @@ export interface StoreDerivedAssetOptions
 
   /**
    * If true (default), also create an `AssetAssociation` record with
-   * `assetId=source.id`, `metaType=<sourceMetaType>`, `metaId=<newId>`,
-   * `role=<role>` so the provenance link is queryable independent of
-   * `parentId`.
+   * `assetId=source.id`, `metaType=<derivativeMetaType>`,
+   * `metaId=<newAssetId>`, `role=<role>` so the provenance link is
+   * queryable independent of `parentId`.
    *
    * Set to `false` if you only want the hierarchical `parentId` link.
    */
   linkAssociation?: boolean;
 
   /**
-   * `metaType` string to use when creating the association. Defaults to
-   * `'Asset'`. Callers with STI subclasses (e.g. `Image`) should pass
-   * the subclass name here.
+   * `metaType` string stored on the `AssetAssociation`. This describes
+   * the *derivative* object (the target of `metaId`), not the source.
+   *
+   * Defaults to `'Asset'`. Callers whose derivatives are STI subclasses
+   * — e.g. an `Image` produced from a PDF — should pass the subclass
+   * name here so consumers can distinguish subtype derivatives from
+   * plain assets. This matches the convention used by
+   * `smrt-images`' `ImageDeriver.deriveWithAssociations()`.
    */
-  sourceMetaType?: string;
+  derivativeMetaType?: string;
 }
 
 /**
@@ -118,7 +123,11 @@ export interface StoreDerivedAssetOptions
  */
 export interface LinkDerivationOptions {
   role?: AssetRole | string;
-  sourceMetaType?: string;
+  /**
+   * `metaType` describing the derivative object (target of `metaId`).
+   * See `StoreDerivedAssetOptions.derivativeMetaType`.
+   */
+  derivativeMetaType?: string;
 }
 
 /**
@@ -171,7 +180,7 @@ export class AssetRuntime implements AssetRuntimeLike {
     const {
       role: rawRole,
       linkAssociation = true,
-      sourceMetaType = 'Asset',
+      derivativeMetaType = 'Asset',
       ...storeOpts
     } = opts;
     const role = rawRole ?? ASSET_ROLES.DERIVATION_SOURCE;
@@ -184,7 +193,7 @@ export class AssetRuntime implements AssetRuntimeLike {
     if (linkAssociation && derived.id) {
       await this.associations.associate(
         source.id,
-        sourceMetaType,
+        derivativeMetaType,
         derived.id,
         role,
       );
@@ -208,10 +217,10 @@ export class AssetRuntime implements AssetRuntimeLike {
       );
     }
     const role = opts.role ?? ASSET_ROLES.DERIVATION_SOURCE;
-    const sourceMetaType = opts.sourceMetaType ?? 'Asset';
+    const derivativeMetaType = opts.derivativeMetaType ?? 'Asset';
     return this.associations.associate(
       source.id,
-      sourceMetaType,
+      derivativeMetaType,
       derivative.id,
       role,
     );
@@ -222,6 +231,20 @@ export class AssetRuntime implements AssetRuntimeLike {
    * `description` JSON sidecar. This is a thin convenience over the
    * convention in `asset-conventions.ts` — callers that store
    * metadata elsewhere can ignore it.
+   *
+   * **Important**: this helper treats `asset.description` as a JSON
+   * object sidecar. If the description is free-form text (or any
+   * non-object JSON), the previous value is discarded and replaced
+   * with a fresh JSON object. Callers that need to keep human-readable
+   * prose on `description` should stash it into a reserved key first
+   * (e.g. `{ text: "...", extractionStatus: "..." }`) or store
+   * extraction state on a different surface.
+   *
+   * Error handling: when `status` transitions away from `failed`
+   * without a new `extra.error`, the stale `extractionError` is
+   * cleared so downstream consumers don't misread the current state.
+   * When `status === 'succeeded'`, `extractedAt` is stamped to now
+   * unless the caller provides one.
    */
   async setExtractionStatus(
     asset: Asset,
@@ -235,6 +258,10 @@ export class AssetRuntime implements AssetRuntimeLike {
     };
     if (extra.error !== undefined) {
       next.extractionError = extra.error;
+    } else if (status !== 'failed') {
+      // Transitioning out of a prior failure — drop the stale error
+      // so consumers don't misread it as still-failing.
+      delete next.extractionError;
     }
     if (status === 'succeeded') {
       next.extractedAt = (extra.extractedAt ?? new Date()).toISOString();

--- a/packages/assets/src/asset-runtime.ts
+++ b/packages/assets/src/asset-runtime.ts
@@ -232,13 +232,18 @@ export class AssetRuntime implements AssetRuntimeLike {
    * convention in `asset-conventions.ts` — callers that store
    * metadata elsewhere can ignore it.
    *
-   * **Important**: this helper treats `asset.description` as a JSON
-   * object sidecar. If the description is free-form text (or any
-   * non-object JSON), the previous value is discarded and replaced
-   * with a fresh JSON object. Callers that need to keep human-readable
-   * prose on `description` should stash it into a reserved key first
-   * (e.g. `{ text: "...", extractionStatus: "..." }`) or store
-   * extraction state on a different surface.
+   * **How existing descriptions are handled**:
+   * - Empty / unset → fresh JSON object.
+   * - Valid JSON object → merged into; existing keys preserved.
+   * - Free-form prose or non-object JSON → preserved under the
+   *   reserved `text` key of the resulting object (e.g.
+   *   `{ text: "original prose", extractionStatus: "..." }`). No prose
+   *   is discarded.
+   *
+   * Callers that already use `text` for something else, or that need
+   * an entirely separate metadata surface, should either round-trip
+   * the JSON themselves or skip this helper — its only job is the
+   * `extractionStatus` / `extractionError` / `extractedAt` triple.
    *
    * Error handling: when `status` transitions away from `failed`
    * without a new `extra.error`, the stale `extractionError` is
@@ -251,7 +256,7 @@ export class AssetRuntime implements AssetRuntimeLike {
     status: AssetExtractionStatus,
     extra: { error?: string; extractedAt?: Date } = {},
   ): Promise<void> {
-    const existing = safeParseMetadata(asset.description);
+    const existing = parseDescriptionSidecar(asset.description);
     const next: Record<string, unknown> = {
       ...existing,
       extractionStatus: status,
@@ -308,14 +313,25 @@ export async function createAssetRuntime(
   return new AssetRuntime(collection, associations, store);
 }
 
-function safeParseMetadata(description: string): Record<string, unknown> {
+/**
+ * Parse the `description` field as a JSON sidecar object used by
+ * `setExtractionStatus()`. Free-form prose and non-object JSON values
+ * are preserved under the reserved `text` key so the helper is
+ * non-destructive on assets whose descriptions were authored as
+ * human-readable text.
+ */
+function parseDescriptionSidecar(description: string): Record<string, unknown> {
   if (!description) return {};
   try {
     const parsed = JSON.parse(description);
-    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : {};
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    // Non-object JSON (number, string, array, null) — treat the whole
+    // value as prose-equivalent and stash it under `text`.
+    return { text: description };
   } catch {
-    return {};
+    // Not JSON — preserve the original prose under `text`.
+    return { text: description };
   }
 }

--- a/packages/assets/src/asset-runtime.ts
+++ b/packages/assets/src/asset-runtime.ts
@@ -1,0 +1,294 @@
+/**
+ * AssetRuntime - shared asset runtime surface
+ *
+ * Bundles the pieces an app or agent needs to work with `smrt-assets`
+ * consistently:
+ *
+ *  - `AssetCollection` for records
+ *  - `AssetAssociationCollection` for generic/provenance links
+ *  - `AssetStore` for provider-agnostic byte storage
+ *  - a single `ProviderOptions` that wires storage in one place
+ *
+ * Agents that want to accept a shared asset runtime should take an
+ * `AssetRuntime` (or `AssetRuntimeLike`) in their options, rather than
+ * asking callers to hand-wire a collection + store.
+ */
+
+import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+import type { Asset } from './asset';
+import type { AssetAssociation } from './asset-association';
+import { AssetAssociationCollection } from './asset-associations';
+import {
+  ASSET_ROLES,
+  type AssetExtractionStatus,
+  type AssetRole,
+} from './asset-conventions';
+import {
+  AssetStore,
+  type ProviderOptions,
+  type StoreOptions,
+} from './asset-store';
+import { AssetCollection } from './assets';
+
+/**
+ * DB configuration accepted by the runtime — mirrors the shape
+ * `SmrtCollection.create({ db })` already accepts.
+ */
+export type AssetRuntimeDb = NonNullable<SmrtClassOptions['db']>;
+
+/**
+ * Options for constructing an `AssetRuntime` via `createAssetRuntime()`.
+ */
+export interface AssetRuntimeOptions {
+  /**
+   * Database used for `AssetCollection` and `AssetAssociationCollection`.
+   *
+   * Accepts anything `SmrtCollection.create({ db })` accepts — a string
+   * URL, a config object, or a live `DatabaseInterface`.
+   */
+  db: AssetRuntimeDb;
+
+  /**
+   * Storage provider for `AssetStore`.
+   *
+   * A string is treated as a local filesystem `basePath`; otherwise
+   * forwarded to `@happyvertical/files`.
+   */
+  storage: ProviderOptions;
+
+  /**
+   * Optional collection instance. If omitted, one is created from `db`.
+   * Useful in tests or when the caller already has a configured
+   * collection (e.g. from `ObjectRegistry`).
+   */
+  collection?: AssetCollection;
+
+  /**
+   * Optional associations collection. If omitted, one is created from `db`.
+   */
+  associations?: AssetAssociationCollection;
+}
+
+/**
+ * Structural shape of the runtime. Agents and serving helpers should
+ * depend on `AssetRuntimeLike` rather than the concrete class so tests
+ * can pass in a minimal object.
+ */
+export interface AssetRuntimeLike {
+  readonly collection: AssetCollection;
+  readonly associations: AssetAssociationCollection;
+  readonly store: AssetStore;
+}
+
+/**
+ * Options for `AssetRuntime.storeDerivedAsset()`.
+ */
+export interface StoreDerivedAssetOptions
+  extends Omit<StoreOptions, 'parentId'> {
+  /**
+   * Relationship role for the derivation link.
+   *
+   * Defaults to `ASSET_ROLES.DERIVATION_SOURCE` when `linkAssociation`
+   * is true (the default). Set explicitly for roles like
+   * `document_image` or `thumbnail` when a derivative has a more
+   * specific semantic than "came from".
+   */
+  role?: AssetRole | string;
+
+  /**
+   * If true (default), also create an `AssetAssociation` record with
+   * `assetId=source.id`, `metaType=<sourceMetaType>`, `metaId=<newId>`,
+   * `role=<role>` so the provenance link is queryable independent of
+   * `parentId`.
+   *
+   * Set to `false` if you only want the hierarchical `parentId` link.
+   */
+  linkAssociation?: boolean;
+
+  /**
+   * `metaType` string to use when creating the association. Defaults to
+   * `'Asset'`. Callers with STI subclasses (e.g. `Image`) should pass
+   * the subclass name here.
+   */
+  sourceMetaType?: string;
+}
+
+/**
+ * Options for `AssetRuntime.linkDerivation()`.
+ */
+export interface LinkDerivationOptions {
+  role?: AssetRole | string;
+  sourceMetaType?: string;
+}
+
+/**
+ * Convenience runtime for `smrt-assets` callers. See the package
+ * `CLAUDE.md` for the full "source vs derived" vocabulary.
+ */
+export class AssetRuntime implements AssetRuntimeLike {
+  constructor(
+    public readonly collection: AssetCollection,
+    public readonly associations: AssetAssociationCollection,
+    public readonly store: AssetStore,
+  ) {}
+
+  /**
+   * Create a new source asset with both a record and bytes on disk.
+   *
+   * This is the same as `AssetStore.store()`, but exposed on the runtime
+   * so callers only need one handle.
+   */
+  storeSourceAsset(
+    name: string,
+    data: Buffer,
+    opts: StoreOptions,
+  ): Promise<Asset> {
+    return this.store.store(name, data, opts);
+  }
+
+  /**
+   * Create a derivative of `source`, persist its bytes, and optionally
+   * record a provenance association.
+   *
+   * The new asset's `parentId` always points at `source.id`. When
+   * `linkAssociation` is true (the default), the runtime also writes
+   * an `AssetAssociation` so queries by role (e.g. "all `document_image`
+   * derivatives for this `source_document`") work without scanning
+   * `parent_id` chains.
+   */
+  async storeDerivedAsset(
+    source: Asset,
+    name: string,
+    data: Buffer,
+    opts: StoreDerivedAssetOptions,
+  ): Promise<Asset> {
+    if (!source.id) {
+      throw new Error(
+        'storeDerivedAsset: source asset must be persisted (missing id)',
+      );
+    }
+
+    const {
+      role: rawRole,
+      linkAssociation = true,
+      sourceMetaType = 'Asset',
+      ...storeOpts
+    } = opts;
+    const role = rawRole ?? ASSET_ROLES.DERIVATION_SOURCE;
+
+    const derived = await this.store.store(name, data, {
+      ...storeOpts,
+      parentId: source.id,
+    });
+
+    if (linkAssociation && derived.id) {
+      await this.associations.associate(
+        source.id,
+        sourceMetaType,
+        derived.id,
+        role,
+      );
+    }
+
+    return derived;
+  }
+
+  /**
+   * Record a provenance association between an existing source asset
+   * and an existing derivative asset without touching bytes.
+   */
+  async linkDerivation(
+    source: Asset,
+    derivative: Asset,
+    opts: LinkDerivationOptions = {},
+  ): Promise<AssetAssociation> {
+    if (!source.id || !derivative.id) {
+      throw new Error(
+        'linkDerivation: both source and derivative must be persisted (missing id)',
+      );
+    }
+    const role = opts.role ?? ASSET_ROLES.DERIVATION_SOURCE;
+    const sourceMetaType = opts.sourceMetaType ?? 'Asset';
+    return this.associations.associate(
+      source.id,
+      sourceMetaType,
+      derivative.id,
+      role,
+    );
+  }
+
+  /**
+   * Update the standard extraction-status metadata on an asset's
+   * `description` JSON sidecar. This is a thin convenience over the
+   * convention in `asset-conventions.ts` — callers that store
+   * metadata elsewhere can ignore it.
+   */
+  async setExtractionStatus(
+    asset: Asset,
+    status: AssetExtractionStatus,
+    extra: { error?: string; extractedAt?: Date } = {},
+  ): Promise<void> {
+    const existing = safeParseMetadata(asset.description);
+    const next: Record<string, unknown> = {
+      ...existing,
+      extractionStatus: status,
+    };
+    if (extra.error !== undefined) {
+      next.extractionError = extra.error;
+    }
+    if (status === 'succeeded') {
+      next.extractedAt = (extra.extractedAt ?? new Date()).toISOString();
+    }
+    asset.description = JSON.stringify(next);
+    await asset.save();
+  }
+}
+
+/**
+ * Factory — lazily creates a shared asset runtime from DB + storage
+ * config. Initializes the store's filesystem adapter before returning.
+ *
+ * @example
+ * ```ts
+ * import { createAssetRuntime, ASSET_ROLES } from '@happyvertical/smrt-assets';
+ *
+ * const runtime = await createAssetRuntime({
+ *   db: { type: 'sqlite', url: 'app.db' },
+ *   storage: { type: 's3', bucket: 'my-app' },
+ * });
+ *
+ * const pdf = await runtime.storeSourceAsset('agenda.pdf', bytes, {
+ *   mimeType: 'application/pdf',
+ *   typeSlug: 'document',
+ * });
+ *
+ * await runtime.storeDerivedAsset(pdf, 'agenda-p1.png', pageBytes, {
+ *   mimeType: 'image/png',
+ *   typeSlug: 'image',
+ *   role: ASSET_ROLES.DOCUMENT_IMAGE,
+ * });
+ * ```
+ */
+export async function createAssetRuntime(
+  options: AssetRuntimeOptions,
+): Promise<AssetRuntime> {
+  const collection =
+    options.collection ?? (await AssetCollection.create({ db: options.db }));
+  const associations =
+    options.associations ??
+    (await AssetAssociationCollection.create({ db: options.db }));
+  const store = await new AssetStore(options.storage, collection).initialize();
+  return new AssetRuntime(collection, associations, store);
+}
+
+function safeParseMetadata(description: string): Record<string, unknown> {
+  if (!description) return {};
+  try {
+    const parsed = JSON.parse(description);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}

--- a/packages/assets/src/asset-serving.ts
+++ b/packages/assets/src/asset-serving.ts
@@ -71,6 +71,29 @@ export interface ServeAssetOptions {
   canAccess?: (asset: Asset) => boolean | Promise<boolean>;
 
   /**
+   * How to handle assets whose `sourceUri` is an `http(s)` URL rather
+   * than a store-backed path.
+   *
+   * - `'proxy'` (default): fetch the bytes via `globalThis.fetch` and
+   *   return them inline. Keeps the origin URL hidden from the client
+   *   and preserves the same tenant/access checks the local path gets.
+   * - `'redirect'`: return a `302` to `sourceUri` instead of fetching.
+   *   Skips the byte round-trip but exposes the origin URL.
+   * - `'error'`: treat a remote URI as an error (`500`). Use this when
+   *   you expect every asset to live in the local store.
+   *
+   * Anything that does not look like `http://` or `https://` is read
+   * through the store as usual.
+   */
+  remoteMode?: 'proxy' | 'redirect' | 'error';
+
+  /**
+   * Custom `fetch` implementation for the `remoteMode: 'proxy'` path.
+   * Defaults to `globalThis.fetch` (Node 18+).
+   */
+  fetchImpl?: typeof fetch;
+
+  /**
    * Custom `Response`-like constructor, for runtimes that don't have
    * a global `Response` (pre-Node-18, workers with a custom shim).
    * Defaults to `globalThis.Response`.
@@ -79,6 +102,10 @@ export interface ServeAssetOptions {
 }
 
 type ResponseConstructor = typeof Response;
+
+function isRemoteUri(uri: string): boolean {
+  return /^https?:\/\//i.test(uri);
+}
 
 /**
  * Resolve an asset + bytes for serving, enforcing the same tenant
@@ -123,17 +150,53 @@ export async function resolveAssetForServing(
     }
   }
 
+  const remoteMode = options.remoteMode ?? 'proxy';
   let data: Buffer;
-  try {
-    data = await runtime.store.read(asset);
-  } catch (err) {
-    throw new AssetServeError(
-      `Failed to read asset bytes: ${(err as Error).message}`,
-      500,
-    );
+  let remoteContentType: string | undefined;
+
+  if (isRemoteUri(asset.sourceUri)) {
+    if (remoteMode === 'error') {
+      throw new AssetServeError('Remote asset not supported', 500);
+    }
+    if (remoteMode === 'redirect') {
+      throw new RedirectToSourceUri(asset.sourceUri);
+    }
+    // Proxy — fetch the bytes from the origin URL.
+    const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+    if (!fetchImpl) {
+      throw new AssetServeError(
+        'No fetch implementation available for remote asset',
+        500,
+      );
+    }
+    try {
+      const response = await fetchImpl(asset.sourceUri);
+      if (!response.ok) {
+        throw new AssetServeError(
+          `Remote asset returned ${response.status}`,
+          502,
+        );
+      }
+      data = Buffer.from(await response.arrayBuffer());
+      remoteContentType = response.headers.get('content-type') ?? undefined;
+    } catch (err) {
+      if (err instanceof AssetServeError) throw err;
+      // Log the underlying error so operators can debug without
+      // leaking paths/bucket names to the HTTP client.
+      console.error('serveAsset: remote fetch failed', err);
+      throw new AssetServeError('Failed to fetch remote asset', 502);
+    }
+  } else {
+    try {
+      data = await runtime.store.read(asset);
+    } catch (err) {
+      console.error('serveAsset: store read failed', err);
+      throw new AssetServeError('Failed to read asset bytes', 500);
+    }
   }
 
-  const contentType = asset.mimeType || 'application/octet-stream';
+  const contentType =
+    asset.mimeType || remoteContentType || 'application/octet-stream';
   const filename = options.filename ?? deriveFilename(asset);
 
   return {
@@ -146,11 +209,26 @@ export async function resolveAssetForServing(
 }
 
 /**
+ * Internal signal for `remoteMode: 'redirect'`. Caught by `serveAsset`
+ * and turned into a 302; `resolveAssetForServing` re-throws so direct
+ * callers can inspect it via `err.location`.
+ */
+class RedirectToSourceUri extends Error {
+  constructor(public readonly location: string) {
+    super('Asset stored at remote URL');
+    this.name = 'RedirectToSourceUri';
+  }
+}
+
+/**
  * Serve an asset as a standard Web `Response`.
  *
  * Returns:
  *  - `404` when the asset id doesn't resolve
- *  - `403` when the tenant or `canAccess` check fails
+ *  - `403` when the tenant mismatches or `canAccess` denies
+ *  - `302` when `remoteMode: 'redirect'` and the asset's `sourceUri`
+ *    is an `http(s)` URL
+ *  - `502` when `remoteMode: 'proxy'` and the origin fetch fails
  *  - `500` when bytes fail to read (file missing, provider error)
  *  - `200` with the raw bytes, `Content-Type`, `Content-Length`, and
  *    `Content-Disposition` set otherwise.
@@ -188,14 +266,22 @@ export async function serveAsset(
     // runtimes; Buffer is a Uint8Array subclass so this is safe in Node.
     return new Ctor(data as unknown as BodyInit, { status: 200, headers });
   } catch (err) {
+    if (err instanceof RedirectToSourceUri) {
+      return new Ctor(null, {
+        status: 302,
+        headers: { Location: err.location },
+      });
+    }
     if (err instanceof AssetServeError) {
       return new Ctor(err.message, {
         status: err.status,
         headers: { 'Content-Type': 'text/plain; charset=utf-8' },
       });
     }
-    const message = (err as Error).message ?? 'Internal error serving asset';
-    return new Ctor(message, {
+    // Don't surface the underlying error to clients — it can leak
+    // paths/bucket names/provider details. Log for operators.
+    console.error('serveAsset: unexpected error', err);
+    return new Ctor('Internal error serving asset', {
       status: 500,
       headers: { 'Content-Type': 'text/plain; charset=utf-8' },
     });
@@ -230,11 +316,27 @@ function extractBasename(uri: string): string {
   return last;
 }
 
+function sanitizeDispositionFilename(filename: string): string {
+  // Strip control characters (C0 + DEL) first — they make the header
+  // invalid in Node's Response constructor and could enable CRLF
+  // injection. Then replace quotes, backslashes, and path separators
+  // so the quoted-string form is safe.
+  let stripped = '';
+  for (const ch of filename) {
+    const code = ch.charCodeAt(0);
+    if (code > 0x1f && code !== 0x7f) {
+      stripped += ch;
+    }
+  }
+  const safe = stripped.replace(/["\\/]/g, '_').trim();
+  return safe || 'asset';
+}
+
 function buildContentDisposition(
   disposition: 'inline' | 'attachment',
   filename: string,
 ): string {
-  const safe = filename.replace(/["\\]/g, '_');
-  const encoded = encodeURIComponent(filename);
-  return `${disposition}; filename="${safe}"; filename*=UTF-8''${encoded}`;
+  const sanitized = sanitizeDispositionFilename(filename);
+  const encoded = encodeURIComponent(sanitized);
+  return `${disposition}; filename="${sanitized}"; filename*=UTF-8''${encoded}`;
 }

--- a/packages/assets/src/asset-serving.ts
+++ b/packages/assets/src/asset-serving.ts
@@ -1,0 +1,240 @@
+/**
+ * Generic asset-serving contract
+ *
+ * Framework-agnostic helpers that turn a `smrt-assets` runtime plus
+ * an asset id (or asset instance) into a standard `Response`. Apps
+ * (SvelteKit, Hono, plain Node) can wire this once and stop inventing
+ * agent-specific routes.
+ *
+ * `serveAsset()` returns a Web `Response` built against the global
+ * `Response` available in Node 18+. If a runtime needs an older Node,
+ * pass its own Response constructor via `responseCtor`.
+ */
+
+import type { Asset } from './asset';
+import type { AssetRuntimeLike } from './asset-runtime';
+
+/**
+ * Result of `resolveAssetForServing()` — lets advanced callers
+ * stream bytes themselves while still reusing the access check.
+ */
+export interface ResolvedAssetBytes {
+  asset: Asset;
+  data: Buffer;
+  contentType: string;
+  filename: string;
+  size: number;
+}
+
+/**
+ * Options for `serveAsset()` and `resolveAssetForServing()`.
+ */
+export interface ServeAssetOptions {
+  /** Shared asset runtime (collection + store). */
+  runtime: AssetRuntimeLike;
+
+  /**
+   * Either an asset id to look up or a fully-loaded `Asset`
+   * instance. Passing the instance skips the `collection.get()` call.
+   */
+  asset: string | Asset;
+
+  /**
+   * Tenant of the caller. When provided, the asset must either
+   * belong to this tenant or be a global asset (`tenantId = null`)
+   * or a 403 is returned.
+   */
+  tenantId?: string | null;
+
+  /**
+   * Optional `Content-Disposition` — `'inline'` (default) or
+   * `'attachment'`. Use `'attachment'` for download links.
+   */
+  disposition?: 'inline' | 'attachment';
+
+  /**
+   * Extra headers merged into the 200 response. Does not affect
+   * 403/404/500 responses.
+   */
+  headers?: Record<string, string>;
+
+  /**
+   * Optional override for the filename used in `Content-Disposition`.
+   * Defaults to the basename of the asset's `sourceUri` or `name`.
+   */
+  filename?: string;
+
+  /**
+   * Optional access-check hook. Return `false` to short-circuit with a
+   * 403 before bytes are loaded. Runs after the built-in tenant check.
+   */
+  canAccess?: (asset: Asset) => boolean | Promise<boolean>;
+
+  /**
+   * Custom `Response`-like constructor, for runtimes that don't have
+   * a global `Response` (pre-Node-18, workers with a custom shim).
+   * Defaults to `globalThis.Response`.
+   */
+  responseCtor?: ResponseConstructor;
+}
+
+type ResponseConstructor = typeof Response;
+
+/**
+ * Resolve an asset + bytes for serving, enforcing the same tenant
+ * and access checks as `serveAsset()` but returning the parts so
+ * callers can render their own framework response.
+ *
+ * Throws `AssetServeError` with a status on any error so callers can
+ * map to their HTTP layer.
+ */
+export async function resolveAssetForServing(
+  options: ServeAssetOptions,
+): Promise<ResolvedAssetBytes> {
+  const {
+    runtime,
+    asset: assetOrId,
+    tenantId,
+    canAccess,
+    disposition: _disposition,
+  } = options;
+
+  const asset =
+    typeof assetOrId === 'string'
+      ? ((await runtime.collection.get({ id: assetOrId })) as Asset | null)
+      : assetOrId;
+
+  if (!asset) {
+    throw new AssetServeError('Asset not found', 404);
+  }
+
+  if (
+    tenantId !== undefined &&
+    asset.tenantId !== null &&
+    asset.tenantId !== tenantId
+  ) {
+    throw new AssetServeError('Asset not visible to this tenant', 403);
+  }
+
+  if (canAccess) {
+    const allowed = await canAccess(asset);
+    if (!allowed) {
+      throw new AssetServeError('Asset access denied', 403);
+    }
+  }
+
+  let data: Buffer;
+  try {
+    data = await runtime.store.read(asset);
+  } catch (err) {
+    throw new AssetServeError(
+      `Failed to read asset bytes: ${(err as Error).message}`,
+      500,
+    );
+  }
+
+  const contentType = asset.mimeType || 'application/octet-stream';
+  const filename = options.filename ?? deriveFilename(asset);
+
+  return {
+    asset,
+    data,
+    contentType,
+    filename,
+    size: data.byteLength,
+  };
+}
+
+/**
+ * Serve an asset as a standard Web `Response`.
+ *
+ * Returns:
+ *  - `404` when the asset id doesn't resolve
+ *  - `403` when the tenant or `canAccess` check fails
+ *  - `500` when bytes fail to read (file missing, provider error)
+ *  - `200` with the raw bytes, `Content-Type`, `Content-Length`, and
+ *    `Content-Disposition` set otherwise.
+ *
+ * The resulting `Response` is framework-agnostic: SvelteKit `+server.ts`
+ * endpoints, Hono, and plain Node HTTP all accept it via their Web
+ * interop layer.
+ */
+export async function serveAsset(
+  options: ServeAssetOptions,
+): Promise<Response> {
+  const Ctor =
+    options.responseCtor ?? (globalThis.Response as ResponseConstructor);
+  if (!Ctor) {
+    throw new Error(
+      'serveAsset: no Response constructor available. Pass options.responseCtor or run on Node 18+.',
+    );
+  }
+
+  try {
+    const { data, contentType, filename, size } =
+      await resolveAssetForServing(options);
+
+    const headers: Record<string, string> = {
+      'Content-Type': contentType,
+      'Content-Length': String(size),
+      'Content-Disposition': buildContentDisposition(
+        options.disposition ?? 'inline',
+        filename,
+      ),
+      ...options.headers,
+    };
+
+    // new Response(body) requires Uint8Array / ArrayBuffer / string in most
+    // runtimes; Buffer is a Uint8Array subclass so this is safe in Node.
+    return new Ctor(data as unknown as BodyInit, { status: 200, headers });
+  } catch (err) {
+    if (err instanceof AssetServeError) {
+      return new Ctor(err.message, {
+        status: err.status,
+        headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+      });
+    }
+    const message = (err as Error).message ?? 'Internal error serving asset';
+    return new Ctor(message, {
+      status: 500,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+}
+
+/**
+ * Error raised by `resolveAssetForServing()` with the HTTP status
+ * callers should use when rendering their own response.
+ */
+export class AssetServeError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.name = 'AssetServeError';
+  }
+}
+
+function deriveFilename(asset: Asset): string {
+  if (asset.name) return asset.name;
+  const fromUri = extractBasename(asset.sourceUri);
+  if (fromUri) return fromUri;
+  return asset.id ?? 'asset';
+}
+
+function extractBasename(uri: string): string {
+  if (!uri) return '';
+  const noScheme = uri.replace(/^[a-z][a-z0-9+\-.]*:\/\//i, '');
+  const last = noScheme.split('/').pop() ?? '';
+  return last;
+}
+
+function buildContentDisposition(
+  disposition: 'inline' | 'attachment',
+  filename: string,
+): string {
+  const safe = filename.replace(/["\\]/g, '_');
+  const encoded = encodeURIComponent(filename);
+  return `${disposition}; filename="${safe}"; filename*=UTF-8''${encoded}`;
+}

--- a/packages/assets/src/index.ts
+++ b/packages/assets/src/index.ts
@@ -12,8 +12,34 @@ export { Asset } from './asset';
 export { AssetAssociation } from './asset-association';
 // Collections
 export { AssetAssociationCollection } from './asset-associations';
+export {
+  ASSET_EXTRACTION_STATUS,
+  ASSET_METADATA_KEYS,
+  ASSET_ROLES,
+  type AssetExtractionStatus,
+  type AssetMetadataKey,
+  type AssetRole,
+} from './asset-conventions';
 export { AssetMetafield } from './asset-metafield';
 export { AssetMetafieldCollection } from './asset-metafields';
+// Runtime surface
+export {
+  AssetRuntime,
+  type AssetRuntimeDb,
+  type AssetRuntimeLike,
+  type AssetRuntimeOptions,
+  createAssetRuntime,
+  type LinkDerivationOptions,
+  type StoreDerivedAssetOptions,
+} from './asset-runtime';
+// Serving contract
+export {
+  AssetServeError,
+  type ResolvedAssetBytes,
+  resolveAssetForServing,
+  type ServeAssetOptions,
+  serveAsset,
+} from './asset-serving';
 export { AssetStatus } from './asset-status';
 export { AssetStatusCollection } from './asset-statuses';
 // Utilities


### PR DESCRIPTION
## Summary

Closes #1128. Gives `@happyvertical/smrt-assets` a first-tier public runtime / serving contract so apps and agents (Praeco, Histrio, etc.) can stop inventing bespoke wrappers around `AssetCollection` + `AssetStore`.

- `AssetRuntime` bundles `AssetCollection`, `AssetAssociationCollection`, and `AssetStore` behind one handle. Factory: `createAssetRuntime({ db, storage })`.
- `storeSourceAsset` / `storeDerivedAsset` / `linkDerivation` / `setExtractionStatus` cover the common source-document → derivative flows, including provenance `AssetAssociation`s.
- `serveAsset()` + `resolveAssetForServing()` give apps a framework-agnostic Web `Response` (or bytes + headers) with built-in tenant and `canAccess` checks. Works in SvelteKit `+server.ts`, Hono, plain Node 18+, or custom runtimes via `responseCtor`.
- `ASSET_ROLES` / `ASSET_METADATA_KEYS` / `ASSET_EXTRACTION_STATUS` export the shared vocabulary (`source_document`, `document_image`, `thumbnail`, `proof`, `derivation_source`, ...) and extraction-state keys described in the issue.
- `packages/assets/CLAUDE.md` documents the runtime surface, the serving contract, and the shared role/metadata conventions.

## Test plan

- [x] `pnpm --filter @happyvertical/smrt-assets build` — clean build with manifest generation
- [x] `pnpm --filter @happyvertical/smrt-assets test` — 20/20 tests pass (including 18 new ones across `asset-runtime.test.ts` and `asset-serving.test.ts`)
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `turbo build --filter=@happyvertical/smrt-images --filter=@happyvertical/smrt-content` — downstream packages still build
- [ ] Reviewer sanity-check that the conventions match the anytown.ai Praeco/Histrio use cases