### PR TITLE
[codex] add smrt-assets storage resolver seam

### DIFF
--- a/packages/assets/src/__tests__/asset-runtime.test.ts
+++ b/packages/assets/src/__tests__/asset-runtime.test.ts
@@ -10,7 +10,7 @@ import { tmpdir } from 'node:os';
 import { join as pathJoin } from 'node:path';
 import { getTestDatabase } from '@happyvertical/smrt-core/testing';
 import type { DatabaseInterface } from '@happyvertical/sql';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Asset } from '../asset';
 import { AssetAssociationCollection } from '../asset-associations';
 import { ASSET_ROLES } from '../asset-conventions';
@@ -61,6 +61,38 @@ describe('AssetRuntime', () => {
 
       expect(runtime.collection).toBe(collection);
       expect(runtime.associations).toBe(associations);
+    });
+
+    it('passes store options through to the underlying AssetStore', async () => {
+      const resolver = vi.fn(async (request) =>
+        request.operation === 'write'
+          ? { path: `resolved/${request.path}` }
+          : undefined,
+      );
+      const runtime = await createAssetRuntime({
+        db,
+        storage: storageDir,
+        storeOptions: { resolver },
+      });
+
+      const asset = await runtime.storeSourceAsset(
+        'resolved-notes.txt',
+        Buffer.from('routed through factory'),
+        { mimeType: 'text/plain', typeSlug: 'document' },
+      );
+
+      expect(resolver).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: 'write',
+          path: `document/${asset.id}.txt`,
+        }),
+      );
+      expect(asset.sourceUri).toBe(
+        `file://${storageDir}/resolved/document/${asset.id}.txt`,
+      );
+      await expect(runtime.store.read(asset)).resolves.toEqual(
+        Buffer.from('routed through factory'),
+      );
     });
   });
 

--- a/packages/assets/src/asset-runtime.ts
+++ b/packages/assets/src/asset-runtime.ts
@@ -25,6 +25,7 @@ import {
 } from './asset-conventions';
 import {
   AssetStore,
+  type AssetStoreOptions,
   type ProviderOptions,
   type StoreOptions,
 } from './asset-store';
@@ -55,6 +56,14 @@ export interface AssetRuntimeOptions {
    * forwarded to `@happyvertical/files`.
    */
   storage: ProviderOptions;
+
+  /**
+   * Optional behavior for the underlying `AssetStore`.
+   *
+   * Use this to provide a storage resolver while keeping the convenience
+   * runtime factory.
+   */
+  storeOptions?: AssetStoreOptions;
 
   /**
    * Optional collection instance. If omitted, one is created from `db`.
@@ -309,7 +318,11 @@ export async function createAssetRuntime(
   const associations =
     options.associations ??
     (await AssetAssociationCollection.create({ db: options.db }));
-  const store = await new AssetStore(options.storage, collection).initialize();
+  const store = await new AssetStore(
+    options.storage,
+    collection,
+    options.storeOptions,
+  ).initialize();
   return new AssetRuntime(collection, associations, store);
 }
 

--- a/packages/assets/src/asset-store.test.ts
+++ b/packages/assets/src/asset-store.test.ts
@@ -1,7 +1,10 @@
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { FilesystemInterface } from '@happyvertical/files';
+import {
+  FileNotFoundError,
+  type FilesystemInterface,
+} from '@happyvertical/files';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Asset } from './asset.js';
 import { AssetStore } from './asset-store.js';
@@ -91,6 +94,25 @@ describe('AssetStore storage resolver', () => {
     );
   });
 
+  it('rejects filesystem-only write resolutions without a source URI', async () => {
+    const defaultBasePath = await createDefaultBasePath();
+    const resolvedFilesystem = createMemoryFilesystem();
+    const collection = {} as AssetCollection;
+    const store = new AssetStore(defaultBasePath, collection, {
+      resolver: async () => ({ filesystem: resolvedFilesystem }),
+    });
+    await store.initialize();
+
+    await expect(
+      store.storeFile(
+        { id: 'asset-ambiguous' } as Asset,
+        Buffer.from('ambiguous destination'),
+        { mimeType: 'text/plain', typeSlug: 'document' },
+      ),
+    ).rejects.toThrow(/providerOptions or sourceUri/);
+    expect(resolvedFilesystem.files.size).toBe(0);
+  });
+
   it('lets reads choose a resolved location for the logical asset', async () => {
     const defaultBasePath = await createDefaultBasePath();
     const resolvedFilesystem = createMemoryFilesystem({
@@ -140,6 +162,52 @@ describe('AssetStore storage resolver', () => {
     } as unknown as Asset);
 
     expect(resolvedFilesystem.deleted).toEqual(['replicas/delete-me.bin']);
+    expect(deleteRecord).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not delete the asset record when delete resolution fails', async () => {
+    const defaultBasePath = await createDefaultBasePath();
+    const collection = {} as AssetCollection;
+    const deleteRecord = vi.fn(async () => {});
+    const store = new AssetStore(defaultBasePath, collection, {
+      resolver: async () => {
+        throw new Error('node-local store is offline');
+      },
+    });
+    await store.initialize();
+
+    await expect(
+      store.remove({
+        sourceUri: `file://${defaultBasePath}/file/delete-me.bin`,
+        delete: deleteRecord,
+      } as unknown as Asset),
+    ).rejects.toThrow('node-local store is offline');
+    expect(deleteRecord).not.toHaveBeenCalled();
+  });
+
+  it('still deletes the asset record when the resolved file is already gone', async () => {
+    const defaultBasePath = await createDefaultBasePath();
+    const resolvedFilesystem = createMemoryFilesystem();
+    const deleteFile = vi.fn(async (path: string) => {
+      throw new FileNotFoundError(path, 'memory');
+    });
+    resolvedFilesystem.delete = deleteFile;
+    const collection = {} as AssetCollection;
+    const store = new AssetStore(defaultBasePath, collection, {
+      resolver: async () => ({
+        filesystem: resolvedFilesystem,
+        path: 'replicas/missing.bin',
+      }),
+    });
+    await store.initialize();
+    const deleteRecord = vi.fn(async () => {});
+
+    await store.remove({
+      sourceUri: `file://${defaultBasePath}/file/missing.bin`,
+      delete: deleteRecord,
+    } as unknown as Asset);
+
+    expect(deleteFile).toHaveBeenCalledWith('replicas/missing.bin');
     expect(deleteRecord).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/assets/src/asset-store.test.ts
+++ b/packages/assets/src/asset-store.test.ts
@@ -1,0 +1,145 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FilesystemInterface } from '@happyvertical/files';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Asset } from './asset.js';
+import { AssetStore } from './asset-store.js';
+import type { AssetCollection } from './assets.js';
+
+interface MemoryFilesystem extends FilesystemInterface {
+  files: Map<string, Buffer>;
+  deleted: string[];
+}
+
+function createMemoryFilesystem(
+  initialFiles: Record<string, Buffer | string> = {},
+): MemoryFilesystem {
+  const files = new Map<string, Buffer>();
+  for (const [path, content] of Object.entries(initialFiles)) {
+    files.set(path, Buffer.isBuffer(content) ? content : Buffer.from(content));
+  }
+
+  return {
+    files,
+    deleted: [],
+    async read(path: string) {
+      const data = files.get(path);
+      if (!data) throw new Error(`Missing test file: ${path}`);
+      return data;
+    },
+    async write(path: string, content: string | Buffer) {
+      files.set(
+        path,
+        Buffer.isBuffer(content) ? content : Buffer.from(content),
+      );
+    },
+    async delete(path: string) {
+      files.delete(path);
+      this.deleted.push(path);
+    },
+  } as unknown as MemoryFilesystem;
+}
+
+describe('AssetStore storage resolver', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  async function createDefaultBasePath(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), 'smrt-assets-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it('lets writes target a resolved filesystem instead of the default store', async () => {
+    const defaultBasePath = await createDefaultBasePath();
+    const resolvedFilesystem = createMemoryFilesystem();
+    const collection = {} as AssetCollection;
+    const resolver = vi.fn(async (request) => ({
+      filesystem: resolvedFilesystem,
+      providerOptions: { type: 'local' as const, basePath: '/tenant-store' },
+      path: `tenant-a/${request.path}`,
+    }));
+    const store = new AssetStore(defaultBasePath, collection, { resolver });
+    await store.initialize();
+
+    const sourceUri = await store.storeFile(
+      { id: 'asset-1' } as Asset,
+      Buffer.from('hello tenant storage'),
+      { mimeType: 'image/png', typeSlug: 'image' },
+    );
+
+    expect(sourceUri).toBe('file:///tenant-store/tenant-a/image/asset-1.png');
+    expect(resolvedFilesystem.files.get('tenant-a/image/asset-1.png')).toEqual(
+      Buffer.from('hello tenant storage'),
+    );
+    expect(resolver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operation: 'write',
+        path: 'image/asset-1.png',
+        sourceUri: `file://${defaultBasePath}/image/asset-1.png`,
+        mimeType: 'image/png',
+        typeSlug: 'image',
+      }),
+    );
+  });
+
+  it('lets reads choose a resolved location for the logical asset', async () => {
+    const defaultBasePath = await createDefaultBasePath();
+    const resolvedFilesystem = createMemoryFilesystem({
+      'replicas/video.mp4': 'from replica',
+    });
+    const collection = {} as AssetCollection;
+    const resolver = vi.fn(async () => ({
+      filesystem: resolvedFilesystem,
+      path: 'replicas/video.mp4',
+      sourceUri: 's3://tenant-assets/replicas/video.mp4',
+    }));
+    const store = new AssetStore(defaultBasePath, collection, { resolver });
+    await store.initialize();
+
+    const data = await store.read({
+      sourceUri: `file://${defaultBasePath}/video/original.mp4`,
+    } as Asset);
+
+    expect(data.toString()).toBe('from replica');
+    expect(resolver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operation: 'read',
+        path: 'video/original.mp4',
+        sourceUri: `file://${defaultBasePath}/video/original.mp4`,
+      }),
+    );
+  });
+
+  it('lets deletes target a resolved location before deleting the asset record', async () => {
+    const defaultBasePath = await createDefaultBasePath();
+    const resolvedFilesystem = createMemoryFilesystem({
+      'replicas/delete-me.bin': 'data',
+    });
+    const collection = {} as AssetCollection;
+    const store = new AssetStore(defaultBasePath, collection, {
+      resolver: async () => ({
+        filesystem: resolvedFilesystem,
+        path: 'replicas/delete-me.bin',
+      }),
+    });
+    await store.initialize();
+    const deleteRecord = vi.fn(async () => {});
+
+    await store.remove({
+      sourceUri: `file://${defaultBasePath}/file/delete-me.bin`,
+      delete: deleteRecord,
+    } as unknown as Asset);
+
+    expect(resolvedFilesystem.deleted).toEqual(['replicas/delete-me.bin']);
+    expect(deleteRecord).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/assets/src/asset-store.ts
+++ b/packages/assets/src/asset-store.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  FileNotFoundError,
   type FilesystemInterface,
   type GetFilesystemOptions,
   getFilesystem,
@@ -260,6 +261,16 @@ export class AssetStore {
           defaultFilesystem,
         })
       : undefined;
+    if (
+      request.operation === 'write' &&
+      resolution?.filesystem &&
+      !resolution.providerOptions &&
+      !resolution.sourceUri
+    ) {
+      throw new Error(
+        'Asset storage resolver must return providerOptions or sourceUri when overriding filesystem for write operations.',
+      );
+    }
     const providerOptions = resolution?.providerOptions
       ? normalizeProviderOptions(resolution.providerOptions)
       : this.fsOptions;
@@ -474,15 +485,18 @@ export class AssetStore {
     // Delete the file if it exists
     if (asset.sourceUri) {
       const filePath = AssetStore.pathFromUri(asset.sourceUri);
+      const target = await this.resolveStorage({
+        operation: 'delete',
+        asset,
+        path: AssetStore.providerRelativePath(filePath, this.fsOptions),
+        sourceUri: asset.sourceUri,
+      });
       try {
-        const target = await this.resolveStorage({
-          operation: 'delete',
-          asset,
-          path: AssetStore.providerRelativePath(filePath, this.fsOptions),
-          sourceUri: asset.sourceUri,
-        });
         await target.filesystem.delete(target.path);
-      } catch {
+      } catch (err) {
+        if (!(err instanceof FileNotFoundError)) {
+          throw err;
+        }
         // File may not exist on disk — still delete the record
       }
     }

--- a/packages/assets/src/asset-store.ts
+++ b/packages/assets/src/asset-store.ts
@@ -62,6 +62,66 @@ export interface StoreOptions {
 export type ProviderOptions = GetFilesystemOptions | string;
 
 /**
+ * Asset storage operation currently being resolved.
+ */
+export type AssetStorageOperation = 'read' | 'write' | 'delete';
+
+/**
+ * Context passed to an AssetStore resolver.
+ *
+ * Downstream apps can use this hook to route a logical Asset to whichever
+ * storage backend is appropriate for the current operation.
+ */
+export interface AssetStorageResolveRequest {
+  operation: AssetStorageOperation;
+  asset: Asset;
+  path: string;
+  sourceUri: string;
+  mimeType?: string;
+  typeSlug?: string;
+  defaultProviderOptions: GetFilesystemOptions;
+  defaultFilesystem: FilesystemInterface;
+}
+
+/**
+ * Resolved storage target for an AssetStore operation.
+ */
+export interface AssetStorageResolution {
+  filesystem?: FilesystemInterface;
+  providerOptions?: ProviderOptions;
+  path?: string;
+  sourceUri?: string;
+}
+
+export type AssetStorageResolver = (
+  request: AssetStorageResolveRequest,
+) =>
+  | AssetStorageResolution
+  | null
+  | undefined
+  | Promise<AssetStorageResolution | null | undefined>;
+
+export interface AssetStoreOptions {
+  resolver?: AssetStorageResolver;
+}
+
+interface ResolvedAssetStorageTarget {
+  filesystem: FilesystemInterface;
+  providerOptions: GetFilesystemOptions;
+  path: string;
+  sourceUri: string;
+}
+
+function normalizeProviderOptions(
+  providerOrBasePath: ProviderOptions,
+): GetFilesystemOptions {
+  if (typeof providerOrBasePath === 'string') {
+    return { type: 'local', basePath: providerOrBasePath };
+  }
+  return providerOrBasePath;
+}
+
+/**
  * AssetStore manages file storage and Asset record creation.
  *
  * Files are stored using @happyvertical/files with the convention:
@@ -95,21 +155,21 @@ export type ProviderOptions = GetFilesystemOptions | string;
 export class AssetStore {
   private fs: FilesystemInterface | null = null;
   private readonly fsOptions: GetFilesystemOptions;
+  private readonly fsCache = new Map<string, FilesystemInterface>();
+  private readonly resolver?: AssetStorageResolver;
 
   constructor(
     providerOrBasePath: ProviderOptions,
     private readonly collection: AssetCollection,
+    options: AssetStoreOptions = {},
   ) {
-    if (typeof providerOrBasePath === 'string') {
-      this.fsOptions = { type: 'local', basePath: providerOrBasePath };
-    } else {
-      this.fsOptions = providerOrBasePath;
-    }
+    this.fsOptions = normalizeProviderOptions(providerOrBasePath);
+    this.resolver = options.resolver;
   }
 
   /** The base path for local storage, or empty string for non-local providers */
   get basePath(): string {
-    return (this.fsOptions as any).basePath ?? '';
+    return this.fsOptions.basePath ?? '';
   }
 
   /**
@@ -118,6 +178,7 @@ export class AssetStore {
    */
   async initialize(): Promise<this> {
     this.fs = await getFilesystem(this.fsOptions);
+    this.fsCache.set(this.providerCacheKey(this.fsOptions), this.fs);
     return this;
   }
 
@@ -131,18 +192,121 @@ export class AssetStore {
     return this.fs;
   }
 
+  private providerCacheKey(providerOptions: GetFilesystemOptions): string {
+    return JSON.stringify(providerOptions);
+  }
+
+  private async getFilesystemForOptions(
+    providerOptions: GetFilesystemOptions,
+  ): Promise<FilesystemInterface> {
+    const key = this.providerCacheKey(providerOptions);
+    const cached = this.fsCache.get(key);
+    if (cached) return cached;
+
+    const filesystem = await getFilesystem(providerOptions);
+    this.fsCache.set(key, filesystem);
+    return filesystem;
+  }
+
   /**
    * Build a sourceUri for the given file path based on the provider type.
    */
   private buildSourceUri(filePath: string): string {
-    const type = this.fsOptions.type;
+    return AssetStore.buildSourceUriForProvider(filePath, this.fsOptions);
+  }
+
+  private static buildSourceUriForProvider(
+    filePath: string,
+    providerOptions: GetFilesystemOptions,
+  ): string {
+    const type = providerOptions.type;
     if (type === 's3') {
-      const bucket = (this.fsOptions as any).bucket ?? '';
+      const bucket = providerOptions.bucket ?? '';
       return `s3://${bucket}/${filePath}`;
     }
     // Default to file:// for local and other types
-    const base = this.basePath;
+    const base = providerOptions.basePath ?? '';
     return base ? `file://${base}/${filePath}` : `file://${filePath}`;
+  }
+
+  private static providerRelativePath(
+    filePath: string,
+    providerOptions: GetFilesystemOptions,
+  ): string {
+    const base = providerOptions.basePath ?? '';
+    return base && filePath.startsWith(base)
+      ? filePath.slice(base.length + 1)
+      : filePath;
+  }
+
+  private static requireAssetId(asset: Asset): string {
+    if (!asset.id) {
+      throw new Error('Asset must be saved before storing file data.');
+    }
+    return asset.id;
+  }
+
+  private async resolveStorage(
+    request: Omit<
+      AssetStorageResolveRequest,
+      'defaultProviderOptions' | 'defaultFilesystem'
+    >,
+  ): Promise<ResolvedAssetStorageTarget> {
+    const defaultFilesystem = this.getFs();
+    const resolution = this.resolver
+      ? await this.resolver({
+          ...request,
+          defaultProviderOptions: this.fsOptions,
+          defaultFilesystem,
+        })
+      : undefined;
+    const providerOptions = resolution?.providerOptions
+      ? normalizeProviderOptions(resolution.providerOptions)
+      : this.fsOptions;
+    const path = AssetStore.providerRelativePath(
+      resolution?.path ?? request.path,
+      providerOptions,
+    );
+    const sourceUri =
+      resolution?.sourceUri ??
+      (resolution?.path || resolution?.providerOptions
+        ? AssetStore.buildSourceUriForProvider(path, providerOptions)
+        : request.sourceUri);
+    const filesystem =
+      resolution?.filesystem ??
+      (providerOptions === this.fsOptions
+        ? defaultFilesystem
+        : await this.getFilesystemForOptions(providerOptions));
+
+    return {
+      filesystem,
+      providerOptions,
+      path,
+      sourceUri,
+    };
+  }
+
+  private async writeAssetData(
+    asset: Asset,
+    data: Buffer,
+    opts: { mimeType: string; typeSlug?: string },
+  ): Promise<string> {
+    const ext = MIME_TO_EXT[opts.mimeType] ?? 'bin';
+    const typeSlug = opts.typeSlug ?? 'file';
+    const assetId = AssetStore.requireAssetId(asset);
+    const filePath = `${typeSlug}/${assetId}.${ext}`;
+    const sourceUri = this.buildSourceUri(filePath);
+    const target = await this.resolveStorage({
+      operation: 'write',
+      asset,
+      path: filePath,
+      sourceUri,
+      mimeType: opts.mimeType,
+      typeSlug,
+    });
+
+    await target.filesystem.write(target.path, data, { createParents: true });
+    return target.sourceUri;
   }
 
   /**
@@ -161,13 +325,7 @@ export class AssetStore {
     data: Buffer,
     opts: { mimeType: string; typeSlug?: string },
   ): Promise<string> {
-    const fs = this.getFs();
-    const ext = MIME_TO_EXT[opts.mimeType] ?? 'bin';
-    const typeSlug = opts.typeSlug ?? 'file';
-    const filePath = `${typeSlug}/${asset.id}.${ext}`;
-    const sourceUri = this.buildSourceUri(filePath);
-    await fs.write(filePath, data, { createParents: true });
-    return sourceUri;
+    return this.writeAssetData(asset, data, opts);
   }
 
   /**
@@ -179,8 +337,6 @@ export class AssetStore {
    * @returns Created Asset instance
    */
   async store(name: string, data: Buffer, opts: StoreOptions): Promise<Asset> {
-    const fs = this.getFs();
-    const ext = MIME_TO_EXT[opts.mimeType] ?? 'bin';
     const typeSlug = opts.typeSlug ?? 'file';
 
     // Create the Asset record first to get an ID
@@ -194,13 +350,12 @@ export class AssetStore {
       sourceUri: '', // Will be updated after file write
     })) as Asset;
 
-    // Build file path: {typeSlug}/{assetId}.{ext}
-    const filePath = `${typeSlug}/${asset.id}.${ext}`;
-    const sourceUri = this.buildSourceUri(filePath);
-
     try {
       // Write file to storage
-      await fs.write(filePath, data, { createParents: true });
+      asset.sourceUri = await this.writeAssetData(asset, data, {
+        mimeType: opts.mimeType,
+        typeSlug,
+      });
     } catch (err) {
       // Clean up orphaned Asset record on file write failure
       await asset.delete();
@@ -208,7 +363,6 @@ export class AssetStore {
     }
 
     // Update the Asset with the file URI
-    asset.sourceUri = sourceUri;
     await asset.save();
 
     return asset;
@@ -227,28 +381,27 @@ export class AssetStore {
     data: Buffer,
     opts: Partial<StoreOptions> = {},
   ): Promise<Asset> {
-    const primaryVersionId = asset.primaryVersionId ?? asset.id!;
+    const primaryVersionId =
+      asset.primaryVersionId ?? AssetStore.requireAssetId(asset);
     const newVersion = await this.collection.createNewVersion(
       primaryVersionId,
       '', // sourceUri will be set by store
       { ...opts },
     );
 
-    const fs = this.getFs();
     const mimeType = opts.mimeType ?? asset.mimeType;
-    const ext = MIME_TO_EXT[mimeType] ?? 'bin';
     const typeSlug = opts.typeSlug ?? asset.typeSlug ?? 'file';
-    const filePath = `${typeSlug}/${newVersion.id}.${ext}`;
-    const sourceUri = this.buildSourceUri(filePath);
 
     try {
-      await fs.write(filePath, data, { createParents: true });
+      newVersion.sourceUri = await this.writeAssetData(newVersion, data, {
+        mimeType,
+        typeSlug,
+      });
     } catch (err) {
       await newVersion.delete();
       throw err;
     }
 
-    newVersion.sourceUri = sourceUri;
     if (opts.mimeType) newVersion.mimeType = opts.mimeType;
     await newVersion.save();
 
@@ -263,7 +416,8 @@ export class AssetStore {
    * @returns File data as a Buffer
    */
   async readVersion(asset: Asset, version: number): Promise<Buffer> {
-    const primaryVersionId = asset.primaryVersionId ?? asset.id!;
+    const primaryVersionId =
+      asset.primaryVersionId ?? AssetStore.requireAssetId(asset);
     const versions = await this.collection.listVersions(primaryVersionId);
     const targetVersion = versions.find((v) => v.version === version);
 
@@ -283,14 +437,14 @@ export class AssetStore {
    * @returns File data as a Buffer
    */
   async read(asset: Asset): Promise<Buffer> {
-    const fs = this.getFs();
     const filePath = AssetStore.pathFromUri(asset.sourceUri);
-    const base = this.basePath;
-    const relativePath =
-      base && filePath.startsWith(base)
-        ? filePath.slice(base.length + 1)
-        : filePath;
-    return (await fs.read(relativePath, { raw: true })) as Buffer;
+    const target = await this.resolveStorage({
+      operation: 'read',
+      asset,
+      path: AssetStore.providerRelativePath(filePath, this.fsOptions),
+      sourceUri: asset.sourceUri,
+    });
+    return (await target.filesystem.read(target.path, { raw: true })) as Buffer;
   }
 
   /**
@@ -317,18 +471,17 @@ export class AssetStore {
    * @param asset - Asset to remove
    */
   async remove(asset: Asset): Promise<void> {
-    const fs = this.getFs();
-
     // Delete the file if it exists
     if (asset.sourceUri) {
       const filePath = AssetStore.pathFromUri(asset.sourceUri);
-      const base = this.basePath;
-      const relativePath =
-        base && filePath.startsWith(base)
-          ? filePath.slice(base.length + 1)
-          : filePath;
       try {
-        await fs.delete(relativePath);
+        const target = await this.resolveStorage({
+          operation: 'delete',
+          asset,
+          path: AssetStore.providerRelativePath(filePath, this.fsOptions),
+          sourceUri: asset.sourceUri,
+        });
+        await target.filesystem.delete(target.path);
       } catch {
         // File may not exist on disk — still delete the record
       }

--- a/packages/assets/src/index.ts
+++ b/packages/assets/src/index.ts
@@ -49,7 +49,12 @@ export { AssetStatus } from './asset-status';
 export { AssetStatusCollection } from './asset-statuses';
 // Utilities
 export {
+  type AssetStorageOperation,
+  type AssetStorageResolution,
+  type AssetStorageResolveRequest,
+  type AssetStorageResolver,
   AssetStore,
+  type AssetStoreOptions,
   type ProviderOptions,
   type StoreOptions,
 } from './asset-store';

--- a/packages/assets/src/lib/server/smrt-register.ts
+++ b/packages/assets/src/lib/server/smrt-register.ts
@@ -9,31 +9,41 @@
 
 import { ObjectRegistry } from '@happyvertical/smrt-core';
 
-import { AssetAssociation } from '../../asset-association';
-import '../../asset-associations';
-import { AssetMetafield } from '../../asset-metafield';
-import '../../asset-metafields';
-import { AssetStatus } from '../../asset-status';
-import '../../asset-statuses';
-import { AssetType } from '../../asset-type';
-import '../../asset-types';
 import { Asset } from '../../asset';
-import '../../assets';
+import { AssetAssociation } from '../../asset-association';
+import { AssetMetafield } from '../../asset-metafield';
+import { AssetStatus } from '../../asset-status';
+import { AssetType } from '../../asset-type';
 import { Folder } from '../../folder';
+import '../../asset-associations';
+import '../../asset-metafields';
+import '../../asset-statuses';
+import '../../asset-types';
+import '../../assets';
 import '../../folders';
 
 // Re-register imported objects with explicit package names for bundled runtimes
 ObjectRegistry.register(AssetAssociation, {
+  name: 'AssetAssociation',
   packageName: '@happyvertical/smrt-assets',
 });
 ObjectRegistry.register(AssetMetafield, {
+  name: 'AssetMetafield',
   packageName: '@happyvertical/smrt-assets',
 });
 ObjectRegistry.register(AssetStatus, {
+  name: 'AssetStatus',
   packageName: '@happyvertical/smrt-assets',
 });
 ObjectRegistry.register(AssetType, {
+  name: 'AssetType',
   packageName: '@happyvertical/smrt-assets',
 });
-ObjectRegistry.register(Asset, { packageName: '@happyvertical/smrt-assets' });
-ObjectRegistry.register(Folder, { packageName: '@happyvertical/smrt-assets' });
+ObjectRegistry.register(Asset, {
+  name: 'Asset',
+  packageName: '@happyvertical/smrt-assets',
+});
+ObjectRegistry.register(Folder, {
+  name: 'Folder',
+  packageName: '@happyvertical/smrt-assets',
+});

--- a/packages/assets/src/svelte/playground/AssetDetailPreview.svelte
+++ b/packages/assets/src/svelte/playground/AssetDetailPreview.svelte
@@ -10,10 +10,21 @@ let previewAsset = $state<PersistedAsset | null>(null);
 let statusMessage = $state<string | null>(null);
 let lastAsset: PersistedAsset | null = null;
 
+function clonePersistedAsset(
+  source: PersistedAsset,
+  updates: AssetDetailUpdates = {},
+): PersistedAsset {
+  return Object.assign(
+    Object.create(Object.getPrototypeOf(source)) as PersistedAsset,
+    source,
+    updates,
+  );
+}
+
 $effect(() => {
   if (asset !== lastAsset) {
     lastAsset = asset;
-    previewAsset = { ...asset };
+    previewAsset = clonePersistedAsset(asset);
     statusMessage = null;
     isOpen = false;
   }
@@ -33,10 +44,7 @@ function handleSave(_asset: PersistedAsset, updates: AssetDetailUpdates) {
     return;
   }
 
-  previewAsset = {
-    ...previewAsset,
-    ...updates,
-  };
+  previewAsset = clonePersistedAsset(previewAsset, updates);
   statusMessage = 'Saved changes in the preview harness.';
 }
 

--- a/packages/assets/src/svelte/types.ts
+++ b/packages/assets/src/svelte/types.ts
@@ -121,12 +121,20 @@ export interface AssetToolbarProps {
   sort: AssetSort;
   /** Callback when view changes */
   onViewChange: (view: AssetViewMode) => void;
+  /** @deprecated Use onViewChange */
+  onviewchange?: (view: AssetViewMode) => void;
   /** Callback when filters change */
   onFilterChange: (filters: AssetFilters) => void;
+  /** @deprecated Use onFilterChange */
+  onfilterchange?: (filters: AssetFilters) => void;
   /** Callback when sort changes */
   onSortChange: (sort: AssetSort) => void;
+  /** @deprecated Use onSortChange */
+  onsortchange?: (sort: AssetSort) => void;
   /** Callback when upload is requested */
   onUpload: () => void;
+  /** @deprecated Use onUpload */
+  onupload?: () => void;
 }
 
 /** Props for AssetGrid */
@@ -171,6 +179,10 @@ export interface ActionBarProps {
   customActions?: AssetAction[];
   /** Callback to clear selection */
   onClearSelection: () => void;
+  /** @deprecated Use onClearSelection */
+  onclearselection?: () => void;
   /** Callback for delete action */
   onDelete: (assets: PersistedAsset[]) => void | Promise<void>;
+  /** @deprecated Use onDelete */
+  ondelete?: (assets: PersistedAsset[]) => void | Promise<void>;
 }

--- a/packages/assets/tsconfig.json
+++ b/packages/assets/tsconfig.json
@@ -10,5 +10,11 @@
     "emitDeclarationOnly": false
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "src/routes/**/*"
+  ]
 }

--- a/packages/assets/vite.config.ts
+++ b/packages/assets/vite.config.ts
@@ -47,6 +47,14 @@ export default defineConfig(async ({ mode }) => {
     sourceEntry: 'packages/core/src/vite-plugin/index.ts',
     purpose: 'assets package Vite config',
   });
+  const { smrtConsumer } = await importWorkspaceModule<
+    typeof import('@happyvertical/smrt-core/consumer-plugin')
+  >({
+    packageName: '@happyvertical/smrt-core/consumer-plugin',
+    distEntry: 'packages/core/dist/consumer-plugin.js',
+    sourceEntry: 'packages/core/src/consumer-plugin/index.ts',
+    purpose: 'assets package consumer plugin',
+  });
 
   return {
     resolve: {
@@ -60,6 +68,10 @@ export default defineConfig(async ({ mode }) => {
     },
     plugins: [
       sveltekit(),
+      smrtConsumer({
+        projectRoot: process.cwd(),
+        svelteKit: true,
+      }),
       smrtPlugin({
         include: ['src/**/*.ts'],
         exclude: ['**/*.test.ts', '**/*.spec.ts', 'src/svelte/**/*', 'src/routes/**/*', '**/*.svelte'],


### PR DESCRIPTION
## Summary

- add a small `AssetStore` resolver seam so callers can resolve a storage backend per operation without replacing the package-wide default store
- wire `smrt-assets` dev/check config through `smrtConsumer()` so current SMRT route generation and validation run correctly
- clean up package check issues in the Svelte UI playground/types and generated registration file

## Root Cause / Why This Did Not Pop Up Before

`smrt-assets` package builds run with `SMRT_PACKAGE_BUILD=1`, which exercises the library-mode path and bypasses the dev/check SvelteKit route-generation path. The resolver tests also only covered `asset-store` behavior, not package-wide `svelte-check`.

After the branch was rebased onto the latest SMRT main, core now fails fast when a package uses the SMRT plugin without consumer setup. That stricter validation only appears when `svelte-check` loads the package Vite config and route generation runs. Once that path was active, a couple of older UI typing issues surfaced too: lowercase callback aliases existed at runtime but not in the exported prop types, and the playground preview was spreading `PersistedAsset` into a plain object, losing its class prototype.

## Validation

- `pnpm --filter @happyvertical/smrt-assets check`
- `pnpm --filter @happyvertical/smrt-assets exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @happyvertical/smrt-assets exec vitest run src/asset-store.test.ts`
- `pnpm --filter @happyvertical/smrt-assets build`
- `pnpm exec biome check packages/assets/vite.config.ts packages/assets/tsconfig.json packages/assets/src/svelte/types.ts packages/assets/src/svelte/playground/AssetDetailPreview.svelte packages/assets/src/lib/server/smrt-register.ts packages/assets/src/asset-store.ts packages/assets/src/index.ts packages/assets/src/asset-store.test.ts`
- `git diff --check`
- pre-push hook: format-check and workflow validation
