### PR TITLE
feat(social): add Garrula social primitives

### DIFF
--- a/packages/secrets/src/__tests__/secret-service.test.ts
+++ b/packages/secrets/src/__tests__/secret-service.test.ts
@@ -127,6 +127,22 @@ describe('SecretService', () => {
       expect(rows[0]?.name).toBe('interceptor-free-secret');
       expect(rows[0]?.tenant_id).toBe('tenant-1');
     });
+
+    it('can store and retrieve with an explicit tenant id', async () => {
+      disableTenancy();
+
+      await service.storeForTenant('tenant-1', 'explicit-secret', 'value', {
+        category: 'oauth',
+      });
+
+      const retrieved = await service.retrieveForTenant(
+        'tenant-1',
+        'explicit-secret',
+      );
+
+      expect(retrieved.value).toBe('value');
+      expect(retrieved.category).toBe('oauth');
+    });
   });
 
   describe('Secret lifecycle', () => {

--- a/packages/secrets/src/services/SecretService.ts
+++ b/packages/secrets/src/services/SecretService.ts
@@ -12,7 +12,11 @@ import {
   getSecretStore,
   type SecretStore,
 } from '@happyvertical/secrets';
-import { getCurrentTenant, requireTenantId } from '@happyvertical/smrt-tenancy';
+import {
+  getCurrentTenant,
+  requireTenantId,
+  withTenant,
+} from '@happyvertical/smrt-tenancy';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { SecretAuditLogCollection } from '../collections/SecretAuditLogCollection.js';
 import { SecretCollection } from '../collections/SecretCollection.js';
@@ -235,6 +239,21 @@ export class SecretService {
   }
 
   /**
+   * Store a secret for a specific tenant.
+   *
+   * This is useful for integrations that already resolved tenant ownership but
+   * may be running outside the application's ambient tenant context.
+   */
+  async storeForTenant(
+    tenantId: string,
+    name: string,
+    value: string,
+    options: StoreSecretOptions = {},
+  ): Promise<Secret> {
+    return withTenant({ tenantId }, () => this.store(name, value, options));
+  }
+
+  /**
    * Retrieve a secret for the current tenant
    */
   async retrieve(name: string): Promise<RetrievedSecret> {
@@ -295,6 +314,16 @@ export class SecretService {
       }
       throw error;
     }
+  }
+
+  /**
+   * Retrieve a secret for a specific tenant.
+   */
+  async retrieveForTenant(
+    tenantId: string,
+    name: string,
+  ): Promise<RetrievedSecret> {
+    return withTenant({ tenantId }, () => this.retrieve(name));
   }
 
   /**

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -12,6 +12,15 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./server": {
+      "import": "./dist/server.js",
+      "types": "./dist/server.d.ts"
+    },
+    "./svelte": {
+      "types": "./dist/svelte/index.d.ts",
+      "svelte": "./dist/svelte/index.js",
+      "import": "./dist/svelte/index.js"
+    },
     "./manifest": "./dist/manifest.json",
     "./manifest.json": "./dist/manifest.json"
   },
@@ -28,8 +37,9 @@
     "CLAUDE.md"
   ],
   "scripts": {
-    "build": "vite build --mode library",
+    "build": "vite build --mode library && svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json",
     "build:watch": "vite build --mode library --watch",
+    "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest"
   },
@@ -37,6 +47,7 @@
     "@happyvertical/smrt-config": "workspace:*",
     "@happyvertical/smrt-content": "workspace:*",
     "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-secrets": "workspace:*",
     "@happyvertical/smrt-tenancy": "workspace:*",
     "@happyvertical/smrt-video": "workspace:*",
     "@happyvertical/utils": "catalog:"
@@ -45,7 +56,10 @@
     "@happyvertical/logger": "catalog:",
     "@happyvertical/smrt-vitest": "workspace:*",
     "@happyvertical/sql": "catalog:",
+    "@sveltejs/package": "^2.5.7",
     "@types/node": "25.0.9",
+    "svelte": "^5.0.0",
+    "svelte-check": "^4.3.5",
     "typescript": "^5.9.3",
     "vite": "^7.3.1",
     "vitest": "^4.0.17"

--- a/packages/social/src/collections/index.ts
+++ b/packages/social/src/collections/index.ts
@@ -1,0 +1,8 @@
+export { OAuthStateCollection } from './oauth-state-collection.js';
+export { SocialAccountCollection } from './social-account-collection.js';
+export { SocialPostAnalyticsSnapshotCollection } from './social-post-analytics-snapshot-collection.js';
+export {
+  type CreateSocialPostDraftOptions,
+  type PublishSuccessData,
+  SocialPostCollection,
+} from './social-post-collection.js';

--- a/packages/social/src/collections/oauth-state-collection.ts
+++ b/packages/social/src/collections/oauth-state-collection.ts
@@ -9,8 +9,10 @@ export class OAuthStateCollection extends SmrtCollection<OAuthState> {
   }
 
   async findExpired(now: Date = new Date()): Promise<OAuthState[]> {
-    const states = await this.list({});
-    return states.filter((state) => state.expiresAt.getTime() <= now.getTime());
+    return this.list({
+      where: { 'expiresAt <=': now },
+      orderBy: 'expiresAt ASC',
+    });
   }
 
   async deleteExpired(now: Date = new Date()): Promise<number> {

--- a/packages/social/src/collections/oauth-state-collection.ts
+++ b/packages/social/src/collections/oauth-state-collection.ts
@@ -1,0 +1,21 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { OAuthState } from '../oauth-state.js';
+
+export class OAuthStateCollection extends SmrtCollection<OAuthState> {
+  static readonly _itemClass = OAuthState;
+
+  async findByState(state: string): Promise<OAuthState | null> {
+    return this.get({ state });
+  }
+
+  async findExpired(now: Date = new Date()): Promise<OAuthState[]> {
+    const states = await this.list({});
+    return states.filter((state) => state.expiresAt.getTime() <= now.getTime());
+  }
+
+  async deleteExpired(now: Date = new Date()): Promise<number> {
+    const expired = await this.findExpired(now);
+    await Promise.all(expired.map((state) => state.delete()));
+    return expired.length;
+  }
+}

--- a/packages/social/src/collections/social-account-collection.ts
+++ b/packages/social/src/collections/social-account-collection.ts
@@ -1,0 +1,31 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { SocialAccount, type SocialPlatformType } from '../social-account.js';
+
+export class SocialAccountCollection extends SmrtCollection<SocialAccount> {
+  static readonly _itemClass = SocialAccount;
+
+  async findActive(platform?: SocialPlatformType): Promise<SocialAccount[]> {
+    const accounts = await this.list({
+      where: {
+        isActive: true,
+        ...(platform ? { platform } : {}),
+      },
+      orderBy: 'name ASC',
+    });
+
+    return accounts;
+  }
+
+  async findReady(platform?: SocialPlatformType): Promise<SocialAccount[]> {
+    const accounts = await this.findActive(platform);
+    return accounts.filter((account) => account.isReady);
+  }
+
+  async findNeedsAttention(): Promise<SocialAccount[]> {
+    const accounts = await this.list({
+      where: { isActive: true },
+      orderBy: 'name ASC',
+    });
+    return accounts.filter((account) => account.needsAttention);
+  }
+}

--- a/packages/social/src/collections/social-post-analytics-snapshot-collection.ts
+++ b/packages/social/src/collections/social-post-analytics-snapshot-collection.ts
@@ -1,0 +1,58 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import type { SocialPlatformType } from '../social-account.js';
+import type { PostAnalytics } from '../social-post.js';
+import {
+  type RawAnalyticsPayload,
+  SocialPostAnalyticsSnapshot,
+} from '../social-post-analytics-snapshot.js';
+
+function isRawAnalyticsPayload(value: unknown): value is RawAnalyticsPayload {
+  return (
+    value === null ||
+    Array.isArray(value) ||
+    (typeof value === 'object' && value !== null)
+  );
+}
+
+export class SocialPostAnalyticsSnapshotCollection extends SmrtCollection<SocialPostAnalyticsSnapshot> {
+  static readonly _itemClass = SocialPostAnalyticsSnapshot;
+
+  async recordSnapshot(options: {
+    socialPostId: string;
+    platform: SocialPlatformType;
+    metrics: PostAnalytics;
+    raw?: RawAnalyticsPayload;
+    capturedAt?: Date;
+    tenantId?: string | null;
+  }): Promise<SocialPostAnalyticsSnapshot> {
+    const snapshot = await this.create({
+      socialPostId: options.socialPostId,
+      platform: options.platform,
+      analytics: options.metrics,
+      raw:
+        options.raw ??
+        (isRawAnalyticsPayload(options.metrics.raw)
+          ? options.metrics.raw
+          : null),
+      capturedAt: options.capturedAt ?? new Date(),
+      tenantId: options.tenantId,
+    });
+    return snapshot;
+  }
+
+  async findForPost(
+    socialPostId: string,
+  ): Promise<SocialPostAnalyticsSnapshot[]> {
+    return this.list({
+      where: { socialPostId },
+      orderBy: 'capturedAt DESC',
+    });
+  }
+
+  async findLatestForPost(
+    socialPostId: string,
+  ): Promise<SocialPostAnalyticsSnapshot | null> {
+    const snapshots = await this.findForPost(socialPostId);
+    return snapshots[0] ?? null;
+  }
+}

--- a/packages/social/src/collections/social-post-collection.ts
+++ b/packages/social/src/collections/social-post-collection.ts
@@ -58,17 +58,24 @@ export class SocialPostCollection extends SmrtCollection<SocialPost> {
   }
 
   async findDueForPublish(now: Date = new Date()): Promise<SocialPost[]> {
-    const posts = await this.list({
-      where: {},
-      orderBy: 'scheduledAt ASC',
-    });
+    const [approved, scheduled] = await Promise.all([
+      this.list({
+        where: { status: 'approved' },
+        orderBy: 'scheduledAt ASC',
+      }),
+      this.list({
+        where: { status: 'scheduled', 'scheduledAt <=': now },
+        orderBy: 'scheduledAt ASC',
+      }),
+    ]);
 
-    return posts.filter((post) => {
-      if (post.status !== 'approved' && post.status !== 'scheduled') {
-        return false;
-      }
-      return !post.scheduledAt || post.scheduledAt.getTime() <= now.getTime();
-    });
+    return [
+      ...approved.filter((post) => post.isDueForPublish),
+      ...scheduled,
+    ].sort(
+      (a, b) =>
+        (a.scheduledAt?.getTime() ?? 0) - (b.scheduledAt?.getTime() ?? 0),
+    );
   }
 
   async recordPublishSuccess(
@@ -78,8 +85,9 @@ export class SocialPostCollection extends SmrtCollection<SocialPost> {
     const status = data.status ?? 'published';
     post.platformPostId = data.platformPostId;
     post.platformUrl = data.platformUrl;
-    post.publishedAt =
-      data.publishedAt ?? (status === 'published' ? new Date() : null);
+    if (status === 'published') {
+      post.publishedAt = data.publishedAt ?? post.publishedAt ?? new Date();
+    }
     post.status = status;
     post.errorMessage = null;
     await post.save();
@@ -91,7 +99,7 @@ export class SocialPostCollection extends SmrtCollection<SocialPost> {
     error: Error | string,
   ): Promise<SocialPost> {
     post.status = 'failed';
-    post.errorMessage = error instanceof Error ? error.message : error;
+    post.errorMessage = formatPublishError(error);
     await post.save();
     return post;
   }
@@ -109,4 +117,20 @@ export class SocialPostCollection extends SmrtCollection<SocialPost> {
     await post.save();
     return post;
   }
+}
+
+function formatPublishError(error: Error | string): string {
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  const details = [error.message];
+  const code = (error as Error & { code?: unknown }).code;
+  if (code !== undefined) {
+    details.push(`code=${String(code)}`);
+  }
+  if (error.stack) {
+    details.push(error.stack);
+  }
+  return details.join('\n');
 }

--- a/packages/social/src/collections/social-post-collection.ts
+++ b/packages/social/src/collections/social-post-collection.ts
@@ -1,0 +1,112 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import {
+  type PostAnalytics,
+  type PostStatus,
+  SocialPost,
+  type SocialPostType,
+} from '../social-post.js';
+
+export interface CreateSocialPostDraftOptions {
+  socialAccountId: string;
+  contentId?: string | null;
+  videoContentId?: string | null;
+  postType?: SocialPostType;
+  title?: string | null;
+  description?: string;
+  hashtags?: string[];
+  linkUrl?: string | null;
+  mediaUrl?: string | null;
+  scheduledAt?: Date | null;
+  tenantId?: string | null;
+}
+
+export interface PublishSuccessData {
+  platformPostId: string;
+  platformUrl: string;
+  publishedAt?: Date;
+  status?: PostStatus;
+}
+
+export class SocialPostCollection extends SmrtCollection<SocialPost> {
+  static readonly _itemClass = SocialPost;
+
+  async createDraft(
+    options: CreateSocialPostDraftOptions,
+  ): Promise<SocialPost> {
+    return this.create({
+      ...options,
+      postType:
+        options.postType ??
+        (options.videoContentId || options.mediaUrl
+          ? 'video'
+          : options.linkUrl
+            ? 'link'
+            : 'text'),
+      status: options.scheduledAt ? 'scheduled' : 'draft',
+    });
+  }
+
+  async findByStatus(status: PostStatus): Promise<SocialPost[]> {
+    return this.list({ where: { status }, orderBy: 'scheduledAt ASC' });
+  }
+
+  async findForAccount(socialAccountId: string): Promise<SocialPost[]> {
+    return this.list({
+      where: { socialAccountId },
+      orderBy: 'created_at DESC',
+    });
+  }
+
+  async findDueForPublish(now: Date = new Date()): Promise<SocialPost[]> {
+    const posts = await this.list({
+      where: {},
+      orderBy: 'scheduledAt ASC',
+    });
+
+    return posts.filter((post) => {
+      if (post.status !== 'approved' && post.status !== 'scheduled') {
+        return false;
+      }
+      return !post.scheduledAt || post.scheduledAt.getTime() <= now.getTime();
+    });
+  }
+
+  async recordPublishSuccess(
+    post: SocialPost,
+    data: PublishSuccessData,
+  ): Promise<SocialPost> {
+    const status = data.status ?? 'published';
+    post.platformPostId = data.platformPostId;
+    post.platformUrl = data.platformUrl;
+    post.publishedAt =
+      data.publishedAt ?? (status === 'published' ? new Date() : null);
+    post.status = status;
+    post.errorMessage = null;
+    await post.save();
+    return post;
+  }
+
+  async recordPublishFailure(
+    post: SocialPost,
+    error: Error | string,
+  ): Promise<SocialPost> {
+    post.status = 'failed';
+    post.errorMessage = error instanceof Error ? error.message : error;
+    await post.save();
+    return post;
+  }
+
+  async updateLatestAnalytics(
+    post: SocialPost,
+    analytics: PostAnalytics,
+    syncedAt: Date = new Date(),
+  ): Promise<SocialPost> {
+    post.analytics = {
+      ...analytics,
+      lastUpdated: analytics.lastUpdated ?? syncedAt,
+    };
+    post.analyticsLastSyncedAt = syncedAt;
+    await post.save();
+    return post;
+  }
+}

--- a/packages/social/src/index.ts
+++ b/packages/social/src/index.ts
@@ -37,6 +37,7 @@
 // module loads below. See __smrt-register__.ts for issue #1132 context.
 import './__smrt-register__.js';
 
+export * from './collections/index.js';
 export {
   OAuthState,
   type OAuthStateOptions,
@@ -45,6 +46,7 @@ export {
 export {
   type AccountStatus,
   type LinkBehavior,
+  type PublishMode,
   SocialAccount,
   type SocialAccountOptions,
   type SocialPlatformType,
@@ -54,4 +56,9 @@ export {
   type PostStatus,
   SocialPost,
   type SocialPostOptions,
+  type SocialPostType,
 } from './social-post.js';
+export {
+  SocialPostAnalyticsSnapshot,
+  type SocialPostAnalyticsSnapshotOptions,
+} from './social-post-analytics-snapshot.js';

--- a/packages/social/src/index.ts
+++ b/packages/social/src/index.ts
@@ -59,6 +59,7 @@ export {
   type SocialPostType,
 } from './social-post.js';
 export {
+  type RawAnalyticsPayload,
   SocialPostAnalyticsSnapshot,
   type SocialPostAnalyticsSnapshotOptions,
 } from './social-post-analytics-snapshot.js';

--- a/packages/social/src/server.ts
+++ b/packages/social/src/server.ts
@@ -1,0 +1,118 @@
+import type {
+  LinkBehavior,
+  PublishMode,
+  SocialPlatformType,
+} from './social-account.js';
+
+export type SocialAccountSetupMethod = 'oauth' | 'manual';
+
+export interface SocialPlatformSetup {
+  platform: SocialPlatformType;
+  label: string;
+  setupMethod: SocialAccountSetupMethod;
+  postTypes: Array<'text' | 'link' | 'image' | 'video'>;
+  defaultLinkBehavior: LinkBehavior;
+  defaultPublishMode: PublishMode;
+  supportedPublishModes: PublishMode[];
+  requiredSecretFields: string[];
+}
+
+export const SOCIAL_PLATFORM_SETUPS: SocialPlatformSetup[] = [
+  {
+    platform: 'youtube',
+    label: 'YouTube',
+    setupMethod: 'oauth',
+    postTypes: ['video'],
+    defaultLinkBehavior: 'description',
+    defaultPublishMode: 'private_or_scheduled',
+    supportedPublishModes: ['dry_run', 'private_or_scheduled', 'public'],
+    requiredSecretFields: ['clientId', 'clientSecret', 'accessToken'],
+  },
+  {
+    platform: 'facebook',
+    label: 'Facebook Page',
+    setupMethod: 'oauth',
+    postTypes: ['text', 'link', 'image', 'video'],
+    defaultLinkBehavior: 'attachment',
+    defaultPublishMode: 'private_or_scheduled',
+    supportedPublishModes: [
+      'dry_run',
+      'stage_remote',
+      'private_or_scheduled',
+      'public',
+    ],
+    requiredSecretFields: ['accessToken', 'pageId'],
+  },
+  {
+    platform: 'threads',
+    label: 'Threads',
+    setupMethod: 'oauth',
+    postTypes: ['text', 'link', 'image', 'video'],
+    defaultLinkBehavior: 'attachment',
+    defaultPublishMode: 'stage_remote',
+    supportedPublishModes: ['dry_run', 'stage_remote', 'public'],
+    requiredSecretFields: ['accessToken', 'userId'],
+  },
+  {
+    platform: 'x',
+    label: 'X',
+    setupMethod: 'oauth',
+    postTypes: ['text', 'link', 'image', 'video'],
+    defaultLinkBehavior: 'inline',
+    defaultPublishMode: 'dry_run',
+    supportedPublishModes: ['dry_run', 'stage_remote', 'public'],
+    requiredSecretFields: [
+      'apiKey',
+      'apiSecret',
+      'accessToken',
+      'accessSecret',
+    ],
+  },
+  {
+    platform: 'bluesky',
+    label: 'Bluesky',
+    setupMethod: 'manual',
+    postTypes: ['text', 'link', 'image'],
+    defaultLinkBehavior: 'attachment',
+    defaultPublishMode: 'dry_run',
+    supportedPublishModes: ['dry_run', 'stage_remote', 'public'],
+    requiredSecretFields: ['identifier', 'password'],
+  },
+];
+
+export function getSocialPlatformSetup(
+  platform: SocialPlatformType,
+): SocialPlatformSetup {
+  const setup = SOCIAL_PLATFORM_SETUPS.find(
+    (item) => item.platform === platform,
+  );
+  if (!setup) {
+    throw new Error(`Unsupported social platform: ${platform}`);
+  }
+  return setup;
+}
+
+export function getDefaultSocialAccountName(
+  platform: SocialPlatformType,
+  username?: string | null,
+): string {
+  const setup = getSocialPlatformSetup(platform);
+  return username ? `${setup.label} ${username}` : setup.label;
+}
+
+export function normalizeManualCredentials(
+  platform: SocialPlatformType,
+  values: Record<string, unknown>,
+): Record<string, string> {
+  const setup = getSocialPlatformSetup(platform);
+  const credentials: Record<string, string> = {};
+
+  for (const field of setup.requiredSecretFields) {
+    const value = values[field];
+    if (typeof value === 'string' && value.trim() !== '') {
+      credentials[field] = value.trim();
+    }
+  }
+
+  return credentials;
+}

--- a/packages/social/src/server.ts
+++ b/packages/social/src/server.ts
@@ -80,12 +80,14 @@ export const SOCIAL_PLATFORM_SETUPS: SocialPlatformSetup[] = [
   },
 ];
 
+const SOCIAL_PLATFORM_SETUP_BY_PLATFORM = new Map(
+  SOCIAL_PLATFORM_SETUPS.map((setup) => [setup.platform, setup]),
+);
+
 export function getSocialPlatformSetup(
   platform: SocialPlatformType,
 ): SocialPlatformSetup {
-  const setup = SOCIAL_PLATFORM_SETUPS.find(
-    (item) => item.platform === platform,
-  );
+  const setup = SOCIAL_PLATFORM_SETUP_BY_PLATFORM.get(platform);
   if (!setup) {
     throw new Error(`Unsupported social platform: ${platform}`);
   }
@@ -115,4 +117,21 @@ export function normalizeManualCredentials(
   }
 
   return credentials;
+}
+
+export function validateManualCredentials(
+  platform: SocialPlatformType,
+  values: Record<string, unknown>,
+): string[] {
+  const setup = getSocialPlatformSetup(platform);
+  const missing: string[] = [];
+
+  for (const field of setup.requiredSecretFields) {
+    const value = values[field];
+    if (typeof value !== 'string' || value.trim() === '') {
+      missing.push(field);
+    }
+  }
+
+  return missing;
 }

--- a/packages/social/src/social-account.ts
+++ b/packages/social/src/social-account.ts
@@ -7,22 +7,51 @@
 
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
 import { SmrtObject, smrt } from '@happyvertical/smrt-core';
-import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import {
+  getCurrentTenant,
+  TenantScoped,
+  tenantId,
+  withTenant,
+} from '@happyvertical/smrt-tenancy';
 
 /**
  * Supported social platforms
  */
-export type SocialPlatformType = 'youtube' | 'threads' | 'x' | 'bluesky';
+export type SocialPlatformType =
+  | 'youtube'
+  | 'threads'
+  | 'x'
+  | 'bluesky'
+  | 'facebook';
 
 /**
  * Account connection status
  */
-export type AccountStatus = 'connected' | 'expired' | 'error';
+export type AccountStatus =
+  | 'connected'
+  | 'disconnected'
+  | 'expired'
+  | 'missing_permissions'
+  | 'error';
 
 /**
  * Link behavior for posts with links
  */
-export type LinkBehavior = 'description' | 'reply' | 'none';
+export type LinkBehavior =
+  | 'description'
+  | 'inline'
+  | 'attachment'
+  | 'reply'
+  | 'none';
+
+/**
+ * Controls how far publish operations are allowed to go.
+ */
+export type PublishMode =
+  | 'dry_run'
+  | 'stage_remote'
+  | 'private_or_scheduled'
+  | 'public';
 
 /**
  * Social account creation options
@@ -54,14 +83,29 @@ export interface SocialAccountOptions extends SmrtObjectOptions {
   platformUrl?: string | null;
 
   /**
-   * Encrypted OAuth access token
+   * Deprecated raw OAuth access token
    */
   accessToken?: string | null;
 
   /**
-   * Encrypted OAuth refresh token
+   * Deprecated raw OAuth refresh token
    */
   refreshToken?: string | null;
+
+  /**
+   * Secret name containing the full platform credential payload
+   */
+  credentialSecretId?: string | null;
+
+  /**
+   * Secret name containing the OAuth access token
+   */
+  accessTokenSecretName?: string | null;
+
+  /**
+   * Secret name containing the OAuth refresh token
+   */
+  refreshTokenSecretName?: string | null;
 
   /**
    * Token expiration time
@@ -80,10 +124,32 @@ export interface SocialAccountOptions extends SmrtObjectOptions {
   defaultHashtags?: string[];
 
   /**
+   * Granted OAuth scopes or platform permissions
+   */
+  scopes?: string[];
+
+  /**
+   * Required permissions that still need approval/granting
+   */
+  missingPermissions?: string[];
+
+  /**
    * How to handle links in posts
    * @default 'description'
    */
   linkBehavior?: LinkBehavior;
+
+  /**
+   * Safety mode for publish operations.
+   * @default 'dry_run'
+   */
+  publishMode?: PublishMode;
+
+  /**
+   * Separate latch required before public publishing can happen.
+   * @default false
+   */
+  publicPublishingAllowed?: boolean;
 
   /**
    * Account connection status
@@ -171,28 +237,31 @@ export class SocialAccount extends SmrtObject {
   platformUrl: string | null = null;
 
   /**
-   * OAuth access token
-   *
-   * SECURITY: Tokens should be encrypted before storage using @happyvertical/smrt-secrets:
-   * ```typescript
-   * import { SecretService } from '@happyvertical/smrt-secrets';
-   * const service = await SecretService.create({ db });
-   * await service.store(`social-${account.id}-access-token`, plainTextToken);
-   * ```
-   *
-   * TODO: Integrate with smrt-secrets for automatic encryption
+   * Deprecated raw OAuth access token.
+   * Prefer credentialSecretId/accessTokenSecretName.
    */
   accessToken: string | null = null;
 
   /**
-   * OAuth refresh token
-   *
-   * SECURITY: Tokens should be encrypted before storage using @happyvertical/smrt-secrets.
-   * See accessToken documentation for encryption pattern.
-   *
-   * TODO: Integrate with smrt-secrets for automatic encryption
+   * Deprecated raw OAuth refresh token.
+   * Prefer credentialSecretId/refreshTokenSecretName.
    */
   refreshToken: string | null = null;
+
+  /**
+   * Secret name containing the complete platform credential payload.
+   */
+  credentialSecretId: string | null = null;
+
+  /**
+   * Secret name containing only the access token.
+   */
+  accessTokenSecretName: string | null = null;
+
+  /**
+   * Secret name containing only the refresh token.
+   */
+  refreshTokenSecretName: string | null = null;
 
   /**
    * Token expiration time
@@ -210,12 +279,32 @@ export class SocialAccount extends SmrtObject {
   defaultHashtags: string[] = [];
 
   /**
+   * Granted OAuth scopes or platform permissions.
+   */
+  scopes: string[] = [];
+
+  /**
+   * Required permissions that still need app review or user grant.
+   */
+  missingPermissions: string[] = [];
+
+  /**
    * How to handle links in posts
    * - description: Include link in post body/description
    * - reply: Post link as a reply (better for X algorithm)
    * - none: Don't include link
    */
   linkBehavior: LinkBehavior = 'description';
+
+  /**
+   * Safety mode for publish operations.
+   */
+  publishMode: PublishMode = 'dry_run';
+
+  /**
+   * Separate latch required before public publishing is allowed.
+   */
+  publicPublishingAllowed: boolean = false;
 
   /**
    * Account connection status
@@ -242,17 +331,60 @@ export class SocialAccount extends SmrtObject {
       this.accessToken = options.accessToken;
     if (options.refreshToken !== undefined)
       this.refreshToken = options.refreshToken;
+    if (options.credentialSecretId !== undefined)
+      this.credentialSecretId = options.credentialSecretId;
+    if (options.accessTokenSecretName !== undefined)
+      this.accessTokenSecretName = options.accessTokenSecretName;
+    if (options.refreshTokenSecretName !== undefined)
+      this.refreshTokenSecretName = options.refreshTokenSecretName;
     if (options.tokenExpiresAt !== undefined)
       this.tokenExpiresAt = options.tokenExpiresAt;
     if (options.isActive !== undefined) this.isActive = options.isActive;
     if (options.defaultHashtags !== undefined)
       this.defaultHashtags = options.defaultHashtags;
+    if (options.scopes !== undefined) this.scopes = options.scopes;
+    if (options.missingPermissions !== undefined)
+      this.missingPermissions = options.missingPermissions;
     if (options.linkBehavior !== undefined)
       this.linkBehavior = options.linkBehavior;
+    if (options.publishMode !== undefined)
+      this.publishMode = options.publishMode;
+    if (options.publicPublishingAllowed !== undefined)
+      this.publicPublishingAllowed = options.publicPublishingAllowed;
     if (options.status !== undefined) this.status = options.status;
     if (options.errorMessage !== undefined)
       this.errorMessage = options.errorMessage;
-    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+    if (options.tenantId !== undefined) {
+      this.tenantId = options.tenantId;
+    } else {
+      const rawTenantId = (options as { tenant_id?: string | null }).tenant_id;
+      if (rawTenantId !== undefined) {
+        this.tenantId = rawTenantId;
+      }
+    }
+  }
+
+  /**
+   * Social accounts need a slug identity that is scoped by tenant and platform.
+   * A newsroom may connect `@localnews` on X, YouTube, Threads, and Facebook;
+   * the generic name-derived slug would make those accounts overwrite each
+   * other through SMRT's slug/context upsert identity.
+   */
+  async getSlug(): Promise<string | null | undefined> {
+    if (!this.slug) {
+      const identity =
+        this.platformUserId || this.platformUsername || this.name || this.id;
+      const source = [this.tenantId || 'global', this.platform, identity]
+        .filter(Boolean)
+        .join('-');
+
+      this.slug = source
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/(^-|-$)/g, '');
+    }
+
+    return this.slug;
   }
 
   /**
@@ -269,7 +401,12 @@ export class SocialAccount extends SmrtObject {
    * Check if the account needs attention (expired or error)
    */
   get needsAttention(): boolean {
-    return this.status !== 'connected' || this.isTokenExpired;
+    return (
+      this.status !== 'connected' ||
+      this.isTokenExpired ||
+      this.missingPermissions.length > 0 ||
+      (this.publishMode === 'public' && !this.publicPublishingAllowed)
+    );
   }
 
   /**
@@ -279,8 +416,122 @@ export class SocialAccount extends SmrtObject {
     return (
       this.isActive &&
       this.status === 'connected' &&
-      this.accessToken !== null &&
-      !this.isTokenExpired
+      this.hasCredentials &&
+      this.missingPermissions.length === 0 &&
+      !this.isTokenExpired &&
+      (this.publishMode !== 'public' || this.publicPublishingAllowed)
     );
+  }
+
+  /**
+   * Effective publish mode after applying the public-publishing latch.
+   */
+  get effectivePublishMode(): PublishMode {
+    if (this.publishMode === 'public' && !this.publicPublishingAllowed) {
+      return 'dry_run';
+    }
+    return this.publishMode;
+  }
+
+  /**
+   * Check whether any usable credential reference exists.
+   */
+  get hasCredentials(): boolean {
+    return Boolean(
+      this.credentialSecretId || this.accessTokenSecretName || this.accessToken,
+    );
+  }
+
+  /**
+   * Store all platform credentials in smrt-secrets as a single JSON payload.
+   */
+  async setCredentials(
+    credentials: Record<string, unknown>,
+    options: {
+      description?: string;
+      category?: string;
+    } = {},
+  ): Promise<void> {
+    if (!this.id) {
+      await this.save();
+    }
+
+    const { SecretService } = await import('@happyvertical/smrt-secrets');
+    const secretService = await SecretService.create({ db: this.db });
+    const secretName = this.credentialSecretId ?? `social-account-${this.id}`;
+    const tenantId = this.getCredentialTenantId();
+
+    if (tenantId) {
+      await secretService.storeForTenant(
+        tenantId,
+        secretName,
+        JSON.stringify(credentials),
+        {
+          description: options.description ?? `Credentials for ${this.name}`,
+          category: options.category ?? 'social',
+        },
+      );
+    } else {
+      await secretService.store(secretName, JSON.stringify(credentials), {
+        description: options.description ?? `Credentials for ${this.name}`,
+        category: options.category ?? 'social',
+      });
+    }
+
+    await this.withCredentialTenantContext(async () => {
+      this.credentialSecretId = secretName;
+      await this.save();
+    });
+  }
+
+  /**
+   * Retrieve platform credentials from smrt-secrets, falling back to deprecated fields.
+   */
+  async getCredentials(): Promise<Record<string, unknown> | null> {
+    if (!this.credentialSecretId) {
+      if (!this.accessToken && !this.refreshToken) return null;
+      return {
+        accessToken: this.accessToken,
+        refreshToken: this.refreshToken,
+      };
+    }
+
+    const { SecretService } = await import('@happyvertical/smrt-secrets');
+    const secretService = await SecretService.create({ db: this.db });
+
+    const credentialSecretId = this.credentialSecretId;
+    const tenantId = this.getCredentialTenantId();
+    const secret = tenantId
+      ? await secretService.retrieveForTenant(tenantId, credentialSecretId)
+      : await this.withCredentialTenantContext(() =>
+          secretService.retrieve(credentialSecretId),
+        );
+    return JSON.parse(secret.value);
+  }
+
+  private async withCredentialTenantContext<T>(
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    if (getCurrentTenant()) {
+      return fn();
+    }
+
+    const tenantId = this.getCredentialTenantId();
+    if (tenantId) {
+      return withTenant({ tenantId }, fn);
+    }
+
+    return fn();
+  }
+
+  private getCredentialTenantId(): string | null {
+    if (this.tenantId) {
+      return this.tenantId;
+    }
+
+    const rawTenantId = (this as { tenant_id?: unknown }).tenant_id;
+    return typeof rawTenantId === 'string' && rawTenantId.length > 0
+      ? rawTenantId
+      : null;
   }
 }

--- a/packages/social/src/social-account.ts
+++ b/packages/social/src/social-account.ts
@@ -5,14 +5,17 @@
  * Stores OAuth credentials and account settings.
  */
 
+import { randomUUID } from 'node:crypto';
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
 import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { SecretService } from '@happyvertical/smrt-secrets';
 import {
   getCurrentTenant,
   TenantScoped,
   tenantId,
   withTenant,
 } from '@happyvertical/smrt-tenancy';
+import { getSocialPlatformSetup } from './server.js';
 
 /**
  * Supported social platforms
@@ -354,12 +357,15 @@ export class SocialAccount extends SmrtObject {
     if (options.status !== undefined) this.status = options.status;
     if (options.errorMessage !== undefined)
       this.errorMessage = options.errorMessage;
-    if (options.tenantId !== undefined) {
-      this.tenantId = options.tenantId;
-    } else {
-      const rawTenantId = (options as { tenant_id?: string | null }).tenant_id;
-      if (rawTenantId !== undefined) {
-        this.tenantId = rawTenantId;
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+
+    if (options.platform !== undefined) {
+      const setup = getSocialPlatformSetup(this.platform);
+      if (options.linkBehavior === undefined) {
+        this.linkBehavior = setup.defaultLinkBehavior;
+      }
+      if (options.publishMode === undefined) {
+        this.publishMode = setup.defaultPublishMode;
       }
     }
   }
@@ -374,7 +380,15 @@ export class SocialAccount extends SmrtObject {
     if (!this.slug) {
       const identity =
         this.platformUserId || this.platformUsername || this.name || this.id;
-      const source = [this.tenantId || 'global', this.platform, identity]
+      if (!identity) {
+        return this.slug;
+      }
+
+      const source = [
+        this.tenantId ? `tenant-${this.tenantId}` : 'no-tenant',
+        this.platform,
+        identity,
+      ]
         .filter(Boolean)
         .join('-');
 
@@ -453,33 +467,28 @@ export class SocialAccount extends SmrtObject {
     } = {},
   ): Promise<void> {
     if (!this.id) {
-      await this.save();
+      this.id = randomUUID();
     }
 
-    const { SecretService } = await import('@happyvertical/smrt-secrets');
-    const secretService = await SecretService.create({ db: this.db });
     const secretName = this.credentialSecretId ?? `social-account-${this.id}`;
-    const tenantId = this.getCredentialTenantId();
+    const tenantId = this.requireCredentialTenantId(
+      'store social account credentials',
+    );
+    const secretService = await SecretService.create({ db: this.db });
 
-    if (tenantId) {
-      await secretService.storeForTenant(
-        tenantId,
-        secretName,
-        JSON.stringify(credentials),
-        {
-          description: options.description ?? `Credentials for ${this.name}`,
-          category: options.category ?? 'social',
-        },
-      );
-    } else {
-      await secretService.store(secretName, JSON.stringify(credentials), {
+    await secretService.storeForTenant(
+      tenantId,
+      secretName,
+      JSON.stringify(credentials),
+      {
         description: options.description ?? `Credentials for ${this.name}`,
         category: options.category ?? 'social',
-      });
-    }
+      },
+    );
+
+    this.credentialSecretId = secretName;
 
     await this.withCredentialTenantContext(async () => {
-      this.credentialSecretId = secretName;
       await this.save();
     });
   }
@@ -489,6 +498,32 @@ export class SocialAccount extends SmrtObject {
    */
   async getCredentials(): Promise<Record<string, unknown> | null> {
     if (!this.credentialSecretId) {
+      if (this.accessTokenSecretName || this.refreshTokenSecretName) {
+        const tenantId = this.requireCredentialTenantId(
+          'retrieve social account credentials',
+        );
+        const secretService = await SecretService.create({ db: this.db });
+        const credentials: Record<string, unknown> = {};
+
+        if (this.accessTokenSecretName) {
+          const secret = await secretService.retrieveForTenant(
+            tenantId,
+            this.accessTokenSecretName,
+          );
+          credentials.accessToken = secret.value;
+        }
+
+        if (this.refreshTokenSecretName) {
+          const secret = await secretService.retrieveForTenant(
+            tenantId,
+            this.refreshTokenSecretName,
+          );
+          credentials.refreshToken = secret.value;
+        }
+
+        return credentials;
+      }
+
       if (!this.accessToken && !this.refreshToken) return null;
       return {
         accessToken: this.accessToken,
@@ -496,32 +531,29 @@ export class SocialAccount extends SmrtObject {
       };
     }
 
-    const { SecretService } = await import('@happyvertical/smrt-secrets');
-    const secretService = await SecretService.create({ db: this.db });
-
     const credentialSecretId = this.credentialSecretId;
-    const tenantId = this.getCredentialTenantId();
-    const secret = tenantId
-      ? await secretService.retrieveForTenant(tenantId, credentialSecretId)
-      : await this.withCredentialTenantContext(() =>
-          secretService.retrieve(credentialSecretId),
-        );
+    const tenantId = this.requireCredentialTenantId(
+      'retrieve social account credentials',
+    );
+    const secretService = await SecretService.create({ db: this.db });
+    const secret = await secretService.retrieveForTenant(
+      tenantId,
+      credentialSecretId,
+    );
     return JSON.parse(secret.value);
   }
 
   private async withCredentialTenantContext<T>(
     fn: () => Promise<T>,
   ): Promise<T> {
-    if (getCurrentTenant()) {
+    const tenantId = this.getCredentialTenantId();
+    const currentTenantId = getCurrentTenant()?.tenantId;
+
+    if (!tenantId || currentTenantId === tenantId) {
       return fn();
     }
 
-    const tenantId = this.getCredentialTenantId();
-    if (tenantId) {
-      return withTenant({ tenantId }, fn);
-    }
-
-    return fn();
+    return withTenant({ tenantId }, fn);
   }
 
   private getCredentialTenantId(): string | null {
@@ -529,9 +561,14 @@ export class SocialAccount extends SmrtObject {
       return this.tenantId;
     }
 
-    const rawTenantId = (this as { tenant_id?: unknown }).tenant_id;
-    return typeof rawTenantId === 'string' && rawTenantId.length > 0
-      ? rawTenantId
-      : null;
+    return getCurrentTenant()?.tenantId ?? null;
+  }
+
+  private requireCredentialTenantId(action: string): string {
+    const tenantId = this.getCredentialTenantId();
+    if (!tenantId) {
+      throw new Error(`Tenant context required to ${action}.`);
+    }
+    return tenantId;
   }
 }

--- a/packages/social/src/social-post-analytics-snapshot.ts
+++ b/packages/social/src/social-post-analytics-snapshot.ts
@@ -26,7 +26,7 @@ export interface SocialPostAnalyticsSnapshotOptions extends SmrtObjectOptions {
   /**
    * Platform that produced this snapshot
    */
-  platform?: SocialPlatformType;
+  platform?: SocialPlatformType | null;
 
   /**
    * Normalized platform analytics.
@@ -62,7 +62,8 @@ export class SocialPostAnalyticsSnapshot extends SmrtObject {
   @foreignKey(() => SocialPost)
   socialPostId: string | null = null;
 
-  platform: SocialPlatformType = 'youtube';
+  @field({ required: true })
+  platform: SocialPlatformType | null = null;
 
   analytics: PostAnalytics = {};
 

--- a/packages/social/src/social-post-analytics-snapshot.ts
+++ b/packages/social/src/social-post-analytics-snapshot.ts
@@ -1,0 +1,85 @@
+/**
+ * Social Post Analytics Snapshot Model
+ *
+ * Stores timestamped normalized and raw platform analytics payloads.
+ */
+
+import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
+import { field, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import type { SocialPlatformType } from './social-account.js';
+import { type PostAnalytics, SocialPost } from './social-post.js';
+
+export type RawAnalyticsPayload = Record<string, unknown> | unknown[] | null;
+
+export interface SocialPostAnalyticsSnapshotOptions extends SmrtObjectOptions {
+  /**
+   * Tenant ID for multi-tenant isolation
+   */
+  tenantId?: string | null;
+
+  /**
+   * Social post being measured
+   */
+  socialPostId?: string | null;
+
+  /**
+   * Platform that produced this snapshot
+   */
+  platform?: SocialPlatformType;
+
+  /**
+   * Normalized platform analytics.
+   */
+  analytics?: PostAnalytics;
+
+  /**
+   * Raw platform payload
+   */
+  raw?: RawAnalyticsPayload;
+
+  /**
+   * When the platform data was captured
+   */
+  capturedAt?: Date;
+}
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableStrategy: 'sti',
+  api: {
+    include: ['list', 'get', 'create', 'delete'],
+  },
+  mcp: {
+    include: ['list', 'get'],
+  },
+  cli: true,
+})
+export class SocialPostAnalyticsSnapshot extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  @foreignKey(() => SocialPost)
+  socialPostId: string | null = null;
+
+  platform: SocialPlatformType = 'youtube';
+
+  analytics: PostAnalytics = {};
+
+  @field({ type: 'json', nullable: true })
+  raw: RawAnalyticsPayload = null;
+
+  capturedAt: Date = new Date();
+
+  constructor(options: SocialPostAnalyticsSnapshotOptions = {}) {
+    super(options);
+
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+    if (options.socialPostId !== undefined)
+      this.socialPostId = options.socialPostId;
+    if (options.platform !== undefined) this.platform = options.platform;
+    if (options.analytics !== undefined) this.analytics = options.analytics;
+    if (options.raw !== undefined) this.raw = options.raw;
+    if (options.capturedAt !== undefined) this.capturedAt = options.capturedAt;
+  }
+}

--- a/packages/social/src/social-post.ts
+++ b/packages/social/src/social-post.ts
@@ -16,10 +16,20 @@ import { SocialAccount } from './social-account.js';
  */
 export type PostStatus =
   | 'draft'
+  | 'pending_approval'
+  | 'approved'
   | 'scheduled'
   | 'publishing'
+  | 'dry_run'
+  | 'staged'
   | 'published'
-  | 'failed';
+  | 'failed'
+  | 'cancelled';
+
+/**
+ * Social post type
+ */
+export type SocialPostType = 'text' | 'link' | 'image' | 'video';
 
 /**
  * Post analytics
@@ -29,6 +39,11 @@ export interface PostAnalytics {
    * View/impression count
    */
   views?: number;
+
+  /**
+   * Impression count when the platform distinguishes it from views
+   */
+  impressions?: number;
 
   /**
    * Like/favorite count
@@ -49,6 +64,11 @@ export interface PostAnalytics {
    * Link click count
    */
   clicks?: number;
+
+  /**
+   * Raw platform analytics payload
+   */
+  raw?: unknown;
 
   /**
    * When analytics were last updated
@@ -74,6 +94,16 @@ export interface SocialPostOptions extends SmrtObjectOptions {
    * Generic content ID (for non-video content)
    */
   contentId?: string | null;
+
+  /**
+   * High-level post type
+   */
+  postType?: SocialPostType;
+
+  /**
+   * Public media URL for platforms that cannot upload buffers
+   */
+  mediaUrl?: string | null;
 
   /**
    * Post title (for platforms that support it)
@@ -130,6 +160,11 @@ export interface SocialPostOptions extends SmrtObjectOptions {
    * Engagement analytics
    */
   analytics?: PostAnalytics;
+
+  /**
+   * When analytics were last synced
+   */
+  analyticsLastSyncedAt?: Date | null;
 
   /**
    * Tenant ID for multi-tenant isolation
@@ -196,6 +231,16 @@ export class SocialPost extends SmrtObject {
   contentId: string | null = null;
 
   /**
+   * High-level post type
+   */
+  postType: SocialPostType = 'text';
+
+  /**
+   * Public media URL for platforms that require URL media publishing
+   */
+  mediaUrl: string | null = null;
+
+  /**
    * Post title (for platforms that support it)
    */
   title: string | null = null;
@@ -239,10 +284,15 @@ export class SocialPost extends SmrtObject {
   /**
    * Post status
    * - draft: Not yet submitted for publishing
+   * - pending_approval: Awaiting editorial approval
+   * - approved: Approved and ready to publish
    * - scheduled: Queued for future publishing
    * - publishing: Currently being published
+   * - dry_run: Payload was validated without remote write
+   * - staged: Non-public platform object/container was created
    * - published: Successfully published
    * - failed: Publishing failed
+   * - cancelled: Publishing was cancelled
    */
   status: PostStatus = 'draft';
 
@@ -256,6 +306,11 @@ export class SocialPost extends SmrtObject {
    */
   analytics: PostAnalytics = {};
 
+  /**
+   * When analytics were last synced
+   */
+  analyticsLastSyncedAt: Date | null = null;
+
   constructor(options: SocialPostOptions = {}) {
     super(options);
 
@@ -264,6 +319,8 @@ export class SocialPost extends SmrtObject {
     if (options.videoContentId !== undefined)
       this.videoContentId = options.videoContentId;
     if (options.contentId !== undefined) this.contentId = options.contentId;
+    if (options.postType !== undefined) this.postType = options.postType;
+    if (options.mediaUrl !== undefined) this.mediaUrl = options.mediaUrl;
     if (options.title !== undefined) this.title = options.title;
     if (options.description !== undefined)
       this.description = options.description;
@@ -281,6 +338,8 @@ export class SocialPost extends SmrtObject {
     if (options.errorMessage !== undefined)
       this.errorMessage = options.errorMessage;
     if (options.analytics !== undefined) this.analytics = options.analytics;
+    if (options.analyticsLastSyncedAt !== undefined)
+      this.analyticsLastSyncedAt = options.analyticsLastSyncedAt;
     if (options.tenantId !== undefined) this.tenantId = options.tenantId;
   }
 
@@ -302,7 +361,21 @@ export class SocialPost extends SmrtObject {
    * Check if the post can be edited (draft or failed)
    */
   get isEditable(): boolean {
-    return this.status === 'draft' || this.status === 'failed';
+    return (
+      this.status === 'draft' ||
+      this.status === 'pending_approval' ||
+      this.status === 'failed'
+    );
+  }
+
+  /**
+   * Check if the post is due for publishing now.
+   */
+  get isDueForPublish(): boolean {
+    if (this.status !== 'approved' && this.status !== 'scheduled') {
+      return false;
+    }
+    return !this.scheduledAt || this.scheduledAt.getTime() <= Date.now();
   }
 
   /**

--- a/packages/social/src/social.spec.ts
+++ b/packages/social/src/social.spec.ts
@@ -1,12 +1,55 @@
-import { describe, expect, it, vi } from 'vitest';
+import { getTestDatabase } from '@happyvertical/smrt-core/testing';
+import { SecretService } from '@happyvertical/smrt-secrets';
 import {
+  disableTenancy,
+  enableTenancy,
+  withTenant,
+} from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  OAuthStateCollection,
   SocialAccount,
+  SocialAccountCollection,
   SocialPost,
   SocialPostAnalyticsSnapshot,
+  SocialPostAnalyticsSnapshotCollection,
   SocialPostCollection,
 } from './index.js';
+import {
+  normalizeManualCredentials,
+  validateManualCredentials,
+} from './server.js';
+
+const TEST_AMK =
+  '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+async function withSocialTestDb<T>(
+  fn: (db: DatabaseInterface) => Promise<T>,
+): Promise<T> {
+  const db = await getTestDatabase({
+    classes: [
+      'SocialAccount',
+      'SocialPost',
+      'SocialPostAnalyticsSnapshot',
+      'OAuthState',
+      'Secret',
+      'SecretAuditLog',
+    ],
+  });
+  try {
+    return await fn(db);
+  } finally {
+    await db.close?.();
+  }
+}
 
 describe('smrt-social models', () => {
+  afterEach(() => {
+    disableTenancy();
+    delete process.env.SMRT_SECRET_MASTER_KEY;
+  });
+
   it('marks secret-backed connected accounts as ready', () => {
     const account = new SocialAccount({
       name: 'Bentley Facebook',
@@ -18,7 +61,7 @@ describe('smrt-social models', () => {
     expect(account.hasCredentials).toBe(true);
     expect(account.isReady).toBe(true);
     expect(account.needsAttention).toBe(false);
-    expect(account.effectivePublishMode).toBe('dry_run');
+    expect(account.effectivePublishMode).toBe('private_or_scheduled');
   });
 
   it('requires an explicit latch for public publishing', () => {
@@ -73,10 +116,48 @@ describe('smrt-social models', () => {
       platformUsername: 'buddyrandom',
     });
 
-    expect(await x.getSlug()).toBe('root-blindmanpress-x-buddyrandom');
+    expect(await x.getSlug()).toBe('tenant-root-blindmanpress-x-buddyrandom');
     expect(await youtube.getSlug()).toBe(
-      'root-blindmanpress-youtube-buddyrandom',
+      'tenant-root-blindmanpress-youtube-buddyrandom',
     );
+  });
+
+  it('does not mint a slug before an account has a stable identity', async () => {
+    const account = new SocialAccount({ platform: 'x' });
+
+    expect(await account.getSlug()).toBeNull();
+    expect(account.slug).toBeNull();
+  });
+
+  it('keeps tenant slug scope distinct from the no-tenant sentinel', async () => {
+    const tenantGlobal = new SocialAccount({
+      tenantId: 'global',
+      platform: 'x',
+      platformUsername: 'localnews',
+    });
+    const noTenant = new SocialAccount({
+      platform: 'x',
+      platformUsername: 'localnews',
+    });
+
+    expect(await tenantGlobal.getSlug()).toBe('tenant-global-x-localnews');
+    expect(await noTenant.getSlug()).toBe('no-tenant-x-localnews');
+  });
+
+  it('applies platform setup defaults unless explicitly overridden', () => {
+    const x = new SocialAccount({ platform: 'x' });
+    const youtube = new SocialAccount({ platform: 'youtube' });
+    const explicit = new SocialAccount({
+      platform: 'x',
+      linkBehavior: 'reply',
+      publishMode: 'public',
+    });
+
+    expect(x.linkBehavior).toBe('inline');
+    expect(x.publishMode).toBe('dry_run');
+    expect(youtube.publishMode).toBe('private_or_scheduled');
+    expect(explicit.linkBehavior).toBe('reply');
+    expect(explicit.publishMode).toBe('public');
   });
 
   it('tracks post type, due state, and analytics sync metadata', () => {
@@ -102,26 +183,49 @@ describe('smrt-social models', () => {
   });
 
   it('does not stamp dry-run or staged posts as published', async () => {
-    const post = new SocialPost({
-      socialAccountId: 'account-1',
-      postType: 'link',
-      status: 'publishing',
-    });
-    post.save = vi.fn(async () => post);
+    await withSocialTestDb(async (db) => {
+      const posts = await SocialPostCollection.create({ db });
+      const post = await posts.create({
+        socialAccountId: 'account-1',
+        postType: 'link',
+        status: 'publishing',
+      });
 
-    await SocialPostCollection.prototype.recordPublishSuccess.call(
-      {} as SocialPostCollection,
-      post,
-      {
+      await posts.recordPublishSuccess(post, {
         platformPostId: 'x-dry-run-1',
         platformUrl: '',
         status: 'dry_run',
-      },
-    );
+      });
 
-    expect(post.status).toBe('dry_run');
-    expect(post.publishedAt).toBeNull();
-    expect(post.save).toHaveBeenCalledOnce();
+      const loaded = await posts.get({ id: post.id });
+      expect(loaded?.status).toBe('dry_run');
+      expect(loaded?.publishedAt).toBeNull();
+    });
+  });
+
+  it('preserves an existing published timestamp when a later staged write succeeds', async () => {
+    await withSocialTestDb(async (db) => {
+      const posts = await SocialPostCollection.create({ db });
+      const publishedAt = new Date('2026-05-07T12:00:00Z');
+      const post = await posts.create({
+        socialAccountId: 'account-1',
+        postType: 'link',
+        status: 'publishing',
+        publishedAt,
+      });
+
+      await posts.recordPublishSuccess(post, {
+        platformPostId: 'threads-container-1',
+        platformUrl: '',
+        status: 'staged',
+      });
+
+      const loaded = await posts.get({ id: post.id });
+      expect(loaded?.status).toBe('staged');
+      expect(loaded?.publishedAt?.toISOString()).toBe(
+        publishedAt.toISOString(),
+      );
+    });
   });
 
   it('stores normalized and raw analytics snapshots', () => {
@@ -141,6 +245,277 @@ describe('smrt-social models', () => {
     expect(snapshot.analytics.impressions).toBe(110);
     expect(snapshot.raw).toEqual({
       public_metrics: { impression_count: 110 },
+    });
+  });
+
+  it('stores and retrieves account credentials in the account tenant', async () => {
+    process.env.SMRT_SECRET_MASTER_KEY = TEST_AMK;
+    enableTenancy();
+
+    await withSocialTestDb(async (db) => {
+      const accounts = await SocialAccountCollection.create({ db });
+      const account = new SocialAccount({
+        db,
+        tenantId: 'tenant-a',
+        name: 'Tenant A X',
+        platform: 'x',
+      });
+      await account.initialize();
+
+      await withTenant({ tenantId: 'tenant-b' }, async () => {
+        await account.setCredentials({
+          accessToken: 'tenant-a-access',
+          refreshToken: 'tenant-a-refresh',
+        });
+      });
+
+      const loaded = await withTenant({ tenantId: 'tenant-a' }, () =>
+        accounts.get({ id: account.id }),
+      );
+      const credentials = await withTenant({ tenantId: 'tenant-b' }, () =>
+        loaded?.getCredentials(),
+      );
+
+      expect(loaded?.tenantId).toBe('tenant-a');
+      expect(loaded?.credentialSecretId).toBe(`social-account-${account.id}`);
+      expect(credentials).toEqual({
+        accessToken: 'tenant-a-access',
+        refreshToken: 'tenant-a-refresh',
+      });
+    });
+  });
+
+  it('retrieves split access and refresh token secret references', async () => {
+    process.env.SMRT_SECRET_MASTER_KEY = TEST_AMK;
+
+    await withSocialTestDb(async (db) => {
+      const secrets = await SecretService.create({ db });
+      await secrets.storeForTenant('tenant-a', 'x-access', 'access-token');
+      await secrets.storeForTenant('tenant-a', 'x-refresh', 'refresh-token');
+
+      const account = new SocialAccount({
+        db,
+        tenantId: 'tenant-a',
+        platform: 'x',
+        accessTokenSecretName: 'x-access',
+        refreshTokenSecretName: 'x-refresh',
+      });
+      await account.initialize();
+
+      await expect(account.getCredentials()).resolves.toEqual({
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+      });
+      expect(account.hasCredentials).toBe(true);
+    });
+  });
+
+  it('reports a clear error when secret-backed credentials lack tenant context', async () => {
+    process.env.SMRT_SECRET_MASTER_KEY = TEST_AMK;
+
+    await withSocialTestDb(async (db) => {
+      const account = new SocialAccount({
+        db,
+        platform: 'x',
+      });
+
+      await expect(
+        account.setCredentials({ accessToken: 'token' }),
+      ).rejects.toThrow(
+        'Tenant context required to store social account credentials.',
+      );
+    });
+  });
+
+  it('filters account readiness helpers through the collection', async () => {
+    await withSocialTestDb(async (db) => {
+      const accounts = await SocialAccountCollection.create({ db });
+
+      const ready = await accounts.create({
+        name: 'Ready X',
+        platform: 'x',
+        credentialSecretId: 'ready-secret',
+        status: 'connected',
+      });
+      await accounts.create({
+        name: 'Missing permission X',
+        platform: 'x',
+        credentialSecretId: 'missing-secret',
+        status: 'connected',
+        missingPermissions: ['tweet.write'],
+      });
+      await accounts.create({
+        name: 'Inactive X',
+        platform: 'x',
+        credentialSecretId: 'inactive-secret',
+        status: 'connected',
+        isActive: false,
+      });
+
+      const readyAccounts = await accounts.findReady('x');
+      const needsAttention = await accounts.findNeedsAttention();
+
+      expect(readyAccounts.map((account) => account.id)).toEqual([ready.id]);
+      expect(needsAttention.map((account) => account.name)).toEqual([
+        'Missing permission X',
+      ]);
+    });
+  });
+
+  it('finds only posts that are due for publish', async () => {
+    await withSocialTestDb(async (db) => {
+      const posts = await SocialPostCollection.create({ db });
+      const now = new Date('2026-05-08T12:00:00Z');
+      const approved = await posts.create({
+        socialAccountId: 'account-1',
+        status: 'approved',
+      });
+      const scheduledDue = await posts.create({
+        socialAccountId: 'account-1',
+        status: 'scheduled',
+        scheduledAt: new Date('2026-05-08T11:00:00Z'),
+      });
+      await posts.create({
+        socialAccountId: 'account-1',
+        status: 'scheduled',
+        scheduledAt: new Date('2026-05-08T13:00:00Z'),
+      });
+      await posts.create({
+        socialAccountId: 'account-1',
+        status: 'draft',
+      });
+
+      const due = await posts.findDueForPublish(now);
+
+      expect(due.map((post) => post.id)).toEqual([
+        approved.id,
+        scheduledDue.id,
+      ]);
+    });
+  });
+
+  it('creates drafts and records failure plus analytics lifecycle updates', async () => {
+    await withSocialTestDb(async (db) => {
+      const posts = await SocialPostCollection.create({ db });
+      const syncedAt = new Date('2026-05-08T12:30:00Z');
+      const draft = await posts.createDraft({
+        socialAccountId: 'account-1',
+        linkUrl: 'https://bentleyalberta.com/story',
+      });
+      const scheduled = await posts.createDraft({
+        socialAccountId: 'account-1',
+        mediaUrl: 'https://assets.example/video.mp4',
+        scheduledAt: new Date('2026-05-08T13:00:00Z'),
+      });
+      const publishError = Object.assign(new Error('Publish failed'), {
+        code: 'E_PLATFORM',
+      });
+
+      expect(draft.postType).toBe('link');
+      expect(draft.status).toBe('draft');
+      expect(scheduled.postType).toBe('video');
+      expect(scheduled.status).toBe('scheduled');
+
+      await posts.recordPublishFailure(draft, publishError);
+      let loaded = await posts.get({ id: draft.id });
+      expect(loaded?.status).toBe('failed');
+      expect(loaded?.errorMessage).toContain('Publish failed');
+      expect(loaded?.errorMessage).toContain('code=E_PLATFORM');
+
+      await posts.updateLatestAnalytics(draft, { likes: 3 }, syncedAt);
+      loaded = await posts.get({ id: draft.id });
+      expect(loaded?.analytics).toMatchObject({
+        likes: 3,
+        lastUpdated: syncedAt.toISOString(),
+      });
+      expect(loaded?.analyticsLastSyncedAt?.toISOString()).toBe(
+        syncedAt.toISOString(),
+      );
+    });
+  });
+
+  it('finds and deletes expired oauth states through query filters', async () => {
+    await withSocialTestDb(async (db) => {
+      const states = await OAuthStateCollection.create({ db });
+      const now = new Date('2026-05-08T12:00:00Z');
+      const expired = await states.create({
+        state: 'expired',
+        expiresAt: new Date('2026-05-08T11:59:00Z'),
+      });
+      await states.create({
+        state: 'future',
+        expiresAt: new Date('2026-05-08T12:01:00Z'),
+      });
+
+      const found = await states.findExpired(now);
+      const deleted = await states.deleteExpired(now);
+
+      expect(found.map((state) => state.id)).toEqual([expired.id]);
+      expect(deleted).toBe(1);
+      await expect(states.findByState('expired')).resolves.toBeNull();
+      await expect(states.findByState('future')).resolves.not.toBeNull();
+    });
+  });
+
+  it('records analytics snapshots and exposes the latest snapshot for a post', async () => {
+    await withSocialTestDb(async (db) => {
+      const snapshots = await SocialPostAnalyticsSnapshotCollection.create({
+        db,
+      });
+      await snapshots.recordSnapshot({
+        socialPostId: 'post-1',
+        platform: 'x',
+        metrics: {
+          views: 10,
+          raw: { public_metrics: { impression_count: 10 } },
+        },
+        capturedAt: new Date('2026-05-08T11:00:00Z'),
+      });
+      const latest = await snapshots.recordSnapshot({
+        socialPostId: 'post-1',
+        platform: 'x',
+        metrics: { views: 12 },
+        raw: { public_metrics: { impression_count: 12 } },
+        capturedAt: new Date('2026-05-08T12:00:00Z'),
+      });
+
+      await expect(
+        snapshots.findLatestForPost('post-1'),
+      ).resolves.toMatchObject({
+        id: latest.id,
+        platform: 'x',
+        analytics: { views: 12 },
+        raw: { public_metrics: { impression_count: 12 } },
+      });
+    });
+  });
+
+  it('leaves analytics snapshot platform unset until the caller provides it', () => {
+    const snapshot = new SocialPostAnalyticsSnapshot();
+
+    expect(snapshot.platform).toBeNull();
+  });
+
+  it('validates manual credential fields before normalization', () => {
+    expect(
+      validateManualCredentials('x', {
+        apiKey: 'key',
+        apiSecret: 'secret',
+        accessToken: 'token',
+      }),
+    ).toEqual(['accessSecret']);
+
+    expect(
+      normalizeManualCredentials('x', {
+        apiKey: ' key ',
+        apiSecret: ' secret ',
+        accessToken: ' token ',
+        accessSecret: '',
+      }),
+    ).toEqual({
+      apiKey: 'key',
+      apiSecret: 'secret',
+      accessToken: 'token',
     });
   });
 });

--- a/packages/social/src/social.spec.ts
+++ b/packages/social/src/social.spec.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  SocialAccount,
+  SocialPost,
+  SocialPostAnalyticsSnapshot,
+  SocialPostCollection,
+} from './index.js';
+
+describe('smrt-social models', () => {
+  it('marks secret-backed connected accounts as ready', () => {
+    const account = new SocialAccount({
+      name: 'Bentley Facebook',
+      platform: 'facebook',
+      credentialSecretId: 'social-account-1',
+      status: 'connected',
+    });
+
+    expect(account.hasCredentials).toBe(true);
+    expect(account.isReady).toBe(true);
+    expect(account.needsAttention).toBe(false);
+    expect(account.effectivePublishMode).toBe('dry_run');
+  });
+
+  it('requires an explicit latch for public publishing', () => {
+    const blocked = new SocialAccount({
+      name: 'Bentley X',
+      platform: 'x',
+      credentialSecretId: 'social-account-x',
+      status: 'connected',
+      publishMode: 'public',
+      publicPublishingAllowed: false,
+    });
+    const allowed = new SocialAccount({
+      name: 'Bentley X',
+      platform: 'x',
+      credentialSecretId: 'social-account-x',
+      status: 'connected',
+      publishMode: 'public',
+      publicPublishingAllowed: true,
+    });
+
+    expect(blocked.isReady).toBe(false);
+    expect(blocked.needsAttention).toBe(true);
+    expect(blocked.effectivePublishMode).toBe('dry_run');
+    expect(allowed.isReady).toBe(true);
+    expect(allowed.effectivePublishMode).toBe('public');
+  });
+
+  it('marks accounts with missing permissions as needing attention', () => {
+    const account = new SocialAccount({
+      name: 'Bentley Facebook',
+      platform: 'facebook',
+      credentialSecretId: 'social-account-1',
+      status: 'connected',
+      missingPermissions: ['pages_manage_posts'],
+    });
+
+    expect(account.isReady).toBe(false);
+    expect(account.needsAttention).toBe(true);
+  });
+
+  it('generates platform-scoped slugs for accounts with the same handle', async () => {
+    const x = new SocialAccount({
+      tenantId: 'root-blindmanpress',
+      name: 'buddyrandom',
+      platform: 'x',
+      platformUsername: 'buddyrandom',
+    });
+    const youtube = new SocialAccount({
+      tenantId: 'root-blindmanpress',
+      name: 'buddyrandom',
+      platform: 'youtube',
+      platformUsername: 'buddyrandom',
+    });
+
+    expect(await x.getSlug()).toBe('root-blindmanpress-x-buddyrandom');
+    expect(await youtube.getSlug()).toBe(
+      'root-blindmanpress-youtube-buddyrandom',
+    );
+  });
+
+  it('tracks post type, due state, and analytics sync metadata', () => {
+    const post = new SocialPost({
+      socialAccountId: 'account-1',
+      postType: 'link',
+      linkUrl: 'https://bentleyalberta.com/story',
+      status: 'approved',
+      analytics: {
+        views: 12,
+        likes: 3,
+        raw: { source: 'platform' },
+      },
+      analyticsLastSyncedAt: new Date('2026-05-07T12:00:00Z'),
+    });
+
+    expect(post.postType).toBe('link');
+    expect(post.isDueForPublish).toBe(true);
+    expect(post.analytics.raw).toEqual({ source: 'platform' });
+    expect(post.analyticsLastSyncedAt?.toISOString()).toBe(
+      '2026-05-07T12:00:00.000Z',
+    );
+  });
+
+  it('does not stamp dry-run or staged posts as published', async () => {
+    const post = new SocialPost({
+      socialAccountId: 'account-1',
+      postType: 'link',
+      status: 'publishing',
+    });
+    post.save = vi.fn(async () => post);
+
+    await SocialPostCollection.prototype.recordPublishSuccess.call(
+      {} as SocialPostCollection,
+      post,
+      {
+        platformPostId: 'x-dry-run-1',
+        platformUrl: '',
+        status: 'dry_run',
+      },
+    );
+
+    expect(post.status).toBe('dry_run');
+    expect(post.publishedAt).toBeNull();
+    expect(post.save).toHaveBeenCalledOnce();
+  });
+
+  it('stores normalized and raw analytics snapshots', () => {
+    const snapshot = new SocialPostAnalyticsSnapshot({
+      socialPostId: 'post-1',
+      platform: 'x',
+      analytics: {
+        views: 100,
+        impressions: 110,
+        likes: 8,
+        lastUpdated: new Date('2026-05-07T13:00:00Z'),
+      },
+      raw: { public_metrics: { impression_count: 110 } },
+      capturedAt: new Date('2026-05-07T13:00:00Z'),
+    });
+
+    expect(snapshot.analytics.impressions).toBe(110);
+    expect(snapshot.raw).toEqual({
+      public_metrics: { impression_count: 110 },
+    });
+  });
+});

--- a/packages/social/src/svelte/components/SocialAccountSettings.svelte
+++ b/packages/social/src/svelte/components/SocialAccountSettings.svelte
@@ -31,7 +31,7 @@ const platforms: Array<{ platform: SocialPlatformType; label: string }> = [
 function statusLabel(account: SocialAccountSettingsItem): string {
   if (!account.isActive) return 'inactive';
   if (account.needsAttention) return 'needs attention';
-  return account.status.replace('_', ' ');
+  return account.status.replaceAll('_', ' ');
 }
 </script>
 

--- a/packages/social/src/svelte/components/SocialAccountSettings.svelte
+++ b/packages/social/src/svelte/components/SocialAccountSettings.svelte
@@ -1,0 +1,239 @@
+<script lang="ts">
+import type { SocialPlatformType } from '../../social-account.js';
+import type { SocialAccountSettingsItem } from '../types.js';
+
+let {
+  accounts = [],
+  loading = false,
+  readonly = false,
+  connectHrefs = {},
+  onRefresh,
+  onTest,
+  onDeactivate,
+}: {
+  accounts?: SocialAccountSettingsItem[];
+  loading?: boolean;
+  readonly?: boolean;
+  connectHrefs?: Partial<Record<SocialPlatformType, string>>;
+  onRefresh?: () => void | Promise<void>;
+  onTest?: (account: SocialAccountSettingsItem) => void | Promise<void>;
+  onDeactivate?: (account: SocialAccountSettingsItem) => void | Promise<void>;
+} = $props();
+
+const platforms: Array<{ platform: SocialPlatformType; label: string }> = [
+  { platform: 'youtube', label: 'YouTube' },
+  { platform: 'facebook', label: 'Facebook Page' },
+  { platform: 'threads', label: 'Threads' },
+  { platform: 'x', label: 'X' },
+  { platform: 'bluesky', label: 'Bluesky' },
+];
+
+function statusLabel(account: SocialAccountSettingsItem): string {
+  if (!account.isActive) return 'inactive';
+  if (account.needsAttention) return 'needs attention';
+  return account.status.replace('_', ' ');
+}
+</script>
+
+<section class="social-settings">
+  <header class="toolbar">
+    <div>
+      <h2>Social Accounts</h2>
+      <p>{accounts.length} account{accounts.length === 1 ? '' : 's'} configured</p>
+    </div>
+    {#if onRefresh}
+      <button type="button" class="secondary" onclick={() => onRefresh?.()} disabled={loading}>Refresh</button>
+    {/if}
+  </header>
+
+  {#if !readonly}
+    <div class="connect-row" aria-label="Connect social account">
+      {#each platforms as item}
+        {#if connectHrefs[item.platform]}
+          <a class="connect-button" href={connectHrefs[item.platform]}>{item.label}</a>
+        {:else}
+          <button type="button" class="connect-button" disabled>{item.label}</button>
+        {/if}
+      {/each}
+    </div>
+  {/if}
+
+  {#if loading}
+    <div class="empty">Loading accounts...</div>
+  {:else if accounts.length === 0}
+    <div class="empty">No social accounts are configured yet.</div>
+  {:else}
+    <div class="account-list">
+      {#each accounts as account (account.id)}
+        <article class="account-row" data-status={account.status}>
+          <div class="account-main">
+            <div class="account-title">
+              <h3>{account.name}</h3>
+              <span>{account.platform}</span>
+            </div>
+            {#if account.platformUsername}
+              <p>@{account.platformUsername}</p>
+            {/if}
+            {#if account.publishMode}
+              <p>
+                Mode: {account.publishMode.replaceAll('_', ' ')}
+                {account.publishMode === 'public' && !account.publicPublishingAllowed ? ' (blocked)' : ''}
+              </p>
+            {/if}
+            {#if account.missingPermissions?.length}
+              <p class="warning">Missing: {account.missingPermissions.join(', ')}</p>
+            {/if}
+          </div>
+
+          <div class="account-actions">
+            <span class:attention={account.needsAttention} class="status">{statusLabel(account)}</span>
+            {#if account.platformUrl}
+              <a class="secondary" href={account.platformUrl} target="_blank" rel="noreferrer">Open</a>
+            {/if}
+            {#if onTest}
+              <button type="button" class="secondary" onclick={() => onTest?.(account)}>Test</button>
+            {/if}
+            {#if !readonly && onDeactivate && account.isActive}
+              <button type="button" class="danger" onclick={() => onDeactivate?.(account)}>Deactivate</button>
+            {/if}
+          </div>
+        </article>
+      {/each}
+    </div>
+  {/if}
+</section>
+
+<style>
+  .social-settings {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .toolbar,
+  .account-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  h2,
+  h3,
+  p {
+    margin: 0;
+  }
+
+  h2 {
+    font-size: 1.1rem;
+    color: var(--smrt-color-on-surface, #111827);
+  }
+
+  h3 {
+    font-size: 0.95rem;
+    color: var(--smrt-color-on-surface, #111827);
+  }
+
+  p {
+    color: var(--smrt-color-on-surface-variant, #6b7280);
+    font-size: 0.85rem;
+  }
+
+  .connect-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .account-list {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .account-row {
+    border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
+    border-radius: 8px;
+    background: var(--smrt-color-surface, #fff);
+    padding: 1rem;
+  }
+
+  .account-title {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .account-title span,
+  .status {
+    border-radius: 999px;
+    background: var(--smrt-color-surface-container, #f3f4f6);
+    color: var(--smrt-color-on-surface-variant, #4b5563);
+    font-size: 0.75rem;
+    padding: 0.15rem 0.5rem;
+    text-transform: capitalize;
+  }
+
+  .status.attention,
+  .warning {
+    color: var(--smrt-color-error, #b91c1c);
+  }
+
+  .account-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  button,
+  a {
+    border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
+    border-radius: 6px;
+    background: var(--smrt-color-surface, #fff);
+    color: var(--smrt-color-on-surface, #111827);
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.82rem;
+    line-height: 1;
+    padding: 0.55rem 0.7rem;
+    text-decoration: none;
+  }
+
+  button:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+  }
+
+  .connect-button {
+    background: var(--smrt-color-primary, #2563eb);
+    border-color: var(--smrt-color-primary, #2563eb);
+    color: var(--smrt-color-on-primary, #fff);
+  }
+
+  .secondary {
+    background: var(--smrt-color-surface-container, #f3f4f6);
+  }
+
+  .danger {
+    color: var(--smrt-color-error, #b91c1c);
+  }
+
+  .empty {
+    border: 1px dashed var(--smrt-color-outline-variant, #d1d5db);
+    border-radius: 8px;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
+    padding: 1.25rem;
+    text-align: center;
+  }
+
+  @media (max-width: 720px) {
+    .toolbar,
+    .account-row {
+      display: grid;
+    }
+
+    .account-actions {
+      justify-content: flex-start;
+    }
+  }
+</style>

--- a/packages/social/src/svelte/index.ts
+++ b/packages/social/src/svelte/index.ts
@@ -1,0 +1,9 @@
+import type { ComponentProps } from 'svelte';
+
+import SocialAccountSettings from './components/SocialAccountSettings.svelte';
+
+export { SocialAccountSettings };
+export type SocialAccountSettingsProps = ComponentProps<
+  typeof SocialAccountSettings
+>;
+export type { SocialAccountSettingsItem } from './types.js';

--- a/packages/social/src/svelte/types.ts
+++ b/packages/social/src/svelte/types.ts
@@ -1,0 +1,20 @@
+import type {
+  AccountStatus,
+  PublishMode,
+  SocialPlatformType,
+} from '../social-account.js';
+
+export interface SocialAccountSettingsItem {
+  id: string;
+  name: string;
+  platform: SocialPlatformType;
+  platformUsername?: string | null;
+  platformUrl?: string | null;
+  isActive: boolean;
+  status: AccountStatus;
+  needsAttention?: boolean;
+  missingPermissions?: string[];
+  publishMode?: PublishMode;
+  publicPublishingAllowed?: boolean;
+  tokenExpiresAt?: Date | string | null;
+}

--- a/packages/social/tsconfig.svelte.json
+++ b/packages/social/tsconfig.svelte.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.package-svelte.json",
+  "include": ["ambient.d.ts", "src/**/*.ts", "src/**/*.svelte"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/social/vite.config.ts
+++ b/packages/social/vite.config.ts
@@ -1,3 +1,6 @@
 import { createPackageConfig } from '../../vite.config.base.js';
 
-export default createPackageConfig('social');
+export default createPackageConfig('social', {
+  entries: ['server'],
+  svelte: 'svelte',
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1760,6 +1760,9 @@ importers:
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
+      '@happyvertical/smrt-secrets':
+        specifier: workspace:*
+        version: link:../secrets
       '@happyvertical/smrt-tenancy':
         specifier: workspace:*
         version: link:../tenancy
@@ -1769,9 +1772,6 @@ importers:
       '@happyvertical/utils':
         specifier: ^0.73.2
         version: 0.73.2
-      svelte:
-        specifier: ^5.0.0
-        version: 5.53.5
     devDependencies:
       '@happyvertical/logger':
         specifier: ^0.73.2
@@ -1782,9 +1782,18 @@ importers:
       '@happyvertical/sql':
         specifier: ^0.73.2
         version: 0.73.2
+      '@sveltejs/package':
+        specifier: ^2.5.7
+        version: 2.5.7(svelte@5.53.5)(typescript@5.9.3)
       '@types/node':
         specifier: 24.10.9
         version: 24.10.9
+      svelte:
+        specifier: ^5.0.0
+        version: 5.53.5
+      svelte-check:
+        specifier: ^4.3.5
+        version: 4.4.4(picomatch@4.0.3)(svelte@5.53.5)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
## Summary
- Adds reusable smrt-social account, post, OAuth state, analytics snapshot, server setup, and Svelte settings primitives for Garrula social publishing.
- Moves social credentials toward secret references, with explicit tenant secret store/retrieve helpers in smrt-secrets for OAuth callbacks outside ambient tenancy.
- Adds platform-scoped SocialAccount slugs so the same handle on X and YouTube cannot overwrite each other.
- Adds publish readiness helpers, publish modes, lifecycle helpers, and JSON raw analytics snapshot storage.

## Review Notes
- This intentionally lands the broader smrt-social V1 work and the slug collision fix in one release.
- Raw analytics snapshots are stored as JSON, and credential retrieval now surfaces secret/decryption problems instead of silently returning null.
- The pnpm lockfile diff is limited to the smrt-social importer changes.

## Validation
- pnpm --dir packages/social test
- pnpm --dir packages/social build
- pnpm --dir packages/social check
- pnpm --dir packages/secrets test
- pnpm --dir packages/secrets build
- node ../../scripts/verify-package-types-exports.js .
- pre-push lefthook format-check
- pre-push lefthook validate-all-workflows
