### PR TITLE
[codex] Export content editor building blocks

### DIFF
--- a/packages/content/src/svelte/components/ContentEditor.svelte
+++ b/packages/content/src/svelte/components/ContentEditor.svelte
@@ -2,11 +2,7 @@
 import type { ImageLike } from '@happyvertical/smrt-images/svelte';
 import { ImageUploader } from '@happyvertical/smrt-images/svelte';
 import { untrack } from 'svelte';
-import {
-  type ContentBodyFormat,
-  extractBodyImages,
-  resolveBodyFormat,
-} from '../../body-format';
+import { extractBodyImages, resolveBodyFormat } from '../../body-format';
 import type {
   ContentEditorAssistantActions,
   ContentEditorAssistantContextChange,
@@ -19,6 +15,13 @@ import type {
   FactEvidenceStatus,
 } from '../../mock-smrt-client';
 import { joinApiUrl, normalizeApiBaseUrl } from '../api';
+import {
+  type ContentEditorFormData,
+  getContentEditorInitialFormData,
+  getContentEditorSavePayload,
+  getContentEditorSnapshot,
+  normalizePublishDate,
+} from '../content-editor-form';
 import ContentAgentChat from './ContentAgentChat.svelte';
 import ContentBodyEditor, {
   type ContentBodyEditorChange,
@@ -63,47 +66,6 @@ let {
 
 let editForm = $state<HTMLFormElement | null>(null);
 
-function formatDateTimeLocal(value: unknown): string {
-  if (!value) {
-    return '';
-  }
-
-  const date = value instanceof Date ? value : new Date(value as string);
-  if (Number.isNaN(date.getTime())) {
-    return typeof value === 'string' ? value : '';
-  }
-
-  const localDate = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
-  return localDate.toISOString().slice(0, 16);
-}
-
-function normalizePublishDate(value: unknown): string | null {
-  if (typeof value === 'string') {
-    const trimmed = value.trim();
-    if (!trimmed) {
-      return null;
-    }
-
-    const parsed = new Date(trimmed);
-    return Number.isNaN(parsed.getTime()) ? trimmed : parsed.toISOString();
-  }
-
-  if (value instanceof Date) {
-    return Number.isNaN(value.getTime()) ? null : value.toISOString();
-  }
-
-  return null;
-}
-
-function getSavePayload(data: any) {
-  const { references: _references, ...payload } = data;
-
-  return {
-    ...payload,
-    publish_date: normalizePublishDate(data.publish_date),
-  };
-}
-
 export function triggerSave() {
   if (saveDisabled) return;
   if (editForm?.requestSubmit) {
@@ -111,54 +73,16 @@ export function triggerSave() {
     return;
   }
 
-  onSave(getSavePayload(formData));
+  onSave(getContentEditorSavePayload(formData));
 }
 
-function getInitialFormData(c: any) {
-  return c
-    ? {
-        ...c,
-        bodyFormat: resolveBodyFormat(c.bodyFormat, c.body),
-        tags: c.tags || [],
-        referenceIds: c.referenceIds || [],
-        references: c.references || [],
-        assetIds: c.assetIds || [],
-        assets: c.assets || [],
-        publish_date: formatDateTimeLocal(c.publish_date ?? c.publishDate),
-      }
-    : {
-        title: '',
-        description: '',
-        body: '',
-        bodyFormat: 'html' as ContentBodyFormat,
-        author: '',
-        type: 'article',
-        status: 'draft',
-        state: 'active',
-        source: 'manual',
-        url: '',
-        fileKey: '',
-        publish_date: '',
-        thumbnailAssetId: null,
-        tags: [],
-        referenceIds: [],
-        references: [],
-        assetIds: [],
-        assets: [],
-      };
-}
-
-let formData = $state<any>(getInitialFormData(undefined));
+let formData = $state<ContentEditorFormData>(
+  getContentEditorInitialFormData(undefined),
+);
 let lastContentKey = $state<string | undefined>(undefined);
 let currentEditorState = $derived(formData.body || '');
 let currentReferenceIds = $derived(formData.referenceIds || []);
-const editorSnapshot = $derived({
-  ...getSavePayload(formData),
-  referenceIds: [...(formData.referenceIds || [])],
-  references: [...(formData.references || [])],
-  assetIds: [...(formData.assetIds || [])],
-  assets: [...(formData.assets || [])],
-});
+const editorSnapshot = $derived(getContentEditorSnapshot(formData));
 const showActions = $derived(!hideActions);
 const showChatSidebar = $derived(!hideChat);
 const showAgentChat = $derived(agentChatEnabled && showChatSidebar);
@@ -234,7 +158,7 @@ $effect(() => {
   const newKey = content?.id ?? contentId;
   if (newKey !== lastContentKey) {
     lastContentKey = newKey;
-    formData = getInitialFormData(content);
+    formData = getContentEditorInitialFormData(content);
     fieldUndoStack = [];
     showUndoBanner = false;
   }
@@ -277,7 +201,7 @@ function applyFieldUpdates(fields: Record<string, string>) {
   // Snapshot old values for undo
   const oldValues: Record<string, string> = {};
   for (const key of Object.keys(fields)) {
-    oldValues[key] = formData[key] ?? '';
+    oldValues[key] = String(formData[key] ?? '');
     formData[key] = fields[key];
   }
   fieldUndoStack = [...fieldUndoStack, oldValues];
@@ -793,7 +717,7 @@ function handleSubmit(e: Event) {
   if (saveDisabled) {
     return;
   }
-  onSave(getSavePayload(formData));
+  onSave(getContentEditorSavePayload(formData));
 }
 
 function handleCancel() {
@@ -1105,26 +1029,29 @@ function removeAsset(id: string) {
              <div class="media-gallery">
                 {#if formData.assets && formData.assets.length > 0}
                   <div class="media-grid">
-                    {#each formData.assets as asset (asset.id)}
+                    {#each formData.assets as asset, index (asset.id || `asset-${index}`)}
+                      {@const assetId = typeof asset.id === 'string' ? asset.id : ''}
                       <div
                         class="media-item"
-                        class:is-thumbnail={asset.id === formData.thumbnailAssetId}
+                        class:is-thumbnail={assetId === formData.thumbnailAssetId}
                         draggable="true"
                         title="Drag into the body"
                         ondragstart={(event) => handleAttachedImageDragStart(event, asset)}
                       >
                         <img class="media-item-image" src={getAssetImageSource(asset)} alt={asset.name || 'Asset image'} />
                         <div class="media-item-overlay">
-                           {#if asset.id !== formData.thumbnailAssetId}
-                             <button type="button" class="btn-make-thumbnail" title="Make Thumbnail" onclick={() => setThumbnail(asset.id)}>
+                           {#if assetId && assetId !== formData.thumbnailAssetId}
+                             <button type="button" class="btn-make-thumbnail" title="Make Thumbnail" onclick={() => setThumbnail(assetId)}>
                                <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
                              </button>
                            {/if}
-                           <button type="button" class="btn-remove-asset" title="Remove" onclick={() => removeAsset(asset.id)}>
-                             <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
-                           </button>
+                           {#if assetId}
+                             <button type="button" class="btn-remove-asset" title="Remove" onclick={() => removeAsset(assetId)}>
+                               <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
+                             </button>
+                           {/if}
                         </div>
-                        {#if asset.id === formData.thumbnailAssetId}
+                        {#if assetId === formData.thumbnailAssetId}
                           <div class="thumbnail-badge">Thumbnail</div>
                         {/if}
                       </div>

--- a/packages/content/src/svelte/components/ContentEditor.test.ts
+++ b/packages/content/src/svelte/components/ContentEditor.test.ts
@@ -1002,6 +1002,33 @@ describe('ContentEditor component', () => {
     expect(onSave.mock.calls[0]?.[0]).not.toHaveProperty('publishDate');
   });
 
+  it('omits hydrated assets and references from the save payload', () => {
+    const onSave = vi.fn();
+    const target = renderEditor({
+      content: {
+        title: 'Hydrated Article',
+        referenceIds: ['ref-1'],
+        references: [{ id: 'ref-1', title: 'Minutes' }],
+        assetIds: ['asset-1'],
+        assets: [{ id: 'asset-1', sourceUri: 'https://example.com/a.jpg' }],
+      },
+      onSave,
+    });
+
+    target
+      .querySelector('#content-edit-form')
+      ?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        referenceIds: ['ref-1'],
+        assetIds: ['asset-1'],
+      }),
+    );
+    expect(onSave.mock.calls[0]?.[0]).not.toHaveProperty('references');
+    expect(onSave.mock.calls[0]?.[0]).not.toHaveProperty('assets');
+  });
+
   it('preserves type changes in the save payload', () => {
     const onSave = vi.fn();
     const target = renderEditor({

--- a/packages/content/src/svelte/components/ContentImageBrowser.svelte
+++ b/packages/content/src/svelte/components/ContentImageBrowser.svelte
@@ -1,0 +1,239 @@
+<script lang="ts">
+import {
+  type ImageLike,
+  ImageUploader,
+} from '@happyvertical/smrt-images/svelte';
+
+export interface Props {
+  apiBaseUrl?: string;
+  assets?: any[];
+  thumbnailAssetId?: string | null;
+  addButtonLabel?: string;
+  selectActionLabel?: string;
+  showUploaderInitially?: boolean;
+  onSelectImage?: (image: ImageLike | File | string) => void;
+  onUseAsset?: (asset: any) => void;
+  onRemoveAsset?: (assetId: string) => void;
+  onUseAsThumbnail?: (assetId: string) => void;
+}
+
+let {
+  apiBaseUrl = '/api/v1',
+  assets = [],
+  thumbnailAssetId = null,
+  addButtonLabel = 'Add Image',
+  selectActionLabel = 'Use',
+  showUploaderInitially = false,
+  onSelectImage = undefined,
+  onUseAsset = undefined,
+  onRemoveAsset = undefined,
+  onUseAsThumbnail = undefined,
+}: Props = $props();
+
+let showUploader = $state(false);
+
+$effect(() => {
+  if (showUploaderInitially) {
+    showUploader = true;
+  }
+});
+
+function getAssetImageSource(asset: any): string {
+  return String(
+    asset?.sourceUri ||
+      asset?.thumbnailUri ||
+      asset?.thumbnailUrl ||
+      asset?.deliveryUrl ||
+      asset?.url ||
+      asset?.src ||
+      '',
+  );
+}
+
+function getAssetLabel(asset: any): string {
+  return String(
+    asset?.name || asset?.title || asset?.filename || asset?.id || 'Image',
+  );
+}
+
+function handleSelect(selected: ImageLike | File | string) {
+  onSelectImage?.(selected);
+  showUploader = false;
+}
+</script>
+
+<div class="content-image-browser">
+  {#if assets.length}
+    <div class="asset-grid">
+      {#each assets as asset (asset.id || getAssetLabel(asset))}
+        {@const source = getAssetImageSource(asset)}
+        <article class="asset-card" class:asset-card--thumbnail={thumbnailAssetId === asset.id}>
+          <div class="asset-preview">
+            {#if source}
+              <img src={source} alt={getAssetLabel(asset)} />
+            {:else}
+              <span>{getAssetLabel(asset).slice(0, 1).toUpperCase()}</span>
+            {/if}
+          </div>
+          <div class="asset-meta">
+            <strong>{getAssetLabel(asset)}</strong>
+            {#if thumbnailAssetId === asset.id}
+              <span>Thumbnail</span>
+            {/if}
+          </div>
+          <div class="asset-actions">
+            {#if onUseAsset}
+              <button type="button" onclick={() => onUseAsset?.(asset)}>{selectActionLabel}</button>
+            {/if}
+            {#if onUseAsThumbnail && asset.id && thumbnailAssetId !== asset.id}
+              <button type="button" onclick={() => onUseAsThumbnail?.(asset.id)}>Thumbnail</button>
+            {/if}
+            {#if onRemoveAsset && asset.id}
+              <button type="button" class="danger" onclick={() => onRemoveAsset?.(asset.id)}>Remove</button>
+            {/if}
+          </div>
+        </article>
+      {/each}
+    </div>
+  {:else}
+    <p class="empty-state">No images attached.</p>
+  {/if}
+
+  {#if showUploader}
+    <div class="uploader-panel">
+      <ImageUploader {apiBaseUrl} onSelect={handleSelect} onCancel={() => showUploader = false} />
+    </div>
+  {:else if onSelectImage}
+    <button type="button" class="add-image-button" onclick={() => showUploader = true}>
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <rect x="3" y="3" width="18" height="18" rx="2"></rect>
+        <circle cx="8.5" cy="8.5" r="1.5"></circle>
+        <path d="m21 15-5-5L5 21"></path>
+      </svg>
+      {addButtonLabel}
+    </button>
+  {/if}
+</div>
+
+<style>
+  .content-image-browser {
+    display: grid;
+    gap: 1rem;
+    min-height: 5.5rem;
+    padding: 1rem;
+    border: 1px dashed color-mix(in srgb, var(--smrt-color-outline) 45%, transparent);
+    border-radius: 0.5rem;
+  }
+
+  .asset-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
+    gap: 0.75rem;
+  }
+
+  .asset-card {
+    display: grid;
+    gap: 0.75rem;
+    border: 1px solid color-mix(in srgb, var(--smrt-color-outline) 28%, transparent);
+    border-radius: 0.5rem;
+    background: var(--smrt-color-surface-container-low);
+    padding: 0.75rem;
+  }
+
+  .asset-card--thumbnail {
+    border-color: var(--smrt-color-primary);
+  }
+
+  .asset-preview {
+    display: grid;
+    place-items: center;
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+    border-radius: 0.375rem;
+    background: var(--smrt-color-surface-container);
+    color: var(--smrt-color-on-surface-variant);
+    font-size: 1.5rem;
+    font-weight: 700;
+  }
+
+  .asset-preview img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .asset-meta {
+    display: grid;
+    gap: 0.2rem;
+    min-width: 0;
+  }
+
+  .asset-meta strong {
+    overflow: hidden;
+    color: var(--smrt-color-on-surface);
+    font-size: 0.875rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .asset-meta span,
+  .empty-state {
+    color: var(--smrt-color-on-surface-variant);
+    font-size: 0.875rem;
+  }
+
+  .empty-state {
+    margin: 0;
+    font-style: italic;
+  }
+
+  .asset-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.45rem;
+    min-height: 2.35rem;
+    border: 1px solid var(--smrt-color-outline);
+    border-radius: 0.5rem;
+    background: var(--smrt-color-surface-container);
+    color: var(--smrt-color-on-surface);
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.875rem;
+    font-weight: 600;
+    padding: 0.5rem 0.875rem;
+  }
+
+  button:hover {
+    background: var(--smrt-color-surface-container-high);
+  }
+
+  button.danger {
+    color: var(--smrt-color-error);
+  }
+
+  .add-image-button {
+    justify-self: start;
+  }
+
+  .add-image-button svg {
+    width: 1rem;
+    height: 1rem;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .uploader-panel {
+    border-radius: 0.5rem;
+    overflow: hidden;
+  }
+</style>

--- a/packages/content/src/svelte/components/ContentImageBrowser.svelte
+++ b/packages/content/src/svelte/components/ContentImageBrowser.svelte
@@ -3,16 +3,17 @@ import {
   type ImageLike,
   ImageUploader,
 } from '@happyvertical/smrt-images/svelte';
+import type { ContentEditorAsset } from '../content-editor-form';
 
 export interface Props {
   apiBaseUrl?: string;
-  assets?: any[];
+  assets?: ContentEditorAsset[];
   thumbnailAssetId?: string | null;
   addButtonLabel?: string;
   selectActionLabel?: string;
   showUploaderInitially?: boolean;
   onSelectImage?: (image: ImageLike | File | string) => void;
-  onUseAsset?: (asset: any) => void;
+  onUseAsset?: (asset: ContentEditorAsset) => void;
   onRemoveAsset?: (assetId: string) => void;
   onUseAsThumbnail?: (assetId: string) => void;
 }
@@ -33,12 +34,10 @@ let {
 let showUploader = $state(false);
 
 $effect(() => {
-  if (showUploaderInitially) {
-    showUploader = true;
-  }
+  showUploader = showUploaderInitially;
 });
 
-function getAssetImageSource(asset: any): string {
+function getAssetImageSource(asset: ContentEditorAsset): string {
   return String(
     asset?.sourceUri ||
       asset?.thumbnailUri ||
@@ -50,7 +49,7 @@ function getAssetImageSource(asset: any): string {
   );
 }
 
-function getAssetLabel(asset: any): string {
+function getAssetLabel(asset: ContentEditorAsset): string {
   return String(
     asset?.name || asset?.title || asset?.filename || asset?.id || 'Image',
   );
@@ -65,19 +64,20 @@ function handleSelect(selected: ImageLike | File | string) {
 <div class="content-image-browser">
   {#if assets.length}
     <div class="asset-grid">
-      {#each assets as asset (asset.id || getAssetLabel(asset))}
+      {#each assets as asset, index (asset.id || `${getAssetLabel(asset)}-${index}`)}
         {@const source = getAssetImageSource(asset)}
-        <article class="asset-card" class:asset-card--thumbnail={thumbnailAssetId === asset.id}>
+        {@const assetId = typeof asset.id === 'string' ? asset.id : ''}
+        <article class="asset-card" class:asset-card--thumbnail={thumbnailAssetId === assetId}>
           <div class="asset-preview">
             {#if source}
-              <img src={source} alt={getAssetLabel(asset)} />
+              <img src={source} alt={getAssetLabel(asset)} loading="lazy" decoding="async" />
             {:else}
               <span>{getAssetLabel(asset).slice(0, 1).toUpperCase()}</span>
             {/if}
           </div>
           <div class="asset-meta">
             <strong>{getAssetLabel(asset)}</strong>
-            {#if thumbnailAssetId === asset.id}
+            {#if thumbnailAssetId === assetId}
               <span>Thumbnail</span>
             {/if}
           </div>
@@ -85,11 +85,11 @@ function handleSelect(selected: ImageLike | File | string) {
             {#if onUseAsset}
               <button type="button" onclick={() => onUseAsset?.(asset)}>{selectActionLabel}</button>
             {/if}
-            {#if onUseAsThumbnail && asset.id && thumbnailAssetId !== asset.id}
-              <button type="button" onclick={() => onUseAsThumbnail?.(asset.id)}>Thumbnail</button>
+            {#if onUseAsThumbnail && assetId && thumbnailAssetId !== assetId}
+              <button type="button" onclick={() => onUseAsThumbnail?.(assetId)}>Thumbnail</button>
             {/if}
-            {#if onRemoveAsset && asset.id}
-              <button type="button" class="danger" onclick={() => onRemoveAsset?.(asset.id)}>Remove</button>
+            {#if onRemoveAsset && assetId}
+              <button type="button" class="danger" onclick={() => onRemoveAsset?.(assetId)}>Remove</button>
             {/if}
           </div>
         </article>

--- a/packages/content/src/svelte/components/ContentMetadataFields.svelte
+++ b/packages/content/src/svelte/components/ContentMetadataFields.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+export interface Props {
+  data: Record<string, any>;
+  onChange?: (change: Record<string, unknown>) => void;
+}
+
+let { data, onChange = undefined }: Props = $props();
+
+const tagsValue = $derived(
+  Array.isArray(data.tags) ? data.tags.join(', ') : String(data.tags || ''),
+);
+
+function updateField(key: string, value: unknown) {
+  onChange?.({ [key]: value });
+}
+
+function updateTags(value: string) {
+  updateField(
+    'tags',
+    value
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean),
+  );
+}
+</script>
+
+<div class="content-metadata-fields">
+  <label>
+    <span>Author</span>
+    <input
+      type="text"
+      value={data.author || ''}
+      oninput={(event) => updateField('author', event.currentTarget.value)}
+    />
+  </label>
+  <label>
+    <span>Description</span>
+    <textarea
+      rows="4"
+      value={data.description || ''}
+      oninput={(event) => updateField('description', event.currentTarget.value)}
+    ></textarea>
+  </label>
+  <label>
+    <span>Tags</span>
+    <input
+      type="text"
+      value={tagsValue}
+      placeholder="e.g. news, tech"
+      oninput={(event) => updateTags(event.currentTarget.value)}
+    />
+  </label>
+  <label>
+    <span>URL</span>
+    <input
+      type="url"
+      value={data.url || ''}
+      oninput={(event) => updateField('url', event.currentTarget.value)}
+    />
+  </label>
+  <label>
+    <span>File Key</span>
+    <input
+      type="text"
+      value={data.fileKey || ''}
+      oninput={(event) => updateField('fileKey', event.currentTarget.value)}
+    />
+  </label>
+</div>
+
+<style>
+  .content-metadata-fields {
+    display: grid;
+    gap: 1rem;
+  }
+
+  label {
+    display: grid;
+    gap: 0.45rem;
+    color: var(--smrt-color-on-surface-variant);
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+
+  input,
+  textarea {
+    width: 100%;
+    box-sizing: border-box;
+    border: 1px solid color-mix(in srgb, var(--smrt-color-outline) 50%, transparent);
+    border-radius: 0.5rem;
+    background: var(--smrt-color-surface-container-low);
+    color: var(--smrt-color-on-surface);
+    font: inherit;
+    padding: 0.75rem 0.875rem;
+  }
+
+  textarea {
+    min-height: 7rem;
+    resize: vertical;
+  }
+</style>

--- a/packages/content/src/svelte/components/ContentReferencesPanel.svelte
+++ b/packages/content/src/svelte/components/ContentReferencesPanel.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
+import type { ContentEditorReference } from '../content-editor-form';
+
 export interface Props {
-  apiBaseUrl?: string;
-  contentId?: string;
   referenceIds?: string[];
-  references?: any[];
-  factAudit?: Record<string, any> | null;
+  references?: ContentEditorReference[];
   onReferenceIdsChange?: (referenceIds: string[]) => void;
-  onFactAuditChange?: (state: Record<string, any> | null) => void;
 }
 
 let {
@@ -23,7 +21,7 @@ const visibleReferences = $derived(
     : referenceIds.map((id) => ({ id, title: id })),
 );
 
-function getReferenceLabel(reference: any): string {
+function getReferenceLabel(reference: ContentEditorReference): string {
   return String(
     reference?.title ||
       reference?.name ||
@@ -34,10 +32,26 @@ function getReferenceLabel(reference: any): string {
   );
 }
 
-function getReferenceUrl(reference: any): string {
+function getReferenceUrl(reference: ContentEditorReference): string {
   return String(
     reference?.url || reference?.originalUrl || reference?.source || '',
   );
+}
+
+function getSafeReferenceUrl(reference: ContentEditorReference): string {
+  const url = getReferenceUrl(reference).trim();
+  if (!url) {
+    return '';
+  }
+
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+      ? parsed.href
+      : '';
+  } catch {
+    return '';
+  }
 }
 
 function addReference() {
@@ -59,16 +73,18 @@ function removeReference(id: string) {
 <div class="content-references-panel">
   {#if visibleReferences.length}
     <div class="reference-list">
-      {#each visibleReferences as reference (reference.id || getReferenceLabel(reference))}
+      {#each visibleReferences as reference, index (reference.id || getSafeReferenceUrl(reference) || `${getReferenceLabel(reference)}-${index}`)}
+        {@const safeUrl = getSafeReferenceUrl(reference)}
+        {@const referenceId = typeof reference.id === 'string' ? reference.id : ''}
         <div class="reference-row">
           <div class="reference-copy">
             <strong>{getReferenceLabel(reference)}</strong>
-            {#if getReferenceUrl(reference)}
-              <a href={getReferenceUrl(reference)} target="_blank" rel="noreferrer">{getReferenceUrl(reference)}</a>
+            {#if safeUrl}
+              <a href={safeUrl} target="_blank" rel="noreferrer">{safeUrl}</a>
             {/if}
           </div>
-          {#if reference.id}
-            <button type="button" onclick={() => removeReference(reference.id)}>Remove</button>
+          {#if referenceId}
+            <button type="button" onclick={() => removeReference(referenceId)}>Remove</button>
           {/if}
         </div>
       {/each}
@@ -80,6 +96,7 @@ function removeReference(id: string) {
   <div class="reference-input-row">
     <input
       type="text"
+      aria-label="Add reference by ID or URL"
       placeholder="Reference ID or URL"
       bind:value={newReferenceId}
       onkeydown={(event) => {

--- a/packages/content/src/svelte/components/ContentReferencesPanel.svelte
+++ b/packages/content/src/svelte/components/ContentReferencesPanel.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+export interface Props {
+  apiBaseUrl?: string;
+  contentId?: string;
+  referenceIds?: string[];
+  references?: any[];
+  factAudit?: Record<string, any> | null;
+  onReferenceIdsChange?: (referenceIds: string[]) => void;
+  onFactAuditChange?: (state: Record<string, any> | null) => void;
+}
+
+let {
+  referenceIds = [],
+  references = [],
+  onReferenceIdsChange = undefined,
+}: Props = $props();
+
+let newReferenceId = $state('');
+
+const visibleReferences = $derived(
+  references.length
+    ? references
+    : referenceIds.map((id) => ({ id, title: id })),
+);
+
+function getReferenceLabel(reference: any): string {
+  return String(
+    reference?.title ||
+      reference?.name ||
+      reference?.url ||
+      reference?.source ||
+      reference?.id ||
+      'Reference',
+  );
+}
+
+function getReferenceUrl(reference: any): string {
+  return String(
+    reference?.url || reference?.originalUrl || reference?.source || '',
+  );
+}
+
+function addReference() {
+  const id = newReferenceId.trim();
+  if (!id || referenceIds.includes(id)) {
+    return;
+  }
+  onReferenceIdsChange?.([...referenceIds, id]);
+  newReferenceId = '';
+}
+
+function removeReference(id: string) {
+  onReferenceIdsChange?.(
+    referenceIds.filter((referenceId) => referenceId !== id),
+  );
+}
+</script>
+
+<div class="content-references-panel">
+  {#if visibleReferences.length}
+    <div class="reference-list">
+      {#each visibleReferences as reference (reference.id || getReferenceLabel(reference))}
+        <div class="reference-row">
+          <div class="reference-copy">
+            <strong>{getReferenceLabel(reference)}</strong>
+            {#if getReferenceUrl(reference)}
+              <a href={getReferenceUrl(reference)} target="_blank" rel="noreferrer">{getReferenceUrl(reference)}</a>
+            {/if}
+          </div>
+          {#if reference.id}
+            <button type="button" onclick={() => removeReference(reference.id)}>Remove</button>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {:else}
+    <p class="empty-state">No references.</p>
+  {/if}
+
+  <div class="reference-input-row">
+    <input
+      type="text"
+      placeholder="Reference ID or URL"
+      bind:value={newReferenceId}
+      onkeydown={(event) => {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          addReference();
+        }
+      }}
+    />
+    <button type="button" onclick={addReference}>Add</button>
+  </div>
+</div>
+
+<style>
+  .content-references-panel {
+    display: grid;
+    gap: 0.875rem;
+    padding: 1rem;
+    border: 1px dashed color-mix(in srgb, var(--smrt-color-outline) 45%, transparent);
+    border-radius: 0.5rem;
+  }
+
+  .empty-state {
+    margin: 0;
+    color: var(--smrt-color-on-surface-variant);
+    font-size: 0.875rem;
+    font-style: italic;
+  }
+
+  .reference-list {
+    display: grid;
+    gap: 0.65rem;
+  }
+
+  .reference-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.75rem;
+    border: 1px solid color-mix(in srgb, var(--smrt-color-outline) 28%, transparent);
+    border-radius: 0.5rem;
+    background: var(--smrt-color-surface-container-low);
+  }
+
+  .reference-copy {
+    display: grid;
+    gap: 0.2rem;
+    min-width: 0;
+  }
+
+  .reference-copy strong,
+  .reference-copy a {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .reference-copy strong {
+    color: var(--smrt-color-on-surface);
+    font-size: 0.875rem;
+  }
+
+  .reference-copy a {
+    color: var(--smrt-color-primary);
+    font-size: 0.8125rem;
+    text-decoration: none;
+  }
+
+  .reference-input-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.5rem;
+  }
+
+  input,
+  button {
+    min-height: 2.5rem;
+    border: 1px solid color-mix(in srgb, var(--smrt-color-outline) 50%, transparent);
+    border-radius: 0.5rem;
+    background: var(--smrt-color-surface-container-low);
+    color: var(--smrt-color-on-surface);
+    font: inherit;
+    padding: 0.55rem 0.875rem;
+  }
+
+  button {
+    background: var(--smrt-color-surface-container);
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  button:hover {
+    background: var(--smrt-color-surface-container-high);
+  }
+</style>

--- a/packages/content/src/svelte/components/ContentStatusFields.svelte
+++ b/packages/content/src/svelte/components/ContentStatusFields.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+export interface Props {
+  data: Record<string, any>;
+  onChange?: (change: Record<string, unknown>) => void;
+}
+
+let { data, onChange = undefined }: Props = $props();
+
+function updateField(key: string, value: unknown) {
+  onChange?.({ [key]: value });
+}
+</script>
+
+<div class="content-status-fields">
+  <label>
+    <span>Type</span>
+    <select value={data.type || 'article'} onchange={(event) => updateField('type', event.currentTarget.value)}>
+      <option value="article">Article</option>
+      <option value="document">Document</option>
+      <option value="mirror">Mirror</option>
+      <option value="video-segment">Video Segment</option>
+    </select>
+  </label>
+  <label>
+    <span>State</span>
+    <select value={data.state || 'active'} onchange={(event) => updateField('state', event.currentTarget.value)}>
+      <option value="active">Active</option>
+      <option value="highlighted">Highlighted</option>
+      <option value="deprecated">Deprecated</option>
+    </select>
+  </label>
+  <label>
+    <span>Status</span>
+    <select value={data.status || 'draft'} onchange={(event) => updateField('status', event.currentTarget.value)}>
+      <option value="draft">Draft</option>
+      <option value="review">Review</option>
+      <option value="published">Published</option>
+      <option value="archived">Archived</option>
+    </select>
+  </label>
+  <label>
+    <span>Published</span>
+    <input
+      type="datetime-local"
+      value={data.publish_date || ''}
+      onchange={(event) => updateField('publish_date', event.currentTarget.value)}
+    />
+  </label>
+</div>
+
+<style>
+  .content-status-fields {
+    display: flex;
+    align-items: end;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  label {
+    display: grid;
+    gap: 0.35rem;
+    min-width: 8.5rem;
+    color: var(--smrt-color-on-surface-variant);
+    font-size: 0.75rem;
+    font-weight: 600;
+  }
+
+  select,
+  input {
+    min-height: 2.5rem;
+    border: 1px solid color-mix(in srgb, var(--smrt-color-outline) 50%, transparent);
+    border-radius: 0.5rem;
+    background: var(--smrt-color-surface-container-low);
+    color: var(--smrt-color-on-surface);
+    font: inherit;
+    font-size: 0.875rem;
+    font-weight: 500;
+    padding: 0.55rem 0.75rem;
+  }
+</style>

--- a/packages/content/src/svelte/components/content-editor-building-blocks.test.ts
+++ b/packages/content/src/svelte/components/content-editor-building-blocks.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+
+import { flushSync, mount, unmount } from 'svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@happyvertical/smrt-images/svelte', async () => ({
+  ImageUploader: (await import('../../../test-stubs/ImageUploaderStub.svelte'))
+    .default,
+}));
+
+import ContentImageBrowser from './ContentImageBrowser.svelte';
+import ContentMetadataFields from './ContentMetadataFields.svelte';
+import ContentReferencesPanel from './ContentReferencesPanel.svelte';
+import ContentStatusFields from './ContentStatusFields.svelte';
+
+const mountedComponents: Array<ReturnType<typeof mount>> = [];
+
+function renderComponent(component: any, props: Record<string, unknown> = {}) {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+
+  const mounted = mount(component, {
+    target,
+    props,
+  });
+
+  mountedComponents.push(mounted);
+  flushSync();
+
+  return target;
+}
+
+function setInputValue(
+  element: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement,
+  value: string,
+  eventName = 'input',
+) {
+  element.value = value;
+  element.dispatchEvent(new Event(eventName, { bubbles: true }));
+  flushSync();
+}
+
+afterEach(() => {
+  while (mountedComponents.length > 0) {
+    const component = mountedComponents.pop();
+    if (component) {
+      unmount(component);
+    }
+  }
+
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+});
+
+describe('content editor building block components', () => {
+  it('emits normalized metadata field changes', () => {
+    const onChange = vi.fn();
+    const target = renderComponent(ContentMetadataFields, {
+      data: {
+        author: 'Reporter',
+        description: 'Summary',
+        tags: ['news'],
+      },
+      onChange,
+    });
+
+    const tagsInput = target.querySelector(
+      'input[placeholder="e.g. news, tech"]',
+    ) as HTMLInputElement;
+    setInputValue(tagsInput, 'council, budget');
+
+    expect(onChange).toHaveBeenCalledWith({
+      tags: ['council', 'budget'],
+    });
+  });
+
+  it('emits status field changes', () => {
+    const onChange = vi.fn();
+    const target = renderComponent(ContentStatusFields, {
+      data: {
+        type: 'article',
+        state: 'active',
+        status: 'draft',
+        publish_date: '',
+      },
+      onChange,
+    });
+
+    const statusSelect = target.querySelectorAll('select')[2] as
+      | HTMLSelectElement
+      | undefined;
+    if (!statusSelect) {
+      throw new Error('Expected status select to be rendered');
+    }
+    setInputValue(statusSelect, 'published', 'change');
+
+    expect(onChange).toHaveBeenCalledWith({ status: 'published' });
+  });
+
+  it('renders safe reference links and labels the add-reference input', () => {
+    const onReferenceIdsChange = vi.fn();
+    const target = renderComponent(ContentReferencesPanel, {
+      referenceIds: ['safe-ref'],
+      references: [
+        {
+          id: 'safe-ref',
+          title: 'Safe reference',
+          url: 'https://example.com/ref',
+        },
+        { id: 'bad-ref', title: 'Bad reference', url: 'javascript:alert(1)' },
+      ],
+      onReferenceIdsChange,
+    });
+
+    const links = Array.from(target.querySelectorAll('a')).map((link) =>
+      link.getAttribute('href'),
+    );
+    expect(links).toEqual(['https://example.com/ref']);
+    expect(
+      target.querySelector('input[aria-label="Add reference by ID or URL"]'),
+    ).toBeTruthy();
+  });
+
+  it('adds typed reference input values', () => {
+    const onReferenceIdsChange = vi.fn();
+    const target = renderComponent(ContentReferencesPanel, {
+      referenceIds: ['ref-1'],
+      references: [],
+      onReferenceIdsChange,
+    });
+
+    const input = target.querySelector(
+      'input[aria-label="Add reference by ID or URL"]',
+    ) as HTMLInputElement;
+    const addButton = Array.from(target.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Add',
+    );
+
+    setInputValue(input, 'https://example.com/minutes');
+    addButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    flushSync();
+
+    expect(onReferenceIdsChange).toHaveBeenCalledWith([
+      'ref-1',
+      'https://example.com/minutes',
+    ]);
+  });
+
+  it('renders image assets and lazy-loads previews', () => {
+    const target = renderComponent(ContentImageBrowser, {
+      assets: [
+        {
+          id: 'asset-1',
+          name: 'Main image',
+          sourceUri: 'https://example.com/image.jpg',
+        },
+      ],
+    });
+
+    const image = target.querySelector('img') as HTMLImageElement;
+    expect(image.getAttribute('src')).toBe('https://example.com/image.jpg');
+    expect(image.getAttribute('loading')).toBe('lazy');
+    expect(image.getAttribute('decoding')).toBe('async');
+  });
+
+  it('can show the image uploader initially', () => {
+    const target = renderComponent(ContentImageBrowser, {
+      apiBaseUrl: '/tenant/api/v1',
+      showUploaderInitially: true,
+      onSelectImage: vi.fn(),
+    });
+
+    const uploader = target.querySelector(
+      '[data-testid="image-uploader-stub"]',
+    ) as HTMLElement | null;
+    expect(uploader?.dataset.apiBaseUrl).toBe('/tenant/api/v1');
+  });
+});

--- a/packages/content/src/svelte/content-editor-form.test.ts
+++ b/packages/content/src/svelte/content-editor-form.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type ContentEditorFormData,
+  formatDateTimeLocal,
+  getContentEditorInitialFormData,
+  getContentEditorSavePayload,
+  getContentEditorSnapshot,
+  normalizePublishDate,
+} from './content-editor-form';
+
+describe('content editor form helpers', () => {
+  it('creates normalized initial form data from content records', () => {
+    const formData = getContentEditorInitialFormData({
+      title: 'Council update',
+      body: '# Agenda',
+      bodyFormat: 'markdown',
+      publishDate: '2026-04-05T10:30:00.000Z',
+      tags: ['council'],
+      referenceIds: ['ref-1'],
+      references: [{ id: 'ref-1', title: 'Minutes' }],
+      assetIds: ['asset-1'],
+      assets: [{ id: 'asset-1', sourceUri: 'https://example.com/image.jpg' }],
+    });
+
+    expect(formData).toMatchObject({
+      title: 'Council update',
+      bodyFormat: 'markdown',
+      tags: ['council'],
+      referenceIds: ['ref-1'],
+      assetIds: ['asset-1'],
+    });
+    expect(formData.publish_date).toMatch(/^2026-04-05T/);
+  });
+
+  it('uses safe empty defaults for new content', () => {
+    expect(getContentEditorInitialFormData(undefined)).toMatchObject({
+      title: '',
+      body: '',
+      bodyFormat: 'html',
+      type: 'article',
+      status: 'draft',
+      state: 'active',
+      publish_date: '',
+      referenceIds: [],
+      assetIds: [],
+    });
+  });
+
+  it('normalizes publish dates for local datetime inputs', () => {
+    const localValue = '2026-04-05T10:30';
+
+    expect(formatDateTimeLocal(localValue)).toBe(localValue);
+    expect(normalizePublishDate(localValue)).toBe(
+      new Date(localValue).toISOString(),
+    );
+    expect(normalizePublishDate('')).toBeNull();
+  });
+
+  it('omits hydrated and legacy alias fields from save payloads', () => {
+    const data = {
+      ...getContentEditorInitialFormData(undefined),
+      title: 'Save me',
+      publish_date: '2026-04-05T10:30',
+      publishDate: 'legacy',
+      references: [{ id: 'ref-1' }],
+      assets: [{ id: 'asset-1' }],
+      referenceIds: ['ref-1'],
+      assetIds: ['asset-1'],
+    } satisfies ContentEditorFormData;
+
+    const payload = getContentEditorSavePayload(data);
+
+    expect(payload).toMatchObject({
+      title: 'Save me',
+      referenceIds: ['ref-1'],
+      assetIds: ['asset-1'],
+      publish_date: new Date('2026-04-05T10:30').toISOString(),
+    });
+    expect('references' in payload).toBe(false);
+    expect('assets' in payload).toBe(false);
+    expect('publishDate' in payload).toBe(false);
+  });
+
+  it('keeps hydrated fields in snapshots for editor consumers', () => {
+    const snapshot = getContentEditorSnapshot({
+      ...getContentEditorInitialFormData(undefined),
+      references: [{ id: 'ref-1' }],
+      assets: [{ id: 'asset-1' }],
+    });
+
+    expect(snapshot.references).toEqual([{ id: 'ref-1' }]);
+    expect(snapshot.assets).toEqual([{ id: 'asset-1' }]);
+  });
+});

--- a/packages/content/src/svelte/content-editor-form.ts
+++ b/packages/content/src/svelte/content-editor-form.ts
@@ -1,7 +1,43 @@
 import type { ContentBodyFormat } from '../body-format';
 import { resolveBodyFormat } from '../body-format';
 
-export type ContentEditorFormData = Record<string, any> & {
+export interface ContentEditorAsset {
+  id?: string | null;
+  name?: string | null;
+  title?: string | null;
+  filename?: string | null;
+  sourceUri?: string | null;
+  thumbnailUri?: string | null;
+  thumbnailUrl?: string | null;
+  deliveryUrl?: string | null;
+  url?: string | null;
+  src?: string | null;
+}
+
+export interface ContentEditorReference {
+  id?: string | null;
+  title?: string | null;
+  name?: string | null;
+  url?: string | null;
+  originalUrl?: string | null;
+  source?: string | null;
+  _auditOnly?: boolean;
+  _auditSourceKind?: string;
+  _auditSourceId?: string;
+}
+
+export type ContentEditorInitialContent = Partial<ContentEditorFormData> & {
+  publishDate?: unknown;
+};
+
+export type ContentEditorSavePayload = Omit<
+  ContentEditorFormData,
+  'references' | 'assets' | 'publishDate'
+> & {
+  publish_date: string | null;
+};
+
+export type ContentEditorFormData = {
   title: string;
   description: string;
   body: string;
@@ -17,61 +53,13 @@ export type ContentEditorFormData = Record<string, any> & {
   thumbnailAssetId: string | null;
   tags: string[];
   referenceIds: string[];
-  references: any[];
+  references: ContentEditorReference[];
   assetIds: string[];
-  assets: any[];
+  assets: ContentEditorAsset[];
+  [key: string]: unknown;
 };
 
-function formatDateTimeLocal(value: unknown): string {
-  if (!value) {
-    return '';
-  }
-
-  const date = value instanceof Date ? value : new Date(value as string);
-  if (Number.isNaN(date.getTime())) {
-    return typeof value === 'string' ? value : '';
-  }
-
-  const localDate = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
-  return localDate.toISOString().slice(0, 16);
-}
-
-function normalizePublishDate(value: unknown): string | null {
-  if (typeof value === 'string') {
-    const trimmed = value.trim();
-    if (!trimmed) {
-      return null;
-    }
-
-    const parsed = new Date(trimmed);
-    return Number.isNaN(parsed.getTime()) ? trimmed : parsed.toISOString();
-  }
-
-  if (value instanceof Date) {
-    return Number.isNaN(value.getTime()) ? null : value.toISOString();
-  }
-
-  return null;
-}
-
-export function getContentEditorInitialFormData(
-  content: any,
-): ContentEditorFormData {
-  if (content) {
-    return {
-      ...content,
-      bodyFormat: resolveBodyFormat(content.bodyFormat, content.body),
-      tags: content.tags || [],
-      referenceIds: content.referenceIds || [],
-      references: content.references || [],
-      assetIds: content.assetIds || [],
-      assets: content.assets || [],
-      publish_date: formatDateTimeLocal(
-        content.publish_date ?? content.publishDate,
-      ),
-    };
-  }
-
+function getEmptyContentEditorFormData(): ContentEditorFormData {
   return {
     title: '',
     description: '',
@@ -94,13 +82,89 @@ export function getContentEditorInitialFormData(
   };
 }
 
-export function getContentEditorSavePayload(data: Record<string, any>) {
-  const { references: _references, assets: _assets, ...payload } = data;
+export function formatDateTimeLocal(value: unknown): string {
+  if (!value) {
+    return '';
+  }
+
+  const date = value instanceof Date ? value : new Date(value as string);
+  if (Number.isNaN(date.getTime())) {
+    return typeof value === 'string' ? value : '';
+  }
+
+  const localDate = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
+  return localDate.toISOString().slice(0, 16);
+}
+
+export function normalizePublishDate(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const parsed = new Date(trimmed);
+    return Number.isNaN(parsed.getTime()) ? trimmed : parsed.toISOString();
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  }
+
+  return null;
+}
+
+export function getContentEditorInitialFormData(
+  content: ContentEditorInitialContent | null | undefined,
+): ContentEditorFormData {
+  if (content) {
+    const defaults = getEmptyContentEditorFormData();
+
+    return {
+      ...defaults,
+      ...content,
+      title: content.title ?? defaults.title,
+      description: content.description ?? defaults.description,
+      body: content.body ?? defaults.body,
+      bodyFormat: resolveBodyFormat(content.bodyFormat, content.body),
+      author: content.author ?? defaults.author,
+      type: content.type ?? defaults.type,
+      status: content.status ?? defaults.status,
+      state: content.state ?? defaults.state,
+      source: content.source ?? defaults.source,
+      url: content.url ?? defaults.url,
+      fileKey: content.fileKey ?? defaults.fileKey,
+      thumbnailAssetId: content.thumbnailAssetId ?? defaults.thumbnailAssetId,
+      tags: Array.isArray(content.tags) ? content.tags : [],
+      referenceIds: Array.isArray(content.referenceIds)
+        ? content.referenceIds
+        : [],
+      references: Array.isArray(content.references) ? content.references : [],
+      assetIds: Array.isArray(content.assetIds) ? content.assetIds : [],
+      assets: Array.isArray(content.assets) ? content.assets : [],
+      publish_date: formatDateTimeLocal(
+        content.publish_date ?? content.publishDate,
+      ),
+    };
+  }
+
+  return getEmptyContentEditorFormData();
+}
+
+export function getContentEditorSavePayload(
+  data: ContentEditorFormData,
+): ContentEditorSavePayload {
+  const {
+    references: _references,
+    assets: _assets,
+    publishDate: _publishDate,
+    ...payload
+  } = data;
 
   return {
     ...payload,
     publish_date: normalizePublishDate(data.publish_date),
-  };
+  } as ContentEditorSavePayload;
 }
 
 export function getContentEditorSnapshot(data: ContentEditorFormData) {

--- a/packages/content/src/svelte/content-editor-form.ts
+++ b/packages/content/src/svelte/content-editor-form.ts
@@ -1,0 +1,114 @@
+import type { ContentBodyFormat } from '../body-format';
+import { resolveBodyFormat } from '../body-format';
+
+export type ContentEditorFormData = Record<string, any> & {
+  title: string;
+  description: string;
+  body: string;
+  bodyFormat: ContentBodyFormat;
+  author: string;
+  type: string;
+  status: string;
+  state: string;
+  source: string;
+  url: string;
+  fileKey: string;
+  publish_date: string;
+  thumbnailAssetId: string | null;
+  tags: string[];
+  referenceIds: string[];
+  references: any[];
+  assetIds: string[];
+  assets: any[];
+};
+
+function formatDateTimeLocal(value: unknown): string {
+  if (!value) {
+    return '';
+  }
+
+  const date = value instanceof Date ? value : new Date(value as string);
+  if (Number.isNaN(date.getTime())) {
+    return typeof value === 'string' ? value : '';
+  }
+
+  const localDate = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
+  return localDate.toISOString().slice(0, 16);
+}
+
+function normalizePublishDate(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const parsed = new Date(trimmed);
+    return Number.isNaN(parsed.getTime()) ? trimmed : parsed.toISOString();
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  }
+
+  return null;
+}
+
+export function getContentEditorInitialFormData(
+  content: any,
+): ContentEditorFormData {
+  if (content) {
+    return {
+      ...content,
+      bodyFormat: resolveBodyFormat(content.bodyFormat, content.body),
+      tags: content.tags || [],
+      referenceIds: content.referenceIds || [],
+      references: content.references || [],
+      assetIds: content.assetIds || [],
+      assets: content.assets || [],
+      publish_date: formatDateTimeLocal(
+        content.publish_date ?? content.publishDate,
+      ),
+    };
+  }
+
+  return {
+    title: '',
+    description: '',
+    body: '',
+    bodyFormat: 'html' as ContentBodyFormat,
+    author: '',
+    type: 'article',
+    status: 'draft',
+    state: 'active',
+    source: 'manual',
+    url: '',
+    fileKey: '',
+    publish_date: '',
+    thumbnailAssetId: null,
+    tags: [],
+    referenceIds: [],
+    references: [],
+    assetIds: [],
+    assets: [],
+  };
+}
+
+export function getContentEditorSavePayload(data: Record<string, any>) {
+  const { references: _references, assets: _assets, ...payload } = data;
+
+  return {
+    ...payload,
+    publish_date: normalizePublishDate(data.publish_date),
+  };
+}
+
+export function getContentEditorSnapshot(data: ContentEditorFormData) {
+  return {
+    ...getContentEditorSavePayload(data),
+    referenceIds: [...(data.referenceIds || [])],
+    references: [...(data.references || [])],
+    assetIds: [...(data.assetIds || [])],
+    assets: [...(data.assets || [])],
+  };
+}

--- a/packages/content/src/svelte/index.ts
+++ b/packages/content/src/svelte/index.ts
@@ -27,8 +27,12 @@ import ContentGovernanceManager from './components/ContentGovernanceManager.svel
 import ContentGovernancePanel from './components/ContentGovernancePanel.svelte';
 import ContentGovernancePolicyEditor from './components/ContentGovernancePolicyEditor.svelte';
 import ContentGovernanceProfileEditor from './components/ContentGovernanceProfileEditor.svelte';
+import ContentImageBrowser from './components/ContentImageBrowser.svelte';
 import ContentImageChooser from './components/ContentImageChooser.svelte';
 import ContentList from './components/ContentList.svelte';
+import ContentMetadataFields from './components/ContentMetadataFields.svelte';
+import ContentReferencesPanel from './components/ContentReferencesPanel.svelte';
+import ContentStatusFields from './components/ContentStatusFields.svelte';
 import ContentTransparencyReport from './components/ContentTransparencyReport.svelte';
 import GovernedContentEditor from './components/GovernedContentEditor.svelte';
 import Markdown from './components/Markdown.svelte';
@@ -64,8 +68,12 @@ export {
   ContentGovernancePanel,
   ContentGovernancePolicyEditor,
   ContentGovernanceProfileEditor,
+  ContentImageBrowser,
   ContentImageChooser,
   ContentList,
+  ContentMetadataFields,
+  ContentReferencesPanel,
+  ContentStatusFields,
   ContentTransparencyReport,
   ContentContributionsRoute,
   ContentFactsRoute,
@@ -93,6 +101,18 @@ export type ContentBodyRendererProps = ComponentProps<
 >;
 export type ContentImageChooserProps = ComponentProps<
   typeof ContentImageChooser
+>;
+export type ContentImageBrowserProps = ComponentProps<
+  typeof ContentImageBrowser
+>;
+export type ContentMetadataFieldsProps = ComponentProps<
+  typeof ContentMetadataFields
+>;
+export type ContentReferencesPanelProps = ComponentProps<
+  typeof ContentReferencesPanel
+>;
+export type ContentStatusFieldsProps = ComponentProps<
+  typeof ContentStatusFields
 >;
 export type ContentListProps = ComponentProps<typeof ContentList>;
 export type ContentContributionFormProps = ComponentProps<
@@ -146,6 +166,11 @@ export type PublishedArticleRouteProps = ComponentProps<
   typeof PublishedArticleRoute
 >;
 
+export type { ContentBodyFormat, ContentBodyImage } from '../body-format.js';
+export {
+  extractBodyImages,
+  resolveBodyFormat,
+} from '../body-format.js';
 // Export types
 export type {
   ContentEditorAssistantActions,
@@ -164,6 +189,19 @@ export {
   contentEditorAssistantContextToChatProps,
   createContentEditorAssistantContext,
 } from '../content-editor-assistant.js';
+export type {
+  ContentPublishReadinessState,
+  EvaluateContentPublishReadinessOptions,
+  PublishReadinessProfile,
+  PublishReadinessRequirement,
+} from '../publish-readiness.js';
+export { evaluateContentPublishReadiness } from '../publish-readiness.js';
+export type { ContentEditorFormData } from './content-editor-form.js';
+export {
+  getContentEditorInitialFormData,
+  getContentEditorSavePayload,
+  getContentEditorSnapshot,
+} from './content-editor-form.js';
 export type {
   ContentRouteId,
   ContentRouteKey,

--- a/packages/content/src/svelte/index.ts
+++ b/packages/content/src/svelte/index.ts
@@ -196,11 +196,19 @@ export type {
   PublishReadinessRequirement,
 } from '../publish-readiness.js';
 export { evaluateContentPublishReadiness } from '../publish-readiness.js';
-export type { ContentEditorFormData } from './content-editor-form.js';
+export type {
+  ContentEditorAsset,
+  ContentEditorFormData,
+  ContentEditorInitialContent,
+  ContentEditorReference,
+  ContentEditorSavePayload,
+} from './content-editor-form.js';
 export {
+  formatDateTimeLocal,
   getContentEditorInitialFormData,
   getContentEditorSavePayload,
   getContentEditorSnapshot,
+  normalizePublishDate,
 } from './content-editor-form.js';
 export type {
   ContentRouteId,


### PR DESCRIPTION
## Summary
- Export smaller content editor building blocks from `@happyvertical/smrt-content/svelte`
- Add reusable metadata, status, references, image browser, and form helper modules
- Re-export editor assistant/body-format/publish-readiness helpers through the Svelte entrypoint so apps can assemble their own editor layouts without reaching into internals

## Why
Anytown needs to compose the WYSIWYG editor, image browser, metadata/status sections, and right-sidebar assistant in its own page layout while keeping those pieces package-owned and reusable.

## Validation
- `pnpm --dir packages/content check`
- pre-push `format-check`
- pre-push `validate-all-workflows`