### PR TITLE
fix(core): hydrate sti descendants before save serialization

### DIFF
--- a/.changeset/fix-sti-descendant-hydration.md
+++ b/.changeset/fix-sti-descendant-hydration.md
@@ -1,0 +1,5 @@
+---
+'@happyvertical/smrt-core': patch
+---
+
+Rehydrate STI descendants before save-time serialization so stale external runtime field caches do not coerce sibling integer fields to empty strings.

--- a/packages/core/src/__tests__/external-runtime-hydration.test.ts
+++ b/packages/core/src/__tests__/external-runtime-hydration.test.ts
@@ -1066,4 +1066,137 @@ describe('external runtime field hydration', () => {
       ObjectRegistry.getClassByQualifiedName(childQualifiedName),
     ).toBeDefined();
   });
+
+  it('rehydrates stale STI descendant caches before serializing sibling integer fields on save', async () => {
+    const packageName = '@happyvertical/smrt-runtime-fixture-assets';
+
+    writeScopedPackage(
+      appDir,
+      packageName,
+      fixtureManifest(packageName, {
+        FixtureRuntimeAsset: {
+          decoratorConfig: {
+            tableStrategy: 'sti',
+            tableName: 'fixture_runtime_assets',
+            api: false,
+            cli: false,
+            mcp: false,
+          },
+          fields: {
+            name: { type: 'text' },
+            sourceType: { type: 'text' },
+          },
+        },
+        FixtureRuntimeImage: {
+          extends: 'FixtureRuntimeAsset',
+          decoratorConfig: {
+            tableStrategy: 'sti',
+            tableName: 'fixture_runtime_assets',
+            api: false,
+            cli: false,
+            mcp: false,
+          },
+          fields: {
+            width: { type: 'integer', default: 0 },
+            height: { type: 'integer', default: 0 },
+            alt: { type: 'text', default: '' },
+          },
+        },
+      }),
+    );
+
+    @smrt({
+      tableStrategy: 'sti',
+      tableName: 'fixture_runtime_assets',
+      api: false,
+      cli: false,
+      mcp: false,
+    })
+    class FixtureRuntimeAsset extends SmrtObject {
+      @field()
+      name: string = '';
+
+      @field()
+      sourceType: string = '';
+    }
+
+    @smrt({
+      tableStrategy: 'sti',
+      tableName: 'fixture_runtime_assets',
+      api: false,
+      cli: false,
+      mcp: false,
+    })
+    class FixtureRuntimeImage extends FixtureRuntimeAsset {
+      @field()
+      width: number = 0;
+
+      @field()
+      height: number = 0;
+
+      @field()
+      alt: string = '';
+    }
+
+    const baseRegistered = ObjectRegistry.findClass('FixtureRuntimeAsset');
+    const imageRegistered = ObjectRegistry.findClass('FixtureRuntimeImage');
+
+    expect(baseRegistered).toBeDefined();
+    expect(imageRegistered).toBeDefined();
+
+    baseRegistered!.packageName = packageName;
+    baseRegistered!.qualifiedName = createQualifiedName(
+      packageName,
+      'FixtureRuntimeAsset',
+    );
+
+    imageRegistered!.packageName = packageName;
+    imageRegistered!.qualifiedName = createQualifiedName(
+      packageName,
+      'FixtureRuntimeImage',
+    );
+
+    // Simulate the stale external-runtime cache we saw in production: the child
+    // already has inheritedFields, but only from undecorated runtime metadata.
+    imageRegistered!.inheritedFields = new Map(imageRegistered?.fields);
+
+    const staleWidthField =
+      imageRegistered?.inheritedFields.get('width')?.type || null;
+    expect(staleWidthField).toBe('text');
+
+    const upserts: Array<Record<string, unknown>> = [];
+    const db = {
+      url: ':memory:',
+      tableExists: async () => true,
+      get: async () => null,
+      upsert: async (
+        _tableName: string,
+        _conflictColumns: string[],
+        data: Record<string, unknown>,
+      ) => {
+        upserts.push(data);
+      },
+    };
+
+    const asset = await new FixtureRuntimeAsset({
+      db: db as any,
+      name: 'Blackfalds agenda asset',
+      sourceType: 'remote',
+    }).initialize();
+    (asset as any)._db = db;
+    (asset as any).verifyStorageReady = async () => {};
+
+    await asset.save();
+
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0]?.width).toBeUndefined();
+    expect(upserts[0]?.height).toBeUndefined();
+    expect(upserts[0]?.alt).toBe('');
+
+    const hydratedWidthField =
+      ObjectRegistry.getClass('FixtureRuntimeImage')?.inheritedFields?.get(
+        'width',
+      )?.type || null;
+    expect(hydratedWidthField).toBe('integer');
+  });
 });

--- a/packages/core/src/__tests__/external-runtime-hydration.test.ts
+++ b/packages/core/src/__tests__/external-runtime-hydration.test.ts
@@ -818,6 +818,8 @@ describe('external runtime field hydration', () => {
     const upserts: Array<Record<string, unknown>> = [];
     const db = {
       url: ':memory:',
+      query: async () => [],
+      execute: async () => undefined,
       tableExists: async () => true,
       get: async () => null,
       upsert: async (
@@ -830,7 +832,6 @@ describe('external runtime field hydration', () => {
     };
 
     const forecast = await new FixtureForecast({ db: db as any }).initialize();
-    (forecast as any)._db = db;
     (forecast as any).verifyStorageReady = async () => {};
     await forecast.save();
 
@@ -1167,6 +1168,8 @@ describe('external runtime field hydration', () => {
     const upserts: Array<Record<string, unknown>> = [];
     const db = {
       url: ':memory:',
+      query: async () => [],
+      execute: async () => undefined,
       tableExists: async () => true,
       get: async () => null,
       upsert: async (
@@ -1183,7 +1186,6 @@ describe('external runtime field hydration', () => {
       name: 'Blackfalds agenda asset',
       sourceType: 'remote',
     }).initialize();
-    (asset as any)._db = db;
     (asset as any).verifyStorageReady = async () => {};
 
     await asset.save();

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -1132,19 +1132,21 @@ export class SmrtObject extends SmrtClass {
       }
 
       if (tableStrategy === 'sti') {
-        const descendants = getSTIHierarchyMembers(className);
-        const descendantsNeedingHydration = descendants.filter((descendant) => {
-          const registeredDescendant = ObjectRegistry.getClass(descendant);
-          return registeredDescendant && !registeredDescendant.inheritedFields;
-        });
+        const classesNeedingFreshSTIFieldState = [
+          className,
+          ...getSTIHierarchyMembers(className),
+        ];
 
-        if (descendantsNeedingHydration.length > 0) {
-          await Promise.all(
-            descendantsNeedingHydration.map((descendant) =>
-              ObjectRegistry.getAllFields(descendant),
-            ),
-          );
-        }
+        await Promise.all(
+          classesNeedingFreshSTIFieldState.map(async (stiClassName) => {
+            await ObjectRegistry.ensureManifestLoaded(stiClassName);
+
+            const registeredSTIClass = ObjectRegistry.getClass(stiClassName);
+            if (!registeredSTIClass?.inheritedFields) {
+              await ObjectRegistry.getAllFields(stiClassName);
+            }
+          }),
+        );
       }
 
       const jsonData = this.toJSON();

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -1132,21 +1132,13 @@ export class SmrtObject extends SmrtClass {
       }
 
       if (tableStrategy === 'sti') {
-        const classesNeedingFreshSTIFieldState = [
-          className,
-          ...getSTIHierarchyMembers(className),
-        ];
-
-        await Promise.all(
-          classesNeedingFreshSTIFieldState.map(async (stiClassName) => {
-            await ObjectRegistry.ensureManifestLoaded(stiClassName);
-
-            const registeredSTIClass = ObjectRegistry.getClass(stiClassName);
-            if (!registeredSTIClass?.inheritedFields) {
-              await ObjectRegistry.getAllFields(stiClassName);
-            }
-          }),
+        const classesNeedingFreshSTIFieldState = Array.from(
+          new Set([className, ...getSTIHierarchyMembers(className)]),
         );
+
+        for (const stiClassName of classesNeedingFreshSTIFieldState) {
+          await ObjectRegistry.getAllFields(stiClassName);
+        }
       }
 
       const jsonData = this.toJSON();


### PR DESCRIPTION
## Summary
- rehydrate STI classes before save-time serialization so stale external descendant caches do not leak sibling field type mismatches into base-class saves
- add a focused external-runtime regression for the Asset/Image-style integer sibling field case
- add a changeset for the smrt-core patch release

## Verification
- pnpm exec vitest run packages/core/src/__tests__/external-runtime-hydration.test.ts
- pnpm --filter @happyvertical/smrt-config build
- pnpm --filter @happyvertical/smrt-types build
- pnpm --filter @happyvertical/smrt-core generate:test
- pnpm --filter @happyvertical/smrt-core typecheck