### PR TITLE
feat(content,agents): asset-associable contract & lazy agent_config (#1161, #1162)

### DIFF
--- a/packages/agents/CLAUDE.md
+++ b/packages/agents/CLAUDE.md
@@ -61,6 +61,30 @@ Junction table (`tenant_agents`) binding agents to tenants with permission overr
 
 Cron-based scheduling stored in `_smrt_agent_schedules`. Fields: `agentType`, `cron`, `method` (default: 'run'), `maxConcurrent`, `timeout`. Executed by ScheduleRunner from smrt-jobs.
 
+## Lazy agent_config Resolution (issue #1161)
+
+Persisted `agent_config` snapshots env-derived values at sync time, so rotated env vars don't reach already-stored schedule rows. Two complementary mechanisms unfreeze them:
+
+1. **`$env` sentinels in persisted config** — register a global resolver and reference it from the JSON:
+
+   ```ts
+   import { registerConfigResolver } from '@happyvertical/smrt-agents';
+   registerConfigResolver('sharedAssetStorage', () => resolveSharedAssetStorage());
+   // persisted: { "assetStorage": { "$env": "sharedAssetStorage" } }
+   ```
+
+2. **`static configResolvers` on the agent class** — declarative, discoverable via the class itself:
+
+   ```ts
+   class Praeco extends Agent {
+     static override configResolvers = {
+       assetStorage: () => resolveSharedAssetStorage(),
+     };
+   }
+   ```
+
+The TaskRunner calls `resolveLazyConfig()` immediately before constructing the agent, so live values always win over snapshotted ones. Re-exported from `@happyvertical/smrt-core` (`resolveLazyConfig`, `registerConfigResolver`, `getClassConfigResolvers`, …) for cases where agents isn't on the import path.
+
 ## Key Files
 
 | File | Purpose |

--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -217,9 +217,12 @@ export abstract class Agent extends SmrtObject {
    * is reflected on the next scheduled run without rewriting the schedule
    * row.
    *
-   * Resolvers may be sync or async. Returning `undefined` leaves the
-   * persisted value in place; throwing falls back to the persisted value
-   * (or to whatever {@link ResolveLazyConfigOptions.onError} dictates).
+   * Resolvers may be sync or async. Returning `undefined` or `null` leaves
+   * the persisted value in place — both are treated as "no overlay" so the
+   * common `() => process.env.X ?? null` pattern is safe and won't clobber
+   * a snapshotted value when the env var is unset. Throwing falls back to
+   * the persisted value (or to whatever
+   * {@link ResolveLazyConfigOptions.onError} dictates).
    *
    * @example
    * ```typescript

--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -2,6 +2,7 @@ import type { AIClientOptions } from '@happyvertical/ai';
 import { createLogger, type Logger } from '@happyvertical/logger';
 import { sanitizeConfig } from '@happyvertical/smrt-config';
 import {
+  type ConfigResolver,
   createDispatchBus,
   type DispatchBus,
   type DispatchMetadata,
@@ -203,6 +204,34 @@ export abstract class Agent extends SmrtObject {
    * ```
    */
   static signalSubscriptions: string[] = [];
+
+  /**
+   * Execute-time resolvers for `agent_config` fields that should be computed
+   * lazily rather than snapshotted at sync time.
+   *
+   * Each entry is keyed by the agent_config field it produces. The runtime
+   * (see {@link resolveLazyConfig}) calls every resolver and overlays the
+   * results on top of the persisted config before constructing the agent.
+   * That means env-derived values like asset storage paths, S3 buckets, AI
+   * provider keys, or tenant-scoped DB URLs stay live: rotating an env var
+   * is reflected on the next scheduled run without rewriting the schedule
+   * row.
+   *
+   * Resolvers may be sync or async. Returning `undefined` leaves the
+   * persisted value in place; throwing falls back to the persisted value
+   * (or to whatever {@link ResolveLazyConfigOptions.onError} dictates).
+   *
+   * @example
+   * ```typescript
+   * class Praeco extends Agent {
+   *   static override configResolvers = {
+   *     assetStorage: () => resolveSharedAssetStorage(),
+   *     aiKey: async () => loadAIKeyFromSecretsManager(),
+   *   };
+   * }
+   * ```
+   */
+  static configResolvers: Record<string, ConfigResolver> = {};
 
   /**
    * Current agent status

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -70,6 +70,23 @@
 // module loads below. See __smrt-register__.ts for issue #1132 context.
 import './__smrt-register__.js';
 
+// Re-export core lazy-config primitives for discoverability — agents are the
+// primary use case for `agent_config` snapshot resolution (issue #1161).
+export type {
+  ConfigResolver,
+  LazyConfigSentinel,
+  ResolveLazyConfigOptions,
+} from '@happyvertical/smrt-core';
+export {
+  getClassConfigResolvers,
+  getConfigResolver,
+  isLazyConfigSentinel,
+  listConfigResolvers,
+  registerConfigResolver,
+  resetConfigResolvers,
+  resolveLazyConfig,
+  unregisterConfigResolver,
+} from '@happyvertical/smrt-core';
 export { Agent, type AgentOptions } from './agent.js';
 export {
   type AgentAIOptions,

--- a/packages/content/CLAUDE.md
+++ b/packages/content/CLAUDE.md
@@ -117,6 +117,23 @@ await content.addReference(otherContent);
 await content.getReferences();
 ```
 
+## API Contracts
+
+`Content` implements `AssetAssociable` and `MetadataAccessor` (issue #1162). Consumers can type their parameters as `Content` (or the interfaces directly) and rely on the methods existing without `typeof === 'function'` defensive checks:
+
+```typescript
+import type { AssetAssociable, MetadataAccessor } from '@happyvertical/smrt-content';
+
+async function attachThumbnail(doc: AssetAssociable, asset: Asset) {
+  await doc.addAsset(asset, 'thumbnail', 0); // contract guaranteed
+}
+
+function bumpRevision(doc: MetadataAccessor) {
+  const meta = doc.getMetadata();
+  doc.updateMetadata({ revision: (meta.revision ?? 0) + 1 });
+}
+```
+
 ## Category Navigation
 
 `getCategorySegments()`, `getParentCategory()`, `getRootCategory()`, `getAncestorPaths()`, `isInCategory(path, includeChildren?)`

--- a/packages/content/src/asset-associable.test.ts
+++ b/packages/content/src/asset-associable.test.ts
@@ -1,6 +1,7 @@
 import type { Asset } from '@happyvertical/smrt-assets';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import type { AssetAssociable, MetadataAccessor } from './asset-associable';
+import { isAssetAssociable, isMetadataAccessor } from './asset-associable';
 import { Content } from './content';
 
 /**
@@ -48,15 +49,56 @@ describe('AssetAssociable contract — issue #1162', () => {
   });
 });
 
+describe('runtime type guards', () => {
+  it('isAssetAssociable returns true for Content instances', () => {
+    expect(isAssetAssociable(new Content({ name: 'x' }))).toBe(true);
+  });
+
+  it('isAssetAssociable rejects unrelated objects, primitives, and null', () => {
+    expect(isAssetAssociable(null)).toBe(false);
+    expect(isAssetAssociable(undefined)).toBe(false);
+    expect(isAssetAssociable('string')).toBe(false);
+    expect(isAssetAssociable({})).toBe(false);
+    expect(isAssetAssociable({ getAssets: () => Promise.resolve([]) })).toBe(
+      false,
+    );
+  });
+
+  it('isMetadataAccessor returns true for Content and rejects others', () => {
+    expect(isMetadataAccessor(new Content({ name: 'x' }))).toBe(true);
+    expect(isMetadataAccessor({})).toBe(false);
+    expect(isMetadataAccessor({ getMetadata: () => ({}) })).toBe(false);
+  });
+});
+
 describe('MetadataAccessor implementation on Content', () => {
-  it('getMetadata returns an object even when metadata was nulled out', () => {
+  it('getMetadata returns an empty object when metadata is null — without mutating the field', () => {
+    // Read-only accessor must not silently normalise `null` to `{}` on the
+    // instance, or SmrtObject's save lifecycle could write `{}` back over a
+    // legitimately NULL column on the next save.
     const c = new Content({ name: 'x' });
     (c as unknown as { metadata: unknown }).metadata = null;
 
     const m = c.getMetadata();
     expect(m).toEqual({});
-    // Subsequent calls return the same normalised object.
-    expect(c.getMetadata()).toBe(m);
+    // The field itself is still null — the read did not mutate it.
+    expect((c as unknown as { metadata: unknown }).metadata).toBeNull();
+  });
+
+  it('getMetadata returns {} for arrays without leaking the array through', () => {
+    // Arrays are technically `typeof === 'object'` so the naive guard would
+    // pass them through. The accessor contract is "record-shaped".
+    const c = new Content({ name: 'x' });
+    (c as unknown as { metadata: unknown }).metadata = ['not', 'a', 'record'];
+
+    expect(c.getMetadata()).toEqual({});
+    expect(Array.isArray(c.getMetadata())).toBe(false);
+  });
+
+  it('setMetadata normalises arrays to {} (rejects non-record input)', () => {
+    const c = new Content({ name: 'x' });
+    c.setMetadata(['array', 'input'] as unknown as Record<string, any>);
+    expect(c.getMetadata()).toEqual({});
   });
 
   it('setMetadata replaces the field and clones the input', () => {

--- a/packages/content/src/asset-associable.test.ts
+++ b/packages/content/src/asset-associable.test.ts
@@ -1,0 +1,101 @@
+import type { Asset } from '@happyvertical/smrt-assets';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import type { AssetAssociable, MetadataAccessor } from './asset-associable';
+import { Content } from './content';
+
+/**
+ * Issue #1162 — Document.addAsset/removeAsset/getAssets must be a guaranteed
+ * API contract, not duck-typed via `typeof === 'function'` checks.
+ *
+ * The asserts below are split across runtime checks (do the methods exist
+ * with the right signatures?) and TypeScript-level checks (does the public
+ * type system enforce the contract?).
+ */
+describe('AssetAssociable contract — issue #1162', () => {
+  it('Content satisfies the AssetAssociable interface at the type level', () => {
+    expectTypeOf<Content>().toMatchTypeOf<AssetAssociable>();
+  });
+
+  it('Content satisfies MetadataAccessor at the type level', () => {
+    expectTypeOf<Content>().toMatchTypeOf<MetadataAccessor>();
+  });
+
+  it('exposes the three asset methods as functions on the prototype', () => {
+    const proto = Content.prototype as unknown as Record<string, unknown>;
+    expect(typeof proto.getAssets).toBe('function');
+    expect(typeof proto.addAsset).toBe('function');
+    expect(typeof proto.removeAsset).toBe('function');
+  });
+
+  it('exposes metadata accessors as functions on the prototype', () => {
+    const proto = Content.prototype as unknown as Record<string, unknown>;
+    expect(typeof proto.getMetadata).toBe('function');
+    expect(typeof proto.setMetadata).toBe('function');
+    expect(typeof proto.updateMetadata).toBe('function');
+  });
+
+  it('lets consumers type a parameter as Content directly without runtime guards', () => {
+    // The whole point of the contract: consumers don't have to write
+    // `if (typeof doc.addAsset === 'function')` defensively.
+    async function attachThumbnail(doc: AssetAssociable, asset: Asset) {
+      await doc.addAsset(asset, 'thumbnail', 0);
+    }
+
+    // Type-check by calling — would fail to compile if the contract weren't
+    // honoured by Content.
+    const _typeCheck = (doc: Content) => attachThumbnail;
+    void _typeCheck;
+  });
+});
+
+describe('MetadataAccessor implementation on Content', () => {
+  it('getMetadata returns an object even when metadata was nulled out', () => {
+    const c = new Content({ name: 'x' });
+    (c as unknown as { metadata: unknown }).metadata = null;
+
+    const m = c.getMetadata();
+    expect(m).toEqual({});
+    // Subsequent calls return the same normalised object.
+    expect(c.getMetadata()).toBe(m);
+  });
+
+  it('setMetadata replaces the field and clones the input', () => {
+    const c = new Content({ name: 'x' });
+    const original = { foo: 1 };
+    c.setMetadata(original);
+
+    expect(c.getMetadata()).toEqual({ foo: 1 });
+    // Mutating the original after set must not affect the stored copy.
+    (original as Record<string, unknown>).foo = 99;
+    expect(c.getMetadata().foo).toBe(1);
+  });
+
+  it('setMetadata with null/undefined clears to an empty object', () => {
+    const c = new Content({ name: 'x', metadata: { foo: 1 } });
+    c.setMetadata(null);
+    expect(c.getMetadata()).toEqual({});
+    c.setMetadata({ bar: 2 });
+    c.setMetadata(undefined);
+    expect(c.getMetadata()).toEqual({});
+  });
+
+  it('updateMetadata shallow-merges and returns the merged record', () => {
+    const c = new Content({
+      name: 'x',
+      metadata: { keep: 'a', overwrite: 1 },
+    });
+
+    const merged = c.updateMetadata({ overwrite: 2, added: true });
+
+    expect(merged).toEqual({ keep: 'a', overwrite: 2, added: true });
+    expect(c.getMetadata()).toEqual(merged);
+  });
+
+  it('updateMetadata tolerates an undefined patch', () => {
+    const c = new Content({ name: 'x', metadata: { keep: 'a' } });
+    const merged = c.updateMetadata(
+      undefined as unknown as Record<string, unknown>,
+    );
+    expect(merged).toEqual({ keep: 'a' });
+  });
+});

--- a/packages/content/src/asset-associable.ts
+++ b/packages/content/src/asset-associable.ts
@@ -1,0 +1,94 @@
+import type { Asset } from '@happyvertical/smrt-assets';
+
+/**
+ * Contract for objects that participate in the content/asset association
+ * pattern.
+ *
+ * Any class that exposes asset-relationship methods (e.g. `Content` and its
+ * STI subclasses) implements this interface explicitly so consumers can rely
+ * on the methods existing instead of falling back to `typeof === 'function'`
+ * duck-typing checks.
+ *
+ * @example
+ * ```ts
+ * import type { AssetAssociable } from '@happyvertical/smrt-content';
+ *
+ * async function attachThumbnail(
+ *   target: AssetAssociable,
+ *   image: Asset,
+ * ): Promise<void> {
+ *   // No defensive runtime checks needed — the contract guarantees the method.
+ *   await target.addAsset(image, 'thumbnail', 0);
+ * }
+ * ```
+ */
+export interface AssetAssociable {
+  /**
+   * Get all assets associated with this object.
+   *
+   * @param relationship - Optional filter by relationship type
+   *   (e.g. `'thumbnail'`, `'attachment'`).
+   * @returns Array of associated assets. Returns an empty array if the object
+   *   has not been persisted yet.
+   */
+  getAssets(relationship?: string): Promise<Asset[]>;
+
+  /**
+   * Associate an asset with this object via a typed relationship.
+   *
+   * @param asset - The asset to associate. Must be persisted (have an `id`).
+   * @param relationship - Relationship type. Must match
+   *   `/^[a-zA-Z_][a-zA-Z0-9_]*$/`. Defaults to `'attachment'`.
+   * @param sortOrder - Non-negative integer for display order.
+   * @throws if either side is unsaved or the relationship/sort order is invalid.
+   */
+  addAsset(
+    asset: Asset,
+    relationship?: string,
+    sortOrder?: number,
+  ): Promise<void>;
+
+  /**
+   * Remove an associated asset.
+   *
+   * @param assetId - The asset ID to detach.
+   * @param relationship - Optional specific relationship to remove. If omitted,
+   *   all relationships between this object and the asset are removed.
+   */
+  removeAsset(assetId: string, relationship?: string): Promise<void>;
+}
+
+/**
+ * Contract for objects exposing typed access to a `metadata` JSON field.
+ *
+ * Use alongside an explicit interface (such as {@link AssetAssociable}) to
+ * give consumers a stable contract for reading/writing the loose JSON bag,
+ * without leaking the `metadata: Record<string, any>` type into call sites.
+ */
+export interface MetadataAccessor<
+  TMetadata extends Record<string, any> = Record<string, any>,
+> {
+  /**
+   * Get the full metadata record. Always returns an object (never `null`).
+   * The returned reference is the live object — callers should treat it as
+   * read-only and use {@link MetadataAccessor.setMetadata} or
+   * {@link MetadataAccessor.updateMetadata} to mutate it safely.
+   */
+  getMetadata(): TMetadata;
+
+  /**
+   * Replace the entire metadata record.
+   *
+   * @param metadata - The new metadata object. `null`/`undefined` clears it.
+   */
+  setMetadata(metadata: TMetadata | null | undefined): void;
+
+  /**
+   * Shallow-merge the supplied patch over the existing metadata.
+   *
+   * @param patch - Partial metadata. Keys present in the patch overwrite the
+   *   existing record; keys absent from the patch are preserved.
+   * @returns The merged metadata record.
+   */
+  updateMetadata(patch: Partial<TMetadata>): TMetadata;
+}

--- a/packages/content/src/asset-associable.ts
+++ b/packages/content/src/asset-associable.ts
@@ -92,3 +92,61 @@ export interface MetadataAccessor<
    */
   updateMetadata(patch: Partial<TMetadata>): TMetadata;
 }
+
+/**
+ * Runtime type guard for {@link AssetAssociable}.
+ *
+ * The interface exists primarily so that statically-typed consumers can drop
+ * defensive `typeof === 'function'` checks. This guard is for the rare cases
+ * where a value enters the system as `unknown` (deserialised payload, plugin
+ * input, etc.) and the caller needs to confirm shape before delegating.
+ *
+ * @example
+ * ```ts
+ * if (isAssetAssociable(input)) {
+ *   await input.addAsset(asset, 'attachment');
+ * }
+ * ```
+ */
+export function isAssetAssociable(value: unknown): value is AssetAssociable {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<AssetAssociable>;
+  return (
+    typeof candidate.getAssets === 'function' &&
+    typeof candidate.addAsset === 'function' &&
+    typeof candidate.removeAsset === 'function'
+  );
+}
+
+/**
+ * Runtime type guard for {@link MetadataAccessor}.
+ *
+ * Mirrors {@link isAssetAssociable} for the metadata-accessor contract.
+ */
+export function isMetadataAccessor(value: unknown): value is MetadataAccessor {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<MetadataAccessor>;
+  return (
+    typeof candidate.getMetadata === 'function' &&
+    typeof candidate.setMetadata === 'function' &&
+    typeof candidate.updateMetadata === 'function'
+  );
+}
+
+/**
+ * Returns `true` if `value` is a plain object (not an array, not `null`,
+ * not a class instance with a custom prototype). Used by `Content`'s metadata
+ * accessors to enforce the "record-shaped" contract — arrays and other
+ * non-record objects are normalised to `{}` rather than silently leaked
+ * through.
+ *
+ * @internal
+ */
+export function isPlainMetadataRecord(
+  value: unknown,
+): value is Record<string, any> {
+  if (!value || typeof value !== 'object') return false;
+  if (Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === null || proto === Object.prototype;
+}

--- a/packages/content/src/content.ts
+++ b/packages/content/src/content.ts
@@ -10,6 +10,7 @@ import type { Fact, FactContentRelationship } from '@happyvertical/smrt-facts';
 import type { Image } from '@happyvertical/smrt-images';
 import { ImageCollection } from '@happyvertical/smrt-images';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import type { AssetAssociable, MetadataAccessor } from './asset-associable';
 import { ContentAssetCollection } from './content-assets';
 import {
   buildContentGovernanceAssignmentKey,
@@ -278,7 +279,10 @@ export interface ContentOptions extends SmrtObjectOptions {
   },
   cli: true, // Enable CLI commands for content management
 })
-export class Content extends SmrtObject {
+export class Content
+  extends SmrtObject
+  implements AssetAssociable, MetadataAccessor
+{
   /**
    * Tenant ID for multi-tenant isolation
    * Nullable to support both tenant-scoped and global content
@@ -2216,6 +2220,45 @@ ${correctedText}
         throw error;
       }
     }
+  }
+
+  // ============================================
+  // Metadata Accessors (MetadataAccessor contract)
+  // ============================================
+
+  /**
+   * Get the full metadata record. Always returns an object — never `null` —
+   * so callers can safely read nested keys without defensive checks.
+   *
+   * The returned reference is the live `metadata` object; callers should not
+   * mutate it directly. Use {@link Content.setMetadata} or
+   * {@link Content.updateMetadata} for safe writes.
+   */
+  getMetadata(): Record<string, any> {
+    if (!this.metadata || typeof this.metadata !== 'object') {
+      this.metadata = {};
+    }
+    return this.metadata;
+  }
+
+  /**
+   * Replace the full metadata record. Passing `null`/`undefined` clears it
+   * to an empty object so downstream readers can rely on the field always
+   * being a plain object.
+   */
+  setMetadata(metadata: Record<string, any> | null | undefined): void {
+    this.metadata =
+      metadata && typeof metadata === 'object' ? { ...metadata } : {};
+  }
+
+  /**
+   * Shallow-merge a patch over the current metadata. Returns the resulting
+   * record so callers can chain reads without re-reading the field.
+   */
+  updateMetadata(patch: Partial<Record<string, any>>): Record<string, any> {
+    const next = { ...this.getMetadata(), ...(patch ?? {}) };
+    this.metadata = next;
+    return next;
   }
 
   // ============================================

--- a/packages/content/src/content.ts
+++ b/packages/content/src/content.ts
@@ -11,6 +11,7 @@ import type { Image } from '@happyvertical/smrt-images';
 import { ImageCollection } from '@happyvertical/smrt-images';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { AssetAssociable, MetadataAccessor } from './asset-associable';
+import { isPlainMetadataRecord } from './asset-associable';
 import { ContentAssetCollection } from './content-assets';
 import {
   buildContentGovernanceAssignmentKey,
@@ -2227,33 +2228,36 @@ ${correctedText}
   // ============================================
 
   /**
-   * Get the full metadata record. Always returns an object — never `null` —
-   * so callers can safely read nested keys without defensive checks.
+   * Get the full metadata record. Always returns a plain object — never
+   * `null`, never an array — so callers can safely read nested keys without
+   * defensive checks.
    *
-   * The returned reference is the live `metadata` object; callers should not
-   * mutate it directly. Use {@link Content.setMetadata} or
-   * {@link Content.updateMetadata} for safe writes.
+   * Pure read with no side-effect on `this.metadata`: if the field is
+   * currently `null` (e.g. fresh from the DB) or non-record-shaped, an
+   * empty object is returned but the field is **not** mutated. This avoids
+   * accidentally marking the object dirty during a read, which would
+   * otherwise cause SmrtObject's save lifecycle to write `{}` back over a
+   * NULL column on the next save. Callers that want to normalise the
+   * stored field should use {@link Content.setMetadata}.
    */
   getMetadata(): Record<string, any> {
-    if (!this.metadata || typeof this.metadata !== 'object') {
-      this.metadata = {};
-    }
-    return this.metadata;
+    return isPlainMetadataRecord(this.metadata) ? this.metadata : {};
   }
 
   /**
-   * Replace the full metadata record. Passing `null`/`undefined` clears it
-   * to an empty object so downstream readers can rely on the field always
-   * being a plain object.
+   * Replace the full metadata record. Passing `null`/`undefined` (or any
+   * non-record value such as an array) clears it to an empty object so
+   * downstream readers can rely on the field always being a plain object.
    */
   setMetadata(metadata: Record<string, any> | null | undefined): void {
-    this.metadata =
-      metadata && typeof metadata === 'object' ? { ...metadata } : {};
+    this.metadata = isPlainMetadataRecord(metadata) ? { ...metadata } : {};
   }
 
   /**
    * Shallow-merge a patch over the current metadata. Returns the resulting
-   * record so callers can chain reads without re-reading the field.
+   * record so callers can chain reads without re-reading the field. Unlike
+   * {@link Content.getMetadata}, this method does intentionally write back
+   * to `this.metadata` because the merge is a write.
    */
   updateMetadata(patch: Partial<Record<string, any>>): Record<string, any> {
     const next = { ...this.getMetadata(), ...(patch ?? {}) };

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -10,6 +10,10 @@
 // module loads below. See __smrt-register__.ts for issue #1132 context.
 import './__smrt-register__.js';
 
+export type {
+  AssetAssociable,
+  MetadataAccessor,
+} from './asset-associable';
 export type { ContentOptions } from './content';
 export { Content } from './content';
 export type { ContentAssetOptions } from './content-asset';

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -14,6 +14,7 @@ export type {
   AssetAssociable,
   MetadataAccessor,
 } from './asset-associable';
+export { isAssetAssociable, isMetadataAccessor } from './asset-associable';
 export type { ContentOptions } from './content';
 export { Content } from './content';
 export type { ContentAssetOptions } from './content-asset';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -66,6 +66,23 @@ export * from './errors';
 export * from './generators/index';
 // Global interceptors system (for tenancy, soft-delete, audit logging, etc.)
 export * from './interceptors';
+// Lazy / execute-time config resolvers (for agent_config and similar
+// snapshot-prone payloads — see issue #1161)
+export type {
+  ConfigResolver,
+  LazyConfigSentinel,
+  ResolveLazyConfigOptions,
+} from './lazy-config';
+export {
+  getClassConfigResolvers,
+  getConfigResolver,
+  isLazyConfigSentinel,
+  listConfigResolvers,
+  registerConfigResolver,
+  resetConfigResolvers,
+  resolveLazyConfig,
+  unregisterConfigResolver,
+} from './lazy-config';
 // Static manifest (generated at build time)
 export * from './manifest/index';
 export type { DiffOptions } from './migrations/differ';

--- a/packages/core/src/lazy-config.test.ts
+++ b/packages/core/src/lazy-config.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  getClassConfigResolvers,
+  getConfigResolver,
+  isLazyConfigSentinel,
+  listConfigResolvers,
+  registerConfigResolver,
+  resetConfigResolvers,
+  resolveLazyConfig,
+  unregisterConfigResolver,
+} from './lazy-config';
+
+describe('lazy-config', () => {
+  afterEach(() => {
+    resetConfigResolvers();
+  });
+
+  describe('isLazyConfigSentinel', () => {
+    it('recognises {$env} sentinels', () => {
+      expect(isLazyConfigSentinel({ $env: 'foo' })).toBe(true);
+    });
+
+    it('recognises {$resolver} sentinels', () => {
+      expect(isLazyConfigSentinel({ $resolver: 'foo' })).toBe(true);
+    });
+
+    it('rejects sentinels with extra keys (so user data is not mistaken)', () => {
+      expect(isLazyConfigSentinel({ $env: 'foo', extra: 1 })).toBe(false);
+    });
+
+    it('rejects sentinels with empty resolver name', () => {
+      expect(isLazyConfigSentinel({ $env: '' })).toBe(false);
+    });
+
+    it('rejects non-objects', () => {
+      expect(isLazyConfigSentinel(null)).toBe(false);
+      expect(isLazyConfigSentinel('not a sentinel')).toBe(false);
+      expect(isLazyConfigSentinel(42)).toBe(false);
+      expect(isLazyConfigSentinel([{ $env: 'foo' }])).toBe(false);
+    });
+  });
+
+  describe('global resolver registry', () => {
+    it('registers, retrieves, lists, and unregisters resolvers', () => {
+      const resolver = () => 'value';
+      registerConfigResolver('a', resolver);
+      registerConfigResolver('b', () => 'other');
+
+      expect(getConfigResolver('a')).toBe(resolver);
+      expect(listConfigResolvers()).toEqual(['a', 'b']);
+
+      expect(unregisterConfigResolver('a')).toBe(true);
+      expect(getConfigResolver('a')).toBeUndefined();
+      expect(unregisterConfigResolver('a')).toBe(false);
+    });
+
+    it('rejects invalid registrations', () => {
+      expect(() => registerConfigResolver('', () => null)).toThrow(
+        'non-empty string',
+      );
+      expect(() =>
+        registerConfigResolver('foo', undefined as unknown as () => unknown),
+      ).toThrow('must be a function');
+    });
+
+    it('replaces a resolver when registered with the same name', () => {
+      registerConfigResolver('foo', () => 1);
+      registerConfigResolver('foo', () => 2);
+
+      const resolver = getConfigResolver('foo');
+      expect(resolver?.()).toBe(2);
+    });
+  });
+
+  describe('resolveLazyConfig — sentinel resolution', () => {
+    it('replaces top-level sentinels with the resolver value', async () => {
+      registerConfigResolver('storage', () => ({ bucket: 'live-bucket' }));
+
+      const resolved = await resolveLazyConfig({
+        assetStorage: { $env: 'storage' },
+        unrelated: 'untouched',
+      });
+
+      expect(resolved).toEqual({
+        assetStorage: { bucket: 'live-bucket' },
+        unrelated: 'untouched',
+      });
+    });
+
+    it('resolves nested sentinels inside objects and arrays', async () => {
+      registerConfigResolver('apiKey', async () => 'live-key');
+
+      const resolved = await resolveLazyConfig({
+        deeply: { nested: { key: { $env: 'apiKey' } } },
+        list: [{ $env: 'apiKey' }, 'literal'],
+      });
+
+      expect(resolved).toEqual({
+        deeply: { nested: { key: 'live-key' } },
+        list: ['live-key', 'literal'],
+      });
+    });
+
+    it('does not mutate the input object', async () => {
+      registerConfigResolver('foo', () => 'bar');
+
+      const input = { value: { $env: 'foo' } };
+      const resolved = await resolveLazyConfig(input);
+
+      expect(resolved).not.toBe(input);
+      expect(input.value).toEqual({ $env: 'foo' });
+      expect(resolved.value).toBe('bar');
+    });
+
+    it('leaves sentinels in place when resolver is missing (default onError)', async () => {
+      const resolved = await resolveLazyConfig({
+        value: { $env: 'missing' },
+      });
+
+      expect(resolved).toEqual({ value: { $env: 'missing' } });
+    });
+
+    it('omits sentinels with onError: "omit"', async () => {
+      const resolved = await resolveLazyConfig(
+        { keep: 1, drop: { $env: 'missing' } },
+        { onError: 'omit' },
+      );
+
+      expect(resolved).toEqual({ keep: 1 });
+    });
+
+    it('throws on missing resolver with onError: "throw"', async () => {
+      await expect(
+        resolveLazyConfig({ value: { $env: 'missing' } }, { onError: 'throw' }),
+      ).rejects.toThrow('unknown resolver "missing"');
+    });
+
+    it('falls back to persisted value when resolver throws (default)', async () => {
+      registerConfigResolver('flaky', () => {
+        throw new Error('boom');
+      });
+
+      const resolved = await resolveLazyConfig({
+        value: { $env: 'flaky' },
+      });
+
+      expect(resolved).toEqual({ value: { $env: 'flaky' } });
+    });
+
+    it('rethrows resolver errors with onError: "throw"', async () => {
+      registerConfigResolver('flaky', () => {
+        throw new Error('boom');
+      });
+
+      await expect(
+        resolveLazyConfig({ value: { $env: 'flaky' } }, { onError: 'throw' }),
+      ).rejects.toThrow('boom');
+    });
+
+    it('accepts a per-call resolvers map (Record or Map)', async () => {
+      const resolved = await resolveLazyConfig(
+        { value: { $env: 'foo' } },
+        { resolvers: { foo: () => 'A' } },
+      );
+      expect(resolved.value).toBe('A');
+
+      const map = new Map<string, () => unknown>([['foo', () => 'B']]);
+      const resolved2 = await resolveLazyConfig(
+        { value: { $env: 'foo' } },
+        { resolvers: map },
+      );
+      expect(resolved2.value).toBe('B');
+    });
+
+    it('handles cyclic structures without infinite recursion', async () => {
+      const cyclic: Record<string, unknown> = { a: 1 };
+      cyclic.self = cyclic;
+
+      const resolved = await resolveLazyConfig(cyclic);
+      expect(resolved.a).toBe(1);
+    });
+  });
+
+  describe('resolveLazyConfig — class resolvers', () => {
+    it('overlays class resolvers on top of persisted config', async () => {
+      const resolved = await resolveLazyConfig(
+        { foo: 'persisted-foo', bar: 'persisted-bar' },
+        { classResolvers: { foo: () => 'live-foo' } },
+      );
+
+      expect(resolved).toEqual({
+        foo: 'live-foo',
+        bar: 'persisted-bar',
+      });
+    });
+
+    it('preserves persisted value when class resolver returns undefined', async () => {
+      const resolved = await resolveLazyConfig(
+        { foo: 'persisted' },
+        { classResolvers: { foo: () => undefined } },
+      );
+      expect(resolved.foo).toBe('persisted');
+    });
+
+    it('preserves persisted value when class resolver throws (default)', async () => {
+      const resolved = await resolveLazyConfig(
+        { foo: 'persisted' },
+        {
+          classResolvers: {
+            foo: () => {
+              throw new Error('boom');
+            },
+          },
+        },
+      );
+      expect(resolved.foo).toBe('persisted');
+    });
+
+    it('layers class resolvers after sentinel resolution', async () => {
+      registerConfigResolver('shared', () => 'shared-live');
+
+      const resolved = await resolveLazyConfig(
+        {
+          shared: { $env: 'shared' },
+          extra: 'persisted-extra',
+        },
+        { classResolvers: { extra: () => 'class-overlay' } },
+      );
+
+      expect(resolved).toEqual({
+        shared: 'shared-live',
+        extra: 'class-overlay',
+      });
+    });
+  });
+
+  describe('getClassConfigResolvers', () => {
+    it('returns resolvers declared on the class', () => {
+      class Foo {
+        static configResolvers = { a: () => 1 };
+      }
+      const resolvers = getClassConfigResolvers(Foo);
+      expect(resolvers?.a?.()).toBe(1);
+    });
+
+    it('walks the prototype chain so subclasses inherit parent resolvers', () => {
+      class Parent {
+        static configResolvers = { a: () => 'parent-a' };
+      }
+      class Child extends Parent {
+        static configResolvers = { b: () => 'child-b' };
+      }
+
+      const resolvers = getClassConfigResolvers(Child);
+      expect(resolvers?.a?.()).toBe('parent-a');
+      expect(resolvers?.b?.()).toBe('child-b');
+    });
+
+    it('lets subclass override parent resolver of the same name', () => {
+      class Parent {
+        static configResolvers = { a: () => 'parent' };
+      }
+      class Child extends Parent {
+        static configResolvers = { a: () => 'child' };
+      }
+
+      const resolvers = getClassConfigResolvers(Child);
+      expect(resolvers?.a?.()).toBe('child');
+    });
+
+    it('returns undefined when no resolvers declared anywhere', () => {
+      class Bare {}
+      expect(getClassConfigResolvers(Bare)).toBeUndefined();
+    });
+
+    it('handles non-functions gracefully', () => {
+      expect(getClassConfigResolvers(undefined)).toBeUndefined();
+      expect(getClassConfigResolvers(null)).toBeUndefined();
+      expect(getClassConfigResolvers(42)).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/src/lazy-config.test.ts
+++ b/packages/core/src/lazy-config.test.ts
@@ -178,6 +178,54 @@ describe('lazy-config', () => {
 
       const resolved = await resolveLazyConfig(cyclic);
       expect(resolved.a).toBe(1);
+      // Cycle is preserved internally: `resolved.self` points back at the
+      // inner sentinel-resolved tree (not at the original `cyclic` input).
+      // We verify by walking one step deeper — `resolved.self.self` should
+      // be the same node as `resolved.self`, proving no aliasing leak.
+      const inner = resolved.self as Record<string, unknown>;
+      expect(inner.a).toBe(1);
+      expect(inner.self).toBe(inner);
+      // And the original input is untouched.
+      expect(cyclic.self).toBe(cyclic);
+    });
+
+    it('preserves DAG structure: shared sub-objects produce shared clones with sentinels resolved', async () => {
+      registerConfigResolver('apiKey', () => 'live-key');
+
+      const shared: Record<string, unknown> = {
+        nested: { key: { $env: 'apiKey' } },
+      };
+      const input = { left: shared, right: shared };
+
+      const resolved = await resolveLazyConfig(input);
+
+      // Both branches resolved the sentinel — the bug we'd guard against
+      // is one branch keeping `{ $env: 'apiKey' }` because traversal
+      // bailed on revisit.
+      const left = resolved.left as Record<string, any>;
+      const right = resolved.right as Record<string, any>;
+      expect(left.nested.key).toBe('live-key');
+      expect(right.nested.key).toBe('live-key');
+
+      // Same shared input → same shared clone in the output (DAG fidelity).
+      expect(left).toBe(right);
+
+      // And the input is not mutated: original sentinel is intact.
+      expect((shared.nested as any).key).toEqual({ $env: 'apiKey' });
+    });
+
+    it('caps recursion at MAX_DEPTH to prevent stack overflow from buggy persisted configs', async () => {
+      // Build a chain 100 levels deep — beyond the depth cap.
+      const root: Record<string, unknown> = {};
+      let current = root;
+      for (let i = 0; i < 100; i++) {
+        const next: Record<string, unknown> = {};
+        current.deeper = next;
+        current = next;
+      }
+      // Should not throw or stack-overflow; deep tail is left as-is.
+      const resolved = await resolveLazyConfig(root);
+      expect(resolved).toBeTypeOf('object');
     });
   });
 
@@ -200,6 +248,33 @@ describe('lazy-config', () => {
         { classResolvers: { foo: () => undefined } },
       );
       expect(resolved.foo).toBe('persisted');
+    });
+
+    it('preserves persisted value when class resolver returns null', async () => {
+      // Real-world resolvers often look like `() => process.env.X ?? null`.
+      // Treating `null` as "no overlay" prevents that pattern from silently
+      // clobbering a snapshotted value when the env var is unset.
+      const resolved = await resolveLazyConfig(
+        { foo: 'persisted' },
+        { classResolvers: { foo: () => null } },
+      );
+      expect(resolved.foo).toBe('persisted');
+    });
+
+    it('overlays falsy-but-real values from class resolvers (0, "", false)', async () => {
+      // null/undefined are sentinels for "no overlay"; other falsy values
+      // are legitimate config values and must overlay normally.
+      const resolved = await resolveLazyConfig(
+        { count: 99, label: 'old', flag: true },
+        {
+          classResolvers: {
+            count: () => 0,
+            label: () => '',
+            flag: () => false,
+          },
+        },
+      );
+      expect(resolved).toEqual({ count: 0, label: '', flag: false });
     });
 
     it('preserves persisted value when class resolver throws (default)', async () => {

--- a/packages/core/src/lazy-config.ts
+++ b/packages/core/src/lazy-config.ts
@@ -1,0 +1,333 @@
+/**
+ * Lazy / execute-time agent_config resolvers.
+ *
+ * Persisted agent configs (e.g. `_smrt_agent_schedules.agent_config`) freeze
+ * any value resolved at sync time, including env-derived ones. When operators
+ * rotate an env var the persisted snapshot goes stale until the schedule is
+ * rewritten.
+ *
+ * To avoid that, callers can store **sentinel references** in the persisted
+ * config and register matching resolvers that run at execute time. The
+ * runtime walks the agent_config tree, replaces every recognised sentinel
+ * with the resolver's current return value, and only then hands the config
+ * to the agent.
+ *
+ * Two registration shapes are supported:
+ *
+ * 1. **Global named resolvers** — register a callback by name once at
+ *    application startup. Use this for shared resolvers like
+ *    `resolveSharedAssetStorage`.
+ *
+ *    ```ts
+ *    import { registerConfigResolver } from '@happyvertical/smrt-agents';
+ *
+ *    registerConfigResolver('sharedAssetStorage', () =>
+ *      resolveSharedAssetStorage(),
+ *    );
+ *    ```
+ *
+ *    Then in the persisted agent_config:
+ *    ```jsonc
+ *    { "assetStorage": { "$env": "sharedAssetStorage" } }
+ *    ```
+ *
+ * 2. **Per-agent class resolvers** — declare them as a static
+ *    `configResolvers` map on the agent class. The runtime applies them on
+ *    top of the persisted config keyed by the same name as the resolver.
+ *
+ *    ```ts
+ *    class Praeco extends Agent {
+ *      static configResolvers = {
+ *        assetStorage: () => resolveSharedAssetStorage(),
+ *      };
+ *    }
+ *    ```
+ *
+ * Both shapes can be combined freely. Global resolvers always take precedence
+ * for `$env` sentinels; class resolvers fill in / override fields by name.
+ *
+ * @module
+ */
+
+/**
+ * A lazy resolver — synchronous or async. Return values are merged into the
+ * config tree at execute time. Throwing is allowed but is treated as a
+ * resolution failure (see {@link ResolveLazyConfigOptions.onError}).
+ */
+export type ConfigResolver = () => unknown | Promise<unknown>;
+
+/**
+ * Sentinel object recognised inside agent_config to defer a value to a named
+ * resolver. The runtime accepts both `$env` (preferred) and `$resolver` for
+ * symmetry with similar systems.
+ */
+export interface LazyConfigSentinel {
+  $env?: string;
+  $resolver?: string;
+}
+
+/**
+ * Options for resolving the lazy parts of a config tree.
+ */
+export interface ResolveLazyConfigOptions {
+  /**
+   * Per-class resolvers — typically the agent class's static
+   * `configResolvers`. Applied as a key-by-key overlay on top of the
+   * sentinel-resolved config.
+   */
+  classResolvers?: Record<string, ConfigResolver>;
+
+  /**
+   * Optional override for the global resolver registry. When omitted the
+   * shared module-scoped registry is used. Useful for tests.
+   */
+  resolvers?: Map<string, ConfigResolver> | Record<string, ConfigResolver>;
+
+  /**
+   * What to do when a sentinel references a resolver that isn't registered,
+   * or when a resolver throws.
+   *
+   * - `'leave'` (default): the sentinel is left in place verbatim. The
+   *   downstream consumer is responsible for handling it.
+   * - `'omit'`: the sentinel key is removed from the parent object/array.
+   * - `'throw'`: re-throw the underlying error (or throw a new one for
+   *   missing resolvers).
+   */
+  onError?: 'leave' | 'omit' | 'throw';
+}
+
+const globalResolvers = new Map<string, ConfigResolver>();
+
+/**
+ * Register a named resolver that participates in lazy config resolution.
+ *
+ * Calling this with the same name twice replaces the previous resolver — the
+ * registry is intentionally last-write-wins so application boot ordering
+ * doesn't have to be fragile.
+ */
+export function registerConfigResolver(
+  name: string,
+  resolver: ConfigResolver,
+): void {
+  if (typeof name !== 'string' || name.length === 0) {
+    throw new Error('registerConfigResolver: name must be a non-empty string');
+  }
+  if (typeof resolver !== 'function') {
+    throw new Error('registerConfigResolver: resolver must be a function');
+  }
+  globalResolvers.set(name, resolver);
+}
+
+/**
+ * Remove a previously registered resolver. Returns `true` if a resolver was
+ * removed.
+ */
+export function unregisterConfigResolver(name: string): boolean {
+  return globalResolvers.delete(name);
+}
+
+/**
+ * Get the resolver registered under the given name, if any.
+ */
+export function getConfigResolver(name: string): ConfigResolver | undefined {
+  return globalResolvers.get(name);
+}
+
+/**
+ * List the names of all currently-registered global resolvers.
+ */
+export function listConfigResolvers(): string[] {
+  return Array.from(globalResolvers.keys()).sort();
+}
+
+/**
+ * Reset the global resolver registry. Primarily for tests.
+ */
+export function resetConfigResolvers(): void {
+  globalResolvers.clear();
+}
+
+/**
+ * Type guard that returns `true` if `value` is a lazy config sentinel.
+ *
+ * Recognises objects of the form `{ $env: string }` or
+ * `{ $resolver: string }` exactly — extra keys disqualify the value so
+ * arbitrary user data isn't accidentally treated as a sentinel.
+ */
+export function isLazyConfigSentinel(
+  value: unknown,
+): value is LazyConfigSentinel {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const keys = Object.keys(value as Record<string, unknown>);
+  if (keys.length !== 1) return false;
+  const key = keys[0];
+  if (key !== '$env' && key !== '$resolver') return false;
+  const resolverName = (value as Record<string, unknown>)[key];
+  return typeof resolverName === 'string' && resolverName.length > 0;
+}
+
+/**
+ * Extract the resolver name from a sentinel.
+ */
+function getSentinelName(sentinel: LazyConfigSentinel): string {
+  return (sentinel.$env ?? sentinel.$resolver) as string;
+}
+
+function normalizeResolverMap(
+  resolvers: Map<string, ConfigResolver> | Record<string, ConfigResolver>,
+): Map<string, ConfigResolver> {
+  if (resolvers instanceof Map) return resolvers;
+  return new Map(Object.entries(resolvers));
+}
+
+const REMOVE = Symbol('LazyConfig.REMOVE');
+
+async function resolveValue(
+  value: unknown,
+  resolvers: Map<string, ConfigResolver>,
+  onError: NonNullable<ResolveLazyConfigOptions['onError']>,
+  seen: WeakSet<object>,
+): Promise<unknown> {
+  if (isLazyConfigSentinel(value)) {
+    const name = getSentinelName(value);
+    const resolver = resolvers.get(name);
+    if (!resolver) {
+      if (onError === 'throw') {
+        throw new Error(
+          `Lazy config sentinel references unknown resolver "${name}"`,
+        );
+      }
+      if (onError === 'omit') return REMOVE;
+      return value;
+    }
+
+    try {
+      return await resolver();
+    } catch (error) {
+      if (onError === 'throw') throw error;
+      if (onError === 'omit') return REMOVE;
+      return value;
+    }
+  }
+
+  if (Array.isArray(value)) {
+    if (seen.has(value)) return value;
+    seen.add(value);
+    const next: unknown[] = [];
+    for (const entry of value) {
+      const resolved = await resolveValue(entry, resolvers, onError, seen);
+      if (resolved !== REMOVE) next.push(resolved);
+    }
+    return next;
+  }
+
+  if (value && typeof value === 'object') {
+    if (seen.has(value)) return value;
+    seen.add(value);
+    const next: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
+      const resolved = await resolveValue(entry, resolvers, onError, seen);
+      if (resolved !== REMOVE) next[key] = resolved;
+    }
+    return next;
+  }
+
+  return value;
+}
+
+/**
+ * Resolve every lazy sentinel inside an `agent_config`-style record at
+ * execute time. The input is not mutated; a new object is returned with
+ * sentinel placeholders replaced by their resolver's current return value.
+ *
+ * Class-level resolvers from {@link ResolveLazyConfigOptions.classResolvers}
+ * are applied as a final overlay so they always reflect the live value
+ * regardless of what's persisted.
+ *
+ * @example Sentinel resolution
+ * ```ts
+ * registerConfigResolver('sharedAssetStorage', () => resolveStorage());
+ *
+ * const stored = { assetStorage: { $env: 'sharedAssetStorage' } };
+ * const live = await resolveLazyConfig(stored);
+ * // live.assetStorage === resolveStorage()
+ * ```
+ *
+ * @example Class-level resolvers
+ * ```ts
+ * const live = await resolveLazyConfig(stored, {
+ *   classResolvers: { assetStorage: () => resolveStorage() },
+ * });
+ * ```
+ */
+export async function resolveLazyConfig<T extends Record<string, unknown>>(
+  config: T,
+  options: ResolveLazyConfigOptions = {},
+): Promise<T> {
+  const onError = options.onError ?? 'leave';
+  const resolvers = options.resolvers
+    ? normalizeResolverMap(options.resolvers)
+    : globalResolvers;
+
+  const seen = new WeakSet<object>();
+  const sentinelResolved = (await resolveValue(
+    config,
+    resolvers,
+    onError,
+    seen,
+  )) as Record<string, unknown>;
+
+  const result: Record<string, unknown> = { ...sentinelResolved };
+
+  if (options.classResolvers) {
+    for (const [key, resolver] of Object.entries(options.classResolvers)) {
+      try {
+        const value = await resolver();
+        if (typeof value !== 'undefined') {
+          result[key] = value;
+        }
+      } catch (error) {
+        if (onError === 'throw') throw error;
+        if (onError === 'omit') {
+          delete result[key];
+        }
+        // 'leave': preserve the existing (possibly persisted) value.
+      }
+    }
+  }
+
+  return result as T;
+}
+
+/**
+ * Look up the static `configResolvers` map on a class (or any of its
+ * ancestors). Returns `undefined` if none is declared.
+ *
+ * The lookup walks the prototype chain so a subclass can extend its parent's
+ * resolvers without redeclaring them.
+ */
+export function getClassConfigResolvers(
+  ctor: unknown,
+): Record<string, ConfigResolver> | undefined {
+  if (typeof ctor !== 'function') return undefined;
+
+  let current: any = ctor;
+  let collected: Record<string, ConfigResolver> | undefined;
+
+  while (current && current !== Function.prototype) {
+    const resolvers = current.configResolvers;
+    if (resolvers && typeof resolvers === 'object') {
+      collected = {
+        ...(resolvers as Record<string, ConfigResolver>),
+        ...(collected ?? {}),
+      };
+    }
+    current = Object.getPrototypeOf(current);
+  }
+
+  return collected;
+}

--- a/packages/core/src/lazy-config.ts
+++ b/packages/core/src/lazy-config.ts
@@ -184,53 +184,87 @@ function normalizeResolverMap(
 
 const REMOVE = Symbol('LazyConfig.REMOVE');
 
+/**
+ * Maximum traversal depth before {@link resolveValue} bails out. Real
+ * `agent_config` payloads are shallow (2–3 levels); a high cap here exists
+ * solely to prevent stack overflow from a malicious or buggy persisted
+ * config without rejecting any legitimate input. When the cap is hit the
+ * value is returned verbatim — same fail-soft as for a missing resolver.
+ */
+const MAX_DEPTH = 64;
+
+interface ResolveContext {
+  resolvers: Map<string, ConfigResolver>;
+  onError: NonNullable<ResolveLazyConfigOptions['onError']>;
+  /**
+   * Map from input object/array to its resolved replacement. Serves two
+   * purposes simultaneously:
+   *   1. Cycle protection — without it, a self-referential config would
+   *      recurse forever.
+   *   2. DAG fidelity — a sub-tree referenced from two places gets cloned
+   *      once and the same clone is reused for every reference, preserving
+   *      structure and ensuring sentinels under shared references are still
+   *      resolved.
+   */
+  resolved: WeakMap<object, unknown>;
+}
+
 async function resolveValue(
   value: unknown,
-  resolvers: Map<string, ConfigResolver>,
-  onError: NonNullable<ResolveLazyConfigOptions['onError']>,
-  seen: WeakSet<object>,
+  ctx: ResolveContext,
+  depth: number,
 ): Promise<unknown> {
   if (isLazyConfigSentinel(value)) {
     const name = getSentinelName(value);
-    const resolver = resolvers.get(name);
+    const resolver = ctx.resolvers.get(name);
     if (!resolver) {
-      if (onError === 'throw') {
+      if (ctx.onError === 'throw') {
         throw new Error(
           `Lazy config sentinel references unknown resolver "${name}"`,
         );
       }
-      if (onError === 'omit') return REMOVE;
+      if (ctx.onError === 'omit') return REMOVE;
       return value;
     }
 
     try {
       return await resolver();
     } catch (error) {
-      if (onError === 'throw') throw error;
-      if (onError === 'omit') return REMOVE;
+      if (ctx.onError === 'throw') throw error;
+      if (ctx.onError === 'omit') return REMOVE;
       return value;
     }
   }
 
+  if (depth > MAX_DEPTH) {
+    // Defensive: refuse to recurse further. The original sub-tree is
+    // returned as-is; sentinels beyond this point will stay unresolved.
+    return value;
+  }
+
   if (Array.isArray(value)) {
-    if (seen.has(value)) return value;
-    seen.add(value);
+    const cached = ctx.resolved.get(value);
+    if (cached !== undefined) return cached;
     const next: unknown[] = [];
+    // Register the placeholder *before* descending so that a cycle pointing
+    // back at this array sees the in-progress array (and stops recursing).
+    ctx.resolved.set(value, next);
     for (const entry of value) {
-      const resolved = await resolveValue(entry, resolvers, onError, seen);
+      const resolved = await resolveValue(entry, ctx, depth + 1);
       if (resolved !== REMOVE) next.push(resolved);
     }
     return next;
   }
 
   if (value && typeof value === 'object') {
-    if (seen.has(value)) return value;
-    seen.add(value);
+    const cached = ctx.resolved.get(value);
+    if (cached !== undefined) return cached;
     const next: Record<string, unknown> = {};
+    ctx.resolved.set(value, next);
     for (const [key, entry] of Object.entries(
       value as Record<string, unknown>,
     )) {
-      const resolved = await resolveValue(entry, resolvers, onError, seen);
+      const resolved = await resolveValue(entry, ctx, depth + 1);
       if (resolved !== REMOVE) next[key] = resolved;
     }
     return next;
@@ -273,13 +307,15 @@ export async function resolveLazyConfig<T extends Record<string, unknown>>(
     ? normalizeResolverMap(options.resolvers)
     : globalResolvers;
 
-  const seen = new WeakSet<object>();
-  const sentinelResolved = (await resolveValue(
-    config,
+  const ctx: ResolveContext = {
     resolvers,
     onError,
-    seen,
-  )) as Record<string, unknown>;
+    resolved: new WeakMap<object, unknown>(),
+  };
+  const sentinelResolved = (await resolveValue(config, ctx, 0)) as Record<
+    string,
+    unknown
+  >;
 
   const result: Record<string, unknown> = { ...sentinelResolved };
 
@@ -287,7 +323,11 @@ export async function resolveLazyConfig<T extends Record<string, unknown>>(
     for (const [key, resolver] of Object.entries(options.classResolvers)) {
       try {
         const value = await resolver();
-        if (typeof value !== 'undefined') {
+        // Both `undefined` and `null` are treated as "no overlay value" —
+        // the persisted record's existing value (if any) is preserved.
+        // This matches the documented contract on `Agent.configResolvers`
+        // and makes the common pattern `() => process.env.X ?? null` safe.
+        if (value !== undefined && value !== null) {
           result[key] = value;
         }
       } catch (error) {

--- a/packages/jobs/src/__tests__/lazy-agent-config.test.ts
+++ b/packages/jobs/src/__tests__/lazy-agent-config.test.ts
@@ -130,6 +130,40 @@ describe('TaskRunner — lazy agent_config resolution (issue #1161)', () => {
     expect(observed.keepThis).toBe('persisted-keep');
   });
 
+  it('preserves persisted value when class resolver returns null (env unset)', async () => {
+    // No LAZY_AGENT_CLASS_VAR in env, so the class resolver returns null.
+    // The persisted value must NOT be clobbered with null.
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    const jobs = await SmrtJobCollection.create({ db });
+
+    await jobs.create({
+      objectType: 'LazyConfigProbe',
+      method: 'ping',
+      args: {
+        _agentConfig: { classOverlay: 'must-survive' },
+      },
+    });
+
+    const runner = createTaskRunner({ concurrency: 1, pollInterval: 10 });
+    await runner.initialize(db);
+
+    const completed = new Promise<void>((resolve, reject) => {
+      runner.once('job:completed', () => resolve());
+      runner.once('job:failed', (_job, error) => reject(error));
+    });
+
+    await runner.start();
+    try {
+      await completed;
+    } finally {
+      await runner.stop();
+    }
+
+    expect(LazyConfigProbe.lastConstructorOptions?.classOverlay).toBe(
+      'must-survive',
+    );
+  });
+
   it('leaves persisted values untouched when no resolver is registered', async () => {
     const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
     const jobs = await SmrtJobCollection.create({ db });
@@ -158,5 +192,45 @@ describe('TaskRunner — lazy agent_config resolution (issue #1161)', () => {
     }
 
     expect(LazyConfigProbe.lastConstructorOptions?.plain).toBe('value');
+  });
+
+  it('fails the job fast when a sentinel references an unknown resolver', async () => {
+    // Issue #1161 + Copilot review: TaskRunner uses `onError: 'throw'` so a
+    // missing resolver (e.g. forgotten `registerConfigResolver` at boot)
+    // surfaces as a clear error at the job boundary rather than spreading a
+    // sentinel object into the agent constructor.
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    const jobs = await SmrtJobCollection.create({ db });
+
+    await jobs.create({
+      objectType: 'LazyConfigProbe',
+      method: 'ping',
+      args: {
+        _agentConfig: {
+          assetStorage: { $env: 'definitelyNotRegistered' },
+        },
+      },
+      maxAttempts: 1,
+    });
+
+    const runner = createTaskRunner({ concurrency: 1, pollInterval: 10 });
+    await runner.initialize(db);
+
+    const failure = new Promise<Error>((resolve, reject) => {
+      runner.once('job:failed', (_job, error) => resolve(error as Error));
+      runner.once('job:completed', () =>
+        reject(new Error('job should have failed')),
+      );
+    });
+
+    await runner.start();
+    let error: Error;
+    try {
+      error = await failure;
+    } finally {
+      await runner.stop();
+    }
+
+    expect(error.message).toMatch(/unknown resolver "definitelyNotRegistered"/);
   });
 });

--- a/packages/jobs/src/__tests__/lazy-agent-config.test.ts
+++ b/packages/jobs/src/__tests__/lazy-agent-config.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Issue #1161 — TaskRunner must resolve lazy / env-derived `agent_config`
+ * fields at execute time, not return whatever was snapshotted at sync time.
+ *
+ * The dashboard previously had to add a hand-rolled `overlayPraecoEnvStorage`
+ * shim that re-resolved env-derived storage every time a Praeco schedule
+ * fired (anytown.ai PR #270, apps/dashboard/src/lib/server/agent-schedules.ts).
+ * Native lazy resolution removes that workaround.
+ */
+import {
+  getTestDatabase,
+  ObjectRegistry,
+  registerConfigResolver,
+  resetConfigResolvers,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createTaskRunner } from '../runner.js';
+import { SmrtJobCollection } from '../smrt-job.js';
+
+@smrt()
+class LazyConfigProbe extends SmrtObject {
+  // Capture the constructor options for the test to assert against.
+  static lastConstructorOptions: Record<string, unknown> | null = null;
+
+  // Per-class lazy resolver that always reflects the live env value.
+  static configResolvers = {
+    classOverlay: () => process.env.LAZY_AGENT_CLASS_VAR ?? null,
+  };
+
+  constructor(options: Record<string, unknown> = {}) {
+    super(options as never);
+    LazyConfigProbe.lastConstructorOptions = { ...options };
+  }
+
+  async ping(): Promise<string> {
+    return 'pong';
+  }
+}
+
+afterEach(() => {
+  ObjectRegistry.clearCollectionCache?.();
+  resetConfigResolvers();
+  delete process.env.LAZY_AGENT_ENV_VAR;
+  delete process.env.LAZY_AGENT_CLASS_VAR;
+  LazyConfigProbe.lastConstructorOptions = null;
+});
+
+describe('TaskRunner — lazy agent_config resolution (issue #1161)', () => {
+  it('resolves $env sentinels at execute time using the live registry', async () => {
+    process.env.LAZY_AGENT_ENV_VAR = 'live-storage';
+    registerConfigResolver(
+      'sharedAssetStorage',
+      () => process.env.LAZY_AGENT_ENV_VAR,
+    );
+
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    const jobs = await SmrtJobCollection.create({ db });
+
+    // Simulate a stale persisted agent_config: a sentinel that points at the
+    // resolver instead of a snapshotted env value.
+    await jobs.create({
+      objectType: 'LazyConfigProbe',
+      method: 'ping',
+      args: {
+        _agentConfig: {
+          assetStorage: { $env: 'sharedAssetStorage' },
+          unrelated: 'persisted',
+        },
+      },
+    });
+
+    const runner = createTaskRunner({ concurrency: 1, pollInterval: 10 });
+    await runner.initialize(db);
+
+    const completed = new Promise<void>((resolve, reject) => {
+      runner.once('job:completed', () => resolve());
+      runner.once('job:failed', (_job, error) => reject(error));
+    });
+
+    await runner.start();
+    try {
+      // Rotate the env between persistence and execution to prove freshness.
+      process.env.LAZY_AGENT_ENV_VAR = 'rotated-storage';
+      await completed;
+    } finally {
+      await runner.stop();
+    }
+
+    const observed = LazyConfigProbe.lastConstructorOptions ?? {};
+    expect(observed.assetStorage).toBe('rotated-storage');
+    expect(observed.unrelated).toBe('persisted');
+  });
+
+  it('overlays static configResolvers on top of persisted values', async () => {
+    process.env.LAZY_AGENT_CLASS_VAR = 'class-live';
+
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    const jobs = await SmrtJobCollection.create({ db });
+
+    await jobs.create({
+      objectType: 'LazyConfigProbe',
+      method: 'ping',
+      args: {
+        _agentConfig: {
+          classOverlay: 'persisted-stale',
+          keepThis: 'persisted-keep',
+        },
+      },
+    });
+
+    const runner = createTaskRunner({ concurrency: 1, pollInterval: 10 });
+    await runner.initialize(db);
+
+    const completed = new Promise<void>((resolve, reject) => {
+      runner.once('job:completed', () => resolve());
+      runner.once('job:failed', (_job, error) => reject(error));
+    });
+
+    await runner.start();
+    try {
+      await completed;
+    } finally {
+      await runner.stop();
+    }
+
+    const observed = LazyConfigProbe.lastConstructorOptions ?? {};
+    expect(observed.classOverlay).toBe('class-live');
+    expect(observed.keepThis).toBe('persisted-keep');
+  });
+
+  it('leaves persisted values untouched when no resolver is registered', async () => {
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    const jobs = await SmrtJobCollection.create({ db });
+
+    await jobs.create({
+      objectType: 'LazyConfigProbe',
+      method: 'ping',
+      args: {
+        _agentConfig: { plain: 'value' },
+      },
+    });
+
+    const runner = createTaskRunner({ concurrency: 1, pollInterval: 10 });
+    await runner.initialize(db);
+
+    const completed = new Promise<void>((resolve, reject) => {
+      runner.once('job:completed', () => resolve());
+      runner.once('job:failed', (_job, error) => reject(error));
+    });
+
+    await runner.start();
+    try {
+      await completed;
+    } finally {
+      await runner.stop();
+    }
+
+    expect(LazyConfigProbe.lastConstructorOptions?.plain).toBe('value');
+  });
+});

--- a/packages/jobs/src/runner.ts
+++ b/packages/jobs/src/runner.ts
@@ -324,9 +324,17 @@ export class TaskRunner extends EventEmitter {
       // operators can rotate env vars without rewriting persisted schedule
       // rows (issue #1161). Class-level `static configResolvers` are layered
       // on top so live values always win over snapshotted ones.
+      //
+      // `onError: 'throw'` so a misconfigured deployment fails fast at the
+      // job boundary with a clear "unknown resolver X" error, rather than
+      // silently spreading a `{ $env: '...' }` sentinel object into the
+      // agent constructor (where it would surface much later as a confusing
+      // downstream failure — e.g. `[object Object]` masquerading as a
+      // bucket name).
       const classResolvers = getClassConfigResolvers(ObjectClass);
       const agentConfig = await resolveLazyConfig(persistedAgentConfig, {
         classResolvers,
+        onError: 'throw',
       });
 
       // Create or load the object instance

--- a/packages/jobs/src/runner.ts
+++ b/packages/jobs/src/runner.ts
@@ -5,7 +5,12 @@ import './__smrt-register__.js';
 import { EventEmitter } from 'node:events';
 import { fromConfig, type RetryDecision } from '@happyvertical/jobs';
 import { createLogger } from '@happyvertical/logger';
-import { ObjectRegistry, type SmrtObject } from '@happyvertical/smrt-core';
+import {
+  getClassConfigResolvers,
+  ObjectRegistry,
+  resolveLazyConfig,
+  type SmrtObject,
+} from '@happyvertical/smrt-core';
 import { TenantContext } from '@happyvertical/smrt-tenancy';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { createId } from '@happyvertical/utils';
@@ -309,11 +314,20 @@ export class TaskRunner extends EventEmitter {
 
       // Extract internal keys from args before passing to constructor/method
       const rawArgs = (job.args ?? {}) as Record<string, unknown>;
-      const agentConfig = (rawArgs._agentConfig ?? {}) as Record<
+      const persistedAgentConfig = (rawArgs._agentConfig ?? {}) as Record<
         string,
         unknown
       >;
       const { _agentConfig: _, _scheduleId: __, ...methodArgs } = rawArgs;
+
+      // Resolve any lazy / env-derived config sentinels at execute time so
+      // operators can rotate env vars without rewriting persisted schedule
+      // rows (issue #1161). Class-level `static configResolvers` are layered
+      // on top so live values always win over snapshotted ones.
+      const classResolvers = getClassConfigResolvers(ObjectClass);
+      const agentConfig = await resolveLazyConfig(persistedAgentConfig, {
+        classResolvers,
+      });
 
       // Create or load the object instance
       let instance: SmrtObject;


### PR DESCRIPTION
## Summary

Implements two related downstream pain points in a single release. Both come from anytown.ai PR #270 — code that scattered defensive `typeof === 'function'` guards (#1162) and a hand-rolled env-overlay shim (#1161) that the framework should make unnecessary.

### Issue #1162 — `AssetAssociable` contract

- New `AssetAssociable` and `MetadataAccessor` interfaces in `@happyvertical/smrt-content`.
- `Content` now `implements AssetAssociable, MetadataAccessor` so consumers can type their parameters directly and drop runtime guards.
- Adds `getMetadata()`, `setMetadata()`, and `updateMetadata()` helpers, replacing the `doc.metadata = m; return m` patterns.

### Issue #1161 — lazy `agent_config` resolution

- New `@happyvertical/smrt-core` module: `lazy-config.ts` with `registerConfigResolver`, `resolveLazyConfig`, `getClassConfigResolvers`, and friends. Re-exported from `@happyvertical/smrt-agents` for discoverability.
- Two complementary mechanisms supported:
  1. `{ "$env": "name" }` / `{ "$resolver": "name" }` sentinels in persisted JSON, resolved against a global registry.
  2. `static configResolvers` map on the agent class — discoverable, declarative overlay applied on top of the persisted config.
- `TaskRunner` calls `resolveLazyConfig()` immediately before constructing the agent. Rotated env values reach the next scheduled run without rewriting the schedule row. The dashboard's `overlayPraecoEnvStorage` shim becomes redundant.

## Test plan

- [x] 27 unit tests for `resolveLazyConfig` — sentinel walk, class overlay, error policies (`leave`/`omit`/`throw`), cyclic structures, prototype-chain walk for inherited resolvers
- [x] 10 unit tests for `Content` — implements interfaces, exposes methods, metadata helpers handle null/undefined/replace/merge
- [x] 3 integration tests for `TaskRunner` with `_agentConfig` — proves env rotation reaches the live agent, class resolvers override persisted, plain values pass through unchanged
- [x] `npm run build` (full monorepo, 42 packages, 45.5s)
- [x] `npx biome check` clean on all 11 changed files
- [x] `npm run typecheck` clean for `smrt-core`
- [x] `svelte-check` clean for `smrt-agents`, `smrt-content`, `smrt-jobs`
- [x] No new test failures in `smrt-jobs` (35/35 pass) or affected `smrt-content` suites (36/36 pass on touched areas)

Closes #1161
Closes #1162