### PR TITLE
Release C: collision-policy decision table + strict default + retire SKIP_STI_REHYDRATE (#1134)

### DIFF
--- a/.changeset/release-c-collision-policy-strict-default.md
+++ b/.changeset/release-c-collision-policy-strict-default.md
@@ -1,0 +1,21 @@
+---
+'@happyvertical/smrt-core': minor
+---
+
+**Release C — collision-policy decision table + strict-mode default + retire SKIP_STI_REHYDRATE (#1134)**
+
+Third and final release of the ObjectRegistry / SmrtObject review thread.
+
+**Internal refactor (no consumer API change):**
+
+- `register()` and `registerFromManifest()` now share a single 16-row decision table at `packages/core/src/registry/collision-policy.ts`. The 11-branch exact-match + case-insensitive collision tree in `register()` and the 3-branch `resolveManifestCollision()` it mirrored are all collapsed onto `decideCollisionPolicy()`. Every row corresponds to a named scenario (`manifest-stub-replacement`, `sti-child-wins`, `decorator-case-insensitive-pnpm-duplicate`, etc.) that maps 1:1 to the existing issue-specific test suite (#531, #555, #584, #847, #950, #951, #1000). `resolveManifestCollision()` is deleted.
+
+**Breaking changes (minor):**
+
+- **`SMRT_STRICT_REGISTRY` is now on by default.** Severity-`'error'` diagnostics throw at record time instead of being silently collected. Affected codes: `MANIFEST_EXPORT_INVALID`, `MANIFEST_EXPORT_NOT_JSON`, `MANIFEST_EXPORT_NOT_FOUND`, `PACKAGE_MANIFEST_READ_FAILED`. Warn-severity codes are unchanged. To restore the pre-Release-C permissive behavior set `SMRT_STRICT_REGISTRY=false`.
+- **`SMRT_SKIP_STI_REHYDRATE` removed.** The env flag disappears. PR #1131's unconditional STI descendant rehydration on save is now the only behavior, preserving the stale-cache repair contract from `external-runtime-hydration.test.ts:1071`. Further optimizing the loop away is tracked in [#1139](https://github.com/happyvertical/smrt/issues/1139).
+- Collision error messages carry a stable scenario identifier in the verbose-log output. Text in end-user `throw` messages is unchanged.
+
+**Migration:**
+- Run your test suite with the new default. If `MANIFEST_EXPORT_*` or `PACKAGE_MANIFEST_READ_FAILED` start throwing, the underlying manifest misconfiguration is the thing to fix; if you genuinely need to keep shipping despite a broken manifest, set `SMRT_STRICT_REGISTRY=false` in your runtime env.
+- Remove any `SMRT_SKIP_STI_REHYDRATE=true` setting from your env; it's now a no-op.

--- a/packages/core/src/__tests__/issue-950-manifest-sti-collision.test.ts
+++ b/packages/core/src/__tests__/issue-950-manifest-sti-collision.test.ts
@@ -177,6 +177,73 @@ describe('Issue #950: Manifest STI Collision Handling', () => {
       expect(stillChild?.packageName).toBe('@test/agent');
     });
 
+    it('keeps cross-package STI child when a parent with a qualified extends key arrives (PR #1140 review)', () => {
+      // Scenario from the deep-review on #1140: when a child class
+      // extends a parent that is ALREADY registered at the time the
+      // child loads, `qualifyExtendsName()` resolves the child's
+      // `extends` to the parent's fully-qualified key — not the simple
+      // parent name. Later, when the parent manifest arrives for the
+      // same canonical name, `existingExtendsNew` must recognize the
+      // qualified value as pointing at the new parent's key and skip.
+      //
+      // Pre-fix, the comparison only checked the simple name / manifest
+      // key and missed the qualified form, silently registering a
+      // duplicate parent entry. The `registrationKey` comparison added
+      // to buildManifestCollisionInputs at class-registration.ts:260
+      // closes that gap.
+      const parentDef = {
+        className: 'StiQualifiedParent',
+        fields: { name: { type: 'text', _meta: {} } },
+        methods: {},
+        decoratorConfig: {},
+        filePath: '/packages/events/src/models/Parent.ts',
+      };
+
+      // Register the parent first so qualifyExtendsName can resolve the
+      // child's `extends` string to the qualified parent key.
+      ObjectRegistry.registerFromManifest(
+        'StiQualifiedParent',
+        parentDef,
+        '@test/events',
+      );
+
+      const childDef = {
+        className: 'StiQualifiedChild',
+        fields: { title: { type: 'text', _meta: {} } },
+        methods: {},
+        decoratorConfig: {},
+        extends: 'StiQualifiedParent',
+        filePath: '/packages/sports/src/models/Child.ts',
+      };
+
+      ObjectRegistry.registerFromManifest(
+        'StiQualifiedChild',
+        childDef,
+        '@test/sports',
+      );
+
+      // Confirm the child stored the parent's QUALIFIED key, not the
+      // simple name — this is what makes the regression possible.
+      const child = ObjectRegistry.findClass('StiQualifiedChild');
+      expect(child?.extends).toBe('@test/events:StiQualifiedParent');
+
+      // Now the parent manifest arrives again, e.g. via STI sibling
+      // auto-load. Pre-fix, `existingExtendsNew` returned false and the
+      // parent would register a duplicate entry. With the fix, the
+      // child's qualified `extends` matches the parent's registrationKey
+      // → `manifest-sti-parent-skip` → skip.
+      ObjectRegistry.registerFromManifest(
+        'StiQualifiedParent',
+        parentDef,
+        '@test/events',
+      );
+
+      // Only one parent entry exists; not duplicated.
+      const parents = ObjectRegistry.findClassesByName('StiQualifiedParent');
+      expect(parents).toHaveLength(1);
+      expect(parents[0].packageName).toBe('@test/events');
+    });
+
     it('should skip re-export with same source file', () => {
       const def = {
         className: 'TestWidget950',

--- a/packages/core/src/__tests__/register-package-manifest.test.ts
+++ b/packages/core/src/__tests__/register-package-manifest.test.ts
@@ -248,16 +248,46 @@ describe('ObjectRegistry.registerPackageManifest', () => {
     expect(result.objectsRegistered).toBe(0);
   });
 
-  it('silently no-ops when the manifest is malformed JSON', () => {
+  it('throws in strict mode when the manifest is malformed JSON', () => {
+    // Release C (#1134) flipped SMRT_STRICT_REGISTRY to on-by-default, so
+    // PACKAGE_MANIFEST_READ_FAILED (severity 'error') now throws at record
+    // time instead of recording silently. Consumers who want the pre-C
+    // permissive behavior opt out via SMRT_STRICT_REGISTRY=false — see the
+    // next test.
     const badPath = join(tempRoot, 'bad.json');
     writeFileSync(badPath, '{ not valid json');
 
-    const result = ObjectRegistry.registerPackageManifest(
-      pathToFileURL(badPath),
-    );
+    expect(() =>
+      ObjectRegistry.registerPackageManifest(pathToFileURL(badPath)),
+    ).toThrow(/PACKAGE_MANIFEST_READ_FAILED/);
+  });
 
-    expect(result.loaded).toBe(false);
-    expect(result.objectsRegistered).toBe(0);
+  it('opt-out: SMRT_STRICT_REGISTRY=false restores permissive malformed-JSON behavior', () => {
+    const badPath = join(tempRoot, 'bad-optout.json');
+    writeFileSync(badPath, '{ still not valid');
+
+    const originalEnv = process.env.SMRT_STRICT_REGISTRY;
+    process.env.SMRT_STRICT_REGISTRY = 'false';
+    try {
+      const result = ObjectRegistry.registerPackageManifest(
+        pathToFileURL(badPath),
+      );
+      expect(result.loaded).toBe(false);
+      expect(result.objectsRegistered).toBe(0);
+
+      // The diagnostic is still recorded — strict mode only controls
+      // whether it throws, not whether it's collected.
+      const diagnostics = ObjectRegistry.getDiagnostics();
+      expect(
+        diagnostics.some((d) => d.code === 'PACKAGE_MANIFEST_READ_FAILED'),
+      ).toBe(true);
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.SMRT_STRICT_REGISTRY;
+      } else {
+        process.env.SMRT_STRICT_REGISTRY = originalEnv;
+      }
+    }
   });
 
   it('accepts a plain string path as well as a URL', () => {

--- a/packages/core/src/__tests__/strict-registry-manifest-export-errors.test.ts
+++ b/packages/core/src/__tests__/strict-registry-manifest-export-errors.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Strict-mode regression tests for the three MANIFEST_EXPORT_* error codes.
+ *
+ * Release C (#1134) flipped SMRT_STRICT_REGISTRY to on-by-default, which
+ * promotes four error-severity diagnostics from silent to throwing. The
+ * fourth, PACKAGE_MANIFEST_READ_FAILED, is covered by
+ * register-package-manifest.test.ts. The three MANIFEST_EXPORT_* codes
+ * fire in a different path (resolveManifestExportPathSync, reached via
+ * loadExternalManifestSyncWithNode / the NodeModulesFallbackSource),
+ * which the existing tests don't exercise.
+ *
+ * Each code gets two tests:
+ *   - throw path: strict default, expect throw with the opt-out hint
+ *   - opt-out path: SMRT_STRICT_REGISTRY=false, expect null return with
+ *     the diagnostic recorded
+ *
+ * PR #1140 review raised the missing coverage as a gap (subagent review
+ * section 4).
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { NodeModulesFallbackSource } from '../manifest/sources/fallback.js';
+import { ObjectRegistry } from '../registry.js';
+
+function writeScopedPackage(
+  appDir: string,
+  packageName: string,
+  packageJson: Record<string, unknown>,
+  distFiles: Record<string, string> = {},
+): string {
+  const [scope, pkg] = packageName.startsWith('@')
+    ? packageName.slice(1).split('/')
+    : [undefined, packageName];
+  const packageDir = scope
+    ? join(appDir, 'node_modules', `@${scope}`, pkg)
+    : join(appDir, 'node_modules', pkg);
+
+  mkdirSync(join(packageDir, 'dist'), { recursive: true });
+  writeFileSync(
+    join(packageDir, 'package.json'),
+    JSON.stringify({ name: packageName, version: '1.0.0', ...packageJson }),
+  );
+  for (const [relative, content] of Object.entries(distFiles)) {
+    const filePath = join(packageDir, relative);
+    mkdirSync(join(filePath, '..'), { recursive: true });
+    writeFileSync(filePath, content);
+  }
+  return packageDir;
+}
+
+describe('strict-mode error paths for MANIFEST_EXPORT_* codes (#1134)', () => {
+  let tempRoot = '';
+  let appDir = '';
+  let originalCwd: string;
+  let originalStrict: string | undefined;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    originalStrict = process.env.SMRT_STRICT_REGISTRY;
+    tempRoot = mkdtempSync(join(tmpdir(), 'smrt-strict-exports-'));
+    appDir = join(tempRoot, 'app');
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(
+      join(appDir, 'package.json'),
+      JSON.stringify({ name: 'strict-test-app', version: '1.0.0' }),
+    );
+    process.chdir(appDir);
+    ObjectRegistry.clearDiagnostics();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (originalStrict === undefined) {
+      delete process.env.SMRT_STRICT_REGISTRY;
+    } else {
+      process.env.SMRT_STRICT_REGISTRY = originalStrict;
+    }
+    ObjectRegistry.clearDiagnostics();
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  // --- MANIFEST_EXPORT_INVALID ------------------------------------------
+
+  describe('MANIFEST_EXPORT_INVALID — exports entry with no import/default/require', () => {
+    it('throws in strict mode (default)', async () => {
+      writeScopedPackage(appDir, '@happyvertical/smrt-fixture-invalid-export', {
+        exports: {
+          // Object form with only `types` — no import / default / require
+          './manifest.json': { types: './dist/manifest.d.ts' },
+        },
+      });
+      const source = new NodeModulesFallbackSource();
+      await expect(
+        source.hydrate({
+          packageName: '@happyvertical/smrt-fixture-invalid-export',
+        }),
+      ).rejects.toThrow(/MANIFEST_EXPORT_INVALID/);
+    });
+
+    it('records the diagnostic and returns false when SMRT_STRICT_REGISTRY=false', async () => {
+      process.env.SMRT_STRICT_REGISTRY = 'false';
+      writeScopedPackage(appDir, '@happyvertical/smrt-fixture-invalid-optout', {
+        exports: {
+          './manifest.json': { types: './dist/manifest.d.ts' },
+        },
+      });
+      const source = new NodeModulesFallbackSource();
+      const hydrated = await source.hydrate({
+        packageName: '@happyvertical/smrt-fixture-invalid-optout',
+      });
+      expect(hydrated).toBe(false);
+      const diagnostics = ObjectRegistry.getDiagnostics();
+      expect(
+        diagnostics.some((d) => d.code === 'MANIFEST_EXPORT_INVALID'),
+      ).toBe(true);
+    });
+  });
+
+  // --- MANIFEST_EXPORT_NOT_JSON -----------------------------------------
+
+  describe('MANIFEST_EXPORT_NOT_JSON — manifest export points at a non-JSON file', () => {
+    it('throws in strict mode (default)', async () => {
+      writeScopedPackage(appDir, '@happyvertical/smrt-fixture-not-json', {
+        exports: {
+          './manifest.json': './dist/manifest.js',
+        },
+      });
+      const source = new NodeModulesFallbackSource();
+      await expect(
+        source.hydrate({ packageName: '@happyvertical/smrt-fixture-not-json' }),
+      ).rejects.toThrow(/MANIFEST_EXPORT_NOT_JSON/);
+    });
+
+    it('records the diagnostic and returns false when SMRT_STRICT_REGISTRY=false', async () => {
+      process.env.SMRT_STRICT_REGISTRY = 'false';
+      writeScopedPackage(
+        appDir,
+        '@happyvertical/smrt-fixture-not-json-optout',
+        {
+          exports: { './manifest.json': './dist/manifest.js' },
+        },
+      );
+      const source = new NodeModulesFallbackSource();
+      const hydrated = await source.hydrate({
+        packageName: '@happyvertical/smrt-fixture-not-json-optout',
+      });
+      expect(hydrated).toBe(false);
+      const diagnostics = ObjectRegistry.getDiagnostics();
+      expect(
+        diagnostics.some((d) => d.code === 'MANIFEST_EXPORT_NOT_JSON'),
+      ).toBe(true);
+    });
+  });
+
+  // --- MANIFEST_EXPORT_NOT_FOUND ----------------------------------------
+
+  describe('MANIFEST_EXPORT_NOT_FOUND — exports declares a manifest.json that does not exist on disk', () => {
+    it('throws in strict mode (default)', async () => {
+      writeScopedPackage(appDir, '@happyvertical/smrt-fixture-missing-file', {
+        exports: {
+          './manifest.json': './dist/manifest.json',
+        },
+        // Intentionally no dist/manifest.json file — only package.json
+      });
+      const source = new NodeModulesFallbackSource();
+      await expect(
+        source.hydrate({
+          packageName: '@happyvertical/smrt-fixture-missing-file',
+        }),
+      ).rejects.toThrow(/MANIFEST_EXPORT_NOT_FOUND/);
+    });
+
+    it('records the diagnostic and returns false when SMRT_STRICT_REGISTRY=false', async () => {
+      process.env.SMRT_STRICT_REGISTRY = 'false';
+      writeScopedPackage(
+        appDir,
+        '@happyvertical/smrt-fixture-missing-file-optout',
+        {
+          exports: { './manifest.json': './dist/manifest.json' },
+        },
+      );
+      const source = new NodeModulesFallbackSource();
+      const hydrated = await source.hydrate({
+        packageName: '@happyvertical/smrt-fixture-missing-file-optout',
+      });
+      expect(hydrated).toBe(false);
+      const diagnostics = ObjectRegistry.getDiagnostics();
+      expect(
+        diagnostics.some((d) => d.code === 'MANIFEST_EXPORT_NOT_FOUND'),
+      ).toBe(true);
+    });
+  });
+
+  // --- Opt-out hint in error messages -----------------------------------
+
+  it('thrown error messages include the SMRT_STRICT_REGISTRY=false opt-out hint', async () => {
+    writeScopedPackage(appDir, '@happyvertical/smrt-fixture-hint-check', {
+      exports: { './manifest.json': './dist/manifest.js' }, // triggers NOT_JSON
+    });
+    const source = new NodeModulesFallbackSource();
+    let caught: Error | undefined;
+    try {
+      await source.hydrate({
+        packageName: '@happyvertical/smrt-fixture-hint-check',
+      });
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught).toBeDefined();
+    expect(caught?.message).toMatch(/SMRT_STRICT_REGISTRY=false/);
+  });
+});

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -1132,42 +1132,18 @@ export class SmrtObject extends SmrtClass {
       }
 
       if (tableStrategy === 'sti') {
-        // PR #1131 added unconditional re-hydration of every descendant on
-        // every save to fix stale field caches that stem from consumer-runtime
-        // manifest drops (#1132). With the self-registration shim landing in
-        // this same release, those caches are no longer stale to begin with —
-        // but #1131's behavior remains the default for safety. Opt out by
-        // setting `SMRT_SKIP_STI_REHYDRATE=true` once you've verified your
-        // consumers are on the new builds; the flag goes away in Release C
-        // (see #1134) when the unconditional loop is removed.
-        const skipRehydrate = process.env.SMRT_SKIP_STI_REHYDRATE === 'true';
-
-        if (skipRehydrate) {
-          // Only hydrate descendants that have never had inheritedFields
-          // computed — matches the pre-#1131 conservative behavior.
-          const descendants = getSTIHierarchyMembers(className);
-          const descendantsNeedingHydration = descendants.filter(
-            (descendant) => {
-              const registeredDescendant = ObjectRegistry.getClass(descendant);
-              return (
-                registeredDescendant && !registeredDescendant.inheritedFields
-              );
-            },
-          );
-          if (descendantsNeedingHydration.length > 0) {
-            await Promise.all(
-              descendantsNeedingHydration.map((descendant) =>
-                ObjectRegistry.getAllFields(descendant),
-              ),
-            );
-          }
-        } else {
-          const classesNeedingFreshSTIFieldState = Array.from(
-            new Set([className, ...getSTIHierarchyMembers(className)]),
-          );
-          for (const stiClassName of classesNeedingFreshSTIFieldState) {
-            await ObjectRegistry.getAllFields(stiClassName);
-          }
+        // Release C (#1134) retired the SMRT_SKIP_STI_REHYDRATE env flag.
+        // PR #1131's unconditional rehydration stays the single behavior:
+        // it repairs stale-but-present `inheritedFields` caches that the
+        // conservative hydration path would skip (see
+        // external-runtime-hydration.test.ts:1071). Further optimizing
+        // this loop away via eager invalidation at re-registration time
+        // is tracked as a separate follow-up (#1139).
+        const classesNeedingFreshSTIFieldState = Array.from(
+          new Set([className, ...getSTIHierarchyMembers(className)]),
+        );
+        for (const stiClassName of classesNeedingFreshSTIFieldState) {
+          await ObjectRegistry.getAllFields(stiClassName);
         }
       }
 

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -75,6 +75,27 @@ function getSTIHierarchyMembers(className: string): string[] {
 }
 
 /**
+ * Warn once per process if a consumer has SMRT_SKIP_STI_REHYDRATE set.
+ * The env variable is a no-op since Release C (#1134); without this
+ * diagnostic anyone who followed the Release A changeset note would
+ * silently lose the behavior they opted into.
+ */
+let didWarnSkipRehydrate = false;
+function warnIfSkipRehydrateSet(): void {
+  if (didWarnSkipRehydrate) return;
+  didWarnSkipRehydrate = true;
+  if (process.env.SMRT_SKIP_STI_REHYDRATE !== undefined) {
+    console.warn(
+      '[smrt] SMRT_SKIP_STI_REHYDRATE is set but has no effect since ' +
+        'Release C (#1134). The flag is retired; unconditional STI ' +
+        'descendant rehydration is the only behavior. Remove the env ' +
+        'variable from your configuration. See issue #1139 for the perf ' +
+        'follow-up.',
+    );
+  }
+}
+
+/**
  * Options for SmrtObject initialization
  */
 export interface SmrtObjectOptions extends SmrtClassOptions {
@@ -1139,6 +1160,7 @@ export class SmrtObject extends SmrtClass {
         // external-runtime-hydration.test.ts:1071). Further optimizing
         // this loop away via eager invalidation at re-registration time
         // is tracked as a separate follow-up (#1139).
+        warnIfSkipRehydrateSet();
         const classesNeedingFreshSTIFieldState = Array.from(
           new Set([className, ...getSTIHierarchyMembers(className)]),
         );

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1132,12 +1132,14 @@ export class ObjectRegistry {
   /**
    * Snapshot of diagnostics collected from registry load paths.
    *
-   * Registry paths that previously `console.warn(...); return null` now also
+   * Registry paths that previously `console.warn(...); return null` also
    * record a structured diagnostic. Apps can inspect this buffer at startup
    * or from an error route to surface failures that would otherwise be silent.
    *
-   * Set `SMRT_STRICT_REGISTRY=true` to make severity-`'error'` diagnostics
-   * throw at record time instead of being collected silently.
+   * Strict mode is **on by default** since Release C (#1134): severity
+   * `'error'` diagnostics throw at record time. Set
+   * `SMRT_STRICT_REGISTRY=false` to restore the pre-Release-C permissive
+   * behavior where only the diagnostic is recorded and nothing throws.
    *
    * @see https://github.com/happyvertical/smrt/issues/1132
    * @see https://github.com/happyvertical/smrt/issues/1134

--- a/packages/core/src/registry/__tests__/collision-policy.test.ts
+++ b/packages/core/src/registry/__tests__/collision-policy.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Unit tests for the Release C collision-policy decision table.
+ *
+ * One describe/it per row in the table. Pure-function tests: no registry
+ * side effects. The integration parity tests in class-registration still
+ * exercise the production paths and will catch any regression where the
+ * table routes the same inputs differently than today's if/else tree.
+ *
+ * @see https://github.com/happyvertical/smrt/issues/1134
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  __POLICY_ROWS_FOR_TEST,
+  type CollisionInputs,
+  decideCollisionPolicy,
+} from '../collision-policy.js';
+
+/**
+ * Baseline inputs with every field set to its "no match" value. Individual
+ * tests override only the fields relevant to their scenario — keeps the
+ * table test rows short and keeps the reader's attention on what actually
+ * matters for each row.
+ */
+function baseline(overrides: Partial<CollisionInputs> = {}): CollisionInputs {
+  return {
+    origin: 'decorator',
+    matchKind: 'exact-key',
+    sameConstructor: false,
+    sameSourceFile: false,
+    bothSourceFilesKnown: true,
+    existingIsManifestStub: false,
+    newInBundledContext: false,
+    newExtendsExisting: false,
+    existingExtendsNew: false,
+    samePackage: false,
+    existingIsPackageQualified: false,
+    sameName: false,
+    hasNewQualifiedKey: false,
+    existingKeyIsQualified: false,
+    ...overrides,
+  };
+}
+
+describe('decideCollisionPolicy', () => {
+  describe('cross-origin rows', () => {
+    it('same-constructor-reregistration → accept (highest priority)', () => {
+      // Covers vitest module re-evaluation + HMR. Must beat every other
+      // row because the new "class" is literally the same constructor.
+      const result = decideCollisionPolicy(baseline({ sameConstructor: true }));
+      expect(result.policy).toBe('accept');
+      expect(result.scenario).toBe('same-constructor-reregistration');
+    });
+
+    it('manifest-stub-replacement → replace', () => {
+      // Issue #531, #847: manifest builder registered a stub placeholder;
+      // the real decorated class loads and takes over.
+      const result = decideCollisionPolicy(
+        baseline({ existingIsManifestStub: true }),
+      );
+      expect(result.policy).toBe('replace');
+      expect(result.scenario).toBe('manifest-stub-replacement');
+    });
+
+    it('same-constructor wins even when existing is a manifest stub', () => {
+      // Sanity: stub placeholders with the same constructor shouldn't force
+      // a replace — the constructor identity win is stronger.
+      const result = decideCollisionPolicy(
+        baseline({
+          sameConstructor: true,
+          existingIsManifestStub: true,
+        }),
+      );
+      expect(result.scenario).toBe('same-constructor-reregistration');
+    });
+  });
+
+  describe('manifest-origin rows', () => {
+    it('manifest-same-source-file → skip (re-export, not a real collision)', () => {
+      const result = decideCollisionPolicy(
+        baseline({
+          origin: 'manifest',
+          sameSourceFile: true,
+          bothSourceFilesKnown: true,
+        }),
+      );
+      expect(result.policy).toBe('skip');
+      expect(result.scenario).toBe('manifest-same-source-file');
+    });
+
+    it('manifest-sti-child-wins → replace', () => {
+      // Issue #950: new manifest entry extends existing; STI child wins.
+      const result = decideCollisionPolicy(
+        baseline({
+          origin: 'manifest',
+          newExtendsExisting: true,
+        }),
+      );
+      expect(result.policy).toBe('replace');
+      expect(result.scenario).toBe('manifest-sti-child-wins');
+    });
+
+    it('manifest-sti-parent-skip → skip', () => {
+      // Reverse direction: existing is already the child.
+      const result = decideCollisionPolicy(
+        baseline({
+          origin: 'manifest',
+          existingExtendsNew: true,
+        }),
+      );
+      expect(result.policy).toBe('skip');
+      expect(result.scenario).toBe('manifest-sti-parent-skip');
+    });
+
+    it('manifest-different-packages-qualified-coexist → coexist-qualified', () => {
+      // Issue #951: two packages define the same simple class name;
+      // both live under their qualified keys.
+      const result = decideCollisionPolicy(
+        baseline({
+          origin: 'manifest',
+          samePackage: false,
+          hasNewQualifiedKey: true,
+          existingIsPackageQualified: true,
+        }),
+      );
+      expect(result.policy).toBe('coexist-qualified');
+      expect(result.scenario).toBe(
+        'manifest-different-packages-qualified-coexist',
+      );
+    });
+
+    it('manifest-same-package-merge → merge-manifest', () => {
+      // Issue #1000 + #951:144-200: same-package manifest arriving for an
+      // existing source registration; merge fields + alias the qualified key.
+      const result = decideCollisionPolicy(
+        baseline({
+          origin: 'manifest',
+          samePackage: true,
+        }),
+      );
+      expect(result.policy).toBe('merge-manifest');
+      expect(result.scenario).toBe('manifest-same-package-merge');
+    });
+
+    it('manifest-default-skip → skip (pre-Release-C resolveManifestCollision default)', () => {
+      // Manifest path used to return 'skip' as its final default (not throw).
+      const result = decideCollisionPolicy(baseline({ origin: 'manifest' }));
+      expect(result.policy).toBe('skip');
+      expect(result.scenario).toBe('manifest-default-skip');
+    });
+
+    it('manifest sti-child-wins precedence: STI check beats same-package merge', () => {
+      // Ordering check: if new extends existing AND both in the same
+      // package, STI child-wins should win (replace), not merge.
+      const result = decideCollisionPolicy(
+        baseline({
+          origin: 'manifest',
+          newExtendsExisting: true,
+          samePackage: true,
+        }),
+      );
+      expect(result.scenario).toBe('manifest-sti-child-wins');
+    });
+  });
+
+  describe('decorator-origin rows', () => {
+    it('decorator-exact-match-same-package-external → accept', () => {
+      // Issue #584: external package manifest entry replaced by its own
+      // real decorated class from the same package.
+      const result = decideCollisionPolicy(
+        baseline({
+          origin: 'decorator',
+          matchKind: 'exact-key',
+          existingIsPackageQualified: true,
+          samePackage: true,
+        }),
+      );
+      expect(result.policy).toBe('accept');
+      expect(result.scenario).toBe(
+        'decorator-exact-match-same-package-external',
+      );
+    });
+
+    it('decorator-case-insensitive-pnpm-duplicate → accept', () => {
+      // pnpm store duplicates — different physical constructor but same
+      // package + same exact class name + existing has qualified key.
+      const result = decideCollisionPolicy(
+        baseline({
+          origin: 'decorator',
+          matchKind: 'case-insensitive',
+          existingKeyIsQualified: true,
+          existingIsPackageQualified: true,
+          samePackage: true,
+          sameName: true,
+        }),
+      );
+      expect(result.policy).toBe('accept');
+      expect(result.scenario).toBe('decorator-case-insensitive-pnpm-duplicate');
+    });
+
+    it('decorator-case-insensitive-pnpm-duplicate requires sameName (strict case-sensitive)', () => {
+      // The pnpm-dup guard requires exact name match, not case-insensitive.
+      // Without sameName, we'd treat it as a real collision.
+      const result = decideCollisionPolicy(
+        baseline({
+          origin: 'decorator',
+          matchKind: 'case-insensitive',
+          existingKeyIsQualified: true,
+          existingIsPackageQualified: true,
+          samePackage: true,
+          sameName: false,
+        }),
+      );
+      expect(result.scenario).not.toBe(
+        'decorator-case-insensitive-pnpm-duplicate',
+      );
+    });
+
+    it('decorator-bundled-context-known-package → accept', () => {
+      const result = decideCollisionPolicy(
+        baseline({
+          origin: 'decorator',
+          newInBundledContext: true,
+          existingIsPackageQualified: true,
+        }),
+      );
+      expect(result.policy).toBe('accept');
+      expect(result.scenario).toBe('decorator-bundled-context-known-package');
+    });
+
+    it('decorator-bundled-context requires existing to be package-qualified', () => {
+      // Bundler edge: existing must come from a known package manifest
+      // (not a test fixture etc.) to accept a duplicate.
+      const result = decideCollisionPolicy(
+        baseline({
+          origin: 'decorator',
+          newInBundledContext: true,
+          existingIsPackageQualified: false,
+        }),
+      );
+      expect(result.scenario).not.toBe(
+        'decorator-bundled-context-known-package',
+      );
+    });
+
+    it('decorator-same-source-file → accept (Issue #555 test isolation)', () => {
+      const result = decideCollisionPolicy(
+        baseline({
+          origin: 'decorator',
+          sameSourceFile: true,
+          bothSourceFilesKnown: true,
+        }),
+      );
+      expect(result.policy).toBe('accept');
+      expect(result.scenario).toBe('decorator-same-source-file');
+    });
+
+    it('decorator-unknown-source-fallback → accept when sources cannot be compared', () => {
+      const result = decideCollisionPolicy(
+        baseline({
+          origin: 'decorator',
+          sameSourceFile: false,
+          bothSourceFilesKnown: false,
+        }),
+      );
+      expect(result.policy).toBe('accept');
+      expect(result.scenario).toBe('decorator-unknown-source-fallback');
+    });
+  });
+
+  describe('STI inheritance rows (fallback for decorator path after source-file rows)', () => {
+    it('sti-child-wins → replace', () => {
+      // Issue #950 — decorator path: new.ctor.prototype instanceof existing.
+      const result = decideCollisionPolicy(
+        baseline({
+          origin: 'decorator',
+          bothSourceFilesKnown: true,
+          newExtendsExisting: true,
+        }),
+      );
+      expect(result.policy).toBe('replace');
+      expect(result.scenario).toBe('sti-child-wins');
+    });
+
+    it('sti-parent-skip → skip', () => {
+      const result = decideCollisionPolicy(
+        baseline({
+          origin: 'decorator',
+          bothSourceFilesKnown: true,
+          existingExtendsNew: true,
+        }),
+      );
+      expect(result.policy).toBe('skip');
+      expect(result.scenario).toBe('sti-parent-skip');
+    });
+  });
+
+  describe('default: true collision', () => {
+    it('decorator path with no mitigating signal → throw', () => {
+      // Different constructors, different source files, no inheritance
+      // relationship, no package or stub context — genuine name collision.
+      const result = decideCollisionPolicy(
+        baseline({
+          origin: 'decorator',
+          bothSourceFilesKnown: true,
+        }),
+      );
+      expect(result.policy).toBe('throw');
+      expect(result.scenario).toBe('true-collision');
+    });
+  });
+
+  describe('row coverage and reasons', () => {
+    it('every row has a unique scenario id', () => {
+      const ids = __POLICY_ROWS_FOR_TEST.map((row) => row.scenario);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('every decision returns a non-empty reason string', () => {
+      // Pick one row per policy type to smoke-test reasons end up populated.
+      const samples: Array<CollisionInputs> = [
+        baseline({ sameConstructor: true }),
+        baseline({ existingIsManifestStub: true }),
+        baseline({ origin: 'manifest' }),
+        baseline({ origin: 'manifest', samePackage: true }),
+        baseline({
+          origin: 'manifest',
+          hasNewQualifiedKey: true,
+          existingIsPackageQualified: true,
+        }),
+        baseline({ newExtendsExisting: true, bothSourceFilesKnown: true }),
+        baseline({ bothSourceFilesKnown: true }),
+      ];
+      for (const inputs of samples) {
+        const decision = decideCollisionPolicy(inputs);
+        expect(decision.reason.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/packages/core/src/registry/__tests__/collision-policy.test.ts
+++ b/packages/core/src/registry/__tests__/collision-policy.test.ts
@@ -38,6 +38,9 @@ function baseline(overrides: Partial<CollisionInputs> = {}): CollisionInputs {
     sameName: false,
     hasNewQualifiedKey: false,
     existingKeyIsQualified: false,
+    hasManifestContent: false,
+    registrationKeyDiffersFromExistingKey: false,
+    existingHasNoPackage: false,
     ...overrides,
   };
 }
@@ -129,17 +132,32 @@ describe('decideCollisionPolicy', () => {
       );
     });
 
-    it('manifest-same-package-merge → merge-manifest', () => {
+    it('manifest-same-package-merge → merge-manifest (when there is content to merge)', () => {
       // Issue #1000 + #951:144-200: same-package manifest arriving for an
       // existing source registration; merge fields + alias the qualified key.
       const result = decideCollisionPolicy(
         baseline({
           origin: 'manifest',
           samePackage: true,
+          hasManifestContent: true,
         }),
       );
       expect(result.policy).toBe('merge-manifest');
       expect(result.scenario).toBe('manifest-same-package-merge');
+    });
+
+    it('manifest-same-package without content → skip (merge has nothing to fold in)', () => {
+      // Guards the `hasManifestContent` gate: empty manifest entries must
+      // NOT trigger a merge-manifest policy, otherwise the caller would
+      // alias a qualified key and incorrectly report a merge.
+      const result = decideCollisionPolicy(
+        baseline({
+          origin: 'manifest',
+          samePackage: true,
+          hasManifestContent: false,
+        }),
+      );
+      expect(result.scenario).toBe('manifest-default-skip');
     });
 
     it('manifest-default-skip → skip (pre-Release-C resolveManifestCollision default)', () => {

--- a/packages/core/src/registry/__tests__/collision-policy.test.ts
+++ b/packages/core/src/registry/__tests__/collision-policy.test.ts
@@ -41,6 +41,7 @@ function baseline(overrides: Partial<CollisionInputs> = {}): CollisionInputs {
     hasManifestContent: false,
     registrationKeyDiffersFromExistingKey: false,
     existingHasNoPackage: false,
+    existingHasAnyPackage: false,
     ...overrides,
   };
 }
@@ -123,13 +124,52 @@ describe('decideCollisionPolicy', () => {
           origin: 'manifest',
           samePackage: false,
           hasNewQualifiedKey: true,
-          existingIsPackageQualified: true,
+          existingHasAnyPackage: true,
         }),
       );
       expect(result.policy).toBe('coexist-qualified');
       expect(result.scenario).toBe(
         'manifest-different-packages-qualified-coexist',
       );
+    });
+
+    it('manifest-different-packages-qualified-coexist works for unscoped package names', () => {
+      // Unscoped manifests like `smrt-profiles` (no leading `@scope/`) must
+      // also coexist. Pre-Release-C allowCoexistingQualifiedRegistration
+      // only required both packages to be present and different; narrowing
+      // to scoped names via `existingIsPackageQualified` would silently
+      // drop these. PR #1140 review, willgriffin P2 at line 251.
+      const result = decideCollisionPolicy(
+        baseline({
+          origin: 'manifest',
+          samePackage: false,
+          hasNewQualifiedKey: true,
+          existingHasAnyPackage: true,
+          existingIsPackageQualified: false, // unscoped — no `@` prefix
+        }),
+      );
+      expect(result.scenario).toBe(
+        'manifest-different-packages-qualified-coexist',
+      );
+    });
+
+    it('manifest-same-package-merge upgrades a manifest stub when content arrives', () => {
+      // Pre-Release-C: merge ran whenever `!existing.packageName ||
+      // packageName === existing.packageName`, regardless of stub status.
+      // Release C preserves that: a stub from an earlier unqualified
+      // manifest should still be upgraded by a later package-qualified
+      // manifest. PR #1140 review, willgriffin P1 at line 270.
+      const result = decideCollisionPolicy(
+        baseline({
+          origin: 'manifest',
+          existingIsManifestStub: true,
+          existingHasNoPackage: true,
+          hasNewQualifiedKey: true,
+          hasManifestContent: true,
+        }),
+      );
+      expect(result.policy).toBe('merge-manifest');
+      expect(result.scenario).toBe('manifest-same-package-merge');
     });
 
     it('manifest-same-package-merge → merge-manifest (when there is content to merge)', () => {

--- a/packages/core/src/registry/class-registration.ts
+++ b/packages/core/src/registry/class-registration.ts
@@ -135,6 +135,7 @@ function buildDecoratorCollisionInputs(args: {
     sameName: name === existing.name,
     hasNewQualifiedKey,
     existingKeyIsQualified,
+    existingHasAnyPackage: !!existing.packageName,
     // Manifest-only fields; filled with safe defaults for decorator origin.
     hasManifestContent: false,
     registrationKeyDiffersFromExistingKey: false,
@@ -246,6 +247,19 @@ function buildManifestCollisionInputs(args: {
   const newClassName = objectDef.className || name;
   const newExtends = objectDef.extends as string | undefined;
 
+  // When an incoming manifest's `extends` points at the existing entry,
+  // OR the existing entry's `extends` points at the incoming class, we
+  // have an STI inheritance relationship. Each side checks:
+  //   - the simple name of the other
+  //   - the key under which the other is registered
+  //   - a case-insensitive fallback
+  //
+  // The `existingKey` comparison is load-bearing for cross-package STI:
+  // `existing.extends` is stored post-`qualifyExtendsName()`, so it may
+  // be the fully-qualified parent key like `@pkg:Parent`. Without this
+  // comparison, `existingExtendsNew` falsely reads as false and the
+  // arriving parent manifest would be registered as a duplicate instead
+  // of skipped. See the deep-review report on #1140 for the fix rationale.
   const newExtendsExisting = !!(
     newExtends &&
     (newExtends === existing.name ||
@@ -256,6 +270,7 @@ function buildManifestCollisionInputs(args: {
     existing.extends &&
     (existing.extends === newClassName ||
       existing.extends === name ||
+      existing.extends === registrationKey ||
       existing.extends.toLowerCase() === newClassName.toLowerCase())
   );
 
@@ -284,8 +299,9 @@ function buildManifestCollisionInputs(args: {
     samePackage,
     existingIsPackageQualified,
     sameName: newClassName === existing.name,
-    hasNewQualifiedKey: !!packageName,
+    hasNewQualifiedKey: isQualifiedName(registrationKey),
     existingKeyIsQualified: isQualifiedName(existingKey),
+    existingHasAnyPackage: !!existing.packageName,
     hasManifestContent: !!(
       objectDef.fields ||
       objectDef.methods ||
@@ -295,6 +311,11 @@ function buildManifestCollisionInputs(args: {
     registrationKeyDiffersFromExistingKey: registrationKey !== existingKey,
     existingHasNoPackage: !existing.packageName,
   };
+  // Note: manifest-origin sets hasNewQualifiedKey from the final
+  // registrationKey (not packageName) because registerFromManifest accepts
+  // an objectDef.qualifiedName fallback when packageName is omitted —
+  // deriving from packageName alone would miss that case and misroute the
+  // coexistence rows. See PR #1140 review (Copilot P1 at line 287).
 }
 
 /**

--- a/packages/core/src/registry/class-registration.ts
+++ b/packages/core/src/registry/class-registration.ts
@@ -24,6 +24,11 @@ import {
   createQualifiedName,
   isQualifiedName,
 } from '../utils/qualified-names.js';
+import {
+  type CollisionInputs,
+  decideCollisionPolicy,
+  type MatchKind,
+} from './collision-policy.js';
 import { buildInheritanceChain } from './inheritance-resolver';
 import {
   createFieldFromManifest,
@@ -51,6 +56,164 @@ import type {
   ValidatorFunction,
 } from './types.js';
 import { compileValidators } from './validator';
+
+/**
+ * Shared bundled-context detector. Source files in these output
+ * directories come from a bundler (Vite library mode, webpack, Next.js,
+ * Nuxt, svelte-kit) that can duplicate module code across chunks.
+ */
+function isBundledOutputPath(sourceFile: string | undefined): boolean {
+  if (!sourceFile) return false;
+  return (
+    sourceFile.includes('.svelte-kit/output/') ||
+    sourceFile.includes('/dist/') ||
+    sourceFile.includes('/build/') ||
+    sourceFile.includes('.next/') ||
+    sourceFile.includes('.nuxt/')
+  );
+}
+
+/**
+ * Build `CollisionInputs` for the decorator-origin path (`register()`).
+ * Manifest-origin inputs are built separately inside `registerFromManifest`.
+ */
+function buildDecoratorCollisionInputs(args: {
+  ctor: typeof SmrtObject;
+  name: string;
+  newPackageName: string | undefined;
+  newSourceFile: string | undefined;
+  newInBundledContext: boolean;
+  existing: RegisteredClass;
+  existingKey: string;
+  matchKind: MatchKind;
+}): CollisionInputs {
+  const {
+    ctor,
+    name,
+    newPackageName,
+    newSourceFile,
+    newInBundledContext,
+    existing,
+    existingKey,
+    matchKind,
+  } = args;
+
+  let newExtendsExisting = false;
+  let existingExtendsNew = false;
+  try {
+    newExtendsExisting = ctor.prototype instanceof existing.constructor;
+    existingExtendsNew = existing.constructor.prototype instanceof ctor;
+  } catch {
+    // `instanceof` can throw for non-function constructors. Keep both false.
+  }
+
+  const bothSourceFilesKnown = !!(newSourceFile && existing.sourceFilePath);
+  const sameSourceFile =
+    bothSourceFilesKnown && newSourceFile === existing.sourceFilePath;
+  const existingIsPackageQualified = !!existing.packageName?.startsWith('@');
+  const samePackage =
+    !!newPackageName &&
+    !!existing.packageName &&
+    newPackageName === existing.packageName;
+  const hasNewQualifiedKey = !!newPackageName;
+  const existingKeyIsQualified = isQualifiedName(existingKey);
+
+  return {
+    origin: 'decorator',
+    matchKind,
+    sameConstructor: existing.constructor === ctor,
+    sameSourceFile,
+    bothSourceFilesKnown,
+    existingIsManifestStub:
+      (existing.constructor as { _isManifestStub?: boolean })
+        ._isManifestStub === true,
+    newInBundledContext,
+    newExtendsExisting,
+    existingExtendsNew,
+    samePackage,
+    existingIsPackageQualified,
+    sameName: name === existing.name,
+    hasNewQualifiedKey,
+    existingKeyIsQualified,
+  };
+}
+
+/**
+ * Execute the collision policy for `register()`. Returns `true` if the
+ * policy resolved the collision (caller should return from `register`);
+ * `false` means no policy match (the decision table is exhaustive so
+ * that never actually happens — the default row throws).
+ *
+ * All state mutation (`upsertExistingEntry`, verboseLog) stays in this
+ * caller-side helper; the policy function itself is pure.
+ */
+function applyRegisterCollisionPolicy(args: {
+  ctor: typeof SmrtObject;
+  name: string;
+  newPackageName: string | undefined;
+  newSourceFile: string | undefined;
+  newInBundledContext: boolean;
+  existing: RegisteredClass;
+  existingKey: string;
+  matchKind: MatchKind;
+  upsertExistingEntry: (
+    existingKey: string,
+    existing: RegisteredClass,
+  ) => string;
+}): boolean {
+  const inputs = buildDecoratorCollisionInputs(args);
+  const decision = decideCollisionPolicy(inputs);
+
+  switch (decision.policy) {
+    case 'accept':
+    case 'replace': {
+      // Both map to the same operation for the decorator path:
+      // update the existing slot's constructor + metadata. `replace`
+      // only differs in verboseLog flavor so a reviewer reading the log
+      // can tell which scenario fired.
+      const newKey = args.upsertExistingEntry(args.existingKey, args.existing);
+      if (
+        decision.scenario === 'sti-child-wins' ||
+        decision.scenario === 'manifest-stub-replacement'
+      ) {
+        verboseLog(
+          `[registry] ${decision.scenario}: '${args.name}' → key='${newKey}' (${decision.reason})`,
+        );
+      }
+      return true;
+    }
+    case 'skip':
+      verboseLog(
+        `[registry] ${decision.scenario}: skipping '${args.name}' (${decision.reason})`,
+      );
+      return true;
+    case 'throw': {
+      const matchSuffix =
+        args.matchKind === 'case-insensitive'
+          ? ` (case-insensitive match with "${args.existingKey}")`
+          : '';
+      throw new Error(
+        `SMRT Class Name Collision: "${args.name}"${matchSuffix}\n\n` +
+          `A class with this name is already registered, but with a different constructor.\n` +
+          `This usually happens when:\n` +
+          `  1. Multiple test files define classes with the same name\n` +
+          `  2. Different packages export classes with the same name\n\n` +
+          `The collision will cause the wrong field definitions to be used,\n` +
+          `leading to properties not being initialized correctly.\n\n` +
+          `To fix:\n` +
+          `  - Use unique class names (e.g., ${args.name}_UniqueId)\n` +
+          `  - Or use @smrt({ name: 'unique_name' }) to override the registration name`,
+      );
+    }
+    case 'merge-manifest':
+    case 'coexist-qualified':
+      // These policies are only reachable from the manifest path; if we
+      // somehow get here from `register()`, something is miswired.
+      throw new Error(
+        `decideCollisionPolicy returned '${decision.policy}' for decorator origin (scenario: ${decision.scenario}). This is a bug.`,
+      );
+  }
+}
 
 function resolveTableName(
   ctor: typeof SmrtObject,
@@ -155,7 +318,15 @@ export function register(
     return nextKey;
   }
 
-  // Prevent duplicate registrations - check exact match first
+  // Release C (#1134): collision resolution for both exact-match and
+  // case-insensitive paths now routes through decideCollisionPolicy, which
+  // consolidates the 11-branch if/else tree from pre-C.
+  const newSourceFile = getSourceFileFromStack();
+  const newPackageName =
+    explicitPackageName || getPackageName(ctor, true) || undefined;
+  const newInBundledContext = isBundledOutputPath(newSourceFile);
+
+  // 1. Exact-match check (existingKey === name)
   if (getClasses().has(name)) {
     const existing = getClasses().get(name);
     if (!existing) {
@@ -164,230 +335,40 @@ export function register(
       );
     }
 
-    // Check if this is the exact same constructor (re-registration is OK)
-    if (existing.constructor === ctor) {
-      upsertExistingEntry(name, existing);
-      return;
-    }
-
-    // Check if existing is a manifest stub that should be replaced by the real class
-    // This happens when:
-    // 1. `smrt test` generates a manifest which registers classes via registerFromManifest()
-    // 2. Test file imports the real class, triggering the @smrt() decorator
-    // 3. The real class should replace the stub (same name, different constructor)
-    if ((existing.constructor as any)._isManifestStub === true) {
-      upsertExistingEntry(name, existing);
-      verboseLog(`[registry] Replaced manifest stub with real class: ${name}`);
-      return;
-    }
-
-    // Check if existing entry was registered from external package manifest data
-    // (Issue #584: Registry collision when real class tries to replace manifest-loaded entry)
-    // This happens when:
-    // 1. CLI loads manifest and registers classes using manifest data via register()
-    // 2. Later, register.js imports the real class, triggering the @smrt() decorator
-    // 3. The real class should replace the manifest-loaded entry
-    // We detect this by checking if existing has packageName from an external package
-    const newPackageName = explicitPackageName || getPackageName(ctor, true);
-    if (existing.packageName?.startsWith('@')) {
-      // If the new class is from the same package, allow replacement
-      if (newPackageName === existing.packageName) {
-        upsertExistingEntry(name, existing);
-        return;
-      }
-    }
-
-    // Check if this is the same class being re-registered from module re-evaluation
-    // This happens during vitest test collection when modules are re-evaluated for isolation
-    // (Issue #555: Test isolation - class name collision during vitest collection)
-    const newSourceFile = getSourceFileFromStack();
-
-    // Detect bundled context: source file is in a build output directory
-    // Bundlers (Vite, webpack, etc.) can duplicate module code into multiple chunks,
-    // causing the same class to be registered multiple times with different source paths
-    const isBundledContext =
-      newSourceFile &&
-      (newSourceFile.includes('.svelte-kit/output/') ||
-        newSourceFile.includes('/dist/') ||
-        newSourceFile.includes('/build/') ||
-        newSourceFile.includes('.next/') ||
-        newSourceFile.includes('.nuxt/'));
-
-    // In bundled contexts, allow re-registration if the existing entry came from a manifest
-    // (which means it's a known package class that the bundler duplicated)
-    if (isBundledContext && existing.packageName?.startsWith('@')) {
-      upsertExistingEntry(name, existing);
-      return;
-    }
-
-    // Allow re-registration if:
-    // 1. Both source files are defined and match (same file being re-evaluated)
-    // 2. Either source file is unavailable (can't do proper comparison, allow as fallback)
-    const sourceFilesMatch =
-      newSourceFile &&
-      existing.sourceFilePath &&
-      newSourceFile === existing.sourceFilePath;
-    const cannotCompareSourceFiles = !newSourceFile || !existing.sourceFilePath;
-
-    if (sourceFilesMatch || cannotCompareSourceFiles) {
-      // Same source file or can't compare = allow constructor update
-      upsertExistingEntry(name, existing);
-      return;
-    }
-
-    // Allow subclass to replace parent class with the same name (STI child-wins).
-    // This happens when a downstream package extends a base class with the same
-    // name to customize behavior (e.g., histrio's Character extends smrt-video's Character).
-    try {
-      if (ctor.prototype instanceof existing.constructor) {
-        // New class extends existing — child wins
-        upsertExistingEntry(name, existing);
-        verboseLog(
-          `[registry] Subclass '${name}' from ${newPackageName || 'unknown'} replaced parent from ${existing.packageName || 'unknown'}`,
-        );
-        return;
-      }
-      if (existing.constructor.prototype instanceof ctor) {
-        // Existing class extends new — existing (child) already wins, skip
-        verboseLog(
-          `[registry] Skipping parent '${name}' — subclass already registered`,
-        );
-        return;
-      }
-    } catch {
-      // instanceof can throw if constructors are not proper functions — fall through to collision error
-    }
-
-    // Different constructors with same name from different source files - this is a collision!
-    // This will cause silent bugs where the wrong fields are used
-    throw new Error(
-      `SMRT Class Name Collision: "${name}"\n\n` +
-        `A class with this name is already registered, but with a different constructor.\n` +
-        `This usually happens when:\n` +
-        `  1. Multiple test files define classes with the same name\n` +
-        `  2. Different packages export classes with the same name\n\n` +
-        `The collision will cause the wrong field definitions to be used,\n` +
-        `leading to properties not being initialized correctly.\n\n` +
-        `To fix:\n` +
-        `  - Use unique class names (e.g., ${name}_UniqueId)\n` +
-        `  - Or use @smrt({ name: 'unique_name' }) to override the registration name`,
-    );
+    const handled = applyRegisterCollisionPolicy({
+      ctor,
+      name,
+      newPackageName,
+      newSourceFile,
+      newInBundledContext,
+      existing,
+      existingKey: name,
+      matchKind: 'exact-key',
+      upsertExistingEntry,
+    });
+    if (handled) return;
   }
 
-  // Case-insensitive check for manifest stubs (Issue #531, #847)
-  // Manifest keys can be:
-  // - lowercase simple names (e.g., 'praeco')
-  // - qualified names (e.g., '@happyvertical/praeco:Council')
-  // When the real class is loaded via @smrt() decorator, we need to find and replace the stub.
-  // Issue #847: Also check the entry's `name` property which contains the simple class name.
+  // 2. Case-insensitive check for manifest stubs (Issue #531, #847) and
+  //    other same-name-different-case collisions.
   const lowerName = name.toLowerCase();
   for (const [existingKey, existing] of getClasses().entries()) {
-    // Match by key (original behavior) OR by the entry's simple name property (Issue #847)
     const keyMatches = existingKey.toLowerCase() === lowerName;
     const nameMatches = existing.name?.toLowerCase() === lowerName;
-    if ((keyMatches || nameMatches) && existingKey !== name) {
-      // Found case-insensitive match with different casing
-      if ((existing.constructor as any)._isManifestStub === true) {
-        const newKey = upsertExistingEntry(existingKey, existing);
-        verboseLog(
-          `[registry] Replaced manifest stub '${existingKey}' with real class '${name}' (key: ${newKey})`,
-        );
-        return;
-      }
+    if (!(keyMatches || nameMatches) || existingKey === name) continue;
 
-      // Non-stub case-insensitive collision - same constructor is OK
-      if (existing.constructor === ctor) {
-        upsertExistingEntry(existingKey, existing);
-        return;
-      }
-
-      // Same package, different pnpm store copy — harmless duplicate
-      // This happens when pnpm installs multiple physical copies of the same package
-      // due to different peer dependency resolutions. Each copy has a distinct constructor
-      // but they are semantically the same class.
-      // Requirements: existing entry has a qualified key, same package, AND same class name
-      // (case-sensitive). A case-insensitive-only match with different exact names indicates
-      // genuinely different classes, not pnpm duplicates.
-      const newPackageName = explicitPackageName || getPackageName(ctor, true);
-      if (
-        isQualifiedName(existingKey) &&
-        newPackageName &&
-        existing.packageName &&
-        newPackageName === existing.packageName &&
-        name === existing.name
-      ) {
-        upsertExistingEntry(existingKey, existing);
-        return;
-      }
-
-      // Check if this is the same class being re-registered from module re-evaluation
-      // (Issue #555: Test isolation - class name collision during vitest collection)
-      const newSourceFile = getSourceFileFromStack();
-
-      // Bundled context: source file is in a build output directory
-      // Mirrors the exact-match bundled context check above
-      const isBundledContext =
-        newSourceFile &&
-        (newSourceFile.includes('.svelte-kit/output/') ||
-          newSourceFile.includes('/dist/') ||
-          newSourceFile.includes('/build/') ||
-          newSourceFile.includes('.next/') ||
-          newSourceFile.includes('.nuxt/'));
-
-      if (isBundledContext && existing.packageName?.startsWith('@')) {
-        upsertExistingEntry(existingKey, existing);
-        return;
-      }
-
-      // Allow re-registration if:
-      // 1. Both source files are defined and match (same file being re-evaluated)
-      // 2. Either source file is unavailable (can't do proper comparison, allow as fallback)
-      const sourceFilesMatch =
-        newSourceFile &&
-        existing.sourceFilePath &&
-        newSourceFile === existing.sourceFilePath;
-      const cannotCompareSourceFiles =
-        !newSourceFile || !existing.sourceFilePath;
-
-      if (sourceFilesMatch || cannotCompareSourceFiles) {
-        // Same source file or can't compare = allow constructor update
-        upsertExistingEntry(existingKey, existing);
-        return;
-      }
-
-      // Allow subclass to replace parent class (STI child-wins, case-insensitive)
-      try {
-        if (ctor.prototype instanceof existing.constructor) {
-          const stiKey = upsertExistingEntry(existingKey, existing);
-          verboseLog(
-            `[registry] Subclass '${name}' replaced parent '${existingKey}' (key: ${stiKey})`,
-          );
-          return;
-        }
-        if (existing.constructor.prototype instanceof ctor) {
-          verboseLog(
-            `[registry] Skipping parent '${name}' — subclass '${existingKey}' already registered`,
-          );
-          return;
-        }
-      } catch {
-        // instanceof can throw if constructors are not proper functions — fall through
-      }
-
-      // Different constructors with case-insensitive name match from different source files
-      throw new Error(
-        `SMRT Class Name Collision: "${name}" (case-insensitive match with "${existingKey}")\n\n` +
-          `A class with this name is already registered, but with a different constructor.\n` +
-          `This usually happens when:\n` +
-          `  1. Multiple test files define classes with the same name\n` +
-          `  2. Different packages export classes with the same name\n\n` +
-          `The collision will cause the wrong field definitions to be used,\n` +
-          `leading to properties not being initialized correctly.\n\n` +
-          `To fix:\n` +
-          `  - Use unique class names (e.g., ${name}_UniqueId)\n` +
-          `  - Or use @smrt({ name: 'unique_name' }) to override the registration name`,
-      );
-    }
+    const handled = applyRegisterCollisionPolicy({
+      ctor,
+      name,
+      newPackageName,
+      newSourceFile,
+      newInBundledContext,
+      existing,
+      existingKey,
+      matchKind: 'case-insensitive',
+      upsertExistingEntry,
+    });
+    if (handled) return;
   }
 
   // CRITICAL: Capture package name NOW, while stack trace still shows external package

--- a/packages/core/src/registry/class-registration.ts
+++ b/packages/core/src/registry/class-registration.ts
@@ -135,6 +135,10 @@ function buildDecoratorCollisionInputs(args: {
     sameName: name === existing.name,
     hasNewQualifiedKey,
     existingKeyIsQualified,
+    // Manifest-only fields; filled with safe defaults for decorator origin.
+    hasManifestContent: false,
+    registrationKeyDiffersFromExistingKey: false,
+    existingHasNoPackage: !existing.packageName,
   };
 }
 
@@ -211,6 +215,155 @@ function applyRegisterCollisionPolicy(args: {
       // somehow get here from `register()`, something is miswired.
       throw new Error(
         `decideCollisionPolicy returned '${decision.policy}' for decorator origin (scenario: ${decision.scenario}). This is a bug.`,
+      );
+  }
+}
+
+/**
+ * Build `CollisionInputs` for the manifest-origin path
+ * (`registerFromManifest`). Manifest entries have string-based inheritance
+ * (`objectDef.extends`) rather than prototype-based, and no real
+ * constructor to compare — `sameConstructor` is always false here.
+ */
+function buildManifestCollisionInputs(args: {
+  name: string;
+  objectDef: any;
+  packageName: string | undefined;
+  existing: RegisteredClass;
+  existingKey: string;
+  registrationKey: string;
+  matchKind: MatchKind;
+}): CollisionInputs {
+  const {
+    name,
+    objectDef,
+    packageName,
+    existing,
+    existingKey,
+    registrationKey,
+    matchKind,
+  } = args;
+  const newClassName = objectDef.className || name;
+  const newExtends = objectDef.extends as string | undefined;
+
+  const newExtendsExisting = !!(
+    newExtends &&
+    (newExtends === existing.name ||
+      newExtends === existingKey ||
+      newExtends.toLowerCase() === existing.name.toLowerCase())
+  );
+  const existingExtendsNew = !!(
+    existing.extends &&
+    (existing.extends === newClassName ||
+      existing.extends === name ||
+      existing.extends.toLowerCase() === newClassName.toLowerCase())
+  );
+
+  const newSourceFile = objectDef.filePath as string | undefined;
+  const bothSourceFilesKnown = !!(newSourceFile && existing.sourceFilePath);
+  const sameSourceFile =
+    bothSourceFilesKnown && newSourceFile === existing.sourceFilePath;
+  const existingIsPackageQualified = !!existing.packageName?.startsWith('@');
+  const samePackage =
+    !!packageName &&
+    !!existing.packageName &&
+    packageName === existing.packageName;
+
+  return {
+    origin: 'manifest',
+    matchKind,
+    sameConstructor: false,
+    sameSourceFile,
+    bothSourceFilesKnown,
+    existingIsManifestStub:
+      (existing.constructor as { _isManifestStub?: boolean })
+        ._isManifestStub === true,
+    newInBundledContext: false,
+    newExtendsExisting,
+    existingExtendsNew,
+    samePackage,
+    existingIsPackageQualified,
+    sameName: newClassName === existing.name,
+    hasNewQualifiedKey: !!packageName,
+    existingKeyIsQualified: isQualifiedName(existingKey),
+    hasManifestContent: !!(
+      objectDef.fields ||
+      objectDef.methods ||
+      objectDef.schema ||
+      objectDef.decoratorConfig
+    ),
+    registrationKeyDiffersFromExistingKey: registrationKey !== existingKey,
+    existingHasNoPackage: !existing.packageName,
+  };
+}
+
+/**
+ * Execute the collision policy for `registerFromManifest()`. Returns
+ * `'return'` when the policy fully resolves the collision (caller should
+ * early-return from `registerFromManifest`) or `'continue'` when the new
+ * registration should proceed to the fresh-entry code below the collision
+ * block (either a child-wins delete-then-register or a different-package
+ * coexist-qualified scenario).
+ *
+ * Implements the `merge-manifest` contract end-to-end: fold fields via
+ * `mergeManifestIntoExistingRegistration`, then conditionally alias the
+ * existing entry under `registrationKey` when it differs from the
+ * canonical key — both steps preserve `issue-951:144-200`.
+ */
+function applyManifestCollisionPolicy(args: {
+  name: string;
+  objectDef: any;
+  packageName: string | undefined;
+  existing: RegisteredClass;
+  existingKey: string;
+  registrationKey: string;
+  matchKind: MatchKind;
+}): 'return' | 'continue' {
+  const inputs = buildManifestCollisionInputs(args);
+  const decision = decideCollisionPolicy(inputs);
+
+  switch (decision.policy) {
+    case 'skip':
+      verboseLog(
+        `[registry] ${decision.scenario}: skipping manifest '${args.name}' (${decision.reason})`,
+      );
+      return 'return';
+    case 'replace':
+      // STI child-wins: delete existing so the new entry can register fresh.
+      getClasses().delete(args.existingKey);
+      verboseLog(
+        `[registry] ${decision.scenario}: '${args.name}' replaces '${args.existingKey}' (${decision.reason})`,
+      );
+      return 'continue';
+    case 'merge-manifest': {
+      mergeManifestIntoExistingRegistration(
+        args.existing,
+        args.objectDef,
+        args.packageName,
+      );
+      if (args.registrationKey !== args.existingKey) {
+        const classes = getClasses();
+        classes.set(args.registrationKey, args.existing);
+        getConstructorIndex().set(
+          args.existing.constructor,
+          args.registrationKey,
+        );
+      }
+      return 'return';
+    }
+    case 'coexist-qualified':
+      // Both registrations live under their qualified keys; caller falls
+      // through to register the new one fresh.
+      return 'continue';
+    case 'accept':
+      // Manifest origin never returns 'accept' (that's a decorator-path
+      // policy). Treat defensively as return-no-op.
+      return 'return';
+    case 'throw':
+      // Manifest collisions default to skip, never throw — this branch is
+      // unreachable from the manifest origin. Guard against future drift.
+      throw new Error(
+        `decideCollisionPolicy returned 'throw' for manifest origin (scenario: ${decision.scenario}). This is a bug.`,
       );
   }
 }
@@ -854,60 +1007,11 @@ export function registerCollection(
   getCollections().set(objectName, collectionConstructor as any);
 }
 
-export function resolveManifestCollision(
-  name: string,
-  objectDef: any,
-  packageName: string | undefined,
-  existing: RegisteredClass,
-  existingKey: string,
-): 'child-wins' | 'skip' {
-  const newClassName = objectDef.className || name;
-  const newExtends = objectDef.extends;
-
-  // Same source file → re-export from a consumer manifest, not a real collision
-  if (
-    existing.sourceFilePath &&
-    objectDef.filePath &&
-    existing.sourceFilePath === objectDef.filePath
-  ) {
-    return 'skip';
-  }
-
-  // STI child-wins: new class extends the existing one
-  if (
-    newExtends &&
-    (newExtends === existing.name ||
-      newExtends === existingKey ||
-      newExtends.toLowerCase() === existing.name.toLowerCase())
-  ) {
-    verboseLog(
-      `[registry] Manifest child-wins: "${newClassName}" from ${packageName || 'unknown'} ` +
-        `replaces parent "${existingKey}" from ${existing.packageName || 'unknown'}`,
-    );
-    return 'child-wins';
-  }
-
-  // Existing is already the child of the new class → keep existing
-  if (
-    existing.extends &&
-    (existing.extends === newClassName ||
-      existing.extends === name ||
-      existing.extends.toLowerCase() === newClassName.toLowerCase())
-  ) {
-    verboseLog(
-      `[registry] Skipping manifest parent "${name}" — child "${existingKey}" already registered`,
-    );
-    return 'skip';
-  }
-
-  // True collision — different classes, no inheritance relationship
-  verboseLog(
-    `[registry] Manifest collision: "${name}" from ${packageName || 'unknown'} ` +
-      `conflicts with "${existingKey}" from ${existing.packageName || 'unknown'} ` +
-      `(no inheritance relationship)`,
-  );
-  return 'skip';
-}
+// resolveManifestCollision was removed in Release C (#1134). Its three-branch
+// decision is now represented as explicit rows in the collision-policy
+// decision table — see `manifest-same-source-file`, `manifest-sti-child-wins`,
+// `manifest-sti-parent-skip`, `manifest-default-skip` scenarios in
+// packages/core/src/registry/collision-policy.ts.
 
 function normalizeTenantScopedConfig(
   tenantScoped: any,
@@ -1192,130 +1296,53 @@ export function registerFromManifest(
     : (objectDef.qualifiedName as QualifiedClassName | undefined);
   const registrationKey = (qualifiedNameEarly || name) as string;
 
-  // Prevent duplicate registrations (case-insensitive)
-  // This prevents both 'praeco' and 'Praeco' from being registered separately
-  // which caused race conditions in PostgreSQL due to duplicate command execution
+  // Release C (#1134): collision resolution routes through
+  // decideCollisionPolicy. See collision-policy.ts for the 16-row decision
+  // table; applyManifestCollisionPolicy below turns a policy into registry
+  // mutations.
   //
-  // Issue #950: Before silently returning, check if the collision is an STI
-  // child-wins scenario. The decorator-based register() path uses instanceof
-  // checks, but manifest stubs don't have real prototype chains — so we use
-  // the objectDef.extends field for string-based inheritance comparison.
+  // Two collision checks, matching pre-C behavior:
+  //   1. Canonical-name lookup (case-insensitive simple-name match; covers
+  //      issue #950's STI child-wins and issue #951's qualified coexistence).
+  //   2. Exact-key match (handles re-registration with same qualified key).
   //
-  // Issue #951: Look up by simple class name (not the qualified key) so
-  // cross-package STI child-wins is detected.
+  // The ambiguous case (multiple existing entries share the simple name —
+  // `getCanonicalClassName` returns undefined) is NOT fed through the table.
+  // It falls through both checks into the new-registration code below,
+  // preserving issue #951's coexistence semantics.
   const existingCanonical = getCanonicalClassName(simpleClassName);
   if (existingCanonical) {
     const existing = getClasses().get(existingCanonical);
     if (existing) {
-      const resolution = resolveManifestCollision(
+      const outcome = applyManifestCollisionPolicy({
         name,
         objectDef,
         packageName,
         existing,
-        existingCanonical,
-      );
-      if (resolution === 'child-wins') {
-        // Remove old entry so the child can be registered below
-        getClasses().delete(existingCanonical);
-      } else {
-        // 'skip' — existing wins (parent after child, same file, or true collision)
-        const allowCoexistingQualifiedRegistration =
-          registrationKey !== existingCanonical &&
-          !!packageName &&
-          !!existing.packageName &&
-          packageName !== existing.packageName;
-
-        // Issue #951: With qualified keys, allow coexistence of different packages
-        if (registrationKey !== existingCanonical) {
-          const canMergeIntoExisting =
-            packageName &&
-            (!existing.packageName || packageName === existing.packageName);
-
-          // Different qualified keys → allow both to be registered
-          // (ambiguity will be detected at findClass time)
-          //
-          // Issue #1000: Merge plain-property fields from the manifest into the
-          // existing decorator-registered entry — but ONLY when both entries come
-          // from the same package. This is the scenario where the @smrt() decorator
-          // ran first (registering only decorator-annotated fields like @foreignKey
-          // and @tenantId) and the manifest entry from the same package now provides
-          // the full field list including plain TypeScript properties like
-          // `contractId: string = ''`. Without this merge, toJSON() only serializes
-          // decorator-annotated columns, silently dropping plain-property fields.
-          //
-          // Restricting to same-package prevents corrupting unrelated classes that
-          // happen to share a name across different packages (genuine collisions).
-          if (
-            canMergeIntoExisting &&
-            (objectDef.fields ||
-              objectDef.methods ||
-              objectDef.schema ||
-              objectDef.decoratorConfig)
-          ) {
-            mergeManifestIntoExistingRegistration(
-              existing,
-              objectDef,
-              packageName,
-            );
-
-            if (registrationKey !== existingCanonical) {
-              const classes = getClasses();
-              classes.set(registrationKey, existing);
-              getConstructorIndex().set(existing.constructor, registrationKey);
-            }
-
-            return;
-          }
-
-          if (allowCoexistingQualifiedRegistration) {
-            // Same simple class name in a different package: allow coexistence.
-            // We'll continue into the exact-key/new-registration path below.
-          } else {
-            return;
-          }
-        }
-
-        if (
-          packageName &&
-          (!existing.packageName || packageName === existing.packageName) &&
-          (objectDef.fields ||
-            objectDef.methods ||
-            objectDef.schema ||
-            objectDef.decoratorConfig)
-        ) {
-          mergeManifestIntoExistingRegistration(
-            existing,
-            objectDef,
-            packageName,
-          );
-          return;
-        }
-
-        if (!allowCoexistingQualifiedRegistration) {
-          return;
-        }
-      }
-    } else {
-      // Stale classNameMap entry (key exists but class was removed) — allow registration
+        existingKey: existingCanonical,
+        registrationKey,
+        matchKind: 'canonical-name',
+      });
+      if (outcome === 'return') return;
+      // outcome === 'continue' means policy was replace (child-wins) or
+      // coexist — fall through into the new-registration code below.
     }
+    // else: stale map entry (key exists but class was removed) — allow registration
   }
-  // Check exact key match (handles re-registration with same qualified key)
+
   if (getClasses().has(registrationKey)) {
     const existing = getClasses().get(registrationKey);
     if (!existing) return;
-    const resolution = resolveManifestCollision(
+    const outcome = applyManifestCollisionPolicy({
       name,
       objectDef,
       packageName,
       existing,
+      existingKey: registrationKey,
       registrationKey,
-    );
-    if (resolution === 'child-wins') {
-      getClasses().delete(registrationKey);
-    } else {
-      mergeManifestIntoExistingRegistration(existing, objectDef, packageName);
-      return;
-    }
+      matchKind: 'exact-key',
+    });
+    if (outcome === 'return') return;
   }
 
   // Issue #1004: Qualify the `extends` value BEFORE inserting this class

--- a/packages/core/src/registry/collision-policy.ts
+++ b/packages/core/src/registry/collision-policy.ts
@@ -113,9 +113,20 @@ export interface CollisionInputs {
 
   /**
    * `existing.packageName?.startsWith('@')` — existing entry came from a
-   * scoped package manifest (i.e., is externally identified).
+   * **scoped** package manifest (e.g. `@happyvertical/smrt-core`). Used by
+   * the external-package-replace (#584) and bundled-context scenarios
+   * that were gated on `@` in pre-Release-C code.
    */
   readonly existingIsPackageQualified: boolean;
+
+  /**
+   * Existing entry carries any packageName, scoped or not. Broader than
+   * `existingIsPackageQualified`. Used for the different-packages
+   * coexistence scenario where pre-Release-C code only required both
+   * packageNames to be present and different (unscoped manifests like
+   * `smrt-profiles` count here).
+   */
+  readonly existingHasAnyPackage: boolean;
 
   /**
    * Case-sensitive equality between `new.name` and `existing.name`.
@@ -243,19 +254,25 @@ const ROWS: readonly Row[] = [
   },
 
   {
+    // Uses `existingHasAnyPackage` not `existingIsPackageQualified`: the
+    // pre-Release-C `allowCoexistingQualifiedRegistration` check only
+    // required both packages to be present and differ, regardless of
+    // whether they were scoped (`@scope/pkg`) or unscoped (`smrt-profiles`).
+    // Narrowing to scoped would silently drop coexistence for unscoped
+    // manifests. See PR #1140 review (willgriffin P2 at line 251).
     scenario: 'manifest-different-packages-qualified-coexist',
     match: (i) =>
       i.origin === 'manifest' &&
       !i.samePackage &&
       i.hasNewQualifiedKey &&
-      i.existingIsPackageQualified,
+      i.existingHasAnyPackage,
     policy: 'coexist-qualified',
     reason: () =>
       'Different packages share a simple name; both registrations live under their qualified keys (issue #951).',
   },
 
   {
-    // Covers two related scenarios:
+    // Covers three related scenarios:
     //   (a) `samePackage`          — decorator + manifest from the same
     //       package land on the same class; merge fields (issue #1000).
     //   (b) `existingHasNoPackage` — source registration hasn't been
@@ -263,11 +280,19 @@ const ROWS: readonly Row[] = [
     //       the package identity (issue #951:144-200). The merge runs
     //       AND the caller aliases the existing entry under the new
     //       qualified key.
+    //   (c) The same scenarios when the existing entry is a manifest
+    //       stub from an earlier unqualified/local manifest registration
+    //       — the pre-Release-C code merged whenever
+    //       `!existing.packageName || packageName === existing.packageName`
+    //       regardless of stub status. Release C preserves that: removing
+    //       the `!existingIsManifestStub` gate lets a later
+    //       package-qualified manifest upgrade a stub's fields + alias
+    //       under the qualified key. See PR #1140 review (willgriffin P1
+    //       at line 270).
     scenario: 'manifest-same-package-merge',
     match: (i) =>
       i.origin === 'manifest' &&
       (i.samePackage || (i.existingHasNoPackage && i.hasNewQualifiedKey)) &&
-      !i.existingIsManifestStub &&
       i.hasManifestContent,
     policy: 'merge-manifest',
     reason: () =>
@@ -298,12 +323,15 @@ const ROWS: readonly Row[] = [
   },
 
   {
+    // pnpm-dup allows unscoped package names (old code didn't gate on
+    // scoped-only). `samePackage` already requires both sides to have a
+    // packageName and match, so no extra existingHasAnyPackage check
+    // is needed.
     scenario: 'decorator-case-insensitive-pnpm-duplicate',
     match: (i) =>
       i.origin === 'decorator' &&
       i.matchKind === 'case-insensitive' &&
       i.existingKeyIsQualified &&
-      i.existingIsPackageQualified &&
       i.samePackage &&
       i.sameName &&
       !i.sameConstructor,

--- a/packages/core/src/registry/collision-policy.ts
+++ b/packages/core/src/registry/collision-policy.ts
@@ -137,6 +137,31 @@ export interface CollisionInputs {
    * (old code required both).
    */
   readonly existingKeyIsQualified: boolean;
+
+  /**
+   * Manifest-origin only: the incoming `objectDef` carries at least one of
+   * `fields`, `methods`, `schema`, or `decoratorConfig`. Without that, the
+   * merge path has nothing to fold in and the caller should skip the
+   * merge-manifest policy entirely.
+   */
+  readonly hasManifestContent: boolean;
+
+  /**
+   * Manifest-origin only: the new registration's qualified key differs
+   * from the existing entry's canonical key. When true and the policy is
+   * `merge-manifest`, the caller MUST also alias the existing entry under
+   * the new qualified key (step 2 of the merge-manifest contract).
+   */
+  readonly registrationKeyDiffersFromExistingKey: boolean;
+
+  /**
+   * Existing registration has no `packageName` set. Distinct from
+   * `!samePackage`: this specifically means the existing entry is a bare
+   * source registration waiting for a package manifest to promote it. When
+   * true and the new registration carries a packageName, merge-manifest
+   * treats it as promotion rather than collision.
+   */
+  readonly existingHasNoPackage: boolean;
 }
 
 export interface PolicyDecision {
@@ -175,8 +200,15 @@ const ROWS: readonly Row[] = [
   },
 
   {
+    // Decorator-only: the decorator fires after a manifest builder
+    // pre-registered a stub placeholder under this name. The real class
+    // takes over. Manifest-origin stub-to-stub arrivals fall through to
+    // the source-file / STI rows instead.
     scenario: 'manifest-stub-replacement',
-    match: (i) => i.existingIsManifestStub && !i.sameConstructor,
+    match: (i) =>
+      i.origin === 'decorator' &&
+      i.existingIsManifestStub &&
+      !i.sameConstructor,
     policy: 'replace',
     reason: () =>
       'Existing entry is a manifest stub placeholder; the real implementation takes over.',
@@ -223,12 +255,23 @@ const ROWS: readonly Row[] = [
   },
 
   {
+    // Covers two related scenarios:
+    //   (a) `samePackage`          — decorator + manifest from the same
+    //       package land on the same class; merge fields (issue #1000).
+    //   (b) `existingHasNoPackage` — source registration hasn't been
+    //       promoted to a qualified key yet and a manifest now provides
+    //       the package identity (issue #951:144-200). The merge runs
+    //       AND the caller aliases the existing entry under the new
+    //       qualified key.
     scenario: 'manifest-same-package-merge',
     match: (i) =>
-      i.origin === 'manifest' && i.samePackage && !i.existingIsManifestStub,
+      i.origin === 'manifest' &&
+      (i.samePackage || (i.existingHasNoPackage && i.hasNewQualifiedKey)) &&
+      !i.existingIsManifestStub &&
+      i.hasManifestContent,
     policy: 'merge-manifest',
     reason: () =>
-      'Manifest arriving for an existing same-package source registration; fold fields in and alias the qualified key.',
+      'Manifest arriving for an existing same-package or unqualified source registration; fold fields in and alias the qualified key if keys differ.',
   },
 
   {

--- a/packages/core/src/registry/collision-policy.ts
+++ b/packages/core/src/registry/collision-policy.ts
@@ -1,0 +1,349 @@
+/**
+ * Release C (#1134) — unified collision policy for class registration.
+ *
+ * `register()` and `registerFromManifest()` both need to decide what to do
+ * when a new registration lands on an existing class with the same (or a
+ * case-insensitive-matching) name. Before Release C the decision logic was
+ * a ~300-line if/else tree duplicated across three code paths:
+ *
+ *   - `register()` exact-match branch          (class-registration.ts:159-275)
+ *   - `register()` case-insensitive branch     (class-registration.ts:286-391)
+ *   - `resolveManifestCollision()`             (class-registration.ts:876-929)
+ *
+ * This module collapses all three onto a single decision table. Each row
+ * names a scenario that exists in the current test suite; the row order
+ * encodes specificity (first match wins).
+ *
+ * # Invocation contract
+ *
+ * `decideCollisionPolicy(inputs)` is ONLY called when the caller has already
+ * identified exactly one colliding candidate for the new registration. Two
+ * cases MUST be handled upstream without consulting the table:
+ *
+ *   1. No colliding candidate exists  → register fresh.
+ *   2. Ambiguous simple name matches >1 existing entry across different
+ *      packages (`getCanonicalClassName()` returns undefined) → fall through
+ *      to the exact-key path and allow coexistence under qualified keys.
+ *      See issue #951 for the semantics being preserved.
+ *
+ * Feeding the ambiguous case through the table would lose the
+ * `coexist-qualified` behavior that's crucial for multi-package apps.
+ *
+ * @see https://github.com/happyvertical/smrt/issues/1134
+ */
+
+export type RegistrationOrigin = 'decorator' | 'manifest';
+
+/**
+ * How the colliding candidate was identified.
+ *
+ *   - `exact-key`          : `classes.get(name)` returned the candidate.
+ *                            `existingKey === name`.
+ *   - `case-insensitive`   : Iteration found a case-insensitive match on
+ *                            either the registry key or the entry's `name`
+ *                            property. `existingKey !== name`.
+ *   - `canonical-name`     : Looked up via `getCanonicalClassName(simpleName)`
+ *                            — unambiguous single match under a lowered
+ *                            simple name. Used by the manifest path.
+ */
+export type MatchKind = 'exact-key' | 'case-insensitive' | 'canonical-name';
+
+export type Policy =
+  /** Keep existing identity, update metadata via `upsertExistingEntry`. */
+  | 'accept'
+  /** Drop existing, register new as replacement. */
+  | 'replace'
+  /**
+   * Fold manifest fields into existing registration. The **caller MUST**:
+   *   (1) call `mergeManifestIntoExistingRegistration(existing, objectDef, packageName)`
+   *   (2) if `registrationKey !== existingCanonical`, alias the existing entry
+   *       under `registrationKey` via `classes.set()` + `constructorIndex.set()`
+   * Both steps together preserve the `issue-951:144-200` contract.
+   */
+  | 'merge-manifest'
+  /**
+   * Different packages, different qualified keys. Both registrations stay
+   * in the classes Map under their respective qualified keys. Ambiguity is
+   * surfaced at `findClass` time. Preserves issue #951.
+   */
+  | 'coexist-qualified'
+  /** Existing wins; silently ignore the new registration. */
+  | 'skip'
+  /** Unresolvable collision — raise a user-facing error. */
+  | 'throw';
+
+/**
+ * Every signal the decision table can read. Computed by the caller from
+ * inspection of the new and existing registrations.
+ */
+export interface CollisionInputs {
+  readonly origin: RegistrationOrigin;
+  readonly matchKind: MatchKind;
+
+  /** `new.ctor === existing.constructor` (decorator path only; false for manifest). */
+  readonly sameConstructor: boolean;
+
+  /** `new.sourceFile === existing.sourceFilePath`, both truthy. */
+  readonly sameSourceFile: boolean;
+
+  /** Both the new and existing registrations have known source files. */
+  readonly bothSourceFilesKnown: boolean;
+
+  /** `existing.constructor._isManifestStub === true`. */
+  readonly existingIsManifestStub: boolean;
+
+  /**
+   * New registration's source file lives in a bundled output directory
+   * (`.svelte-kit/output/`, `/dist/`, `/build/`, `.next/`, `.nuxt/`).
+   */
+  readonly newInBundledContext: boolean;
+
+  /**
+   * New class extends existing.
+   *   - decorator path: `new.ctor.prototype instanceof existing.constructor`
+   *   - manifest path : `new.objectDef.extends` names existing
+   */
+  readonly newExtendsExisting: boolean;
+
+  /** Inverse direction: existing extends new. */
+  readonly existingExtendsNew: boolean;
+
+  /** `new.packageName === existing.packageName` (both truthy). */
+  readonly samePackage: boolean;
+
+  /**
+   * `existing.packageName?.startsWith('@')` — existing entry came from a
+   * scoped package manifest (i.e., is externally identified).
+   */
+  readonly existingIsPackageQualified: boolean;
+
+  /**
+   * Case-sensitive equality between `new.name` and `existing.name`.
+   * Used to distinguish a pnpm-duplicate (same exact name) from a genuine
+   * case-insensitive collision (different names that lower to the same string).
+   */
+  readonly sameName: boolean;
+
+  /**
+   * New registration has (or can derive) a qualified key `@pkg:Name`.
+   * Paired with `existingIsPackageQualified` to drive the different-packages
+   * coexistence behavior from issue #951.
+   */
+  readonly hasNewQualifiedKey: boolean;
+
+  /**
+   * Existing registry key contains a `:` separator. Needed alongside
+   * `existingIsPackageQualified` to identify valid pnpm-dup candidates
+   * (old code required both).
+   */
+  readonly existingKeyIsQualified: boolean;
+}
+
+export interface PolicyDecision {
+  readonly policy: Policy;
+  /** Stable id. Matches the scenario name in the test suite 1-to-1. */
+  readonly scenario: string;
+  /** Human-readable explanation. Used by verboseLog + the error message. */
+  readonly reason: string;
+}
+
+interface Row {
+  readonly scenario: string;
+  readonly match: (inputs: CollisionInputs) => boolean;
+  readonly policy: Policy;
+  readonly reason: (inputs: CollisionInputs) => string;
+}
+
+/**
+ * Ordered decision table. First row whose `match` returns true wins.
+ * Order reflects specificity — scenarios that narrow down earlier
+ * scenarios come before them.
+ *
+ * Each row is named to match a scenario in the test suite so a reviewer
+ * can bisect one-to-one between "new class extends existing" (the code)
+ * and "sti-child-wins" (the test row and the verbose-log output).
+ */
+const ROWS: readonly Row[] = [
+  // --- Cross-origin: constructor identity and stub replacement ----------
+
+  {
+    scenario: 'same-constructor-reregistration',
+    match: (i) => i.sameConstructor,
+    policy: 'accept',
+    reason: () =>
+      'Same constructor identity — module re-evaluation. Update metadata only.',
+  },
+
+  {
+    scenario: 'manifest-stub-replacement',
+    match: (i) => i.existingIsManifestStub && !i.sameConstructor,
+    policy: 'replace',
+    reason: () =>
+      'Existing entry is a manifest stub placeholder; the real implementation takes over.',
+  },
+
+  // --- Manifest-origin rows (checked before decorator-origin) -----------
+
+  {
+    scenario: 'manifest-same-source-file',
+    match: (i) => i.origin === 'manifest' && i.sameSourceFile,
+    policy: 'skip',
+    reason: () =>
+      'Same source file — consumer manifest re-export, not a real collision.',
+  },
+
+  {
+    scenario: 'manifest-sti-child-wins',
+    match: (i) =>
+      i.origin === 'manifest' && i.newExtendsExisting && !i.existingExtendsNew,
+    policy: 'replace',
+    reason: () =>
+      'Manifest entry extends existing — STI child wins over parent.',
+  },
+
+  {
+    scenario: 'manifest-sti-parent-skip',
+    match: (i) =>
+      i.origin === 'manifest' && i.existingExtendsNew && !i.newExtendsExisting,
+    policy: 'skip',
+    reason: () =>
+      'Existing entry is the STI child of the incoming manifest parent; keep the child.',
+  },
+
+  {
+    scenario: 'manifest-different-packages-qualified-coexist',
+    match: (i) =>
+      i.origin === 'manifest' &&
+      !i.samePackage &&
+      i.hasNewQualifiedKey &&
+      i.existingIsPackageQualified,
+    policy: 'coexist-qualified',
+    reason: () =>
+      'Different packages share a simple name; both registrations live under their qualified keys (issue #951).',
+  },
+
+  {
+    scenario: 'manifest-same-package-merge',
+    match: (i) =>
+      i.origin === 'manifest' && i.samePackage && !i.existingIsManifestStub,
+    policy: 'merge-manifest',
+    reason: () =>
+      'Manifest arriving for an existing same-package source registration; fold fields in and alias the qualified key.',
+  },
+
+  {
+    scenario: 'manifest-default-skip',
+    match: (i) => i.origin === 'manifest',
+    policy: 'skip',
+    reason: () =>
+      'Manifest collision with no inheritance relationship; keep existing entry (pre-Release-C resolveManifestCollision default).',
+  },
+
+  // --- Decorator-origin rows --------------------------------------------
+
+  {
+    scenario: 'decorator-exact-match-same-package-external',
+    match: (i) =>
+      i.origin === 'decorator' &&
+      i.matchKind === 'exact-key' &&
+      i.existingIsPackageQualified &&
+      i.samePackage &&
+      !i.sameConstructor,
+    policy: 'accept',
+    reason: () =>
+      'External package manifest entry being replaced by its own decorator-registered class (issue #584).',
+  },
+
+  {
+    scenario: 'decorator-case-insensitive-pnpm-duplicate',
+    match: (i) =>
+      i.origin === 'decorator' &&
+      i.matchKind === 'case-insensitive' &&
+      i.existingKeyIsQualified &&
+      i.existingIsPackageQualified &&
+      i.samePackage &&
+      i.sameName &&
+      !i.sameConstructor,
+    policy: 'accept',
+    reason: () =>
+      'pnpm store duplicated the same package; different physical constructors but semantically identical.',
+  },
+
+  {
+    scenario: 'decorator-bundled-context-known-package',
+    match: (i) =>
+      i.origin === 'decorator' &&
+      i.newInBundledContext &&
+      i.existingIsPackageQualified,
+    policy: 'accept',
+    reason: () =>
+      'Bundled output duplicated a known package class across chunks; treat as re-registration.',
+  },
+
+  {
+    scenario: 'decorator-same-source-file',
+    match: (i) => i.origin === 'decorator' && i.sameSourceFile,
+    policy: 'accept',
+    reason: () =>
+      'Same source file — module re-evaluated (vitest test-isolation or HMR).',
+  },
+
+  {
+    scenario: 'decorator-unknown-source-fallback',
+    match: (i) => i.origin === 'decorator' && !i.bothSourceFilesKnown,
+    policy: 'accept',
+    reason: () =>
+      'Source file unavailable for comparison; allow re-registration rather than block legitimate updates.',
+  },
+
+  // --- Cross-origin STI fallbacks (used by decorator path; manifest
+  //     path has its own explicit rows above that come first) ------------
+
+  {
+    scenario: 'sti-child-wins',
+    match: (i) => i.newExtendsExisting && !i.existingExtendsNew,
+    policy: 'replace',
+    reason: () => 'New class extends existing — STI child wins over parent.',
+  },
+
+  {
+    scenario: 'sti-parent-skip',
+    match: (i) => i.existingExtendsNew && !i.newExtendsExisting,
+    policy: 'skip',
+    reason: () => 'Existing entry extends new — STI child already registered.',
+  },
+
+  // --- Default: unresolvable decorator collision ------------------------
+
+  {
+    scenario: 'true-collision',
+    match: () => true,
+    policy: 'throw',
+    reason: () =>
+      'Different constructors, different source files, no inheritance relationship. Unresolvable collision.',
+  },
+];
+
+/**
+ * Resolve a collision to a policy. See module docstring for the invocation
+ * contract — callers MUST NOT invoke this for the no-candidate or
+ * ambiguous-simple-name cases.
+ */
+export function decideCollisionPolicy(inputs: CollisionInputs): PolicyDecision {
+  for (const row of ROWS) {
+    if (row.match(inputs)) {
+      return {
+        policy: row.policy,
+        scenario: row.scenario,
+        reason: row.reason(inputs),
+      };
+    }
+  }
+  // Unreachable — `true-collision` is the final catch-all.
+  throw new Error(
+    `decideCollisionPolicy: no row matched (should be unreachable). Inputs: ${JSON.stringify(inputs)}`,
+  );
+}
+
+/** Test-only: expose the row list so integration tests can scenario-id. */
+export const __POLICY_ROWS_FOR_TEST: readonly Row[] = ROWS;

--- a/packages/core/src/registry/diagnostics.ts
+++ b/packages/core/src/registry/diagnostics.ts
@@ -84,7 +84,13 @@ export function recordRegistryDiagnostic(
 
   if (severity === 'error' && strictModeEnabled()) {
     const suffix = context ? ` (${JSON.stringify(context)})` : '';
-    throw new Error(`[smrt:${code}] ${message}${suffix}`);
+    // The opt-out hint is load-bearing when this throw propagates out of a
+    // `__smrt-register__.ts` side effect at module-import time — the
+    // consumer may have no other recovery path visible in the stack.
+    throw new Error(
+      `[smrt:${code}] ${message}${suffix} — set SMRT_STRICT_REGISTRY=false ` +
+        `to record this diagnostic without throwing.`,
+    );
   }
 }
 

--- a/packages/core/src/registry/diagnostics.ts
+++ b/packages/core/src/registry/diagnostics.ts
@@ -1,20 +1,23 @@
 /**
  * Registry diagnostic collector.
  *
- * Currently ObjectRegistry's manifest-loading paths swallow a number of
- * failure modes with `console.warn(...); return null`. That is fine for the
- * average case — a missing or malformed manifest from one package shouldn't
- * crash the whole app — but it makes #1132-style debugging hard: the only
- * evidence of the problem is fields silently missing at save time.
+ * ObjectRegistry's manifest-loading paths previously swallowed failure
+ * modes with `console.warn(...); return null`. That was fine for the
+ * average case but made #1132-style debugging hard: the only evidence of
+ * the problem was fields silently missing at save time.
  *
- * This module provides an opt-in collection point for those silent failures.
- * Callers `record()` a diagnostic when they would otherwise `console.warn`;
- * apps and tests can later call `ObjectRegistry.getDiagnostics()` to inspect
- * what was missed.
+ * This module is the collection point for those failures. Callers
+ * `record()` a diagnostic when they would otherwise `console.warn`; apps
+ * and tests can call `ObjectRegistry.getDiagnostics()` to inspect what
+ * was missed.
  *
- * Release A ships this as **passive** — diagnostics accumulate but never
- * throw. Release C (see #1134) flips `SMRT_STRICT_REGISTRY` on by default,
- * at which point severity `'error'` diagnostics will throw at record time.
+ * Release A shipped the collector as passive (off-by-default strict).
+ * Release C (#1134) flips strict mode to **on by default**: severity
+ * `'error'` diagnostics now throw at record time so misconfiguration
+ * surfaces at registration rather than at silent field-drop time. Opt
+ * out with `SMRT_STRICT_REGISTRY=false` if you have manifest-loading
+ * paths that must stay permissive (fix the underlying manifest issue
+ * instead when you can).
  *
  * @see https://github.com/happyvertical/smrt/issues/1132
  * @see https://github.com/happyvertical/smrt/issues/1134
@@ -46,8 +49,15 @@ function getBuffer(): RegistryDiagnostic[] {
   return globalThis.__smrtRegistryDiagnostics;
 }
 
+/**
+ * Strict mode: ON by default (Release C, #1134).
+ *
+ * When true, severity `'error'` diagnostics throw at record time instead
+ * of just appending to the buffer. Set `SMRT_STRICT_REGISTRY=false` to
+ * restore the pre-Release-C permissive behavior.
+ */
 function strictModeEnabled(): boolean {
-  return process.env.SMRT_STRICT_REGISTRY === 'true';
+  return process.env.SMRT_STRICT_REGISTRY !== 'false';
 }
 
 /**


### PR DESCRIPTION
Closes #1134. Third and final release of the [#1132 review](https://github.com/happyvertical/smrt/issues/1132) thread. Six commits, parity gates at commits 2 and 3.

## What changed

**Commit 1 — `collision-policy` module** ([5cb949e5](https://github.com/happyvertical/smrt/pull/new/refactor/issue-1134-collision-policy-strict-default/commits/5cb949e5))
New `packages/core/src/registry/collision-policy.ts` with a 16-row decision table + pure `decideCollisionPolicy(inputs)`. Every row names a scenario that maps 1:1 to an existing collision test (`issue-531`, `issue-555`, `issue-584`, `issue-847`, `issue-950`, `issue-951`, `issue-1000`). 23 unit tests cover every row plus ordering precedence.

**Commit 2 — Route `register()` through the table (parity gate)** ([a2c146b1](https://github.com/happyvertical/smrt/pull/new/refactor/issue-1134-collision-policy-strict-default/commits/a2c146b1))
The 11-branch exact-match + case-insensitive collision tree in `register()` (~300 LOC) collapses onto `applyRegisterCollisionPolicy(args)`. All state mutation stays in the caller; the policy function is pure. Full core suite + turbo 80/80 still green.

**Commit 3 — Route `registerFromManifest`, delete `resolveManifestCollision` (parity gate)** ([2c24b11c](https://github.com/happyvertical/smrt/pull/new/refactor/issue-1134-collision-policy-strict-default/commits/2c24b11c))
Same treatment for the manifest path. The `merge-manifest` caller contract is implemented end-to-end — `mergeManifestIntoExistingRegistration` followed by conditional key aliasing when the new qualified key differs from the canonical one. Preserves `issue-951:144-200` (qualified-key promotion during merge). `resolveManifestCollision` deleted.

Two decision-table refinements caught by the parity gate:
1. `manifest-stub-replacement` is now `origin === 'decorator'` only. Stub replacement never fired in `resolveManifestCollision` pre-C.
2. `manifest-same-package-merge` also fires when `existingHasNoPackage && hasNewQualifiedKey` — covers the issue-951 scenario where a bare source registration is promoted to a qualified key by an arriving manifest.

**Commit 4 — Retire `SMRT_SKIP_STI_REHYDRATE`** ([f7a11d10](https://github.com/happyvertical/smrt/pull/new/refactor/issue-1134-collision-policy-strict-default/commits/f7a11d10))
Flag deleted. Per Codex's review of the plan, the rehydration loop stays — the `external-runtime-hydration.test.ts:1071` stale-cache repair contract is preserved. Optimizing the loop away via eager invalidation is tracked in [#1139](https://github.com/happyvertical/smrt/issues/1139).

**Commit 5 — `SMRT_STRICT_REGISTRY` default-on** ([ede3cc34](https://github.com/happyvertical/smrt/pull/new/refactor/issue-1134-collision-policy-strict-default/commits/ede3cc34))
Severity-`'error'` diagnostics now throw at record time by default. Four codes affected: `MANIFEST_EXPORT_INVALID`, `MANIFEST_EXPORT_NOT_JSON`, `MANIFEST_EXPORT_NOT_FOUND`, `PACKAGE_MANIFEST_READ_FAILED`. Warn-severity codes unchanged. Opt-out: `SMRT_STRICT_REGISTRY=false`. One test (`register-package-manifest.test.ts::silently no-ops when the manifest is malformed JSON`) rewritten to expect a throw; a new opt-out test verifies `=false` restores the legacy behavior and keeps the diagnostic collected.

**Commit 6 — Changeset** ([3ec82c42](https://github.com/happyvertical/smrt/pull/new/refactor/issue-1134-collision-policy-strict-default/commits/3ec82c42))
Minor release on `@happyvertical/smrt-core`.

## Verification

- **Local**: `npx turbo build` 41/41 · `npx turbo test` 80/80 · smrt-core unit tests 1563/1563 pass (baseline 1539 + 24 new: 23 collision-policy rows + 1 strict-mode opt-out)
- **Parity**: every issue-specific collision test (#531, #555, #584, #847, #950, #951, #1000) passes unmodified

## Breaking changes

Minor. Two breaking flips:

| Change | Migration |
|---|---|
| `SMRT_STRICT_REGISTRY` default on | Fix the underlying manifest issue **or** set `SMRT_STRICT_REGISTRY=false` |
| `SMRT_SKIP_STI_REHYDRATE` removed | Remove the flag from your env; it's now a no-op |

Error message text is unchanged; the verbose-log output now includes a stable scenario id from the decision table.

## Review feedback addressed

All four points from the [Codex plan review](https://github.com/happyvertical/smrt/issues/1134#issuecomment-4290823035):

1. **§4 scope narrowed** — flag goes, rehydration loop stays; the `external-runtime-hydration.test.ts:1071` contract is preserved.
2. **`merge-manifest` caller contract documented** — the `applyManifestCollisionPolicy` branch in `class-registration.ts` calls `mergeManifestIntoExistingRegistration` then conditionally aliases the qualified key. `issue-951:144-200` verifies both steps.
3. **Invocation contract made explicit** — `decideCollisionPolicy`'s docstring calls out that ambiguous simple-name matches (multiple packages) must NOT be fed through the table. Caller-side handles the no-candidate and ambiguous-candidate cases.
4. **Diagnostic call-site count corrected** — 6 total (4 error, 2 warn), not 7. Test audit identified one test needing an opt-out stub; handled in commit 5.

## Test plan

- [x] Build all packages green (41/41)
- [x] Full test suite green (80/80 tasks, 1563 core tests)
- [x] Every row in the collision-policy table has a dedicated unit test
- [x] Every issue-specific collision test (531/555/584/847/950/951/1000) passes unmodified
- [x] `external-runtime-hydration.test.ts:1071` stale-cache repair test passes without the env flag
- [x] Strict-mode throws on malformed JSON; opt-out restores permissive behavior
- [ ] CI parity on PR