### PR TITLE
fix(core): tolerate concurrent system index creation

### DIFF
--- a/packages/core/src/__tests__/system-table-compatibility.test.ts
+++ b/packages/core/src/__tests__/system-table-compatibility.test.ts
@@ -285,4 +285,117 @@ describe('system table compatibility', () => {
       ),
     ).toBe(false);
   });
+
+  it('tolerates a verified Postgres concurrent index creation race', async () => {
+    let createdAtIndexLookups = 0;
+    const query = vi
+      .fn()
+      .mockImplementation(async (sql: string, ...params: unknown[]) => {
+        if (sql === 'SELECT 1 FROM _smrt_job_events LIMIT 1') {
+          return { rows: [{ '?column?': 1 }] };
+        }
+
+        if (sql.includes('information_schema.columns')) {
+          return { rows: [{ '?column?': 1 }] };
+        }
+
+        if (sql.includes('pg_indexes')) {
+          const [indexName] = params;
+          if (indexName === 'idx_smrt_job_events_created_at') {
+            createdAtIndexLookups += 1;
+            return {
+              rows: createdAtIndexLookups === 1 ? [] : [{ '?column?': 1 }],
+            };
+          }
+
+          return { rows: [{ '?column?': 1 }] };
+        }
+
+        if (
+          sql.includes(
+            'CREATE INDEX IF NOT EXISTS idx_smrt_job_events_created_at',
+          )
+        ) {
+          const error = new Error('Failed query') as Error & {
+            originalError?: {
+              code: string;
+              message: string;
+              detail: string;
+            };
+          };
+          error.originalError = {
+            code: '23505',
+            message:
+              'duplicate key value violates unique constraint "pg_class_relname_nsp_index"',
+            detail:
+              'Key (relname, relnamespace)=(idx_smrt_job_events_created_at, 2200) already exists.',
+          };
+          throw error;
+        }
+
+        throw new Error(`Unexpected query: ${sql}`);
+      });
+
+    await expect(
+      ensureJobEventsSystemTableCompatibility({
+        url: 'postgresql://localhost:5432/test',
+        query,
+      } as any),
+    ).resolves.toBeUndefined();
+
+    expect(createdAtIndexLookups).toBe(2);
+    expect(
+      query.mock.calls.filter(([sql]) =>
+        String(sql).includes(
+          'CREATE INDEX IF NOT EXISTS idx_smrt_job_events_created_at',
+        ),
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('still fails Postgres index creation when the index race cannot be verified', async () => {
+    const query = vi
+      .fn()
+      .mockImplementation(async (sql: string, ...params: unknown[]) => {
+        if (sql === 'SELECT 1 FROM _smrt_job_events LIMIT 1') {
+          return { rows: [{ '?column?': 1 }] };
+        }
+
+        if (sql.includes('information_schema.columns')) {
+          return { rows: [{ '?column?': 1 }] };
+        }
+
+        if (sql.includes('pg_indexes')) {
+          const [indexName] = params;
+          if (indexName === 'idx_smrt_job_events_created_at') {
+            return { rows: [] };
+          }
+
+          return { rows: [{ '?column?': 1 }] };
+        }
+
+        if (
+          sql.includes(
+            'CREATE INDEX IF NOT EXISTS idx_smrt_job_events_created_at',
+          )
+        ) {
+          const error = new Error(
+            'permission denied for schema public',
+          ) as Error & {
+            code?: string;
+          };
+          error.code = '42501';
+          throw error;
+        }
+
+        throw new Error(`Unexpected query: ${sql}`);
+      });
+
+    await expect(
+      ensureJobEventsSystemTableCompatibility({
+        url: 'postgresql://localhost:5432/test',
+        query,
+      } as any),
+    ).rejects.toThrow('permission denied for schema public');
+  });
 });

--- a/packages/core/src/system/compatibility.ts
+++ b/packages/core/src/system/compatibility.ts
@@ -74,6 +74,69 @@ function isDuplicateColumnError(error: unknown): boolean {
   );
 }
 
+function collectErrorDetails(
+  error: unknown,
+  seen = new Set<unknown>(),
+): {
+  codes: Set<string>;
+  messages: string[];
+} {
+  const codes = new Set<string>();
+  const messages: string[] = [];
+
+  if (!error || seen.has(error)) {
+    return { codes, messages };
+  }
+
+  seen.add(error);
+
+  if (typeof error === 'object') {
+    const errorRecord = error as Record<string, unknown>;
+
+    if (typeof errorRecord.code === 'string') {
+      codes.add(errorRecord.code);
+    }
+
+    for (const messageKey of ['message', 'detail']) {
+      if (typeof errorRecord[messageKey] === 'string') {
+        messages.push(errorRecord[messageKey]);
+      }
+    }
+
+    for (const nestedKey of ['cause', 'originalError']) {
+      const nested = collectErrorDetails(errorRecord[nestedKey], seen);
+      for (const code of nested.codes) {
+        codes.add(code);
+      }
+      messages.push(...nested.messages);
+    }
+  } else {
+    messages.push(String(error));
+  }
+
+  return { codes, messages };
+}
+
+function isDuplicateIndexRaceError(error: unknown, indexName: string): boolean {
+  const { codes, messages } = collectErrorDetails(error);
+  const message = messages.join('\n').toLowerCase();
+  const normalizedIndexName = indexName.toLowerCase();
+
+  if (!message.includes(normalizedIndexName)) {
+    return false;
+  }
+
+  if (codes.has('23505') && message.includes('pg_class_relname_nsp_index')) {
+    return true;
+  }
+
+  if (codes.has('42P07') && /relation .*already exists/i.test(message)) {
+    return true;
+  }
+
+  return false;
+}
+
 async function addColumnIfMissing(
   db: DatabaseInterface,
   tableName: string,
@@ -144,9 +207,19 @@ async function addIndexIfMissing(
     return;
   }
 
-  await db.query(
-    `CREATE INDEX IF NOT EXISTS ${indexName} ON ${tableName}(${columnName})`,
-  );
+  try {
+    await db.query(
+      `CREATE INDEX IF NOT EXISTS ${indexName} ON ${tableName}(${columnName})`,
+    );
+  } catch (error) {
+    if (isDuplicateIndexRaceError(error, indexName)) {
+      if (await indexExists(db, indexName)) {
+        return;
+      }
+    }
+
+    throw error;
+  }
 }
 
 export async function ensureDispatchSystemTableCompatibility(


### PR DESCRIPTION
## Summary
- tolerate verified Postgres duplicate-index catalog races during SMRT system table compatibility checks
- re-check the exact index after the race before treating it as benign
- keep unrelated index creation failures visible

## Test Plan
- pnpm --filter @happyvertical/smrt-core exec vitest run src/__tests__/system-table-compatibility.test.ts
- pnpm --filter @happyvertical/smrt-core typecheck
- pnpm --filter @happyvertical/smrt-core build