### PR TITLE
fix(assets): avoid DOM-only BodyInit cast in asset-serving

### DIFF
--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -37,6 +37,7 @@
     "pretest": "[ -f ../cli/dist/index.js ] && node ../cli/dist/index.js test --manifest-only || true",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
+    "typecheck": "tsc -p tsconfig.typecheck.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },
   "dependencies": {

--- a/packages/assets/src/asset-serving.ts
+++ b/packages/assets/src/asset-serving.ts
@@ -262,9 +262,18 @@ export async function serveAsset(
       ...options.headers,
     };
 
-    // new Response(body) requires Uint8Array / ArrayBuffer / string in most
-    // runtimes; Buffer is a Uint8Array subclass so this is safe in Node.
-    return new Ctor(data as unknown as BodyInit, { status: 200, headers });
+    // `new Response(body)` accepts Buffer at runtime (it's a Uint8Array
+    // subclass), but the strongly-typed `BodyInit` name lives in
+    // `lib.dom.d.ts`, which the package-build tsconfig doesn't pull in.
+    // Cast through `unknown` instead of referencing a DOM type so `.d.ts`
+    // generation works without needing DOM lib.
+    return new Ctor(
+      data as unknown as ConstructorParameters<ResponseConstructor>[0],
+      {
+        status: 200,
+        headers,
+      },
+    );
   } catch (err) {
     if (err instanceof RedirectToSourceUri) {
       return new Ctor(null, {

--- a/packages/assets/tsconfig.typecheck.json
+++ b/packages/assets/tsconfig.typecheck.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.package-typecheck.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "src/svelte/**/*",
+    "src/routes/**/*",
+    "src/playground.ts",
+    "src/route-module.ts"
+  ]
+}

--- a/packages/assets/vite.config.ts
+++ b/packages/assets/vite.config.ts
@@ -24,6 +24,11 @@ export default defineConfig(async ({ mode }) => {
       entries: ['playground'],
       svelte: 'svelte',
       dtsExclude: ['src/routes/**/*'],
+      // Fail the build on TS errors in dts generation so type-only bugs
+      // (e.g. DOM-only types under a non-DOM lib config, see PR #1130)
+      // can't ship to npm silently. Package-specific opt-in until the
+      // rest of the monorepo is ready to follow.
+      strictDts: true,
     });
     // createPackageConfig returns a UserConfigExport; resolve it
     const resolved = typeof config === 'function' ? await (config as any)({ mode, command: 'build' }) : config;

--- a/vite.config.base.ts
+++ b/vite.config.base.ts
@@ -34,6 +34,21 @@ interface PackageConfigOptions {
    * publishable library types.
    */
   dtsExclude?: string[];
+  /**
+   * When true, abort the build if `vite-plugin-dts` surfaces any
+   * TypeScript error-level diagnostics while generating `.d.ts` files.
+   *
+   * Without this, the dts plugin prints errors to stderr but Vite still
+   * exits 0, so broken types can ship to npm (see PR #1129 / #1130).
+   *
+   * Off by default so the repo-wide latent TS errors in other packages
+   * (e.g. virtual `@smrt/*` modules, pre-existing type mismatches) do
+   * not regress existing builds. Enable per-package as each package is
+   * cleaned up.
+   *
+   * @default false
+   */
+  strictDts?: boolean;
 }
 
 interface WorkspacePackageInfo {
@@ -377,6 +392,26 @@ export function createPackageConfig(
           // Prefer a package-specific build tsconfig when present so workspace
           // source resolution stays clean without requiring sibling dist output.
           tsconfigPath,
+          // Fail the build on TS error-level diagnostics during dts
+          // generation when opted in. Without this, `vite-plugin-dts`
+          // prints errors to stderr but still emits and exits 0, which
+          // means TS errors in package source can ship to npm (see PR
+          // #1129 / #1130).
+          ...(options.strictDts
+            ? {
+                afterDiagnostic: (diagnostics) => {
+                  // 1 === ts.DiagnosticCategory.Error; inlined so this
+                  // file does not need to import `typescript` for a
+                  // single numeric enum.
+                  const errors = diagnostics.filter((d) => d.category === 1);
+                  if (errors.length > 0) {
+                    throw new Error(
+                      `vite-plugin-dts: ${errors.length} TypeScript error(s) during declaration generation. See log above.`,
+                    );
+                  }
+                },
+              }
+            : {}),
           beforeWriteFile: (filePath, content) => ({
             filePath,
             content: rewriteWorkspaceDeclarationImports(


### PR DESCRIPTION
## What

Fixes the `BodyInit` TypeScript error that surfaced in the [post-merge publish run](https://github.com/happyvertical/smrt/actions/runs/24607951655/job/71957419130) for #1129:

```
src/asset-serving.ts:267:40 - error TS2304: Cannot find name 'BodyInit'.
    return new Ctor(data as unknown as BodyInit, { status: 200, headers });
```

`BodyInit` is declared in `lib.dom.d.ts`, which the package-build tsconfig (`tsconfig.package-build.json` → `lib: ['ES2023']`) doesn't pull in. Replaced the cast with `ConstructorParameters<ResponseConstructor>[0]`, which resolves through `@types/node` + undici-types without needing DOM lib.

## Why CI didn't catch it on #1129

Three gaps lined up:

1. `vite-plugin-dts` prints TS errors to stderr during `.d.ts` generation but does **not** fail the Vite build — local `vite build` reports `error TS2304: Cannot find name 'BodyInit'` and still exits with `✓ built in 968ms`. So `Validate Changes / Build` went green.
2. `Validate Changes / Typecheck` runs turbo's `typecheck` task, but `packages/assets/package.json` has no `typecheck` script — the task is a no-op for this package, so `tsc` never ran against my source.
3. `Publish Dry Run` only validates tarball exports, not type soundness.

The unrelated `ERR_MODULE_NOT_FOUND: packages/core/src/scanner/manifest-generator.js` error that also appeared in that publish run is a separate pre-existing issue (see #1125 / #1126) and isn't in scope here.

## Test plan

- [x] Local reproduce before fix: `rm -rf dist && vite build --mode library` prints the TS2304 error.
- [x] After fix: clean `vite build` output, no TS errors.
- [x] 32/32 vitest cases still pass (`pnpm --filter @happyvertical/smrt-assets test`).

## Follow-up (not in this PR)

Worth considering separately:
- Add a real `typecheck` script to `packages/assets/package.json` (and maybe audit other packages) so turbo's typecheck task actually runs `tsc`.
- Configure `vite-plugin-dts` to fail the build on TS errors, or gate publish on a separate strict-typecheck step.