### PR TITLE
fix(embeddings): prefer AI for fact embedding work

### DIFF
--- a/.changeset/bright-facts-embed-safely.md
+++ b/.changeset/bright-facts-embed-safely.md
@@ -3,4 +3,4 @@
 "@happyvertical/smrt-facts": patch
 ---
 
-Prefer configured AI embeddings for automatic embedding generation and avoid duplicate fact embedding work during reconciliation.
+Prefer configured AI embeddings for fact embedding work and avoid duplicate fact embedding generation during reconciliation.

--- a/.changeset/bright-facts-embed-safely.md
+++ b/.changeset/bright-facts-embed-safely.md
@@ -1,0 +1,6 @@
+---
+"@happyvertical/smrt-core": patch
+"@happyvertical/smrt-facts": patch
+---
+
+Prefer configured AI embeddings for automatic embedding generation and avoid duplicate fact embedding work during reconciliation.

--- a/packages/core/src/__tests__/embedding-auto-generate.test.ts
+++ b/packages/core/src/__tests__/embedding-auto-generate.test.ts
@@ -24,6 +24,12 @@ function createMockEmbeddings(text: string): number[] {
   return [Math.sin(hash), Math.cos(hash), Math.sin(hash * 2)];
 }
 
+async function flushBackgroundTasks(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
 // Test document with auto-generation ENABLED
 @smrt({
   embeddings: {
@@ -212,6 +218,35 @@ describe('Embedding Auto-Generation Hook', () => {
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // embed should have been called (content changed)
+      expect(embedSpy).toHaveBeenCalled();
+    });
+
+    it('uses _skipAutoEmbeddings only for the first save', async () => {
+      const collection = await AutoGenDocumentCollection.create({
+        db: { type: 'sqlite', url: dbPath },
+        ai: {
+          embed: async (texts: string | string[]) => {
+            const textArray = Array.isArray(texts) ? texts : [texts];
+            return {
+              embeddings: textArray.map((t) => createMockEmbeddings(t)),
+            };
+          },
+        } as any,
+      });
+
+      const doc = await collection.create({
+        title: 'One Shot Skip Test',
+        content: 'Initial content skips automatic embeddings',
+        _skipAutoEmbeddings: true,
+      });
+
+      await flushBackgroundTasks();
+      expect(embedSpy).not.toHaveBeenCalled();
+
+      doc.content = 'Updated content should trigger embeddings';
+      await doc.save();
+      await flushBackgroundTasks();
+
       expect(embedSpy).toHaveBeenCalled();
     });
   });

--- a/packages/core/src/__tests__/embedding-provider-transformers-resolution.test.ts
+++ b/packages/core/src/__tests__/embedding-provider-transformers-resolution.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { resolveLocalTransformersModule } from '../embeddings/provider';
+import {
+  DEFAULT_EMBEDDING_CONFIG,
+  EmbeddingProvider,
+  resolveLocalTransformersModule,
+} from '../embeddings/provider';
 
 describe('EmbeddingProvider transformer resolution', () => {
   it('prefers @huggingface/transformers when both packages are available', async () => {
@@ -54,5 +58,41 @@ describe('EmbeddingProvider transformer resolution', () => {
     await expect(resolveLocalTransformersModule(importModule)).rejects.toThrow(
       'sharp native module failed to load',
     );
+  });
+});
+
+describe('EmbeddingProvider auto provider', () => {
+  it('uses configured AI embeddings before local transformers', async () => {
+    const ai = {
+      embed: vi.fn(async () => ({ embeddings: [[1, 2, 3]] })),
+    };
+    const provider = new EmbeddingProvider(
+      {
+        ...DEFAULT_EMBEDDING_CONFIG,
+        provider: 'auto',
+        aiModel: 'test-ai-model',
+        localModel: 'test-local-model',
+        dimensions: 3,
+      },
+      ai,
+    );
+
+    await expect(provider.embed('hello')).resolves.toEqual([[1, 2, 3]]);
+    expect(ai.embed).toHaveBeenCalledWith(['hello'], {
+      model: 'test-ai-model',
+      dimensions: 3,
+    });
+    expect(provider.getModelName()).toBe('test-ai-model');
+  });
+
+  it('keeps local model naming when auto has no AI client', () => {
+    const provider = new EmbeddingProvider({
+      ...DEFAULT_EMBEDDING_CONFIG,
+      provider: 'auto',
+      aiModel: 'test-ai-model',
+      localModel: 'test-local-model',
+    });
+
+    expect(provider.getModelName()).toBe('test-local-model');
   });
 });

--- a/packages/core/src/__tests__/embedding-search.test.ts
+++ b/packages/core/src/__tests__/embedding-search.test.ts
@@ -386,6 +386,25 @@ describe('Semantic Search', () => {
       expect(stats.skipped).toBe(1);
     });
 
+    it('should regenerate embeddings when the resolved model changes', async () => {
+      const getModelName = vi.mocked(EmbeddingProvider.prototype.getModelName);
+      getModelName.mockReturnValue('legacy-model');
+
+      const doc = await collection.create({
+        title: 'Migrated Model',
+        content: 'This document has embeddings from an older model',
+      });
+      await doc.save();
+      await doc.generateEmbeddings();
+
+      getModelName.mockReturnValue('current-model');
+
+      const stats = await collection.generateMissingEmbeddings();
+
+      expect(stats.generated).toBe(1);
+      expect(stats.skipped).toBe(0);
+    });
+
     it('should report progress', async () => {
       // Create documents
       for (let i = 0; i < 3; i++) {

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -70,6 +70,7 @@ type SmrtInternalKeys =
   | '_className'
   | 'options'
   | '_skipLoad'
+  | '_skipAutoEmbeddings'
   | '_extractingFields'
   | 'initialize'
   | 'save'
@@ -110,6 +111,8 @@ export type SmrtCreateInput<T extends SmrtObject> = Partial<
   _meta_type?: string;
   /** Skip database loading (framework internal) */
   _skipLoad?: boolean;
+  /** Skip save-time embedding auto-generation (framework internal) */
+  _skipAutoEmbeddings?: boolean;
   /** Allow arbitrary additional fields for dynamic usage */
   [key: string]: unknown;
 };
@@ -2168,11 +2171,18 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       );
     }
 
-    // Get project config for embedding provider
-    const projectConfig = ObjectRegistry.getProjectEmbeddingConfig();
-
-    // Create embedding provider
-    const provider = new EmbeddingProvider(projectConfig, this.ai);
+    // Create embedding provider from the resolved class/project config so
+    // query embeddings use the same model as stored object embeddings.
+    const provider = new EmbeddingProvider(
+      {
+        dimensions: embeddingConfig.dimensions,
+        provider: embeddingConfig.provider,
+        localModel: embeddingConfig.localModel,
+        aiModel: embeddingConfig.aiModel,
+        fallbackToAI: embeddingConfig.fallbackToAI,
+      },
+      this.ai,
+    );
 
     // Generate embedding for query
     const [queryEmbedding] = await provider.embed(query);

--- a/packages/core/src/embeddings/provider.ts
+++ b/packages/core/src/embeddings/provider.ts
@@ -2,7 +2,8 @@
  * Embedding Provider
  *
  * Unified interface for generating embeddings using local models or AI APIs.
- * Supports transformers.js packages for local inference and @happyvertical/ai for cloud.
+ * Supports transformers.js packages for local inference and @happyvertical/ai
+ * for cloud embeddings.
  */
 
 import type { EmbeddingProviderType, ProjectEmbeddingConfig } from './types';
@@ -85,7 +86,12 @@ type FeatureExtractionPipeline = (
 ) => Promise<{ tolist: () => number[][] }>;
 
 /**
- * Embedding provider that supports both local and AI-based embedding generation
+ * Embedding provider that supports both local and AI-based embedding generation.
+ *
+ * The default "auto" provider prefers an already-configured AI embedding client.
+ * Local transformer models are still available via provider: "local", but should
+ * be an explicit choice for server workloads because model initialization can be
+ * CPU and memory intensive.
  */
 export class EmbeddingProvider {
   private localPipeline: FeatureExtractionPipeline | null = null;
@@ -132,18 +138,13 @@ export class EmbeddingProvider {
       return this.embedWithAI(texts);
     }
 
-    // 'auto' - try local first, fallback to AI
-    try {
-      return await this.embedLocal(texts);
-    } catch (error) {
-      if (this.config.fallbackToAI && this.ai) {
-        console.warn(
-          `Local embedding failed, falling back to AI: ${error instanceof Error ? error.message : error}`,
-        );
-        return this.embedWithAI(texts);
-      }
-      throw error;
+    // 'auto' - use the configured AI client when present. This avoids
+    // unexpectedly loading a large local transformer model inside app workers.
+    if (this.ai) {
+      return this.embedWithAI(texts);
     }
+
+    return this.embedLocal(texts);
   }
 
   /**
@@ -217,7 +218,10 @@ export class EmbeddingProvider {
    * Get the model name being used
    */
   getModelName(): string {
-    if (this.config.provider === 'ai') {
+    if (
+      this.config.provider === 'ai' ||
+      (this.config.provider === 'auto' && this.ai)
+    ) {
       return this.config.aiModel || 'text-embedding-3-small';
     }
     return this.config.localModel || 'Xenova/bge-base-en-v1.5';
@@ -255,7 +259,7 @@ export class EmbeddingProvider {
  */
 export const DEFAULT_EMBEDDING_CONFIG: ProjectEmbeddingConfig = {
   dimensions: 768,
-  provider: 'local',
+  provider: 'auto',
   localModel: 'Xenova/bge-base-en-v1.5',
   aiModel: 'text-embedding-3-small',
   fallbackToAI: true,

--- a/packages/core/src/embeddings/provider.ts
+++ b/packages/core/src/embeddings/provider.ts
@@ -88,7 +88,7 @@ type FeatureExtractionPipeline = (
 /**
  * Embedding provider that supports both local and AI-based embedding generation.
  *
- * The default "auto" provider prefers an already-configured AI embedding client.
+ * The "auto" provider prefers an already-configured AI embedding client.
  * Local transformer models are still available via provider: "local", but should
  * be an explicit choice for server workloads because model initialization can be
  * CPU and memory intensive.
@@ -140,6 +140,8 @@ export class EmbeddingProvider {
 
     // 'auto' - use the configured AI client when present. This avoids
     // unexpectedly loading a large local transformer model inside app workers.
+    // Local embeddings remain the explicit no-AI fallback for callers that
+    // invoke embedding generation without an AI client.
     if (this.ai) {
       return this.embedWithAI(texts);
     }
@@ -259,8 +261,7 @@ export class EmbeddingProvider {
  */
 export const DEFAULT_EMBEDDING_CONFIG: ProjectEmbeddingConfig = {
   dimensions: 768,
-  provider: 'auto',
+  provider: 'local',
   localModel: 'Xenova/bge-base-en-v1.5',
   aiModel: 'text-embedding-3-small',
-  fallbackToAI: true,
 };

--- a/packages/core/src/embeddings/types.ts
+++ b/packages/core/src/embeddings/types.ts
@@ -26,7 +26,7 @@ export interface ProjectEmbeddingConfig {
    * - 'ai': Use AI library (OpenAI, etc.)
    * - 'auto': Prefer configured AI embeddings, otherwise use local embeddings
    *   when explicitly invoked
-   * @default 'auto'
+   * @default 'local'
    */
   provider: EmbeddingProviderType;
 
@@ -43,8 +43,11 @@ export interface ProjectEmbeddingConfig {
   aiModel?: string;
 
   /**
-   * Whether to fallback to AI if local fails
-   * @default true
+   * Legacy local-first auto fallback option.
+   *
+   * @deprecated `auto` now selects AI first when available and otherwise uses
+   * local embeddings. This option is accepted for backwards compatibility but
+   * no longer changes provider selection.
    */
   fallbackToAI?: boolean;
 
@@ -124,7 +127,7 @@ export interface ResolvedEmbeddingConfig extends ClassEmbeddingConfig {
   aiModel: string;
 
   /**
-   * Fallback behavior
+   * Legacy fallback behavior retained for compatibility
    */
   fallbackToAI: boolean;
 }

--- a/packages/core/src/embeddings/types.ts
+++ b/packages/core/src/embeddings/types.ts
@@ -21,10 +21,12 @@ export interface ProjectEmbeddingConfig {
 
   /**
    * Embedding provider type
-   * - 'local': Use local Node.js model (@xenova/transformers)
+   * - 'local': Use local Node.js model (@huggingface/transformers or
+   *   @xenova/transformers)
    * - 'ai': Use AI library (OpenAI, etc.)
-   * - 'auto': Try local first, fallback to AI
-   * @default 'local'
+   * - 'auto': Prefer configured AI embeddings, otherwise use local embeddings
+   *   when explicitly invoked
+   * @default 'auto'
    */
   provider: EmbeddingProviderType;
 

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -135,6 +135,14 @@ export interface SmrtObjectOptions extends SmrtClassOptions {
   _skipLoad?: boolean;
 
   /**
+   * Flag to skip save-time embedding auto-generation (internal use).
+   *
+   * This is used when framework code will generate embeddings explicitly after
+   * saving and wants to avoid racing a duplicate background generation.
+   */
+  _skipAutoEmbeddings?: boolean;
+
+  /**
    * Allow arbitrary field values to be passed
    */
   [key: string]: any;
@@ -1237,27 +1245,33 @@ export class SmrtObject extends SmrtClass {
       // Execute afterSave interceptors (e.g., tenant audit logging)
       await GlobalInterceptors.executeAfterSave(this, interceptorContext);
 
-      // Auto-generate embeddings if configured
-      const embeddingConfig = ObjectRegistry.getEmbeddingConfig(className);
-      const aiClient =
-        embeddingConfig && embeddingConfig.autoGenerate !== false
-          ? await this.getOptionalAiClient()
-          : undefined;
+      // Auto-generate embeddings if configured. Default/auto embeddings prefer
+      // a configured AI provider; local background generation only runs when a
+      // class/project explicitly asks for provider: "local".
+      const embeddingConfig = ObjectRegistry.resolveEmbeddingConfig(className);
+      const skipAutoEmbeddings =
+        (this.options as any)._skipAutoEmbeddings === true;
       if (
         embeddingConfig &&
         embeddingConfig.autoGenerate !== false &&
-        aiClient
+        !skipAutoEmbeddings
       ) {
+        const aiClient = await this.getOptionalAiClient();
+        const canAutoGenerate =
+          embeddingConfig.provider === 'local' || Boolean(aiClient);
+
         // Check if any embedding field content has changed
-        const isStale = await this.hasStaleEmbeddings();
-        if (isStale) {
-          // Generate embeddings in background to avoid blocking save
-          this.generateEmbeddings().catch((error) => {
-            console.warn(
-              `Failed to auto-generate embeddings for ${this.constructor.name}:`,
-              error instanceof Error ? error.message : error,
-            );
-          });
+        if (canAutoGenerate) {
+          const isStale = await this.hasStaleEmbeddings();
+          if (isStale) {
+            // Generate embeddings in background to avoid blocking save
+            this.generateEmbeddings().catch((error) => {
+              console.warn(
+                `Failed to auto-generate embeddings for ${this.constructor.name}:`,
+                error instanceof Error ? error.message : error,
+              );
+            });
+          }
         }
       }
 

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -1245,23 +1245,20 @@ export class SmrtObject extends SmrtClass {
       // Execute afterSave interceptors (e.g., tenant audit logging)
       await GlobalInterceptors.executeAfterSave(this, interceptorContext);
 
-      // Auto-generate embeddings if configured. Default/auto embeddings prefer
-      // a configured AI provider; local background generation only runs when a
-      // class/project explicitly asks for provider: "local".
+      // Auto-generate embeddings only when an AI client is configured. Manual
+      // generation can still use local embeddings, but save-time background
+      // work should not unexpectedly load a local transformer model.
       const embeddingConfig = ObjectRegistry.resolveEmbeddingConfig(className);
-      const skipAutoEmbeddings =
-        (this.options as any)._skipAutoEmbeddings === true;
+      const skipAutoEmbeddings = this.options._skipAutoEmbeddings === true;
       if (
         embeddingConfig &&
         embeddingConfig.autoGenerate !== false &&
         !skipAutoEmbeddings
       ) {
         const aiClient = await this.getOptionalAiClient();
-        const canAutoGenerate =
-          embeddingConfig.provider === 'local' || Boolean(aiClient);
 
         // Check if any embedding field content has changed
-        if (canAutoGenerate) {
+        if (aiClient) {
           const isStale = await this.hasStaleEmbeddings();
           if (isStale) {
             // Generate embeddings in background to avoid blocking save
@@ -1273,6 +1270,9 @@ export class SmrtObject extends SmrtClass {
             });
           }
         }
+      }
+      if (skipAutoEmbeddings) {
+        this.options._skipAutoEmbeddings = false;
       }
 
       return this;
@@ -2349,6 +2349,7 @@ export class SmrtObject extends SmrtClass {
     // Determine which fields to process
     const fieldsToProcess = options.fields || config.fields;
     const provider = options.provider || config.provider;
+    const aiClient = await this.getOptionalAiClient();
 
     // Create embedding provider
     const embeddingProvider = new EmbeddingProvider(
@@ -2359,7 +2360,7 @@ export class SmrtObject extends SmrtClass {
         aiModel: config.aiModel,
         fallbackToAI: config.fallbackToAI,
       },
-      this._ai,
+      aiClient,
     );
 
     // Resolve vector capabilities for native storage
@@ -2501,6 +2502,7 @@ export class SmrtObject extends SmrtClass {
         this.constructor.name,
       );
       if (config) {
+        const aiClient = await this.getOptionalAiClient();
         // Create EmbeddingProvider to get consistent model name
         const provider = new EmbeddingProvider(
           {
@@ -2510,7 +2512,7 @@ export class SmrtObject extends SmrtClass {
             aiModel: config.aiModel,
             fallbackToAI: config.fallbackToAI,
           },
-          this._ai,
+          aiClient,
         );
         modelName = provider.getModelName();
       } else {
@@ -2555,6 +2557,19 @@ export class SmrtObject extends SmrtClass {
       return false;
     }
 
+    const aiClient = await this.getOptionalAiClient();
+    const embeddingProvider = new EmbeddingProvider(
+      {
+        dimensions: config.dimensions,
+        provider: config.provider,
+        localModel: config.localModel,
+        aiModel: config.aiModel,
+        fallbackToAI: config.fallbackToAI,
+      },
+      aiClient,
+    );
+    const modelName = embeddingProvider.getModelName();
+
     // Get stored embeddings for this object
     const storedEmbeddings = await EmbeddingStorage.getForObject(
       this.systemDb,
@@ -2570,10 +2585,12 @@ export class SmrtObject extends SmrtClass {
       }
 
       const currentHash = ContentHasher.hash(content);
-      const stored = storedEmbeddings.find((e) => e.field_name === fieldName);
+      const stored = storedEmbeddings.find(
+        (e) => e.field_name === fieldName && e.model === modelName,
+      );
 
       if (!stored) {
-        return true; // No embedding exists
+        return true; // No embedding exists for the current provider/model
       }
 
       if (stored.content_hash !== currentHash) {
@@ -2594,7 +2611,8 @@ export class SmrtObject extends SmrtClass {
 
       const currentHash = ContentHasher.hash(combinedContent);
       const stored = storedEmbeddings.find(
-        (e) => e.field_name === config.combinedField?.name,
+        (e) =>
+          e.field_name === config.combinedField?.name && e.model === modelName,
       );
 
       if (!stored || stored.content_hash !== currentHash) {

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -2944,7 +2944,7 @@ export class ObjectRegistry {
    * //   provider: 'local',
    * //   localModel: 'Xenova/bge-base-en-v1.5',
    * //   aiModel: 'text-embedding-3-small',
-   * //   fallbackToAI: true
+   * //   fallbackToAI: false
    * // }
    * ```
    */

--- a/packages/core/src/registry/embedding-manager.ts
+++ b/packages/core/src/registry/embedding-manager.ts
@@ -63,7 +63,7 @@ export function getProjectEmbeddingConfig(): ProjectEmbeddingConfig {
 
   return {
     dimensions: embeddingConfig?.dimensions ?? 768,
-    provider: embeddingConfig?.provider ?? 'local',
+    provider: embeddingConfig?.provider ?? 'auto',
     localModel: embeddingConfig?.localModel ?? 'Xenova/bge-base-en-v1.5',
     aiModel: embeddingConfig?.aiModel ?? 'text-embedding-3-small',
     fallbackToAI: embeddingConfig?.fallbackToAI ?? true,

--- a/packages/core/src/registry/embedding-manager.ts
+++ b/packages/core/src/registry/embedding-manager.ts
@@ -63,10 +63,10 @@ export function getProjectEmbeddingConfig(): ProjectEmbeddingConfig {
 
   return {
     dimensions: embeddingConfig?.dimensions ?? 768,
-    provider: embeddingConfig?.provider ?? 'auto',
+    provider: embeddingConfig?.provider ?? 'local',
     localModel: embeddingConfig?.localModel ?? 'Xenova/bge-base-en-v1.5',
     aiModel: embeddingConfig?.aiModel ?? 'text-embedding-3-small',
-    fallbackToAI: embeddingConfig?.fallbackToAI ?? true,
+    fallbackToAI: embeddingConfig?.fallbackToAI ?? false,
     storage: embeddingConfig?.storage ?? 'json',
   };
 }
@@ -92,7 +92,7 @@ export function resolveEmbeddingConfig(
     provider: classConfig.provider ?? projectConfig.provider,
     localModel: projectConfig.localModel ?? 'Xenova/bge-base-en-v1.5',
     aiModel: projectConfig.aiModel ?? 'text-embedding-3-small',
-    fallbackToAI: projectConfig.fallbackToAI ?? true,
+    fallbackToAI: projectConfig.fallbackToAI ?? false,
     autoGenerate: classConfig.autoGenerate ?? true,
     regenerateOnChange: classConfig.regenerateOnChange ?? true,
   };

--- a/packages/facts/src/__tests__/reconcile.test.ts
+++ b/packages/facts/src/__tests__/reconcile.test.ts
@@ -167,6 +167,23 @@ describe('reconcile()', () => {
       expect(result.source?.sourceUrl).toBe('https://example.com/article');
       expect(result.source?.credibility).toBe(0.9);
     });
+
+    it('generates embeddings once when creating facts explicitly', async () => {
+      const embedSpy = vi.spyOn(EmbeddingProvider.prototype, 'embed');
+
+      await collection.reconcile({
+        rawInput: 'The mayor announced a budget update',
+        type: 'event',
+        domain: 'politics',
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // One query embedding for semantic search, then Fact's configured field
+      // and combined field. Save-time auto-generation is suppressed here so
+      // reconcile owns the explicit fact embedding work.
+      expect(embedSpy).toHaveBeenCalledTimes(3);
+    });
   });
 
   describe('MERGE action', () => {

--- a/packages/facts/src/__tests__/reconcile.test.ts
+++ b/packages/facts/src/__tests__/reconcile.test.ts
@@ -169,7 +169,8 @@ describe('reconcile()', () => {
     });
 
     it('generates embeddings once when creating facts explicitly', async () => {
-      const embedSpy = vi.spyOn(EmbeddingProvider.prototype, 'embed');
+      const embedSpy = vi.mocked(EmbeddingProvider.prototype.embed);
+      embedSpy.mockClear();
 
       await collection.reconcile({
         rawInput: 'The mayor announced a budget update',
@@ -177,7 +178,7 @@ describe('reconcile()', () => {
         domain: 'politics',
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await new Promise((resolve) => setImmediate(resolve));
 
       // One query embedding for semantic search, then Fact's configured field
       // and combined field. Save-time auto-generation is suppressed here so

--- a/packages/facts/src/fact.ts
+++ b/packages/facts/src/fact.ts
@@ -21,6 +21,7 @@ import type {
   tableStrategy: 'sti',
   embeddings: {
     fields: ['textRefined'],
+    provider: 'auto',
     autoGenerate: true,
     combinedField: {
       name: 'full_context',

--- a/packages/facts/src/facts.ts
+++ b/packages/facts/src/facts.ts
@@ -293,6 +293,7 @@ export class FactCollection extends SmrtCollection<Fact> {
           sourceCount: source ? 1 : 0,
           avgSourceCredibility: source?.credibility ?? 0.5,
         }),
+        _skipAutoEmbeddings: true,
       });
 
       // Generate embeddings for the new fact
@@ -448,6 +449,7 @@ Based ONLY on the semantic relationship between the existing fact and the new in
       parentId,
       evolutionType,
       status: data.status || 'active',
+      _skipAutoEmbeddings: true,
     } as any);
 
     // Generate embeddings for the child fact


### PR DESCRIPTION
## Summary
- make `Fact` embeddings explicitly use provider `auto`, which prefers the configured AI embedding client and avoids implicit local transformer startup in AI-enabled workers
- keep the project default embedding provider as `local` to avoid a surprise model migration for existing consumers
- make stale/missing embedding checks model-aware so provider/model changes regenerate embeddings instead of reusing vectors from a different model
- suppress duplicate background embedding generation during fact reconciliation with a one-shot `_skipAutoEmbeddings` flag

## Why
Anytown/Praeco large-document jobs were getting past PDF extraction, then dying while fact processing unexpectedly initialized the local transformer embedding stack inside the worker. This keeps fact embedding work on the configured AI path without changing the global default for every existing embedding consumer.

## Verification
- `pnpm --filter @happyvertical/smrt-core test -- src/__tests__/embedding-provider-transformers-resolution.test.ts src/__tests__/embedding-auto-generate.test.ts src/__tests__/embedding-search.test.ts src/__tests__/embedding-lifecycle.test.ts` (package script ran the full core suite: 1598 passed, 29 skipped)
- `pnpm --filter @happyvertical/smrt-core typecheck`
- `pnpm --filter @happyvertical/smrt-core build`
- `pnpm --filter @happyvertical/smrt-facts test -- src/__tests__/reconcile.test.ts` (package script ran the full facts suite: 139 passed)
- `pnpm --filter @happyvertical/smrt-facts build`
- `pnpm exec biome check .changeset/bright-facts-embed-safely.md packages/core/src/__tests__/embedding-auto-generate.test.ts packages/core/src/__tests__/embedding-search.test.ts packages/core/src/embeddings/provider.ts packages/core/src/embeddings/types.ts packages/core/src/object.ts packages/core/src/registry.ts packages/core/src/registry/embedding-manager.ts packages/facts/src/__tests__/reconcile.test.ts packages/facts/src/fact.ts`
- `git diff --check`
