### PR TITLE
chore: Agents & Runtime packages Phase 2 alignment (epic #1191, category #1208)

### DIFF
--- a/packages/profiles/CLAUDE.md
+++ b/packages/profiles/CLAUDE.md
@@ -4,7 +4,7 @@ Central identity system with multi-auth, relationships, controlled metadata, and
 
 ## Models
 
-- **Profile** (STI base → Bot, Organization, Person): email (globally unique), `typeId` FK to ProfileType, `metadata`
+- **Profile** (STI base → Bot, Organization, Person): email (globally unique), `typeId` FK to ProfileType, plus a `metadata` `@oneToMany('ProfileMetadata')` relationship for controlled per-profile values.
 - **ProfileAsset**: dedicated owned-asset join in `profile_assets` with `relationship` and `sortOrder`.
 - **ProfileRelationship**: bidirectional — creating one auto-creates reciprocal inverse. `contextProfileId` for tertiary relationships. `ProfileRelationshipTerm` tracks start/end dates.
 - **ProfileMetafield**: controlled vocabulary with `validationSchema`. **ProfileMetadata**: per-profile values linked to metafields.
@@ -19,13 +19,29 @@ Central identity system with multi-auth, relationships, controlled metadata, and
 | ApiKey | SHA-256 hashed. **Plaintext returned once only** on `generate()`. `keyPrefix` for identification. Scope-based with expiry. |
 | MagicLinkToken | One-time token with expiry for passwordless auth. |
 
-## Key Collection Methods
+## Identity Resolution
 
-- `UserCollection.getOrCreateFromOidc(claims, provider)` — creates Profile + OidcIdentity + User in one flow
-- `Profile.getAssets()` / `addAsset()` / `removeAsset()` and the matching `ProfileCollection` wrappers — canonical owned asset helpers backed by `profile_assets`
-- `ProfileCollection.addMetadata()`/`getMetadata()` — validates against metafield schema
-- `Profile.getRelationships({ direction: 'from'|'to'|'all' })` — direction matters
-- AI: `generateBio()` (do), `matches(criteria)` (is)
+Auth helpers in `src/auth/` build profiles from external identity claims:
+
+- `resolveIdentity()` — top-level dispatcher that returns/creates a Profile from Nostr signatures, OIDC claims, magic link tokens, or API keys.
+- `createProfileFromOidc(claims, provider)` — creates `Profile` + `OidcIdentity` for first-time OIDC sign-in.
+- `createProfileFromNostr(email, nostrData)` — creates `Profile` + `NostrIdentity` for Nostr-authenticated users.
+
+## Key Methods
+
+- `Profile.getAssets()` / `addAsset()` / `removeAsset()` and the matching `ProfileCollection` wrappers — canonical owned asset helpers backed by `profile_assets`.
+- `Profile.addMetadata(metafieldSlug, value)` / `Profile.getMetadata()` — validates against metafield schema. `ProfileCollection.batchGetMetadata()` / `batchUpdateMetadata()` for bulk reads/writes.
+- `Profile.getRelationships({ direction: 'from'|'to'|'all' })` — direction matters.
+- AI: `generateBio()` (uses `smrtProfiles.profile.generateBio` prompt via `@happyvertical/smrt-prompts`), `matches(criteria)` (delegates to `is()`).
+
+## Prompt Registry
+
+`generateBio()` is registered with `@happyvertical/smrt-prompts` so tenants can override template/model/params at runtime:
+
+```typescript
+import { smrtProfilesGenerateBioPrompt } from '@happyvertical/smrt-profiles';
+// key: 'smrtProfiles.profile.generateBio'
+```
 
 ## Gotchas
 

--- a/packages/profiles/package.json
+++ b/packages/profiles/package.json
@@ -35,6 +35,7 @@
     "@happyvertical/logger": "catalog:",
     "@happyvertical/smrt-assets": "workspace:*",
     "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-prompts": "workspace:*",
     "@happyvertical/sql": "catalog:",
     "@happyvertical/utils": "catalog:",
     "@noble/curves": "^1.8.1",

--- a/packages/profiles/src/__tests__/generateBio.test.ts
+++ b/packages/profiles/src/__tests__/generateBio.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for `Profile.generateBio()` — verifies the smrt-prompts integration
+ * landed in PR 1209: prompt resolution, variable substitution, and that
+ * email is NOT passed to the AI provider (PII).
+ *
+ * The AI client is stubbed via a `getAiClient()` override so no network calls
+ * are made. The `db` plumbing is exercised separately via the smrt-prompts
+ * package's own integration tests; here we focus on Profile-level behavior.
+ */
+
+import { clearPromptCache } from '@happyvertical/smrt-prompts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Profile } from '../models/Profile.js';
+import { smrtProfilesGenerateBioPrompt } from '../prompts.js';
+
+describe('Profile.generateBio()', () => {
+  let aiMessageMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    aiMessageMock = vi.fn().mockResolvedValue('Generated bio text  ');
+    clearPromptCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makeProfile(opts: ConstructorParameters<typeof Profile>[0] = {}) {
+    const profile = new Profile({
+      name: 'Ada Lovelace',
+      email: 'ada@example.com',
+      description: 'Mathematician and computing pioneer',
+      ...opts,
+    });
+    // Stub the AI client so generateBio doesn't reach a real provider.
+    (profile as any).getAiClient = async () => ({
+      message: aiMessageMock,
+    });
+    return profile;
+  }
+
+  it('uses the registered prompt key', () => {
+    expect(smrtProfilesGenerateBioPrompt.key).toBe(
+      'smrtProfiles.profile.generateBio',
+    );
+  });
+
+  it('resolves the registered bio prompt and returns trimmed AI output', async () => {
+    const profile = makeProfile();
+
+    const result = await profile.generateBio();
+
+    expect(result).toBe('Generated bio text');
+    expect(aiMessageMock).toHaveBeenCalledTimes(1);
+
+    // The prompt sent to the AI should contain the substituted name and
+    // description from the registered template.
+    const [text] = aiMessageMock.mock.calls[0];
+    expect(text).toContain('Ada Lovelace');
+    expect(text).toContain('Mathematician and computing pioneer');
+  });
+
+  it('does NOT pass email to the AI provider (PII reduction)', async () => {
+    const profile = makeProfile();
+
+    await profile.generateBio();
+
+    const [text] = aiMessageMock.mock.calls[0];
+    expect(text).not.toContain('ada@example.com');
+    expect(text.toLowerCase()).not.toContain('email');
+  });
+
+  it('passes resolvedPrompt.ai params (model/temperature/maxTokens) through to ai.message', async () => {
+    const profile = makeProfile();
+
+    await profile.generateBio();
+
+    expect(aiMessageMock).toHaveBeenCalledTimes(1);
+    // Second arg is the AI options object derived from the prompt's `ai`
+    // config plus any tenant overrides. The default registered prompt has
+    // no model/temperature/maxTokens, so options should be an empty object
+    // (or contain only ai.params if the prompt registered them).
+    const [, options] = aiMessageMock.mock.calls[0];
+    expect(options).toBeTypeOf('object');
+  });
+});

--- a/packages/profiles/src/index.ts
+++ b/packages/profiles/src/index.ts
@@ -11,6 +11,9 @@
 // downstream. Must come first so the side effect runs ahead of the class
 // module loads below. See __smrt-register__.ts for issue #1132 context.
 import './__smrt-register__.js';
+// Register prompts at module-load time so consumers and tenants can
+// override them via `resolvePrompt()` without further plumbing.
+import './prompts.js';
 
 // Auth module - Identity resolution
 // Auth module - Nostr crypto
@@ -106,6 +109,13 @@ export type { ProfileTypeOptions } from './models/ProfileType';
 export { ProfileType } from './models/ProfileType';
 // Export profile subclasses (STI)
 export { Bot, Organization, Person } from './models/ProfileTypes';
+
+// Export prompt registrations so consumers can reference the key for
+// tenant-aware overrides via `@happyvertical/smrt-prompts`.
+export {
+  promptMessageOptions,
+  smrtProfilesGenerateBioPrompt,
+} from './prompts';
 
 // Export types
 export type {

--- a/packages/profiles/src/models/Profile.ts
+++ b/packages/profiles/src/models/Profile.ts
@@ -500,12 +500,14 @@ export class Profile extends SmrtObject {
    * @returns Generated bio text
    */
   async generateBio(): Promise<string> {
-    // Pass either `db` or its `persistence` alias — when callers use the
-    // alias on a not-yet-initialized instance, `this.options.db` is still
-    // undefined because SmrtClass only resolves the alias during
-    // initialize(). Falling back to `persistence` ensures stored prompt
-    // overrides in `_smrt_prompt_overrides` are honored on first call.
-    const db = this.options.db ?? (this.options as any).persistence;
+    // Resolve `db` from either the canonical `db` option or its `persistence`
+    // alias. SmrtClass maps `persistence → db` lazily during `initialize()`,
+    // so on a freshly-constructed Profile that has not yet been initialized,
+    // `this.options.db` may be undefined while `this.options.persistence` is
+    // set. Falling back here ensures stored app- and tenant-level prompt
+    // overrides in `_smrt_prompt_overrides` are honored on the first call —
+    // before `getAiClient()` triggers full initialization further below.
+    const db = this.options.db ?? this.options.persistence;
 
     const resolvedPrompt = await resolvePrompt(
       smrtProfilesGenerateBioPrompt.key,
@@ -514,7 +516,6 @@ export class Profile extends SmrtObject {
         tenantId: this.tenantId,
         variables: {
           profileName: this.name || '',
-          profileEmail: this.email || '',
           profileDescription: this.description || '',
         },
       },

--- a/packages/profiles/src/models/Profile.ts
+++ b/packages/profiles/src/models/Profile.ts
@@ -500,10 +500,17 @@ export class Profile extends SmrtObject {
    * @returns Generated bio text
    */
   async generateBio(): Promise<string> {
+    // Pass either `db` or its `persistence` alias — when callers use the
+    // alias on a not-yet-initialized instance, `this.options.db` is still
+    // undefined because SmrtClass only resolves the alias during
+    // initialize(). Falling back to `persistence` ensures stored prompt
+    // overrides in `_smrt_prompt_overrides` are honored on first call.
+    const db = this.options.db ?? (this.options as any).persistence;
+
     const resolvedPrompt = await resolvePrompt(
       smrtProfilesGenerateBioPrompt.key,
       {
-        db: this.options.db,
+        db,
         tenantId: this.tenantId,
         variables: {
           profileName: this.name || '',
@@ -514,15 +521,10 @@ export class Profile extends SmrtObject {
     );
 
     const ai = await this.getAiClient();
-    if (typeof (ai as any).message !== 'function') {
-      throw new Error(
-        'AI bio generation requires an AI client with a message() method',
-      );
-    }
-
-    const response = await (
-      ai as { message: (prompt: string, options?: any) => Promise<string> }
-    ).message(resolvedPrompt.text, promptMessageOptions(resolvedPrompt.ai));
+    const response = await ai.message(
+      resolvedPrompt.text,
+      promptMessageOptions(resolvedPrompt.ai),
+    );
 
     return response.trim();
   }

--- a/packages/profiles/src/models/Profile.ts
+++ b/packages/profiles/src/models/Profile.ts
@@ -20,7 +20,12 @@ import {
   type SmrtObjectOptions,
   smrt,
 } from '@happyvertical/smrt-core';
+import { resolvePrompt } from '@happyvertical/smrt-prompts';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import {
+  promptMessageOptions,
+  smrtProfilesGenerateBioPrompt,
+} from '../prompts';
 import type { ProfileRelationship } from './ProfileRelationship';
 import { ProfileType } from './ProfileType';
 
@@ -488,10 +493,38 @@ export class Profile extends SmrtObject {
   /**
    * AI-powered: Generate a professional bio for this profile
    *
+   * Uses the `smrtProfiles.profile.generateBio` prompt registered via
+   * `@happyvertical/smrt-prompts`, allowing tenant- or instance-level
+   * overrides of the template, model, and parameters at runtime.
+   *
    * @returns Generated bio text
    */
   async generateBio(): Promise<string> {
-    return await this.do('Write a short, professional bio for this person.');
+    const resolvedPrompt = await resolvePrompt(
+      smrtProfilesGenerateBioPrompt.key,
+      {
+        db: this.options.db,
+        tenantId: this.tenantId,
+        variables: {
+          profileName: this.name || '',
+          profileEmail: this.email || '',
+          profileDescription: this.description || '',
+        },
+      },
+    );
+
+    const ai = await this.getAiClient();
+    if (typeof (ai as any).message !== 'function') {
+      throw new Error(
+        'AI bio generation requires an AI client with a message() method',
+      );
+    }
+
+    const response = await (
+      ai as { message: (prompt: string, options?: any) => Promise<string> }
+    ).message(resolvedPrompt.text, promptMessageOptions(resolvedPrompt.ai));
+
+    return response.trim();
   }
 
   /**

--- a/packages/profiles/src/prompts.ts
+++ b/packages/profiles/src/prompts.ts
@@ -1,0 +1,42 @@
+/**
+ * Prompt registrations for the @happyvertical/smrt-profiles package.
+ *
+ * Prompts are registered at module-load time via `definePrompt()` so that
+ * tenant-aware overrides can be applied at call time via `resolvePrompt()`.
+ *
+ * Mirrors the pattern used by `@happyvertical/smrt-content` (see
+ * `content-prompts.ts`) and `@happyvertical/smrt-facts` (see `prompts.ts`).
+ */
+
+import {
+  definePrompt,
+  type ResolvedPromptAI,
+} from '@happyvertical/smrt-prompts';
+
+export const smrtProfilesGenerateBioPrompt = definePrompt({
+  key: 'smrtProfiles.profile.generateBio',
+  template: `Write a short, professional bio for this person.
+
+Profile name: {profileName}
+Profile email: {profileEmail}
+Profile description: {profileDescription}
+
+Return only the bio text, with no commentary or surrounding quotation marks.`,
+  editable: {
+    template: true,
+    profile: true,
+    model: true,
+    params: true,
+  },
+});
+
+export function promptMessageOptions(ai: ResolvedPromptAI) {
+  return {
+    ...(ai.params || {}),
+    ...(ai.model ? { model: ai.model } : {}),
+    ...(typeof ai.temperature === 'number'
+      ? { temperature: ai.temperature }
+      : {}),
+    ...(typeof ai.maxTokens === 'number' ? { maxTokens: ai.maxTokens } : {}),
+  };
+}

--- a/packages/profiles/src/prompts.ts
+++ b/packages/profiles/src/prompts.ts
@@ -13,12 +13,15 @@ import {
   type ResolvedPromptAI,
 } from '@happyvertical/smrt-prompts';
 
+// Bio generation only uses non-PII profile fields (name + description).
+// Email is intentionally NOT passed to the AI provider — see review on PR
+// #1209 — to minimize PII exposure. If a downstream tenant needs email in
+// the bio, they can override the template via PromptOverride.
 export const smrtProfilesGenerateBioPrompt = definePrompt({
   key: 'smrtProfiles.profile.generateBio',
   template: `Write a short, professional bio for this person.
 
 Profile name: {profileName}
-Profile email: {profileEmail}
 Profile description: {profileDescription}
 
 Return only the bio text, with no commentary or surrounding quotation marks.`,

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -34,7 +34,6 @@
     "@happyvertical/sql": "catalog:"
   },
   "devDependencies": {
-    "@happyvertical/smrt-cli": "workspace:*",
     "@happyvertical/smrt-vitest": "workspace:*",
     "@types/node": "25.0.9",
     "typescript": "^5.9.3",

--- a/packages/users/CLAUDE.md
+++ b/packages/users/CLAUDE.md
@@ -2,13 +2,14 @@
 
 Multi-tenant user management with RBAC, hierarchical tenants, session handling, and SvelteKit integration.
 
-## Models (12)
+## Models (13)
 
 | Model | Key Pattern |
 |-------|-------------|
 | User | Auth identity. `profileId` is plain string (not FK) to smrt-profiles. Email auto-lowercased. |
 | Tenant | **STI** + hierarchical parent-child. `hierarchyPath` (materialized path), `hierarchyLevel`. Max depth 10. |
 | Session | Server-side. Secure UUID. TTL in **seconds** (not ms). Status auto-updates to EXPIRED on access. |
+| MagicLinkToken | Single-use email login token. Backed by `MagicLinkService`. |
 | Role | `tenantId = null` → system role (available to all tenants). `isSystem: true` blocks deletion. |
 | Permission | Slug format: `resource.action`. Parsed by PermissionResolver. |
 | Membership | User + Tenant + Role junction. UNIQUE(userId, tenantId). |

--- a/packages/users/src/services/PermissionResolver.ts
+++ b/packages/users/src/services/PermissionResolver.ts
@@ -101,10 +101,12 @@ export class PermissionResolver {
   /**
    * Initialize collections
    *
-   * Note: The 'as any' casts are required because SmrtCollection.create() has a
-   * protected constructor pattern that TypeScript cannot infer correctly for
-   * subclasses. This is a known limitation of the SMRT framework's static factory
-   * pattern. See: https://github.com/happyvertical/smrt/issues/XXX
+   * Note: The `as any` casts are required because `SmrtCollection.create()` is
+   * declared with a protected constructor and a static factory. TypeScript
+   * cannot infer that the static `create()` returns the concrete subclass type
+   * when invoked through a subclass reference, so the cast is needed to call
+   * `create(options)` on each collection. This is a known SMRT framework
+   * limitation around the protected-constructor + static-factory pattern.
    */
   async initialize(): Promise<void> {
     // TypeScript cannot infer that Collection.create() returns the correct subclass type

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1343,6 +1343,9 @@ importers:
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
+      '@happyvertical/smrt-prompts':
+        specifier: workspace:*
+        version: link:../prompts
       '@happyvertical/smrt-tenancy':
         specifier: workspace:*
         version: link:../tenancy

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1472,9 +1472,6 @@ importers:
         specifier: ^0.73.2
         version: 0.73.2
     devDependencies:
-      '@happyvertical/smrt-cli':
-        specifier: workspace:*
-        version: link:../cli
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
         version: link:../vitest


### PR DESCRIPTION
## Summary

Second Phase 2 category PR — Agents & Runtime layer alignment. Closes [#1208](https://github.com/happyvertical/smrt/issues/1208).

## Per-package work

### `users` — small (`feat/agents-runtime-users-alignment`, `14803a48`)

- `PermissionResolver.ts:107` placeholder `https://github.com/happyvertical/smrt/issues/XXX` URL replaced with inline comment explaining the `as any` cast (protected-constructor + static-factory limitation in SmrtCollection.create)
- CLAUDE.md drift patched: model count corrected (12→13), `MagicLinkToken` row added to model table

### `profiles` — small-to-medium (`feat/agents-runtime-profiles-alignment`, `a5a8dc0d`)

- New `src/prompts.ts` registering `smrtProfiles.profile.generateBio` via `definePrompt` (matches the facts/content reference pattern)
- `Profile.generateBio()` refactored from inline `this.do(...)` to `resolvePrompt() + ai.message()` so tenants can override the bio template/model/params at runtime
- `@happyvertical/smrt-prompts` added to dependencies
- CLAUDE.md drift patched: removed nonexistent `UserCollection.getOrCreateFromOidc()` reference (replaced with the actual `resolveIdentity()` helpers from `src/auth/`); corrected metadata-method locations (`Profile.addMetadata` is on the model, `batchGetMetadata` is on the collection); added Prompt Registry section

### `agents`, `jobs` — no Phase 2 deltas

CLAUDE.md verified against current code. No drift.

## Review history

- **users** branch: manual review (13-line additive diff) — approved
- **profiles** branch:
  - **Codex** (gpt-5.5/xhigh): 2 P2 findings:
    - Provider routing — `resolvedPrompt.ai.provider` not honored. **Framework-wide pattern** (also affects content and facts). Deferred to dedicated PR.
    - `persistence` alias not handled — `this.options.db` is undefined when caller uses the alias on an uninitialized instance. **Fixed in `01a07bf8`** (use `db ?? persistence` fallback).
  - **Claude correctness review**: 1 important finding:
    - Unnecessary `as any` cast + `typeof message` guard. **Fixed in `01a07bf8`** (removed both; `getAiClient()` returns `Promise<AIClient>` with a typed `message()`).

## Commits

```
01a07bf8  fix(profiles): apply review feedback on generateBio adoption
b25ff9ef  Merge branch 'feat/agents-runtime-profiles-alignment'
612fce59  Merge branch 'feat/agents-runtime-users-alignment'
a5a8dc0d  chore(profiles): Phase 2 alignment — adopt smrt-prompts for generateBio, verify docs
14803a48  chore(users): Phase 2 alignment — resolve PermissionResolver placeholder, verify docs
```

**Do not squash on merge** — per-package commits should land as bisect-friendly history.

## Out of scope (deferred to dedicated PRs)

- **profiles**: NostrIdentity SecretService migration, ApiKey storage trade-off doc, MagicLinkToken hashed-token verification
- **users**: MagicLinkService JWT signing key migration to SecretService, Session.data encryption migration, #1028, #1039, #1115
- **framework-wide**: provider routing through `resolvedPrompt.ai.provider` when stored override selects a named AI profile (affects profiles, content, facts uniformly)

## Next phases

- ✅ Foundation (#1207)
- ✅ **Agents & Runtime** ← this PR
- ⏳ Domain (`events`, `places`, `facts`, `sites`, `properties`, `tags`, `social`, `secrets`, `prompts`, `features`, `languages`)
- ⏳ Content & Media
- ⏳ Business
- ⏳ Tooling/Templates