### PR TITLE
[codex] fix(core): stop leaking test manifests into consumers

### DIFF
--- a/.changeset/fix-test-manifest-leak.md
+++ b/.changeset/fix-test-manifest-leak.md
@@ -1,0 +1,5 @@
+---
+'@happyvertical/smrt-core': patch
+---
+
+Fix test manifest loading so downstream consumers do not register core-only test classes, and skip `SmrtCollection` manifest stubs when building test database schemas.

--- a/packages/core/src/__tests__/test-database-manifest-schema.test.ts
+++ b/packages/core/src/__tests__/test-database-manifest-schema.test.ts
@@ -114,4 +114,119 @@ describe('getTestDatabase manifest schemas', () => {
       'relationship',
     ]);
   });
+
+  it('prefers the STI item schema over collection manifest stubs that share the same table', async () => {
+    ObjectRegistry.registerFromManifest(
+      '@test/pkg:Meetings',
+      {
+        className: 'Meetings',
+        extends: 'SmrtCollection',
+        extendsTypeArg: 'Event',
+        fields: {},
+        methods: {},
+        decoratorConfig: {
+          tableName: 'events',
+        },
+        schema: {
+          tableName: 'events',
+          ddl: `CREATE TABLE IF NOT EXISTS "events" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "slug" TEXT NOT NULL,
+  "context" TEXT NOT NULL DEFAULT '',
+  "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp
+)`,
+          columns: {
+            id: { type: 'TEXT', notNull: true, primaryKey: true },
+            slug: { type: 'TEXT', notNull: true },
+            context: { type: 'TEXT', notNull: true, default: '' },
+            created_at: {
+              type: 'TIMESTAMP',
+              notNull: true,
+              default: 'current_timestamp',
+            },
+            updated_at: {
+              type: 'TIMESTAMP',
+              notNull: true,
+              default: 'current_timestamp',
+            },
+          },
+          indexes: [],
+          version: 'test-version',
+        },
+      },
+      '@test/pkg',
+    );
+
+    ObjectRegistry.registerFromManifest(
+      '@test/pkg:Event',
+      {
+        className: 'Event',
+        fields: {
+          name: { type: 'text', required: false, default: '' },
+        },
+        methods: {},
+        decoratorConfig: {
+          tableName: 'events',
+          tableStrategy: 'sti',
+        },
+        schema: {
+          tableName: 'events',
+          ddl: `CREATE TABLE IF NOT EXISTS "events" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "slug" TEXT NOT NULL,
+  "context" TEXT NOT NULL DEFAULT '',
+  "_meta_type" TEXT NOT NULL,
+  "_meta_data" JSON,
+  "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "name" TEXT DEFAULT ''
+)`,
+          columns: {
+            id: { type: 'TEXT', notNull: true, primaryKey: true },
+            slug: { type: 'TEXT', notNull: true },
+            context: { type: 'TEXT', notNull: true, default: '' },
+            _meta_type: { type: 'TEXT', notNull: true },
+            _meta_data: { type: 'JSON', notNull: false },
+            created_at: {
+              type: 'TIMESTAMP',
+              notNull: true,
+              default: 'current_timestamp',
+            },
+            updated_at: {
+              type: 'TIMESTAMP',
+              notNull: true,
+              default: 'current_timestamp',
+            },
+            name: { type: 'TEXT', notNull: false, default: '' },
+          },
+          indexes: [
+            {
+              name: 'events_meta_type_idx',
+              columns: ['_meta_type'],
+              unique: false,
+            },
+          ],
+          version: 'test-version',
+        },
+      },
+      '@test/pkg',
+    );
+
+    const db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['Meetings', 'Event'],
+    });
+
+    const columnsResult = await db.query(`PRAGMA table_info('events')`);
+    const columns = Array.isArray(columnsResult)
+      ? columnsResult
+      : columnsResult.rows;
+    const columnNames = columns.map((row: { name: string }) => row.name);
+
+    expect(columnNames).toContain('_meta_type');
+    expect(columnNames).toContain('_meta_data');
+    expect(columnNames).toContain('name');
+  });
 });

--- a/packages/core/src/__tests__/test-database-manifest-schema.test.ts
+++ b/packages/core/src/__tests__/test-database-manifest-schema.test.ts
@@ -6,6 +6,105 @@ import { getTestDatabase } from '../testing/database.js';
 describe('getTestDatabase manifest schemas', () => {
   let restoreRegistry: () => void;
 
+  function registerCollectionStubWithSTIItem(): void {
+    ObjectRegistry.registerFromManifest(
+      '@test/pkg:Meetings',
+      {
+        className: 'Meetings',
+        extends: 'SmrtCollection',
+        extendsTypeArg: 'Event',
+        fields: {},
+        methods: {},
+        decoratorConfig: {
+          tableName: 'events',
+        },
+        schema: {
+          tableName: 'events',
+          ddl: `CREATE TABLE IF NOT EXISTS "events" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "slug" TEXT NOT NULL,
+  "context" TEXT NOT NULL DEFAULT '',
+  "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp
+)`,
+          columns: {
+            id: { type: 'TEXT', notNull: true, primaryKey: true },
+            slug: { type: 'TEXT', notNull: true },
+            context: { type: 'TEXT', notNull: true, default: '' },
+            created_at: {
+              type: 'TIMESTAMP',
+              notNull: true,
+              default: 'current_timestamp',
+            },
+            updated_at: {
+              type: 'TIMESTAMP',
+              notNull: true,
+              default: 'current_timestamp',
+            },
+          },
+          indexes: [],
+          version: 'test-version',
+        },
+      },
+      '@test/pkg',
+    );
+
+    ObjectRegistry.registerFromManifest(
+      '@test/pkg:Event',
+      {
+        className: 'Event',
+        fields: {
+          name: { type: 'text', required: false, default: '' },
+        },
+        methods: {},
+        decoratorConfig: {
+          tableName: 'events',
+          tableStrategy: 'sti',
+        },
+        schema: {
+          tableName: 'events',
+          ddl: `CREATE TABLE IF NOT EXISTS "events" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "slug" TEXT NOT NULL,
+  "context" TEXT NOT NULL DEFAULT '',
+  "_meta_type" TEXT NOT NULL,
+  "_meta_data" JSON,
+  "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "name" TEXT DEFAULT ''
+)`,
+          columns: {
+            id: { type: 'TEXT', notNull: true, primaryKey: true },
+            slug: { type: 'TEXT', notNull: true },
+            context: { type: 'TEXT', notNull: true, default: '' },
+            _meta_type: { type: 'TEXT', notNull: true },
+            _meta_data: { type: 'JSON', notNull: false },
+            created_at: {
+              type: 'TIMESTAMP',
+              notNull: true,
+              default: 'current_timestamp',
+            },
+            updated_at: {
+              type: 'TIMESTAMP',
+              notNull: true,
+              default: 'current_timestamp',
+            },
+            name: { type: 'TEXT', notNull: false, default: '' },
+          },
+          indexes: [
+            {
+              name: 'events_meta_type_idx',
+              columns: ['_meta_type'],
+              unique: false,
+            },
+          ],
+          version: 'test-version',
+        },
+      },
+      '@test/pkg',
+    );
+  }
+
   beforeEach(() => {
     restoreRegistry = snapshotObjectRegistryState();
   });
@@ -116,107 +215,32 @@ describe('getTestDatabase manifest schemas', () => {
   });
 
   it('prefers the STI item schema over collection manifest stubs that share the same table', async () => {
-    ObjectRegistry.registerFromManifest(
-      '@test/pkg:Meetings',
-      {
-        className: 'Meetings',
-        extends: 'SmrtCollection',
-        extendsTypeArg: 'Event',
-        fields: {},
-        methods: {},
-        decoratorConfig: {
-          tableName: 'events',
-        },
-        schema: {
-          tableName: 'events',
-          ddl: `CREATE TABLE IF NOT EXISTS "events" (
-  "id" TEXT PRIMARY KEY NOT NULL,
-  "slug" TEXT NOT NULL,
-  "context" TEXT NOT NULL DEFAULT '',
-  "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp
-)`,
-          columns: {
-            id: { type: 'TEXT', notNull: true, primaryKey: true },
-            slug: { type: 'TEXT', notNull: true },
-            context: { type: 'TEXT', notNull: true, default: '' },
-            created_at: {
-              type: 'TIMESTAMP',
-              notNull: true,
-              default: 'current_timestamp',
-            },
-            updated_at: {
-              type: 'TIMESTAMP',
-              notNull: true,
-              default: 'current_timestamp',
-            },
-          },
-          indexes: [],
-          version: 'test-version',
-        },
-      },
-      '@test/pkg',
-    );
-
-    ObjectRegistry.registerFromManifest(
-      '@test/pkg:Event',
-      {
-        className: 'Event',
-        fields: {
-          name: { type: 'text', required: false, default: '' },
-        },
-        methods: {},
-        decoratorConfig: {
-          tableName: 'events',
-          tableStrategy: 'sti',
-        },
-        schema: {
-          tableName: 'events',
-          ddl: `CREATE TABLE IF NOT EXISTS "events" (
-  "id" TEXT PRIMARY KEY NOT NULL,
-  "slug" TEXT NOT NULL,
-  "context" TEXT NOT NULL DEFAULT '',
-  "_meta_type" TEXT NOT NULL,
-  "_meta_data" JSON,
-  "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  "name" TEXT DEFAULT ''
-)`,
-          columns: {
-            id: { type: 'TEXT', notNull: true, primaryKey: true },
-            slug: { type: 'TEXT', notNull: true },
-            context: { type: 'TEXT', notNull: true, default: '' },
-            _meta_type: { type: 'TEXT', notNull: true },
-            _meta_data: { type: 'JSON', notNull: false },
-            created_at: {
-              type: 'TIMESTAMP',
-              notNull: true,
-              default: 'current_timestamp',
-            },
-            updated_at: {
-              type: 'TIMESTAMP',
-              notNull: true,
-              default: 'current_timestamp',
-            },
-            name: { type: 'TEXT', notNull: false, default: '' },
-          },
-          indexes: [
-            {
-              name: 'events_meta_type_idx',
-              columns: ['_meta_type'],
-              unique: false,
-            },
-          ],
-          version: 'test-version',
-        },
-      },
-      '@test/pkg',
-    );
+    registerCollectionStubWithSTIItem();
 
     const db = await getTestDatabase({
       type: 'sqlite',
       url: ':memory:',
       classes: ['Meetings', 'Event'],
+    });
+
+    const columnsResult = await db.query(`PRAGMA table_info('events')`);
+    const columns = Array.isArray(columnsResult)
+      ? columnsResult
+      : columnsResult.rows;
+    const columnNames = columns.map((row: { name: string }) => row.name);
+
+    expect(columnNames).toContain('_meta_type');
+    expect(columnNames).toContain('_meta_data');
+    expect(columnNames).toContain('name');
+  });
+
+  it('maps requested collection classes to their STI item schema', async () => {
+    registerCollectionStubWithSTIItem();
+
+    const db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['Meetings'],
     });
 
     const columnsResult = await db.query(`PRAGMA table_info('events')`);

--- a/packages/core/src/manifest/manifest-loader.ts
+++ b/packages/core/src/manifest/manifest-loader.ts
@@ -45,6 +45,7 @@ import {
   getStaticManifestCache as getStaticManifestCacheFromStore,
   getTestManifestCache as getTestManifestCacheFromStore,
   isTestEnvironment as isTestEnvFromStore,
+  shouldLoadCoreTestManifest,
 } from './store.js';
 
 /**
@@ -291,18 +292,19 @@ function getStaticManifest(): SmartObjectManifest {
 }
 
 /**
- * Lazy-load test manifest ONLY when in test environment
- * This prevents test classes from being loaded in production and causing collisions
+ * Lazy-load smrt-core's internal test manifest only for smrt-core's own tests.
+ * Consumer packages should never see these fixtures, or they can collide with
+ * real external classes during downstream test runs.
  */
 function getTestManifest(): SmartObjectManifest | null {
   if (!getTestManifestLoadAttempted()) {
     setTestManifestLoadAttempted(true);
 
-    // CRITICAL: Only load test manifest in test environment
-    if (!isTestEnvironment()) {
+    // CRITICAL: Scope the core test manifest to smrt-core's own test suite.
+    if (!shouldLoadCoreTestManifest()) {
       if (process.env.DEBUG_TEST_ENV) {
         console.log(
-          '[manifest-loader] ⚠️  Skipping test manifest load (not in test environment)',
+          '[manifest-loader] ⚠️  Skipping core test manifest load (not smrt-core test environment)',
         );
       }
       setTestManifestCache(null);

--- a/packages/core/src/manifest/sources/__tests__/manifest-sources.test.ts
+++ b/packages/core/src/manifest/sources/__tests__/manifest-sources.test.ts
@@ -21,7 +21,7 @@ import {
   it,
 } from 'vitest';
 import type { SmartObjectManifest } from '../../../scanner/types.js';
-import { getManifestCache } from '../../store.js';
+import { getManifestCache, shouldLoadCoreTestManifest } from '../../store.js';
 import { CompositeManifestSource } from '../composite.js';
 import { EmbeddedManifestSource } from '../embedded.js';
 import { ExplicitPathsManifestSource } from '../explicit-paths.js';
@@ -84,6 +84,8 @@ function restoreCaches(snapshot: ReturnType<typeof snapshotCaches>) {
 
 describe('ManifestSource implementations', () => {
   let originalSnapshot: ReturnType<typeof snapshotCaches>;
+  const originalPackageName = process.env.npm_package_name;
+  const originalCwd = process.cwd();
 
   beforeAll(() => {
     originalSnapshot = snapshotCaches();
@@ -99,6 +101,12 @@ describe('ManifestSource implementations', () => {
   });
 
   afterAll(() => {
+    if (originalPackageName) {
+      process.env.npm_package_name = originalPackageName;
+    } else {
+      delete process.env.npm_package_name;
+    }
+    process.chdir(originalCwd);
     restoreCaches(originalSnapshot);
   });
 
@@ -138,15 +146,86 @@ describe('ManifestSource implementations', () => {
 
   describe('TestManifestSource', () => {
     it('activates only when __smrtManifestTest is populated', () => {
-      const source = new TestManifestSource();
-      expect(source.lookup({ className: 'Anything' })).toBeUndefined();
+      const originalPackageName = process.env.npm_package_name;
+      process.env.npm_package_name = '@happyvertical/smrt-core';
 
-      (globalThis as ManifestGlobals).__smrtManifestTest = manifest(
-        '@acme/pkg',
-        { Widget: {} },
+      const source = new TestManifestSource();
+      try {
+        expect(source.lookup({ className: 'Anything' })).toBeUndefined();
+
+        (globalThis as ManifestGlobals).__smrtManifestTest = manifest(
+          '@acme/pkg',
+          { Widget: {} },
+        );
+        const hit = source.lookup({ className: 'Widget' });
+        expect(hit?.source).toBe('test');
+      } finally {
+        if (originalPackageName) {
+          process.env.npm_package_name = originalPackageName;
+        } else {
+          delete process.env.npm_package_name;
+        }
+      }
+    });
+
+    it('stays inert in consumer package test environments', () => {
+      const originalPackageName = process.env.npm_package_name;
+      process.env.npm_package_name = 'consumer-app';
+
+      try {
+        (globalThis as ManifestGlobals).__smrtManifestTest = manifest(
+          '@happyvertical/smrt-core',
+          { TestObject: {} },
+        );
+
+        const source = new TestManifestSource();
+        expect(source.lookup({ className: 'TestObject' })).toBeUndefined();
+        expect([...source.entries()]).toEqual([]);
+      } finally {
+        if (originalPackageName) {
+          process.env.npm_package_name = originalPackageName;
+        } else {
+          delete process.env.npm_package_name;
+        }
+      }
+    });
+
+    it('does not treat non-smrt workspaces as core test environments', () => {
+      const tmp = mkdtempSync(join(tmpdir(), 'smrt-consumer-workspace-'));
+      const workspacePath = join(tmp, 'pnpm-workspace.yaml');
+      const packagePath = join(tmp, 'package.json');
+      const originalPackageName = process.env.npm_package_name;
+      const originalNodeEnv = process.env.NODE_ENV;
+      const originalVitest = process.env.VITEST;
+
+      writeFileSync(workspacePath, 'packages: []\n');
+      writeFileSync(
+        packagePath,
+        JSON.stringify({ name: 'consumer-app', type: 'module' }),
       );
-      const hit = source.lookup({ className: 'Widget' });
-      expect(hit?.source).toBe('test');
+
+      try {
+        process.chdir(tmp);
+        delete process.env.npm_package_name;
+        process.env.NODE_ENV = 'test';
+        process.env.VITEST = 'true';
+
+        expect(shouldLoadCoreTestManifest()).toBe(false);
+      } finally {
+        process.chdir(originalCwd);
+        if (originalPackageName) {
+          process.env.npm_package_name = originalPackageName;
+        } else {
+          delete process.env.npm_package_name;
+        }
+        process.env.NODE_ENV = originalNodeEnv;
+        if (originalVitest) {
+          process.env.VITEST = originalVitest;
+        } else {
+          delete process.env.VITEST;
+        }
+        rmSync(tmp, { recursive: true, force: true });
+      }
     });
   });
 

--- a/packages/core/src/manifest/sources/__tests__/manifest-sources.test.ts
+++ b/packages/core/src/manifest/sources/__tests__/manifest-sources.test.ts
@@ -218,7 +218,62 @@ describe('ManifestSource implementations', () => {
         } else {
           delete process.env.npm_package_name;
         }
-        process.env.NODE_ENV = originalNodeEnv;
+        if (originalNodeEnv) {
+          process.env.NODE_ENV = originalNodeEnv;
+        } else {
+          delete process.env.NODE_ENV;
+        }
+        if (originalVitest) {
+          process.env.VITEST = originalVitest;
+        } else {
+          delete process.env.VITEST;
+        }
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it('does not treat sibling workspace packages as core test environments', () => {
+      const tmp = mkdtempSync(join(tmpdir(), 'smrt-workspace-'));
+      const coreDir = join(tmp, 'packages', 'core');
+      const consumerDir = join(tmp, 'packages', 'consumer');
+      const originalPackageName = process.env.npm_package_name;
+      const originalNodeEnv = process.env.NODE_ENV;
+      const originalVitest = process.env.VITEST;
+
+      mkdirSync(coreDir, { recursive: true });
+      mkdirSync(consumerDir, { recursive: true });
+      writeFileSync(
+        join(tmp, 'pnpm-workspace.yaml'),
+        'packages:\n  - packages/*\n',
+      );
+      writeFileSync(
+        join(coreDir, 'package.json'),
+        JSON.stringify({ name: '@happyvertical/smrt-core', type: 'module' }),
+      );
+      writeFileSync(
+        join(consumerDir, 'package.json'),
+        JSON.stringify({ name: '@acme/consumer-app', type: 'module' }),
+      );
+
+      try {
+        process.chdir(consumerDir);
+        delete process.env.npm_package_name;
+        process.env.NODE_ENV = 'test';
+        process.env.VITEST = 'true';
+
+        expect(shouldLoadCoreTestManifest()).toBe(false);
+      } finally {
+        process.chdir(originalCwd);
+        if (originalPackageName) {
+          process.env.npm_package_name = originalPackageName;
+        } else {
+          delete process.env.npm_package_name;
+        }
+        if (originalNodeEnv) {
+          process.env.NODE_ENV = originalNodeEnv;
+        } else {
+          delete process.env.NODE_ENV;
+        }
         if (originalVitest) {
           process.env.VITEST = originalVitest;
         } else {

--- a/packages/core/src/manifest/sources/test.ts
+++ b/packages/core/src/manifest/sources/test.ts
@@ -7,7 +7,7 @@
  * @see https://github.com/happyvertical/smrt/issues/1133
  */
 
-import { getTestManifestCache, isTestEnvironment } from '../store.js';
+import { getTestManifestCache, shouldLoadCoreTestManifest } from '../store.js';
 import {
   type ManifestEntry,
   type ManifestLookupQuery,
@@ -21,7 +21,7 @@ export class TestManifestSource implements ManifestSource {
   readonly name = 'test';
 
   lookup(query: ManifestLookupQuery): ManifestEntry | undefined {
-    if (!isTestEnvironment()) return undefined;
+    if (!shouldLoadCoreTestManifest()) return undefined;
     const manifest = getTestManifestCache();
     if (!manifest) return undefined;
 
@@ -31,7 +31,7 @@ export class TestManifestSource implements ManifestSource {
   }
 
   *entries(): Iterable<ManifestEntry> {
-    if (!isTestEnvironment()) return;
+    if (!shouldLoadCoreTestManifest()) return;
     yield* manifestEntriesOf(getTestManifestCache(), this.name);
   }
 }

--- a/packages/core/src/manifest/store.ts
+++ b/packages/core/src/manifest/store.ts
@@ -48,6 +48,105 @@ export function isTestEnvironment(): boolean {
   );
 }
 
+/**
+ * Best-effort detection of the current package under test.
+ *
+ * In workspace consumers, `process.cwd()` points at the consuming app/package,
+ * while in smrt-core's own tests it points at `packages/core`. We use that
+ * distinction to keep smrt-core's internal test manifest scoped to its own
+ * test suite instead of leaking those fixtures into every consumer test run.
+ */
+export function getCurrentPackageName(): string | null {
+  const explicitPackageName = process.env.npm_package_name;
+  if (explicitPackageName) {
+    return explicitPackageName;
+  }
+
+  const builtins = getNodeBuiltins();
+  if (!builtins) {
+    return null;
+  }
+
+  let currentDir = process.cwd();
+
+  while (true) {
+    const packageJsonPath = builtins.path.join(currentDir, 'package.json');
+    if (builtins.fs.existsSync(packageJsonPath)) {
+      try {
+        const packageJson = JSON.parse(
+          builtins.fs.readFileSync(packageJsonPath, 'utf-8'),
+        ) as { name?: string };
+        return packageJson.name ?? null;
+      } catch {
+        return null;
+      }
+    }
+
+    const parentDir = builtins.path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      return null;
+    }
+
+    currentDir = parentDir;
+  }
+}
+
+/**
+ * smrt-core's committed test manifest is for smrt-core's own tests only.
+ * Consumer packages should expose only their local test manifest plus real
+ * published manifests from dependencies.
+ */
+export function shouldLoadCoreTestManifest(): boolean {
+  if (!isTestEnvironment()) {
+    return false;
+  }
+
+  const explicitPackageName = process.env.npm_package_name;
+  if (explicitPackageName) {
+    return explicitPackageName === '@happyvertical/smrt-core';
+  }
+
+  const builtins = getNodeBuiltins();
+  if (!builtins) {
+    return false;
+  }
+
+  const moduleDir = builtins.path.dirname(
+    builtins.url.fileURLToPath(import.meta.url),
+  );
+  const workspaceRoot = findWorkspaceRootSync(moduleDir);
+  if (!workspaceRoot) {
+    return false;
+  }
+
+  const corePackageJsonPath = builtins.path.join(
+    workspaceRoot,
+    'packages',
+    'core',
+    'package.json',
+  );
+  if (!builtins.fs.existsSync(corePackageJsonPath)) {
+    return false;
+  }
+
+  try {
+    const packageJson = JSON.parse(
+      builtins.fs.readFileSync(corePackageJsonPath, 'utf-8'),
+    ) as { name?: string };
+    if (packageJson.name !== '@happyvertical/smrt-core') {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+
+  const relative = builtins.path.relative(workspaceRoot, process.cwd());
+  return (
+    relative === '' ||
+    (!relative.startsWith('..') && !builtins.path.isAbsolute(relative))
+  );
+}
+
 // ── Node builtins access ─────────────────────────────────────────────────
 
 /**

--- a/packages/core/src/manifest/store.ts
+++ b/packages/core/src/manifest/store.ts
@@ -101,9 +101,9 @@ export function shouldLoadCoreTestManifest(): boolean {
     return false;
   }
 
-  const explicitPackageName = process.env.npm_package_name;
-  if (explicitPackageName) {
-    return explicitPackageName === '@happyvertical/smrt-core';
+  const currentPackageName = getCurrentPackageName();
+  if (currentPackageName) {
+    return currentPackageName === '@happyvertical/smrt-core';
   }
 
   const builtins = getNodeBuiltins();
@@ -119,28 +119,8 @@ export function shouldLoadCoreTestManifest(): boolean {
     return false;
   }
 
-  const corePackageJsonPath = builtins.path.join(
-    workspaceRoot,
-    'packages',
-    'core',
-    'package.json',
-  );
-  if (!builtins.fs.existsSync(corePackageJsonPath)) {
-    return false;
-  }
-
-  try {
-    const packageJson = JSON.parse(
-      builtins.fs.readFileSync(corePackageJsonPath, 'utf-8'),
-    ) as { name?: string };
-    if (packageJson.name !== '@happyvertical/smrt-core') {
-      return false;
-    }
-  } catch {
-    return false;
-  }
-
-  const relative = builtins.path.relative(workspaceRoot, process.cwd());
+  const corePackageDir = builtins.path.join(workspaceRoot, 'packages', 'core');
+  const relative = builtins.path.relative(corePackageDir, process.cwd());
   return (
     relative === '' ||
     (!relative.startsWith('..') && !builtins.path.isAbsolute(relative))

--- a/packages/core/src/testing/database.ts
+++ b/packages/core/src/testing/database.ts
@@ -142,6 +142,17 @@ export async function getTestDatabase(
   const createdTables = new Set<string>();
 
   for (const className of classNames) {
+    const registered = ObjectRegistry.getClass(className);
+
+    // Collection classes can share the same table name as their item class
+    // (for example `Meetings` -> `events`) but do not own the authoritative
+    // schema. If we create the table from the collection manifest first, we
+    // can miss STI columns like `_meta_type` and then skip the real item class
+    // because the table name is already marked created.
+    if (registered?.extends === 'SmrtCollection') {
+      continue;
+    }
+
     // Skip STI children - their schema is part of the base class table
     const stiBase = ObjectRegistry.getSTIBase(className);
     if (stiBase && stiBase !== className) {

--- a/packages/core/src/testing/database.ts
+++ b/packages/core/src/testing/database.ts
@@ -64,6 +64,66 @@ export interface TestDatabaseOptions {
   includeSystemTables?: boolean;
 }
 
+function resolveRequestedSchemaClassName(className: string): string {
+  const registered = ObjectRegistry.getClass(className);
+  if (!registered || registered.extends !== 'SmrtCollection') {
+    return className;
+  }
+
+  const tableName =
+    registered.schema?.tableName ||
+    registered.config.tableName ||
+    ObjectRegistry.getTableName(className);
+  if (!tableName) {
+    return className;
+  }
+
+  const collectionPackage = registered.packageName;
+
+  for (const candidate of ObjectRegistry.getAllClasses().values()) {
+    if (candidate === registered || candidate.extends === 'SmrtCollection') {
+      continue;
+    }
+
+    const candidateTableName =
+      candidate.schema?.tableName || candidate.config.tableName;
+    if (candidateTableName !== tableName) {
+      continue;
+    }
+
+    if (
+      collectionPackage &&
+      candidate.packageName &&
+      candidate.packageName !== collectionPackage
+    ) {
+      continue;
+    }
+
+    const candidateLookupName = candidate.qualifiedName || candidate.name;
+    const stiBase = ObjectRegistry.getSTIBase(candidateLookupName);
+    return stiBase || candidateLookupName;
+  }
+
+  return className;
+}
+
+function resolveRequestedSchemaClassNames(classNames: string[]): string[] {
+  const resolved: string[] = [];
+  const seen = new Set<string>();
+
+  for (const className of classNames) {
+    const schemaClassName = resolveRequestedSchemaClassName(className);
+    if (seen.has(schemaClassName)) {
+      continue;
+    }
+
+    seen.add(schemaClassName);
+    resolved.push(schemaClassName);
+  }
+
+  return resolved;
+}
+
 /**
  * Creates an in-memory test database with schemas pre-created
  *
@@ -128,7 +188,9 @@ export async function getTestDatabase(
   }
 
   // Get class names to setup
-  const classNames = classes ?? ObjectRegistry.getClassNames();
+  const classNames = resolveRequestedSchemaClassNames(
+    classes ?? ObjectRegistry.getClassNames(),
+  );
 
   // Skip if no classes registered
   if (classNames.length === 0) {
@@ -142,17 +204,6 @@ export async function getTestDatabase(
   const createdTables = new Set<string>();
 
   for (const className of classNames) {
-    const registered = ObjectRegistry.getClass(className);
-
-    // Collection classes can share the same table name as their item class
-    // (for example `Meetings` -> `events`) but do not own the authoritative
-    // schema. If we create the table from the collection manifest first, we
-    // can miss STI columns like `_meta_type` and then skip the real item class
-    // because the table name is already marked created.
-    if (registered?.extends === 'SmrtCollection') {
-      continue;
-    }
-
     // Skip STI children - their schema is part of the base class table
     const stiBase = ObjectRegistry.getSTIBase(className);
     if (stiBase && stiBase !== className) {


### PR DESCRIPTION
## Summary

This scopes `@happyvertical/smrt-core`'s internal test manifest to `smrt-core`'s own test suite instead of exposing it to every downstream Vitest/Jest consumer.

## Root Cause

We were treating "test environment" as equivalent to "smrt-core's own tests".

That meant published `smrt-core` could load `dist/manifest/test-manifest-stub.js` during downstream consumer test runs, which leaked core fixture classes like `EventCollection` into consumer manifest discovery and caused collisions with real package classes.

## What Changed

- add `shouldLoadCoreTestManifest()` in the manifest store to distinguish `smrt-core` tests from consumer package tests
- gate both the legacy manifest loader and `TestManifestSource` on that narrower condition
- add coverage proving the core test manifest stays inert in consumer package test environments
- add a regression around `getTestDatabase()` schema selection for STI item schemas when collection stubs share the same table

## Impact

Downstream consumers should only see:
- their own local test manifest
- real published runtime manifests from dependencies

They should no longer see `smrt-core`'s internal test fixtures during test setup, which fixes the collision reported in #1145.

## Validation

- `pnpm --filter @happyvertical/smrt-core exec vitest run src/manifest/sources/__tests__/manifest-sources.test.ts src/manifest/__tests__/manifest-loading.spec.ts src/__tests__/test-database-manifest-schema.test.ts`

Fixes #1145.
