### PR TITLE
[codex] Handle legacy STI discriminator saves

### DIFF
--- a/packages/cli/src/commands/__tests__/sti-upgrade.test.ts
+++ b/packages/cli/src/commands/__tests__/sti-upgrade.test.ts
@@ -1,6 +1,10 @@
 import { ObjectRegistry, SmrtObject, smrt } from '@happyvertical/smrt-core';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { resolveStiDiscriminatorUpgrade } from '../sti-upgrade.js';
+import { type DatabaseProvider, getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  repairStiDiscriminatorRows,
+  resolveStiDiscriminatorUpgrade,
+} from '../sti-upgrade.js';
 
 @smrt({ tableStrategy: 'sti', tableName: 'sti_upgrade_assets' })
 class StiUpgradeAsset extends SmrtObject {}
@@ -8,7 +12,18 @@ class StiUpgradeAsset extends SmrtObject {}
 @smrt()
 class StiUpgradeImage extends StiUpgradeAsset {}
 
+@smrt({
+  tableStrategy: 'sti',
+  tableName: 'sti_upgrade_customs',
+  conflictColumns: ['external_key', '_meta_type'],
+})
+class StiUpgradeCustomIdentity extends SmrtObject {
+  externalKey: string = '';
+}
+
 describe('resolveStiDiscriminatorUpgrade', () => {
+  let db: DatabaseProvider | undefined;
+
   beforeEach(() => {
     ObjectRegistry.clear();
     ObjectRegistry.register(StiUpgradeAsset, {
@@ -17,6 +32,17 @@ describe('resolveStiDiscriminatorUpgrade', () => {
     ObjectRegistry.register(StiUpgradeImage, {
       packageName: '@happyvertical/smrt-images',
     });
+    ObjectRegistry.register(StiUpgradeCustomIdentity, {
+      packageName: '@happyvertical/smrt-cli',
+      tableStrategy: 'sti',
+      tableName: 'sti_upgrade_customs',
+      conflictColumns: ['external_key', '_meta_type'],
+    });
+  });
+
+  afterEach(async () => {
+    await db?.close?.();
+    db = undefined;
   });
 
   it('skips discriminators that are already current', () => {
@@ -99,5 +125,161 @@ describe('resolveStiDiscriminatorUpgrade', () => {
     });
 
     findClassesByName.mockRestore();
+  });
+
+  it('repairs lone legacy discriminator rows by id', async () => {
+    db = await getDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      __smrtSkipVitestSchemaPreparation: true,
+    });
+    await db.query(`
+      CREATE TABLE sti_upgrade_assets (
+        id TEXT PRIMARY KEY,
+        slug TEXT NOT NULL,
+        context TEXT NOT NULL DEFAULT '',
+        _meta_type TEXT NOT NULL
+      )
+    `);
+    await db.query(
+      'CREATE UNIQUE INDEX sti_upgrade_assets_identity_idx ON sti_upgrade_assets(slug, context, _meta_type)',
+    );
+    await db.query(`
+      INSERT INTO sti_upgrade_assets (id, slug, context, _meta_type)
+      VALUES ('legacy-1', 'same-place', '', 'StiUpgradeImage')
+    `);
+
+    const result = await repairStiDiscriminatorRows({
+      db,
+      tableName: 'sti_upgrade_assets',
+      className: 'StiUpgradeImage',
+      legacyMetaType: 'StiUpgradeImage',
+      qualifiedMetaType: '@happyvertical/smrt-images:StiUpgradeImage',
+    });
+
+    expect(result).toMatchObject({
+      checkedRows: 1,
+      updatedRows: 1,
+      wouldUpdateRows: 0,
+      conflicts: [],
+    });
+    const rows = (
+      await db.query('SELECT id, _meta_type FROM sti_upgrade_assets')
+    ).rows;
+    expect(rows).toEqual([
+      {
+        id: 'legacy-1',
+        _meta_type: '@happyvertical/smrt-images:StiUpgradeImage',
+      },
+    ]);
+  });
+
+  it('reports qualified duplicates instead of violating the STI unique index', async () => {
+    db = await getDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      __smrtSkipVitestSchemaPreparation: true,
+    });
+    await db.query(`
+      CREATE TABLE sti_upgrade_assets (
+        id TEXT PRIMARY KEY,
+        slug TEXT NOT NULL,
+        context TEXT NOT NULL DEFAULT '',
+        _meta_type TEXT NOT NULL
+      )
+    `);
+    await db.query(
+      'CREATE UNIQUE INDEX sti_upgrade_assets_identity_idx ON sti_upgrade_assets(slug, context, _meta_type)',
+    );
+    await db.query(`
+      INSERT INTO sti_upgrade_assets (id, slug, context, _meta_type)
+      VALUES ('legacy-1', 'same-place', '', 'StiUpgradeImage')
+    `);
+    await db.query(`
+      INSERT INTO sti_upgrade_assets (id, slug, context, _meta_type)
+      VALUES ('qualified-1', 'same-place', '', '@happyvertical/smrt-images:StiUpgradeImage')
+    `);
+
+    const result = await repairStiDiscriminatorRows({
+      db,
+      tableName: 'sti_upgrade_assets',
+      className: 'StiUpgradeImage',
+      legacyMetaType: 'StiUpgradeImage',
+      qualifiedMetaType: '@happyvertical/smrt-images:StiUpgradeImage',
+    });
+
+    expect(result.updatedRows).toBe(0);
+    expect(result.conflicts).toEqual([
+      {
+        tableName: 'sti_upgrade_assets',
+        legacyMetaType: 'StiUpgradeImage',
+        qualifiedMetaType: '@happyvertical/smrt-images:StiUpgradeImage',
+        legacyId: 'legacy-1',
+        qualifiedId: 'qualified-1',
+        conflictIdentity: {
+          slug: 'same-place',
+          context: '',
+        },
+      },
+    ]);
+    const rows = (
+      await db.query(
+        'SELECT id, _meta_type FROM sti_upgrade_assets ORDER BY id',
+      )
+    ).rows;
+    expect(rows.map((row: any) => row._meta_type)).toEqual([
+      'StiUpgradeImage',
+      '@happyvertical/smrt-images:StiUpgradeImage',
+    ]);
+  });
+
+  it('uses custom STI conflict columns when finding qualified duplicates', async () => {
+    db = await getDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      __smrtSkipVitestSchemaPreparation: true,
+    });
+    await db.query(`
+      CREATE TABLE sti_upgrade_customs (
+        id TEXT PRIMARY KEY,
+        slug TEXT NOT NULL,
+        context TEXT NOT NULL DEFAULT '',
+        external_key TEXT NOT NULL,
+        _meta_type TEXT NOT NULL
+      )
+    `);
+    await db.query(
+      'CREATE UNIQUE INDEX sti_upgrade_customs_identity_idx ON sti_upgrade_customs(external_key, _meta_type)',
+    );
+    await db.query(`
+      INSERT INTO sti_upgrade_customs (id, slug, context, external_key, _meta_type)
+      VALUES ('legacy-1', 'legacy-slug', '', 'shared-key', 'StiUpgradeCustomIdentity')
+    `);
+    await db.query(`
+      INSERT INTO sti_upgrade_customs (id, slug, context, external_key, _meta_type)
+      VALUES ('qualified-1', 'different-slug', '', 'shared-key', '@happyvertical/smrt-cli:StiUpgradeCustomIdentity')
+    `);
+
+    const result = await repairStiDiscriminatorRows({
+      db,
+      tableName: 'sti_upgrade_customs',
+      className: 'StiUpgradeCustomIdentity',
+      legacyMetaType: 'StiUpgradeCustomIdentity',
+      qualifiedMetaType: '@happyvertical/smrt-cli:StiUpgradeCustomIdentity',
+    });
+
+    expect(result.updatedRows).toBe(0);
+    expect(result.conflicts).toEqual([
+      {
+        tableName: 'sti_upgrade_customs',
+        legacyMetaType: 'StiUpgradeCustomIdentity',
+        qualifiedMetaType: '@happyvertical/smrt-cli:StiUpgradeCustomIdentity',
+        legacyId: 'legacy-1',
+        qualifiedId: 'qualified-1',
+        conflictIdentity: {
+          external_key: 'shared-key',
+        },
+      },
+    ]);
   });
 });

--- a/packages/cli/src/commands/sti-upgrade.ts
+++ b/packages/cli/src/commands/sti-upgrade.ts
@@ -4,6 +4,10 @@ import {
   ObjectRegistry,
 } from '@happyvertical/smrt-core';
 
+type QueryableDb = {
+  query(sql: string, ...params: any[]): Promise<any>;
+};
+
 export type StiDiscriminatorUpgradeResult =
   | {
       action: 'skip';
@@ -15,6 +19,25 @@ export type StiDiscriminatorUpgradeResult =
       currentQualifiedName: string;
       sourceKind: 'simple' | 'stale-qualified';
     };
+
+export interface StiDiscriminatorRepairConflict {
+  tableName: string;
+  legacyMetaType: string;
+  qualifiedMetaType: string;
+  legacyId: string | null;
+  qualifiedId: string | null;
+  conflictIdentity: Record<string, any>;
+}
+
+export interface StiDiscriminatorRepairResult {
+  tableName: string;
+  legacyMetaType: string;
+  qualifiedMetaType: string;
+  checkedRows: number;
+  updatedRows: number;
+  wouldUpdateRows: number;
+  conflicts: StiDiscriminatorRepairConflict[];
+}
 
 export function resolveStiDiscriminatorUpgrade(
   metaType: string,
@@ -49,4 +72,122 @@ export function resolveStiDiscriminatorUpgrade(
     currentQualifiedName,
     sourceKind: isQualifiedName(metaType) ? 'stale-qualified' : 'simple',
   };
+}
+
+function quoteIdentifier(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+function rowsFromResult(result: any): any[] {
+  if (Array.isArray(result)) {
+    return result;
+  }
+  return Array.isArray(result?.rows) ? result.rows : [];
+}
+
+function getRowCount(result: any): number | undefined {
+  return typeof result?.rowCount === 'number' ? result.rowCount : undefined;
+}
+
+function buildNullSafeIdentityPredicate(columns: string[]): string {
+  return columns
+    .map((column) => {
+      const quoted = quoteIdentifier(column);
+      return `(${quoted} = ? OR (${quoted} IS NULL AND ? IS NULL))`;
+    })
+    .join(' AND ');
+}
+
+function getIdentityParams(row: Record<string, any>, columns: string[]): any[] {
+  const params: any[] = [];
+  for (const column of columns) {
+    params.push(row[column], row[column]);
+  }
+  return params;
+}
+
+export function getStiConflictIdentityColumns(className: string): string[] {
+  return ObjectRegistry.getConflictColumns(className).filter(
+    (column) => column !== '_meta_type',
+  );
+}
+
+export async function repairStiDiscriminatorRows(options: {
+  db: QueryableDb;
+  tableName: string;
+  className: string;
+  legacyMetaType: string;
+  qualifiedMetaType: string;
+  dryRun?: boolean;
+}): Promise<StiDiscriminatorRepairResult> {
+  const {
+    db,
+    tableName,
+    className,
+    legacyMetaType,
+    qualifiedMetaType,
+    dryRun = false,
+  } = options;
+  const identityColumns = getStiConflictIdentityColumns(className);
+  const selectColumns = Array.from(new Set(['id', ...identityColumns]));
+  const quotedTable = quoteIdentifier(tableName);
+  const selectSql = `SELECT ${selectColumns.map(quoteIdentifier).join(', ')} FROM ${quotedTable} WHERE ${quoteIdentifier('_meta_type')} = ?`;
+  const legacyRows = rowsFromResult(await db.query(selectSql, legacyMetaType));
+  const result: StiDiscriminatorRepairResult = {
+    tableName,
+    legacyMetaType,
+    qualifiedMetaType,
+    checkedRows: legacyRows.length,
+    updatedRows: 0,
+    wouldUpdateRows: 0,
+    conflicts: [],
+  };
+
+  for (const row of legacyRows) {
+    const conflictIdentity = Object.fromEntries(
+      identityColumns.map((column) => [column, row[column]]),
+    );
+    const identityPredicate = buildNullSafeIdentityPredicate(identityColumns);
+    const duplicateSql = [
+      `SELECT ${quoteIdentifier('id')} FROM ${quotedTable}`,
+      `WHERE ${quoteIdentifier('_meta_type')} = ?`,
+      identityPredicate ? `AND ${identityPredicate}` : '',
+      'LIMIT 1',
+    ]
+      .filter(Boolean)
+      .join(' ');
+    const duplicateRows = rowsFromResult(
+      await db.query(
+        duplicateSql,
+        qualifiedMetaType,
+        ...getIdentityParams(row, identityColumns),
+      ),
+    );
+
+    if (duplicateRows.length > 0) {
+      result.conflicts.push({
+        tableName,
+        legacyMetaType,
+        qualifiedMetaType,
+        legacyId: row.id ?? null,
+        qualifiedId: duplicateRows[0].id ?? null,
+        conflictIdentity,
+      });
+      continue;
+    }
+
+    if (dryRun) {
+      result.wouldUpdateRows++;
+      continue;
+    }
+
+    const updateResult = await db.query(
+      `UPDATE ${quotedTable} SET ${quoteIdentifier('_meta_type')} = ? WHERE ${quoteIdentifier('id')} = ?`,
+      qualifiedMetaType,
+      row.id,
+    );
+    result.updatedRows += getRowCount(updateResult) ?? 1;
+  }
+
+  return result;
 }

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -39,7 +39,11 @@ import {
   runRuntimeCheckSafely,
   runtimeCheckCommand,
 } from './runtime-check-command.js';
-import { resolveStiDiscriminatorUpgrade } from './sti-upgrade.js';
+import {
+  repairStiDiscriminatorRows,
+  resolveStiDiscriminatorUpgrade,
+  type StiDiscriminatorRepairConflict,
+} from './sti-upgrade.js';
 
 /**
  * Column definition type for migration comparison
@@ -205,6 +209,24 @@ function parseExpectedIndexes(schema: {
 function quoteIdentifier(name: string): string {
   // Escape any double quotes in the identifier by doubling them
   return `"${name.replace(/"/g, '""')}"`;
+}
+
+function formatStiConflictIdentity(
+  conflict: StiDiscriminatorRepairConflict,
+): string {
+  const entries = Object.entries(conflict.conflictIdentity);
+  const identity =
+    entries.length > 0
+      ? entries
+          .map(([column, value]) => `${column}=${JSON.stringify(value)}`)
+          .join(', ')
+      : 'no non-_meta_type conflict columns';
+  const ids =
+    conflict.legacyId || conflict.qualifiedId
+      ? ` (legacy id: ${conflict.legacyId ?? 'unknown'}, qualified id: ${conflict.qualifiedId ?? 'unknown'})`
+      : '';
+
+  return `${identity}${ids}`;
 }
 
 /**
@@ -1063,7 +1085,7 @@ export default testManifest;
       'upgrade-sti': {
         type: 'boolean',
         description:
-          'Upgrade STI discriminators from simple class names to qualified names (@pkg:Class)',
+          'Safely upgrade STI discriminators from simple class names to qualified names (@pkg:Class)',
         default: false,
       },
       'drop-indexes': {
@@ -1554,7 +1576,7 @@ export default testManifest;
           );
         }
 
-        // 13.5 Handle --upgrade-sti flag for STI discriminator migration
+        // 13.5 Handle --upgrade-sti flag for STI discriminator data repair
         if (options['upgrade-sti']) {
           console.log(
             '\n🔄 Upgrading STI discriminators to qualified names...\n',
@@ -1630,32 +1652,50 @@ export default testManifest;
                   continue;
                 }
 
-                const qualifiedName = resolution.currentQualifiedName;
-
-                // Generate UPDATE statement (? placeholders are converted to $1, $2 by sql package)
-                const updateSql = `UPDATE ${quoteIdentifier(tableName)} SET ${quoteIdentifier('_meta_type')} = ? WHERE ${quoteIdentifier('_meta_type')} = ?`;
-
-                if (isDryRun) {
-                  console.log(`  [DRY RUN] ${updateSql}`);
-                  console.log(
-                    `            params: ['${qualifiedName}', '${metaType}']`,
-                  );
-                  stiSuccessCount++;
-                  continue;
-                }
-
                 try {
-                  const updateResult = await db.query(
-                    updateSql,
-                    qualifiedName,
-                    metaType,
-                  );
-                  const rowsAffected = updateResult.rowCount || 0;
-                  console.log(
-                    `  ✓ ${tableName}: "${metaType}" → "${qualifiedName}" (${rowsAffected} row(s))`,
-                  );
-                  stiSuccessCount++;
+                  const repair = await repairStiDiscriminatorRows({
+                    db,
+                    tableName,
+                    className: resolution.className,
+                    legacyMetaType: metaType,
+                    qualifiedMetaType: resolution.currentQualifiedName,
+                    dryRun: isDryRun,
+                  });
+
+                  if (repair.conflicts.length > 0) {
+                    console.error(
+                      `  ✗ ${tableName}: "${metaType}" → "${repair.qualifiedMetaType}" blocked by ${repair.conflicts.length} duplicate row(s)`,
+                    );
+                    for (const conflict of repair.conflicts) {
+                      console.error(
+                        `     ${formatStiConflictIdentity(conflict)}`,
+                      );
+                    }
+                    stiErrorCount += repair.conflicts.length;
+                  }
+
+                  if (isDryRun) {
+                    if (repair.wouldUpdateRows > 0) {
+                      console.log(
+                        `  [DRY RUN] ${tableName}: "${metaType}" → "${repair.qualifiedMetaType}" (${repair.wouldUpdateRows} row(s) would be updated by id)`,
+                      );
+                      stiSuccessCount += repair.wouldUpdateRows;
+                    } else if (repair.conflicts.length === 0) {
+                      stiSkippedCount++;
+                    }
+                    continue;
+                  }
+
+                  if (repair.updatedRows > 0) {
+                    console.log(
+                      `  ✓ ${tableName}: "${metaType}" → "${repair.qualifiedMetaType}" (${repair.updatedRows} row(s))`,
+                    );
+                    stiSuccessCount += repair.updatedRows;
+                  } else if (repair.conflicts.length === 0) {
+                    stiSkippedCount++;
+                  }
                 } catch (error: any) {
+                  const qualifiedName = resolution.currentQualifiedName;
                   const errorMsg =
                     error instanceof Error ? error.message : String(error);
                   const originalError = error?.context?.originalError;
@@ -1670,7 +1710,7 @@ export default testManifest;
             console.log();
             if (stiErrorCount > 0) {
               console.log(
-                `⚠️  STI upgrade completed with errors: ${stiSuccessCount} succeeded, ${stiErrorCount} failed`,
+                `⚠️  STI upgrade completed with errors: ${stiSuccessCount} row(s) upgraded, ${stiErrorCount} conflict/error(s)`,
               );
               if (stiSkippedCount > 0) {
                 console.log(
@@ -1683,7 +1723,7 @@ export default testManifest;
               );
             } else {
               console.log(
-                `✅ Successfully upgraded ${stiSuccessCount} STI discriminator(s)`,
+                `✅ Successfully upgraded ${stiSuccessCount} STI discriminator row(s)`,
               );
               if (stiSkippedCount > 0) {
                 console.log(

--- a/packages/core/src/__tests__/issue-1170-sti-legacy-discriminator-save.test.ts
+++ b/packages/core/src/__tests__/issue-1170-sti-legacy-discriminator-save.test.ts
@@ -4,10 +4,18 @@
  */
 
 import type { DatabaseInterface } from '@happyvertical/sql';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
 import { field } from '../decorators';
 import { SmrtObject } from '../object';
-import { smrt } from '../registry';
+import { ObjectRegistry, smrt } from '../registry';
 import { getTestDatabase } from '../testing/database';
 
 @smrt({
@@ -19,18 +27,71 @@ class Issue1170Place extends SmrtObject {
   name: string = '';
 }
 
+@smrt({
+  tableStrategy: 'sti',
+  tableName: 'issue_1170_external_places',
+})
+class Issue1170ExternalPlace extends SmrtObject {
+  @field()
+  name: string = '';
+}
+
+@smrt({
+  tableStrategy: 'sti',
+  tableName: 'issue_1170_custom_places',
+  conflictColumns: ['external_key', '_meta_type'],
+})
+class Issue1170CustomIdentityPlace extends SmrtObject {
+  @field()
+  externalKey: string = '';
+
+  @field()
+  name: string = '';
+}
+
 const tableName = 'issue_1170_places';
+const externalTableName = 'issue_1170_external_places';
+const customTableName = 'issue_1170_custom_places';
 const legacyMetaType = 'Issue1170Place';
 const qualifiedMetaType = '@happyvertical/smrt-core:Issue1170Place';
+const externalLegacyMetaType = 'Issue1170ExternalPlace';
+const externalQualifiedMetaType =
+  '@happyvertical/smrt-places:Issue1170ExternalPlace';
+const customLegacyMetaType = 'Issue1170CustomIdentityPlace';
+const customQualifiedMetaType =
+  '@happyvertical/smrt-core:Issue1170CustomIdentityPlace';
+
+const externalPlaceClass = ObjectRegistry.findClass('Issue1170ExternalPlace');
+const originalExternalPackageName = externalPlaceClass?.packageName;
+const originalExternalQualifiedName = externalPlaceClass?.qualifiedName;
 
 describe('Issue #1170: legacy STI discriminator save handling', () => {
   let db: DatabaseInterface;
+
+  beforeAll(() => {
+    if (!externalPlaceClass) {
+      throw new Error('Issue1170ExternalPlace was not registered');
+    }
+    externalPlaceClass.packageName = '@happyvertical/smrt-places';
+    externalPlaceClass.qualifiedName = externalQualifiedMetaType;
+  });
+
+  afterAll(() => {
+    if (externalPlaceClass) {
+      externalPlaceClass.packageName = originalExternalPackageName;
+      externalPlaceClass.qualifiedName = originalExternalQualifiedName;
+    }
+  });
 
   beforeEach(async () => {
     db = await getTestDatabase({
       type: 'sqlite',
       url: ':memory:',
-      classes: ['Issue1170Place'],
+      classes: [
+        'Issue1170Place',
+        'Issue1170ExternalPlace',
+        'Issue1170CustomIdentityPlace',
+      ],
     });
   });
 
@@ -55,6 +116,7 @@ describe('Issue #1170: legacy STI discriminator save handling', () => {
 
     loaded.name = 'Migrated Place';
     await expect(loaded.save()).resolves.toBe(loaded);
+    expect((loaded as any)._meta_type).toBe(qualifiedMetaType);
 
     const rows = await db.list(tableName, {
       slug: 'shared-place',
@@ -101,6 +163,10 @@ describe('Issue #1170: legacy STI discriminator save handling', () => {
         id: 'legacy-place',
         slug: 'shared-place',
         context: 'weather',
+        conflictIdentity: {
+          slug: 'shared-place',
+          context: 'weather',
+        },
         legacyMetaType,
         qualifiedMetaType,
         duplicateId: 'qualified-place',
@@ -116,5 +182,82 @@ describe('Issue #1170: legacy STI discriminator save handling', () => {
     expect(rows.map((row) => row._meta_type).sort()).toEqual(
       [legacyMetaType, qualifiedMetaType].sort(),
     );
+  });
+
+  it('uses the registered package namespace when upgrading a legacy discriminator', async () => {
+    await db.insert(externalTableName, {
+      id: 'external-legacy-place',
+      slug: 'external-place',
+      context: 'weather',
+      _meta_type: externalLegacyMetaType,
+      name: 'Legacy External Place',
+    });
+
+    const loaded = (await new Issue1170ExternalPlace({
+      db,
+      id: 'external-legacy-place',
+    }).initialize()) as Issue1170ExternalPlace;
+    expect((loaded as any)._meta_type).toBe(externalLegacyMetaType);
+    expect(loaded.toJSON()._meta_type).toBe(externalQualifiedMetaType);
+
+    loaded.name = 'Migrated External Place';
+    await expect(loaded.save()).resolves.toBe(loaded);
+    expect((loaded as any)._meta_type).toBe(externalQualifiedMetaType);
+
+    const rows = await db.list(externalTableName, {
+      slug: 'external-place',
+      context: 'weather',
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: 'external-legacy-place',
+      _meta_type: externalQualifiedMetaType,
+      name: 'Migrated External Place',
+    });
+  });
+
+  it('uses custom STI conflict columns when checking for qualified duplicates', async () => {
+    await db.insert(customTableName, [
+      {
+        id: 'custom-legacy-place',
+        slug: 'legacy-slug',
+        context: 'weather',
+        external_key: 'same-logical-place',
+        _meta_type: customLegacyMetaType,
+        name: 'Legacy Custom Place',
+      },
+      {
+        id: 'custom-qualified-place',
+        slug: 'qualified-slug',
+        context: 'weather',
+        external_key: 'same-logical-place',
+        _meta_type: customQualifiedMetaType,
+        name: 'Qualified Custom Place',
+      },
+    ]);
+
+    const loaded = (await new Issue1170CustomIdentityPlace({
+      db,
+      id: 'custom-legacy-place',
+    }).initialize()) as Issue1170CustomIdentityPlace;
+    loaded.name = 'Edited Legacy Custom Place';
+
+    await expect(loaded.save()).rejects.toMatchObject({
+      code: 'DB_STI_DISCRIMINATOR_CONFLICT',
+      details: {
+        className: 'Issue1170CustomIdentityPlace',
+        tableName: customTableName,
+        id: 'custom-legacy-place',
+        slug: 'legacy-slug',
+        context: 'weather',
+        conflictIdentity: {
+          external_key: 'same-logical-place',
+        },
+        legacyMetaType: customLegacyMetaType,
+        qualifiedMetaType: customQualifiedMetaType,
+        duplicateId: 'custom-qualified-place',
+      },
+    });
   });
 });

--- a/packages/core/src/__tests__/issue-1170-sti-legacy-discriminator-save.test.ts
+++ b/packages/core/src/__tests__/issue-1170-sti-legacy-discriminator-save.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Issue #1170: legacy STI discriminator rows should not hit generic
+ * primary-key/upsert collisions when save() serializes them to qualified names.
+ */
+
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { field } from '../decorators';
+import { SmrtObject } from '../object';
+import { smrt } from '../registry';
+import { getTestDatabase } from '../testing/database';
+
+@smrt({
+  tableStrategy: 'sti',
+  tableName: 'issue_1170_places',
+})
+class Issue1170Place extends SmrtObject {
+  @field()
+  name: string = '';
+}
+
+const tableName = 'issue_1170_places';
+const legacyMetaType = 'Issue1170Place';
+const qualifiedMetaType = '@happyvertical/smrt-core:Issue1170Place';
+
+describe('Issue #1170: legacy STI discriminator save handling', () => {
+  let db: DatabaseInterface;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['Issue1170Place'],
+    });
+  });
+
+  afterEach(async () => {
+    await db.close?.();
+  });
+
+  it('updates a lone legacy discriminator row in place by id', async () => {
+    await db.insert(tableName, {
+      id: 'legacy-place',
+      slug: 'shared-place',
+      context: 'weather',
+      _meta_type: legacyMetaType,
+      name: 'Legacy Place',
+    });
+
+    const loaded = (await new Issue1170Place({
+      db,
+      id: 'legacy-place',
+    }).initialize()) as Issue1170Place;
+    expect((loaded as any)._meta_type).toBe(legacyMetaType);
+
+    loaded.name = 'Migrated Place';
+    await expect(loaded.save()).resolves.toBe(loaded);
+
+    const rows = await db.list(tableName, {
+      slug: 'shared-place',
+      context: 'weather',
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: 'legacy-place',
+      _meta_type: qualifiedMetaType,
+      name: 'Migrated Place',
+    });
+  });
+
+  it('fails with an actionable STI discriminator conflict when a qualified duplicate exists', async () => {
+    await db.insert(tableName, [
+      {
+        id: 'legacy-place',
+        slug: 'shared-place',
+        context: 'weather',
+        _meta_type: legacyMetaType,
+        name: 'Legacy Place',
+      },
+      {
+        id: 'qualified-place',
+        slug: 'shared-place',
+        context: 'weather',
+        _meta_type: qualifiedMetaType,
+        name: 'Qualified Place',
+      },
+    ]);
+
+    const loaded = (await new Issue1170Place({
+      db,
+      id: 'legacy-place',
+    }).initialize()) as Issue1170Place;
+    loaded.name = 'Edited Legacy Place';
+
+    await expect(loaded.save()).rejects.toMatchObject({
+      code: 'DB_STI_DISCRIMINATOR_CONFLICT',
+      details: {
+        className: 'Issue1170Place',
+        tableName,
+        id: 'legacy-place',
+        slug: 'shared-place',
+        context: 'weather',
+        legacyMetaType,
+        qualifiedMetaType,
+        duplicateId: 'qualified-place',
+      },
+    });
+
+    const rows = await db.list(tableName, {
+      slug: 'shared-place',
+      context: 'weather',
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row._meta_type).sort()).toEqual(
+      [legacyMetaType, qualifiedMetaType].sort(),
+    );
+  });
+});

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -263,14 +263,19 @@ export class DatabaseError extends SmrtError {
     id: string;
     slug: string;
     context: string;
+    conflictIdentity: Record<string, any>;
     legacyMetaType: string;
     qualifiedMetaType: string;
     duplicateId: string;
   }): DatabaseError {
+    const identityText = Object.entries(details.conflictIdentity)
+      .map(([key, value]) => `${key} '${String(value)}'`)
+      .join(', ');
+
     return new DatabaseError(
       `Legacy STI discriminator collision for ${details.className} (${details.tableName}). ` +
         `Row '${details.id}' would upgrade _meta_type from '${details.legacyMetaType}' to '${details.qualifiedMetaType}', ` +
-        `but row '${details.duplicateId}' already uses the qualified discriminator for slug '${details.slug}' and context '${details.context}'. ` +
+        `but row '${details.duplicateId}' already uses the qualified discriminator for ${identityText || 'the same conflict identity'}. ` +
         `Merge or remove the duplicate legacy/qualified rows before saving.`,
       'DB_STI_DISCRIMINATOR_CONFLICT',
       details,

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -163,6 +163,7 @@ function getPrimaryCauseMessage(cause?: Error): {
  * - `DatabaseError.constraintViolation(constraint, value, cause)` — FK/CHECK/UNIQUE
  * - `DatabaseError.corruptedData(field, class, cause)` — unparse-able column data
  * - `DatabaseError.missingDiscriminator(class, rowId)` — STI row missing `_meta_type`
+ * - `DatabaseError.stiDiscriminatorConflict(...)` — legacy STI discriminator collides during qualification
  * - `DatabaseError.schemaMissing(table, class)` — table not yet migrated
  *
  * All errors have `category: 'database'` and codes prefixed with `DB_`.
@@ -253,6 +254,26 @@ export class DatabaseError extends SmrtError {
         `This may indicate a schema mismatch or manual database modification.`,
       'DB_MISSING_DISCRIMINATOR',
       { className, rowId },
+    );
+  }
+
+  static stiDiscriminatorConflict(details: {
+    className: string;
+    tableName: string;
+    id: string;
+    slug: string;
+    context: string;
+    legacyMetaType: string;
+    qualifiedMetaType: string;
+    duplicateId: string;
+  }): DatabaseError {
+    return new DatabaseError(
+      `Legacy STI discriminator collision for ${details.className} (${details.tableName}). ` +
+        `Row '${details.id}' would upgrade _meta_type from '${details.legacyMetaType}' to '${details.qualifiedMetaType}', ` +
+        `but row '${details.duplicateId}' already uses the qualified discriminator for slug '${details.slug}' and context '${details.context}'. ` +
+        `Merge or remove the duplicate legacy/qualified rows before saving.`,
+      'DB_STI_DISCRIMINATOR_CONFLICT',
+      details,
     );
   }
 

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -76,7 +76,7 @@ function getSTIHierarchyMembers(className: string): string[] {
 
 type PersistenceWritePlan =
   | { type: 'upsert'; conflictColumns: string[] }
-  | { type: 'updateById' };
+  | { type: 'updateById'; qualifiedMetaType: string };
 
 /**
  * Warn once per process if a consumer has SMRT_SKIP_STI_REHYDRATE set.
@@ -322,6 +322,15 @@ export class SmrtObject extends SmrtClass {
       return upsertPlan;
     }
     const qualifiedMetaType = String(nextMetaType);
+    const conflictIdentity: Record<string, any> = {};
+    for (const column of conflictColumns.filter(
+      (conflictColumn) => conflictColumn !== '_meta_type',
+    )) {
+      if (!Object.hasOwn(data, column)) {
+        return upsertPlan;
+      }
+      conflictIdentity[column] = data[column];
+    }
 
     const id = String(data.id);
     const existingById = await ErrorUtils.withRetry(
@@ -330,7 +339,7 @@ export class SmrtObject extends SmrtClass {
           return await this.db.get(this.tableName, { id });
         } catch (error) {
           throw DatabaseError.queryFailed(
-            `get(${this.tableName}, { id: ${id} })`,
+            `get(${this.tableName}, legacy STI id)`,
             error instanceof Error ? error : new Error(String(error)),
           );
         }
@@ -349,13 +358,12 @@ export class SmrtObject extends SmrtClass {
       async () => {
         try {
           return await this.db.get(this.tableName, {
-            slug,
-            context,
+            ...conflictIdentity,
             _meta_type: qualifiedMetaType,
           });
         } catch (error) {
           throw DatabaseError.queryFailed(
-            `get(${this.tableName}, { slug: ${slug}, context: ${context}, _meta_type: ${qualifiedMetaType} })`,
+            `get(${this.tableName}, qualified STI conflict identity)`,
             error instanceof Error ? error : new Error(String(error)),
           );
         }
@@ -371,13 +379,16 @@ export class SmrtObject extends SmrtClass {
         id,
         slug,
         context,
+        conflictIdentity,
         legacyMetaType: currentMetaType,
         qualifiedMetaType,
         duplicateId: String(existingQualified.id),
       });
     }
 
-    return { type: 'updateById' };
+    // This mirrors save()'s current last-writer-wins behavior: the probe and
+    // update are not transactional, so concurrent saves may both choose this.
+    return { type: 'updateById', qualifiedMetaType };
   }
 
   /**
@@ -1333,6 +1344,7 @@ export class SmrtObject extends SmrtClass {
             if (writePlan.type === 'updateById') {
               const { id: _id, ...updateData } = data;
               await this.db.update(this.tableName, { id: data.id }, updateData);
+              this.setMetaType(writePlan.qualifiedMetaType);
             } else {
               await this.db.upsert(
                 this.tableName,
@@ -1356,7 +1368,7 @@ export class SmrtObject extends SmrtClass {
               }
               const operation =
                 writePlan.type === 'updateById'
-                  ? `UPDATE ${this.tableName} WHERE id = ${data.id}`
+                  ? `UPDATE ${this.tableName} (id-targeted)`
                   : `UPSERT INTO ${this.tableName}`;
               throw DatabaseError.queryFailed(operation, error);
             }

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -74,6 +74,10 @@ function getSTIHierarchyMembers(className: string): string[] {
   );
 }
 
+type PersistenceWritePlan =
+  | { type: 'upsert'; conflictColumns: string[] }
+  | { type: 'updateById' };
+
 /**
  * Warn once per process if a consumer has SMRT_SKIP_STI_REHYDRATE set.
  * The env variable is a no-op since Release C (#1134); without this
@@ -269,6 +273,111 @@ export class SmrtObject extends SmrtClass {
     return (
       registered?.qualifiedName || registered?.name || this.constructor.name
     );
+  }
+
+  private getCurrentMetaType(): string | undefined {
+    const metaType = (this as any)._meta_type;
+    return typeof metaType === 'string' ? metaType : undefined;
+  }
+
+  private isLegacySTIDiscriminatorUpgrade(
+    currentMetaType: string | undefined,
+    nextMetaType: unknown,
+    className: string,
+  ): currentMetaType is string {
+    return (
+      typeof nextMetaType === 'string' &&
+      typeof currentMetaType === 'string' &&
+      currentMetaType !== nextMetaType &&
+      !currentMetaType.includes(':') &&
+      isValidMetaType(currentMetaType, className) &&
+      isValidMetaType(nextMetaType, className)
+    );
+  }
+
+  private async planPersistenceWrite(
+    className: string,
+    tableStrategy: string,
+    data: Record<string, any>,
+    conflictColumns: string[],
+  ): Promise<PersistenceWritePlan> {
+    const upsertPlan: PersistenceWritePlan = {
+      type: 'upsert',
+      conflictColumns,
+    };
+
+    if (tableStrategy !== 'sti' || !data.id) {
+      return upsertPlan;
+    }
+
+    const currentMetaType = this.getCurrentMetaType();
+    const nextMetaType = data._meta_type;
+    if (
+      !this.isLegacySTIDiscriminatorUpgrade(
+        currentMetaType,
+        nextMetaType,
+        className,
+      )
+    ) {
+      return upsertPlan;
+    }
+    const qualifiedMetaType = String(nextMetaType);
+
+    const id = String(data.id);
+    const existingById = await ErrorUtils.withRetry(
+      async () => {
+        try {
+          return await this.db.get(this.tableName, { id });
+        } catch (error) {
+          throw DatabaseError.queryFailed(
+            `get(${this.tableName}, { id: ${id} })`,
+            error instanceof Error ? error : new Error(String(error)),
+          );
+        }
+      },
+      3,
+      500,
+    );
+
+    if (!existingById || existingById._meta_type !== currentMetaType) {
+      return upsertPlan;
+    }
+
+    const slug = String(data.slug ?? '');
+    const context = String(data.context ?? '');
+    const existingQualified = await ErrorUtils.withRetry(
+      async () => {
+        try {
+          return await this.db.get(this.tableName, {
+            slug,
+            context,
+            _meta_type: qualifiedMetaType,
+          });
+        } catch (error) {
+          throw DatabaseError.queryFailed(
+            `get(${this.tableName}, { slug: ${slug}, context: ${context}, _meta_type: ${qualifiedMetaType} })`,
+            error instanceof Error ? error : new Error(String(error)),
+          );
+        }
+      },
+      3,
+      500,
+    );
+
+    if (existingQualified && existingQualified.id !== id) {
+      throw DatabaseError.stiDiscriminatorConflict({
+        className,
+        tableName: this.tableName,
+        id,
+        slug,
+        context,
+        legacyMetaType: currentMetaType,
+        qualifiedMetaType,
+        duplicateId: String(existingQualified.id),
+      });
+    }
+
+    return { type: 'updateById' };
   }
 
   /**
@@ -1211,11 +1320,26 @@ export class SmrtObject extends SmrtClass {
 
       // Get conflict columns from registry (supports custom columns for junction tables)
       const conflictColumns = ObjectRegistry.getConflictColumns(className);
+      const writePlan = await this.planPersistenceWrite(
+        className,
+        tableStrategy,
+        data,
+        conflictColumns,
+      );
 
       await ErrorUtils.withRetry(
         async () => {
           try {
-            await this.db.upsert(this.tableName, conflictColumns, data);
+            if (writePlan.type === 'updateById') {
+              const { id: _id, ...updateData } = data;
+              await this.db.update(this.tableName, { id: data.id }, updateData);
+            } else {
+              await this.db.upsert(
+                this.tableName,
+                writePlan.conflictColumns,
+                data,
+              );
+            }
           } catch (error) {
             // Detect specific database error types
             if (error instanceof Error) {
@@ -1230,10 +1354,11 @@ export class SmrtObject extends SmrtClass {
                 const field = this.extractConstraintField(error.message);
                 throw ValidationError.requiredField(field, className);
               }
-              throw DatabaseError.queryFailed(
-                `UPSERT INTO ${this.tableName}`,
-                error,
-              );
+              const operation =
+                writePlan.type === 'updateById'
+                  ? `UPDATE ${this.tableName} WHERE id = ${data.id}`
+                  : `UPSERT INTO ${this.tableName}`;
+              throw DatabaseError.queryFailed(operation, error);
             }
             throw error;
           }


### PR DESCRIPTION
## Summary

- Resolves #1170 by detecting legacy STI discriminator upgrades before the normal `(slug, context, _meta_type)` upsert runs.
- Updates a lone legacy row in place by primary key so `Place` -> `@happyvertical/smrt-places:Place` migrations do not try to insert a second row with the same id.
- Raises `DB_STI_DISCRIMINATOR_CONFLICT` with row ids and logical identity when both legacy and qualified rows already exist.
- Adds regression coverage for both the safe in-place upgrade and the duplicate-row conflict path.

## Review Notes

During self-review I found the first pass did discriminator planning outside the save retry path. I tightened that by retrying the new read probes while still keeping the intentional duplicate conflict non-retryable.

## Validation

- `pnpm --filter @happyvertical/smrt-core exec vitest run src/__tests__/issue-1170-sti-legacy-discriminator-save.test.ts src/__tests__/sti-meta-fields.test.ts src/__tests__/sti-polymorphic-queries.test.ts src/__tests__/issue-1165-tenant-upsert-repair.test.ts`
- `pnpm --filter @happyvertical/smrt-core typecheck`
- `pnpm exec biome check packages/core/src/object.ts packages/core/src/errors.ts packages/core/src/__tests__/issue-1170-sti-legacy-discriminator-save.test.ts`
- `pnpm --filter @happyvertical/smrt-core test`
- `pnpm --filter @happyvertical/smrt-core build`
- pre-push `format-check` and workflow validation