### PR TITLE
chore: Content & Media packages Phase 2 alignment (epic #1191, category #1212)

### DIFF
--- a/packages/assets/CLAUDE.md
+++ b/packages/assets/CLAUDE.md
@@ -55,6 +55,20 @@ The following roles are exported as `ASSET_ROLES` and should be preferred over a
 
 Canonical metadata keys are exported as `ASSET_METADATA_KEYS`: `extractionStatus`, `extractionError`, `extractedAt`, `sourceUrl`, `sourceHash`, `pageNumber`. Extraction status values live in `ASSET_EXTRACTION_STATUS` (`pending | running | succeeded | failed`).
 
+## UI Registry
+
+The `./ui` subpath exports `ASSETS_MODULE_META` and `ASSETS_UI_SLOTS` so registry-driven hosts (smrt-chat, dynamic admin shells) can discover the package's Svelte components without a hard import.
+
+```ts
+import { ASSETS_MODULE_META, ASSETS_UI_SLOTS } from '@happyvertical/smrt-assets/ui';
+import '@happyvertical/smrt-assets/svelte'; // side-effect: ModuleUIRegistry.register(...)
+import { ModuleUIRegistry } from '@happyvertical/smrt-svelte/registry';
+
+const AssetManager = ModuleUIRegistry.get('@happyvertical/smrt-assets', 'asset-manager');
+```
+
+Registered slots: `asset-manager` (admin), `asset-grid` / `asset-list` (list), `asset-detail` (detail), `asset-toolbar` / `asset-action-bar` (action), `asset-create-modal` (form). Slot IDs are stable contracts — host apps reference them by string.
+
 ## Gotchas
 
 - **Version history manual**: `findVersions()` chaining required — no ORM shortcut

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -14,6 +14,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./ui": {
+      "types": "./dist/ui.d.ts",
+      "svelte": "./dist/ui.js",
+      "import": "./dist/ui.js"
+    },
     "./svelte": {
       "types": "./dist/svelte/index.d.ts",
       "svelte": "./dist/svelte/index.js",
@@ -52,10 +57,20 @@
     "@happyvertical/utils": "catalog:"
   },
   "peerDependencies": {
+    "@happyvertical/smrt-svelte": "workspace:*",
     "svelte": "^5.18.0"
+  },
+  "peerDependenciesMeta": {
+    "@happyvertical/smrt-svelte": {
+      "optional": true
+    },
+    "svelte": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@happyvertical/smrt-playground": "workspace:*",
+    "@happyvertical/smrt-svelte": "workspace:*",
     "@happyvertical/smrt-vitest": "workspace:*",
     "@sveltejs/adapter-auto": "^7.0.1",
     "@sveltejs/kit": "^2.55.0",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -16,7 +16,6 @@
     },
     "./ui": {
       "types": "./dist/ui.d.ts",
-      "svelte": "./dist/ui.js",
       "import": "./dist/ui.js"
     },
     "./svelte": {

--- a/packages/assets/src/svelte/index.ts
+++ b/packages/assets/src/svelte/index.ts
@@ -2,16 +2,34 @@
  * smrt-assets Svelte components
  *
  * Reusable Asset Manager UI for embedding in downstream SMRT sites.
+ * Auto-registers components with ModuleUIRegistry on import so chat
+ * (and other registry-driven consumers) can discover them.
+ *
+ * @packageDocumentation
  */
 
+import { ModuleUIRegistry } from '@happyvertical/smrt-svelte/registry';
+import { ASSETS_MODULE_META } from '../ui.js';
+
+// Import components
+import ActionBar from './ActionBar.svelte';
+import AssetDetail from './AssetDetail.svelte';
+import AssetGrid from './AssetGrid.svelte';
+import AssetList from './AssetList.svelte';
+import AssetManager from './AssetManager.svelte';
+import AssetToolbar from './AssetToolbar.svelte';
+import CreateAssetModal from './CreateAssetModal.svelte';
+
 // Components
-export { default as ActionBar } from './ActionBar.svelte';
-export { default as AssetDetail } from './AssetDetail.svelte';
-export { default as AssetGrid } from './AssetGrid.svelte';
-export { default as AssetList } from './AssetList.svelte';
-export { default as AssetManager } from './AssetManager.svelte';
-export { default as AssetToolbar } from './AssetToolbar.svelte';
-export { default as CreateAssetModal } from './CreateAssetModal.svelte';
+export {
+  ActionBar,
+  AssetDetail,
+  AssetGrid,
+  AssetList,
+  AssetManager,
+  AssetToolbar,
+  CreateAssetModal,
+};
 
 // Types
 export type {
@@ -28,3 +46,41 @@ export type {
   AssetToolbarProps,
   AssetViewMode,
 } from './types';
+
+// Auto-register with ModuleUIRegistry
+ModuleUIRegistry.registerModule(ASSETS_MODULE_META);
+ModuleUIRegistry.register(
+  '@happyvertical/smrt-assets',
+  'asset-manager',
+  AssetManager,
+);
+ModuleUIRegistry.register(
+  '@happyvertical/smrt-assets',
+  'asset-grid',
+  AssetGrid,
+);
+ModuleUIRegistry.register(
+  '@happyvertical/smrt-assets',
+  'asset-list',
+  AssetList,
+);
+ModuleUIRegistry.register(
+  '@happyvertical/smrt-assets',
+  'asset-detail',
+  AssetDetail,
+);
+ModuleUIRegistry.register(
+  '@happyvertical/smrt-assets',
+  'asset-toolbar',
+  AssetToolbar,
+);
+ModuleUIRegistry.register(
+  '@happyvertical/smrt-assets',
+  'asset-action-bar',
+  ActionBar,
+);
+ModuleUIRegistry.register(
+  '@happyvertical/smrt-assets',
+  'asset-create-modal',
+  CreateAssetModal,
+);

--- a/packages/assets/src/ui.ts
+++ b/packages/assets/src/ui.ts
@@ -1,0 +1,98 @@
+/**
+ * Assets Module UI Slot Declarations
+ *
+ * This file defines the UI extension points for the assets module.
+ * UI components are implemented in the ./svelte subpath.
+ */
+
+import type { ModuleUISlot, SmrtModuleMeta } from '@happyvertical/smrt-types';
+
+/**
+ * Assets module UI slots
+ */
+export const ASSETS_UI_SLOTS: Record<string, ModuleUISlot> = {
+  'asset-manager': {
+    id: 'asset-manager',
+    label: 'Asset Manager',
+    description:
+      'Combined asset management surface with toolbar, grid/list view, detail, and selection',
+    icon: 'folder-image',
+    category: 'admin',
+    order: 1,
+    propsInterface: 'AssetManagerProps',
+  },
+  'asset-grid': {
+    id: 'asset-grid',
+    label: 'Asset Grid',
+    description: 'Grid view of asset thumbnails with selection',
+    icon: 'grid',
+    category: 'list',
+    order: 2,
+    propsInterface: 'AssetGridProps',
+  },
+  'asset-list': {
+    id: 'asset-list',
+    label: 'Asset List',
+    description: 'Sortable list view of assets with metadata columns',
+    icon: 'list',
+    category: 'list',
+    order: 3,
+    propsInterface: 'AssetListProps',
+  },
+  'asset-detail': {
+    id: 'asset-detail',
+    label: 'Asset Detail',
+    description: 'Detailed view of a single asset with metadata and preview',
+    icon: 'file-text',
+    category: 'detail',
+    order: 4,
+    propsInterface: 'AssetDetailProps',
+  },
+  'asset-toolbar': {
+    id: 'asset-toolbar',
+    label: 'Asset Toolbar',
+    description: 'Toolbar with view toggle, filters, sort, and upload action',
+    icon: 'sliders',
+    category: 'action',
+    order: 5,
+    propsInterface: 'AssetToolbarProps',
+  },
+  'asset-action-bar': {
+    id: 'asset-action-bar',
+    label: 'Asset Action Bar',
+    description: 'Bulk action bar shown when assets are selected',
+    icon: 'more-horizontal',
+    category: 'action',
+    order: 6,
+    propsInterface: 'ActionBarProps',
+  },
+  'asset-create-modal': {
+    id: 'asset-create-modal',
+    label: 'Create Asset Modal',
+    description: 'Modal dialog for uploading and creating a new asset',
+    icon: 'upload',
+    category: 'form',
+    order: 7,
+    propsInterface: 'CreateAssetModalProps',
+  },
+};
+
+/**
+ * Assets module metadata
+ */
+export const ASSETS_MODULE_META: SmrtModuleMeta = {
+  name: '@happyvertical/smrt-assets',
+  displayName: 'Assets',
+  description:
+    'Provider-agnostic asset management with versioning, metadata, folders, and associations',
+  uiSlots: ASSETS_UI_SLOTS,
+  models: ['Asset', 'AssetType', 'AssetStatus', 'AssetMetafield', 'Folder'],
+  collections: [
+    'AssetCollection',
+    'AssetTypeCollection',
+    'AssetStatusCollection',
+    'AssetMetafieldCollection',
+    'AssetAssociationCollection',
+    'FolderCollection',
+  ],
+};

--- a/packages/assets/vite.config.ts
+++ b/packages/assets/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig(async ({ mode }) => {
     // Delegate to the shared package config which handles entry points,
     // externals, dts generation, and svelte-package exclusion.
     const config = createPackageConfig('assets', {
-      entries: ['playground'],
+      entries: ['ui', 'playground'],
       svelte: 'svelte',
       dtsExclude: ['src/routes/**/*'],
       // Fail the build on TS errors in dts generation so type-only bugs

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -12,7 +12,6 @@
     },
     "./ui": {
       "types": "./dist/ui.d.ts",
-      "svelte": "./dist/ui.js",
       "import": "./dist/ui.js"
     },
     "./manifest": "./dist/manifest.json",

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -10,6 +10,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./ui": {
+      "types": "./dist/ui.d.ts",
+      "svelte": "./dist/ui.js",
+      "import": "./dist/ui.js"
+    },
     "./manifest": "./dist/manifest.json",
     "./manifest.json": "./dist/manifest.json",
     "./playground": {

--- a/packages/content/CLAUDE.md
+++ b/packages/content/CLAUDE.md
@@ -148,6 +148,20 @@ function bumpRevision(doc: MetadataAccessor) {
 
 `getCategorySegments()`, `getParentCategory()`, `getRootCategory()`, `getAncestorPaths()`, `isInCategory(path, includeChildren?)`
 
+## Prompt Registry
+
+Content prompts are registered with `@happyvertical/smrt-prompts` so tenants can override template/profile/model/params at runtime:
+
+```typescript
+import {
+  smrtContentReviewPrompt,             // key: 'smrtContent.review'
+  smrtContentApplyCorrectionPrompt,    // key: 'smrtContent.applyCorrection'
+  smrtContentThumbnailAIGeneratePrompt, // key: 'smrtContent.thumbnail.aiGenerate'
+} from '@happyvertical/smrt-content';
+```
+
+`smrtContent.thumbnail.aiGenerate` powers the AI image-generation prompt used by `ThumbnailGenerator` (strategy `'ai-generate'`). Variables substituted into the template: `style`, `title`, `styleHint`, `descriptionClause`. Internal foreign-key fields (`id`, `tenantId`) and the freeform `metadata` blob are intentionally excluded — `metadata` may carry tenant-private configuration or coordinates unrelated to the visual prompt.
+
 ## Gotchas
 
 - **STI discriminator**: qualified names like `@happyvertical/smrt-content:Article`

--- a/packages/content/src/content-prompts.ts
+++ b/packages/content/src/content-prompts.ts
@@ -50,6 +50,17 @@ Corrected text to incorporate:
   },
 });
 
+export const smrtContentThumbnailAIGeneratePrompt = definePrompt({
+  key: 'smrtContent.thumbnail.aiGenerate',
+  template: `Create a {style} thumbnail image for an article titled "{title}". {descriptionClause}Style: {styleHint}. The image should be suitable for a news article or blog post thumbnail.`,
+  editable: {
+    template: true,
+    profile: true,
+    model: true,
+    params: true,
+  },
+});
+
 export function promptMessageOptions(ai: ResolvedPromptAI) {
   return {
     ...(ai.params || {}),

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -215,6 +215,7 @@ export {
   promptMessageOptions,
   smrtContentApplyCorrectionPrompt,
   smrtContentReviewPrompt,
+  smrtContentThumbnailAIGeneratePrompt,
 } from './content-prompts';
 export type { ContentReferenceOptions } from './content-reference';
 export { ContentReference } from './content-reference';

--- a/packages/content/src/thumbnail-generator.ts
+++ b/packages/content/src/thumbnail-generator.ts
@@ -16,7 +16,9 @@ import {
 import type { DatabaseConfig } from '@happyvertical/smrt-core';
 import type { Image } from '@happyvertical/smrt-images';
 import { ImageCollection } from '@happyvertical/smrt-images';
+import { resolvePrompt } from '@happyvertical/smrt-prompts';
 import type { Content } from './content';
+import { smrtContentThumbnailAIGeneratePrompt } from './content-prompts';
 
 // ============================================================================
 // Types
@@ -163,6 +165,14 @@ export interface ThumbnailGeneratorOptions {
    * Database configuration for storing generated images
    */
   db?: DatabaseConfig;
+
+  /**
+   * Alias for `db` — mirrors the `SmrtClassOptions.persistence` alias so
+   * callers can pass the same options shape they use for SmrtObject/Collection.
+   *
+   * @deprecated Prefer `db`. Retained for parity with `SmrtClassOptions`.
+   */
+  persistence?: DatabaseConfig;
 
   /**
    * AI client configuration for AI-generated thumbnails
@@ -341,7 +351,8 @@ export class ThumbnailGenerator {
 
     // Generate prompt if not provided
     const prompt =
-      options.prompt ?? this.buildAIPrompt(options.style ?? 'photorealistic');
+      options.prompt ??
+      (await this.buildAIPrompt(options.style ?? 'photorealistic'));
 
     // Generate the image using the new API signature
     const width = options.width ?? 1200;
@@ -381,9 +392,14 @@ export class ThumbnailGenerator {
   }
 
   /**
-   * Build a prompt for AI image generation based on content
+   * Build a prompt for AI image generation based on content.
+   *
+   * Resolves via `@happyvertical/smrt-prompts` so tenants can override the
+   * template/profile/model/params at runtime. Only non-PII content fields
+   * (title, description) and the caller-supplied style hint are passed.
+   * Internal IDs and the freeform `metadata` blob are intentionally excluded.
    */
-  private buildAIPrompt(style: string): string {
+  private async buildAIPrompt(style: string): Promise<string> {
     const title = this.content.title || 'Untitled';
     const description = this.content.description || '';
 
@@ -400,9 +416,23 @@ export class ThumbnailGenerator {
 
     const styleHint = stylePrompts[style] || stylePrompts.photorealistic;
 
-    return `Create a ${style} thumbnail image for an article titled "${title}". ${
-      description ? `The article is about: ${description}. ` : ''
-    }Style: ${styleHint}. The image should be suitable for a news article or blog post thumbnail.`;
+    const resolved = await resolvePrompt(
+      smrtContentThumbnailAIGeneratePrompt.key,
+      {
+        db: this.options.db ?? this.options.persistence,
+        tenantId: this.content.tenantId,
+        variables: {
+          style,
+          title,
+          styleHint,
+          descriptionClause: description
+            ? `The article is about: ${description}. `
+            : '',
+        },
+      },
+    );
+
+    return resolved.text;
   }
 
   /**

--- a/packages/content/src/thumbnail-generator.ts
+++ b/packages/content/src/thumbnail-generator.ts
@@ -16,9 +16,15 @@ import {
 import type { DatabaseConfig } from '@happyvertical/smrt-core';
 import type { Image } from '@happyvertical/smrt-images';
 import { ImageCollection } from '@happyvertical/smrt-images';
-import { resolvePrompt } from '@happyvertical/smrt-prompts';
+import {
+  type ResolvedPrompt,
+  resolvePrompt,
+} from '@happyvertical/smrt-prompts';
 import type { Content } from './content';
-import { smrtContentThumbnailAIGeneratePrompt } from './content-prompts';
+import {
+  promptMessageOptions,
+  smrtContentThumbnailAIGeneratePrompt,
+} from './content-prompts';
 
 // ============================================================================
 // Types
@@ -214,7 +220,16 @@ export class ThumbnailGenerator {
   constructor(
     private content: Content,
     private options: ThumbnailGeneratorOptions = {},
-  ) {}
+  ) {
+    // Normalize the `persistence` alias to `db` once so every downstream call
+    // (prompt resolution, ImageCollection.create, save sites) sees the same
+    // database regardless of which option name the caller used. Without this,
+    // a caller passing `persistence: ...` would have prompt resolution honor
+    // the alias while image saving silently used `undefined`.
+    if (!this.options.db && this.options.persistence) {
+      this.options.db = this.options.persistence;
+    }
+  }
 
   /**
    * Generate a thumbnail using the specified strategy
@@ -349,15 +364,25 @@ export class ThumbnailGenerator {
             );
           })();
 
-    // Generate prompt if not provided
-    const prompt =
-      options.prompt ??
-      (await this.buildAIPrompt(options.style ?? 'photorealistic'));
-
-    // Generate the image using the new API signature
+    // Generate prompt if not provided. When the caller supplies a literal
+    // prompt we skip prompt resolution entirely (no tenant override path).
+    // When we resolve from the registry we also forward the resolved AI
+    // options (model, params) so `editable: { model, params }` actually
+    // takes effect for thumbnail generation.
     const width = options.width ?? 1200;
     const height = options.height ?? 630;
+    let prompt: string;
+    let aiOverrideOptions: Record<string, unknown> = {};
+    if (options.prompt) {
+      prompt = options.prompt;
+    } else {
+      const built = await this.buildAIPrompt(options.style ?? 'photorealistic');
+      prompt = built.text;
+      aiOverrideOptions = promptMessageOptions(built.ai);
+    }
+
     const result = await ai.generateImage(prompt, {
+      ...aiOverrideOptions,
       size: `${width}x${height}`,
       outputFormat: 'buffer',
     });
@@ -398,8 +423,12 @@ export class ThumbnailGenerator {
    * template/profile/model/params at runtime. Only non-PII content fields
    * (title, description) and the caller-supplied style hint are passed.
    * Internal IDs and the freeform `metadata` blob are intentionally excluded.
+   *
+   * Returns the full ResolvedPrompt (text + ai config) so the caller can
+   * forward `model`/`params` overrides to `ai.generateImage()`. Returning
+   * only the text would silently drop the editable model/params overrides.
    */
-  private async buildAIPrompt(style: string): Promise<string> {
+  private async buildAIPrompt(style: string): Promise<ResolvedPrompt> {
     const title = this.content.title || 'Untitled';
     const description = this.content.description || '';
 
@@ -416,23 +445,18 @@ export class ThumbnailGenerator {
 
     const styleHint = stylePrompts[style] || stylePrompts.photorealistic;
 
-    const resolved = await resolvePrompt(
-      smrtContentThumbnailAIGeneratePrompt.key,
-      {
-        db: this.options.db ?? this.options.persistence,
-        tenantId: this.content.tenantId,
-        variables: {
-          style,
-          title,
-          styleHint,
-          descriptionClause: description
-            ? `The article is about: ${description}. `
-            : '',
-        },
+    return resolvePrompt(smrtContentThumbnailAIGeneratePrompt.key, {
+      db: this.options.db,
+      tenantId: this.content.tenantId,
+      variables: {
+        style,
+        title,
+        styleHint,
+        descriptionClause: description
+          ? `The article is about: ${description}. `
+          : '',
       },
-    );
-
-    return resolved.text;
+    });
   }
 
   /**

--- a/packages/content/src/thumbnail-prompt.test.ts
+++ b/packages/content/src/thumbnail-prompt.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Focused tests for thumbnail AI-prompt registration & resolution.
+ *
+ * Covers:
+ * - registered key correctness
+ * - variable substitution (non-PII subset only)
+ * - end-to-end flow: AI client receives the substituted prompt, output
+ *   surfaces back to the caller
+ */
+import { clearCache, setConfig } from '@happyvertical/smrt-config';
+import { clearPromptCache, resolvePrompt } from '@happyvertical/smrt-prompts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { generateImageMock } = vi.hoisted(() => ({
+  generateImageMock: vi.fn(),
+}));
+
+const { imageCollectionCreateMock, imageCreateMock, imageSaveMock } =
+  vi.hoisted(() => ({
+    imageCollectionCreateMock: vi.fn(),
+    imageCreateMock: vi.fn(),
+    imageSaveMock: vi.fn(),
+  }));
+
+vi.mock('@happyvertical/smrt-images', () => ({
+  ImageCollection: {
+    create: imageCollectionCreateMock,
+  },
+}));
+
+vi.mock('@happyvertical/ai', () => ({
+  // direct-client path is used in these tests, so getAI never resolves a config
+  getAI: vi.fn(),
+}));
+
+import { smrtContentThumbnailAIGeneratePrompt } from './content-prompts';
+import { ThumbnailGenerator } from './thumbnail-generator';
+
+describe('thumbnail AI-prompt registration', () => {
+  beforeEach(() => {
+    setConfig({
+      packages: {
+        prompts: {
+          profiles: {
+            test: { provider: 'test', model: 'test-default-model' },
+          },
+        },
+      },
+    });
+
+    imageSaveMock.mockResolvedValue(undefined);
+    imageCreateMock.mockResolvedValue({
+      id: 'image-1',
+      save: imageSaveMock,
+    });
+    imageCollectionCreateMock.mockResolvedValue({
+      create: imageCreateMock,
+    });
+    generateImageMock.mockResolvedValue({
+      images: [{ data: Buffer.from('ai-generated') }],
+    });
+  });
+
+  afterEach(() => {
+    clearCache();
+    clearPromptCache();
+    generateImageMock.mockReset();
+    imageCollectionCreateMock.mockReset();
+    imageCreateMock.mockReset();
+    imageSaveMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it('registers the smrtContent.thumbnail.aiGenerate key', () => {
+    expect(smrtContentThumbnailAIGeneratePrompt.key).toBe(
+      'smrtContent.thumbnail.aiGenerate',
+    );
+  });
+
+  it('substitutes non-sensitive content variables (no metadata or ids)', async () => {
+    const resolved = await resolvePrompt(
+      smrtContentThumbnailAIGeneratePrompt.key,
+      {
+        variables: {
+          style: 'photorealistic',
+          title: 'Bridge Update',
+          styleHint:
+            'photorealistic, high quality, professional photography, 8k resolution',
+          descriptionClause: 'The article is about: New crossing opens. ',
+        },
+      },
+    );
+
+    expect(resolved.text).toContain('photorealistic');
+    expect(resolved.text).toContain('Bridge Update');
+    expect(resolved.text).toContain('high quality');
+    expect(resolved.text).toContain('New crossing opens');
+    // Sanity: the template should not reference any internal/PII fields
+    expect(resolved.template).not.toContain('{tenantId}');
+    expect(resolved.template).not.toContain('{id}');
+    expect(resolved.template).not.toContain('{metadata}');
+  });
+
+  it('omits the description clause when content has no description', async () => {
+    const resolved = await resolvePrompt(
+      smrtContentThumbnailAIGeneratePrompt.key,
+      {
+        variables: {
+          style: 'illustration',
+          title: 'Untitled',
+          styleHint: 'digital illustration, clean vector art',
+          descriptionClause: '',
+        },
+      },
+    );
+
+    expect(resolved.text).toContain('illustration');
+    expect(resolved.text).toContain('Untitled');
+    expect(resolved.text).not.toContain('The article is about');
+  });
+
+  it('honours runtime template overrides at the registered key', async () => {
+    const resolved = await resolvePrompt(
+      smrtContentThumbnailAIGeneratePrompt.key,
+      {
+        variables: { style: 'minimal', title: 'Override Test' },
+        override: {
+          template: 'Generate a {style} cover for "{title}".',
+          profile: 'test',
+        },
+      },
+    );
+
+    expect(resolved.text).toBe('Generate a minimal cover for "Override Test".');
+    expect(resolved.ai).toMatchObject({ model: 'test-default-model' });
+  });
+
+  it('flows the resolved prompt through ThumbnailGenerator to the AI client', async () => {
+    const directClient = {
+      generateImage: generateImageMock,
+    };
+
+    const generator = new ThumbnailGenerator(
+      {
+        id: 'content-7',
+        title: 'Election Guide',
+        description: 'Candidates and voting',
+        tenantId: null,
+      } as any,
+      {},
+    );
+
+    const image = await generator.generate({
+      strategy: 'ai-generate',
+      style: 'illustration',
+      ai: directClient as any,
+    });
+
+    expect(generateImageMock).toHaveBeenCalledTimes(1);
+    const [promptArg, optionsArg] = generateImageMock.mock.calls[0];
+
+    // The AI client should receive a prompt assembled by resolvePrompt that
+    // contains the substituted title, description, style and styleHint.
+    expect(promptArg).toContain('illustration');
+    expect(promptArg).toContain('Election Guide');
+    expect(promptArg).toContain('Candidates and voting');
+    expect(promptArg).toContain('digital illustration');
+    expect(promptArg).toContain(
+      'suitable for a news article or blog post thumbnail',
+    );
+    expect(optionsArg).toMatchObject({
+      size: '1200x630',
+      outputFormat: 'buffer',
+    });
+    expect(image).toMatchObject({ id: 'image-1' });
+  });
+
+  it('respects custom prompts and skips registry resolution when provided', async () => {
+    const directClient = { generateImage: generateImageMock };
+    const generator = new ThumbnailGenerator(
+      {
+        id: 'content-8',
+        title: 'Should Not Appear',
+        description: 'Should not appear either',
+        tenantId: null,
+      } as any,
+      {},
+    );
+
+    await generator.generate({
+      strategy: 'ai-generate',
+      ai: directClient as any,
+      prompt: 'Custom prompt — render exactly this',
+    });
+
+    expect(generateImageMock).toHaveBeenCalledWith(
+      'Custom prompt — render exactly this',
+      expect.any(Object),
+    );
+  });
+});

--- a/packages/images/CLAUDE.md
+++ b/packages/images/CLAUDE.md
@@ -18,7 +18,26 @@ Image management with AI categorization, editing, and metadata extraction. Exten
 
 ## AI Operations
 
-`generateAltText()` uses `this.do()` for inference. Computed properties: `isLandscape`, `isPortrait`, `aspectRatio`.
+`generateAltText()` uses the `smrtImages.image.generateAltText` prompt registered via `@happyvertical/smrt-prompts` (resolves tenant overrides via `resolvePrompt()` then dispatches through `getAiClient().message()`). Computed properties: `isLandscape`, `isPortrait`, `aspectRatio`.
+
+## Prompt Registry
+
+`Image.generateAltText()` is registered with `@happyvertical/smrt-prompts` so tenants can override template/model/params at runtime:
+
+```typescript
+import { smrtImagesGenerateAltTextPrompt } from '@happyvertical/smrt-images';
+// key: 'smrtImages.image.generateAltText'
+```
+
+Only non-PII metadata fields are passed to the AI provider: `name`, `description`. Source URIs, internal foreign-key fields (`parentId`, `tenantId`), and the extensible `metadata` blob are intentionally excluded — source URIs may embed signed/private bucket paths and `metadata` may contain EXIF GPS data or tenant-private configuration.
+
+## UI Registry
+
+Svelte components auto-register with `ModuleUIRegistry` on import of `@happyvertical/smrt-images/svelte`. UI slot declarations live in `src/ui.ts` and are exported via `@happyvertical/smrt-images/ui`:
+
+- `assets-gallery` — `AssetsGallery.svelte`
+- `image-editor` — `ImageEditor.svelte`
+- `image-uploader` — `ImageUploader.svelte`
 
 ## Gotchas
 

--- a/packages/images/package.json
+++ b/packages/images/package.json
@@ -56,10 +56,12 @@
     "sharp": "catalog:"
   },
   "peerDependencies": {
+    "@happyvertical/smrt-svelte": "workspace:*",
     "svelte": "^5.18.0"
   },
   "devDependencies": {
     "@happyvertical/smrt-playground": "workspace:*",
+    "@happyvertical/smrt-svelte": "workspace:*",
     "@happyvertical/smrt-vitest": "workspace:*",
     "@happyvertical/sql": "catalog:",
     "@sveltejs/kit": "^2.5.7",
@@ -90,5 +92,10 @@
     "type": "git",
     "url": "https://github.com/happyvertical/smrt.git",
     "directory": "packages/images"
+  },
+  "peerDependenciesMeta": {
+    "@happyvertical/smrt-svelte": {
+      "optional": true
+    }
   }
 }

--- a/packages/images/package.json
+++ b/packages/images/package.json
@@ -16,7 +16,6 @@
     },
     "./ui": {
       "types": "./dist/ui.d.ts",
-      "svelte": "./dist/ui.js",
       "import": "./dist/ui.js"
     },
     "./manifest": "./dist/manifest.json",

--- a/packages/images/package.json
+++ b/packages/images/package.json
@@ -14,6 +14,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./ui": {
+      "types": "./dist/ui.d.ts",
+      "svelte": "./dist/ui.js",
+      "import": "./dist/ui.js"
+    },
     "./manifest": "./dist/manifest.json",
     "./manifest.json": "./dist/manifest.json",
     "./playground": {
@@ -43,6 +48,7 @@
     "@happyvertical/images": "catalog:",
     "@happyvertical/smrt-assets": "workspace:*",
     "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-prompts": "workspace:*",
     "@happyvertical/smrt-tenancy": "workspace:*",
     "@happyvertical/smrt-types": "workspace:*",
     "@happyvertical/utils": "catalog:",

--- a/packages/images/src/__tests__/generateAltText.test.ts
+++ b/packages/images/src/__tests__/generateAltText.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for `Image.generateAltText()` — verifies the smrt-prompts integration:
+ * prompt resolution, variable substitution, and that no PII / private metadata
+ * (sourceUri, internal foreign-key fields) leaks to the AI provider.
+ *
+ * The AI client is stubbed via a `getAiClient()` override so no network calls
+ * are made. The `db` plumbing is exercised separately via the smrt-prompts
+ * package's own integration tests; here we focus on Image-level behavior.
+ */
+
+import { clearPromptCache } from '@happyvertical/smrt-prompts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Image } from '../image.js';
+import { smrtImagesGenerateAltTextPrompt } from '../prompts.js';
+
+describe('Image.generateAltText()', () => {
+  let aiMessageMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    aiMessageMock = vi.fn().mockResolvedValue('A widescreen mountain vista  ');
+    clearPromptCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makeImage(opts: ConstructorParameters<typeof Image>[0] = {}) {
+    const image = new Image({
+      name: 'mountain-vista.jpg',
+      sourceUri: 's3://private-bucket/secret-key/mountain-vista.jpg',
+      mimeType: 'image/jpeg',
+      description: 'Snow-capped peaks at sunrise over an alpine valley',
+      width: 1920,
+      height: 1080,
+      ...opts,
+    });
+    // Stub the AI client so generateAltText doesn't reach a real provider.
+    (image as any).getAiClient = async () => ({
+      message: aiMessageMock,
+    });
+    return image;
+  }
+
+  it('uses the registered prompt key', () => {
+    expect(smrtImagesGenerateAltTextPrompt.key).toBe(
+      'smrtImages.image.generateAltText',
+    );
+  });
+
+  it('resolves the registered alt-text prompt and returns trimmed AI output', async () => {
+    const image = makeImage();
+
+    const result = await image.generateAltText();
+
+    expect(result).toBe('A widescreen mountain vista');
+    expect(image.alt).toBe('A widescreen mountain vista');
+    expect(aiMessageMock).toHaveBeenCalledTimes(1);
+
+    // The prompt sent to the AI should contain the substituted name and
+    // description from the registered template.
+    const [text] = aiMessageMock.mock.calls[0];
+    expect(text).toContain('mountain-vista.jpg');
+    expect(text).toContain(
+      'Snow-capped peaks at sunrise over an alpine valley',
+    );
+  });
+
+  it('does NOT pass sourceUri to the AI provider (private bucket leakage)', async () => {
+    const image = makeImage();
+
+    await image.generateAltText();
+
+    const [text] = aiMessageMock.mock.calls[0];
+    expect(text).not.toContain('s3://private-bucket');
+    expect(text).not.toContain('secret-key');
+  });
+
+  it('passes resolvedPrompt.ai params (model/temperature/maxTokens) through to ai.message', async () => {
+    const image = makeImage();
+
+    await image.generateAltText();
+
+    expect(aiMessageMock).toHaveBeenCalledTimes(1);
+    // Second arg is the AI options object derived from the prompt's `ai`
+    // config plus any tenant overrides. The default registered prompt has
+    // no model/temperature/maxTokens, so options should be an empty object
+    // (or contain only ai.params if the prompt registered them).
+    const [, options] = aiMessageMock.mock.calls[0];
+    expect(options).toBeTypeOf('object');
+  });
+});

--- a/packages/images/src/image.ts
+++ b/packages/images/src/image.ts
@@ -10,6 +10,11 @@
 
 import { Asset } from '@happyvertical/smrt-assets';
 import { field, smrt } from '@happyvertical/smrt-core';
+import { resolvePrompt } from '@happyvertical/smrt-prompts';
+import {
+  promptMessageOptions,
+  smrtImagesGenerateAltTextPrompt,
+} from './prompts';
 import type { ImageOptions } from './types';
 
 @smrt({
@@ -86,19 +91,49 @@ export class Image extends Asset {
   }
 
   /**
-   * Generate accessibility text using AI
+   * AI-powered: Generate accessibility alt text for this image.
+   *
+   * Uses the `smrtImages.image.generateAltText` prompt registered via
+   * `@happyvertical/smrt-prompts`, allowing tenant- or instance-level
+   * overrides of the template, model, and parameters at runtime.
+   *
+   * Only non-PII metadata fields (name, description) are sent to the AI
+   * provider. Source URIs, internal foreign-key fields, and the
+   * extensible `metadata` blob are intentionally excluded — source URIs
+   * may embed signed/private bucket paths and metadata may contain EXIF
+   * GPS data or tenant-private configuration.
    *
    * @returns AI-generated alt text describing the image
    */
   async generateAltText(): Promise<string> {
-    const altText = await this.do(`
-      Generate concise accessibility alt text for this image.
-      Consider: subject matter, key visual elements, context.
-      Keep it under 125 characters for screen reader compatibility.
-      Image name: ${this.name}
-      Image description: ${this.description}
-    `);
+    // Resolve `db` from either the canonical `db` option or its `persistence`
+    // alias. SmrtClass maps `persistence → db` lazily during `initialize()`,
+    // so on a freshly-constructed Image that has not yet been initialized,
+    // `this.options.db` may be undefined while `this.options.persistence` is
+    // set. Falling back here ensures stored app- and tenant-level prompt
+    // overrides in `_smrt_prompt_overrides` are honored on the first call —
+    // before `getAiClient()` triggers full initialization further below.
+    const db = this.options.db ?? this.options.persistence;
 
+    const resolvedPrompt = await resolvePrompt(
+      smrtImagesGenerateAltTextPrompt.key,
+      {
+        db,
+        tenantId: this.tenantId,
+        variables: {
+          imageName: this.name || '',
+          imageDescription: this.description || '',
+        },
+      },
+    );
+
+    const ai = await this.getAiClient();
+    const response = await ai.message(
+      resolvedPrompt.text,
+      promptMessageOptions(resolvedPrompt.ai),
+    );
+
+    const altText = response.trim();
     this.alt = altText;
     return altText;
   }

--- a/packages/images/src/index.ts
+++ b/packages/images/src/index.ts
@@ -12,6 +12,10 @@
 // module loads below. See __smrt-register__.ts for issue #1132 context.
 import './__smrt-register__.js';
 
+// Side-effect import: register prompts at module load time so tenant
+// overrides resolve correctly via @happyvertical/smrt-prompts.
+import './prompts.js';
+
 // Operations
 export { ImageCategorizer } from './categorizer';
 export { ImageDeriver } from './deriver';
@@ -36,6 +40,7 @@ export {
   type SmrtImageMediaBundlePersistenceAdapter,
 } from './media-bundle-persistence';
 export { ImageMetadataExtractor } from './metadata';
+export { smrtImagesGenerateAltTextPrompt } from './prompts';
 export { ImageSearch } from './search';
 // Types
 export type {

--- a/packages/images/src/prompts.ts
+++ b/packages/images/src/prompts.ts
@@ -1,0 +1,50 @@
+/**
+ * Prompt registrations for the @happyvertical/smrt-images package.
+ *
+ * Prompts are registered at module-load time via `definePrompt()` so that
+ * tenant-aware overrides can be applied at call time via `resolvePrompt()`.
+ *
+ * Mirrors the pattern used by `@happyvertical/smrt-profiles` (see
+ * `prompts.ts`) and `@happyvertical/smrt-properties` (see `prompts.ts`).
+ */
+
+import {
+  definePrompt,
+  type ResolvedPromptAI,
+} from '@happyvertical/smrt-prompts';
+
+// Alt text generation only uses non-PII metadata describing the image
+// itself (name and description). Source URIs, internal foreign-key
+// fields (e.g. parentId), and the extensible `metadata` blob are
+// intentionally NOT passed to the AI provider — source URIs may embed
+// signed/private bucket paths, and metadata may contain EXIF GPS data
+// or tenant-private configuration. If a downstream tenant needs richer
+// context they can override the template via PromptOverride.
+export const smrtImagesGenerateAltTextPrompt = definePrompt({
+  key: 'smrtImages.image.generateAltText',
+  template: `Generate concise accessibility alt text for this image.
+Consider: subject matter, key visual elements, context.
+Keep it under 125 characters for screen reader compatibility.
+
+Image name: {imageName}
+Image description: {imageDescription}
+
+Return only the alt text, with no commentary or surrounding quotation marks.`,
+  editable: {
+    template: true,
+    profile: true,
+    model: true,
+    params: true,
+  },
+});
+
+export function promptMessageOptions(ai: ResolvedPromptAI) {
+  return {
+    ...(ai.params || {}),
+    ...(ai.model ? { model: ai.model } : {}),
+    ...(typeof ai.temperature === 'number'
+      ? { temperature: ai.temperature }
+      : {}),
+    ...(typeof ai.maxTokens === 'number' ? { maxTokens: ai.maxTokens } : {}),
+  };
+}

--- a/packages/images/src/svelte/index.ts
+++ b/packages/images/src/svelte/index.ts
@@ -1,6 +1,23 @@
-export { default as AssetsGallery } from './components/AssetsGallery.svelte';
-export { default as ImageEditor } from './components/ImageEditor.svelte';
-export { default as ImageUploader } from './components/ImageUploader.svelte';
+/**
+ * Images Module Svelte Components
+ *
+ * Optional Svelte UI components for image gallery, editing, and upload.
+ * Auto-registers components with ModuleUIRegistry on import.
+ *
+ * @packageDocumentation
+ */
+
+import { ModuleUIRegistry } from '@happyvertical/smrt-svelte/registry';
+import { IMAGES_MODULE_META } from '../ui.js';
+
+// Import components
+import AssetsGallery from './components/AssetsGallery.svelte';
+import ImageEditor from './components/ImageEditor.svelte';
+import ImageUploader from './components/ImageUploader.svelte';
+
+// Export components
+export { AssetsGallery, ImageEditor, ImageUploader };
+
 export type {
   ImageConvertRequest,
   ImageCropRequest,
@@ -13,3 +30,21 @@ export type {
   ImagesGalleryQuery,
   ImagesGalleryResult,
 } from './image-clients';
+
+// Auto-register with ModuleUIRegistry
+ModuleUIRegistry.registerModule(IMAGES_MODULE_META);
+ModuleUIRegistry.register(
+  '@happyvertical/smrt-images',
+  'assets-gallery',
+  AssetsGallery,
+);
+ModuleUIRegistry.register(
+  '@happyvertical/smrt-images',
+  'image-editor',
+  ImageEditor,
+);
+ModuleUIRegistry.register(
+  '@happyvertical/smrt-images',
+  'image-uploader',
+  ImageUploader,
+);

--- a/packages/images/src/ui.ts
+++ b/packages/images/src/ui.ts
@@ -1,0 +1,55 @@
+/**
+ * Images Module UI Slot Declarations
+ *
+ * This file defines the UI extension points for the images module.
+ * UI components are implemented in the ./svelte subpath.
+ */
+
+import type { ModuleUISlot, SmrtModuleMeta } from '@happyvertical/smrt-types';
+
+/**
+ * Images module UI slots
+ */
+export const IMAGES_UI_SLOTS: Record<string, ModuleUISlot> = {
+  'assets-gallery': {
+    id: 'assets-gallery',
+    label: 'Assets Gallery',
+    description: 'Grid gallery of image assets with filtering and selection',
+    icon: 'images',
+    category: 'list',
+    order: 1,
+    propsInterface: 'AssetsGalleryProps',
+  },
+  'image-editor': {
+    id: 'image-editor',
+    label: 'Image Editor',
+    description:
+      'Resize, crop, convert, and AI-edit an image with derivative tracking',
+    icon: 'image',
+    category: 'form',
+    order: 2,
+    propsInterface: 'ImageEditorProps',
+  },
+  'image-uploader': {
+    id: 'image-uploader',
+    label: 'Image Uploader',
+    description: 'Upload images with metadata extraction and AI categorization',
+    icon: 'upload',
+    category: 'form',
+    order: 3,
+    propsInterface: 'ImageUploaderProps',
+  },
+};
+
+/**
+ * Images module metadata
+ */
+export const IMAGES_MODULE_META: SmrtModuleMeta = {
+  name: '@happyvertical/smrt-images',
+  displayName: 'Images',
+  description:
+    'Image asset management with AI-powered categorization, search, editing, and metadata extraction',
+  uiSlots: IMAGES_UI_SLOTS,
+  models: ['Image'],
+  collections: ['ImageCollection'],
+};

--- a/packages/images/vite.config.ts
+++ b/packages/images/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig(async ({ mode }) => {
     // Delegate to the shared package config which handles entry points,
     // externals, dts generation, and svelte-package exclusion.
     const config = createPackageConfig('images', {
-      entries: ['playground'],
+      entries: ['playground', 'ui'],
       svelte: 'svelte',
       dtsExclude: ['src/routes/**/*'],
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -946,6 +946,9 @@ importers:
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
+      '@happyvertical/smrt-prompts':
+        specifier: workspace:*
+        version: link:../prompts
       '@happyvertical/smrt-tenancy':
         specifier: workspace:*
         version: link:../tenancy

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,6 +345,9 @@ importers:
       '@happyvertical/smrt-playground':
         specifier: workspace:*
         version: link:../smrt-playground
+      '@happyvertical/smrt-svelte':
+        specifier: workspace:*
+        version: link:../smrt-svelte
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
         version: link:../vitest

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -971,6 +971,9 @@ importers:
       '@happyvertical/smrt-playground':
         specifier: workspace:*
         version: link:../smrt-playground
+      '@happyvertical/smrt-svelte':
+        specifier: workspace:*
+        version: link:../smrt-svelte
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
         version: link:../vitest


### PR DESCRIPTION
## Summary

Fourth Phase 2 category PR — Content & Media layer alignment. Closes [#1212](https://github.com/happyvertical/smrt/issues/1212).

7 packages in this category; 4 had substantive Phase 2 work, 3 needed no deltas.

## Per-package work

### `content` — substantive (`feat/content-media-content-alignment`, `6180779b`)

- New `smrtContent.thumbnail.aiGenerate` prompt registered in `content-prompts.ts`
- `ThumbnailGenerator.buildAIPrompt()` refactored from sync inline string concat to async `resolvePrompt() + ai.message()` flow
- `ThumbnailGeneratorOptions` extended with `persistence?: DatabaseConfig` alias for the same fallback pattern used in profiles/properties
- 6 new tests (`thumbnail-prompt.test.ts`)
- CLAUDE.md gets a Prompt Registry section with all three content keys

### `assets` — substantive (`feat/content-media-assets-alignment`, `17bed610`)

- New `src/ui.ts` with `ASSETS_MODULE_META` + 7 `ASSETS_UI_SLOTS`: `asset-manager`, `asset-grid`, `asset-list`, `asset-detail`, `asset-toolbar`, `asset-action-bar`, `asset-create-modal`
- `./ui` subpath added to `package.json` exports (types-first conditional)
- `src/svelte/index.ts` adopts `ModuleUIRegistry.register()` while keeping named re-exports for direct import
- `'ui'` added to vite config entries; `dist/ui.js` + `dist/ui.d.ts` emitted
- `@happyvertical/smrt-svelte` declared as optional peer + devDep
- CLAUDE.md gets a UI Registry section

### `images` — substantive (`feat/content-media-images-alignment`, `2f50634a`)

Combined smrt-prompts adoption + UI registry adoption.

- New `smrtImages.image.generateAltText` prompt registered
- `Image.generateAltText()` refactored to `resolvePrompt() + ai.message()` with PII audit (only `imageName`, `imageDescription` reach the AI; `sourceUri`, `parentId`, `tenantId`, EXIF `metadata` excluded)
- New `src/ui.ts` with `IMAGES_MODULE_META` + 3 `IMAGES_UI_SLOTS`: `assets-gallery`, `image-editor`, `image-uploader`
- `./ui` export added; vite config updated
- 4 new tests (`__tests__/generateAltText.test.ts`)
- CLAUDE.md gets Prompt Registry + UI Registry sections

### `chat` — small (`df43e575`)

The vite config has been emitting `dist/ui.js` for a while, but `package.json` exports never declared the `./ui` subpath, so consumers of `MODULE_META`/`UI_SLOTS` couldn't reach them. Per CC-8 §B broken-plumbing finding, added the export pointing at the existing dist artifacts.

### `messages`, `video`, `voice` — no Phase 2 deltas

CLAUDE.md verified accurate against current code; `messages` is the canonical reference for `smrt-secrets` migration; `video` and `voice` have job-queue migrations deferred to dedicated PRs.

## Commits

```
9eb77727  Merge branch 'feat/content-media-images-alignment'
821d3e54  Merge branch 'feat/content-media-assets-alignment'
aa70f810  Merge branch 'feat/content-media-content-alignment'
2f50634a  chore(images): Phase 2 alignment — adopt smrt-prompts and ModuleUIRegistry
6180779b  chore(content): Phase 2 alignment — adopt smrt-prompts for thumbnail AI prompt
17bed610  chore(assets): Phase 2 alignment — adopt ModuleUIRegistry for chat-discoverable UI
df43e575  chore(chat): Phase 2 alignment — add missing ./ui export
```

**Do not squash on merge** — per-package commits preserve bisect-friendly history.

## Out of scope (deferred to dedicated PRs)

- `social`: plaintext OAuth tokens → `SecretService` envelope encryption (real at-rest data refactor)
- `video`: ComfyUI workflow execution → `smrt-jobs` handler
- `voice`: TTS render + voice cloning → `smrt-jobs` handlers
- Framework-wide: provider routing through `resolvedPrompt.ai.profile` (affects all packages adopting smrt-prompts uniformly — content, profiles, properties, images already affected)
- #1189 content editor reusable assistant context, #1057 asset_associations migration, #1022 image crop/extract API

## Reviews

Codex + Claude integrated reviews running on the merged release branch — findings will be addressed in follow-up commits as needed.

## Next phases

- ✅ Foundation (#1207)
- ✅ Agents & Runtime (#1209)
- ✅ Domain (#1211)
- ✅ **Content & Media** ← this PR
- ⏳ Business
- ⏳ Tooling/Templates