### PR TITLE
fix(ledgers,smrt-svelte): publish CLAUDE.md to npm

### DIFF
--- a/packages/ledgers/package.json
+++ b/packages/ledgers/package.json
@@ -14,7 +14,8 @@
     "./manifest.json": "./dist/manifest.json"
   },
   "files": [
-    "dist"
+    "dist",
+    "CLAUDE.md"
   ],
   "scripts": {
     "build": "vite build --mode library",

--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -74,7 +74,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "CLAUDE.md"
   ],
   "scripts": {
     "build": "svelte-package -i src --tsconfig tsconfig.svelte.json",


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` to the `files` field in `packages/ledgers/package.json` and `packages/smrt-svelte/package.json` so it ships in the published tarball.
- The other 9 SMRT packages already include theirs; these two were the holdouts.

## Why
Prereq for [#1178](https://github.com/happyvertical/smrt/issues/1178) (deprecate `smrt docs:claude` in favor of native CLAUDE.md @-imports). Downstream projects need the file in `node_modules` to resolve `@./node_modules/@happyvertical/smrt-ledgers/CLAUDE.md`.

## Test plan
- [x] `npm pack --dry-run` in `packages/ledgers` includes `CLAUDE.md` (1.4kB)
- [x] `npm pack --dry-run` in `packages/smrt-svelte` includes `CLAUDE.md` (3.5kB)
- [ ] CI green