### PR TITLE
fix(cli): preserve package names in generated registers

### DIFF
--- a/packages/assets/src/lib/server/smrt-register.ts
+++ b/packages/assets/src/lib/server/smrt-register.ts
@@ -2,7 +2,7 @@
  * Auto-generated SMRT object registration
  * DO NOT EDIT - changes will be overwritten
  *
- * Importing these modules triggers their @smrt() decorators, which performs
+ * Importing these modules triggers their @smrt() decorators, which perform
  * the initial registration. The explicit re-registration below is intentional:
  * it upgrades bundled runtimes to deterministic qualified registrations.
  */

--- a/packages/cli/src/commands/__tests__/generate-register.test.ts
+++ b/packages/cli/src/commands/__tests__/generate-register.test.ts
@@ -144,6 +144,12 @@ describe('generate-register', () => {
       /ObjectRegistry\.register\(Profile/g,
     );
     expect(profileRegistrations).toHaveLength(1);
+    expect(content).toContain(
+      'ObjectRegistry.register(Profile, { name: "Profile", packageName: "@happyvertical/smrt-profiles" });',
+    );
+    expect(content).not.toContain(
+      'name: "@happyvertical/smrt-profiles:Profile"',
+    );
   });
 
   it('filters out test-visibility objects', async () => {
@@ -198,6 +204,39 @@ describe('generate-register', () => {
     // Test objects should NOT be present
     expect(content).not.toContain('PerfTestUser');
     expect(content).not.toContain('Issue144TestProfile');
+  });
+
+  it('keeps package names separate when manifest keys are qualified', async () => {
+    mockedAutoDiscover.mockResolvedValue({
+      discovered: [
+        {
+          path: '/fake/agents/manifest.json',
+          source: 'package',
+          packageName: '@happyvertical/smrt-agents',
+        },
+      ],
+    } as any);
+
+    mockedLoadManifest.mockResolvedValue({
+      objects: {
+        '@happyvertical/smrt-agents:Agent': {
+          exportName: 'Agent',
+          packageName: '@happyvertical/smrt-agents',
+          qualifiedName: '@happyvertical/smrt-agents:Agent',
+          hasCollection: false,
+          visibility: 'public',
+        },
+      },
+    });
+
+    await handler([], { 'output-path': outputPath });
+
+    const content = await readFile(outputPath, 'utf-8');
+
+    expect(content).toContain(
+      'ObjectRegistry.register(Agent, { name: "Agent", packageName: "@happyvertical/smrt-agents" });',
+    );
+    expect(content).not.toContain('name: "@happyvertical/smrt-agents:Agent"');
   });
 
   it('imports from canonical packageName, not the manifest package', async () => {
@@ -370,8 +409,12 @@ describe('generate-register', () => {
     expect(content).toContain("import { Gadget } from '@happyvertical/pkg-b'");
 
     // Both objects should be registered
-    expect(content).toContain('ObjectRegistry.register(Widget');
-    expect(content).toContain('ObjectRegistry.register(Gadget');
+    expect(content).toContain(
+      'ObjectRegistry.register(Widget, { name: "Widget", packageName: "@happyvertical/pkg-a" });',
+    );
+    expect(content).toContain(
+      'ObjectRegistry.register(Gadget, { name: "Gadget", packageName: "@happyvertical/pkg-b" });',
+    );
 
     // ItemCollection should only appear once (from Widget's package)
     const collectionImports = content.match(/ItemCollection/g);

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -398,6 +398,9 @@ export const generateCommands: Record<string, CLICommand> = {
             const importPath = def.importPath || def.packageName || packageName;
             const hasCollection = def.hasCollection && !skipCollection;
             const tableName = def.collection || objectName.toLowerCase();
+            const registrationName =
+              def.className || objectName.split(':').pop() || objectName;
+            const registrationPackageName = def.packageName || packageName;
 
             // Generate import statement
             if (hasCollection && collectionExportName) {
@@ -408,9 +411,14 @@ export const generateCommands: Record<string, CLICommand> = {
               imports.push(`import { ${exportName} } from '${importPath}';`);
             }
 
-            // Generate registration calls
+            // Generate registration calls. Keep the class name and package name
+            // separate so ObjectRegistry can use package-aware collision policy.
+            const registrationOptions = [
+              `name: ${JSON.stringify(registrationName)}`,
+              `packageName: ${JSON.stringify(registrationPackageName)}`,
+            ].join(', ');
             registrations.push(
-              `ObjectRegistry.register(${exportName}, { name: '${objectName}' });`,
+              `ObjectRegistry.register(${exportName}, { ${registrationOptions} });`,
             );
 
             if (hasCollection && collectionExportName) {

--- a/packages/content/src/lib/server/smrt-register.ts
+++ b/packages/content/src/lib/server/smrt-register.ts
@@ -2,7 +2,7 @@
  * Auto-generated SMRT object registration
  * DO NOT EDIT - changes will be overwritten
  *
- * Importing these modules triggers their @smrt() decorators, which performs
+ * Importing these modules triggers their @smrt() decorators, which perform
  * the initial registration. The explicit re-registration below is intentional:
  * it upgrades bundled runtimes to deterministic qualified registrations.
  */

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -582,7 +582,7 @@ async function generateRegistrationFile(
  * Auto-generated SMRT object registration
  * DO NOT EDIT - changes will be overwritten
  *
- * Importing these modules triggers their @smrt() decorators, which performs
+ * Importing these modules triggers their @smrt() decorators, which perform
  * the initial registration. The explicit re-registration below is intentional:
  * it upgrades bundled runtimes to deterministic qualified registrations.
  */

--- a/packages/images/src/lib/server/smrt-register.ts
+++ b/packages/images/src/lib/server/smrt-register.ts
@@ -2,7 +2,7 @@
  * Auto-generated SMRT object registration
  * DO NOT EDIT - changes will be overwritten
  *
- * Importing these modules triggers their @smrt() decorators, which performs
+ * Importing these modules triggers their @smrt() decorators, which perform
  * the initial registration. The explicit re-registration below is intentional:
  * it upgrades bundled runtimes to deterministic qualified registrations.
  */


### PR DESCRIPTION
## Summary
- generate external register calls with separate `name` and `packageName` fields
- add a regression for qualified manifest keys like `@happyvertical/smrt-agents:Agent`
- fix the generated register grammar typo in bundled register files

## Why
Anytown PR validation is failing when generated SMRT registers pass qualified names as `name`, which bypasses package-aware collision handling and throws duplicate registration errors.

## Verification
- `pnpm --filter @happyvertical/smrt-cli test -- --runInBand packages/cli/src/commands/__tests__/generate-register.test.ts`
- `pnpm --filter @happyvertical/smrt-cli typecheck`
- `pnpm --filter @happyvertical/smrt-cli build`
- `pnpm --filter @happyvertical/smrt-core test`
- `git diff --check`