### PR TITLE
fix(core,cli): repair index drift in db:migrate (#1165)

### DIFF
--- a/packages/cli/src/commands/__tests__/db-migrate-actions.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-actions.test.ts
@@ -149,6 +149,64 @@ describe('partitionSchemaChanges', () => {
     expect(manualInterventions).toEqual([]);
   });
 
+  it('preserves drop_index changes (issue #1165 shape-drift repair)', () => {
+    // The shape-drift repair emits drop_index + add_index in change order.
+    // partitionSchemaChanges must surface BOTH in the executable migration
+    // set with the drop preceding the add — otherwise the add's IF NOT
+    // EXISTS silently no-ops against the wrong-shape index that's still
+    // there, and the migration looks "successful" but changes nothing.
+    const { migrations, manualInterventions } = partitionSchemaChanges(
+      [
+        {
+          type: 'drop_index',
+          table: 'tenants',
+          name: 'tenants_slug_context_meta_type_idx',
+          sql: 'DROP INDEX IF EXISTS "tenants_slug_context_meta_type_idx"',
+        },
+        {
+          type: 'add_index',
+          table: 'tenants',
+          name: 'tenants_slug_context_meta_type_idx',
+          index: {
+            name: 'tenants_slug_context_meta_type_idx',
+            columns: ['slug', 'context', '_meta_type'],
+            unique: true,
+          },
+          sql: 'CREATE UNIQUE INDEX "tenants_slug_context_meta_type_idx" ON "tenants" ("slug", "context", "_meta_type")',
+        },
+      ],
+      () => 'Tenant',
+    );
+
+    expect(manualInterventions).toEqual([]);
+    expect(migrations).toHaveLength(2);
+    expect(migrations[0]).toEqual({
+      type: 'drop_index',
+      tableName: 'tenants',
+      className: 'Tenant',
+      indexName: 'tenants_slug_context_meta_type_idx',
+      sql: 'DROP INDEX IF EXISTS "tenants_slug_context_meta_type_idx"',
+    });
+    expect(migrations[1].type).toBe('add_index');
+    expect(migrations[1].index?.unique).toBe(true);
+  });
+
+  it('skips drop_index when name is missing', () => {
+    const { migrations } = partitionSchemaChanges(
+      [
+        {
+          type: 'drop_index',
+          table: 'tenants',
+          // no name — invalid input, must be skipped not crashed
+          sql: 'DROP INDEX IF EXISTS ""',
+        },
+      ],
+      () => 'Tenant',
+    );
+
+    expect(migrations).toHaveLength(0);
+  });
+
   it('separates incompatible type mismatches from executable repairs', () => {
     const { migrations, manualInterventions } = partitionSchemaChanges(
       [
@@ -286,6 +344,37 @@ describe('failed migration classification', () => {
       ],
       other: [],
     });
+  });
+
+  it('tracks drop_index changes as unresolved when present in the live diff', () => {
+    // Issue #1165 — synthetic name for a drop must roundtrip through the
+    // unresolved/superseded classifier so a failed shape-drift drop shows
+    // up in the right bucket on `smrt db:status`.
+    const unresolvedNames = getUnresolvedGeneratedMigrationNames([
+      {
+        type: 'drop_index',
+        table: 'tenants',
+        name: 'tenants_slug_context_meta_type_idx',
+      },
+    ]);
+
+    expect(
+      unresolvedNames.has('drop_index_tenants_slug_context_meta_type_idx'),
+    ).toBe(true);
+
+    const summary = summarizeFailedMigrations(
+      [
+        {
+          name: 'drop_index_tenants_slug_context_meta_type_idx',
+          error_message: 'transient pg lock failure',
+        },
+      ],
+      unresolvedNames,
+    );
+    expect(summary.unresolved).toHaveLength(1);
+    expect(summary.unresolved[0].name).toBe(
+      'drop_index_tenants_slug_context_meta_type_idx',
+    );
   });
 
   it('falls back to direct-review classification when live drift comparison is unavailable', () => {

--- a/packages/cli/src/commands/__tests__/db-migrate-actions.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-actions.test.ts
@@ -350,31 +350,91 @@ describe('failed migration classification', () => {
     // Issue #1165 — synthetic name for a drop must roundtrip through the
     // unresolved/superseded classifier so a failed shape-drift drop shows
     // up in the right bucket on `smrt db:status`.
+    //
+    // The synthetic name now embeds a short SQL fingerprint to avoid
+    // checksum collisions when an index is recreated under the same name
+    // with a different shape across migrate runs. The classifier matches
+    // by `drop_index_` prefix, so the fingerprint suffix doesn't change
+    // routing — but assertions on exact names must use the same name on
+    // both sides of the comparison (i.e., feed the SAME `change.sql` into
+    // both the unresolved-set builder and the failed-migration record).
+    const failedSql =
+      'DROP INDEX IF EXISTS "tenants_slug_context_meta_type_idx"';
     const unresolvedNames = getUnresolvedGeneratedMigrationNames([
       {
         type: 'drop_index',
         table: 'tenants',
         name: 'tenants_slug_context_meta_type_idx',
+        sql: failedSql,
       },
     ]);
 
-    expect(
-      unresolvedNames.has('drop_index_tenants_slug_context_meta_type_idx'),
-    ).toBe(true);
+    // The unresolved set should contain exactly one drop_index_* entry.
+    const dropEntries = [...unresolvedNames].filter((n) =>
+      n.startsWith('drop_index_tenants_slug_context_meta_type_idx_'),
+    );
+    expect(dropEntries).toHaveLength(1);
+    const failedMigrationName = dropEntries[0];
 
     const summary = summarizeFailedMigrations(
       [
         {
-          name: 'drop_index_tenants_slug_context_meta_type_idx',
+          name: failedMigrationName,
           error_message: 'transient pg lock failure',
         },
       ],
       unresolvedNames,
     );
     expect(summary.unresolved).toHaveLength(1);
-    expect(summary.unresolved[0].name).toBe(
-      'drop_index_tenants_slug_context_meta_type_idx',
-    );
+    expect(summary.unresolved[0].name).toBe(failedMigrationName);
+  });
+
+  it('emits the same synthetic id for the same SQL across runs and a different one when the SQL changes', () => {
+    // Same shape twice → same id. Different shape (drift) → different id.
+    // This is the property that lets MigrationTracker apply repeat repairs
+    // without "checksum mismatch" errors.
+    const idA = getUnresolvedGeneratedMigrationNames([
+      {
+        type: 'add_index',
+        table: 'tenants',
+        name: 'tenants_slug_context_meta_type_idx',
+        index: {
+          name: 'tenants_slug_context_meta_type_idx',
+          columns: ['slug', 'context', '_meta_type'],
+          unique: true,
+        },
+        sql: 'CREATE UNIQUE INDEX "x" ON "y" ("a", "b", "c")',
+      },
+    ]);
+    const idASame = getUnresolvedGeneratedMigrationNames([
+      {
+        type: 'add_index',
+        table: 'tenants',
+        name: 'tenants_slug_context_meta_type_idx',
+        index: {
+          name: 'tenants_slug_context_meta_type_idx',
+          columns: ['slug', 'context', '_meta_type'],
+          unique: true,
+        },
+        sql: 'CREATE UNIQUE INDEX "x" ON "y" ("a", "b", "c")',
+      },
+    ]);
+    const idDrifted = getUnresolvedGeneratedMigrationNames([
+      {
+        type: 'add_index',
+        table: 'tenants',
+        name: 'tenants_slug_context_meta_type_idx',
+        index: {
+          name: 'tenants_slug_context_meta_type_idx',
+          columns: ['slug', 'context', '_meta_type'],
+          unique: false, // ← shape drifted
+        },
+        sql: 'CREATE INDEX "x" ON "y" ("a", "b", "c")',
+      },
+    ]);
+
+    expect([...idA]).toEqual([...idASame]);
+    expect([...idA]).not.toEqual([...idDrifted]);
   });
 
   it('falls back to direct-review classification when live drift comparison is unavailable', () => {

--- a/packages/cli/src/commands/db-diff.ts
+++ b/packages/cli/src/commands/db-diff.ts
@@ -58,6 +58,12 @@ export const dbDiffCommand: CLICommand = {
       default: false,
       short: 'v',
     },
+    'drop-indexes': {
+      type: 'boolean',
+      description:
+        'Include orphan-index drops in the diff (indexes in DB but not in the manifest, excluding *_pkey/*_key implicit-from-constraint indexes). Off by default for safety.',
+      default: false,
+    },
   },
   handler: async (_args: string[], options: any) => {
     let db: any;
@@ -144,6 +150,7 @@ export const dbDiffCommand: CLICommand = {
       const comparer = new SchemaComparer(db, {
         includeDroppedTables: false,
         includeDroppedColumns: false,
+        includeDroppedIndexes: Boolean(options['drop-indexes']),
         ignoreTypeMismatches: !options.verbose,
       });
 

--- a/packages/cli/src/commands/db-diff.ts
+++ b/packages/cli/src/commands/db-diff.ts
@@ -195,9 +195,23 @@ export const dbDiffCommand: CLICommand = {
       const indexChanges = diff.changes.filter(
         (c: any) => c.type === 'add_index',
       );
+      const indexDrops = diff.changes.filter(
+        (c: any) => c.type === 'drop_index',
+      );
       const typeMismatches = diff.changes.filter(
         (c: any) => c.type === 'type_mismatch',
       );
+
+      // Identify shape-drift recreate pairs (drop+add on same name) so the
+      // operator sees them as a single repair action rather than two
+      // disconnected events. Issue #1165.
+      const recreateNames = new Set<string>();
+      const dropNames = new Set(indexDrops.map((c: any) => c.name));
+      for (const add of indexChanges) {
+        if (add.name && dropNames.has(add.name)) {
+          recreateNames.add(add.name);
+        }
+      }
 
       if (columnChanges.length > 0) {
         console.log(`  📊 New columns (${columnChanges.length}):`);
@@ -207,9 +221,36 @@ export const dbDiffCommand: CLICommand = {
         console.log();
       }
 
-      if (indexChanges.length > 0) {
-        console.log(`  🗂️  New indexes (${indexChanges.length}):`);
-        for (const change of indexChanges) {
+      if (recreateNames.size > 0) {
+        console.log(`  ♻️  Indexes to recreate (${recreateNames.size}):`);
+        for (const name of recreateNames) {
+          const add = indexChanges.find((c: any) => c.name === name);
+          const cols = add?.index?.columns?.join(', ') ?? '?';
+          const unique = add?.index?.unique ? 'UNIQUE ' : '';
+          console.log(`     ↻ ${name} → ${unique}(${cols})`);
+        }
+        console.log(
+          '     (each recreate is a drop_index followed by add_index)\n',
+        );
+      }
+
+      const orphanDrops = indexDrops.filter(
+        (c: any) => !recreateNames.has(c.name),
+      );
+      if (orphanDrops.length > 0) {
+        console.log(`  🗑️  Indexes to drop (${orphanDrops.length}):`);
+        for (const change of orphanDrops) {
+          console.log(`     - ${change.name} on ${change.table}`);
+        }
+        console.log();
+      }
+
+      const newIndexes = indexChanges.filter(
+        (c: any) => !recreateNames.has(c.name),
+      );
+      if (newIndexes.length > 0) {
+        console.log(`  🗂️  New indexes (${newIndexes.length}):`);
+        for (const change of newIndexes) {
           console.log(`     + ${change.name} on ${change.table}`);
         }
         console.log();

--- a/packages/cli/src/commands/db-migrate-actions.ts
+++ b/packages/cli/src/commands/db-migrate-actions.ts
@@ -1,5 +1,10 @@
 export interface MigrationAction {
-  type: 'add_column' | 'add_index' | 'type_mismatch' | 'type_upgrade';
+  type:
+    | 'add_column'
+    | 'add_index'
+    | 'drop_index'
+    | 'type_mismatch'
+    | 'type_upgrade';
   tableName: string;
   className: string;
   column?: {
@@ -14,6 +19,13 @@ export interface MigrationAction {
     columns: string[];
     unique?: boolean;
   };
+  /**
+   * Set on `drop_index` actions — the index name being dropped. We track
+   * this separately from `index` because the differ does not (and cannot,
+   * for the orphan-drop case) always know the original column list of a
+   * DB-side index that's being removed.
+   */
+  indexName?: string;
   mismatch?: {
     column: string;
     expected: string;
@@ -118,6 +130,13 @@ export function getSyntheticMigrationNameForAction(
     case 'add_index':
       return action.index ? `add_index_${action.index.name}` : null;
 
+    case 'drop_index':
+      // Drops are emitted as part of shape-drift repair (paired with an
+      // add_index of the same name) or as orphan cleanups. The synthetic
+      // name needs to differ from the paired add_index so the tracker
+      // doesn't treat them as the same migration. Issue #1165.
+      return action.indexName ? `drop_index_${action.indexName}` : null;
+
     case 'type_upgrade':
       return action.column
         ? `type_upgrade_${action.tableName}_${action.column.name}`
@@ -139,6 +158,9 @@ export function getSyntheticMigrationNameForChange(
       const indexName = change.index?.name ?? change.name;
       return indexName ? `add_index_${indexName}` : null;
     }
+
+    case 'drop_index':
+      return change.name ? `drop_index_${change.name}` : null;
 
     case 'type_upgrade':
       return change.name ? `type_upgrade_${change.table}_${change.name}` : null;
@@ -170,6 +192,7 @@ export function classifyFailedMigration(
   if (
     !migrationName.startsWith('add_column_') &&
     !migrationName.startsWith('add_index_') &&
+    !migrationName.startsWith('drop_index_') &&
     !migrationName.startsWith('type_upgrade_')
   ) {
     return 'other';
@@ -189,6 +212,7 @@ export function getUnresolvedGeneratedMigrationNames(
     if (
       change.type !== 'add_column' &&
       change.type !== 'add_index' &&
+      change.type !== 'drop_index' &&
       change.type !== 'type_upgrade'
     ) {
       continue;
@@ -311,6 +335,28 @@ export function partitionSchemaChanges(
             columns: idx.columns,
             unique: idx.unique,
           },
+          sql: change.sql,
+          ...(change.sqlStatements
+            ? { sqlStatements: change.sqlStatements }
+            : {}),
+        });
+        break;
+      }
+
+      case 'drop_index': {
+        // Issue #1165: shape-drift repair pushes `drop_index` then
+        // `add_index` for the same name in change-order. We preserve that
+        // order in `migrations` by pushing here, so the drop runs before
+        // the add and the recreate actually happens (otherwise the add's
+        // `IF NOT EXISTS` silently no-ops against the wrong-shape index).
+        // Orphan-index drops (opt-in via includeDroppedIndexes) flow
+        // through the same path.
+        if (!change.name) continue;
+        migrations.push({
+          type: 'drop_index',
+          tableName: change.table,
+          className,
+          indexName: change.name,
           sql: change.sql,
           ...(change.sqlStatements
             ? { sqlStatements: change.sqlStatements }

--- a/packages/cli/src/commands/db-migrate-actions.ts
+++ b/packages/cli/src/commands/db-migrate-actions.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 export interface MigrationAction {
   type:
     | 'add_column'
@@ -97,6 +99,44 @@ export interface DbMigrateFailureState {
   dryRun?: boolean;
 }
 
+/**
+ * Short stable fingerprint of the SQL we'd execute for an action, used
+ * to disambiguate index synthetic ids when an index's shape changes
+ * across migrations.
+ *
+ * Issue #1165: when shape-drift repair recreates an index under the same
+ * name (e.g., `tenants_slug_context_meta_type_idx` flipped non-unique →
+ * unique), the new `add_index_<name>` migration carries different SQL
+ * than the previous run's record. The MigrationTracker rejects "Already
+ * applied with different checksum" even under `reconcile: true`. By
+ * including this fingerprint in the synthetic id, each distinct shape
+ * gets its own tracker row and the repair always applies cleanly.
+ */
+function sqlShapeFingerprint(action: {
+  sql?: string;
+  sqlStatements?: string[];
+  index?: { name: string; columns: string[]; unique?: boolean };
+}): string {
+  const parts: string[] = [];
+  if (action.sqlStatements && action.sqlStatements.length > 0) {
+    parts.push(...action.sqlStatements);
+  } else if (action.sql) {
+    parts.push(action.sql);
+  } else if (action.index) {
+    // Fallback: derive a fingerprint from the structural index shape so
+    // callers without SQL still get distinct ids for distinct shapes.
+    parts.push(
+      `${action.index.name}|${(action.index.unique ?? false) ? 'U' : 'N'}|${action.index.columns.join(',')}`,
+    );
+  }
+  if (parts.length === 0) {
+    return '';
+  }
+  // Normalize whitespace so trivial reformatting doesn't churn the hash.
+  const normalized = parts.map((s) => s.replace(/\s+/g, ' ').trim()).join(';');
+  return createHash('sha256').update(normalized).digest('hex').slice(0, 8);
+}
+
 export function classifyTypeUpgradeSql(sql?: string): TypeUpgradeExecutionKind {
   const trimmed = sql?.trim();
 
@@ -127,15 +167,24 @@ export function getSyntheticMigrationNameForAction(
         ? `add_column_${action.tableName}_${action.column.name}`
         : null;
 
-    case 'add_index':
-      return action.index ? `add_index_${action.index.name}` : null;
+    case 'add_index': {
+      if (!action.index) return null;
+      // The 8-char fingerprint dodges checksum collisions when the same
+      // index name is recreated with a different shape across migrate
+      // runs. Issue #1165.
+      const fingerprint = sqlShapeFingerprint(action);
+      return fingerprint
+        ? `add_index_${action.index.name}_${fingerprint}`
+        : `add_index_${action.index.name}`;
+    }
 
-    case 'drop_index':
-      // Drops are emitted as part of shape-drift repair (paired with an
-      // add_index of the same name) or as orphan cleanups. The synthetic
-      // name needs to differ from the paired add_index so the tracker
-      // doesn't treat them as the same migration. Issue #1165.
-      return action.indexName ? `drop_index_${action.indexName}` : null;
+    case 'drop_index': {
+      if (!action.indexName) return null;
+      const fingerprint = sqlShapeFingerprint(action);
+      return fingerprint
+        ? `drop_index_${action.indexName}_${fingerprint}`
+        : `drop_index_${action.indexName}`;
+    }
 
     case 'type_upgrade':
       return action.column
@@ -156,11 +205,27 @@ export function getSyntheticMigrationNameForChange(
 
     case 'add_index': {
       const indexName = change.index?.name ?? change.name;
-      return indexName ? `add_index_${indexName}` : null;
+      if (!indexName) return null;
+      const fingerprint = sqlShapeFingerprint({
+        sql: change.sql,
+        sqlStatements: change.sqlStatements,
+        index: change.index,
+      });
+      return fingerprint
+        ? `add_index_${indexName}_${fingerprint}`
+        : `add_index_${indexName}`;
     }
 
-    case 'drop_index':
-      return change.name ? `drop_index_${change.name}` : null;
+    case 'drop_index': {
+      if (!change.name) return null;
+      const fingerprint = sqlShapeFingerprint({
+        sql: change.sql,
+        sqlStatements: change.sqlStatements,
+      });
+      return fingerprint
+        ? `drop_index_${change.name}_${fingerprint}`
+        : `drop_index_${change.name}`;
+    }
 
     case 'type_upgrade':
       return change.name ? `type_upgrade_${change.table}_${change.name}` : null;

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -1066,6 +1066,12 @@ export default testManifest;
           'Upgrade STI discriminators from simple class names to qualified names (@pkg:Class)',
         default: false,
       },
+      'drop-indexes': {
+        type: 'boolean',
+        description:
+          'Drop orphan indexes (in DB but not in manifest, excluding *_pkey/*_key implicit-from-constraint indexes). Off by default.',
+        default: false,
+      },
       verbose: {
         type: 'boolean',
         description: 'Show detailed output',
@@ -1223,8 +1229,13 @@ export default testManifest;
 
         console.log('🔍 Comparing schemas...\n');
 
-        // Use SchemaComparer from core for consistent schema diff
-        const comparer = new SchemaComparer(db);
+        // Use SchemaComparer from core for consistent schema diff. The
+        // same-name shape drift detection is always on (unblocks issue
+        // #1165 automatically); orphan-index drops are gated behind
+        // --drop-indexes for safety.
+        const comparer = new SchemaComparer(db, {
+          includeDroppedIndexes: Boolean(options['drop-indexes']),
+        });
         const diff = await comparer.compare(manifestSchemas);
 
         // Helper to get class name for a table (for reporting)
@@ -1369,6 +1380,7 @@ export default testManifest;
           const indexMigrations = migrations.filter(
             (m) => m.type === 'add_index',
           );
+          const indexDrops = migrations.filter((m) => m.type === 'drop_index');
 
           if (columnMigrations.length > 0) {
             console.log(`  📊 Columns to add: ${columnMigrations.length}`);
@@ -1376,6 +1388,17 @@ export default testManifest;
               console.log(
                 `     ${m.tableName}.${m.column?.name} (${m.column?.type})`,
               );
+            }
+            console.log();
+          }
+
+          if (indexDrops.length > 0) {
+            // Drops are listed before adds because that's the execution
+            // order (a shape-drift recreate emits drop+add for the same
+            // name; the drop must precede the add).
+            console.log(`  🗑️  Indexes to drop: ${indexDrops.length}`);
+            for (const m of indexDrops) {
+              console.log(`     ${m.indexName} on ${m.tableName}`);
             }
             console.log();
           }
@@ -1441,6 +1464,12 @@ export default testManifest;
               } else if (migration.type === 'add_index' && migration.index) {
                 migrationSql = migration.sql || '';
                 actionDesc = `Created index ${migration.index.name} on ${migration.tableName}`;
+              } else if (
+                migration.type === 'drop_index' &&
+                migration.indexName
+              ) {
+                migrationSql = migration.sql || '';
+                actionDesc = `Dropped index ${migration.indexName} on ${migration.tableName}`;
               } else {
                 continue;
               }
@@ -1455,10 +1484,18 @@ export default testManifest;
                     ? `Add column ${migration.column?.name} to ${migration.tableName}`
                     : migration.type === 'type_upgrade'
                       ? `Upgrade column ${migration.column?.name} on ${migration.tableName} from ${migration.mismatch?.actual} to ${migration.mismatch?.expected}`
-                      : `Add index ${migration.index?.name} on ${migration.tableName}`,
+                      : migration.type === 'drop_index'
+                        ? `Drop index ${migration.indexName} on ${migration.tableName}`
+                        : `Add index ${migration.index?.name} on ${migration.tableName}`,
                 version: '1.0.0',
+                // Auto-migrations don't carry a DOWN script. For shape-drift
+                // index recreates (drop_index + add_index), this means a
+                // rollback would leave the table without the index entirely.
+                // Issue #1165 — surfaced and accepted: the alternative is
+                // capturing the DB-side index shape we just dropped, which
+                // we don't have the introspection wiring for yet.
                 up: migrationSqlStatements,
-                down: [], // Auto-migrations don't have rollback by default
+                down: [],
               };
 
               // Apply migration - tracker handles checksum validation and idempotency

--- a/packages/core/src/__tests__/issue-1165-tenant-upsert-repair.test.ts
+++ b/packages/core/src/__tests__/issue-1165-tenant-upsert-repair.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Issue #1165 — end-to-end regression
+ *
+ * Reproduces the anytown.ai failure mode: a Tenant table whose live schema
+ * carries the wrong index shape (`tenants_slug_context_meta_type_idx`
+ * non-unique, plus a stale 2-column unique on `(slug, context)`), so
+ * `Tenant.save()` fails with "no unique or exclusion constraint matching the
+ * ON CONFLICT specification" on PostgreSQL.
+ *
+ * The fix is in the migration differ: it now detects same-name index-shape
+ * drift (uniqueness flips, column changes) and orphan indexes, emitting a
+ * drop+add repair plan. After applying that plan against the stale schema,
+ * the STI subclass UPSERT succeeds.
+ *
+ * SQLite is permissive enough that the broken-shape index alone doesn't
+ * surface the bug as obviously as PostgreSQL, but the *differ output* is
+ * what we're really asserting — the repair plan must drop the wrong index
+ * and create the right one.
+ */
+
+import type { DatabaseProvider } from '@happyvertical/sql';
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getSQLFromDiff, SchemaComparer } from '../migrations/differ.js';
+import type { SchemaDefinition } from '../schema/types.js';
+
+describe('Issue #1165: tenants STI UPSERT repair via migrate', () => {
+  let db: DatabaseProvider;
+
+  beforeEach(async () => {
+    db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+
+    // Materialize the broken anytown.ai shape exactly as reported in the
+    // issue: 3-column index NON-unique, stale 2-column unique still around.
+    await db.query(`
+      CREATE TABLE tenants (
+        id TEXT PRIMARY KEY,
+        slug TEXT NOT NULL,
+        context TEXT NOT NULL DEFAULT '',
+        _meta_type TEXT NOT NULL,
+        _meta_data TEXT,
+        name TEXT,
+        status TEXT,
+        created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+        updated_at TIMESTAMP NOT NULL DEFAULT current_timestamp
+      )
+    `);
+    await db.query('CREATE INDEX tenants_id_idx ON tenants(id)');
+    await db.query('CREATE INDEX tenants_meta_type_idx ON tenants(_meta_type)');
+    // Stale 2-column unique from an older schema generation.
+    await db.query(
+      'CREATE UNIQUE INDEX tenants_slug_context_idx ON tenants(slug, context)',
+    );
+    // The broken case: right name and columns, but NOT unique. PostgreSQL
+    // would reject ON CONFLICT(slug, context, _meta_type) against this.
+    await db.query(
+      'CREATE INDEX tenants_slug_context_meta_type_idx ON tenants(slug, context, _meta_type)',
+    );
+  });
+
+  afterEach(async () => {
+    await db.close?.();
+  });
+
+  /** What the manifest now declares for the tenants table (STI). */
+  function tenantsManifest(): Record<string, SchemaDefinition> {
+    return {
+      tenants: {
+        tableName: 'tenants',
+        ddl: '',
+        columns: {
+          id: { type: 'TEXT', primaryKey: true, notNull: true },
+          slug: { type: 'TEXT', notNull: true },
+          context: { type: 'TEXT', notNull: true, defaultValue: '' },
+          _meta_type: { type: 'TEXT', notNull: true },
+          _meta_data: { type: 'JSON' },
+          name: { type: 'TEXT' },
+          status: { type: 'TEXT' },
+          created_at: {
+            type: 'TIMESTAMP',
+            notNull: true,
+            defaultValue: 'current_timestamp',
+          },
+          updated_at: {
+            type: 'TIMESTAMP',
+            notNull: true,
+            defaultValue: 'current_timestamp',
+          },
+        },
+        indexes: [
+          { name: 'tenants_id_idx', columns: ['id'], unique: false },
+          {
+            name: 'tenants_meta_type_idx',
+            columns: ['_meta_type'],
+            unique: false,
+          },
+          {
+            name: 'tenants_slug_context_meta_type_idx',
+            columns: ['slug', 'context', '_meta_type'],
+            unique: true,
+          },
+        ],
+        triggers: [],
+        foreignKeys: [],
+        dependencies: [],
+        version: '1.0.0',
+      },
+    };
+  }
+
+  it('produces a drop+add repair plan for the stale index shape', async () => {
+    const comparer = new SchemaComparer(db, { includeDroppedIndexes: true });
+    const diff = await comparer.compare(tenantsManifest());
+
+    const events = diff.changes
+      .filter((c) => c.type === 'drop_index' || c.type === 'add_index')
+      .map((c) => `${c.type}:${c.name}`);
+
+    // The broken-shape recreate.
+    expect(events).toContain('drop_index:tenants_slug_context_meta_type_idx');
+    expect(events).toContain('add_index:tenants_slug_context_meta_type_idx');
+
+    // The stale 2-column unique gets dropped.
+    expect(events).toContain('drop_index:tenants_slug_context_idx');
+
+    // Maintenance indexes that already match are left alone.
+    expect(events).not.toContain('drop_index:tenants_id_idx');
+    expect(events).not.toContain('drop_index:tenants_meta_type_idx');
+  });
+
+  it('after applying the repair plan, ON CONFLICT(slug, context, _meta_type) UPSERT succeeds', async () => {
+    const comparer = new SchemaComparer(db, { includeDroppedIndexes: true });
+    const diff = await comparer.compare(tenantsManifest());
+
+    // Apply the repair SQL the differ produced.
+    for (const sql of getSQLFromDiff(diff)) {
+      await db.query(sql);
+    }
+
+    // Now the table carries a unique index matching the conflict target,
+    // so the upsert plan that previously failed now binds correctly. Use
+    // db.upsert directly so we exercise the same code path SmrtObject.save
+    // takes for STI rows (`['slug', 'context', '_meta_type']`).
+    await db.upsert('tenants', ['slug', 'context', '_meta_type'], {
+      id: 't_doctor_test_1',
+      slug: 'doctor-test-1',
+      context: '/tenants',
+      _meta_type: '@happyvertical/smrt-tenancy:Network',
+      name: 'Doctor Test',
+      status: 'active',
+    });
+
+    // Re-upserting the same key updates the existing row in place.
+    await db.upsert('tenants', ['slug', 'context', '_meta_type'], {
+      id: 't_doctor_test_1',
+      slug: 'doctor-test-1',
+      context: '/tenants',
+      _meta_type: '@happyvertical/smrt-tenancy:Network',
+      name: 'Doctor Test (renamed)',
+      status: 'active',
+    });
+
+    const rowsResult = await db.query(
+      'SELECT name FROM tenants WHERE slug = ? AND context = ? AND _meta_type = ?',
+      ['doctor-test-1', '/tenants', '@happyvertical/smrt-tenancy:Network'],
+    );
+    const rows = Array.isArray(rowsResult) ? rowsResult : rowsResult.rows;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe('Doctor Test (renamed)');
+  });
+
+  it('two STI subtypes can share (slug, context) with the repaired index', async () => {
+    // The whole point of including _meta_type in the conflict target.
+    const comparer = new SchemaComparer(db, { includeDroppedIndexes: true });
+    const diff = await comparer.compare(tenantsManifest());
+    for (const sql of getSQLFromDiff(diff)) {
+      await db.query(sql);
+    }
+
+    await db.upsert('tenants', ['slug', 'context', '_meta_type'], {
+      id: 't_a',
+      slug: 'shared',
+      context: '/tenants',
+      _meta_type: '@happyvertical/smrt-tenancy:Network',
+      name: 'Network A',
+    });
+    await db.upsert('tenants', ['slug', 'context', '_meta_type'], {
+      id: 't_b',
+      slug: 'shared',
+      context: '/tenants',
+      _meta_type: '@happyvertical/smrt-tenancy:Publication',
+      name: 'Publication B',
+    });
+
+    const rowsResult = await db.query(
+      "SELECT _meta_type, name FROM tenants WHERE slug = 'shared' ORDER BY _meta_type",
+    );
+    const rows = Array.isArray(rowsResult) ? rowsResult : rowsResult.rows;
+    expect(rows).toHaveLength(2);
+  });
+});

--- a/packages/core/src/migrations/__tests__/index-drift.test.ts
+++ b/packages/core/src/migrations/__tests__/index-drift.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Tests for index drift detection in SchemaComparer.
+ *
+ * Covers two repair paths the differ now emits:
+ *
+ * - **Same-name shape drift** — DB has an index with the manifest's name but
+ *   different columns or uniqueness. The differ emits drop_index + add_index
+ *   so the next migration recreates it correctly. This is the failure mode
+ *   from issue #1165 (`tenants_slug_context_meta_type_idx` materialized
+ *   non-unique while the manifest declared it unique, breaking PostgreSQL
+ *   UPSERT against the STI conflict target).
+ *
+ * - **Orphan in DB** — DB carries an index the manifest no longer references.
+ *   Emitted only when the caller opts in via `includeDroppedIndexes`, and
+ *   never for `*_pkey` / `*_key` (PostgreSQL implicit-from-constraint
+ *   indexes that need a separate DROP CONSTRAINT path the differ does not
+ *   own yet).
+ */
+
+import type { DatabaseProvider } from '@happyvertical/sql';
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { SchemaDefinition } from '../../schema/types.js';
+import { SchemaComparer } from '../differ.js';
+
+function tableSchema(
+  overrides: Partial<SchemaDefinition> = {},
+): SchemaDefinition {
+  return {
+    tableName: 'tenants',
+    ddl: 'CREATE TABLE tenants (id TEXT PRIMARY KEY, slug TEXT, context TEXT, _meta_type TEXT);',
+    columns: {
+      id: { type: 'TEXT', primaryKey: true },
+      slug: { type: 'TEXT' },
+      context: { type: 'TEXT' },
+      _meta_type: { type: 'TEXT' },
+    },
+    indexes: [],
+    triggers: [],
+    foreignKeys: [],
+    dependencies: [],
+    version: '1.0.0',
+    ...overrides,
+  };
+}
+
+describe('SchemaComparer index drift', () => {
+  let db: DatabaseProvider;
+
+  beforeEach(async () => {
+    db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+    await db.query(
+      'CREATE TABLE tenants (id TEXT PRIMARY KEY, slug TEXT, context TEXT, _meta_type TEXT);',
+    );
+  });
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') {
+      try {
+        await db.close();
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  describe('same-name shape drift (issue #1165)', () => {
+    it('recreates an index whose uniqueness flag drifted (non-unique → unique)', async () => {
+      // The bug: index exists with the right name and columns but NOT unique.
+      // PostgreSQL UPSERT against ON CONFLICT(slug, context, _meta_type)
+      // can't bind to it because no unique constraint matches.
+      await db.query(
+        'CREATE INDEX tenants_slug_context_meta_type_idx ON tenants(slug, context, _meta_type);',
+      );
+
+      const comparer = new SchemaComparer(db);
+      const diff = await comparer.compare({
+        tenants: tableSchema({
+          indexes: [
+            {
+              name: 'tenants_slug_context_meta_type_idx',
+              columns: ['slug', 'context', '_meta_type'],
+              unique: true,
+            },
+          ],
+        }),
+      });
+
+      const indexChanges = diff.changes.filter(
+        (c) =>
+          c.name === 'tenants_slug_context_meta_type_idx' &&
+          (c.type === 'drop_index' || c.type === 'add_index'),
+      );
+
+      expect(indexChanges).toHaveLength(2);
+      // Drop must come before add so SQLite/Postgres can recreate the name.
+      expect(indexChanges[0].type).toBe('drop_index');
+      expect(indexChanges[1].type).toBe('add_index');
+      expect(indexChanges[1].index?.unique).toBe(true);
+    });
+
+    it('recreates an index whose columns drifted', async () => {
+      // Same name, different columns — still a recreate.
+      await db.query('CREATE INDEX idx_tenants_lookup ON tenants(slug);');
+
+      const comparer = new SchemaComparer(db);
+      const diff = await comparer.compare({
+        tenants: tableSchema({
+          indexes: [
+            {
+              name: 'idx_tenants_lookup',
+              columns: ['slug', 'context'],
+              unique: false,
+            },
+          ],
+        }),
+      });
+
+      const recreate = diff.changes.filter(
+        (c) =>
+          c.name === 'idx_tenants_lookup' &&
+          (c.type === 'drop_index' || c.type === 'add_index'),
+      );
+
+      expect(recreate.map((c) => c.type)).toEqual(['drop_index', 'add_index']);
+      expect(recreate[1].index?.columns).toEqual(['slug', 'context']);
+    });
+
+    it('does not flag drift when name and shape both match', async () => {
+      await db.query(
+        'CREATE UNIQUE INDEX tenants_slug_context_meta_type_idx ON tenants(slug, context, _meta_type);',
+      );
+
+      const comparer = new SchemaComparer(db);
+      const diff = await comparer.compare({
+        tenants: tableSchema({
+          indexes: [
+            {
+              name: 'tenants_slug_context_meta_type_idx',
+              columns: ['slug', 'context', '_meta_type'],
+              unique: true,
+            },
+          ],
+        }),
+      });
+
+      const indexChanges = diff.changes.filter(
+        (c) => c.type === 'add_index' || c.type === 'drop_index',
+      );
+      expect(indexChanges).toHaveLength(0);
+    });
+  });
+
+  describe('orphan-index drops', () => {
+    it('does not drop orphans by default (safety)', async () => {
+      await db.query('CREATE INDEX tenants_legacy_idx ON tenants(slug);');
+
+      const comparer = new SchemaComparer(db);
+      const diff = await comparer.compare({ tenants: tableSchema() });
+
+      const drops = diff.changes.filter((c) => c.type === 'drop_index');
+      expect(drops).toHaveLength(0);
+    });
+
+    it('drops orphan indexes when includeDroppedIndexes is enabled', async () => {
+      await db.query(
+        'CREATE UNIQUE INDEX tenants_slug_context_idx ON tenants(slug, context);',
+      );
+
+      const comparer = new SchemaComparer(db, {
+        includeDroppedIndexes: true,
+      });
+      const diff = await comparer.compare({
+        tenants: tableSchema({
+          // Manifest no longer wants the 2-column unique — the new STI shape
+          // is on (slug, context, _meta_type).
+          indexes: [
+            {
+              name: 'tenants_slug_context_meta_type_idx',
+              columns: ['slug', 'context', '_meta_type'],
+              unique: true,
+            },
+          ],
+        }),
+      });
+
+      const droppedNames = diff.changes
+        .filter((c) => c.type === 'drop_index')
+        .map((c) => c.name);
+      expect(droppedNames).toContain('tenants_slug_context_idx');
+    });
+
+    it('never drops *_pkey / *_key (implicit-from-constraint indexes)', async () => {
+      // The differ doesn't emit DROP CONSTRAINT, so it must not drop the
+      // implicit indexes those constraints own — the constraint would still
+      // be there but the index would be gone, breaking the table.
+      await db.query(
+        'CREATE TABLE constrained (id TEXT PRIMARY KEY, slug TEXT, context TEXT, UNIQUE(slug, context));',
+      );
+
+      const comparer = new SchemaComparer(db, {
+        includeDroppedIndexes: true,
+      });
+      const diff = await comparer.compare({
+        constrained: {
+          tableName: 'constrained',
+          ddl: '',
+          columns: {
+            id: { type: 'TEXT', primaryKey: true },
+            slug: { type: 'TEXT' },
+            context: { type: 'TEXT' },
+          },
+          indexes: [],
+          triggers: [],
+          foreignKeys: [],
+          dependencies: [],
+          version: '1.0.0',
+        },
+      });
+
+      const dropped = diff.changes
+        .filter((c) => c.type === 'drop_index')
+        .map((c) => c.name ?? '');
+
+      // No protected name should be dropped, regardless of which suffix the
+      // engine used (`_pkey` for PG, `sqlite_autoindex_*` for SQLite — the
+      // SQLite case is filtered upstream by the introspection layer).
+      for (const name of dropped) {
+        expect(name.endsWith('_pkey')).toBe(false);
+        expect(name.endsWith('_key')).toBe(false);
+      }
+    });
+
+    it('keeps a DB index that is signature-equivalent to a manifest index under a different name (issue #741)', async () => {
+      await db.query(
+        'CREATE UNIQUE INDEX renamed_unique ON tenants(slug, context, _meta_type);',
+      );
+
+      const comparer = new SchemaComparer(db, {
+        includeDroppedIndexes: true,
+      });
+      const diff = await comparer.compare({
+        tenants: tableSchema({
+          indexes: [
+            {
+              name: 'tenants_slug_context_meta_type_idx',
+              columns: ['slug', 'context', '_meta_type'],
+              unique: true,
+            },
+          ],
+        }),
+      });
+
+      // Should NOT add (signature already covered) and should NOT drop
+      // the equivalent existing index.
+      expect(
+        diff.changes.filter(
+          (c) => c.type === 'add_index' || c.type === 'drop_index',
+        ),
+      ).toHaveLength(0);
+    });
+  });
+
+  describe('issue #1165 anytown.ai scenario', () => {
+    it('emits the right repair plan for a deployed-stale tenants schema', async () => {
+      // Recreate the live anytown.ai shape from the issue:
+      // - tenants_id_idx (id) non-unique
+      // - tenants_meta_type_idx (_meta_type) non-unique
+      // - tenants_slug_context_idx UNIQUE (slug, context)         ← stale
+      // - tenants_slug_context_meta_type_idx (slug, context, _meta_type) non-unique  ← broken
+      await db.query('CREATE INDEX tenants_id_idx ON tenants(id);');
+      await db.query(
+        'CREATE INDEX tenants_meta_type_idx ON tenants(_meta_type);',
+      );
+      await db.query(
+        'CREATE UNIQUE INDEX tenants_slug_context_idx ON tenants(slug, context);',
+      );
+      await db.query(
+        'CREATE INDEX tenants_slug_context_meta_type_idx ON tenants(slug, context, _meta_type);',
+      );
+
+      const comparer = new SchemaComparer(db, {
+        includeDroppedIndexes: true,
+      });
+      const diff = await comparer.compare({
+        tenants: tableSchema({
+          indexes: [
+            {
+              name: 'tenants_id_idx',
+              columns: ['id'],
+              unique: false,
+            },
+            {
+              name: 'tenants_meta_type_idx',
+              columns: ['_meta_type'],
+              unique: false,
+            },
+            {
+              name: 'tenants_slug_context_meta_type_idx',
+              columns: ['slug', 'context', '_meta_type'],
+              unique: true,
+            },
+          ],
+        }),
+      });
+
+      const byTypeAndName = diff.changes
+        .filter((c) => c.type === 'add_index' || c.type === 'drop_index')
+        .map((c) => `${c.type}:${c.name}`);
+
+      // The broken non-unique index gets dropped and recreated as unique.
+      expect(byTypeAndName).toContain(
+        'drop_index:tenants_slug_context_meta_type_idx',
+      );
+      expect(byTypeAndName).toContain(
+        'add_index:tenants_slug_context_meta_type_idx',
+      );
+
+      // The stale 2-column unique gets dropped (orphan).
+      expect(byTypeAndName).toContain('drop_index:tenants_slug_context_idx');
+
+      // The unrelated maintenance indexes are untouched.
+      expect(byTypeAndName).not.toContain('drop_index:tenants_id_idx');
+      expect(byTypeAndName).not.toContain('drop_index:tenants_meta_type_idx');
+    });
+  });
+});

--- a/packages/core/src/migrations/__tests__/index-drift.test.ts
+++ b/packages/core/src/migrations/__tests__/index-drift.test.ts
@@ -259,6 +259,39 @@ describe('SchemaComparer index drift', () => {
         ),
       ).toHaveLength(0);
     });
+
+    it('keeps multiple DB indexes that share a signature with a manifest index', async () => {
+      // Pathological-but-legal case: two indexes with the same columns
+      // and uniqueness under different names. Earlier the comparer's
+      // signature map only remembered ONE, so the other got swept by
+      // the orphan pass. Both must survive when their signature matches
+      // the manifest. (Copilot review on PR #1166.)
+      await db.query('CREATE INDEX dup_a ON tenants(slug, context);');
+      await db.query('CREATE INDEX dup_b ON tenants(slug, context);');
+
+      const comparer = new SchemaComparer(db, {
+        includeDroppedIndexes: true,
+      });
+      const diff = await comparer.compare({
+        tenants: tableSchema({
+          indexes: [
+            {
+              name: 'tenants_slug_context_idx',
+              columns: ['slug', 'context'],
+              unique: false,
+            },
+          ],
+        }),
+      });
+
+      const dropped = diff.changes
+        .filter((c) => c.type === 'drop_index')
+        .map((c) => c.name);
+
+      // Neither dup_a nor dup_b — both share the manifest signature.
+      expect(dropped).not.toContain('dup_a');
+      expect(dropped).not.toContain('dup_b');
+    });
   });
 
   describe('issue #1165 anytown.ai scenario', () => {

--- a/packages/core/src/migrations/__tests__/postgres-statement-planner.test.ts
+++ b/packages/core/src/migrations/__tests__/postgres-statement-planner.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for `planPostgresStatements` — the helper that decides
+ * which statements run inside the migration transaction and which run
+ * outside of it under `--postgres-safe` mode.
+ *
+ * Issue #1165: shape-drift recreates and orphan-index cleanups emit
+ * DROP INDEX statements. Earlier the tracker only rewrote CREATE INDEX
+ * to CONCURRENTLY in safe mode and only routed CREATE … CONCURRENTLY
+ * outside the transaction. DROP INDEX without CONCURRENTLY then ran
+ * in-transaction with stronger locks (contradicting `--postgres-safe`
+ * help text), and any DROP INDEX CONCURRENTLY arriving from a generated
+ * migration file would error with "DROP INDEX CONCURRENTLY cannot run
+ * inside a transaction block."
+ */
+
+import { describe, expect, it } from 'vitest';
+import { planPostgresStatements } from '../tracker.js';
+
+describe('planPostgresStatements', () => {
+  describe('without --postgres-safe (useConcurrentIndexes = false)', () => {
+    it('routes pre-existing CONCURRENTLY statements outside the transaction', () => {
+      const { concurrent, regular } = planPostgresStatements(
+        [
+          'CREATE INDEX CONCURRENTLY foo ON t (a)',
+          'CREATE UNIQUE INDEX CONCURRENTLY bar ON t (a, b)',
+          'DROP INDEX CONCURRENTLY baz',
+          'CREATE INDEX qux ON t (c)',
+          'DROP INDEX quux',
+          'ALTER TABLE t ADD COLUMN x TEXT',
+        ],
+        false,
+      );
+
+      expect(concurrent).toEqual([
+        'CREATE INDEX CONCURRENTLY foo ON t (a)',
+        'CREATE UNIQUE INDEX CONCURRENTLY bar ON t (a, b)',
+        'DROP INDEX CONCURRENTLY baz',
+      ]);
+      expect(regular).toEqual([
+        'CREATE INDEX qux ON t (c)',
+        'DROP INDEX quux',
+        'ALTER TABLE t ADD COLUMN x TEXT',
+      ]);
+    });
+  });
+
+  describe('with --postgres-safe (useConcurrentIndexes = true)', () => {
+    it('rewrites plain CREATE INDEX to CREATE INDEX CONCURRENTLY and routes outside transaction', () => {
+      const { concurrent, regular } = planPostgresStatements(
+        ['CREATE INDEX foo ON t (a)', 'CREATE UNIQUE INDEX bar ON t (b)'],
+        true,
+      );
+
+      expect(concurrent).toEqual([
+        'CREATE INDEX CONCURRENTLY foo ON t (a)',
+        'CREATE UNIQUE INDEX CONCURRENTLY bar ON t (b)',
+      ]);
+      expect(regular).toEqual([]);
+    });
+
+    it('rewrites plain DROP INDEX to DROP INDEX CONCURRENTLY (issue #1165)', () => {
+      // Without this rewrite, the auto-migrate path would run drops
+      // inside the transaction, which contradicts the --postgres-safe
+      // help text and risks stronger locks during the repair window.
+      const { concurrent, regular } = planPostgresStatements(
+        [
+          'DROP INDEX IF EXISTS "tenants_slug_context_meta_type_idx"',
+          'DROP INDEX my_orphan',
+        ],
+        true,
+      );
+
+      expect(concurrent).toEqual([
+        'DROP INDEX CONCURRENTLY IF EXISTS "tenants_slug_context_meta_type_idx"',
+        'DROP INDEX CONCURRENTLY my_orphan',
+      ]);
+      expect(regular).toEqual([]);
+    });
+
+    it('keeps already-CONCURRENTLY statements as-is', () => {
+      const { concurrent, regular } = planPostgresStatements(
+        [
+          'DROP INDEX CONCURRENTLY IF EXISTS foo',
+          'CREATE INDEX CONCURRENTLY bar ON t (a)',
+        ],
+        true,
+      );
+
+      expect(concurrent).toEqual([
+        'DROP INDEX CONCURRENTLY IF EXISTS foo',
+        'CREATE INDEX CONCURRENTLY bar ON t (a)',
+      ]);
+      expect(regular).toEqual([]);
+    });
+
+    it('leaves non-index statements in the transaction set', () => {
+      const { concurrent, regular } = planPostgresStatements(
+        [
+          'ALTER TABLE t ADD COLUMN x TEXT',
+          'UPDATE t SET x = NULL',
+          'DROP INDEX foo',
+        ],
+        true,
+      );
+
+      expect(concurrent).toEqual(['DROP INDEX CONCURRENTLY foo']);
+      expect(regular).toEqual([
+        'ALTER TABLE t ADD COLUMN x TEXT',
+        'UPDATE t SET x = NULL',
+      ]);
+    });
+
+    it('preserves the per-statement order within each set', () => {
+      // Within a set, the original input order must be preserved so
+      // dependencies (e.g., a column add followed by a value migration)
+      // run in the right sequence.
+      const { regular } = planPostgresStatements(
+        [
+          'ALTER TABLE t ADD COLUMN x TEXT',
+          "UPDATE t SET x = COALESCE(legacy, '')",
+          'ALTER TABLE t ALTER COLUMN x SET NOT NULL',
+        ],
+        true,
+      );
+
+      expect(regular).toEqual([
+        'ALTER TABLE t ADD COLUMN x TEXT',
+        "UPDATE t SET x = COALESCE(legacy, '')",
+        'ALTER TABLE t ALTER COLUMN x SET NOT NULL',
+      ]);
+    });
+  });
+});

--- a/packages/core/src/migrations/differ.ts
+++ b/packages/core/src/migrations/differ.ts
@@ -310,17 +310,34 @@ export class SchemaComparer {
     const changes: SchemaChange[] = [];
 
     // Index DB indexes by name and by signature for fast lookup.
+    // dbIndexSignatures groups *all* DB index names sharing a signature so
+    // duplicates under different names all get claimed by a single matching
+    // manifest entry — otherwise the orphan sweep would drop the un-claimed
+    // siblings even though they are functionally equivalent to the manifest.
     const dbIndexesByName = new Map<
       string,
       { columns: string[]; unique: boolean }
     >();
-    const dbIndexSignatures = new Map<string, string>();
+    const dbIndexSignatures = new Map<string, Set<string>>();
     for (const idx of dbSchema.indexes) {
       const unique = idx.unique ?? false;
       dbIndexesByName.set(idx.name, { columns: idx.columns, unique });
-      dbIndexSignatures.set(
-        this.getIndexSignature(idx.columns, unique),
-        idx.name,
+      const signature = this.getIndexSignature(idx.columns, unique);
+      let bucket = dbIndexSignatures.get(signature);
+      if (!bucket) {
+        bucket = new Set();
+        dbIndexSignatures.set(signature, bucket);
+      }
+      bucket.add(idx.name);
+    }
+
+    // Manifest signatures — used during the orphan sweep to skip DB indexes
+    // that match a manifest entry's signature even if no specific manifest
+    // entry "claimed" them by name.
+    const manifestSignatureSet = new Set<string>();
+    for (const idx of manifest.indexes) {
+      manifestSignatureSet.add(
+        this.getIndexSignature(idx.columns, idx.unique ?? false),
       );
     }
 
@@ -376,9 +393,14 @@ export class SchemaComparer {
       }
 
       // (b) Different name in DB but functionally equivalent — keep as-is.
-      const equivalentIndexName = dbIndexSignatures.get(manifestSignature);
-      if (equivalentIndexName) {
-        claimedDbIndexes.add(equivalentIndexName);
+      // Claim *every* DB name sharing this signature so duplicate-shape
+      // indexes (e.g., a stale `<name>_idx` plus the implicit `<name>_key`
+      // from the same constraint) all survive the orphan sweep.
+      const equivalentIndexNames = dbIndexSignatures.get(manifestSignature);
+      if (equivalentIndexNames && equivalentIndexNames.size > 0) {
+        for (const name of equivalentIndexNames) {
+          claimedDbIndexes.add(name);
+        }
         continue;
       }
 
@@ -397,6 +419,18 @@ export class SchemaComparer {
       for (const idx of dbSchema.indexes) {
         if (claimedDbIndexes.has(idx.name)) continue;
         if (isProtectedDbIndexName(idx.name)) continue;
+
+        // Belt-and-suspenders: even if a DB index wasn't formally claimed
+        // by a manifest entry (e.g., shape-drift recreate consumed the
+        // claim slot), don't drop it if its signature still matches
+        // something the manifest declares. That would contradict the
+        // option doc ("not functionally equivalent to anything in the
+        // manifest") and risk dropping a still-needed index.
+        const idxSignature = this.getIndexSignature(
+          idx.columns,
+          idx.unique ?? false,
+        );
+        if (manifestSignatureSet.has(idxSignature)) continue;
 
         changes.push({
           type: 'drop_index',
@@ -758,10 +792,21 @@ export class SchemaComparer {
   }
 
   /**
-   * Generate SQL for dropping an index. Note that the migration-level
-   * generator emits `CONCURRENTLY` for PostgreSQL; the differ's preview SQL
-   * is fine without it because the differ is the diff source, not the
-   * applier — `MigrationGenerator.generateDropIndex` is what actually runs.
+   * Generate SQL for dropping an index.
+   *
+   * This SQL is consumed by *both* execution paths:
+   *
+   * - `db:diff --generate` writes a migration file using the SQL produced
+   *   by `MigrationGenerator.generateDropIndex` (which adds CONCURRENTLY
+   *   for PostgreSQL).
+   * - `db:migrate` runs the SQL we put in `change.sql` directly, with the
+   *   tracker's `executePostgresStatements` adding CONCURRENTLY when
+   *   `--postgres-safe` is on.
+   *
+   * Either way, PostgreSQL ends up with `CONCURRENTLY` when it should.
+   * Keeping this method engine-agnostic also means the diff preview text
+   * stays readable (no engine-specific noise) for engines like SQLite
+   * where CONCURRENTLY isn't a thing.
    */
   private generateDropIndexSQL(indexName: string): string {
     return `DROP INDEX IF EXISTS ${this.quoteIdentifier(indexName)}`;

--- a/packages/core/src/migrations/differ.ts
+++ b/packages/core/src/migrations/differ.ts
@@ -50,8 +50,31 @@ export interface DiffOptions {
   includeDroppedTables?: boolean;
   /** Include dropped columns in diff (default: false for safety) */
   includeDroppedColumns?: boolean;
+  /**
+   * Drop indexes that exist in the database but are absent from the manifest
+   * AND are not functionally equivalent to anything in the manifest. Default:
+   * false. The differ always skips primary-key indexes (`*_pkey`) and the
+   * implicit indexes that PostgreSQL creates from inline UNIQUE constraints
+   * (`*_key`) — those are owned by table-level constraints, not by the
+   * index list, and dropping them here would break the constraint.
+   */
+  includeDroppedIndexes?: boolean;
   /** Ignore type mismatches (just log warnings) */
   ignoreTypeMismatches?: boolean;
+}
+
+/**
+ * Suffix patterns for indexes that the differ refuses to drop.
+ * - `_pkey`: PostgreSQL primary key implicit index.
+ * - `_key`: PostgreSQL implicit index for inline `UNIQUE (...)` table
+ *   constraints. Dropping these by name does not drop the underlying
+ *   constraint, and dropping the constraint requires a separate DDL path
+ *   (`ALTER TABLE ... DROP CONSTRAINT`) the differ does not emit today.
+ */
+const PROTECTED_INDEX_SUFFIXES = ['_pkey', '_key'];
+
+function isProtectedDbIndexName(name: string): boolean {
+  return PROTECTED_INDEX_SUFFIXES.some((suffix) => name.endsWith(suffix));
 }
 
 /**
@@ -68,6 +91,7 @@ export class SchemaComparer {
     this.options = {
       includeDroppedTables: false,
       includeDroppedColumns: false,
+      includeDroppedIndexes: false,
       ignoreTypeMismatches: false,
       ...options,
     };
@@ -257,10 +281,26 @@ export class SchemaComparer {
   /**
    * Compare indexes between manifest and database
    *
-   * Issue #741: Also checks for functionally equivalent indexes to avoid
-   * detecting indexes as "missing" when a different-named index with the
-   * same columns already exists. This is critical for STI tables where
-   * child classes may generate indexes with different name prefixes.
+   * Three classes of drift the differ now detects:
+   *
+   * 1. **Missing index** — manifest has an index neither the DB has by name
+   *    nor any equivalent-by-signature. Emit `add_index`. (Issue #741: the
+   *    signature check protects against creating duplicates when STI child
+   *    classes register indexes with different name prefixes.)
+   *
+   * 2. **Same-name shape drift** — DB has an index with the manifest's name,
+   *    but its columns or uniqueness flag differ. This is the failure mode
+   *    in issue #1165: `tenants_slug_context_meta_type_idx` exists but is
+   *    non-unique, while the manifest declares it unique. Emit
+   *    `drop_index` + `add_index` so the next migrate cycle recreates it
+   *    with the correct shape.
+   *
+   * 3. **Orphan in DB** — DB has an index with no manifest counterpart by
+   *    name and no signature equivalent. Emit `drop_index` *only* when the
+   *    caller opts in via `includeDroppedIndexes`, and even then never for
+   *    PostgreSQL implicit indexes (`*_pkey`, `*_key`) — those are owned by
+   *    table-level constraints and need a separate `DROP CONSTRAINT` path
+   *    that the differ does not emit yet.
    */
   private compareIndexes(
     tableName: string,
@@ -268,41 +308,81 @@ export class SchemaComparer {
     dbSchema: SqlTableSchemaInfo,
   ): SchemaChange[] {
     const changes: SchemaChange[] = [];
-    const dbIndexNames = new Set(dbSchema.indexes.map((idx) => idx.name));
 
-    // Build a map of existing index signatures for functional equivalence checking
-    // Signature format: "col1,col2:unique" with columns in their defined order
+    // Index DB indexes by name and by signature for fast lookup.
+    const dbIndexesByName = new Map<
+      string,
+      { columns: string[]; unique: boolean }
+    >();
     const dbIndexSignatures = new Map<string, string>();
     for (const idx of dbSchema.indexes) {
-      const signature = this.getIndexSignature(
-        idx.columns,
-        idx.unique ?? false,
+      const unique = idx.unique ?? false;
+      dbIndexesByName.set(idx.name, { columns: idx.columns, unique });
+      dbIndexSignatures.set(
+        this.getIndexSignature(idx.columns, unique),
+        idx.name,
       );
-      dbIndexSignatures.set(signature, idx.name);
     }
 
-    // Check for new indexes
-    for (const idx of manifest.indexes) {
-      // First, check by exact name match
-      if (dbIndexNames.has(idx.name)) {
-        continue; // Index exists with same name
-      }
+    // Track which DB indexes a manifest entry has claimed, so the orphan
+    // pass below doesn't re-flag indexes that match by signature alone.
+    const claimedDbIndexes = new Set<string>();
 
-      // Second, check for functionally equivalent index (same columns, same uniqueness)
-      // This prevents creating redundant indexes with different names
+    for (const idx of manifest.indexes) {
+      const manifestUnique = idx.unique ?? false;
       const manifestSignature = this.getIndexSignature(
         idx.columns,
-        idx.unique ?? false,
+        manifestUnique,
       );
-      const equivalentIndexName = dbIndexSignatures.get(manifestSignature);
 
-      if (equivalentIndexName) {
-        // A functionally equivalent index already exists
-        // Skip this index to avoid PostgreSQL "relation already exists" errors
+      // (a) Same name in DB — verify shape matches.
+      const dbByName = dbIndexesByName.get(idx.name);
+      if (dbByName) {
+        claimedDbIndexes.add(idx.name);
+        const dbSignature = this.getIndexSignature(
+          dbByName.columns,
+          dbByName.unique,
+        );
+        if (dbSignature === manifestSignature) {
+          continue; // Same name, same shape — nothing to do.
+        }
+
+        // Same name, drifted shape. Most often this is a uniqueness flip
+        // (issue #1165: 3-column index materialized non-unique). Recreate.
+        //
+        // Rollback caveat: the auto-generated DOWN script for the
+        // `add_index` half drops the (newly correct) index, and the
+        // `drop_index` half has no DOWN. Rolling back a recreate leaves
+        // the table without the index entirely instead of restoring the
+        // wrong-shape original. Capturing the original shape would
+        // require richer DB introspection than the differ currently has,
+        // so this asymmetry is accepted — the failure mode after an
+        // un-rolled-back recreate is "missing index" rather than
+        // "permanently broken UPSERT," which is recoverable.
+        changes.push({
+          type: 'drop_index',
+          table: tableName,
+          name: idx.name,
+          sql: this.generateDropIndexSQL(idx.name),
+        });
+        changes.push({
+          type: 'add_index',
+          table: tableName,
+          name: idx.name,
+          index: idx,
+          sql: this.generateAddIndexSQL(tableName, idx),
+        });
         continue;
       }
 
-      // No equivalent index found - this is genuinely missing
+      // (b) Different name in DB but functionally equivalent — keep as-is.
+      const equivalentIndexName = dbIndexSignatures.get(manifestSignature);
+      if (equivalentIndexName) {
+        claimedDbIndexes.add(equivalentIndexName);
+        continue;
+      }
+
+      // (c) Genuinely missing — add it.
       changes.push({
         type: 'add_index',
         table: tableName,
@@ -310,6 +390,21 @@ export class SchemaComparer {
         index: idx,
         sql: this.generateAddIndexSQL(tableName, idx),
       });
+    }
+
+    // Orphan-index sweep (opt-in via includeDroppedIndexes).
+    if (this.options.includeDroppedIndexes) {
+      for (const idx of dbSchema.indexes) {
+        if (claimedDbIndexes.has(idx.name)) continue;
+        if (isProtectedDbIndexName(idx.name)) continue;
+
+        changes.push({
+          type: 'drop_index',
+          table: tableName,
+          name: idx.name,
+          sql: this.generateDropIndexSQL(idx.name),
+        });
+      }
     }
 
     return changes;
@@ -660,6 +755,16 @@ export class SchemaComparer {
       .map((c) => this.quoteIdentifier(c))
       .join(', ');
     return `CREATE ${uniqueStr}INDEX ${this.quoteIdentifier(idx.name)} ON ${this.quoteIdentifier(tableName)} (${quotedColumns})`;
+  }
+
+  /**
+   * Generate SQL for dropping an index. Note that the migration-level
+   * generator emits `CONCURRENTLY` for PostgreSQL; the differ's preview SQL
+   * is fine without it because the differ is the diff source, not the
+   * applier — `MigrationGenerator.generateDropIndex` is what actually runs.
+   */
+  private generateDropIndexSQL(indexName: string): string {
+    return `DROP INDEX IF EXISTS ${this.quoteIdentifier(indexName)}`;
   }
 }
 

--- a/packages/core/src/migrations/index.ts
+++ b/packages/core/src/migrations/index.ts
@@ -36,7 +36,7 @@ export {
   MigrationGenerator,
 } from './generator.js';
 // Core classes
-export { MigrationTracker } from './tracker.js';
+export { MigrationTracker, planPostgresStatements } from './tracker.js';
 
 // Types
 export type {

--- a/packages/core/src/migrations/tracker.ts
+++ b/packages/core/src/migrations/tracker.ts
@@ -617,17 +617,30 @@ export class MigrationTracker {
    *
    * - CONCURRENTLY statements run outside transaction
    * - Regular statements run in transaction with lock_timeout
+   *
+   * Both CREATE and DROP variants of CONCURRENTLY must be detected — Postgres
+   * forbids `DROP INDEX CONCURRENTLY` inside a transaction block, just like
+   * the create variant. Issue #1165: the migration generator emits
+   * `DROP INDEX CONCURRENTLY` for shape-drift recreates and orphan-index
+   * cleanups, so the regex needs to cover both keywords.
    */
   private async executePostgresStatements(statements: string[]): Promise<void> {
+    const concurrentRegex =
+      /(?:CREATE\s+(?:UNIQUE\s+)?INDEX|DROP\s+INDEX)\s+CONCURRENTLY/i;
+
     // Separate CONCURRENTLY statements (cannot be in transaction)
     const concurrentStatements = statements.filter((s) =>
-      /CREATE\s+(UNIQUE\s+)?INDEX\s+CONCURRENTLY/i.test(s),
+      concurrentRegex.test(s),
     );
     const regularStatements = statements.filter(
-      (s) => !/CREATE\s+(UNIQUE\s+)?INDEX\s+CONCURRENTLY/i.test(s),
+      (s) => !concurrentRegex.test(s),
     );
 
-    // Transform regular CREATE INDEX to CONCURRENTLY if enabled
+    // Transform regular CREATE INDEX to CONCURRENTLY if enabled.
+    // Note: we don't transform DROP INDEX → DROP INDEX CONCURRENTLY because
+    // the migration generator already emits CONCURRENTLY explicitly for
+    // PostgreSQL drops, and forcing it on user-provided statements would be
+    // surprising.
     const transformedStatements = this.options.useConcurrentIndexes
       ? regularStatements.map((s) => {
           if (/CREATE\s+(UNIQUE\s+)?INDEX\s+(?!CONCURRENTLY)/i.test(s)) {
@@ -642,10 +655,10 @@ export class MigrationTracker {
 
     // Re-separate after transformation
     const finalConcurrent = transformedStatements.filter((s) =>
-      /CREATE\s+(UNIQUE\s+)?INDEX\s+CONCURRENTLY/i.test(s),
+      concurrentRegex.test(s),
     );
     const finalRegular = transformedStatements.filter(
-      (s) => !/CREATE\s+(UNIQUE\s+)?INDEX\s+CONCURRENTLY/i.test(s),
+      (s) => !concurrentRegex.test(s),
     );
 
     // Execute regular statements in transaction with timeouts

--- a/packages/core/src/migrations/tracker.ts
+++ b/packages/core/src/migrations/tracker.ts
@@ -625,41 +625,13 @@ export class MigrationTracker {
    * cleanups, so the regex needs to cover both keywords.
    */
   private async executePostgresStatements(statements: string[]): Promise<void> {
-    const concurrentRegex =
-      /(?:CREATE\s+(?:UNIQUE\s+)?INDEX|DROP\s+INDEX)\s+CONCURRENTLY/i;
+    const { concurrent: finalConcurrent, regular: finalRegular } =
+      planPostgresStatements(statements, !!this.options.useConcurrentIndexes);
 
-    // Separate CONCURRENTLY statements (cannot be in transaction)
-    const concurrentStatements = statements.filter((s) =>
-      concurrentRegex.test(s),
-    );
-    const regularStatements = statements.filter(
-      (s) => !concurrentRegex.test(s),
-    );
-
-    // Transform regular CREATE INDEX to CONCURRENTLY if enabled.
-    // Note: we don't transform DROP INDEX → DROP INDEX CONCURRENTLY because
-    // the migration generator already emits CONCURRENTLY explicitly for
-    // PostgreSQL drops, and forcing it on user-provided statements would be
-    // surprising.
-    const transformedStatements = this.options.useConcurrentIndexes
-      ? regularStatements.map((s) => {
-          if (/CREATE\s+(UNIQUE\s+)?INDEX\s+(?!CONCURRENTLY)/i.test(s)) {
-            return s.replace(
-              /CREATE\s+(UNIQUE\s+)?INDEX\s+/i,
-              'CREATE $1INDEX CONCURRENTLY ',
-            );
-          }
-          return s;
-        })
-      : regularStatements;
-
-    // Re-separate after transformation
-    const finalConcurrent = transformedStatements.filter((s) =>
-      concurrentRegex.test(s),
-    );
-    const finalRegular = transformedStatements.filter(
-      (s) => !concurrentRegex.test(s),
-    );
+    // CONCURRENTLY statements come from `planPostgresStatements`, which
+    // also pushes any post-transform CREATE/DROP CONCURRENTLY into the
+    // outside-transaction set. The original `concurrentStatements` list
+    // is folded in there too so callers below see one merged stream.
 
     // Execute regular statements in transaction with timeouts
     if (finalRegular.length > 0 && this.db.transaction) {
@@ -683,11 +655,64 @@ export class MigrationTracker {
     }
 
     // Execute CONCURRENTLY statements outside transaction
-    const allConcurrent = [...concurrentStatements, ...finalConcurrent];
-    for (const sql of allConcurrent) {
+    for (const sql of finalConcurrent) {
       // Set lock timeout for the session
       await this.db.query(`SET lock_timeout = '${this.options.lockTimeout}ms'`);
       await this.db.query(sql);
     }
   }
+}
+
+/**
+ * Split a batch of SQL statements into a transaction-safe set and a
+ * concurrent set, applying `--postgres-safe` rewriting if requested.
+ *
+ * Exported for unit testing and to give external callers a way to
+ * reason about what the tracker would execute in PostgreSQL safe mode.
+ *
+ * Rules:
+ * - Statements already containing `CONCURRENTLY` (CREATE or DROP) always
+ *   go to the concurrent set — Postgres rejects them inside transactions.
+ * - When `useConcurrentIndexes` is true, plain `CREATE INDEX` and plain
+ *   `DROP INDEX` are rewritten to use `CONCURRENTLY`, then routed to
+ *   the concurrent set. This is what the CLI `--postgres-safe` flag and
+ *   the auto-migrate path rely on for issue #1165's shape-drift drops.
+ * - All other statements stay in the regular (transaction) set.
+ */
+export function planPostgresStatements(
+  statements: string[],
+  useConcurrentIndexes: boolean,
+): { concurrent: string[]; regular: string[] } {
+  const concurrentRegex =
+    /(?:CREATE\s+(?:UNIQUE\s+)?INDEX|DROP\s+INDEX)\s+CONCURRENTLY/i;
+
+  const concurrent: string[] = [];
+  const regular: string[] = [];
+
+  for (const sql of statements) {
+    if (concurrentRegex.test(sql)) {
+      concurrent.push(sql);
+      continue;
+    }
+    if (useConcurrentIndexes) {
+      if (/CREATE\s+(UNIQUE\s+)?INDEX\s+(?!CONCURRENTLY)/i.test(sql)) {
+        concurrent.push(
+          sql.replace(
+            /CREATE\s+(UNIQUE\s+)?INDEX\s+/i,
+            'CREATE $1INDEX CONCURRENTLY ',
+          ),
+        );
+        continue;
+      }
+      if (/DROP\s+INDEX\s+(?!CONCURRENTLY)/i.test(sql)) {
+        concurrent.push(
+          sql.replace(/DROP\s+INDEX\s+/i, 'DROP INDEX CONCURRENTLY '),
+        );
+        continue;
+      }
+    }
+    regular.push(sql);
+  }
+
+  return { concurrent, regular };
 }

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -2613,6 +2613,12 @@ export class ObjectRegistry {
    * - CTI: ['slug', 'context']
    * - STI: ['slug', 'context', '_meta_type']
    *
+   * STI subclasses share a table, so the discriminator participates in
+   * identity — two subtypes can coexist with the same (slug, context). The
+   * matching unique constraint on `(slug, context, _meta_type)` must exist
+   * in the live schema; if a deployment carries a stale 2-column unique
+   * instead, run `smrt db:migrate` to repair it (see issue #1165).
+   *
    * @param className - Name of the class to get conflict columns for
    * @returns Array of column names to use for conflict detection
    *

--- a/packages/core/src/schema/generator.ts
+++ b/packages/core/src/schema/generator.ts
@@ -768,7 +768,12 @@ export class SchemaGenerator {
       description: 'Primary key index',
     });
 
-    // Unique index for slug, context, and type (STI variation)
+    // Unique index for slug, context, and type (STI variation).
+    // STI subclasses share a table, so the discriminator participates in
+    // identity — two subtypes can share the same (slug, context). PostgreSQL
+    // UPSERT requires the live schema to carry a matching unique index; the
+    // migration differ repairs older deployments where this index was created
+    // non-unique or never created at all (issue #1165).
     indexes.push({
       name: `${tableName}_slug_context_meta_type_idx`,
       columns: ['slug', 'context', '_meta_type'],
@@ -957,7 +962,8 @@ export class SchemaGenerator {
       columns: ['id'],
     });
 
-    // Unique index for slug, context, and type (STI variation)
+    // Unique index for slug, context, and type (STI variation) — see
+    // generateSTISchemaFromRegistry for the rationale.
     indexes.push({
       name: `${tableName}_slug_context_meta_type_idx`,
       columns: ['slug', 'context', '_meta_type'],


### PR DESCRIPTION
## Summary

Closes #1165. The migration differ couldn't detect or repair index drift, so older deployments with a non-unique `tenants_slug_context_meta_type_idx` (or any STI table) silently failed all UPSERTs against PostgreSQL. The fix gives the differ + `db:migrate` pipeline a real index-repair path; STI semantics (`(slug, context, _meta_type)` as the conflict target — letting different subtypes share `(slug, context)`) are unchanged.

## Root cause

`compareIndexes` only ever emitted `add_index`. When an older manifest's index name was reused with a new shape (e.g., a 3-column index that should be unique), or when an old index lingered in the DB after the manifest dropped it, the differ saw the name match and emitted nothing. Even when it eventually emitted `drop_index`, the CLI's `partitionSchemaChanges` switch had no arm for it and silently discarded the action — so `db:migrate` ran the paired `add_index` with `IF NOT EXISTS`, no-op'd against the wrong-shape index, and recorded a "successful" migration that changed nothing.

## What's in this PR

- **Differ** detects three drift classes: missing (existing), same-name shape drift (new — always on), orphan in DB (new — opt-in via `includeDroppedIndexes`). Refuses to drop `*_pkey` / `*_key` (PG implicit-from-constraint indexes that need a separate `DROP CONSTRAINT` path).
- **CLI** `partitionSchemaChanges` now surfaces `drop_index`; `db:migrate` executes drops and shows them in `--dry-run`. New `--drop-indexes` flag on both `db:migrate` and `db:diff` (orphan drops are off by default; shape-drift recreate is always on).
- **Tracker** `executePostgresStatements` recognizes `DROP INDEX CONCURRENTLY` in addition to `CREATE INDEX CONCURRENTLY` and routes both outside the transaction (PG forbids both inside transaction blocks).
- **Tests** 13 new tests covering uniqueness flips, column flips, orphan drops, `*_pkey`/`*_key` protection, signature-equivalent renames, the full anytown.ai composite scenario, `partitionSchemaChanges` roundtrip, and synthetic-name classification.

## Validation

- Full `@happyvertical/smrt-core`: **1640 pass / 29 skipped**
- Full `@happyvertical/smrt-cli`: **308 pass / 2 skipped**
- Typecheck + biome lint clean across all touched files
- **Live anytown.ai schema** cloned to a sandbox and run end-to-end through the new path:
  - Differ produces the expected plan: `drop_index tenants_slug_context_meta_type_idx` → `add_index tenants_slug_context_meta_type_idx (UNIQUE)` → `drop_index tenants_slug_context_idx`
  - `partitionSchemaChanges` preserves the order
  - After applying, `INSERT … ON CONFLICT(slug, context, _meta_type) DO UPDATE …` succeeds (verified via psql)
  - `tenants_slug_context_key` (PG implicit constraint index) is correctly left alone

## Known limitation

`tenants_slug_context_key` — the leftover implicit index from an older inline `UNIQUE(slug, context)` constraint — is auto-protected because the differ doesn't currently emit `DROP CONSTRAINT`. It still blocks two STI subtypes from sharing `(slug, context)`, so anytown.ai (and any similarly-evolved deployment) will need a one-shot `ALTER TABLE tenants DROP CONSTRAINT IF EXISTS tenants_slug_context_key` after upgrading. Closing that gap requires teaching the differ to track table-level UNIQUE constraints separately from indexes; that's a larger piece of work and out of scope here.

## Rollback caveat (documented in code)

Auto-generated DOWN scripts don't capture the original DB-side index shape, so rolling back a shape-drift recreate leaves the table without the index entirely (recoverable by re-running `db:migrate`) rather than restoring the wrong-shape original.

## Recommended sequence for affected deployments

```bash
smrt db:diff --drop-indexes --json | jq '.changes'   # preview
smrt db:migrate --drop-indexes                        # apply
psql -c "ALTER TABLE tenants DROP CONSTRAINT IF EXISTS tenants_slug_context_key"   # one-time
```

## Test plan
- [x] Differ unit tests: shape drift (uniqueness flip + column flip), no-op, orphan default off, orphan opt-in, `*_pkey`/`*_key` protection, signature-equivalent rename, full anytown composite
- [x] `partitionSchemaChanges` test: `drop_index` roundtrips through executable migration set in correct order
- [x] Synthetic-name classification covers `drop_index_*`
- [x] End-to-end regression: build broken anytown schema, run differ, apply SQL, verify UPSERT works (single-subtype + two-subtype-sharing-slug)
- [x] Full `@happyvertical/smrt-core` suite green
- [x] Full `@happyvertical/smrt-cli` suite green
- [x] Typecheck + biome lint clean
- [x] Live validation against anytown.ai sandbox via full `compare → partition → apply` pipeline