### PR TITLE
fix(core): close two STI inheritance-cache invalidation gaps (#1139)

### DIFF
--- a/packages/core/src/__tests__/issue-1139-invalidation-gaps.test.ts
+++ b/packages/core/src/__tests__/issue-1139-invalidation-gaps.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Regression tests for the two invalidation gaps fixed in #1139.
+ *
+ * Gap 1: `ObjectRegistry.invalidateInheritanceCache(className)` used to
+ * recurse via `childClass.extends === className` — exact simple-name
+ * match. Manifest registration stores qualified extends values (e.g.
+ * `@pkg:Parent`). If the invalidator was given the simple name,
+ * descendants with qualified extends stayed stale. The fix rewires the
+ * public helper through `invalidateInheritanceEntries`, which matches
+ * against both simple and qualified names.
+ *
+ * Gap 2: `upsertExistingEntry` mutates `existing.name`,
+ * `existing.packageName`, `existing.qualifiedName`, `existing.config`,
+ * `existing.constructor`, and `existing.schema.tableName` in place.
+ * Descendants whose `inheritedFields` cache was computed against the
+ * pre-mutation identity stayed stale. The fix captures the pre-mutation
+ * identity and passes it to `invalidateInheritanceEntries` so the sweep
+ * catches descendants referencing either the old or the new name.
+ *
+ * @see https://github.com/happyvertical/smrt/issues/1139
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { field } from '../decorators/index.js';
+import { SmrtObject } from '../object.js';
+import { ObjectRegistry, smrt } from '../registry.js';
+import { snapshotObjectRegistryState } from '../test-utils.js';
+
+describe('#1139 invalidation gaps', () => {
+  let restoreRegistry: () => void;
+
+  beforeAll(() => {
+    restoreRegistry = snapshotObjectRegistryState();
+  });
+
+  afterEach(() => {
+    ObjectRegistry.clear();
+  });
+
+  afterAll(() => {
+    restoreRegistry();
+  });
+
+  describe('Gap 1 — invalidateInheritanceCache with qualified extends', () => {
+    it('invalidates a descendant whose `extends` is stored as a qualified name', () => {
+      // Scenario: parent is package-qualified (@test/a:RehydrateBase). Child
+      // from another package extends it; after Release C's qualifyExtendsName,
+      // `child.extends = '@test/a:RehydrateBase'` (qualified, not simple).
+      //
+      // `ObjectRegistry.invalidateInheritanceCache('RehydrateBase')` is called
+      // with the SIMPLE name (what registry.ts's manifest-load field-change
+      // path does). Pre-fix the public helper only recursed on exact-simple
+      // match, so the qualified child stayed stale. Post-fix it delegates to
+      // `invalidateInheritanceEntries` which matches both forms.
+
+      // Register parent.
+      ObjectRegistry.registerFromManifest(
+        'RehydrateBase',
+        {
+          className: 'RehydrateBase',
+          fields: { title: { type: 'text', _meta: {} } },
+          methods: {},
+          decoratorConfig: { tableStrategy: 'sti' },
+          filePath: '/pkg/a/base.ts',
+        },
+        '@test/a',
+      );
+
+      // Register child — extends will be qualified to @test/a:RehydrateBase.
+      ObjectRegistry.registerFromManifest(
+        'RehydrateChild',
+        {
+          className: 'RehydrateChild',
+          fields: { body: { type: 'text', _meta: {} } },
+          methods: {},
+          decoratorConfig: { tableStrategy: 'sti' },
+          extends: 'RehydrateBase',
+          filePath: '/pkg/b/child.ts',
+        },
+        '@test/b',
+      );
+
+      const child = ObjectRegistry.findClass('RehydrateChild');
+      expect(child?.extends).toBe('@test/a:RehydrateBase');
+
+      // Prime the cache.
+      const baseWalk = ObjectRegistry.getClass('RehydrateBase');
+      const childWalk = ObjectRegistry.getClass('RehydrateChild');
+      if (baseWalk)
+        baseWalk.inheritedFields = new Map([['cached', 'sentinel']]);
+      if (childWalk)
+        childWalk.inheritedFields = new Map([['cached', 'sentinel']]);
+
+      // Fire the public invalidator with the SIMPLE name.
+      ObjectRegistry.invalidateInheritanceCache('RehydrateBase');
+
+      // Parent cache: cleared (direct lookup hit).
+      expect(baseWalk?.inheritedFields).toBeUndefined();
+
+      // Child cache: also cleared because the child's extends resolves to
+      // the same class via qualified-name match.
+      expect(childWalk?.inheritedFields).toBeUndefined();
+    });
+  });
+
+  describe('Gap 2 — upsertExistingEntry invalidates descendants', () => {
+    it("clears a descendant's cached inheritedFields when the parent's identity is mutated via promotion", () => {
+      // Scenario: parent registered without a packageName (simple key
+      // 'PromoteBase'). Child registered with `extends: 'PromoteBase'`.
+      // Parent later promoted to `@test/promote:PromoteBase` via a
+      // register() call that carries the packageName. upsertExistingEntry
+      // mutates `existing.name`/`packageName`/`qualifiedName` in place.
+      //
+      // Pre-fix the post-mutation invalidation sweep used only the NEW
+      // identity to match descendants — but the child's `extends` still
+      // referenced the OLD qualified name, so its cache stayed stale.
+      // Post-fix we capture the pre-mutation identity and pass both old
+      // and new forms into `invalidateInheritanceEntries`.
+
+      // Register a "source-only" parent via the decorator path — the only
+      // path that reaches upsertExistingEntry with a real class.
+      @smrt({ tableStrategy: 'sti' })
+      class PromoteBase extends SmrtObject {
+        @field({ type: 'text' })
+        baseField: string = '';
+      }
+
+      // Register a child whose extends points at the simple name.
+      ObjectRegistry.registerFromManifest(
+        'PromoteChild',
+        {
+          className: 'PromoteChild',
+          fields: { childField: { type: 'text', _meta: {} } },
+          methods: {},
+          decoratorConfig: { tableStrategy: 'sti' },
+          extends: 'PromoteBase',
+          filePath: '/pkg/a/promote-child.ts',
+        },
+        '@test/promote',
+      );
+
+      // Prime the cache on the child with a sentinel.
+      const child = ObjectRegistry.findClass('PromoteChild');
+      if (child) child.inheritedFields = new Map([['sentinel', 'present']]);
+
+      // Re-register the parent with a packageName — routes through
+      // register() → exact-key match → upsertExistingEntry, which promotes
+      // the parent's key from 'PromoteBase' to '@test/promote:PromoteBase'.
+      ObjectRegistry.register(PromoteBase, { packageName: '@test/promote' });
+
+      const childAfter = ObjectRegistry.findClass('PromoteChild');
+      expect(childAfter?.inheritedFields?.get('sentinel')).toBeUndefined();
+      // Suppress the unused-class warning — the decorator ran on it.
+      void PromoteBase;
+    });
+  });
+});

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -46,6 +46,7 @@ import {
 } from './manifest/store.js';
 import type { SmrtObject } from './object';
 import {
+  invalidateInheritanceEntries as _invalidateInheritanceEntries,
   register as _register,
   registerCollection as _registerCollection,
   registerFromManifest as _registerFromManifest,
@@ -1203,22 +1204,22 @@ export class ObjectRegistry {
    * ```
    */
   static invalidateInheritanceCache(className: string): void {
-    // Clear inheritance chain cache
-    ObjectRegistry.getInheritanceCache().delete(className);
-
-    // Clear merged fields/methods cache
+    // Delegate to the stronger sweep in class-registration.ts. The previous
+    // implementation here recursed via `childClass.extends === className`
+    // — a simple-string exact match — so qualified-extends descendants
+    // (e.g. a child whose `extends` is stored as `@pkg:Parent` after
+    // `qualifyExtendsName`) were silently missed. The shared sweep checks
+    // both `extends === existing.name` and `extends === existing.qualifiedName`,
+    // plus transitive descendants via the inheritance-chain cache. See
+    // #1139 Gap 1.
     const registered = ObjectRegistry.findClass(className);
-    if (registered) {
-      registered.inheritedFields = undefined;
-      registered.inheritedMethods = undefined;
+    if (!registered) {
+      // Class not found: still clear any stray chain-cache entry keyed on
+      // this name so a future lookup rebuilds from scratch.
+      ObjectRegistry.getInheritanceCache().delete(className);
+      return;
     }
-
-    // Also invalidate all descendants (they depend on this class's fields)
-    for (const [_key, childClass] of ObjectRegistry.classes) {
-      if (childClass.extends === className) {
-        ObjectRegistry.invalidateInheritanceCache(childClass.name || _key);
-      }
-    }
+    _invalidateInheritanceEntries(registered);
   }
 
   /**

--- a/packages/core/src/registry/class-registration.ts
+++ b/packages/core/src/registry/class-registration.ts
@@ -435,7 +435,13 @@ export function register(
     const nextKey = nextPackageName
       ? createQualifiedName(nextPackageName, name)
       : name;
-    const oldName = existing.name;
+    // Capture pre-mutation identity so descendants whose `extends` still
+    // references the old name/qualifiedName are caught by the post-mutation
+    // invalidation sweep (#1139 Gap 2).
+    const previousIdentity = {
+      name: existing.name,
+      qualifiedName: existing.qualifiedName as string | undefined,
+    };
 
     existing.name = name;
     existing.packageName = nextPackageName;
@@ -489,6 +495,16 @@ export function register(
     }
 
     getConstructorIndex().set(ctor, nextKey);
+
+    // Release C follow-up #1139 Gap 2: we just mutated `existing.name`,
+    // `existing.packageName`, `existing.qualifiedName`, `existing.config`,
+    // `existing.constructor`, and `existing.schema.tableName`. Any
+    // descendant whose cached `inheritedFields` was computed against the
+    // prior identity now carries stale data. Invalidate `existing` and
+    // every descendant whose `extends` matches the pre- or post-mutation
+    // identity so the next field read re-merges from the current state.
+    invalidateInheritanceEntries(existing, previousIdentity);
+
     return nextKey;
   }
 
@@ -1127,7 +1143,33 @@ function applySqlTypeOverrides(
   }
 }
 
-function invalidateInheritanceEntries(existing: RegisteredClass): void {
+/**
+ * Invalidate cached inheritance state (chain + inheritedFields +
+ * inheritedMethods) on `existing` AND every descendant whose `extends` or
+ * `inheritanceChain` references it.
+ *
+ * This covers both simple-name and qualified-name `extends` matches, which
+ * is why `ObjectRegistry.invalidateInheritanceCache` delegates here (Release
+ * C follow-up #1139 Gap 1 — the old recursive public helper only matched
+ * `extends === className` by exact string, silently missing qualified
+ * descendants like `@pkg:Parent`).
+ *
+ * `previousIdentity` is used by `upsertExistingEntry` (Gap 2): when a class
+ * is promoted (its name/packageName/qualifiedName are mutated in place),
+ * descendants registered against the pre-mutation identity need to be
+ * invalidated too. Pass the pre-mutation `{ name, qualifiedName }` so this
+ * sweep matches against both the old and new identity.
+ *
+ * Exported for the public `ObjectRegistry.invalidateInheritanceCache`
+ * shim in registry.ts.
+ */
+export function invalidateInheritanceEntries(
+  existing: RegisteredClass,
+  previousIdentity?: {
+    name?: string;
+    qualifiedName?: string;
+  },
+): void {
   const cache = getInheritanceCache();
   const affectedNames = new Set<string>();
 
@@ -1137,18 +1179,27 @@ function invalidateInheritanceEntries(existing: RegisteredClass): void {
     }
   };
 
-  remember(existing.name);
-  remember(existing.qualifiedName);
+  const matchNames = new Set<string>();
+  const rememberMatch = (name: string | undefined): void => {
+    if (name) matchNames.add(name);
+  };
+  rememberMatch(existing.name);
+  rememberMatch(existing.qualifiedName);
+  rememberMatch(previousIdentity?.name);
+  rememberMatch(previousIdentity?.qualifiedName);
+
+  for (const name of matchNames) {
+    remember(name);
+  }
 
   for (const [key, candidate] of getClasses()) {
-    if (
-      candidate === existing ||
-      candidate.extends === existing.name ||
-      candidate.extends === existing.qualifiedName ||
-      candidate.inheritanceChain?.includes(existing.name) ||
-      (existing.qualifiedName &&
-        candidate.inheritanceChain?.includes(existing.qualifiedName))
-    ) {
+    const extendsMatches =
+      !!candidate.extends && matchNames.has(candidate.extends);
+    const chainMatches =
+      !!candidate.inheritanceChain &&
+      candidate.inheritanceChain.some((n) => matchNames.has(n));
+
+    if (candidate === existing || extendsMatches || chainMatches) {
       candidate.inheritanceChain = undefined;
       candidate.inheritedFields = undefined;
       candidate.inheritedMethods = undefined;


### PR DESCRIPTION
## Summary

Closes the two invalidation gaps surfaced in the #1139 review. Scope is **gap fixes only** — the save-time STI rehydration loop stays in place for now because the bundled-consumer / `NodeModulesFallbackSource` scenario exercised by `external-runtime-hydration.test.ts` still depends on it (verified: the two synthetic tests in that file still fail if the loop is removed, even after these gap fixes). Retiring the loop will need a separate investigation into what bridges `stripPackageIdentity`-shaped state back to fresh manifest data without a per-save walk.

### Gap 1 — simple-name-only invalidation

`ObjectRegistry.invalidateInheritanceCache(className)` recursed via exact simple-name match (`childClass.extends === className`). After Release C's `qualifyExtendsName`, descendants store `extends` as `@pkg:Parent` — qualified — so invalidator calls with the simple name silently missed those descendants.

The public helper now delegates to the stronger `invalidateInheritanceEntries` sweep in `class-registration.ts`, which matches `extends` against both `existing.name` and `existing.qualifiedName` plus transitive descendants via the inheritance-chain cache.

### Gap 2 — `upsertExistingEntry` post-mutation invalidation

`upsertExistingEntry` mutates `existing.name`, `packageName`, `qualifiedName`, `config`, `constructor`, and `schema.tableName` in place during a class's promotion. A naive post-mutation invalidation doesn't work because descendants' `extends` still references the *pre-mutation* identity.

Fix: capture `{ name, qualifiedName }` before mutation and pass both to a new `previousIdentity` parameter on `invalidateInheritanceEntries`. The sweep now matches against the union of old and new identities.

## Test plan

- [x] `npx vitest run src/__tests__/issue-1139-invalidation-gaps.test.ts` — both gap reproducers pass
- [x] `npx vitest run src/__tests__/external-runtime-hydration.test.ts` — all 14 tests pass (including the two synthetic stripPackageIdentity-based tests that verify the save-time loop is still doing load-bearing work)
- [x] `npx vitest run src/registry/__tests__/collision-policy.test.ts` — 25 tests pass
- [x] Full core suite (`npx vitest run`) — 1575 passed, 29 skipped
- [x] `npx turbo run typecheck --filter=@happyvertical/smrt-core` — clean
- [ ] CI green across the monorepo

## Changed from previous revision

The previous push of this branch also removed the save-time STI rehydration loop and added a benchmark. Reverted both after willgriffin confirmed the loop is still load-bearing via `NodeModulesFallbackSource`, and after review caught a bug in the benchmark's hierarchy construction (every iteration produced a class named `Child`, collision-upserted to a single registry entry — the reported speedup was not measuring what it claimed). Scope narrowed to the two real fixes.

Refs #1139