### PR TITLE
chore: Domain packages Phase 2 alignment (epic #1191, category #1210)

### DIFF
--- a/packages/properties/CLAUDE.md
+++ b/packages/properties/CLAUDE.md
@@ -13,6 +13,23 @@ Digital properties (websites, apps) with hierarchical zones for content/ad place
 
 In-memory depth caching prevents N+1 queries during tree operations.
 
+## Property Key Methods
+
+- `getZones()` / `getZoneTree()` / `createZone()` — ZoneCollection wrappers loaded lazily via dynamic import.
+- `isActive()` — convenience status check.
+- AI: `summarize()` (uses `smrtProperties.property.summarize` prompt via `@happyvertical/smrt-prompts`).
+
+## Prompt Registry
+
+`Property.summarize()` is registered with `@happyvertical/smrt-prompts` so tenants can override the template/model/params at runtime:
+
+```typescript
+import { smrtPropertiesSummarizePrompt } from '@happyvertical/smrt-properties';
+// key: 'smrtProperties.property.summarize'
+```
+
+Only non-PII fields are passed to the AI provider: `name`, `domain`, `description`, `status`, plus aggregate zone information (count + top-level zone names). Internal foreign-key fields (`ownerId`, `repositoryId`, `tenantId`) and the extensible `metadata` blob are intentionally excluded — `metadata` may contain analytics IDs or tenant-private configuration.
+
 ## Gotchas
 
 - **Empty allowedFormats = all formats**: empty array means no restrictions, not no formats

--- a/packages/properties/package.json
+++ b/packages/properties/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-prompts": "workspace:*",
     "@happyvertical/smrt-tenancy": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/properties/src/__tests__/summarize.test.ts
+++ b/packages/properties/src/__tests__/summarize.test.ts
@@ -115,17 +115,37 @@ describe('Property.summarize()', () => {
     expect(text).not.toMatch(/Top-level zones:[^\n]*\bHeader Slot\b/);
   });
 
-  it('passes resolvedPrompt.ai params (model/temperature/maxTokens) through to ai.message', async () => {
+  it('passes empty AI options for the default registered prompt (no ai config)', async () => {
     const property = makeProperty();
 
     await property.summarize();
 
     expect(aiMessageMock).toHaveBeenCalledTimes(1);
-    // Second arg is the AI options object derived from the prompt's `ai`
-    // config plus any tenant overrides. The default registered prompt has
-    // no model/temperature/maxTokens, so options should be an empty object
-    // (or contain only ai.params if the prompt registered them).
+    // The default registered prompt has no model/temperature/maxTokens/params,
+    // so the options object derived by promptMessageOptions should be empty.
     const [, options] = aiMessageMock.mock.calls[0];
-    expect(options).toBeTypeOf('object');
+    expect(options).toEqual({});
+  });
+
+  it('forwards model/temperature/maxTokens from a runtime ai override to ai.message', async () => {
+    // Drive promptMessageOptions directly with a synthetic ResolvedPromptAI
+    // shape — this exercises the same helper Property.summarize calls and
+    // documents the contract for tenant overrides that set ai-config fields.
+    const { promptMessageOptions } = await import('../prompts.js');
+
+    const options = promptMessageOptions({
+      profile: null,
+      model: 'gpt-test-1',
+      temperature: 0.42,
+      maxTokens: 256,
+      params: { topP: 0.9 },
+    });
+
+    expect(options).toEqual({
+      topP: 0.9,
+      model: 'gpt-test-1',
+      temperature: 0.42,
+      maxTokens: 256,
+    });
   });
 });

--- a/packages/properties/src/__tests__/summarize.test.ts
+++ b/packages/properties/src/__tests__/summarize.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for `Property.summarize()` — verifies the smrt-prompts integration:
+ * prompt resolution, variable substitution, trimmed AI output, and that
+ * internal/PII-adjacent fields (ownerId, repositoryId, tenantId, metadata)
+ * are NOT passed to the AI provider.
+ *
+ * The AI client is stubbed via a `getAiClient()` override so no network calls
+ * are made. The `db` plumbing is exercised separately via the smrt-prompts
+ * package's own integration tests; here we focus on Property-level behavior.
+ */
+
+import { clearPromptCache } from '@happyvertical/smrt-prompts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Property } from '../models/Property.js';
+import { smrtPropertiesSummarizePrompt } from '../prompts.js';
+
+describe('Property.summarize()', () => {
+  let aiMessageMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    aiMessageMock = vi.fn().mockResolvedValue('Generated summary text  ');
+    clearPromptCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makeProperty(opts: ConstructorParameters<typeof Property>[0] = {}) {
+    const property = new Property({
+      name: 'Oak Creek News',
+      domain: 'oakcreeknews.com',
+      url: 'https://oakcreeknews.com',
+      description: 'Local community news for Oak Creek',
+      status: 'active',
+      // Internal/PII-adjacent fields that should NOT reach the AI provider:
+      ownerId: 'owner-profile-uuid-1234',
+      repositoryId: 'repo-uuid-5678',
+      tenantId: 'tenant-uuid-9999',
+      metadata: {
+        analyticsId: 'UA-PRIVATE-12345',
+        secretKey: 'do-not-leak',
+      },
+      ...opts,
+    });
+    // Stub the AI client so summarize doesn't reach a real provider.
+    (property as any).getAiClient = async () => ({
+      message: aiMessageMock,
+    });
+    // Stub getZones so we don't need a real DB for this focused test.
+    (property as any).getZones = async () => [];
+    return property;
+  }
+
+  it('uses the registered prompt key', () => {
+    expect(smrtPropertiesSummarizePrompt.key).toBe(
+      'smrtProperties.property.summarize',
+    );
+  });
+
+  it('resolves the registered summarize prompt and returns trimmed AI output', async () => {
+    const property = makeProperty();
+
+    const result = await property.summarize();
+
+    expect(result).toBe('Generated summary text');
+    expect(aiMessageMock).toHaveBeenCalledTimes(1);
+
+    // The prompt sent to the AI should contain the substituted name,
+    // domain, description, and status from the registered template.
+    const [text] = aiMessageMock.mock.calls[0];
+    expect(text).toContain('Oak Creek News');
+    expect(text).toContain('oakcreeknews.com');
+    expect(text).toContain('Local community news for Oak Creek');
+    expect(text).toContain('active');
+  });
+
+  it('does NOT pass internal/PII-adjacent fields to the AI provider', async () => {
+    const property = makeProperty();
+
+    await property.summarize();
+
+    const [text] = aiMessageMock.mock.calls[0];
+    // Foreign-key references that link to identifying records.
+    expect(text).not.toContain('owner-profile-uuid-1234');
+    expect(text).not.toContain('repo-uuid-5678');
+    expect(text).not.toContain('tenant-uuid-9999');
+    // Extensible metadata may contain analytics IDs, secrets, or other
+    // tenant-private configuration — must not leak into prompts.
+    expect(text).not.toContain('UA-PRIVATE-12345');
+    expect(text).not.toContain('do-not-leak');
+  });
+
+  it('substitutes zone aggregates without leaking zone metadata', async () => {
+    const property = makeProperty();
+    // Override getZones with a few fake zones to exercise the aggregate
+    // substitution path. Zone names are intentionally non-PII labels.
+    (property as any).getZones = async () => [
+      { id: 'z1', name: 'Home', parentId: null },
+      { id: 'z2', name: 'About', parentId: null },
+      { id: 'z3', name: 'Header Slot', parentId: 'z1' },
+    ];
+
+    await property.summarize();
+
+    const [text] = aiMessageMock.mock.calls[0];
+    expect(text).toContain('Total zones: 3');
+    expect(text).toContain('Home');
+    expect(text).toContain('About');
+    // Children of a parent zone should not be listed as top-level entries.
+    // The slot is a child of `z1`, so it must not appear in the comma-
+    // separated top-level zones list rendered by the template.
+    expect(text).toMatch(/Top-level zones:[^\n]*\bHome\b/);
+    expect(text).toMatch(/Top-level zones:[^\n]*\bAbout\b/);
+    expect(text).not.toMatch(/Top-level zones:[^\n]*\bHeader Slot\b/);
+  });
+
+  it('passes resolvedPrompt.ai params (model/temperature/maxTokens) through to ai.message', async () => {
+    const property = makeProperty();
+
+    await property.summarize();
+
+    expect(aiMessageMock).toHaveBeenCalledTimes(1);
+    // Second arg is the AI options object derived from the prompt's `ai`
+    // config plus any tenant overrides. The default registered prompt has
+    // no model/temperature/maxTokens, so options should be an empty object
+    // (or contain only ai.params if the prompt registered them).
+    const [, options] = aiMessageMock.mock.calls[0];
+    expect(options).toBeTypeOf('object');
+  });
+});

--- a/packages/properties/src/index.ts
+++ b/packages/properties/src/index.ts
@@ -62,6 +62,9 @@
 // downstream. Must come first so the side effect runs ahead of the class
 // module loads below. See __smrt-register__.ts for issue #1132 context.
 import './__smrt-register__.js';
+// Register prompts at module-load time so consumers and tenants can
+// override them via `resolvePrompt()` without further plumbing.
+import './prompts.js';
 
 // Export collections
 export { PropertyCollection } from './collections/Properties';
@@ -70,6 +73,13 @@ export { ZoneCollection } from './collections/Zones';
 // Export models
 export { Property } from './models/Property';
 export { Zone } from './models/Zone';
+
+// Export prompt registrations so consumers can reference the key for
+// tenant-aware overrides via `@happyvertical/smrt-prompts`.
+export {
+  promptMessageOptions,
+  smrtPropertiesSummarizePrompt,
+} from './prompts';
 
 // Export types
 export type {

--- a/packages/properties/src/models/Property.ts
+++ b/packages/properties/src/models/Property.ts
@@ -6,7 +6,12 @@
  */
 
 import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { resolvePrompt } from '@happyvertical/smrt-prompts';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import {
+  promptMessageOptions,
+  smrtPropertiesSummarizePrompt,
+} from '../prompts';
 import type { PropertyOptions, PropertyStatus } from '../types';
 
 @TenantScoped({ mode: 'optional' })
@@ -129,20 +134,53 @@ export class Property extends SmrtObject {
   }
 
   /**
-   * Generate a summary of the property and its zones
+   * AI-powered: Generate a summary of the property and its zones.
+   *
+   * Uses the `smrtProperties.property.summarize` prompt registered via
+   * `@happyvertical/smrt-prompts`, allowing tenant- or instance-level
+   * overrides of the template, model, and parameters at runtime.
+   *
+   * Only non-PII fields (name, domain, description, status) plus aggregate
+   * zone information are sent to the AI provider. Internal foreign-key
+   * fields and the extensible `metadata` blob are intentionally excluded.
+   *
+   * @returns Generated summary text
    */
   async summarize(): Promise<string> {
     const zones = await this.getZones();
     const topLevelZones = zones.filter((z) => z.parentId === null);
 
-    return await this.do(
-      `Summarize this digital property:\n` +
-        `Name: ${this.name}\n` +
-        `Domain: ${this.domain}\n` +
-        `Description: ${this.description}\n` +
-        `Status: ${this.status}\n` +
-        `Total zones: ${zones.length}\n` +
-        `Top-level zones: ${topLevelZones.map((z) => z.name).join(', ')}`,
+    // Resolve `db` from either the canonical `db` option or its `persistence`
+    // alias. SmrtClass maps `persistence → db` lazily during `initialize()`,
+    // so on a freshly-constructed Property that has not yet been initialized,
+    // `this.options.db` may be undefined while `this.options.persistence` is
+    // set. Falling back here ensures stored app- and tenant-level prompt
+    // overrides in `_smrt_prompt_overrides` are honored on the first call —
+    // before `getAiClient()` triggers full initialization further below.
+    const db = this.options.db ?? this.options.persistence;
+
+    const resolvedPrompt = await resolvePrompt(
+      smrtPropertiesSummarizePrompt.key,
+      {
+        db,
+        tenantId: this.tenantId,
+        variables: {
+          propertyName: this.name || '',
+          propertyDomain: this.domain || '',
+          propertyDescription: this.description || '',
+          propertyStatus: this.status || '',
+          totalZones: String(zones.length),
+          topLevelZones: topLevelZones.map((z) => z.name).join(', '),
+        },
+      },
     );
+
+    const ai = await this.getAiClient();
+    const response = await ai.message(
+      resolvedPrompt.text,
+      promptMessageOptions(resolvedPrompt.ai),
+    );
+
+    return response.trim();
   }
 }

--- a/packages/properties/src/prompts.ts
+++ b/packages/properties/src/prompts.ts
@@ -1,0 +1,49 @@
+/**
+ * Prompt registrations for the @happyvertical/smrt-properties package.
+ *
+ * Prompts are registered at module-load time via `definePrompt()` so that
+ * tenant-aware overrides can be applied at call time via `resolvePrompt()`.
+ *
+ * Mirrors the pattern used by `@happyvertical/smrt-profiles` (see
+ * `prompts.ts`) and `@happyvertical/smrt-content` (see `content-prompts.ts`).
+ */
+
+import {
+  definePrompt,
+  type ResolvedPromptAI,
+} from '@happyvertical/smrt-prompts';
+
+// Property summarization only uses non-PII property fields
+// (name, domain, description, status) plus aggregate zone information.
+// Internal/foreign-key fields like ownerId, repositoryId, tenantId, and the
+// extensible `metadata` blob are intentionally NOT passed to the AI
+// provider — they may link to identifying records or contain analytics IDs
+// and other configuration secrets. If a downstream tenant needs richer
+// context they can override the template via PromptOverride.
+export const smrtPropertiesSummarizePrompt = definePrompt({
+  key: 'smrtProperties.property.summarize',
+  template: `Summarize this digital property:
+Name: {propertyName}
+Domain: {propertyDomain}
+Description: {propertyDescription}
+Status: {propertyStatus}
+Total zones: {totalZones}
+Top-level zones: {topLevelZones}`,
+  editable: {
+    template: true,
+    profile: true,
+    model: true,
+    params: true,
+  },
+});
+
+export function promptMessageOptions(ai: ResolvedPromptAI) {
+  return {
+    ...(ai.params || {}),
+    ...(ai.model ? { model: ai.model } : {}),
+    ...(typeof ai.temperature === 'number'
+      ? { temperature: ai.temperature }
+      : {}),
+    ...(typeof ai.maxTokens === 'number' ? { maxTokens: ai.maxTokens } : {}),
+  };
+}

--- a/packages/secrets/CLAUDE.md
+++ b/packages/secrets/CLAUDE.md
@@ -33,3 +33,27 @@ Secret value → encrypted with TDEK (per-tenant Data Encryption Key)
 - **Expired secrets filtered by default**: pass `includeExpired: true` to list them
 - **TenantKeyCollection.cleanupRetiredKeys()**: hard-deletes after 90 days
 - **Audit logging optional but default**: failures logged to console, not thrown
+
+## Known exceptions to monorepo standards
+
+Per `docs/content/standards.md §7`, tenant-aware models should normally apply
+`@TenantScoped({ mode: 'optional' })` from `@happyvertical/smrt-tenancy`. The three
+models in this package deviate intentionally; each `@smrt(...)` block carries an
+inline comment pointing back to this section.
+
+- **`Secret` (`src/models/Secret.ts`)** — uses the inline `tenantScoped: true` form
+  on `@smrt()` instead of the `@TenantScoped` decorator. `SecretService.store()`
+  performs manual scoping by populating `context = tenantId` on each row, so the
+  `(slug, context)` upsert key from the base `SmrtObject` is what isolates secret
+  names per tenant. Switching to the decorator without rethinking the upsert key
+  would surface false-positive name collisions across tenants.
+- **`TenantKey` (`src/models/TenantKey.ts`)** — deliberately NOT tenant-scoped at
+  all. The row carries a `tenantId` column because each TDEK belongs to a tenant,
+  but key-rotation tooling, AMK rewrap jobs, and super-admin audits must query
+  across tenants; the tenancy interceptor would silently filter rows those flows
+  rely on.
+- **`SecretAuditLog` (`src/models/SecretAuditLog.ts`)** — uses the inline
+  `tenantScoped: true` form rather than the decorator. Audit reads run in mixed
+  contexts (tenant-scoped reports vs. super-admin compliance review); pairing the
+  boolean form with explicit `withSuperAdminBypass()` at compliance call sites
+  keeps cross-tenant audit queries explicit instead of magical.

--- a/packages/secrets/CLAUDE.md
+++ b/packages/secrets/CLAUDE.md
@@ -54,6 +54,9 @@ inline comment pointing back to this section.
   rely on.
 - **`SecretAuditLog` (`src/models/SecretAuditLog.ts`)** — uses the inline
   `tenantScoped: true` form rather than the decorator. Audit reads run in mixed
-  contexts (tenant-scoped reports vs. super-admin compliance review); pairing the
-  boolean form with explicit `withSuperAdminBypass()` at compliance call sites
-  keeps cross-tenant audit queries explicit instead of magical.
+  contexts (tenant-scoped reports vs. super-admin compliance review). Cross-
+  tenant audit queries should be wrapped in `withSuperAdminBypass()` from
+  `@happyvertical/smrt-tenancy` at the call site — there are no such cross-
+  tenant call sites in this package today, but consumers building compliance
+  tooling should adopt that pattern explicitly rather than relying on
+  decorator-implicit filtering.

--- a/packages/secrets/src/models/Secret.ts
+++ b/packages/secrets/src/models/Secret.ts
@@ -37,6 +37,16 @@ export type SecretStatus = 'active' | 'disabled' | 'expired';
  * });
  * ```
  */
+// Intentional exception to standards.md §7 (`@TenantScoped({ mode: 'optional' })`):
+// `Secret` uses the inline `tenantScoped: true` form on `@smrt()` rather than the
+// dedicated `@TenantScoped` decorator from `@happyvertical/smrt-tenancy`. The boolean
+// form gives us required-mode tenant scoping without depending on the tenancy package
+// at the model layer, while `SecretService` performs manual scoping by setting
+// `context = tenantId` on each row. The `(slug, context)` upsert key derived from the
+// base `SmrtObject` fields is what gives different tenants isolated namespaces for
+// secret names — switching to the decorator without changing the upsert key would
+// surface false-positive name collisions across tenants. See
+// `packages/secrets/CLAUDE.md` "Known exceptions to monorepo standards" for context.
 @smrt({
   tenantScoped: true,
   // NO API or MCP exposure for security

--- a/packages/secrets/src/models/SecretAuditLog.ts
+++ b/packages/secrets/src/models/SecretAuditLog.ts
@@ -63,11 +63,12 @@ export type SecretAuditResult = 'success' | 'failure' | 'denied';
 // Intentional exception to standards.md §7 (`@TenantScoped({ mode: 'optional' })`):
 // `SecretAuditLog` uses the inline `tenantScoped: true` form on `@smrt()` rather than
 // the dedicated `@TenantScoped` decorator. Audit-trail queries are read-mostly and run
-// in mixed contexts — under a tenant for tenant-scoped reports, and under super-admin
-// bypass for compliance review. Pairing the boolean form with explicit
-// `withSuperAdminBypass()` at the call site keeps the cross-tenant audit query
-// behavior surprise-free. See `packages/secrets/CLAUDE.md` "Known exceptions to
-// monorepo standards" for context.
+// in mixed contexts — under a tenant for tenant-scoped reports, and (prospectively)
+// under super-admin bypass for compliance review. Cross-tenant audit queries should
+// be wrapped in `withSuperAdminBypass()` from `@happyvertical/smrt-tenancy` at the
+// call site; this package has no such call sites today, so the pattern is
+// prescriptive guidance for compliance tooling rather than current practice. See
+// `packages/secrets/CLAUDE.md` "Known exceptions to monorepo standards" for context.
 @smrt({
   tenantScoped: true,
   api: { include: [] }, // No API exposure

--- a/packages/secrets/src/models/SecretAuditLog.ts
+++ b/packages/secrets/src/models/SecretAuditLog.ts
@@ -60,6 +60,14 @@ export type SecretAuditResult = 'success' | 'failure' | 'denied';
  * });
  * ```
  */
+// Intentional exception to standards.md §7 (`@TenantScoped({ mode: 'optional' })`):
+// `SecretAuditLog` uses the inline `tenantScoped: true` form on `@smrt()` rather than
+// the dedicated `@TenantScoped` decorator. Audit-trail queries are read-mostly and run
+// in mixed contexts — under a tenant for tenant-scoped reports, and under super-admin
+// bypass for compliance review. Pairing the boolean form with explicit
+// `withSuperAdminBypass()` at the call site keeps the cross-tenant audit query
+// behavior surprise-free. See `packages/secrets/CLAUDE.md` "Known exceptions to
+// monorepo standards" for context.
 @smrt({
   tenantScoped: true,
   api: { include: [] }, // No API exposure

--- a/packages/secrets/src/models/TenantKey.ts
+++ b/packages/secrets/src/models/TenantKey.ts
@@ -40,6 +40,14 @@ export type TenantKeyStatus = 'active' | 'rotating' | 'retired' | 'compromised';
  * });
  * ```
  */
+// Intentional exception to standards.md §7 (`@TenantScoped({ mode: 'optional' })`):
+// `TenantKey` is deliberately NOT tenant-scoped — neither via the decorator nor via
+// `tenantScoped: true` on `@smrt()`. The row carries a `tenantId` column because each
+// TDEK belongs to a tenant, but the model itself must remain queryable across tenants
+// (e.g. cross-tenant key-rotation tooling, AMK rewrap jobs, super-admin auditing).
+// Adding the tenancy interceptor here would silently filter out keys the rotation
+// service needs to inspect. See `packages/secrets/CLAUDE.md` "Known exceptions to
+// monorepo standards" for the full rationale.
 @smrt({
   // NOT tenant-scoped - this model tracks keys FOR tenants
   api: { include: [] }, // No API exposure

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1499,6 +1499,9 @@ importers:
       '@happyvertical/smrt-projects':
         specifier: workspace:*
         version: link:../projects
+      '@happyvertical/smrt-prompts':
+        specifier: workspace:*
+        version: link:../prompts
       '@happyvertical/smrt-tenancy':
         specifier: workspace:*
         version: link:../tenancy


### PR DESCRIPTION
## Summary

Third Phase 2 category PR — Domain layer alignment. Closes [#1210](https://github.com/happyvertical/smrt/issues/1210).

11 packages in this category; 2 had substantive Phase 2 work, 9 needed no deltas (CLAUDE.md verified accurate against current code).

## Per-package work

### `properties` — substantive (`feat/domain-properties-alignment`, `a0f7cada`)

- New `src/prompts.ts` registering `smrtProperties.property.summarize` via `definePrompt`
- `Property.summarize()` refactored from inline `this.do(...)` to `resolvePrompt() + ai.message()` — mirrors the profiles pattern from PR #1209 (no `as any` cast, persistence-alias fallback, direct `ai.message()` call)
- **PII audit**: `ownerId`, `repositoryId`, `tenantId`, `metadata`, `url` deliberately excluded from the prompt. Variables passed: `propertyName`, `propertyDomain`, `propertyDescription`, `propertyStatus`, `totalZones`, `topLevelZones`
- 5 vitest cases including sentinel-string assertions for the excluded fields
- `@happyvertical/smrt-prompts` added to deps
- CLAUDE.md: added Property Key Methods + Prompt Registry sections

### `secrets` — small (`feat/domain-secrets-alignment`, `7a708df8`)

Pure documentation. The package's three models (`Secret`, `TenantKey`, `SecretAuditLog`) deliberately do not use the `@TenantScoped` decorator and have specific reasons for that, which were undocumented before this PR.

- Inline `@smrt(...)` block comments on each model explaining the tenancy decision
- New "Known exceptions to monorepo standards" section in CLAUDE.md (mirrors the pattern landed for tenancy in PR #1207)
- `Secret` and `SecretAuditLog`: use `tenantScoped: true` inline form to avoid depending on the tenancy package at the model layer; `SecretService` performs manual scoping via `context = tenantId`
- `TenantKey`: deliberately NOT tenant-scoped at all so cross-tenant key-rotation, AMK rewrap, and super-admin audit flows work without interceptor filtering

### `events`, `places`, `facts`, `sites`, `tags`, `social`, `prompts`, `features`, `languages` — no Phase 2 deltas

CLAUDE.md verified accurate. No code changes.

`facts` is already a reference impl for `smrt-prompts` adoption. `social`'s OAuth-token encryption migration to `smrt-secrets` is a real refactor with at-rest data implications — deferred to dedicated PR.

## Commits

```
786c0c3f  Merge branch 'feat/domain-secrets-alignment'
205be4dc  Merge branch 'feat/domain-properties-alignment'
7a708df8  chore(secrets): Phase 2 alignment — document tenancy decorator exception
a0f7cada  chore(properties): Phase 2 alignment — adopt smrt-prompts for summarize
```

**Do not squash on merge** — per-package commits preserve bisect-friendly history.

## Out of scope (deferred)

- `places`: rate-limited geocode → smrt-jobs migration; #1152 stale dist
- `social`: plaintext OAuth tokens → SecretService envelope encryption; `social.post.publish` job
- #1112 tenancy/secrets duplicate runtime instances

## Reviews

Codex + Claude integrated reviews running on the merged release branch — findings will be addressed in follow-up commits as needed.

## Next phases

- ✅ Foundation (#1207)
- ✅ Agents & Runtime (#1209)
- ✅ **Domain** ← this PR
- ⏳ Content & Media
- ⏳ Business
- ⏳ Tooling/Templates