### PR TITLE
fix(core): handle wrapped system index races

### DIFF
--- a/packages/core/src/__tests__/system-table-compatibility.test.ts
+++ b/packages/core/src/__tests__/system-table-compatibility.test.ts
@@ -353,6 +353,68 @@ describe('system table compatibility', () => {
     ).toHaveLength(1);
   });
 
+  it('tolerates a verified Postgres index race wrapped by sql context text', async () => {
+    let createdAtIndexLookups = 0;
+    const query = vi
+      .fn()
+      .mockImplementation(async (sql: string, ...params: unknown[]) => {
+        if (sql === 'SELECT 1 FROM _smrt_job_events LIMIT 1') {
+          return { rows: [{ '?column?': 1 }] };
+        }
+
+        if (sql.includes('information_schema.columns')) {
+          return { rows: [{ '?column?': 1 }] };
+        }
+
+        if (sql.includes('pg_indexes')) {
+          const [indexName] = params;
+          if (indexName === 'idx_smrt_job_events_created_at') {
+            createdAtIndexLookups += 1;
+            return {
+              rows: createdAtIndexLookups === 1 ? [] : [{ '?column?': 1 }],
+            };
+          }
+
+          return { rows: [{ '?column?': 1 }] };
+        }
+
+        if (
+          sql.includes(
+            'CREATE INDEX IF NOT EXISTS idx_smrt_job_events_created_at',
+          )
+        ) {
+          const error = new Error('Failed to execute raw query') as Error & {
+            context?: {
+              originalError: string;
+            };
+          };
+          error.context = {
+            originalError:
+              'duplicate key value violates unique constraint "pg_class_relname_nsp_index", code=23505, detail=Key (relname, relnamespace)=(idx_smrt_job_events_created_at, 2200) already exists., severity=ERROR',
+          };
+          throw error;
+        }
+
+        throw new Error(`Unexpected query: ${sql}`);
+      });
+
+    await expect(
+      ensureJobEventsSystemTableCompatibility({
+        url: 'postgresql://localhost:5432/test',
+        query,
+      } as any),
+    ).resolves.toBeUndefined();
+
+    expect(createdAtIndexLookups).toBe(2);
+    expect(
+      query.mock.calls.filter(([sql]) =>
+        String(sql).includes(
+          'CREATE INDEX IF NOT EXISTS idx_smrt_job_events_created_at',
+        ),
+      ),
+    ).toHaveLength(1);
+  });
+
   it('still fails Postgres index creation when the index race cannot be verified', async () => {
     const query = vi
       .fn()

--- a/packages/core/src/system/compatibility.ts
+++ b/packages/core/src/system/compatibility.ts
@@ -103,7 +103,7 @@ function collectErrorDetails(
       }
     }
 
-    for (const nestedKey of ['cause', 'originalError']) {
+    for (const nestedKey of ['cause', 'context', 'originalError']) {
       const nested = collectErrorDetails(errorRecord[nestedKey], seen);
       for (const code of nested.codes) {
         codes.add(code);
@@ -121,16 +121,20 @@ function isDuplicateIndexRaceError(error: unknown, indexName: string): boolean {
   const { codes, messages } = collectErrorDetails(error);
   const message = messages.join('\n').toLowerCase();
   const normalizedIndexName = indexName.toLowerCase();
+  const hasDuplicateCode =
+    codes.has('23505') || /\bcode\s*=\s*23505\b/.test(message);
+  const hasRelationExistsCode =
+    codes.has('42P07') || /\bcode\s*=\s*42p07\b/i.test(message);
 
   if (!message.includes(normalizedIndexName)) {
     return false;
   }
 
-  if (codes.has('23505') && message.includes('pg_class_relname_nsp_index')) {
+  if (hasDuplicateCode && message.includes('pg_class_relname_nsp_index')) {
     return true;
   }
 
-  if (codes.has('42P07') && /relation .*already exists/i.test(message)) {
+  if (hasRelationExistsCode && /relation .*already exists/i.test(message)) {
     return true;
   }
 


### PR DESCRIPTION
## Summary
- include SQL wrapper context when detecting duplicate Postgres index creation races
- recognize text-form Postgres error codes emitted through @happyvertical/sql context.originalError
- add regression coverage for the wrapped _smrt_job_events index race seen in anytown production boot smoke

## Verification
- pnpm --dir packages/core exec vitest run src/__tests__/system-table-compatibility.test.ts
- pnpm exec biome check packages/core/src/system/compatibility.ts packages/core/src/__tests__/system-table-compatibility.test.ts
- pnpm --filter @happyvertical/smrt-core build