### PR TITLE
fix(core): restore api path typing

### DIFF
--- a/packages/agents/src/server/__tests__/api-routes.test.ts
+++ b/packages/agents/src/server/__tests__/api-routes.test.ts
@@ -1,3 +1,4 @@
+import type { ApiConfig } from '@happyvertical/smrt-core';
 import { describe, expect, it } from 'vitest';
 import { buildRouteMap, resolveAPIRoute } from '../api-routes.js';
 import type { PackageManifest } from '../manifest-utils.js';
@@ -35,12 +36,13 @@ describe('buildRouteMap', () => {
   });
 
   it('prefers api.path over table name', () => {
+    const videoApiConfig: ApiConfig = { include: ['list'], path: 'videos' };
     const manifest = makeManifest({
       VideoShot: {
         className: 'VideoShot',
         decoratorConfig: {
           tableName: 'video_shots',
-          api: { include: ['list'], path: 'videos' },
+          api: videoApiConfig,
         },
       },
     });

--- a/packages/core/src/registry/index.ts
+++ b/packages/core/src/registry/index.ts
@@ -57,6 +57,7 @@ export {
 } from './shared-state';
 // Types
 export type {
+  ApiConfig,
   RegisteredClass,
   RelationshipMetadata,
   RelationshipType,

--- a/packages/core/src/registry/types.ts
+++ b/packages/core/src/registry/types.ts
@@ -85,6 +85,15 @@ export interface ApiSerializersConfig {
 
 export interface ApiConfig {
   /**
+   * Optional collection path override for generated CRUD routes.
+   *
+   * When omitted, SMRT derives the path from `tableName` by replacing `_` with `-`.
+   * This remains the supported way to keep legacy/public route shapes stable when
+   * the storage table name differs from the desired URL segment.
+   */
+  path?: string;
+
+  /**
    * Exclude specific endpoints (supports both standard CRUD actions and custom methods)
    */
   exclude?: string[];

--- a/packages/places/src/collections/PlaceCollection.ts
+++ b/packages/places/src/collections/PlaceCollection.ts
@@ -24,6 +24,20 @@ import type {
 } from '../types';
 import { PlaceTypeCollection } from './PlaceTypeCollection';
 
+type PoiSearchOptions = Pick<
+  DiscoverNearbyOptions,
+  'types' | 'keyword' | 'limit' | 'language'
+>;
+
+type GeoAdapterWithPoiSearch = GeoAdapter & {
+  findPoisNear?: (
+    latitude: number,
+    longitude: number,
+    radiusMeters: number,
+    options?: PoiSearchOptions,
+  ) => Promise<Location[]>;
+};
+
 export class PlaceCollection extends SmrtCollection<Place> {
   static readonly _itemClass = Place;
 
@@ -490,7 +504,7 @@ export class PlaceCollection extends SmrtCollection<Place> {
    */
   private async getGeoAdapter(
     provider: 'google' | 'openstreetmap',
-  ): Promise<GeoAdapter> {
+  ): Promise<GeoAdapterWithPoiSearch> {
     return getGeoAdapter(this.getGeoAdapterOptions(provider));
   }
 


### PR DESCRIPTION
## Summary
- restore `ApiConfig.path` typing in smrt-core so supported collection path overrides compile again
- add compile-visible coverage in the API route test that types `api.path` through `ApiConfig`

## Verification
- `pnpm exec vitest run packages/agents/src/server/__tests__/api-routes.test.ts`
- `pnpm --filter @happyvertical/smrt-core typecheck`

## Note
This unblocks the `VideoSegment` decorator warning in Anytown/Histrio after the SMRT update, without changing the downstream model or adding a local type escape hatch.
