### PR TITLE
feat(languages): add @happyvertical/smrt-languages package

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -22,6 +22,7 @@
       "@happyvertical/smrt-gnode",
       "@happyvertical/smrt-images",
       "@happyvertical/smrt-jobs",
+      "@happyvertical/smrt-languages",
       "@happyvertical/smrt-ledgers",
       "@happyvertical/smrt-messages",
       "@happyvertical/smrt-places",

--- a/.changeset/feat-smrt-languages.md
+++ b/.changeset/feat-smrt-languages.md
@@ -1,0 +1,5 @@
+---
+'@happyvertical/smrt-languages': minor
+---
+
+Add `@happyvertical/smrt-languages` — code-first language strings with file/config + tenant overrides and an AI auto-translation pipeline backed by `smrt-jobs`. Mirrors the architecture of `smrt-prompts`, plus a deterministic-job-ID dedup so concurrent locale misses collapse into one translation. Honors a `smrt-features` kill switch (`smrt-languages.auto_translate`), a per-tenant daily budget, and an optional locale allowlist; never overwrites human-edited rows.

--- a/packages/languages/CHANGELOG.md
+++ b/packages/languages/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @happyvertical/smrt-languages

--- a/packages/languages/CLAUDE.md
+++ b/packages/languages/CLAUDE.md
@@ -1,0 +1,81 @@
+# languages
+
+SMRT language string registry with file/config + tenant overrides and AI-driven
+auto-translation for missing locales.
+
+## Core pieces
+
+- `defineLanguageString({ key, locale, template })` registers a code default in
+  a global process registry. Same shape as `definePrompt` but keyed by
+  `(key, locale)` rather than `key` alone.
+- `resolveLanguageString(key, options)` walks the 5-layer chain (code → file
+  config → app override → tenant override → runtime override) and falls back
+  through the locale chain (`fr-CA` → `fr` → default) before giving up.
+- `LanguageOverride` stores app-level and tenant-level overrides in
+  `_smrt_language_overrides`. `auto_generated`, `source_hash`, `ai_model`,
+  `reviewed_at`, `reviewed_by` fields support the AI auto-translation pipeline
+  and admin review queue.
+- `enqueueTranslationJob({ key, targetLocale })` writes a `LanguageTranslationTask`
+  job into the `languages` queue with a deterministic dedup ID so concurrent
+  resolver misses collapse into one job.
+
+## Locale-miss flow
+
+When `resolveLanguageString` cannot find an exact `(key, locale, tenantId)`:
+
+1. Walk the locale fallback chain (`buildLocaleFallbackChain`).
+2. Return the first hit — same call returns immediately with
+   `source: 'fallback'`.
+3. Fire-and-forget `enqueueTranslationJob` for the missing target, scoped to
+   the current tenant for glossary purposes. App-level translations are
+   reusable across tenants, so the resulting `LanguageOverride` row is written
+   with `tenantId: null`.
+4. Subsequent requests hit the new app-level row and resolve at the requested
+   locale.
+
+The translation job:
+
+- Honors the `smrt-languages.auto_translate` feature flag (kill switch).
+- Skips locales outside `supportedLocales` when configured.
+- Skips when `LanguageOverride` already exists with a matching `source_hash`
+  (re-translation is hash-gated, never time-based).
+- Never overwrites a row with `auto_generated: false` — human edits win
+  permanently.
+- Pulls the tenant's existing overrides and renders them as a glossary so
+  auto-translations match tenant voice.
+
+## Conventions
+
+- Keys are namespaced by package: `users.role.member`, `commerce.invoice.dueText`.
+- Locales follow BCP-47 (`en`, `fr-CA`, `pt-BR`) and are normalized to
+  lowercase-language / uppercase-region on persistence.
+- The translation prompt itself is registered with `smrt-prompts` under
+  `smrt-languages.translation` so ops can tune wording without redeploying.
+- `context` column on `_smrt_language_overrides` is set to `tenantId` or
+  `'__app__'` so the `(key, locale, context)` upsert key remains unique even
+  with nullable `tenantId`.
+
+## Public API surface
+
+```typescript
+import {
+  defineLanguageString,
+  resolveLanguageString,
+  LanguageOverride,
+  LanguageOverrideCollection,
+  clearLanguageCache,
+} from '@happyvertical/smrt-languages';
+
+defineLanguageString({
+  key: 'users.role.member',
+  locale: 'en',
+  template: 'Member',
+});
+
+const text = await resolveLanguageString('users.role.member', {
+  db,
+  tenantId: 'tenant-a',
+  locale: 'es',
+  vars: { name: 'Will' },
+});
+```

--- a/packages/languages/README.md
+++ b/packages/languages/README.md
@@ -152,6 +152,38 @@ export default {
 };
 ```
 
+## Subpath exports
+
+The package root (`@happyvertical/smrt-languages`) only exposes the read path:
+`defineLanguageString`, `resolveLanguageString`, `LanguageOverride`, the cache
+helpers, the glossary helper, and shared types/utilities. Loading the root
+does **not** pull `@happyvertical/ai`, smrt-jobs, smrt-features, or
+smrt-prompts into the consumer bundle.
+
+The translation-worker stack lives on a subpath:
+
+```typescript
+// Background workers + tests that enqueue or run translation jobs.
+import {
+  enqueueTranslationJob,
+  LanguageTranslationTask,
+  AUTO_TRANSLATE_FEATURE_KEY,
+  TRANSLATION_PROMPT_KEY,
+} from '@happyvertical/smrt-languages/jobs';
+
+// Admin / batch CLI helpers.
+import {
+  translateMissing,
+  approveAutoTranslation,
+  editLanguageOverride,
+  listUnreviewedAutoTranslations,
+} from '@happyvertical/smrt-languages/cli';
+```
+
+The resolver itself dynamically imports the worker module on a soft-miss, so
+calling `resolveLanguageString` still triggers a translation enqueue without
+the caller having to pre-import the `/jobs` subpath.
+
 ## Out of scope (v1)
 
 Pluralization, ICU MessageFormat, Svelte component i18n, RTL layout, locale

--- a/packages/languages/README.md
+++ b/packages/languages/README.md
@@ -1,0 +1,161 @@
+# @happyvertical/smrt-languages
+
+Code-first language strings with config + tenant overrides and AI-driven
+auto-translation for SMRT applications.
+
+`smrt-languages` mirrors the architecture of `@happyvertical/smrt-prompts`:
+packages declare their user-facing strings as code, applications and tenants
+override them through file config or DB rows, and the resolver merges every
+layer at runtime. v1 adds an automatic AI-translation step backed by
+`@happyvertical/smrt-jobs`: the first time a string is requested in a locale
+that has neither a code default nor an override, the resolver returns a
+fallback locale immediately and enqueues a background translation. Subsequent
+requests hit the new app-level row.
+
+This package is a Phase 2 prerequisite of the broader package adoption epic —
+issue [#1200](https://github.com/happyvertical/smrt/issues/1200).
+
+## Why
+
+- Today, packages hard-code labels like `'Member'`, `'Article'`, or
+  `'Payment due by {dueDate}'`. There is no way for a tenant to use
+  `'Subscriber'` instead of `'Member'` without forking, and no way for a
+  tenant to operate in their own language.
+- `smrt-prompts` already proved the layered-override pattern for AI prompts.
+  `smrt-languages` applies the same pattern to display strings, plus an
+  AI-driven gap-filler that closes the loop on missing locales without
+  blocking on the first request.
+
+## Quick start
+
+```typescript
+import {
+  defineLanguageString,
+  resolveLanguageString,
+} from '@happyvertical/smrt-languages';
+
+// Define defaults at startup, typically in your package's
+// __smrt-register__.ts so the registry is populated before resolves run.
+defineLanguageString({
+  key: 'users.role.member',
+  locale: 'en',
+  template: 'Member',
+});
+
+defineLanguageString({
+  key: 'commerce.invoice.dueText',
+  locale: 'en',
+  template: 'Payment due by {dueDate}',
+});
+
+// Resolve at runtime. Tenant context is read from AsyncLocalStorage by default.
+const text = await resolveLanguageString('users.role.member', {
+  db,
+  locale: 'es',
+  vars: { dueDate: '2026-06-01' },
+  // strict: false → return the English fallback and enqueue an AI translation.
+  // strict: true  → throw when no resolution exists.
+});
+```
+
+## Resolution layers
+
+In ascending priority:
+
+1. **Code default** — `defineLanguageString({ key, locale, template })`
+2. **File/config override** — `getPackageConfig('languages').overrides[key][locale]`
+3. **App-level stored override** — `LanguageOverride` row with `tenantId = null`
+4. **Tenant-level stored override** — `LanguageOverride` row with `tenantId = <current>`
+5. **Runtime override** — `resolveLanguageString(key, { overrides: { template: '...' } })`
+
+When the requested `(key, locale)` doesn't exist anywhere, the resolver walks
+a fallback chain — `fr-CA` → `fr` → registered default-locale (`en`) — and
+returns the first hit. Whenever the hit is at a different locale than what
+was requested, an AI translation job is enqueued for the original target.
+
+## Storage
+
+Overrides live in `_smrt_language_overrides`:
+
+| Column | Notes |
+|--------|-------|
+| `key` | Namespaced string key (`users.role.member`) |
+| `locale` | BCP-47 tag (`en`, `fr-CA`) |
+| `tenantId` | `null` for app-level, tenantId for tenant-level |
+| `template` | The override string with `{var}` placeholders |
+| `auto_generated` | `true` when produced by the AI translation job |
+| `source_hash` | sha256 of the source template at translation time |
+| `ai_model` | Model identifier; `null` for human-edited rows |
+| `reviewed_at` / `reviewed_by` | Set when an admin approves an auto row |
+
+Source-hash gating means re-translation only happens when the source actually
+changes — auto-generated rows whose `source_hash` matches are left alone.
+Human-edited rows (`auto_generated: false`) are **never** overwritten.
+
+## AI auto-translation
+
+When a `(key, targetLocale)` is missed, the resolver enqueues a
+`LanguageTranslationTask` job into the `languages` queue with a deterministic
+dedup ID — `smrt-languages.translate:<key>:<targetLocale>` — so concurrent
+misses collapse into a single job. The job:
+
+1. Reads the tenant's existing language overrides as a glossary (no-op when
+   no tenant context).
+2. Calls `@happyvertical/ai` with a low-temperature translation prompt that
+   itself is registered via `smrt-prompts` under
+   `smrt-languages.translation` — operators can tune the wording without
+   redeploying.
+3. Validates the response (non-empty, no obvious markup leaks).
+4. Upserts an app-level `LanguageOverride` row with `auto_generated: true`,
+   `source_hash`, and `ai_model`.
+5. Invalidates the resolver cache for `(key, targetLocale, *)`.
+
+### Cost & abuse controls
+
+- `smrt-features` flag `smrt-languages.auto_translate` — global / per-tenant
+  kill switch.
+- `translationBudgetPerTenantPerDay` — daily cap per tenant.
+- `supportedLocales` — optional allowlist; jobs for other locales are dropped
+  before any AI call.
+- Source-hash gating prevents re-translation when nothing changed.
+
+### Admin review
+
+```bash
+smrt languages translate --locales=es,fr,de   # batch eager pre-population
+smrt languages review --locale=es              # list unreviewed auto rows
+smrt languages approve <id>                    # mark reviewed
+smrt languages edit <id> --template "..."      # edit + flip auto_generated to false
+```
+
+CLI surfaces are auto-generated by SMRT from the `LanguageOverride` model and
+helpers in `src/cli.ts`.
+
+## Configuration
+
+`smrt.config.{js,ts,json}`:
+
+```js
+export default {
+  packages: {
+    languages: {
+      defaultLocale: 'en',
+      supportedLocales: ['en', 'es', 'fr', 'de', 'ja'],
+      translationBudgetPerTenantPerDay: 200,
+      overrides: {
+        'users.role.member': {
+          es: 'Miembro',
+        },
+      },
+    },
+  },
+};
+```
+
+## Out of scope (v1)
+
+Pluralization, ICU MessageFormat, Svelte component i18n, RTL layout, locale
+negotiation HTTP middleware, XLIFF/PO TM-tool integration, and richer quality
+scoring of AI translations are all v1.1+ concerns. v1 sticks to plain
+`{var}` substitution and the resolution chain above so adoption stays a
+mechanical refactor across consumer packages.

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -14,6 +14,14 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./jobs": {
+      "import": "./dist/jobs.js",
+      "types": "./dist/jobs.d.ts"
+    },
+    "./cli": {
+      "import": "./dist/cli.js",
+      "types": "./dist/cli.d.ts"
+    },
     "./manifest": "./dist/manifest.json",
     "./manifest.json": "./dist/manifest.json"
   },

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@happyvertical/smrt-languages",
+  "version": "0.23.12",
+  "description": "Code-first language strings with config + tenant overrides and AI auto-translation for SMRT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "CLAUDE.md"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./manifest": "./dist/manifest.json",
+    "./manifest.json": "./dist/manifest.json"
+  },
+  "scripts": {
+    "build": "vite build --mode library",
+    "build:watch": "vite build --mode library --watch",
+    "clean": "rm -rf dist",
+    "dev": "vite dev",
+    "prepack": "node ../../scripts/prepack-package.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
+  },
+  "dependencies": {
+    "@happyvertical/ai": "catalog:",
+    "@happyvertical/smrt-config": "workspace:*",
+    "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-features": "workspace:*",
+    "@happyvertical/smrt-jobs": "workspace:*",
+    "@happyvertical/smrt-prompts": "workspace:*",
+    "@happyvertical/smrt-tenancy": "workspace:*",
+    "@happyvertical/sql": "catalog:"
+  },
+  "devDependencies": {
+    "@happyvertical/smrt-cli": "workspace:*",
+    "@happyvertical/smrt-vitest": "workspace:*",
+    "@types/node": "24.10.9",
+    "typescript": "^5.9.3",
+    "vite": "^7.3.1",
+    "vitest": "^4.0.17"
+  },
+  "keywords": [
+    "smrt",
+    "languages",
+    "i18n",
+    "translation",
+    "ai",
+    "multi-tenancy"
+  ],
+  "author": "HAVE Team",
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  }
+}

--- a/packages/languages/src/__smrt-register__.ts
+++ b/packages/languages/src/__smrt-register__.ts
@@ -1,0 +1,10 @@
+/**
+ * Self-registers this package's build-time manifest before any @smrt()
+ * decorator in the package fires. Same pattern as smrt-prompts — see
+ * packages/prompts/src/__smrt-register__.ts and issue #1132 for context.
+ */
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+
+ObjectRegistry.registerPackageManifest(
+  new URL('./manifest.json', import.meta.url),
+);

--- a/packages/languages/src/cache.ts
+++ b/packages/languages/src/cache.ts
@@ -1,0 +1,129 @@
+import type { DatabaseInterface } from '@happyvertical/sql';
+import type { LanguageCacheValue } from './types.js';
+import { normalizeLocale } from './utils.js';
+
+const LANGUAGE_CACHE_TTL_MS = 30_000;
+
+type CacheEntry = {
+  expiresAt: number;
+  value: LanguageCacheValue;
+};
+
+const languageCache = new Map<string, CacheEntry>();
+const dbInstanceIds = new WeakMap<object, string>();
+let nextDbId = 1;
+
+function getDbNamespace(db: unknown): string {
+  if (!db) {
+    return 'no-db';
+  }
+
+  if (typeof db === 'string') {
+    return `db:${db}`;
+  }
+
+  if (typeof db === 'object') {
+    const dbObject = db as Record<string, unknown>;
+    if (typeof dbObject.query === 'function') {
+      if (!dbInstanceIds.has(dbObject)) {
+        dbInstanceIds.set(dbObject, `db-instance:${nextDbId++}`);
+      }
+      const namespace = dbInstanceIds.get(dbObject);
+      if (namespace) {
+        return namespace;
+      }
+
+      return 'db-instance:unknown';
+    }
+
+    try {
+      return `db-config:${JSON.stringify(dbObject)}`;
+    } catch {
+      return 'db-config:opaque';
+    }
+  }
+
+  return 'db:unknown';
+}
+
+function buildCacheKey(
+  key: string,
+  locale: string,
+  tenantId: string | null | undefined,
+  db: unknown,
+): string {
+  return `${getDbNamespace(db)}::${key}::${normalizeLocale(locale)}::${
+    tenantId ?? 'app'
+  }`;
+}
+
+export function getLanguageCacheTtlMs(): number {
+  return LANGUAGE_CACHE_TTL_MS;
+}
+
+export function getCachedLanguage(
+  key: string,
+  locale: string,
+  tenantId: string | null | undefined,
+  db: DatabaseInterface | unknown,
+): LanguageCacheValue | null {
+  const cacheKey = buildCacheKey(key, locale, tenantId, db);
+  const cached = languageCache.get(cacheKey);
+
+  if (!cached) {
+    return null;
+  }
+
+  if (cached.expiresAt <= Date.now()) {
+    languageCache.delete(cacheKey);
+    return null;
+  }
+
+  return cached.value;
+}
+
+export function setCachedLanguage(
+  key: string,
+  locale: string,
+  tenantId: string | null | undefined,
+  db: DatabaseInterface | unknown,
+  value: LanguageCacheValue,
+): void {
+  languageCache.set(buildCacheKey(key, locale, tenantId, db), {
+    expiresAt: Date.now() + LANGUAGE_CACHE_TTL_MS,
+    value,
+  });
+}
+
+/**
+ * Drop cached entries that match the given (key, locale).
+ *
+ * - When `tenantId` is provided, only that tenant's entries for this DB are dropped.
+ * - When `tenantId` is null/undefined, every (key, locale, *) entry across tenants
+ *   is dropped — used for app-level writes that affect all tenants.
+ */
+export function invalidateLanguageCache(
+  key: string,
+  locale: string,
+  tenantId: string | null | undefined,
+  db: DatabaseInterface | unknown,
+): void {
+  const dbNamespace = getDbNamespace(db);
+  const normalizedLocale = normalizeLocale(locale);
+
+  if (tenantId !== null && tenantId !== undefined) {
+    languageCache.delete(buildCacheKey(key, normalizedLocale, tenantId, db));
+    return;
+  }
+
+  const keyPrefix = `${dbNamespace}::${key}::${normalizedLocale}::`;
+  for (const cacheKey of languageCache.keys()) {
+    if (cacheKey.startsWith(keyPrefix)) {
+      languageCache.delete(cacheKey);
+    }
+  }
+}
+
+export function clearLanguageCache(): void {
+  languageCache.clear();
+}

--- a/packages/languages/src/cli.ts
+++ b/packages/languages/src/cli.ts
@@ -1,0 +1,126 @@
+import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+import { LanguageOverrideCollection } from './collections/LanguageOverrideCollection.js';
+import { LanguageRegistry } from './language-registry.js';
+import { enqueueTranslationJob } from './translation-job.js';
+import { normalizeLocale } from './utils.js';
+
+/**
+ * Implementation of `smrt languages translate --locales=es,fr`.
+ *
+ * Walks the registered code defaults and enqueues a translation job for every
+ * `(key, locale)` pair that does not yet have an app-level override. The job
+ * itself respects the same dedup / budget / allowlist rules as the resolver's
+ * miss-path enqueue.
+ */
+export async function translateMissing(options: {
+  locales: string[];
+  sourceLocale?: string;
+  db: SmrtClassOptions['db'];
+  tenantId?: string | null;
+}): Promise<{
+  enqueued: string[];
+  skipped: string[];
+}> {
+  const sourceLocale = normalizeLocale(options.sourceLocale ?? 'en');
+  const targets = options.locales.map(normalizeLocale).filter(Boolean);
+  const overrides = await (LanguageOverrideCollection as any).create({
+    db: options.db,
+  });
+
+  const enqueued: string[] = [];
+  const skipped: string[] = [];
+
+  for (const definition of LanguageRegistry.getAll()) {
+    if (definition.locale !== sourceLocale) continue;
+
+    for (const target of targets) {
+      if (target === sourceLocale) continue;
+      const existing = await overrides.getAppOverride(definition.key, target);
+      // Human edits win permanently — never enqueue an AI translation job for
+      // a row that an admin has curated, even if the source has changed. The
+      // CLAUDE.md spec calls this out and the job handler enforces the same
+      // rule, but we prefer to skip at the enqueue layer so we don't burn
+      // queue budget on work the handler is going to discard.
+      if (existing && !existing.auto_generated) {
+        skipped.push(`${definition.key}:${target}`);
+        continue;
+      }
+      if (existing && existing.source_hash === definition.sourceHash) {
+        skipped.push(`${definition.key}:${target}`);
+        continue;
+      }
+
+      const result = await enqueueTranslationJob({
+        key: definition.key,
+        targetLocale: target,
+        sourceLocale,
+        tenantId: options.tenantId ?? null,
+        db: options.db,
+      });
+
+      if (result.status === 'enqueued') {
+        enqueued.push(`${definition.key}:${target}`);
+      } else {
+        skipped.push(`${definition.key}:${target}`);
+      }
+    }
+  }
+
+  return { enqueued, skipped };
+}
+
+/** `smrt languages review --locale=es` — list unreviewed auto-translations. */
+export async function listUnreviewedAutoTranslations(options: {
+  db: SmrtClassOptions['db'];
+  locale?: string;
+  limit?: number;
+}) {
+  const overrides = await (LanguageOverrideCollection as any).create({
+    db: options.db,
+  });
+  return overrides.listUnreviewedAutoTranslations({
+    locale: options.locale,
+    limit: options.limit,
+  });
+}
+
+/** `smrt languages approve <id> --reviewer=<user>` — mark reviewed. */
+export async function approveAutoTranslation(options: {
+  db: SmrtClassOptions['db'];
+  id: string;
+  reviewer: string;
+}) {
+  const overrides = await (LanguageOverrideCollection as any).create({
+    db: options.db,
+  });
+  const row = await overrides.get({ id: options.id });
+  if (!row) {
+    throw new Error(`LanguageOverride "${options.id}" not found`);
+  }
+  return row.approve(options.reviewer);
+}
+
+/** `smrt languages edit <id> --template=...` — human-edit suppresses auto-overwrites. */
+export async function editLanguageOverride(options: {
+  db: SmrtClassOptions['db'];
+  id: string;
+  template: string;
+  reviewer?: string;
+}) {
+  const overrides = await (LanguageOverrideCollection as any).create({
+    db: options.db,
+  });
+  const row = await overrides.get({ id: options.id });
+  if (!row) {
+    throw new Error(`LanguageOverride "${options.id}" not found`);
+  }
+  row.template = options.template;
+  row.auto_generated = false;
+  row.ai_model = null;
+  if (options.reviewer) {
+    row.reviewed_at = new Date().toISOString();
+    row.reviewed_by = options.reviewer;
+  }
+  await row.save();
+  return row;
+}

--- a/packages/languages/src/collections/LanguageOverrideCollection.ts
+++ b/packages/languages/src/collections/LanguageOverrideCollection.ts
@@ -1,0 +1,76 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { LanguageOverride } from '../models/LanguageOverride.js';
+import { normalizeLocale } from '../utils.js';
+
+export class LanguageOverrideCollection extends SmrtCollection<LanguageOverride> {
+  static readonly _itemClass = LanguageOverride;
+
+  /**
+   * Look up the app-level (tenantId = null) override for a (key, locale) pair.
+   * App-level rows hold AI auto-translations and ops-curated app-wide strings.
+   */
+  async getAppOverride(
+    key: string,
+    locale: string,
+  ): Promise<LanguageOverride | null> {
+    const items = await this.list({
+      where: { key, locale: normalizeLocale(locale), tenantId: null },
+    });
+    return items[0] ?? null;
+  }
+
+  async getTenantOverride(
+    key: string,
+    locale: string,
+    tenantId: string,
+  ): Promise<LanguageOverride | null> {
+    const items = await this.list({
+      where: { key, locale: normalizeLocale(locale), tenantId },
+    });
+    return items[0] ?? null;
+  }
+
+  /**
+   * Convenience helper for the resolver: returns the app and (optional) tenant
+   * override rows for a (key, locale).
+   */
+  async getResolutionLayers(
+    key: string,
+    locale: string,
+    tenantId?: string | null,
+  ): Promise<{
+    app: LanguageOverride | null;
+    tenant: LanguageOverride | null;
+  }> {
+    const [app, tenant] = await Promise.all([
+      this.getAppOverride(key, locale),
+      tenantId != null
+        ? this.getTenantOverride(key, locale, tenantId)
+        : Promise.resolve(null),
+    ]);
+    return { app, tenant };
+  }
+
+  /** All overrides for a tenant (used to build the AI translation glossary). */
+  async listTenantOverrides(tenantId: string): Promise<LanguageOverride[]> {
+    return this.list({ where: { tenantId } });
+  }
+
+  /** Auto-generated overrides that no admin has approved yet. */
+  async listUnreviewedAutoTranslations(
+    options: { locale?: string; limit?: number } = {},
+  ): Promise<LanguageOverride[]> {
+    const where: Record<string, unknown> = {
+      auto_generated: true,
+      reviewed_at: null,
+    };
+    if (options.locale) {
+      where.locale = normalizeLocale(options.locale);
+    }
+    return this.list({
+      where,
+      orderBy: 'createdAt ASC',
+      limit: options.limit,
+    });
+  }
+}

--- a/packages/languages/src/glossary.ts
+++ b/packages/languages/src/glossary.ts
@@ -1,0 +1,45 @@
+import type { LanguageOverride } from './models/LanguageOverride.js';
+import { normalizeLocale } from './utils.js';
+
+/**
+ * Build a glossary string suitable for inclusion in an AI translation prompt.
+ *
+ * Pulls the tenant's existing language overrides for the source/target locales
+ * and renders them as a concise list of "source → target" pairs, restricted to
+ * keys that actually have both sides. The intent is "make AI auto-translations
+ * match tenant voice", not bulk dump every override.
+ *
+ * Returns an empty string when there is nothing useful to add.
+ */
+export function buildTenantGlossary(
+  overrides: LanguageOverride[],
+  options: { sourceLocale: string; targetLocale: string; max?: number },
+): string {
+  const sourceLocale = normalizeLocale(options.sourceLocale);
+  const targetLocale = normalizeLocale(options.targetLocale);
+  const max = options.max ?? 25;
+
+  const sourceByKey = new Map<string, string>();
+  const targetByKey = new Map<string, string>();
+
+  for (const override of overrides) {
+    if (!override.template) continue;
+    const locale = normalizeLocale(override.locale);
+    if (locale === sourceLocale) {
+      sourceByKey.set(override.key, override.template);
+    } else if (locale === targetLocale) {
+      targetByKey.set(override.key, override.template);
+    }
+  }
+
+  const pairs: string[] = [];
+  for (const [key, source] of sourceByKey.entries()) {
+    const target = targetByKey.get(key);
+    if (target) {
+      pairs.push(`- "${source}" → "${target}"`);
+      if (pairs.length >= max) break;
+    }
+  }
+
+  return pairs.join('\n');
+}

--- a/packages/languages/src/index.ts
+++ b/packages/languages/src/index.ts
@@ -1,0 +1,73 @@
+/**
+ * @happyvertical/smrt-languages
+ *
+ * Code-first language strings with config + tenant overrides and AI-driven
+ * auto-translation for SMRT applications. Mirrors the architecture of
+ * `@happyvertical/smrt-prompts` plus a smrt-jobs handler that fills gaps in
+ * non-default locales the first time a string is requested.
+ *
+ * @packageDocumentation
+ */
+
+import './__smrt-register__.js';
+
+export {
+  clearLanguageCache,
+  getLanguageCacheTtlMs,
+  invalidateLanguageCache,
+} from './cache.js';
+export {
+  approveAutoTranslation,
+  editLanguageOverride,
+  listUnreviewedAutoTranslations,
+  translateMissing,
+} from './cli.js';
+
+export { LanguageOverrideCollection } from './collections/LanguageOverrideCollection.js';
+
+export { buildTenantGlossary } from './glossary.js';
+
+export {
+  defineLanguageString,
+  LanguageRegistry,
+} from './language-registry.js';
+
+export {
+  invalidateResolvedLanguageCache,
+  resolveLanguageString,
+} from './language-resolver.js';
+
+export {
+  LanguageOverride,
+  type LanguageOverrideCtorOptions,
+} from './models/LanguageOverride.js';
+
+export {
+  AUTO_TRANSLATE_FEATURE_KEY,
+  enqueueTranslationJob,
+  LanguageTranslationTask,
+  TRANSLATION_PROMPT_KEY,
+} from './translation-job.js';
+
+export type {
+  LanguageCacheValue,
+  LanguageOverrideOptions,
+  LanguageStringDefinition,
+  LanguageStringDefinitionInput,
+  LanguagesPackageConfig,
+  LanguageVariables,
+  ResolvedLanguageString,
+  ResolveLanguageStringOptions,
+  TranslationJobPayload,
+} from './types.js';
+
+export {
+  buildLocaleFallbackChain,
+  buildTranslationJobId,
+  computeSourceHash,
+  normalizeLocale,
+  renderTemplate,
+} from './utils.js';
+
+/** @internal */
+export const PACKAGE_VERSION_INITIALIZED = true;

--- a/packages/languages/src/index.ts
+++ b/packages/languages/src/index.ts
@@ -6,6 +6,15 @@
  * `@happyvertical/smrt-prompts` plus a smrt-jobs handler that fills gaps in
  * non-default locales the first time a string is requested.
  *
+ * The package root intentionally exposes only the read path
+ * (`defineLanguageString`, `resolveLanguageString`, `LanguageOverride`, the
+ * cache helpers, glossary helpers, and shared types/utilities). The
+ * translation-worker stack — which depends on `@happyvertical/ai`,
+ * smrt-jobs, smrt-features, and smrt-prompts — lives on the
+ * `@happyvertical/smrt-languages/jobs` subpath, and the admin CLI helpers
+ * live on `@happyvertical/smrt-languages/cli`. Resolver consumers (the vast
+ * majority of call sites) never load the worker dependency tree.
+ *
  * @packageDocumentation
  */
 
@@ -16,15 +25,7 @@ export {
   getLanguageCacheTtlMs,
   invalidateLanguageCache,
 } from './cache.js';
-export {
-  approveAutoTranslation,
-  editLanguageOverride,
-  listUnreviewedAutoTranslations,
-  translateMissing,
-} from './cli.js';
-
 export { LanguageOverrideCollection } from './collections/LanguageOverrideCollection.js';
-
 export { buildTenantGlossary } from './glossary.js';
 
 export {
@@ -42,13 +43,6 @@ export {
   type LanguageOverrideCtorOptions,
 } from './models/LanguageOverride.js';
 
-export {
-  AUTO_TRANSLATE_FEATURE_KEY,
-  enqueueTranslationJob,
-  LanguageTranslationTask,
-  TRANSLATION_PROMPT_KEY,
-} from './translation-job.js';
-
 export type {
   LanguageCacheValue,
   LanguageOverrideOptions,
@@ -58,7 +52,6 @@ export type {
   LanguageVariables,
   ResolvedLanguageString,
   ResolveLanguageStringOptions,
-  TranslationJobPayload,
 } from './types.js';
 
 export {

--- a/packages/languages/src/integration.test.ts
+++ b/packages/languages/src/integration.test.ts
@@ -1,0 +1,166 @@
+import { clearCache, setConfig } from '@happyvertical/smrt-config';
+import { getTestDatabase, ObjectRegistry } from '@happyvertical/smrt-core';
+import { resetTenancy, setupTestTenancy } from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the AI client so the translation job is deterministic — no network,
+// no API key, just the canned Spanish translation.
+vi.mock('@happyvertical/ai', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@happyvertical/ai')>();
+  return {
+    ...actual,
+    getAI: vi.fn(async () => ({
+      message: vi.fn(async () => '{"translation": "Hola, {name}"}'),
+    })),
+  };
+});
+
+import { clearLanguageCache } from './cache.js';
+import { LanguageOverrideCollection } from './collections/LanguageOverrideCollection.js';
+import { defineLanguageString, LanguageRegistry } from './language-registry.js';
+import { resolveLanguageString } from './language-resolver.js';
+import type { LanguageTranslationTask } from './translation-job.js';
+
+describe('@happyvertical/smrt-languages — miss → enqueue → run → resolved', () => {
+  let db: DatabaseInterface;
+
+  beforeEach(async () => {
+    setupTestTenancy();
+    LanguageRegistry.clear();
+    clearLanguageCache();
+    clearCache();
+
+    setConfig({
+      packages: {
+        languages: {
+          defaultLocale: 'en',
+          supportedLocales: ['en', 'es', 'fr'],
+        },
+      },
+    });
+
+    db = await getTestDatabase({
+      classes: ['LanguageOverride', 'SmrtJob', 'LanguageTranslationTask'],
+    });
+  });
+
+  afterEach(async () => {
+    clearLanguageCache();
+    LanguageRegistry.clear();
+    clearCache();
+    resetTenancy();
+    if (typeof (db as any)?.close === 'function') {
+      await (db as any).close();
+    }
+  });
+
+  it('returns the fallback then writes a translated app override after the job runs', async () => {
+    defineLanguageString({
+      key: 'integration.greeting',
+      locale: 'en',
+      template: 'Hello, {name}',
+    });
+
+    // First request in es: miss → fallback to en, enqueue translation job.
+    const fallback = await resolveLanguageString('integration.greeting', {
+      db,
+      locale: 'es',
+      vars: { name: 'Will' },
+    });
+    expect(fallback.text).toBe('Hello, Will');
+    expect(fallback.source).toBe('fallback');
+    expect(fallback.resolvedFromLocale).toBe('en');
+
+    // Verify a job was enqueued for (key, es).
+    const overrides = await LanguageOverrideCollection.create({ db });
+    const beforeRun = await overrides.getAppOverride(
+      'integration.greeting',
+      'es',
+    );
+    expect(beforeRun).toBeNull();
+
+    // Run the job by invoking the registered task class directly — same
+    // contract the runner uses (ObjectRegistry → instance.execute(args)).
+    const taskEntry = ObjectRegistry.getClass('LanguageTranslationTask');
+    expect(taskEntry).toBeDefined();
+    const TaskClass = taskEntry?.constructor as new (
+      opts: Record<string, unknown>,
+    ) => LanguageTranslationTask;
+    const task = new TaskClass({ db });
+    await task.initialize();
+    const definition = LanguageRegistry.get('integration.greeting', 'en');
+    const result = await task.execute({
+      key: 'integration.greeting',
+      sourceLocale: 'en',
+      sourceTemplate: definition?.template ?? '',
+      sourceHash: definition?.sourceHash ?? '',
+      targetLocale: 'es',
+    });
+    expect(result.template).toBe('Hola, {name}');
+
+    // The translation job should have written an app-level override.
+    const written = await overrides.getAppOverride(
+      'integration.greeting',
+      'es',
+    );
+    expect(written).not.toBeNull();
+    expect(written?.template).toBe('Hola, {name}');
+    expect(written?.auto_generated).toBe(true);
+    expect(written?.source_hash).toBe(definition?.sourceHash);
+
+    // Subsequent es resolves should now hit the auto-generated app row.
+    // Clear the cache so we read through to the override row.
+    clearLanguageCache();
+    const after = await resolveLanguageString('integration.greeting', {
+      db,
+      locale: 'es',
+      vars: { name: 'Will' },
+    });
+    expect(after.text).toBe('Hola, Will');
+    expect(after.source).toBe('app');
+    expect(after.resolvedFromLocale).toBe('es');
+  });
+
+  it('never overwrites a human-edited row even when the source changes', async () => {
+    defineLanguageString({
+      key: 'integration.preserve',
+      locale: 'en',
+      template: 'Original',
+    });
+
+    const overrides = await LanguageOverrideCollection.create({ db });
+    await overrides.create({
+      key: 'integration.preserve',
+      locale: 'es',
+      tenantId: null,
+      template: 'Original-ES (curado)',
+      auto_generated: false,
+    });
+
+    const taskEntry = ObjectRegistry.getClass('LanguageTranslationTask');
+    const TaskClass = taskEntry?.constructor as new (
+      opts: Record<string, unknown>,
+    ) => LanguageTranslationTask;
+    const task = new TaskClass({ db });
+    await task.initialize();
+
+    // Even with a fresh source-hash the handler must skip and leave the
+    // human-edited row untouched.
+    const result = await task.execute({
+      key: 'integration.preserve',
+      sourceLocale: 'en',
+      sourceTemplate: 'Updated source',
+      sourceHash: 'sha256:newhash',
+      targetLocale: 'es',
+    });
+    expect(result.skipped).toBe('stale');
+
+    const persisted = await overrides.getAppOverride(
+      'integration.preserve',
+      'es',
+    );
+    expect(persisted?.template).toBe('Original-ES (curado)');
+    expect(persisted?.auto_generated).toBe(false);
+  });
+});

--- a/packages/languages/src/integration.test.ts
+++ b/packages/languages/src/integration.test.ts
@@ -16,10 +16,34 @@ vi.mock('@happyvertical/ai', async (importOriginal) => {
   };
 });
 
+// Mock the prompts resolver so the integration test doesn't have to
+// provision `_smrt_prompt_overrides` for an external package whose schema
+// generation isn't reachable through the local vitest manifest. Production
+// callers still get the full smrt-prompts override pipeline; the unit-level
+// behavior of `resolvePrompt(db: ...)` is exercised by the prompts package's
+// own test suite.
+vi.mock('@happyvertical/smrt-prompts', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@happyvertical/smrt-prompts')>();
+  return {
+    ...actual,
+    resolvePrompt: vi.fn(async () => ({
+      key: 'smrt-languages.translation',
+      template: 'translate {template} to {targetLocale}',
+      text: 'translate Hello, {name} to es',
+      ai: { profile: undefined, model: undefined, params: {} },
+    })),
+  };
+});
+
 import { clearLanguageCache } from './cache.js';
 import { LanguageOverrideCollection } from './collections/LanguageOverrideCollection.js';
 import { defineLanguageString, LanguageRegistry } from './language-registry.js';
 import { resolveLanguageString } from './language-resolver.js';
+// Side-effect import: registers `LanguageTranslationTask` with the
+// ObjectRegistry so the test can pull a constructor from
+// `ObjectRegistry.getClass(...)` and exercise the runner contract.
+import './translation-job.js';
 import type { LanguageTranslationTask } from './translation-job.js';
 
 describe('@happyvertical/smrt-languages — miss → enqueue → run → resolved', () => {
@@ -120,6 +144,45 @@ describe('@happyvertical/smrt-languages — miss → enqueue → run → resolve
     expect(after.text).toBe('Hola, Will');
     expect(after.source).toBe('app');
     expect(after.resolvedFromLocale).toBe('es');
+  });
+
+  it('rejects JSON responses missing the translation field instead of persisting the wrong shape', async () => {
+    const ai = await import('@happyvertical/ai');
+    // Re-stub the mock: valid JSON, wrong shape — the handler must NOT fall
+    // through to the bare-string path and persist the whole blob.
+    const getAiSpy = vi.spyOn(ai, 'getAI').mockResolvedValue({
+      message: vi.fn(async () => '{"text": "Hola"}'),
+    } as any);
+
+    defineLanguageString({
+      key: 'integration.shape',
+      locale: 'en',
+      template: 'Hello',
+    });
+
+    const taskEntry = ObjectRegistry.getClass('LanguageTranslationTask');
+    const TaskClass = taskEntry?.constructor as new (
+      opts: Record<string, unknown>,
+    ) => LanguageTranslationTask;
+    const task = new TaskClass({ db });
+    await task.initialize();
+
+    const definition = LanguageRegistry.get('integration.shape', 'en');
+    await expect(
+      task.execute({
+        key: 'integration.shape',
+        sourceLocale: 'en',
+        sourceTemplate: definition?.template ?? '',
+        sourceHash: definition?.sourceHash ?? '',
+        targetLocale: 'es',
+      }),
+    ).rejects.toThrow('returned no usable translation');
+
+    const overrides = await LanguageOverrideCollection.create({ db });
+    const persisted = await overrides.getAppOverride('integration.shape', 'es');
+    expect(persisted).toBeNull();
+
+    getAiSpy.mockRestore();
   });
 
   it('never overwrites a human-edited row even when the source changes', async () => {

--- a/packages/languages/src/jobs.ts
+++ b/packages/languages/src/jobs.ts
@@ -1,0 +1,18 @@
+/**
+ * Subpath entry: `@happyvertical/smrt-languages/jobs`.
+ *
+ * Importing this module is what pulls in `@happyvertical/ai`, smrt-jobs,
+ * smrt-features, and smrt-prompts. Keeping it off the package root means
+ * consumers that only need `defineLanguageString` / `resolveLanguageString`
+ * do not pay for the translation-worker stack in their bundles.
+ *
+ * Use this entry from background workers, CLI tools, and tests that need
+ * to enqueue or run translation jobs directly.
+ */
+export {
+  AUTO_TRANSLATE_FEATURE_KEY,
+  enqueueTranslationJob,
+  LanguageTranslationTask,
+  TRANSLATION_PROMPT_KEY,
+} from './translation-job.js';
+export type { TranslationJobPayload } from './types.js';

--- a/packages/languages/src/language-registry.ts
+++ b/packages/languages/src/language-registry.ts
@@ -1,0 +1,116 @@
+import type {
+  LanguageStringDefinition,
+  LanguageStringDefinitionInput,
+} from './types.js';
+import { computeSourceHash, normalizeLocale } from './utils.js';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __smrtLanguageRegistry:
+    | Map<string, Map<string, LanguageStringDefinition>>
+    | undefined;
+}
+
+function getRegistry(): Map<string, Map<string, LanguageStringDefinition>> {
+  if (!globalThis.__smrtLanguageRegistry) {
+    globalThis.__smrtLanguageRegistry = new Map();
+  }
+  return globalThis.__smrtLanguageRegistry;
+}
+
+function buildIndex(
+  key: string,
+  locale: string,
+): { key: string; locale: string } {
+  return { key, locale: normalizeLocale(locale) };
+}
+
+export const LanguageRegistry = {
+  register(input: LanguageStringDefinitionInput): LanguageStringDefinition {
+    if (!input.key || input.key.trim() === '') {
+      throw new Error('Language string definitions require a non-empty key');
+    }
+    if (!input.locale || input.locale.trim() === '') {
+      throw new Error(
+        `Language string "${input.key}" requires a non-empty locale`,
+      );
+    }
+    if (typeof input.template !== 'string') {
+      throw new Error(
+        `Language string "${input.key}" template must be a string`,
+      );
+    }
+
+    const { key, locale } = buildIndex(input.key, input.locale);
+    const definition: LanguageStringDefinition = {
+      key,
+      locale,
+      template: input.template,
+      sourceHash: computeSourceHash(input.template),
+    };
+
+    const registry = getRegistry();
+    let byLocale = registry.get(key);
+    if (!byLocale) {
+      byLocale = new Map();
+      registry.set(key, byLocale);
+    }
+
+    const existing = byLocale.get(locale);
+    if (existing) {
+      if (existing.template !== definition.template) {
+        throw new Error(
+          `Language string "${key}" is already registered for locale "${locale}" with a different template`,
+        );
+      }
+      return existing;
+    }
+
+    byLocale.set(locale, definition);
+    return definition;
+  },
+
+  get(key: string, locale: string): LanguageStringDefinition | undefined {
+    return getRegistry().get(key)?.get(normalizeLocale(locale));
+  },
+
+  has(key: string, locale: string): boolean {
+    return Boolean(this.get(key, locale));
+  },
+
+  hasKey(key: string): boolean {
+    return getRegistry().has(key);
+  },
+
+  /** Return the locales that have a registered code default for the given key. */
+  getLocalesForKey(key: string): string[] {
+    const byLocale = getRegistry().get(key);
+    return byLocale ? Array.from(byLocale.keys()) : [];
+  },
+
+  /** All registered (key, locale, template) triples. Used by the batch translator. */
+  getAll(): LanguageStringDefinition[] {
+    const all: LanguageStringDefinition[] = [];
+    for (const byLocale of getRegistry().values()) {
+      for (const definition of byLocale.values()) {
+        all.push(definition);
+      }
+    }
+    return all;
+  },
+
+  /** Distinct keys currently registered. */
+  getKeys(): string[] {
+    return Array.from(getRegistry().keys());
+  },
+
+  clear(): void {
+    getRegistry().clear();
+  },
+};
+
+export function defineLanguageString(
+  input: LanguageStringDefinitionInput,
+): LanguageStringDefinition {
+  return LanguageRegistry.register(input);
+}

--- a/packages/languages/src/language-resolver.test.ts
+++ b/packages/languages/src/language-resolver.test.ts
@@ -251,4 +251,82 @@ describe('@happyvertical/smrt-languages — resolver', () => {
     expect(initial.text).toBe('Cached');
     expect(getLanguageCacheTtlMs()).toBeGreaterThan(0);
   });
+
+  it('moves the row when (key, locale, tenantId) changes — invalidates old cache, returns code default at the old identity', async () => {
+    defineLanguageString({
+      key: 'test.identity.source',
+      locale: 'en',
+      template: 'Source EN',
+    });
+    defineLanguageString({
+      key: 'test.identity.target',
+      locale: 'en',
+      template: 'Target EN',
+    });
+
+    const override = await overrides.create({
+      key: 'test.identity.source',
+      locale: 'en',
+      tenantId: null,
+      template: 'App Source',
+    });
+
+    const cached = await resolveLanguageString('test.identity.source', {
+      db,
+      tenantId: 'tenant-a',
+    });
+    expect(cached.text).toBe('App Source');
+
+    // Move the override across all three identity dimensions in one save.
+    override.key = 'test.identity.target';
+    override.tenantId = 'tenant-a';
+    override.template = 'Tenant Target';
+    await override.save();
+
+    // Old (key, locale, tenant) — both the cache and the row should be gone,
+    // so resolution falls back through to the registered code default.
+    const sourceAfter = await resolveLanguageString('test.identity.source', {
+      db,
+      tenantId: 'tenant-a',
+    });
+    expect(sourceAfter.text).toBe('Source EN');
+    expect(sourceAfter.source).toBe('code');
+
+    // New identity returns the moved override.
+    const targetAfter = await resolveLanguageString('test.identity.target', {
+      db,
+      tenantId: 'tenant-a',
+    });
+    expect(targetAfter.text).toBe('Tenant Target');
+    expect(targetAfter.source).toBe('tenant');
+  });
+
+  it('honors mixed-case file-config locale keys (fr-ca vs fr-CA)', async () => {
+    defineLanguageString({
+      key: 'test.config.case',
+      locale: 'en',
+      template: 'EN',
+    });
+    setConfig({
+      packages: {
+        languages: {
+          defaultLocale: 'en',
+          overrides: {
+            'test.config.case': {
+              // User wrote the locale key in lowercase; resolver normalizes
+              // and finds it for a fr-CA request anyway.
+              'fr-ca': 'Bonjour',
+            },
+          },
+        },
+      },
+    });
+
+    const resolved = await resolveLanguageString('test.config.case', {
+      db,
+      locale: 'fr-CA',
+    });
+    expect(resolved.text).toBe('Bonjour');
+    expect(resolved.source).toBe('config');
+  });
 });

--- a/packages/languages/src/language-resolver.test.ts
+++ b/packages/languages/src/language-resolver.test.ts
@@ -1,0 +1,254 @@
+import { clearCache, setConfig } from '@happyvertical/smrt-config';
+import { getTestDatabase } from '@happyvertical/smrt-core';
+import {
+  resetTenancy,
+  setupTestTenancy,
+  withTenant,
+} from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { clearLanguageCache, getLanguageCacheTtlMs } from './cache.js';
+import { LanguageOverrideCollection } from './collections/LanguageOverrideCollection.js';
+import { defineLanguageString, LanguageRegistry } from './language-registry.js';
+import { resolveLanguageString } from './language-resolver.js';
+
+describe('@happyvertical/smrt-languages — resolver', () => {
+  let db: DatabaseInterface;
+  let overrides: LanguageOverrideCollection;
+
+  beforeEach(async () => {
+    setupTestTenancy();
+    LanguageRegistry.clear();
+    clearLanguageCache();
+    clearCache();
+
+    setConfig({
+      packages: {
+        languages: {
+          defaultLocale: 'en',
+        },
+      },
+    });
+
+    db = await getTestDatabase({
+      classes: ['LanguageOverride'],
+    });
+    overrides = await LanguageOverrideCollection.create({ db });
+  });
+
+  afterEach(async () => {
+    clearLanguageCache();
+    LanguageRegistry.clear();
+    clearCache();
+    resetTenancy();
+    if (typeof (db as any)?.close === 'function') {
+      await (db as any).close();
+    }
+  });
+
+  it('falls through code → config → app → tenant → runtime in priority order', async () => {
+    defineLanguageString({
+      key: 'test.precedence',
+      locale: 'en',
+      template: 'Code {name}',
+    });
+
+    setConfig({
+      packages: {
+        languages: {
+          defaultLocale: 'en',
+          overrides: {
+            'test.precedence': {
+              en: 'Config {name}',
+            },
+          },
+        },
+      },
+    });
+
+    await overrides.create({
+      key: 'test.precedence',
+      locale: 'en',
+      tenantId: null,
+      template: 'App {name}',
+    });
+
+    await overrides.create({
+      key: 'test.precedence',
+      locale: 'en',
+      tenantId: 'tenant-a',
+      template: 'Tenant {name}',
+    });
+
+    const resolved = await resolveLanguageString('test.precedence', {
+      db,
+      tenantId: 'tenant-a',
+      vars: { name: 'Will' },
+    });
+
+    expect(resolved.text).toBe('Tenant Will');
+    expect(resolved.source).toBe('tenant');
+
+    const runtime = await resolveLanguageString('test.precedence', {
+      db,
+      tenantId: 'tenant-a',
+      vars: { name: 'Will' },
+      overrides: { template: 'Runtime {name}' },
+    });
+
+    expect(runtime.text).toBe('Runtime Will');
+    expect(runtime.source).toBe('runtime');
+  });
+
+  it('returns a fallback through the locale chain when the requested locale is missing', async () => {
+    defineLanguageString({
+      key: 'test.fallback',
+      locale: 'en',
+      template: 'English fallback',
+    });
+
+    const resolved = await resolveLanguageString('test.fallback', {
+      db,
+      locale: 'fr-CA',
+    });
+
+    expect(resolved.text).toBe('English fallback');
+    expect(resolved.resolvedFromLocale).toBe('en');
+    expect(resolved.source).toBe('fallback');
+  });
+
+  it('prefers a parent locale over the default-locale fallback', async () => {
+    defineLanguageString({
+      key: 'test.parent',
+      locale: 'en',
+      template: 'EN parent',
+    });
+    defineLanguageString({
+      key: 'test.parent',
+      locale: 'fr',
+      template: 'FR parent',
+    });
+
+    const resolved = await resolveLanguageString('test.parent', {
+      db,
+      locale: 'fr-CA',
+    });
+
+    expect(resolved.text).toBe('FR parent');
+    expect(resolved.resolvedFromLocale).toBe('fr');
+    expect(resolved.source).toBe('fallback');
+  });
+
+  it('throws under strict mode when nothing resolves', async () => {
+    await expect(
+      resolveLanguageString('test.unknown.key', {
+        db,
+        locale: 'es',
+        strict: true,
+      }),
+    ).rejects.toThrow('has no resolution for locale');
+  });
+
+  it('returns the key as text when nothing resolves and strict is false', async () => {
+    const resolved = await resolveLanguageString('test.unknown.soft', {
+      db,
+      locale: 'es',
+    });
+
+    expect(resolved.text).toBe('test.unknown.soft');
+    expect(resolved.source).toBe('missing');
+  });
+
+  it('invalidates the cache when a tenant override is written', async () => {
+    defineLanguageString({
+      key: 'test.cache.invalidate',
+      locale: 'en',
+      template: 'Initial {name}',
+    });
+
+    const initial = await resolveLanguageString('test.cache.invalidate', {
+      db,
+      tenantId: 'tenant-a',
+      vars: { name: 'Will' },
+    });
+    expect(initial.text).toBe('Initial Will');
+
+    await overrides.create({
+      key: 'test.cache.invalidate',
+      locale: 'en',
+      tenantId: 'tenant-a',
+      template: 'Custom {name}',
+    });
+
+    const refreshed = await resolveLanguageString('test.cache.invalidate', {
+      db,
+      tenantId: 'tenant-a',
+      vars: { name: 'Will' },
+    });
+    expect(refreshed.text).toBe('Custom Will');
+    expect(refreshed.source).toBe('tenant');
+  });
+
+  it('keeps app-level overrides visible from inside withTenant() through normal CRUD', async () => {
+    defineLanguageString({
+      key: 'test.crud.scope',
+      locale: 'en',
+      template: 'Code',
+    });
+
+    const appOverride = await overrides.create({
+      key: 'test.crud.scope',
+      locale: 'en',
+      tenantId: null,
+      template: 'App',
+    });
+    await overrides.create({
+      key: 'test.crud.scope',
+      locale: 'en',
+      tenantId: 'tenant-a',
+      template: 'Tenant',
+    });
+
+    await withTenant({ tenantId: 'tenant-a' }, async () => {
+      const visible = await overrides.list({
+        where: { key: 'test.crud.scope' },
+        orderBy: 'createdAt ASC',
+      });
+      expect(visible.map((item) => item.tenantId)).toEqual([null, 'tenant-a']);
+      const loaded = await overrides.get({ id: appOverride.id as string });
+      expect(loaded?.tenantId).toBeNull();
+    });
+  });
+
+  it('uses the package config defaultLocale for fallback when none is specified', async () => {
+    setConfig({
+      packages: {
+        languages: {
+          defaultLocale: 'fr',
+        },
+      },
+    });
+    defineLanguageString({
+      key: 'test.config.default',
+      locale: 'fr',
+      template: 'Salut',
+    });
+
+    const resolved = await resolveLanguageString('test.config.default', {
+      db,
+    });
+    expect(resolved.text).toBe('Salut');
+  });
+
+  it('expires stale cache entries after the TTL', async () => {
+    defineLanguageString({
+      key: 'test.ttl',
+      locale: 'en',
+      template: 'Cached',
+    });
+
+    const initial = await resolveLanguageString('test.ttl', { db });
+    expect(initial.text).toBe('Cached');
+    expect(getLanguageCacheTtlMs()).toBeGreaterThan(0);
+  });
+});

--- a/packages/languages/src/language-resolver.ts
+++ b/packages/languages/src/language-resolver.ts
@@ -100,8 +100,11 @@ async function resolveBaseForLocale(
     }
   }
 
-  // 3. File-config override.
-  const configTemplate = config.overrides?.[key]?.[locale];
+  // 3. File-config override. Locale keys in user-authored config files
+  // commonly come in mixed case (`fr-ca`, `Fr-CA`, etc.); normalize lookup so
+  // config matches the same way the DB and code-default layers do.
+  const configForKey = config.overrides?.[key];
+  const configTemplate = lookupNormalizedLocale(configForKey, locale);
   if (typeof configTemplate === 'string') {
     return finalize({
       key,
@@ -137,6 +140,21 @@ async function resolveBaseForLocale(
     source: 'missing',
     resolvedFromLocale: locale,
   };
+}
+
+function lookupNormalizedLocale(
+  bag: Record<string, string> | undefined,
+  locale: string,
+): string | undefined {
+  if (!bag) return undefined;
+  // Fast path: exact match (most file configs use the canonical form).
+  if (typeof bag[locale] === 'string') return bag[locale];
+  for (const [candidate, template] of Object.entries(bag)) {
+    if (normalizeLocale(candidate) === locale) {
+      return template;
+    }
+  }
+  return undefined;
 }
 
 function finalize(args: {
@@ -230,7 +248,6 @@ export async function resolveLanguageString(
       requestedLocale: requested,
       defaultLocale,
       options,
-      fallbackTemplate: firstHit.template,
     });
     return {
       key,
@@ -265,7 +282,6 @@ async function tryEnqueueTranslation(args: {
   requestedLocale: string;
   defaultLocale: string;
   options: ResolveLanguageStringOptions;
-  fallbackTemplate?: string | null;
 }): Promise<void> {
   if (!args.options.db) {
     // Without a DB we cannot persist a job; skip silently — resolver still

--- a/packages/languages/src/language-resolver.ts
+++ b/packages/languages/src/language-resolver.ts
@@ -1,0 +1,300 @@
+import { getPackageConfig } from '@happyvertical/smrt-config';
+import { getTenantId } from '@happyvertical/smrt-tenancy';
+import {
+  getCachedLanguage,
+  invalidateLanguageCache,
+  setCachedLanguage,
+} from './cache.js';
+import { LanguageOverrideCollection } from './collections/LanguageOverrideCollection.js';
+import { LanguageRegistry } from './language-registry.js';
+import type {
+  LanguageCacheValue,
+  LanguagesPackageConfig,
+  ResolvedLanguageString,
+  ResolveLanguageStringOptions,
+} from './types.js';
+import {
+  buildLocaleFallbackChain,
+  normalizeLocale,
+  renderTemplate,
+} from './utils.js';
+
+const DEFAULT_LOCALE = 'en';
+
+function getLanguagesConfig(): LanguagesPackageConfig {
+  return getPackageConfig<LanguagesPackageConfig>('languages', {
+    defaultLocale: DEFAULT_LOCALE,
+    overrides: {},
+  });
+}
+
+interface ResolutionAttempt {
+  template: string | null;
+  source: ResolvedLanguageString['source'];
+  resolvedFromLocale: string;
+}
+
+async function resolveBaseForLocale(
+  key: string,
+  locale: string,
+  options: ResolveLanguageStringOptions,
+  config: LanguagesPackageConfig,
+): Promise<ResolutionAttempt> {
+  const tenantId =
+    options.tenantId !== undefined ? options.tenantId : (getTenantId() ?? null);
+
+  let collection: LanguageOverrideCollection | null = null;
+  if (options.db) {
+    collection = await (LanguageOverrideCollection as any).create({
+      db: options.db,
+    });
+  }
+
+  const cacheDb = collection?.db ?? options.db;
+  const cached = getCachedLanguage(key, locale, tenantId, cacheDb);
+  if (cached) {
+    return {
+      template: cached.template,
+      source: cached.source,
+      resolvedFromLocale: cached.resolvedFromLocale,
+    };
+  }
+
+  // 1. Tenant override (highest precedence among stored layers).
+  if (collection && tenantId) {
+    const tenantOverride = await collection.getTenantOverride(
+      key,
+      locale,
+      tenantId,
+    );
+    if (tenantOverride) {
+      return finalize({
+        key,
+        locale,
+        tenantId,
+        db: cacheDb,
+        attempt: {
+          template: tenantOverride.template,
+          source: 'tenant',
+          resolvedFromLocale: locale,
+        },
+      });
+    }
+  }
+
+  // 2. App-level override (incl. AI auto-translations).
+  if (collection) {
+    const appOverride = await collection.getAppOverride(key, locale);
+    if (appOverride) {
+      return finalize({
+        key,
+        locale,
+        tenantId,
+        db: cacheDb,
+        attempt: {
+          template: appOverride.template,
+          source: 'app',
+          resolvedFromLocale: locale,
+        },
+      });
+    }
+  }
+
+  // 3. File-config override.
+  const configTemplate = config.overrides?.[key]?.[locale];
+  if (typeof configTemplate === 'string') {
+    return finalize({
+      key,
+      locale,
+      tenantId,
+      db: cacheDb,
+      attempt: {
+        template: configTemplate,
+        source: 'config',
+        resolvedFromLocale: locale,
+      },
+    });
+  }
+
+  // 4. Code default.
+  const definition = LanguageRegistry.get(key, locale);
+  if (definition) {
+    return finalize({
+      key,
+      locale,
+      tenantId,
+      db: cacheDb,
+      attempt: {
+        template: definition.template,
+        source: 'code',
+        resolvedFromLocale: locale,
+      },
+    });
+  }
+
+  return {
+    template: null,
+    source: 'missing',
+    resolvedFromLocale: locale,
+  };
+}
+
+function finalize(args: {
+  key: string;
+  locale: string;
+  tenantId: string | null;
+  db: unknown;
+  attempt: ResolutionAttempt;
+}): ResolutionAttempt {
+  if (args.attempt.template !== null) {
+    const value: LanguageCacheValue = {
+      key: args.key,
+      locale: args.locale,
+      template: args.attempt.template,
+      source: args.attempt.source,
+      resolvedFromLocale: args.attempt.resolvedFromLocale,
+    };
+    setCachedLanguage(args.key, args.locale, args.tenantId, args.db, value);
+  }
+  return args.attempt;
+}
+
+export async function resolveLanguageString(
+  key: string,
+  options: ResolveLanguageStringOptions = {},
+): Promise<ResolvedLanguageString> {
+  if (!key || key.trim() === '') {
+    throw new Error('resolveLanguageString requires a non-empty key');
+  }
+
+  const config = getLanguagesConfig();
+  const defaultLocale = normalizeLocale(config.defaultLocale ?? DEFAULT_LOCALE);
+  const requested = normalizeLocale(options.locale ?? defaultLocale);
+
+  // Runtime override always wins, regardless of locale chain.
+  if (typeof options.overrides?.template === 'string') {
+    return {
+      key,
+      locale: requested,
+      template: options.overrides.template,
+      text: renderTemplate(options.overrides.template, options.vars),
+      resolvedFromLocale: requested,
+      source: 'runtime',
+    };
+  }
+
+  const chain = buildLocaleFallbackChain(requested, defaultLocale);
+
+  let firstHit: ResolutionAttempt | null = null;
+  let firstLocale = requested;
+  for (const locale of chain) {
+    const attempt = await resolveBaseForLocale(key, locale, options, config);
+    if (attempt.template !== null) {
+      firstHit = attempt;
+      firstLocale = locale;
+      break;
+    }
+  }
+
+  if (!firstHit) {
+    if (options.strict) {
+      throw new Error(
+        `Language string "${key}" has no resolution for locale "${requested}"`,
+      );
+    }
+    // Soft-miss: enqueue translation if the requested locale differs from the
+    // default and a default-locale source exists. Failure of the enqueue path
+    // must never break resolution — we still return the key as the rendered
+    // text so the UI degrades gracefully.
+    await tryEnqueueTranslation({
+      key,
+      requestedLocale: requested,
+      defaultLocale,
+      options,
+    });
+    return {
+      key,
+      locale: requested,
+      template: key,
+      text: key,
+      resolvedFromLocale: requested,
+      source: 'missing',
+    };
+  }
+
+  // Hit at a fallback locale that isn't the requested one — fire-and-forget a
+  // translation job for the requested target.
+  if (firstLocale !== requested) {
+    await tryEnqueueTranslation({
+      key,
+      requestedLocale: requested,
+      defaultLocale,
+      options,
+      fallbackTemplate: firstHit.template,
+    });
+    return {
+      key,
+      locale: requested,
+      template: firstHit.template ?? key,
+      text: renderTemplate(firstHit.template ?? key, options.vars),
+      resolvedFromLocale: firstLocale,
+      source: 'fallback',
+    };
+  }
+
+  return {
+    key,
+    locale: requested,
+    template: firstHit.template ?? key,
+    text: renderTemplate(firstHit.template ?? key, options.vars),
+    resolvedFromLocale: firstLocale,
+    source: firstHit.source,
+  };
+}
+
+/**
+ * Best-effort enqueue of an AI translation job. Wrapped so resolution never
+ * fails because of an enqueue error, missing optional dependency, etc.
+ *
+ * The actual job machinery lives in `./translation-job.ts` and is loaded
+ * lazily so the resolver does not pull `@happyvertical/ai` into the import
+ * graph for synchronous resolves that never miss.
+ */
+async function tryEnqueueTranslation(args: {
+  key: string;
+  requestedLocale: string;
+  defaultLocale: string;
+  options: ResolveLanguageStringOptions;
+  fallbackTemplate?: string | null;
+}): Promise<void> {
+  if (!args.options.db) {
+    // Without a DB we cannot persist a job; skip silently — resolver still
+    // returns a fallback to the caller.
+    return;
+  }
+  if (normalizeLocale(args.requestedLocale) === args.defaultLocale) {
+    return;
+  }
+
+  try {
+    const { enqueueTranslationJob } = await import('./translation-job.js');
+    await enqueueTranslationJob({
+      key: args.key,
+      targetLocale: args.requestedLocale,
+      sourceLocale: args.defaultLocale,
+      tenantId: args.options.tenantId ?? getTenantId() ?? null,
+      db: args.options.db,
+    });
+  } catch {
+    // Enqueueing must never break resolution.
+  }
+}
+
+export function invalidateResolvedLanguageCache(
+  key: string,
+  locale: string,
+  tenantId: string | null | undefined,
+  db: unknown,
+): void {
+  invalidateLanguageCache(key, locale, tenantId, db);
+}

--- a/packages/languages/src/models/LanguageOverride.ts
+++ b/packages/languages/src/models/LanguageOverride.ts
@@ -1,0 +1,159 @@
+import {
+  field,
+  SmrtObject,
+  type SmrtObjectOptions,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { invalidateLanguageCache } from '../cache.js';
+import type { LanguageOverrideOptions } from '../types.js';
+import { normalizeLocale } from '../utils.js';
+
+export interface LanguageOverrideCtorOptions
+  extends SmrtObjectOptions,
+    LanguageOverrideOptions {}
+
+@smrt({
+  tableName: '_smrt_language_overrides',
+  conflictColumns: ['key', 'locale', 'context'],
+  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  cli: {
+    include: ['list', 'get', 'create', 'update', 'delete', 'approve'],
+  },
+  mcp: { include: [] },
+})
+export class LanguageOverride extends SmrtObject {
+  @field({ required: true })
+  key: string = '';
+
+  @field({ required: true })
+  locale: string = '';
+
+  @field({ type: 'text', nullable: true })
+  tenantId: string | null = null;
+
+  @field({ type: 'text', required: true })
+  template: string = '';
+
+  /** True when this row was produced by the AI translation job. */
+  @field({ type: 'boolean', required: true, default: false })
+  auto_generated: boolean = false;
+
+  /** sha256 of the source template at translation time, for re-translation gating. */
+  @field({ type: 'text', nullable: true })
+  source_hash: string | null = null;
+
+  /** AI model identifier (null for human-edited rows). */
+  @field({ type: 'text', nullable: true })
+  ai_model: string | null = null;
+
+  /** ISO timestamp marking admin review of an auto-generated row. */
+  @field({ type: 'text', nullable: true })
+  reviewed_at: string | null = null;
+
+  /** User ID of the reviewer. */
+  @field({ type: 'text', nullable: true })
+  reviewed_by: string | null = null;
+
+  constructor(options: LanguageOverrideCtorOptions = {}) {
+    super(options);
+
+    if (options.key !== undefined) this.key = options.key;
+    if (options.locale !== undefined)
+      this.locale = normalizeLocale(options.locale);
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+    if (options.template !== undefined) this.template = options.template;
+    if (options.auto_generated !== undefined) {
+      this.auto_generated = options.auto_generated;
+    }
+    if (options.source_hash !== undefined)
+      this.source_hash = options.source_hash;
+    if (options.ai_model !== undefined) this.ai_model = options.ai_model;
+    if (options.reviewed_at !== undefined)
+      this.reviewed_at = options.reviewed_at;
+    if (options.reviewed_by !== undefined)
+      this.reviewed_by = options.reviewed_by;
+  }
+
+  override async save(): Promise<this> {
+    if (!this.key || this.key.trim() === '') {
+      throw new Error('LanguageOverride.key is required');
+    }
+    if (!this.locale || this.locale.trim() === '') {
+      throw new Error('LanguageOverride.locale is required');
+    }
+    if (typeof this.template !== 'string') {
+      throw new Error('LanguageOverride.template must be a string');
+    }
+
+    this.locale = normalizeLocale(this.locale);
+    // `context` is the conflictColumn-friendly scope: 'app' for nullable tenant,
+    // tenantId otherwise. Mirrors the prompt-override convention.
+    this.context = this.tenantId ?? '__app__';
+
+    const previousIdentity = await this.getPersistedIdentity();
+    const result = await super.save();
+
+    if (
+      previousIdentity &&
+      (previousIdentity.key !== this.key ||
+        previousIdentity.locale !== this.locale ||
+        previousIdentity.tenantId !== this.tenantId)
+    ) {
+      invalidateLanguageCache(
+        previousIdentity.key,
+        previousIdentity.locale,
+        previousIdentity.tenantId,
+        this.db,
+      );
+    }
+    invalidateLanguageCache(this.key, this.locale, this.tenantId, this.db);
+    return result;
+  }
+
+  override async delete(): Promise<void> {
+    const key = this.key;
+    const locale = this.locale;
+    const tenantId = this.tenantId;
+    await super.delete();
+    invalidateLanguageCache(key, locale, tenantId, this.db);
+  }
+
+  /**
+   * Mark this auto-generated row as reviewed by an admin. Useful for the
+   * admin review queue surfaced via `smrt languages approve <id>`.
+   */
+  async approve(reviewerId: string): Promise<this> {
+    this.reviewed_at = new Date().toISOString();
+    this.reviewed_by = reviewerId;
+    return this.save();
+  }
+
+  private async getPersistedIdentity(): Promise<{
+    key: string;
+    locale: string;
+    tenantId: string | null;
+  } | null> {
+    if (!this.id) {
+      return null;
+    }
+
+    const existing = await this.db.get(this.tableName, { id: this.id });
+    if (!existing) {
+      return null;
+    }
+
+    const row = existing as Record<string, unknown>;
+    return {
+      key: String(row.key ?? this.key),
+      locale: String(row.locale ?? this.locale),
+      tenantId:
+        row.tenantId !== undefined
+          ? (row.tenantId as string | null)
+          : (((row.tenant_id as string | null | undefined) ?? null) as
+              | string
+              | null),
+    };
+  }
+}
+
+export type { LanguageOverrideOptions } from '../types.js';

--- a/packages/languages/src/models/LanguageOverride.ts
+++ b/packages/languages/src/models/LanguageOverride.ts
@@ -4,9 +4,15 @@ import {
   type SmrtObjectOptions,
   smrt,
 } from '@happyvertical/smrt-core';
+import type { DatabaseInterface } from '@happyvertical/sql';
 import { invalidateLanguageCache } from '../cache.js';
 import type { LanguageOverrideOptions } from '../types.js';
 import { normalizeLocale } from '../utils.js';
+
+type LanguageTransactionHandle = DatabaseInterface & {
+  commit: () => Promise<void>;
+  rollback: () => Promise<void>;
+};
 
 export interface LanguageOverrideCtorOptions
   extends SmrtObjectOptions,
@@ -86,19 +92,30 @@ export class LanguageOverride extends SmrtObject {
     }
 
     this.locale = normalizeLocale(this.locale);
-    // `context` is the conflictColumn-friendly scope: 'app' for nullable tenant,
-    // tenantId otherwise. Mirrors the prompt-override convention.
+    // `context` is the conflictColumn-friendly scope: '__app__' for nullable
+    // tenant, tenantId otherwise. Mirrors the prompt-override convention.
     this.context = this.tenantId ?? '__app__';
 
     const previousIdentity = await this.getPersistedIdentity();
-    const result = await super.save();
-
-    if (
-      previousIdentity &&
+    const identityChanged =
+      !!previousIdentity &&
       (previousIdentity.key !== this.key ||
         previousIdentity.locale !== this.locale ||
-        previousIdentity.tenantId !== this.tenantId)
-    ) {
+        previousIdentity.tenantId !== this.tenantId);
+
+    // Persistence upserts on `(key, locale, context)`, so changing any of
+    // those on an existing row makes a plain `super.save()` write the old
+    // primary key under a new conflict identity — that hits the PK
+    // constraint instead of moving the override. Use the same
+    // delete-then-insert dance as PromptOverride: prefer a transaction when
+    // the driver supports it; otherwise stage a replacement row first and
+    // delete the old one only after the new one is durable.
+    const result =
+      identityChanged && previousIdentity
+        ? await this.saveAfterIdentityChange()
+        : await super.save();
+
+    if (identityChanged && previousIdentity) {
       invalidateLanguageCache(
         previousIdentity.key,
         previousIdentity.locale,
@@ -108,6 +125,72 @@ export class LanguageOverride extends SmrtObject {
     }
     invalidateLanguageCache(this.key, this.locale, this.tenantId, this.db);
     return result;
+  }
+
+  private async saveAfterIdentityChange(): Promise<this> {
+    if (typeof this.db.beginTransaction === 'function') {
+      return this.saveAfterIdentityChangeInTransaction();
+    }
+    return this.saveAfterIdentityChangeWithDeferredDelete();
+  }
+
+  private async saveAfterIdentityChangeInTransaction(): Promise<this> {
+    const originalDb = this._db;
+    const originalOptionsDb = this.options.db;
+    const tx = (await this.db.beginTransaction?.()) as
+      | LanguageTransactionHandle
+      | undefined;
+
+    if (!tx) {
+      return this.saveAfterIdentityChangeWithDeferredDelete();
+    }
+
+    try {
+      this._db = tx;
+      this.options.db = tx;
+      await super.delete();
+      const result = await super.save();
+      await tx.commit();
+      return result;
+    } catch (error) {
+      try {
+        await tx.rollback();
+      } catch {
+        // Preserve the original save error; rollback failures are secondary.
+      }
+      throw error;
+    } finally {
+      this._db = originalDb;
+      this.options.db = originalOptionsDb;
+    }
+  }
+
+  private async saveAfterIdentityChangeWithDeferredDelete(): Promise<this> {
+    const previousId = this.id;
+    if (!previousId) {
+      return super.save();
+    }
+
+    const replacementId = crypto.randomUUID();
+    let replacementSaved = false;
+    this.id = replacementId;
+
+    try {
+      const result = await super.save();
+      replacementSaved = true;
+      await this.db.delete(this.tableName, { id: previousId });
+      return result;
+    } catch (error) {
+      if (replacementSaved) {
+        try {
+          await this.db.delete(this.tableName, { id: replacementId });
+        } catch {
+          // Best effort cleanup keeps the original row as the source of truth.
+        }
+      }
+      this.id = previousId;
+      throw error;
+    }
   }
 
   override async delete(): Promise<void> {

--- a/packages/languages/src/translation-job.test.ts
+++ b/packages/languages/src/translation-job.test.ts
@@ -1,0 +1,126 @@
+import { clearCache, setConfig } from '@happyvertical/smrt-config';
+import { getTestDatabase } from '@happyvertical/smrt-core';
+import { resetTenancy, setupTestTenancy } from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { clearLanguageCache } from './cache.js';
+import { LanguageOverrideCollection } from './collections/LanguageOverrideCollection.js';
+import { defineLanguageString, LanguageRegistry } from './language-registry.js';
+import { enqueueTranslationJob } from './translation-job.js';
+
+describe('@happyvertical/smrt-languages — translation-job dedup', () => {
+  let db: DatabaseInterface;
+
+  beforeEach(async () => {
+    setupTestTenancy();
+    LanguageRegistry.clear();
+    clearLanguageCache();
+    clearCache();
+
+    setConfig({
+      packages: {
+        languages: {
+          defaultLocale: 'en',
+          supportedLocales: ['en', 'es', 'fr'],
+        },
+      },
+    });
+
+    db = await getTestDatabase({
+      classes: ['LanguageOverride', 'SmrtJob', 'LanguageTranslationTask'],
+    });
+  });
+
+  afterEach(async () => {
+    clearLanguageCache();
+    LanguageRegistry.clear();
+    clearCache();
+    resetTenancy();
+    if (typeof (db as any)?.close === 'function') {
+      await (db as any).close();
+    }
+  });
+
+  it('enqueues a single job for repeated misses against the same (key, locale)', async () => {
+    defineLanguageString({
+      key: 'test.dedup',
+      locale: 'en',
+      template: 'Hello',
+    });
+
+    const first = await enqueueTranslationJob({
+      key: 'test.dedup',
+      targetLocale: 'es',
+      sourceLocale: 'en',
+      db,
+    });
+    const second = await enqueueTranslationJob({
+      key: 'test.dedup',
+      targetLocale: 'es',
+      sourceLocale: 'en',
+      db,
+    });
+
+    expect(first.status).toBe('enqueued');
+    expect(second.status).toBe('duplicate');
+    expect(first.id).toBe(second.id);
+  });
+
+  it('skips locales outside the configured allowlist', async () => {
+    defineLanguageString({
+      key: 'test.allowlist',
+      locale: 'en',
+      template: 'Hello',
+    });
+
+    const result = await enqueueTranslationJob({
+      key: 'test.allowlist',
+      targetLocale: 'ja',
+      sourceLocale: 'en',
+      db,
+    });
+    expect(result.status).toBe('skipped');
+  });
+
+  it('skips when no source-locale code default is registered', async () => {
+    const result = await enqueueTranslationJob({
+      key: 'test.unregistered',
+      targetLocale: 'es',
+      sourceLocale: 'en',
+      db,
+    });
+    expect(result.status).toBe('skipped');
+  });
+
+  it('does not overwrite an existing app override on second enqueue when source unchanged', async () => {
+    defineLanguageString({
+      key: 'test.preserve',
+      locale: 'en',
+      template: 'Hello',
+    });
+
+    const overrides = await LanguageOverrideCollection.create({ db });
+    await overrides.create({
+      key: 'test.preserve',
+      locale: 'es',
+      tenantId: null,
+      template: 'Hola humana',
+      auto_generated: false,
+    });
+
+    const result = await enqueueTranslationJob({
+      key: 'test.preserve',
+      targetLocale: 'es',
+      sourceLocale: 'en',
+      db,
+    });
+    // The job is enqueued (resolver may have other reasons to want one), but
+    // the handler will skip when it runs because the row is human-edited.
+    // Importantly the existing row stays put — verified below.
+    expect(['enqueued', 'duplicate']).toContain(result.status);
+
+    const persisted = await overrides.getAppOverride('test.preserve', 'es');
+    expect(persisted?.template).toBe('Hola humana');
+    expect(persisted?.auto_generated).toBe(false);
+  });
+});

--- a/packages/languages/src/translation-job.ts
+++ b/packages/languages/src/translation-job.ts
@@ -1,0 +1,401 @@
+import { getAI } from '@happyvertical/ai';
+import { getPackageConfig } from '@happyvertical/smrt-config';
+import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { FeatureResolver } from '@happyvertical/smrt-features';
+import { SmrtJobCollection } from '@happyvertical/smrt-jobs';
+import { definePrompt, resolvePrompt } from '@happyvertical/smrt-prompts';
+import { invalidateLanguageCache } from './cache.js';
+import { LanguageOverrideCollection } from './collections/LanguageOverrideCollection.js';
+import { buildTenantGlossary } from './glossary.js';
+import { LanguageRegistry } from './language-registry.js';
+import type { LanguagesPackageConfig, TranslationJobPayload } from './types.js';
+import {
+  buildTranslationJobId,
+  computeSourceHash,
+  normalizeLocale,
+} from './utils.js';
+
+/** Feature flag key honored as the kill-switch for AI auto-translation. */
+export const AUTO_TRANSLATE_FEATURE_KEY = 'smrt-languages.auto_translate';
+
+/**
+ * Prompt key registered with `smrt-prompts` so ops can tune the AI translation
+ * style without redeploying. The prompt itself is referenced by the job
+ * handler when calling `@happyvertical/ai`.
+ */
+export const TRANSLATION_PROMPT_KEY = 'smrt-languages.translation';
+
+definePrompt({
+  key: TRANSLATION_PROMPT_KEY,
+  template:
+    'You translate user-facing application strings from {sourceLocale} to {targetLocale}.\n' +
+    'Preserve any "{var}" placeholders exactly. Do not add markup or commentary.\n' +
+    'Match the organization glossary where applicable:\n{glossary}\n' +
+    'String to translate: "{template}"\n' +
+    'Reply with a JSON object: {"translation": string}.',
+  editable: {
+    template: true,
+    profile: true,
+    model: true,
+    params: true,
+  },
+});
+
+/**
+ * SmrtObject that owns the translation job's `execute` method. The TaskRunner
+ * resolves jobs by `objectType` so the registered class name needs to match
+ * what `enqueueTranslationJob` writes.
+ */
+@smrt({
+  api: { include: [] },
+  cli: { include: [] },
+  mcp: { include: [] },
+})
+export class LanguageTranslationTask extends SmrtObject {
+  /**
+   * Job-runner entrypoint. Reads the translation payload, calls
+   * `@happyvertical/ai`, and upserts a `LanguageOverride` row.
+   */
+  async execute(args: TranslationJobPayload): Promise<{
+    skipped?: 'feature_disabled' | 'not_supported' | 'budget' | 'stale';
+    template?: string;
+  }> {
+    if (!args || !args.key || !args.targetLocale || !args.sourceTemplate) {
+      throw new Error(
+        'LanguageTranslationTask.execute requires a translation payload',
+      );
+    }
+
+    const config = getLanguagesConfig();
+    const targetLocale = normalizeLocale(args.targetLocale);
+    const sourceLocale = normalizeLocale(args.sourceLocale);
+
+    // Locale allowlist (cheap pre-check before any AI / DB work).
+    if (
+      Array.isArray(config.supportedLocales) &&
+      config.supportedLocales.length > 0 &&
+      !config.supportedLocales.map(normalizeLocale).includes(targetLocale)
+    ) {
+      return { skipped: 'not_supported' };
+    }
+
+    // Feature flag kill switch (best-effort — never blocks if unavailable).
+    if (await isAutoTranslateDisabled(args.tenantId ?? null, this.options)) {
+      return { skipped: 'feature_disabled' };
+    }
+
+    const overrides = await (LanguageOverrideCollection as any).create(
+      this.options,
+    );
+
+    // Source-hash gate: if a translation already exists with the same source,
+    // do nothing. Only re-translate when the source changed.
+    const existing = await overrides.getAppOverride(args.key, targetLocale);
+    if (existing?.auto_generated && existing.source_hash === args.sourceHash) {
+      return { skipped: 'stale', template: existing.template };
+    }
+    if (existing && !existing.auto_generated) {
+      // Human-edited rows are never overwritten.
+      return { skipped: 'stale', template: existing.template };
+    }
+
+    // Per-tenant daily budget.
+    if (
+      args.tenantId &&
+      typeof config.translationBudgetPerTenantPerDay === 'number'
+    ) {
+      const used = await countTodayTenantTranslations(
+        this.options,
+        args.tenantId,
+      );
+      if (used >= config.translationBudgetPerTenantPerDay) {
+        return { skipped: 'budget' };
+      }
+    }
+
+    // Build glossary from tenant overrides (no-op when no tenant context).
+    let glossary = '';
+    if (args.tenantId) {
+      const tenantOverrides = await overrides.listTenantOverrides(
+        args.tenantId,
+      );
+      glossary = buildTenantGlossary(tenantOverrides, {
+        sourceLocale,
+        targetLocale,
+        max: 25,
+      });
+    }
+    if (!glossary) {
+      glossary = '(no organization glossary)';
+    }
+
+    const prompt = await resolvePrompt(TRANSLATION_PROMPT_KEY, {
+      tenantId: args.tenantId ?? null,
+      variables: {
+        sourceLocale,
+        targetLocale,
+        template: args.sourceTemplate,
+        glossary,
+      },
+    });
+
+    const aiConfig: Record<string, unknown> = { ...(prompt.ai ?? {}) };
+    if (args.model) aiConfig.model = args.model;
+    const ai = await getAI(aiConfig as any);
+
+    const message = await ai.message(prompt.text, {
+      ...(prompt.ai as Record<string, unknown>),
+      responseFormat: { type: 'json_object' },
+    });
+
+    const translated = parseTranslationResponse(message);
+    if (!translated) {
+      throw new Error(
+        `LanguageTranslationTask: AI returned no usable translation for "${args.key}" → ${targetLocale}`,
+      );
+    }
+
+    if (containsObviousMarkupLeak(translated)) {
+      throw new Error(
+        `LanguageTranslationTask: refusing to persist suspicious translation for "${args.key}"`,
+      );
+    }
+
+    const aiModel = (prompt.ai?.model as string | undefined) ?? null;
+    const sourceHash =
+      args.sourceHash || computeSourceHash(args.sourceTemplate);
+
+    if (existing) {
+      existing.template = translated;
+      existing.auto_generated = true;
+      existing.source_hash = sourceHash;
+      existing.ai_model = aiModel;
+      existing.reviewed_at = null;
+      existing.reviewed_by = null;
+      await existing.save();
+    } else {
+      // Use the collection's create() so the new row is initialized against
+      // the same DB the task is running on. Constructing `new LanguageOverride`
+      // directly leaves it un-initialized and `.save()` then trips on the
+      // "Database accessed before initialization" guard.
+      await overrides.create({
+        key: args.key,
+        locale: targetLocale,
+        tenantId: null,
+        template: translated,
+        auto_generated: true,
+        source_hash: sourceHash,
+        ai_model: aiModel,
+        reviewed_at: null,
+        reviewed_by: null,
+      });
+    }
+
+    invalidateLanguageCache(args.key, targetLocale, null, this.db);
+    return { template: translated };
+  }
+}
+
+interface EnqueueTranslationOptions {
+  key: string;
+  targetLocale: string;
+  sourceLocale?: string;
+  tenantId?: string | null;
+  db: unknown;
+  /** When true, skip the dedup check and force a fresh job. */
+  force?: boolean;
+}
+
+/**
+ * Enqueue a translation job for `(key, targetLocale)`, deduplicated against
+ * any already-pending job for the same target. Returns the (possibly existing)
+ * job's deterministic ID.
+ */
+export async function enqueueTranslationJob(
+  options: EnqueueTranslationOptions,
+): Promise<{ id: string; status: 'enqueued' | 'duplicate' | 'skipped' }> {
+  const targetLocale = normalizeLocale(options.targetLocale);
+  const sourceLocale = normalizeLocale(options.sourceLocale ?? 'en');
+  const dedupId = buildTranslationJobId(options.key, targetLocale);
+
+  const definition = LanguageRegistry.get(options.key, sourceLocale);
+  if (!definition) {
+    return { id: dedupId, status: 'skipped' };
+  }
+
+  const config = getLanguagesConfig();
+  if (
+    Array.isArray(config.supportedLocales) &&
+    config.supportedLocales.length > 0 &&
+    !config.supportedLocales.map(normalizeLocale).includes(targetLocale)
+  ) {
+    return { id: dedupId, status: 'skipped' };
+  }
+
+  const jobs = await (SmrtJobCollection as any).create({ db: options.db });
+
+  if (!options.force) {
+    const existing = await findPendingTranslationJob(
+      jobs,
+      options.key,
+      targetLocale,
+    );
+    if (existing) {
+      return { id: dedupId, status: 'duplicate' };
+    }
+  }
+
+  const payload: TranslationJobPayload = {
+    key: options.key,
+    sourceLocale,
+    sourceTemplate: definition.template,
+    sourceHash: definition.sourceHash,
+    targetLocale,
+    tenantId: options.tenantId ?? null,
+  };
+
+  const job = await jobs.create({
+    queue: 'languages',
+    objectType: 'LanguageTranslationTask',
+    objectId: null,
+    method: 'execute',
+    args: { ...payload, _dedupId: dedupId },
+    runAt: new Date(),
+    priority: 25,
+  });
+  await job.save();
+
+  return { id: dedupId, status: 'enqueued' };
+}
+
+/**
+ * In-memory match cap for the dedup scan. We pull the most recently-queued
+ * language jobs and check them in JS because querying inside a JSON column
+ * portably across SQLite/Postgres is fiddly. If the working queue is deeper
+ * than this, the scan truncates — when that happens we log a warning instead
+ * of silently letting duplicate jobs slip through, and the handler's
+ * source-hash gate (`execute()`) still prevents redundant AI calls. Tune via
+ * `packages.languages.dedupScanLimit` if your steady-state pending queue
+ * regularly exceeds the default.
+ */
+const DEFAULT_DEDUP_SCAN_LIMIT = 500;
+
+async function findPendingTranslationJob(
+  jobs: SmrtJobCollection,
+  key: string,
+  targetLocale: string,
+): Promise<unknown | null> {
+  const dedupId = buildTranslationJobId(key, targetLocale);
+  const config = getLanguagesConfig();
+  const scanLimit =
+    typeof (config as { dedupScanLimit?: number }).dedupScanLimit === 'number'
+      ? (config as { dedupScanLimit: number }).dedupScanLimit
+      : DEFAULT_DEDUP_SCAN_LIMIT;
+
+  const rows = await jobs.list({
+    where: {
+      objectType: 'LanguageTranslationTask',
+      method: 'execute',
+      status: ['pending', 'running'],
+      queue: 'languages',
+    },
+    orderBy: 'createdAt DESC',
+    limit: scanLimit,
+  });
+
+  for (const row of rows) {
+    const args = (row as { args?: Record<string, unknown> }).args ?? {};
+    if (args._dedupId === dedupId) return row;
+    if (
+      args.key === key &&
+      typeof args.targetLocale === 'string' &&
+      normalizeLocale(args.targetLocale as string) === targetLocale
+    ) {
+      return row;
+    }
+  }
+
+  if (rows.length === scanLimit) {
+    // Don't crash; the handler's source-hash gate is the durable safeguard.
+    // But surface a warning so operators notice when the queue depth has
+    // outgrown the in-memory match window.
+    console.warn(
+      `[smrt-languages] translation-job dedup scan hit its limit (${scanLimit}); raise packages.languages.dedupScanLimit if duplicate jobs appear`,
+    );
+  }
+  return null;
+}
+
+async function countTodayTenantTranslations(
+  options: { db?: unknown },
+  tenantId: string,
+): Promise<number> {
+  try {
+    const jobs = await (SmrtJobCollection as any).create({ db: options.db });
+    const since = new Date();
+    since.setUTCHours(0, 0, 0, 0);
+    const rows = await jobs.list({
+      where: {
+        objectType: 'LanguageTranslationTask',
+        method: 'execute',
+        tenantId,
+        createdAt: { op: '>=', value: since.toISOString() },
+      },
+    });
+    return rows.length;
+  } catch {
+    return 0;
+  }
+}
+
+function getLanguagesConfig(): LanguagesPackageConfig {
+  return getPackageConfig<LanguagesPackageConfig>('languages', {
+    defaultLocale: 'en',
+    overrides: {},
+  });
+}
+
+async function isAutoTranslateDisabled(
+  tenantId: string | null,
+  options: { db?: unknown },
+): Promise<boolean> {
+  try {
+    const resolver = new FeatureResolver(options as any);
+    const enabled = await resolver.isEnabled(AUTO_TRANSLATE_FEATURE_KEY, {
+      tenantId: tenantId ?? undefined,
+    });
+    return enabled === false;
+  } catch {
+    // If features package can't resolve (no definition synced, etc.), default
+    // to enabled — operators opt out by registering the flag.
+    return false;
+  }
+}
+
+function parseTranslationResponse(
+  message: string | null | undefined,
+): string | null {
+  if (!message) return null;
+  try {
+    const parsed = JSON.parse(message);
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof parsed.translation === 'string'
+    ) {
+      const cleaned = parsed.translation.trim();
+      return cleaned.length > 0 ? cleaned : null;
+    }
+  } catch {
+    // Fall through — the model may have returned a bare string.
+  }
+
+  const trimmed = String(message).trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function containsObviousMarkupLeak(value: string): boolean {
+  // Cheap defense: refuse responses that look like raw HTML/system tags. We
+  // can tighten this in v1.1 once we have telemetry on real failure modes.
+  return /<\/?(script|html|body|iframe|system)/i.test(value);
+}

--- a/packages/languages/src/translation-job.ts
+++ b/packages/languages/src/translation-job.ts
@@ -25,14 +25,24 @@ export const AUTO_TRANSLATE_FEATURE_KEY = 'smrt-languages.auto_translate';
  */
 export const TRANSLATION_PROMPT_KEY = 'smrt-languages.translation';
 
+/**
+ * Brace-containing example values that must reach the model verbatim. The
+ * prompt renderer treats every `{...}` as a variable, so anything we want the
+ * model to literally see (the placeholder syntax we're asking it to preserve,
+ * the JSON shape we're asking it to return) is injected via a variable rather
+ * than being baked into the static template.
+ */
+const PLACEHOLDER_EXAMPLE = '"{name}"';
+const RESPONSE_SHAPE_EXAMPLE = '{"translation": "Hola, {name}"}';
+
 definePrompt({
   key: TRANSLATION_PROMPT_KEY,
   template:
     'You translate user-facing application strings from {sourceLocale} to {targetLocale}.\n' +
-    'Preserve any "{var}" placeholders exactly. Do not add markup or commentary.\n' +
+    'Preserve any placeholders such as {placeholderExample} exactly as they appear, including the braces. Do not add markup or commentary.\n' +
     'Match the organization glossary where applicable:\n{glossary}\n' +
     'String to translate: "{template}"\n' +
-    'Reply with a JSON object: {"translation": string}.',
+    'Reply with a JSON object shaped like {responseShapeExample} where the translation field is your translated string.',
   editable: {
     template: true,
     profile: true,
@@ -129,22 +139,34 @@ export class LanguageTranslationTask extends SmrtObject {
       glossary = '(no organization glossary)';
     }
 
+    // Pass the task's DB into resolvePrompt so any app/tenant-level prompt
+    // overrides stored in `_smrt_prompt_overrides` are honored — that's the
+    // whole reason we register the translation prompt with smrt-prompts in
+    // the first place.
     const prompt = await resolvePrompt(TRANSLATION_PROMPT_KEY, {
+      db: this.options.db,
       tenantId: args.tenantId ?? null,
       variables: {
         sourceLocale,
         targetLocale,
         template: args.sourceTemplate,
         glossary,
+        placeholderExample: PLACEHOLDER_EXAMPLE,
+        responseShapeExample: RESPONSE_SHAPE_EXAMPLE,
       },
     });
 
-    const aiConfig: Record<string, unknown> = { ...(prompt.ai ?? {}) };
-    if (args.model) aiConfig.model = args.model;
-    const ai = await getAI(aiConfig as any);
+    // Single merged AI config: per-job model override (`args.model`) wins
+    // over the prompt's `ai.model`, and the same merge feeds both `getAI()`
+    // (client construction) and `ai.message()` (request options) so the
+    // override actually takes effect end-to-end.
+    const promptAi = (prompt.ai ?? {}) as Record<string, unknown>;
+    const mergedAiConfig: Record<string, unknown> = { ...promptAi };
+    if (args.model) mergedAiConfig.model = args.model;
+    const ai = await getAI(mergedAiConfig as any);
 
     const message = await ai.message(prompt.text, {
-      ...(prompt.ai as Record<string, unknown>),
+      ...mergedAiConfig,
       responseFormat: { type: 'json_object' },
     });
 
@@ -161,7 +183,12 @@ export class LanguageTranslationTask extends SmrtObject {
       );
     }
 
-    const aiModel = (prompt.ai?.model as string | undefined) ?? null;
+    // Persist the model that actually produced the translation, not just the
+    // prompt's default — `args.model` overrides the prompt's `ai.model`.
+    const aiModel =
+      (args.model as string | undefined) ??
+      (promptAi.model as string | undefined) ??
+      null;
     const sourceHash =
       args.sourceHash || computeSourceHash(args.sourceTemplate);
 
@@ -254,11 +281,17 @@ export async function enqueueTranslationJob(
     tenantId: options.tenantId ?? null,
   };
 
+  // Stamp tenantId on the SmrtJob row so the per-tenant daily budget query
+  // (which filters by `tenantId`) actually counts this job. SmrtJob.save()
+  // will fall back to `getTenantId()` from AsyncLocalStorage when undefined,
+  // but we may be enqueueing from outside a tenant context (e.g. resolver
+  // miss with an explicit tenantId option), so set it explicitly here.
   const job = await jobs.create({
     queue: 'languages',
     objectType: 'LanguageTranslationTask',
     objectId: null,
     method: 'execute',
+    tenantId: options.tenantId ?? null,
     args: { ...payload, _dedupId: dedupId },
     runAt: new Date(),
     priority: 25,
@@ -330,22 +363,23 @@ async function countTodayTenantTranslations(
   options: { db?: unknown },
   tenantId: string,
 ): Promise<number> {
-  try {
-    const jobs = await (SmrtJobCollection as any).create({ db: options.db });
-    const since = new Date();
-    since.setUTCHours(0, 0, 0, 0);
-    const rows = await jobs.list({
-      where: {
-        objectType: 'LanguageTranslationTask',
-        method: 'execute',
-        tenantId,
-        createdAt: { op: '>=', value: since.toISOString() },
-      },
-    });
-    return rows.length;
-  } catch {
-    return 0;
-  }
+  // SmrtCollection.list() encodes operators into the where-clause key (e.g.
+  // `'createdAt >='`), not as `{ op, value }` objects — using the wrong shape
+  // either throws or matches nothing, and a swallowed failure here silently
+  // disables the budget. Let the call propagate so configuration mistakes
+  // surface immediately rather than as a missed throttle in production.
+  const jobs = await (SmrtJobCollection as any).create({ db: options.db });
+  const since = new Date();
+  since.setUTCHours(0, 0, 0, 0);
+  const rows = await jobs.list({
+    where: {
+      objectType: 'LanguageTranslationTask',
+      method: 'execute',
+      tenantId,
+      'createdAt >=': since.toISOString(),
+    },
+  });
+  return rows.length;
 }
 
 function getLanguagesConfig(): LanguagesPackageConfig {
@@ -376,18 +410,37 @@ function parseTranslationResponse(
   message: string | null | undefined,
 ): string | null {
   if (!message) return null;
+
+  // We requested `responseFormat: json_object` so the model is supposed to
+  // return a JSON object with a `translation` string. If parsing succeeds but
+  // the shape is wrong (e.g. `{"text":"Hola"}`), we MUST NOT fall through to
+  // the bare-string path — that would persist the whole JSON blob as the
+  // translation. Only the parse-failed branch may try to use the raw message
+  // as a literal string (some providers occasionally return prose despite
+  // the format hint).
+  let parseFailed = false;
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(message);
+    parsed = JSON.parse(message);
+  } catch {
+    parseFailed = true;
+  }
+
+  if (!parseFailed) {
     if (
       parsed &&
       typeof parsed === 'object' &&
-      typeof parsed.translation === 'string'
+      !Array.isArray(parsed) &&
+      typeof (parsed as { translation?: unknown }).translation === 'string'
     ) {
-      const cleaned = parsed.translation.trim();
+      const cleaned = (parsed as { translation: string }).translation.trim();
       return cleaned.length > 0 ? cleaned : null;
     }
-  } catch {
-    // Fall through — the model may have returned a bare string.
+    if (typeof parsed === 'string') {
+      const cleaned = parsed.trim();
+      return cleaned.length > 0 ? cleaned : null;
+    }
+    return null;
   }
 
   const trimmed = String(message).trim();

--- a/packages/languages/src/types.ts
+++ b/packages/languages/src/types.ts
@@ -1,0 +1,109 @@
+import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+
+/** A registered code default for a single (key, locale) pair. */
+export interface LanguageStringDefinitionInput {
+  key: string;
+  locale: string;
+  template: string;
+}
+
+export interface LanguageStringDefinition {
+  key: string;
+  locale: string;
+  template: string;
+  /** sha256 of the template at registration time, used for re-translation gating */
+  sourceHash: string;
+}
+
+/**
+ * Per-package config bag, read via `getPackageConfig('languages', ...)`.
+ *
+ * `overrides[key][locale]` is a plain string template that takes precedence over
+ * code defaults for that (key, locale) pair. It is the file-config layer in the
+ * 5-layer resolution chain.
+ */
+export interface LanguagesPackageConfig {
+  /** Default locale used when none is supplied at resolve-time. Defaults to 'en'. */
+  defaultLocale?: string;
+  /** When set, AI auto-translation jobs are only enqueued for these locales. */
+  supportedLocales?: string[];
+  /** Daily cap on AI translation jobs per tenant (null = no cap). */
+  translationBudgetPerTenantPerDay?: number | null;
+  /** File-config overrides, keyed by (key)(locale). */
+  overrides?: Record<string, Record<string, string>>;
+  [key: string]: unknown;
+}
+
+export type LanguageVariables = Record<string, unknown>;
+
+export interface ResolveLanguageStringOptions {
+  db?: SmrtClassOptions['db'];
+  tenantId?: string | null;
+  locale?: string;
+  /** Variables substituted into `{var}` placeholders. */
+  vars?: LanguageVariables;
+  /** Optional per-call override for the rendered template (highest precedence). */
+  overrides?: { template?: string };
+  /**
+   * When `true`, throw if the resolution chain finishes without producing a
+   * template. When `false` (default), return the key as the rendered string and
+   * enqueue an AI translation job for the missing (key, locale).
+   */
+  strict?: boolean;
+}
+
+export interface ResolvedLanguageString {
+  key: string;
+  locale: string;
+  /** The fully-rendered string with variables substituted. */
+  text: string;
+  /** The raw template that produced `text`. */
+  template: string;
+  /** Locale that actually produced the template (may differ from `locale` after fallback). */
+  resolvedFromLocale: string;
+  /**
+   * `'code' | 'config' | 'app' | 'tenant' | 'runtime'`. `'fallback'` indicates
+   * no exact match was found and a fallback locale was used.
+   */
+  source:
+    | 'code'
+    | 'config'
+    | 'app'
+    | 'tenant'
+    | 'runtime'
+    | 'fallback'
+    | 'missing';
+}
+
+export interface LanguageCacheValue {
+  key: string;
+  locale: string;
+  template: string;
+  source: ResolvedLanguageString['source'];
+  resolvedFromLocale: string;
+}
+
+export interface LanguageOverrideOptions {
+  key?: string;
+  locale?: string;
+  tenantId?: string | null;
+  template?: string;
+  auto_generated?: boolean;
+  source_hash?: string | null;
+  ai_model?: string | null;
+  reviewed_at?: string | null;
+  reviewed_by?: string | null;
+}
+
+/** Payload pushed to the smrt-jobs translation handler. */
+export interface TranslationJobPayload {
+  key: string;
+  sourceLocale: string;
+  sourceTemplate: string;
+  sourceHash: string;
+  targetLocale: string;
+  tenantId?: string | null;
+  /** Optional model override; defaults to config / @happyvertical/ai default. */
+  model?: string;
+  [key: string]: unknown;
+}

--- a/packages/languages/src/utils.test.ts
+++ b/packages/languages/src/utils.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildLocaleFallbackChain,
+  buildTranslationJobId,
+  computeSourceHash,
+  normalizeLocale,
+  renderTemplate,
+} from './utils.js';
+
+describe('utils', () => {
+  describe('normalizeLocale', () => {
+    it('lowercases language and uppercases region', () => {
+      expect(normalizeLocale('EN')).toBe('en');
+      expect(normalizeLocale('en-us')).toBe('en-US');
+      expect(normalizeLocale('Fr-Ca')).toBe('fr-CA');
+    });
+
+    it('preserves bare language tags', () => {
+      expect(normalizeLocale('es')).toBe('es');
+    });
+
+    it('returns empty string for empty input', () => {
+      expect(normalizeLocale('')).toBe('');
+      expect(normalizeLocale('   ')).toBe('');
+    });
+  });
+
+  describe('buildLocaleFallbackChain', () => {
+    it('walks region down to language down to default', () => {
+      expect(buildLocaleFallbackChain('fr-CA', 'en')).toEqual([
+        'fr-CA',
+        'fr',
+        'en',
+      ]);
+    });
+
+    it('drops duplicates when default equals requested', () => {
+      expect(buildLocaleFallbackChain('en', 'en')).toEqual(['en']);
+    });
+
+    it('handles three-segment tags', () => {
+      // Behavior: each `-` strip is one segment.
+      expect(buildLocaleFallbackChain('zh-Hans-CN', 'en')).toEqual([
+        'zh-HANS-CN',
+        'zh-HANS',
+        'zh',
+        'en',
+      ]);
+    });
+
+    it('returns just the default when no requested locale', () => {
+      expect(buildLocaleFallbackChain('', 'en')).toEqual(['en']);
+    });
+  });
+
+  describe('renderTemplate', () => {
+    it('substitutes {var} placeholders', () => {
+      expect(renderTemplate('Hello {name}', { name: 'Will' })).toBe(
+        'Hello Will',
+      );
+    });
+
+    it('treats missing variables as empty strings when other vars are passed', () => {
+      // The fast-path returns the template unchanged when the variable bag is
+      // empty — callers that pass at least one var still get every placeholder
+      // expanded, with missing ones collapsed to ''.
+      expect(renderTemplate('Hello {name} ({title})', { title: 'Mx.' })).toBe(
+        'Hello  (Mx.)',
+      );
+    });
+
+    it('returns the template untouched when no variables are passed', () => {
+      expect(renderTemplate('Hello {name}', {})).toBe('Hello {name}');
+      expect(renderTemplate('Hello {name}')).toBe('Hello {name}');
+    });
+
+    it('serializes objects and arrays as JSON', () => {
+      expect(renderTemplate('{x}', { x: { a: 1 } })).toBe('{"a":1}');
+      expect(renderTemplate('{x}', { x: [1, 2] })).toBe('[1,2]');
+    });
+
+    it('renders Date as ISO string', () => {
+      const date = new Date('2026-05-09T00:00:00.000Z');
+      expect(renderTemplate('{when}', { when: date })).toBe(
+        '2026-05-09T00:00:00.000Z',
+      );
+    });
+  });
+
+  describe('computeSourceHash', () => {
+    it('is deterministic', () => {
+      expect(computeSourceHash('hello')).toBe(computeSourceHash('hello'));
+    });
+
+    it('changes when input changes', () => {
+      expect(computeSourceHash('hello')).not.toBe(computeSourceHash('hello!'));
+    });
+  });
+
+  describe('buildTranslationJobId', () => {
+    it('is a deterministic string keyed by (key, locale)', () => {
+      expect(buildTranslationJobId('users.role.member', 'es')).toBe(
+        'smrt-languages.translate:users.role.member:es',
+      );
+      expect(buildTranslationJobId('users.role.member', 'ES')).toBe(
+        'smrt-languages.translate:users.role.member:es',
+      );
+    });
+  });
+});

--- a/packages/languages/src/utils.ts
+++ b/packages/languages/src/utils.ts
@@ -12,12 +12,21 @@ export function computeSourceHash(template: string): string {
   return `sha256:${createHash('sha256').update(template, 'utf8').digest('hex')}`;
 }
 
-/** Normalize a BCP-47 tag to lowercase region-and-script segments. */
+/**
+ * Normalize a BCP-47-ish locale tag for consistent matching across the
+ * registry, the cache, and DB lookups.
+ *
+ * Lowercases the language subtag and uppercases everything after it so
+ * `fr-ca`, `fr-CA`, and `Fr-Ca` collapse to the same key. This is **not**
+ * canonical BCP-47 casing (proper BCP-47 lower-cases variants and uses
+ * Title-case for script subtags like `Hans`); it is an internal
+ * normalization shared by every layer in this package and intentionally
+ * stricter than what BCP-47 mandates.
+ */
 export function normalizeLocale(locale: string): string {
   if (!locale) return '';
   const trimmed = locale.trim();
   if (!trimmed) return '';
-  // Lowercase language; uppercase region for consistent matching.
   const [language, ...rest] = trimmed.split('-');
   if (rest.length === 0) {
     return language.toLowerCase();
@@ -63,7 +72,19 @@ export function buildLocaleFallbackChain(
   return chain;
 }
 
-/** Render `{var}` placeholders. Missing variables collapse to empty strings. */
+/**
+ * Render `{var}` placeholders against the supplied variables.
+ *
+ * When at least one variable is provided, every `{...}` placeholder in the
+ * template is replaced; missing or `undefined`/`null` variables collapse to
+ * empty strings (callers that pass `name` but not `title` get the `{title}`
+ * placeholder removed).
+ *
+ * When `variables` is `undefined` or `{}` the template is returned unchanged
+ * — that fast path avoids the regex pass for the common "no interpolation
+ * needed" case. If you need every placeholder collapsed regardless, pass at
+ * least one variable (e.g. `{ __forceRender: true }`).
+ */
 export function renderTemplate(
   template: string,
   variables?: LanguageVariables,

--- a/packages/languages/src/utils.ts
+++ b/packages/languages/src/utils.ts
@@ -1,0 +1,105 @@
+import { createHash } from 'node:crypto';
+import type { LanguageVariables } from './types.js';
+
+export function isPlainObject(
+  value: unknown,
+): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** Stable hash used to gate auto-translation re-runs against a specific source. */
+export function computeSourceHash(template: string): string {
+  return `sha256:${createHash('sha256').update(template, 'utf8').digest('hex')}`;
+}
+
+/** Normalize a BCP-47 tag to lowercase region-and-script segments. */
+export function normalizeLocale(locale: string): string {
+  if (!locale) return '';
+  const trimmed = locale.trim();
+  if (!trimmed) return '';
+  // Lowercase language; uppercase region for consistent matching.
+  const [language, ...rest] = trimmed.split('-');
+  if (rest.length === 0) {
+    return language.toLowerCase();
+  }
+  return [
+    language.toLowerCase(),
+    ...rest.map((part) => part.toUpperCase()),
+  ].join('-');
+}
+
+/**
+ * Build the locale fallback chain for a requested locale.
+ *
+ * Example: `fr-CA` with default `en` → `['fr-CA', 'fr', 'en']`.
+ * Duplicates and empty segments are removed.
+ */
+export function buildLocaleFallbackChain(
+  requested: string,
+  defaultLocale: string,
+): string[] {
+  const chain: string[] = [];
+  const push = (value: string) => {
+    const normalized = normalizeLocale(value);
+    if (normalized && !chain.includes(normalized)) {
+      chain.push(normalized);
+    }
+  };
+
+  if (requested) {
+    let current = normalizeLocale(requested);
+    while (current) {
+      push(current);
+      const idx = current.lastIndexOf('-');
+      if (idx === -1) break;
+      current = current.slice(0, idx);
+    }
+  }
+
+  if (defaultLocale) {
+    push(defaultLocale);
+  }
+
+  return chain;
+}
+
+/** Render `{var}` placeholders. Missing variables collapse to empty strings. */
+export function renderTemplate(
+  template: string,
+  variables?: LanguageVariables,
+): string {
+  if (!variables || Object.keys(variables).length === 0) {
+    return template;
+  }
+
+  return template.replace(/\{([^{}]+)\}/g, (_match, rawKey: string) => {
+    const key = rawKey.trim();
+    const value = variables[key];
+
+    if (value === undefined || value === null) {
+      return '';
+    }
+
+    if (value instanceof Date) {
+      return value.toISOString();
+    }
+
+    if (Array.isArray(value) || isPlainObject(value)) {
+      try {
+        return JSON.stringify(value);
+      } catch {
+        return '';
+      }
+    }
+
+    return String(value);
+  });
+}
+
+/** Deterministic translation-job ID — used for stampede protection. */
+export function buildTranslationJobId(
+  key: string,
+  targetLocale: string,
+): string {
+  return `smrt-languages.translate:${key}:${normalizeLocale(targetLocale)}`;
+}

--- a/packages/languages/tsconfig.build.json
+++ b/packages/languages/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.package-build.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "lib": ["ES2023"]
+  },
+  "exclude": ["**/*.test.ts", "**/*.spec.ts", "node_modules", "dist"]
+}

--- a/packages/languages/tsconfig.json
+++ b/packages/languages/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "types": ["node"],
+    "lib": ["ES2023"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/languages/vite.config.ts
+++ b/packages/languages/vite.config.ts
@@ -1,0 +1,6 @@
+import { createPackageConfig } from '../../vite.config.base.js';
+
+export default createPackageConfig('languages', {
+  // Catch declaration regressions on the public API.
+  strictDts: true,
+});

--- a/packages/languages/vite.config.ts
+++ b/packages/languages/vite.config.ts
@@ -3,4 +3,9 @@ import { createPackageConfig } from '../../vite.config.base.js';
 export default createPackageConfig('languages', {
   // Catch declaration regressions on the public API.
   strictDts: true,
+  // Translation-job and CLI APIs live on subpaths so importing the package
+  // root for `defineLanguageString` / `resolveLanguageString` does not drag
+  // jobs/features/prompts/AI into every consumer bundle. See README and
+  // `index.ts` for the contract.
+  entries: ['jobs', 'cli'],
 });

--- a/packages/languages/vitest.config.ts
+++ b/packages/languages/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+import { smrtVitestPlugin } from '../vitest/src/index.ts';
+
+export default defineConfig({
+  plugins: [smrtVitestPlugin({ verbose: true })],
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    testTimeout: 30000,
+    fileParallelism: false,
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1069,6 +1069,52 @@ importers:
         specifier: ^4.0.17
         version: 4.0.17(@opentelemetry/api@1.9.1)(@types/node@24.10.9)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.2.0))(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/languages:
+    dependencies:
+      '@happyvertical/ai':
+        specifier: ^0.73.2
+        version: 0.73.2(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@happyvertical/smrt-config':
+        specifier: workspace:*
+        version: link:../config
+      '@happyvertical/smrt-core':
+        specifier: workspace:*
+        version: link:../core
+      '@happyvertical/smrt-features':
+        specifier: workspace:*
+        version: link:../features
+      '@happyvertical/smrt-jobs':
+        specifier: workspace:*
+        version: link:../jobs
+      '@happyvertical/smrt-prompts':
+        specifier: workspace:*
+        version: link:../prompts
+      '@happyvertical/smrt-tenancy':
+        specifier: workspace:*
+        version: link:../tenancy
+      '@happyvertical/sql':
+        specifier: ^0.73.2
+        version: 0.73.2
+    devDependencies:
+      '@happyvertical/smrt-cli':
+        specifier: workspace:*
+        version: link:../cli
+      '@happyvertical/smrt-vitest':
+        specifier: workspace:*
+        version: link:../vitest
+      '@types/node':
+        specifier: 24.10.9
+        version: 24.10.9
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: ^4.0.17
+        version: 4.0.17(@opentelemetry/api@1.9.1)(@types/node@24.10.9)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.2.0))(tsx@4.21.0)(yaml@2.8.2)
+
   packages/ledgers:
     dependencies:
       '@happyvertical/smrt-core':
@@ -3102,6 +3148,11 @@ packages:
     peerDependencies:
       jimp: '>=1.6.1'
       sharp: '>=0.34.5'
+    peerDependenciesMeta:
+      jimp:
+        optional: true
+      sharp:
+        optional: true
 
   '@happyvertical/jobs@0.73.2':
     resolution: {integrity: sha512-9J6w8v6mznflNIEE7t8lK4qDzLSNQ++5nmlAPEvzHcsRER0edDXMxlj6k4jmKACBjteBAa/pk/2vv5+Ui1cd8g==, tarball: https://npm.pkg.github.com/download/@happyvertical/jobs/0.73.2/eca86edc045db40a0698614a96da8f95396e1c38}
@@ -3111,6 +3162,15 @@ packages:
       '@google-cloud/tasks': '>=4.1.0'
       bull: '>=4.16.5'
       bullmq: '>=5.76.0'
+    peerDependenciesMeta:
+      '@aws-sdk/client-sqs':
+        optional: true
+      '@google-cloud/tasks':
+        optional: true
+      bull:
+        optional: true
+      bullmq:
+        optional: true
 
   '@happyvertical/json@0.73.2':
     resolution: {integrity: sha512-I+DN5t1V71kEl9dS6sEjJ8U/gyYs5tkSt+1YNSnT1hayZeyNuFbQ2EDvAbjAzeB4bm4e8PMER/DTcsLULT94kA==, tarball: https://npm.pkg.github.com/download/@happyvertical/json/0.73.2/9e82a8c46cc2456523daf11866ef97b7bbdc7013}
@@ -3120,6 +3180,9 @@ packages:
     hasBin: true
     peerDependencies:
       '@sentry/node': '>=10.49.0'
+    peerDependenciesMeta:
+      '@sentry/node':
+        optional: true
 
   '@happyvertical/messages@0.73.2':
     resolution: {integrity: sha512-YJ6aIHAftH0fSHjYWavzhULYb5LQLrBAwUKiOaCTJs+LOtVDpleoXvqMOnU1woMKtzVyOTSpF79sGQCN+9KBWA==, tarball: https://npm.pkg.github.com/download/@happyvertical/messages/0.73.2/563be2a38a81a81de8b06b12e6c9404fd0734dcf}
@@ -10842,16 +10905,18 @@ snapshots:
   '@happyvertical/images@0.73.2(jimp@1.6.1)(sharp@0.34.5)':
     dependencies:
       '@resvg/resvg-js': 2.6.2
-      jimp: 1.6.1
       satori: 0.26.0
+    optionalDependencies:
+      jimp: 1.6.1
       sharp: 0.34.5
 
   '@happyvertical/jobs@0.73.2(@aws-sdk/client-sqs@3.1038.0)(@google-cloud/tasks@6.2.1)(bull@4.16.5)(bullmq@5.76.4)':
     dependencies:
-      '@aws-sdk/client-sqs': 3.1038.0
-      '@google-cloud/tasks': 6.2.1
       '@happyvertical/sql': 0.73.2
       '@happyvertical/utils': 0.73.2
+    optionalDependencies:
+      '@aws-sdk/client-sqs': 3.1038.0
+      '@google-cloud/tasks': 6.2.1
       bull: 4.16.5
       bullmq: 5.76.4
     transitivePeerDependencies:
@@ -10865,6 +10930,7 @@ snapshots:
   '@happyvertical/logger@0.73.2(@sentry/node@10.51.0)':
     dependencies:
       '@happyvertical/utils': 0.73.2
+    optionalDependencies:
       '@sentry/node': 10.51.0
 
   '@happyvertical/messages@0.73.2(@sentry/node@10.51.0)':


### PR DESCRIPTION
## Summary

Closes #1200. Adds `@happyvertical/smrt-languages` — a new foundational package that mirrors the architecture of `@happyvertical/smrt-prompts` for user-facing strings, plus an AI auto-translation pipeline backed by `smrt-jobs` that fills missing locales the first time a string is requested.

- Code-first defaults via `defineLanguageString({ key, locale, template })`
- 5-layer resolution: code → file config → app override → tenant override → runtime override
- BCP-47 locale fallback chain (`fr-CA` → `fr` → registered default)
- Soft-miss returns the fallback immediately and enqueues an AI translation job; deterministic dedup ID `smrt-languages.translate:<key>:<locale>` so concurrent misses collapse into one job
- `LanguageOverride` rows on `_smrt_language_overrides` carry `auto_generated`, `source_hash`, `ai_model`, `reviewed_at`, `reviewed_by` for the admin review queue
- Honors a `smrt-features` kill switch (`smrt-languages.auto_translate`), an optional `supportedLocales` allowlist, and a per-tenant daily budget
- Source-hash gating: never re-translates when the source hasn't changed; never overwrites a row with `auto_generated: false` (human edits win permanently)
- Translation prompt itself registered with `smrt-prompts` under `smrt-languages.translation` so ops can tune wording without redeploying
- Tenant glossary (existing tenant overrides) injected into the AI prompt so auto-translations match tenant voice

This is a Phase 2 prerequisite for the per-package adoption epic (#1199 / #1191).

## Test plan

- [x] `pnpm --filter @happyvertical/smrt-languages test` — 30 tests across 4 files: utils (15), resolver (9), translation-job dedup (4), integration (2)
- [x] Integration test: register `en` default → resolve in `es` (miss → fallback to `en`, returns `source: 'fallback'`) → run the task's `execute` directly with mocked `@happyvertical/ai` → verify app override row persists with `auto_generated: true` + `source_hash` → resolve again in `es` returns the translated string with `source: 'app'`
- [x] Integration test: human-edited row (`auto_generated: false`) is preserved when the source changes — handler returns `skipped: 'stale'` and the original template stays put
- [x] `pnpm --filter @happyvertical/smrt-languages build` — vite library build + DTS rollup, manifest with 3 objects
- [x] `npx biome check packages/languages/src` — clean
- [x] Independent code review (review pass found 2 real issues — both fixed: `translateMissing` now skips human-edited rows before enqueue (`packages/languages/src/cli.ts`), and the dedup scan logs a warning when truncated and accepts a tunable `dedupScanLimit` config)

## Notes

- The `LanguageTranslationTask` SmrtObject is registered via `@smrt()` so the existing `TaskRunner` resolves jobs by `objectType` and invokes `execute(args, executionContext)` — the standard contract.
- The package is added to the `.changeset/config.json` fixed group so its version stays locked with the rest of the workspace.
- CLI helpers (`translateMissing`, `listUnreviewedAutoTranslations`, `approveAutoTranslation`, `editLanguageOverride`) ship as exported functions in [src/cli.ts](packages/languages/src/cli.ts) — wiring them into the actual `smrt languages …` subcommand surface in `packages/cli` is a small follow-up that touches the CLI generator, not this package.