### PR TITLE
feat(jobs): add durable job telemetry

### DIFF
--- a/packages/core/src/__tests__/system-table-compatibility.test.ts
+++ b/packages/core/src/__tests__/system-table-compatibility.test.ts
@@ -1,7 +1,10 @@
 import { getDatabase } from '@happyvertical/sql';
 import { describe, expect, it, vi } from 'vitest';
 import { SmrtObject } from '../object';
-import { ensureJobsSystemTableCompatibility } from '../system/compatibility';
+import {
+  ensureJobEventsSystemTableCompatibility,
+  ensureJobsSystemTableCompatibility,
+} from '../system/compatibility';
 import { SMRT_SCHEMA_VERSION } from '../system/schema';
 
 class LegacySystemTableProbe extends SmrtObject {
@@ -155,6 +158,47 @@ describe('system table compatibility', () => {
     expect(indexNames).toContain('idx_smrt_jobs_tenant_id');
   });
 
+  it('upgrades legacy job event tables without replaying system DDL', async () => {
+    const db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+
+    await db.query(`
+      CREATE TABLE _smrt_job_events (
+        id TEXT PRIMARY KEY,
+        job_id TEXT NOT NULL,
+        type TEXT NOT NULL DEFAULT 'log',
+        level TEXT NOT NULL DEFAULT 'info',
+        stage TEXT,
+        progress INTEGER,
+        message TEXT NOT NULL DEFAULT '',
+        data TEXT,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+
+    await ensureJobEventsSystemTableCompatibility(db);
+
+    const columns = await db.query(`PRAGMA table_info(_smrt_job_events)`);
+    const columnNames = columns.rows.map((row: { name: string }) => row.name);
+    expect(columnNames).toContain('tenant_id');
+
+    const indexes = await db.query(`
+      SELECT name FROM sqlite_master
+      WHERE type = 'index'
+        AND name IN (
+          'idx_smrt_job_events_tenant_id',
+          'idx_smrt_job_events_job_id',
+          'idx_smrt_job_events_type',
+          'idx_smrt_job_events_created_at'
+        )
+    `);
+    const indexNames = indexes.rows.map((row: { name: string }) => row.name);
+    expect(indexNames).toContain('idx_smrt_job_events_tenant_id');
+    expect(indexNames).toContain('idx_smrt_job_events_job_id');
+    expect(indexNames).toContain('idx_smrt_job_events_type');
+    expect(indexNames).toContain('idx_smrt_job_events_created_at');
+  });
+
   it('skips Postgres jobs DDL when the compatibility column and index already exist', async () => {
     const query = vi
       .fn()
@@ -192,6 +236,52 @@ describe('system table compatibility', () => {
         String(sql).includes(
           'CREATE INDEX IF NOT EXISTS idx_smrt_jobs_tenant_id',
         ),
+      ),
+    ).toBe(false);
+  });
+
+  it('skips Postgres job event DDL when compatibility columns and indexes already exist', async () => {
+    const existingIndexes = new Set([
+      'idx_smrt_job_events_tenant_id',
+      'idx_smrt_job_events_job_id',
+      'idx_smrt_job_events_type',
+      'idx_smrt_job_events_created_at',
+    ]);
+    const query = vi
+      .fn()
+      .mockImplementation(async (sql: string, ...params: unknown[]) => {
+        if (sql === 'SELECT 1 FROM _smrt_job_events LIMIT 1') {
+          return { rows: [{ '?column?': 1 }] };
+        }
+
+        if (sql.includes('information_schema.columns')) {
+          expect(sql).toContain('table_schema = current_schema()');
+          expect(params).toEqual(['_smrt_job_events', 'tenant_id']);
+          return { rows: [{ '?column?': 1 }] };
+        }
+
+        if (sql.includes('pg_indexes')) {
+          const [indexName] = params;
+          expect(existingIndexes.has(String(indexName))).toBe(true);
+          return { rows: [{ '?column?': 1 }] };
+        }
+
+        throw new Error(`Unexpected query: ${sql}`);
+      });
+
+    await ensureJobEventsSystemTableCompatibility({
+      url: 'postgresql://localhost:5432/test',
+      query,
+    } as any);
+
+    expect(
+      query.mock.calls.some(([sql]) =>
+        String(sql).includes('ALTER TABLE _smrt_job_events ADD COLUMN'),
+      ),
+    ).toBe(false);
+    expect(
+      query.mock.calls.some(([sql]) =>
+        String(sql).includes('CREATE INDEX IF NOT EXISTS'),
       ),
     ).toBe(false);
   });

--- a/packages/core/src/system/compatibility.ts
+++ b/packages/core/src/system/compatibility.ts
@@ -203,10 +203,45 @@ export async function ensureJobsSystemTableCompatibility(
   );
 }
 
+export async function ensureJobEventsSystemTableCompatibility(
+  db: DatabaseInterface,
+): Promise<void> {
+  if (!(await tableExists(db, '_smrt_job_events'))) {
+    return;
+  }
+
+  await addColumnIfMissing(db, '_smrt_job_events', 'tenant_id', 'TEXT');
+  await addIndexIfMissing(
+    db,
+    'idx_smrt_job_events_tenant_id',
+    '_smrt_job_events',
+    'tenant_id',
+  );
+  await addIndexIfMissing(
+    db,
+    'idx_smrt_job_events_job_id',
+    '_smrt_job_events',
+    'job_id',
+  );
+  await addIndexIfMissing(
+    db,
+    'idx_smrt_job_events_type',
+    '_smrt_job_events',
+    'type',
+  );
+  await addIndexIfMissing(
+    db,
+    'idx_smrt_job_events_created_at',
+    '_smrt_job_events',
+    'created_at',
+  );
+}
+
 export async function ensureLegacySystemTableCompatibility(
   db: DatabaseInterface,
 ): Promise<void> {
   await ensureDispatchSystemTableCompatibility(db);
   await ensureDispatchSubscriptionsSystemTableCompatibility(db);
   await ensureJobsSystemTableCompatibility(db);
+  await ensureJobEventsSystemTableCompatibility(db);
 }

--- a/packages/jobs/src/__tests__/job-telemetry.test.ts
+++ b/packages/jobs/src/__tests__/job-telemetry.test.ts
@@ -1,0 +1,236 @@
+import {
+  getTestDatabase,
+  ObjectRegistry,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { withTenant } from '@happyvertical/smrt-tenancy';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { JobExecutionContext } from '../logger-extension.js';
+import { createTaskRunner } from '../runner.js';
+import { SmrtJobCollection } from '../smrt-job.js';
+import { SmrtJobEventCollection } from '../smrt-job-event.js';
+
+@smrt()
+class JobTelemetryProbe extends SmrtObject {
+  async legacyEcho(args: { value: string }): Promise<string> {
+    return args.value;
+  }
+
+  async reportProgress(
+    _args: Record<string, unknown>,
+    context?: JobExecutionContext,
+  ): Promise<string> {
+    await context?.progress({
+      stage: 'processing',
+      progress: 42,
+      message: 'Processing fixture',
+      detail: 'halfway-ish',
+      source: 'vitest',
+    });
+    await context?.event({
+      type: 'status',
+      level: 'info',
+      stage: 'checkpoint',
+      message: 'Checkpoint recorded',
+      data: { ok: true },
+    });
+    return 'done';
+  }
+}
+
+afterEach(() => {
+  ObjectRegistry.clearCollectionCache?.();
+});
+
+describe('job telemetry', () => {
+  it('appends and lists durable tenant-scoped job events', async () => {
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    const events = await SmrtJobEventCollection.create({ db });
+
+    const first = await events.append({
+      tenantId: 'tenant-a',
+      jobId: 'job-1',
+      type: 'progress',
+      level: 'info',
+      stage: 'download',
+      progress: 12,
+      message: 'Downloading',
+    });
+    await events.append({
+      tenantId: 'tenant-b',
+      jobId: 'job-1',
+      type: 'progress',
+      level: 'info',
+      stage: 'process',
+      progress: 80,
+      message: 'Processing',
+    });
+    const second = await events.append({
+      tenantId: 'tenant-a',
+      jobId: 'job-1',
+      type: 'progress',
+      level: 'info',
+      stage: 'upload',
+      progress: 120,
+      message: 'Uploading',
+    });
+
+    const tenantEvents = await events.listByJob('job-1', {
+      tenantId: 'tenant-a',
+    });
+    expect(tenantEvents.map((event) => event.message)).toEqual([
+      'Downloading',
+      'Uploading',
+    ]);
+
+    const afterFirst = await events.listByJob('job-1', {
+      tenantId: 'tenant-a',
+      cursor: first.toCursor(),
+    });
+    expect(afterFirst.map((event) => event.id)).toEqual([second.id]);
+
+    const latest = await events.latestProgressByJobIds(['job-1'], {
+      tenantId: 'tenant-a',
+    });
+    expect(latest.get('job-1')?.stage).toBe('upload');
+    expect(latest.get('job-1')?.progress).toBe(100);
+  });
+
+  it('uses ambient tenant context for event list helpers', async () => {
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    const events = await SmrtJobEventCollection.create({ db });
+
+    await events.append({
+      tenantId: 'tenant-a',
+      jobId: 'job-1',
+      type: 'progress',
+      level: 'info',
+      stage: 'download',
+      progress: 12,
+      message: 'Downloading',
+    });
+    await events.append({
+      tenantId: 'tenant-b',
+      jobId: 'job-1',
+      type: 'progress',
+      level: 'info',
+      stage: 'process',
+      progress: 80,
+      message: 'Processing',
+    });
+
+    const tenantEvents = await withTenant({ tenantId: 'tenant-a' }, async () =>
+      events.listByJob('job-1'),
+    );
+    expect(tenantEvents.map((event) => event.message)).toEqual(['Downloading']);
+
+    const latest = await withTenant({ tenantId: 'tenant-b' }, async () =>
+      events.latestProgressByJobIds(['job-1']),
+    );
+    expect(latest.get('job-1')?.stage).toBe('process');
+  });
+
+  it('passes an optional execution context without breaking one-arg methods', async () => {
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    const jobs = await SmrtJobCollection.create({ db });
+    const events = await SmrtJobEventCollection.create({ db });
+
+    const legacyJob = await jobs.create({
+      tenantId: 'tenant-runner',
+      objectType: 'JobTelemetryProbe',
+      method: 'legacyEcho',
+      args: { value: 'legacy-ok' },
+    });
+    const progressJob = await jobs.create({
+      tenantId: 'tenant-runner',
+      objectType: 'JobTelemetryProbe',
+      method: 'reportProgress',
+      args: {},
+    });
+
+    const runner = createTaskRunner({ concurrency: 1, pollInterval: 10 });
+    await runner.initialize(db);
+
+    const completed = new Promise<unknown[]>((resolve, reject) => {
+      const results: unknown[] = [];
+      runner.on('job:completed', (_job, result) => {
+        results.push((result as { result?: unknown }).result);
+        if (results.length === 2) {
+          resolve(results);
+        }
+      });
+      runner.once('job:failed', (_job, error) => reject(error));
+      runner.once('runner:error', reject);
+    });
+
+    await runner.start();
+
+    try {
+      const results = await completed;
+      expect(results).toContain('legacy-ok');
+      expect(results).toContain('done');
+    } finally {
+      await runner.stop();
+    }
+
+    const legacyEvents = await events.listByJob(legacyJob.id ?? '', {
+      tenantId: 'tenant-runner',
+    });
+    expect(legacyEvents.some((event) => event.stage === 'completed')).toBe(
+      true,
+    );
+
+    const progressEvents = await events.listByJob(progressJob.id ?? '', {
+      tenantId: 'tenant-runner',
+    });
+    expect(
+      progressEvents.some(
+        (event) =>
+          event.type === 'progress' &&
+          event.stage === 'processing' &&
+          event.progress === 42,
+      ),
+    ).toBe(true);
+    expect(
+      progressEvents.some((event) => event.message === 'Checkpoint recorded'),
+    ).toBe(true);
+  });
+
+  it('keeps running jobs when telemetry persistence is unavailable', async () => {
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    const jobs = await SmrtJobCollection.create({ db });
+
+    await jobs.create({
+      tenantId: 'tenant-runner',
+      objectType: 'JobTelemetryProbe',
+      method: 'legacyEcho',
+      args: { value: 'telemetry-best-effort' },
+    });
+
+    const runner = createTaskRunner({ concurrency: 1, pollInterval: 10 });
+    await runner.initialize(db);
+    await db.query('DROP TABLE _smrt_job_events');
+
+    const telemetryErrors: Error[] = [];
+    runner.on('runner:error', (error) => {
+      telemetryErrors.push(error);
+    });
+
+    const completed = new Promise<unknown>((resolve, reject) => {
+      runner.once('job:completed', (_job, result) =>
+        resolve((result as { result?: unknown }).result),
+      );
+      runner.once('job:failed', (_job, error) => reject(error));
+    });
+
+    await runner.start();
+
+    try {
+      await expect(completed).resolves.toBe('telemetry-best-effort');
+      expect(telemetryErrors.length).toBeGreaterThan(0);
+    } finally {
+      await runner.stop();
+    }
+  });
+});

--- a/packages/jobs/src/__tests__/job-telemetry.test.ts
+++ b/packages/jobs/src/__tests__/job-telemetry.test.ts
@@ -131,6 +131,160 @@ describe('job telemetry', () => {
     expect(latest.get('job-1')?.stage).toBe('process');
   });
 
+  it('treats tenantId undefined as ambient tenant context', async () => {
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    const events = await SmrtJobEventCollection.create({ db });
+
+    await events.append({
+      tenantId: 'tenant-a',
+      jobId: 'job-undefined-tenant',
+      type: 'progress',
+      level: 'info',
+      stage: 'download',
+      progress: 10,
+      message: 'Tenant A',
+    });
+    await events.append({
+      tenantId: 'tenant-b',
+      jobId: 'job-undefined-tenant',
+      type: 'progress',
+      level: 'info',
+      stage: 'process',
+      progress: 90,
+      message: 'Tenant B',
+    });
+
+    const tenantEvents = await withTenant({ tenantId: 'tenant-a' }, async () =>
+      events.listByJob('job-undefined-tenant', { tenantId: undefined }),
+    );
+    expect(tenantEvents.map((event) => event.message)).toEqual(['Tenant A']);
+
+    const latest = await withTenant({ tenantId: 'tenant-b' }, async () =>
+      events.latestProgressByJobIds(['job-undefined-tenant'], {
+        tenantId: undefined,
+      }),
+    );
+    expect(latest.get('job-undefined-tenant')?.message).toBe('Tenant B');
+  });
+
+  it('requires explicit tenant scope for raw event list helpers', async () => {
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    const events = await SmrtJobEventCollection.create({ db });
+
+    await events.append({
+      tenantId: 'tenant-a',
+      jobId: 'job-scope-required',
+      type: 'progress',
+      level: 'info',
+      stage: 'download',
+      progress: 10,
+      message: 'Tenant A',
+    });
+
+    await expect(events.listByJob('job-scope-required')).rejects.toThrow(
+      /require tenantId/,
+    );
+    await expect(
+      events.latestProgressByJobIds(['job-scope-required']),
+    ).rejects.toThrow(/require tenantId/);
+  });
+
+  it('supports explicit global tenant scope', async () => {
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    const events = await SmrtJobEventCollection.create({ db });
+
+    await events.append({
+      tenantId: null,
+      jobId: 'job-global',
+      type: 'progress',
+      level: 'info',
+      stage: 'global',
+      progress: 30,
+      message: 'Global event',
+    });
+    await events.append({
+      tenantId: 'tenant-a',
+      jobId: 'job-global',
+      type: 'progress',
+      level: 'info',
+      stage: 'tenant',
+      progress: 90,
+      message: 'Tenant event',
+    });
+
+    const globalEvents = await events.listByJob('job-global', {
+      tenantId: null,
+    });
+    expect(globalEvents.map((event) => event.message)).toEqual([
+      'Global event',
+    ]);
+
+    const latest = await events.latestProgressByJobIds(['job-global'], {
+      tenantId: null,
+    });
+    expect(latest.get('job-global')?.stage).toBe('global');
+  });
+
+  it('paginates across legacy SQLite timestamp formats', async () => {
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    const events = await SmrtJobEventCollection.create({ db });
+
+    await db.query(
+      `INSERT INTO _smrt_job_events (
+         id, slug, context, created_at, updated_at, tenant_id, job_id, type,
+         level, stage, progress, message, data
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      'legacy-event',
+      'legacy-event',
+      '',
+      '2026-04-25 12:00:00',
+      '2026-04-25 12:00:00',
+      'tenant-a',
+      'job-legacy-cursor',
+      'progress',
+      'info',
+      'legacy',
+      10,
+      'Legacy timestamp',
+      '{}',
+    );
+    await db.query(
+      `INSERT INTO _smrt_job_events (
+         id, slug, context, created_at, updated_at, tenant_id, job_id, type,
+         level, stage, progress, message, data
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      'iso-event',
+      'iso-event',
+      '',
+      '2026-04-25T12:00:01.000Z',
+      '2026-04-25T12:00:01.000Z',
+      'tenant-a',
+      'job-legacy-cursor',
+      'progress',
+      'info',
+      'iso',
+      20,
+      'ISO timestamp',
+      '{}',
+    );
+
+    const allEvents = await events.listByJob('job-legacy-cursor', {
+      tenantId: 'tenant-a',
+    });
+    expect(allEvents.map((event) => event.message)).toEqual([
+      'Legacy timestamp',
+      'ISO timestamp',
+    ]);
+
+    const afterLegacy = await events.listByJob('job-legacy-cursor', {
+      tenantId: 'tenant-a',
+      cursor: allEvents[0]?.toCursor(),
+    });
+    expect(afterLegacy.map((event) => event.message)).toEqual([
+      'ISO timestamp',
+    ]);
+  });
+
   it('passes an optional execution context without breaking one-arg methods', async () => {
     const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
     const jobs = await SmrtJobCollection.create({ db });

--- a/packages/jobs/src/index.ts
+++ b/packages/jobs/src/index.ts
@@ -55,6 +55,9 @@ export {
 export {
   type JobContext,
   JobContextLogger,
+  type JobEventInput,
+  type JobExecutionContext,
+  type JobProgressInput,
 } from './logger-extension.js';
 // Object extension (mixin)
 export {
@@ -87,3 +90,14 @@ export {
   type SmrtJobData,
   type TimeoutBehavior,
 } from './smrt-job.js';
+
+// Durable job telemetry
+export {
+  type JobEventCursor,
+  type ListJobEventsOptions,
+  SmrtJobEvent,
+  SmrtJobEventCollection,
+  type SmrtJobEventData,
+  type SmrtJobEventLevel,
+  type SmrtJobEventType,
+} from './smrt-job-event.js';

--- a/packages/jobs/src/logger-extension.ts
+++ b/packages/jobs/src/logger-extension.ts
@@ -11,6 +11,36 @@ export interface JobContext {
   method: string;
 }
 
+export interface JobEventInput {
+  type?: string;
+  level?: 'debug' | 'info' | 'warn' | 'error';
+  stage?: string | null;
+  progress?: number | null;
+  message?: string;
+  data?: Record<string, unknown>;
+}
+
+export interface JobProgressInput {
+  stage: string;
+  progress: number;
+  message?: string;
+  detail?: string;
+  source?: string;
+  data?: Record<string, unknown>;
+}
+
+export interface JobExecutionContext {
+  job: JobContext & { tenantId?: string | null };
+  logger: Logger;
+  event(input: JobEventInput): Promise<void>;
+  progress(input: JobProgressInput): Promise<void>;
+  log(
+    level: 'debug' | 'info' | 'warn' | 'error',
+    message: string,
+    data?: Record<string, unknown>,
+  ): Promise<void>;
+}
+
 /**
  * Logger extension that auto-injects job context into all log entries
  *

--- a/packages/jobs/src/runner.ts
+++ b/packages/jobs/src/runner.ts
@@ -9,8 +9,14 @@ import { ObjectRegistry, type SmrtObject } from '@happyvertical/smrt-core';
 import { TenantContext } from '@happyvertical/smrt-tenancy';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { createId } from '@happyvertical/utils';
-import { JobContextLogger } from './logger-extension.js';
+import {
+  JobContextLogger,
+  type JobEventInput,
+  type JobExecutionContext,
+  type JobProgressInput,
+} from './logger-extension.js';
 import { type SmrtJob, SmrtJobCollection } from './smrt-job.js';
+import { type SmrtJobEvent, SmrtJobEventCollection } from './smrt-job-event.js';
 import {
   DEFAULT_TASK_HEARTBEAT_INTERVAL_MS,
   getEffectiveStaleJobThresholdMs,
@@ -41,6 +47,8 @@ export interface TaskRunnerConfig {
  */
 export interface TaskRunnerEvents {
   'job:started': (job: SmrtJob) => void;
+  'job:event': (job: SmrtJob, event: SmrtJobEvent) => void;
+  'job:progress': (job: SmrtJob, event: SmrtJobEvent) => void;
   'job:completed': (job: SmrtJob, result: unknown) => void;
   'job:failed': (job: SmrtJob, error: Error) => void;
   'job:retrying': (job: SmrtJob, error: Error, delay: number) => void;
@@ -76,6 +84,7 @@ export class TaskRunner extends EventEmitter {
   readonly id: string;
   private readonly config: Required<TaskRunnerConfig>;
   private collection: SmrtJobCollection | null = null;
+  private eventCollection: SmrtJobEventCollection | null = null;
   private running = false;
   private activeJobs = new Map<string, SmrtJob>();
   private pollTimer: NodeJS.Timeout | null = null;
@@ -98,11 +107,8 @@ export class TaskRunner extends EventEmitter {
    */
   async initialize(db: DatabaseInterface): Promise<void> {
     this.db = db;
-    this.collection = await SmrtJobCollection.create({
-      db: { type: 'sqlite', url: ':memory:' }, // Placeholder, overridden
-    });
-    // Override the internal db reference
-    (this.collection as unknown as { _db: DatabaseInterface })._db = db;
+    this.collection = await SmrtJobCollection.create({ db });
+    this.eventCollection = await SmrtJobEventCollection.create({ db });
   }
 
   /**
@@ -240,6 +246,13 @@ export class TaskRunner extends EventEmitter {
 
     this.activeJobs.set(jobId, job);
     this.emit('job:started', job);
+    await this.appendJobEvent(job, {
+      type: 'status',
+      level: 'info',
+      stage: 'started',
+      progress: 0,
+      message: `Started job: ${job.getDescription()}`,
+    });
 
     try {
       // Set up timeout
@@ -258,6 +271,13 @@ export class TaskRunner extends EventEmitter {
       job.resultPointer = result?.resultPointer ?? null;
       await job.save();
 
+      await this.appendJobEvent(job, {
+        type: 'progress',
+        level: 'info',
+        stage: 'completed',
+        progress: 100,
+        message: `Completed job: ${job.getDescription()}`,
+      });
       this.emit('job:completed', job, result);
     } catch (error) {
       await this.handleJobError(job, error as Error);
@@ -330,19 +350,23 @@ export class TaskRunner extends EventEmitter {
 
       // Log job start
       contextLogger.info(`Starting job: ${job.getDescription()}`);
+      const executionContext = this.createExecutionContext(job, contextLogger);
 
       // Invoke the method with cleaned args (no internal keys)
       const method = (
         instance as unknown as Record<
           string,
-          (args: unknown) => Promise<unknown>
+          (
+            args: unknown,
+            context?: JobExecutionContext,
+          ) => Promise<unknown> | unknown
         >
       )[job.method];
       if (typeof method !== 'function') {
         throw new Error(`Method not found: ${job.objectType}.${job.method}`);
       }
 
-      const result = await method.call(instance, methodArgs);
+      const result = await method.call(instance, methodArgs, executionContext);
 
       return { result };
     };
@@ -375,6 +399,13 @@ export class TaskRunner extends EventEmitter {
       job.workerHeartbeat = null;
       await job.save();
 
+      await this.appendJobEvent(job, {
+        type: 'status',
+        level: 'warn',
+        stage: 'retrying',
+        message: `Retrying job after failure: ${error.message}`,
+        data: { delay: decision.delay, attempts: job.attempts },
+      });
       this.emit('job:retrying', job, error, decision.delay);
     } else {
       // Job failed permanently
@@ -383,7 +414,109 @@ export class TaskRunner extends EventEmitter {
       job.lastError = error.message;
       await job.save();
 
+      await this.appendJobEvent(job, {
+        type: 'error',
+        level: 'error',
+        stage: 'failed',
+        message: error.message,
+        data: { attempts: job.attempts },
+      });
       this.emit('job:failed', job, error);
+    }
+  }
+
+  private createExecutionContext(
+    job: SmrtJob,
+    contextLogger: JobContextLogger,
+  ): JobExecutionContext {
+    const jobContext = {
+      jobId: job.id ?? '',
+      tenantId: job.tenantId ?? null,
+      attempt: job.attempts,
+      queue: job.queue,
+      objectType: job.objectType,
+      method: job.method,
+    };
+
+    return {
+      job: jobContext,
+      logger: contextLogger,
+      event: async (input: JobEventInput) => {
+        await this.appendJobEvent(job, input);
+      },
+      progress: async (input: JobProgressInput) => {
+        const data = {
+          ...(input.data ?? {}),
+          ...(input.detail ? { detail: input.detail } : {}),
+          ...(input.source ? { source: input.source } : {}),
+        };
+        await this.appendJobEvent(job, {
+          type: 'progress',
+          level: 'info',
+          stage: input.stage,
+          progress: input.progress,
+          message:
+            input.message ??
+            input.detail ??
+            `${input.stage} ${Math.round(input.progress)}%`,
+          data,
+        });
+      },
+      log: async (
+        level: 'debug' | 'info' | 'warn' | 'error',
+        message: string,
+        data?: Record<string, unknown>,
+      ) => {
+        contextLogger[level](message, data);
+        await this.appendJobEvent(job, {
+          type: level === 'error' ? 'error' : 'log',
+          level,
+          message,
+          data,
+        });
+      },
+    };
+  }
+
+  private async appendJobEvent(
+    job: SmrtJob,
+    input: JobEventInput,
+  ): Promise<SmrtJobEvent | null> {
+    if (!this.eventCollection || !job.id) {
+      return null;
+    }
+
+    try {
+      const event = await this.eventCollection.append({
+        tenantId: job.tenantId ?? null,
+        jobId: job.id,
+        type: input.type ?? 'log',
+        level: input.level ?? 'info',
+        stage: input.stage ?? null,
+        progress: input.progress ?? null,
+        message: input.message ?? '',
+        data: input.data ?? {},
+      });
+
+      this.emit('job:event', job, event);
+      if (event.type === 'progress') {
+        this.emit('job:progress', job, event);
+      }
+
+      return event;
+    } catch (error) {
+      const telemetryError =
+        error instanceof Error
+          ? error
+          : new Error(`Failed to append job telemetry: ${String(error)}`);
+
+      try {
+        this.emit('runner:error', telemetryError);
+      } catch {
+        // Telemetry is best-effort and must not change job outcomes.
+      }
+
+      return null;
     }
   }
 
@@ -450,6 +583,12 @@ export class TaskRunner extends EventEmitter {
       job.workerId = null;
       job.workerHeartbeat = null;
       const error = new Error(errorMessage);
+      await this.appendJobEvent(job, {
+        type: 'error',
+        level: 'error',
+        stage: 'stale-recovery',
+        message: errorMessage,
+      });
       this.emit('job:failed', job, error);
     }
   }

--- a/packages/jobs/src/smrt-job-event.ts
+++ b/packages/jobs/src/smrt-job-event.ts
@@ -40,6 +40,22 @@ export interface ListJobEventsOptions {
   cursor?: string | JobEventCursor;
 }
 
+const JOB_EVENT_STORAGE_COLUMNS = [
+  'id',
+  'slug',
+  'context',
+  'created_at',
+  'updated_at',
+  'tenant_id',
+  'job_id',
+  'type',
+  'level',
+  'stage',
+  'progress',
+  'message',
+  'data',
+].join(', ');
+
 @smrt({
   tableName: '_smrt_job_events',
   api: { include: ['list', 'get'] },
@@ -109,6 +125,34 @@ function parseCursor(cursor: string | JobEventCursor): JobEventCursor {
   };
 }
 
+function normalizeCursorDate(value: string | Date): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  const parsed = new Date(value);
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed.toISOString();
+  }
+
+  return value;
+}
+
+function usesSqliteDateFunctions(dbUrl: string): boolean {
+  const normalized = dbUrl.toLowerCase();
+  return !(
+    normalized.startsWith('postgres:') || normalized.startsWith('postgresql:')
+  );
+}
+
+function getQueryRows(result: unknown): Record<string, unknown>[] {
+  if (Array.isArray(result)) {
+    return result as Record<string, unknown>[];
+  }
+
+  return (result as { rows?: Record<string, unknown>[] }).rows ?? [];
+}
+
 export class SmrtJobEventCollection extends SmrtCollection<SmrtJobEvent> {
   static readonly _itemClass = SmrtJobEvent;
 
@@ -153,36 +197,19 @@ export class SmrtJobEventCollection extends SmrtCollection<SmrtJobEvent> {
       params.push(options.jobId);
     }
 
-    if ('tenantId' in options) {
-      if (options.tenantId === null) {
-        where.push('tenant_id IS NULL');
-      } else if (typeof options.tenantId === 'string') {
-        where.push('tenant_id = ?');
-        params.push(options.tenantId);
-      }
-    } else {
-      const contextTenantId = getTenantId();
-      if (contextTenantId) {
-        where.push('tenant_id = ?');
-        params.push(contextTenantId);
-      }
-    }
+    this.addTenantPredicate(where, params, options);
 
     if (options.cursor) {
       const cursor = parseCursor(options.cursor);
-      const createdAt =
-        cursor.createdAt instanceof Date
-          ? cursor.createdAt.toISOString()
-          : String(cursor.createdAt);
-      where.push('(created_at > ? OR (created_at = ? AND id > ?))');
+      const createdAt = await this.resolveCursorCreatedAt(cursor, options);
+      const createdAtExpression = this.createdAtComparableExpression();
+      where.push(
+        `(${createdAtExpression} > ? OR (${createdAtExpression} = ? AND id > ?))`,
+      );
       params.push(createdAt, createdAt, cursor.id);
     } else if (options.since) {
-      where.push('created_at > ?');
-      params.push(
-        options.since instanceof Date
-          ? options.since.toISOString()
-          : String(options.since),
-      );
+      where.push(`${this.createdAtComparableExpression()} > ?`);
+      params.push(normalizeCursorDate(options.since));
     }
 
     if (options.afterId) {
@@ -194,10 +221,10 @@ export class SmrtJobEventCollection extends SmrtCollection<SmrtJobEvent> {
 
     const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
     return this.query(
-      `SELECT *
+      `SELECT ${JOB_EVENT_STORAGE_COLUMNS}
          FROM _smrt_job_events
         ${whereSql}
-        ORDER BY created_at ASC, id ASC
+        ORDER BY ${this.createdAtComparableExpression()} ASC, id ASC
         LIMIT ?`,
       params,
       { allowRawOnTenantScoped: true },
@@ -219,37 +246,94 @@ export class SmrtJobEventCollection extends SmrtCollection<SmrtJobEvent> {
     ];
     const params: unknown[] = [...uniqueJobIds];
 
-    if ('tenantId' in options) {
-      if (options.tenantId === null) {
-        where.push('tenant_id IS NULL');
-      } else if (typeof options.tenantId === 'string') {
-        where.push('tenant_id = ?');
-        params.push(options.tenantId);
-      }
-    } else {
-      const contextTenantId = getTenantId();
-      if (contextTenantId) {
-        where.push('tenant_id = ?');
-        params.push(contextTenantId);
-      }
-    }
+    this.addTenantPredicate(where, params, options);
+    const createdAtExpression = this.createdAtComparableExpression();
 
     const events = await this.query(
-      `SELECT *
-         FROM _smrt_job_events
-        WHERE ${where.join(' AND ')}
-        ORDER BY created_at DESC, id DESC`,
+      `SELECT ${JOB_EVENT_STORAGE_COLUMNS}
+         FROM (
+           SELECT ${JOB_EVENT_STORAGE_COLUMNS},
+                  ${createdAtExpression} AS smrt_created_at_sort,
+                  ROW_NUMBER() OVER (
+                    PARTITION BY job_id
+                    ORDER BY ${createdAtExpression} DESC, id DESC
+                  ) AS smrt_rank
+             FROM _smrt_job_events
+            WHERE ${where.join(' AND ')}
+         ) ranked
+        WHERE smrt_rank = 1
+        ORDER BY smrt_created_at_sort DESC, id DESC`,
       params,
       { allowRawOnTenantScoped: true },
     );
 
     for (const event of events) {
-      if (!latestByJobId.has(event.jobId)) {
-        latestByJobId.set(event.jobId, event);
-      }
+      latestByJobId.set(event.jobId, event);
     }
 
     return latestByJobId;
+  }
+
+  private addTenantPredicate(
+    where: string[],
+    params: unknown[],
+    options: { tenantId?: string | null },
+  ): void {
+    if (options.tenantId === null) {
+      where.push('tenant_id IS NULL');
+      return;
+    }
+
+    const tenantId =
+      typeof options.tenantId === 'string' ? options.tenantId : getTenantId();
+
+    if (tenantId) {
+      where.push('tenant_id = ?');
+      params.push(tenantId);
+      return;
+    }
+
+    throw new Error(
+      'Tenant-scoped job event queries require tenantId, tenantId: null, or an ambient tenant context.',
+    );
+  }
+
+  private createdAtComparableExpression(): string {
+    if (usesSqliteDateFunctions(this.db.url)) {
+      return "strftime('%Y-%m-%dT%H:%M:%fZ', created_at)";
+    }
+
+    return 'created_at';
+  }
+
+  private async resolveCursorCreatedAt(
+    cursor: JobEventCursor,
+    options: ListJobEventsOptions & { jobId?: string },
+  ): Promise<string> {
+    if (!cursor.id) {
+      return normalizeCursorDate(cursor.createdAt);
+    }
+
+    const where = ['id = ?'];
+    const params: unknown[] = [cursor.id];
+    if (options.jobId) {
+      where.push('job_id = ?');
+      params.push(options.jobId);
+    }
+    this.addTenantPredicate(where, params, options);
+
+    const result = await this.db.query(
+      `SELECT ${this.createdAtComparableExpression()} AS cursor_created_at
+         FROM _smrt_job_events
+        WHERE ${where.join(' AND ')}
+        LIMIT 1`,
+      ...params,
+    );
+    const cursorCreatedAt = getQueryRows(result)[0]?.cursor_created_at;
+
+    return typeof cursorCreatedAt === 'string' && cursorCreatedAt.trim()
+      ? cursorCreatedAt
+      : normalizeCursorDate(cursor.createdAt);
   }
 }
 

--- a/packages/jobs/src/smrt-job-event.ts
+++ b/packages/jobs/src/smrt-job-event.ts
@@ -1,0 +1,256 @@
+// Self-register this package's manifest for consumers that import via this
+// subpath without the main entry. See src/__smrt-register__.ts (issue #1132).
+import './__smrt-register__.js';
+
+import {
+  ensureJobEventsSystemTableCompatibility,
+  field,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { getTenantId, tenantId } from '@happyvertical/smrt-tenancy';
+
+export type SmrtJobEventType = 'status' | 'progress' | 'log' | 'error' | string;
+
+export type SmrtJobEventLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface SmrtJobEventData {
+  tenantId?: string | null;
+  jobId: string;
+  type?: SmrtJobEventType;
+  level?: SmrtJobEventLevel;
+  stage?: string | null;
+  progress?: number | null;
+  message?: string;
+  data?: Record<string, unknown>;
+  createdAt?: Date;
+}
+
+export interface JobEventCursor {
+  createdAt: string | Date;
+  id: string;
+}
+
+export interface ListJobEventsOptions {
+  tenantId?: string | null;
+  limit?: number;
+  since?: string | Date;
+  afterId?: string;
+  cursor?: string | JobEventCursor;
+}
+
+@smrt({
+  tableName: '_smrt_job_events',
+  api: { include: ['list', 'get'] },
+  cli: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
+})
+export class SmrtJobEvent extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null | undefined = undefined;
+
+  @field({ type: 'text', required: true })
+  jobId: string = '';
+
+  @field({ type: 'text', required: true, default: 'log' })
+  type: SmrtJobEventType = 'log';
+
+  @field({ type: 'text', required: true, default: 'info' })
+  level: SmrtJobEventLevel = 'info';
+
+  @field({ type: 'text', nullable: true })
+  stage: string | null = null;
+
+  @field({ type: 'integer', nullable: true })
+  progress: number | null = null;
+
+  @field({ type: 'text', required: true, default: '' })
+  message: string = '';
+
+  @field({ type: 'json' })
+  data: Record<string, unknown> = {};
+
+  @field({ type: 'datetime', required: true })
+  createdAt: Date = new Date();
+
+  toCursor(): string {
+    const createdAt =
+      this.createdAt instanceof Date
+        ? this.createdAt.toISOString()
+        : String(this.createdAt);
+    return `${createdAt}|${this.id ?? ''}`;
+  }
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  const numeric =
+    typeof limit === 'number' && Number.isFinite(limit) ? limit : 250;
+  return Math.max(1, Math.min(1000, Math.floor(numeric)));
+}
+
+function normalizeProgress(progress: unknown): number | null {
+  if (typeof progress !== 'number' || !Number.isFinite(progress)) {
+    return null;
+  }
+
+  return Math.max(0, Math.min(100, Math.round(progress)));
+}
+
+function parseCursor(cursor: string | JobEventCursor): JobEventCursor {
+  if (typeof cursor !== 'string') return cursor;
+  const separator = cursor.lastIndexOf('|');
+  if (separator === -1) {
+    return { createdAt: cursor, id: '' };
+  }
+  return {
+    createdAt: cursor.slice(0, separator),
+    id: cursor.slice(separator + 1),
+  };
+}
+
+export class SmrtJobEventCollection extends SmrtCollection<SmrtJobEvent> {
+  static readonly _itemClass = SmrtJobEvent;
+
+  override async initialize(): Promise<this> {
+    await super.initialize();
+    await ensureJobEventsSystemTableCompatibility(this.db);
+    return this;
+  }
+
+  async append(input: SmrtJobEventData): Promise<SmrtJobEvent> {
+    return this.create({
+      tenantId: input.tenantId,
+      jobId: input.jobId,
+      type: input.type ?? 'log',
+      level: input.level ?? 'info',
+      stage: input.stage ?? null,
+      progress: normalizeProgress(input.progress),
+      message: input.message ?? '',
+      data: input.data ?? {},
+      createdAt: input.createdAt ?? new Date(),
+    });
+  }
+
+  async listByJob(
+    jobId: string,
+    options: ListJobEventsOptions = {},
+  ): Promise<SmrtJobEvent[]> {
+    return this.listSinceCursor({
+      ...options,
+      jobId,
+    });
+  }
+
+  async listSinceCursor(
+    options: ListJobEventsOptions & { jobId?: string } = {},
+  ): Promise<SmrtJobEvent[]> {
+    const where: string[] = [];
+    const params: unknown[] = [];
+
+    if (options.jobId) {
+      where.push('job_id = ?');
+      params.push(options.jobId);
+    }
+
+    if ('tenantId' in options) {
+      if (options.tenantId === null) {
+        where.push('tenant_id IS NULL');
+      } else if (typeof options.tenantId === 'string') {
+        where.push('tenant_id = ?');
+        params.push(options.tenantId);
+      }
+    } else {
+      const contextTenantId = getTenantId();
+      if (contextTenantId) {
+        where.push('tenant_id = ?');
+        params.push(contextTenantId);
+      }
+    }
+
+    if (options.cursor) {
+      const cursor = parseCursor(options.cursor);
+      const createdAt =
+        cursor.createdAt instanceof Date
+          ? cursor.createdAt.toISOString()
+          : String(cursor.createdAt);
+      where.push('(created_at > ? OR (created_at = ? AND id > ?))');
+      params.push(createdAt, createdAt, cursor.id);
+    } else if (options.since) {
+      where.push('created_at > ?');
+      params.push(
+        options.since instanceof Date
+          ? options.since.toISOString()
+          : String(options.since),
+      );
+    }
+
+    if (options.afterId) {
+      where.push('id > ?');
+      params.push(options.afterId);
+    }
+
+    params.push(normalizeLimit(options.limit));
+
+    const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
+    return this.query(
+      `SELECT *
+         FROM _smrt_job_events
+        ${whereSql}
+        ORDER BY created_at ASC, id ASC
+        LIMIT ?`,
+      params,
+      { allowRawOnTenantScoped: true },
+    );
+  }
+
+  async latestProgressByJobIds(
+    jobIds: string[],
+    options: { tenantId?: string | null } = {},
+  ): Promise<Map<string, SmrtJobEvent>> {
+    const uniqueJobIds = [...new Set(jobIds.filter(Boolean))];
+    const latestByJobId = new Map<string, SmrtJobEvent>();
+    if (uniqueJobIds.length === 0) return latestByJobId;
+
+    const placeholders = uniqueJobIds.map(() => '?').join(', ');
+    const where: string[] = [
+      `job_id IN (${placeholders})`,
+      "type = 'progress'",
+    ];
+    const params: unknown[] = [...uniqueJobIds];
+
+    if ('tenantId' in options) {
+      if (options.tenantId === null) {
+        where.push('tenant_id IS NULL');
+      } else if (typeof options.tenantId === 'string') {
+        where.push('tenant_id = ?');
+        params.push(options.tenantId);
+      }
+    } else {
+      const contextTenantId = getTenantId();
+      if (contextTenantId) {
+        where.push('tenant_id = ?');
+        params.push(contextTenantId);
+      }
+    }
+
+    const events = await this.query(
+      `SELECT *
+         FROM _smrt_job_events
+        WHERE ${where.join(' AND ')}
+        ORDER BY created_at DESC, id DESC`,
+      params,
+      { allowRawOnTenantScoped: true },
+    );
+
+    for (const event of events) {
+      if (!latestByJobId.has(event.jobId)) {
+        latestByJobId.set(event.jobId, event);
+      }
+    }
+
+    return latestByJobId;
+  }
+}
+
+export default SmrtJobEvent;

--- a/packages/jobs/src/smrt-job.ts
+++ b/packages/jobs/src/smrt-job.ts
@@ -1,12 +1,12 @@
 import type { RetryStrategyConfig } from '@happyvertical/jobs';
 import {
+  ensureJobsSystemTableCompatibility,
   field,
   SmrtCollection,
   SmrtObject,
   smrt,
 } from '@happyvertical/smrt-core';
 import { getTenantId, tenantId } from '@happyvertical/smrt-tenancy';
-import { ensureJobsSystemTableCompatibility } from '../../core/src/system/compatibility.js';
 
 /**
  * Job status type


### PR DESCRIPTION
## Summary
- add a durable `_smrt_job_events` telemetry model and collection helpers for append/list/cursor/latest-progress queries
- pass an optional `JobExecutionContext` into task methods with progress/event/log helpers while preserving one-argument job methods
- emit runner lifecycle telemetry and expose `job:event` / `job:progress` events
- add compatibility upgrades for existing job event tables and move jobs system-table helpers behind the public core package boundary

## Review notes
- Made telemetry best-effort on the runner path so event persistence/listener failures do not fail otherwise healthy jobs.
- Tenant-scoped raw telemetry queries now infer ambient tenant context and opt into the raw-query tenant guard only after adding their own tenant predicate.
- Progress values are normalized to finite `0..100` integers.

## Verification
- `pnpm --filter @happyvertical/smrt-jobs test`
- `pnpm --filter @happyvertical/smrt-jobs check`
- `pnpm --filter @happyvertical/smrt-jobs build`
- `pnpm --filter @happyvertical/smrt-core test -- src/__tests__/system-table-compatibility.test.ts` (runs the full core suite: 1,594 passed, 29 skipped)
- `pnpm --filter @happyvertical/smrt-core build`
- `git diff --cached --check`
- pre-push hooks: format-check and workflow validation