### PR TITLE
chore: Business packages Phase 2 alignment (epic #1191, category #1214)

### DIFF
--- a/packages/ads/CLAUDE.md
+++ b/packages/ads/CLAUDE.md
@@ -14,6 +14,29 @@ Ad delivery with priority waterfall, weighted A/B testing, and immutable event t
 
 `contractId` → smrt-commerce, `zoneId`/`siteId` → smrt-properties, `assetId` → smrt-assets, `verticalSlug` → smrt-tags
 
+## Tenancy
+
+Optional tenancy via `@TenantScoped({ mode: 'optional' })` is applied to the
+three transactional models — `AdGroup`, `AdVariation`, and `AdEvent` — which
+participate in per-tenant ad serving and event tracking.
+
+`AdFormat` and `AdDeliveryTier` are deliberately **NOT** tenant-scoped: they
+are shared catalog/lookup tables.
+
+- `AdFormat` rows describe IAB standard ad dimensions (e.g. `728x90`
+  Leaderboard, `300x250` Medium Rectangle). The dimensions are an industry
+  standard, not a tenant-specific configuration.
+- `AdDeliveryTier` rows describe the priority waterfall for ad selection
+  (Sponsorship → Standard → House). Tiers are part of the package's
+  ad-serving contract; per-tenant tier definitions would fragment the
+  selection algorithm without a clear use case.
+
+Either model can still be filtered by tenant manually if a deployment ever
+needs tenant-specific overrides, but the default is global. This mirrors the
+documented exception pattern in `packages/secrets/CLAUDE.md` (`TenantKey`).
+Each `@smrt(...)` block on these two classes carries an inline comment
+pointing back here.
+
 ## Gotchas
 
 - **Priority waterfall**: lower priority number = higher priority in selection
@@ -21,4 +44,4 @@ Ad delivery with priority waterfall, weighted A/B testing, and immutable event t
 - **Denormalized counts need async refresh**: impressions/clicks on AdVariation are eventually consistent
 - **No frequency capping or budget enforcement built-in**: external responsibility
 - **Targeting rules stored as JSON string**: no schema validation
-- **Optional tenancy** on AdVariation and AdEvent
+- **Optional tenancy** on `AdGroup`, `AdVariation`, `AdEvent` only — see Tenancy section above for `AdFormat`/`AdDeliveryTier` rationale

--- a/packages/ads/src/models/AdDeliveryTier.ts
+++ b/packages/ads/src/models/AdDeliveryTier.ts
@@ -24,6 +24,13 @@ import { PricingModel } from '../types/index.js';
  * });
  * ```
  */
+// Intentional exception to standards.md §7 (`@TenantScoped`):
+// `AdDeliveryTier` is a shared catalog model describing the priority waterfall
+// for ad selection (Sponsorship → Standard → House). Tier definitions are part
+// of the package's ad-serving contract, not per-tenant configuration. Adding
+// `@TenantScoped` would require every tenant to seed the same three rows and
+// would fragment the selection algorithm without a clear use case. See
+// `packages/ads/CLAUDE.md` "Tenancy" section for context.
 @smrt({
   api: { include: ['list', 'get', 'create', 'update'] },
   mcp: { include: ['list', 'get'] },

--- a/packages/ads/src/models/AdFormat.ts
+++ b/packages/ads/src/models/AdFormat.ts
@@ -19,6 +19,12 @@ import { AdFormatType } from '../types/index.js';
  * });
  * ```
  */
+// Intentional exception to standards.md §7 (`@TenantScoped`):
+// `AdFormat` is a shared catalog model describing IAB standard ad dimensions
+// (e.g. 728x90 Leaderboard). The dimensions are an industry standard, not a
+// per-tenant configuration. Adding `@TenantScoped` would require every tenant
+// to seed the same IAB rows. See `packages/ads/CLAUDE.md` "Tenancy" section
+// for context.
 @smrt({
   api: { include: ['list', 'get', 'create', 'update'] },
   mcp: { include: ['list', 'get'] },

--- a/packages/affiliates/CLAUDE.md
+++ b/packages/affiliates/CLAUDE.md
@@ -23,9 +23,39 @@ Effective sales rate = salesRate × (1 - parentCommissionShare)
 
 `profileId` → smrt-profiles, `propertyId` → smrt-properties, `eventId` → smrt-ads, `invoiceId` → smrt-commerce
 
+## Tenancy
+
+Per `docs/content/standards.md §7`, tenant-aware models normally apply
+`@TenantScoped({ mode: 'optional' })` from `@happyvertical/smrt-tenancy`. The
+three models in this package deviate intentionally; each `@smrt(...)` block
+carries an inline comment pointing back to this section.
+
+`Partner`, `Commission`, and `Payout` are deliberately **NOT** tenant-scoped.
+The affiliate network is a cross-tenant graph by design:
+
+- A single `Partner` (e.g. a publisher operating multiple sites across
+  different tenants) needs a stable identity for revenue aggregation,
+  payout thresholds, and tax reporting. Slicing partner identity per
+  tenant would either duplicate the row or hide payouts owed across
+  tenants.
+- `Commission` rows attribute revenue to a partner across whichever tenant
+  generated the ad event; the cross-tenant attribution is the point of the
+  network.
+- `Payout` aggregates commissions for a partner regardless of which tenant
+  the underlying revenue came from. A tenant-scoped query would produce
+  systematically incorrect totals.
+
+This is the same reasoning that keeps `TenantKey` in `packages/secrets`
+out of the tenancy interceptor: rows that must be queried across tenants
+to fulfil their purpose should not be silently filtered.
+
+Operators that need tenant-attributed reporting should aggregate by
+joining `Commission` rows back to `eventId` (smrt-ads) and the originating
+ad's tenant — not by adding `@TenantScoped` here.
+
 ## Gotchas
 
-- **No tenancy** (intentional): cross-tenant network visibility for affiliate tracking
+- **No tenancy** (intentional): cross-tenant network visibility for affiliate tracking — see Tenancy section above for rationale
 - **partnerTypes is JSON string**: must parse with `getPartnerTypes()` helper
 - **Commission rate copied at event time**: immutable record, not a live reference to Partner.commissionRate
 - **Payout amounts in cents**: divide by 100 for display

--- a/packages/affiliates/src/models/Commission.ts
+++ b/packages/affiliates/src/models/Commission.ts
@@ -35,6 +35,12 @@ import { CommissionStatus, CommissionType } from '../types/index.js';
  * });
  * ```
  */
+// Intentional exception to standards.md §7 (`@TenantScoped`):
+// `Commission` is deliberately NOT tenant-scoped. The affiliate network
+// attributes revenue to a `Partner` across whichever tenant generated the
+// underlying ad event; cross-tenant attribution is the point of the network.
+// Tenant-attributed reporting should aggregate by joining back through
+// `eventId` (smrt-ads). See `packages/affiliates/CLAUDE.md` "Tenancy" section.
 @smrt({
   api: { include: ['create', 'list', 'get'] }, // No delete (audit trail)
   mcp: { include: ['create', 'list'] },

--- a/packages/affiliates/src/models/Partner.ts
+++ b/packages/affiliates/src/models/Partner.ts
@@ -41,6 +41,12 @@ import { PartnerStatus, PartnerType, PayoutMethod } from '../types/index.js';
  * });
  * ```
  */
+// Intentional exception to standards.md §7 (`@TenantScoped`):
+// `Partner` is deliberately NOT tenant-scoped. A single partner (e.g. a
+// publisher operating sites across multiple tenants) needs a stable identity
+// for revenue aggregation, payout thresholds, and tax reporting; slicing
+// identity per tenant would duplicate the row or hide payouts owed across
+// tenants. See `packages/affiliates/CLAUDE.md` "Tenancy" section.
 @smrt({
   api: { include: ['list', 'get', 'create', 'update'] },
   mcp: { include: ['list', 'get', 'create'] },

--- a/packages/affiliates/src/models/Payout.ts
+++ b/packages/affiliates/src/models/Payout.ts
@@ -33,6 +33,11 @@ import { PayoutStatus } from '../types/index.js';
  * });
  * ```
  */
+// Intentional exception to standards.md §7 (`@TenantScoped`):
+// `Payout` is deliberately NOT tenant-scoped. Payouts aggregate commissions
+// for a `Partner` regardless of which tenant generated the underlying revenue;
+// a tenant-scoped query would systematically under-report what is owed. See
+// `packages/affiliates/CLAUDE.md` "Tenancy" section.
 @smrt({
   api: { include: ['list', 'get', 'create', 'update'] },
   mcp: { include: ['list', 'get', 'create'] },

--- a/packages/analytics/CLAUDE.md
+++ b/packages/analytics/CLAUDE.md
@@ -35,7 +35,13 @@ Three prompts are registered at module-load time via `definePrompt()` from `@hap
 - `providerMetadata` — extensible JSON blob that may contain credentials, account IDs, or other configuration secrets.
 - `lastError`, raw `dimensionFilter` / `metricFilter` JSON — internal error strings (may contain auth tokens) and filter expressions that may reference cookie IDs, user-pseudo-IDs, or IP-derived geos.
 
-`resultData` is passed through as opaque aggregate; callers must ensure the analytics provider has already de-PII'd the rows before persisting them.
+**`resultData` is forwarded verbatim.** This package does not — and cannot — strip PII from result rows, because the row schema is determined by the dimensions/metrics the caller asked the analytics provider to return. If the caller persists rows containing a `userPseudoId`, `clientId`, IP-derived geolocation, or any other identifier, those fields WILL reach the AI provider. Callers must:
+
+- exclude PII-bearing dimensions before persisting `resultData` (e.g. don't request `userPseudoId` as a GA4 dimension), or
+- apply a column allowlist at the call site before invoking `analyzeResults()`, or
+- override the prompt template via `PromptOverride` to redact rows.
+
+The forwarding contract is pinned by a regression test in `src/__tests__/analytics-report-prompt.test.ts`.
 
 See `src/prompts.ts` for the full rationale block.
 

--- a/packages/analytics/CLAUDE.md
+++ b/packages/analytics/CLAUDE.md
@@ -17,7 +17,39 @@ All models use STI (`tableStrategy: 'sti'`).
 
 ## AI Operations
 
-`analyzePerformance()`, `isPerformingWell()`, `analyzeResults()`, `hasPositiveTrends()` — uses `do()` and `is()`.
+`analyzePerformance()`, `analyzeResults()`, `hasPositiveTrends()` route through registered prompts (see Prompt Registry below) so tenant overrides apply via `resolvePrompt()`. `isPerformingWell()` still uses the inline `is()` shortcut.
+
+## Prompt Registry
+
+Three prompts are registered at module-load time via `definePrompt()` from `@happyvertical/smrt-prompts`. Re-exported from the package root for tenant override targeting.
+
+| Key | Method | Variables (PII-conscious) |
+|-----|--------|---------------------------|
+| `smrtAnalytics.property.analyzePerformance` | `AnalyticsProperty.analyzePerformance()` | `period`, `propertyDisplayName`, `propertyProvider` |
+| `smrtAnalytics.report.analyzeResults` | `AnalyticsReport.analyzeResults()` | `reportName`, `reportDimensions`, `reportMetrics`, `dateRangeStart`, `dateRangeEnd`, `rowCount`, `reportData` |
+| `smrtAnalytics.report.hasPositiveTrends` | `AnalyticsReport.hasPositiveTrends()` | `reportMetrics`, `reportData` |
+
+**Excluded from variables (never reach the AI provider):**
+- `id`, `propertyId`, `tenantId`, `externalId` — internal foreign keys / UUIDs that link to identifying records.
+- `apiSecret`, `measurementId`, `siteDomain` — provider credentials and platform-specific identifiers (GA4 API secrets, Matomo `idSite`, custom `G-XXXX` measurement IDs).
+- `providerMetadata` — extensible JSON blob that may contain credentials, account IDs, or other configuration secrets.
+- `lastError`, raw `dimensionFilter` / `metricFilter` JSON — internal error strings (may contain auth tokens) and filter expressions that may reference cookie IDs, user-pseudo-IDs, or IP-derived geos.
+
+`resultData` is passed through as opaque aggregate; callers must ensure the analytics provider has already de-PII'd the rows before persisting them.
+
+See `src/prompts.ts` for the full rationale block.
+
+## UI Registry
+
+Svelte components live in `src/svelte/` and auto-register with `ModuleUIRegistry` from `@happyvertical/smrt-svelte/registry` when `@happyvertical/smrt-analytics/svelte` is imported.
+
+Slot declarations live in `src/ui.ts`, exported via the `./ui` package subpath. The slots are: `analytics-summary`, `events-table`, `property-info`, `property-status-badge`, `stat-card`, `trend-badge` (see `ANALYTICS_UI_SLOTS` for icons / categories / display order).
+
+```typescript
+import '@happyvertical/smrt-analytics/svelte'; // side-effect: registers slots
+import { ModuleUIRegistry } from '@happyvertical/smrt-svelte/registry';
+const StatCard = ModuleUIRegistry.get('@happyvertical/smrt-analytics', 'stat-card');
+```
 
 ## Gotchas
 
@@ -25,3 +57,4 @@ All models use STI (`tableStrategy: 'sti'`).
 - **Event retry at model level**: no background job integration
 - **JSON fields**: params, dimensions, metrics use string storage with getter/setter helpers
 - **Measurement IDs differ per platform**: G-XXXXXX (GA4 web) vs Firebase app ID (mobile)
+- **`analyzeResults` is now a single AI call**: previously issued a second freeform `do()` to summarize "top 3 insights"; folded into the registered template, and `insights` mirrors `analysis` in the response shape.

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -46,17 +46,24 @@
   },
   "dependencies": {
     "@happyvertical/smrt-core": "workspace:*",
-    "@happyvertical/smrt-prompts": "workspace:*"
+    "@happyvertical/smrt-prompts": "workspace:*",
+    "@happyvertical/smrt-types": "workspace:*"
   },
   "peerDependencies": {
+    "@happyvertical/smrt-svelte": "workspace:*",
     "svelte": "^5.18.0"
   },
   "peerDependenciesMeta": {
+    "@happyvertical/smrt-svelte": {
+      "optional": true
+    },
     "svelte": {
       "optional": true
     }
   },
   "devDependencies": {
+    "@happyvertical/smrt-svelte": "workspace:*",
+    "@happyvertical/smrt-tenancy": "workspace:*",
     "@happyvertical/smrt-vitest": "workspace:*",
     "@happyvertical/sql": "catalog:",
     "@sveltejs/package": "^2.5.7",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -20,6 +20,10 @@
       "types": "./dist/playground.d.ts",
       "import": "./dist/playground.js"
     },
+    "./ui": {
+      "types": "./dist/ui.d.ts",
+      "import": "./dist/ui.js"
+    },
     "./svelte": {
       "types": "./dist/svelte/index.d.ts",
       "svelte": "./dist/svelte/index.js",
@@ -41,10 +45,11 @@
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },
   "dependencies": {
-    "@happyvertical/smrt-core": "workspace:*"
+    "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-prompts": "workspace:*"
   },
   "peerDependencies": {
-    "svelte": "^5.0.0"
+    "svelte": "^5.18.0"
   },
   "peerDependenciesMeta": {
     "svelte": {
@@ -58,7 +63,7 @@
     "@types/node": "25.0.9",
     "fast-glob": "3.3.3",
     "svelte-check": "^4.3.5",
-    "svelte": "^5.0.0",
+    "svelte": "^5.18.0",
     "typescript": "^5.9.3",
     "vite": "^7.3.1",
     "vitest": "^4.0.17"

--- a/packages/analytics/src/__tests__/analytics-property-prompt.test.ts
+++ b/packages/analytics/src/__tests__/analytics-property-prompt.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { clearPromptCache } from '@happyvertical/smrt-prompts';
+import { withTenant } from '@happyvertical/smrt-tenancy';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AnalyticsProperty } from '../models/AnalyticsProperty.js';
 import {
@@ -110,6 +111,47 @@ describe('AnalyticsProperty.analyzePerformance()', () => {
     expect(aiMessageMock).toHaveBeenCalledTimes(1);
     const [, options] = aiMessageMock.mock.calls[0];
     expect(options).toEqual({});
+  });
+
+  it('OMITS tenantId from resolvePrompt options so withTenant context is honored', async () => {
+    // Regression test pinning the codex P2 fix from PR #1214: the analytics
+    // models do not declare a `tenantId` field (intentionally not
+    // @TenantScoped), and the previous implementation passed
+    // `tenantId: null` explicitly. That short-circuited resolvePrompt's
+    // AsyncLocalStorage fallback (which uses `getTenantId() ?? null` only
+    // when `options.tenantId === undefined`) and silently ignored
+    // tenant-specific prompt overrides for any caller running inside a
+    // `withTenant(...)` block.
+    //
+    // The fix is to OMIT the field — not pass `null` — so the resolver
+    // falls back to the active tenancy context. This test pins that
+    // contract by inspecting the options object the model passes to
+    // resolvePrompt.
+    const property = makeProperty();
+    const promptsModule = await import('@happyvertical/smrt-prompts');
+    const observed: Array<Record<string, unknown> | undefined> = [];
+    const originalResolve = promptsModule.resolvePrompt;
+    const spy = vi
+      .spyOn(promptsModule, 'resolvePrompt')
+      .mockImplementation((key, options) => {
+        observed.push(options as Record<string, unknown> | undefined);
+        return originalResolve(key, options);
+      });
+
+    try {
+      await withTenant({ tenantId: 'tenant-context-X' }, async () => {
+        await property.analyzePerformance({ period: '7 days' });
+      });
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(observed).toHaveLength(1);
+    const opts = observed[0] ?? {};
+    // Critical: `tenantId` is NOT a key on the options object — that lets
+    // resolvePrompt's `options.tenantId !== undefined ? ... : (getTenantId() ?? null)`
+    // gate fall through to the AsyncLocalStorage tenant context.
+    expect('tenantId' in opts).toBe(false);
   });
 
   it('forwards model/temperature/maxTokens from a runtime ai override via promptMessageOptions', () => {

--- a/packages/analytics/src/__tests__/analytics-property-prompt.test.ts
+++ b/packages/analytics/src/__tests__/analytics-property-prompt.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for `AnalyticsProperty.analyzePerformance()` — verifies the
+ * smrt-prompts integration: prompt resolution, variable substitution,
+ * and that internal/PII-adjacent fields (`externalId`, `apiSecret`,
+ * `measurementId`, `providerMetadata`) are NOT passed to the AI provider.
+ *
+ * The AI client is stubbed via a `getAiClient()` override so no network
+ * calls are made. Mirrors the structural template established in
+ * `packages/properties/src/__tests__/summarize.test.ts`.
+ */
+
+import { clearPromptCache } from '@happyvertical/smrt-prompts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AnalyticsProperty } from '../models/AnalyticsProperty.js';
+import {
+  promptMessageOptions,
+  smrtAnalyticsAnalyzePerformancePrompt,
+} from '../prompts.js';
+import { AnalyticsProvider } from '../types/index.js';
+
+describe('AnalyticsProperty.analyzePerformance()', () => {
+  let aiMessageMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    aiMessageMock = vi.fn().mockResolvedValue('Performance analysis text  ');
+    clearPromptCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makeProperty() {
+    const property = new AnalyticsProperty({
+      name: 'properties/123456789',
+      displayName: 'Oak Creek News GA4',
+      provider: AnalyticsProvider.GA4,
+      // Internal/PII-adjacent fields that should NOT reach the AI provider:
+      externalId: 'properties/123456789',
+      measurementId: 'G-PRIVATE-MID-1234',
+      apiSecret: 'super-secret-ga4-token',
+      siteDomain: 'private-site.example.com',
+      providerMetadata: JSON.stringify({
+        accountId: 'accounts/9999999',
+        privateKey: 'do-not-leak',
+      }),
+    });
+    // Stub AI client so analyzePerformance doesn't reach a real provider.
+    (property as any).getAiClient = async () => ({
+      message: aiMessageMock,
+    });
+    return property;
+  }
+
+  it('uses the registered prompt key', () => {
+    expect(smrtAnalyticsAnalyzePerformancePrompt.key).toBe(
+      'smrtAnalytics.property.analyzePerformance',
+    );
+  });
+
+  it('resolves the registered analyzePerformance prompt and returns trimmed analysis', async () => {
+    const property = makeProperty();
+
+    const result = await property.analyzePerformance({ period: '14 days' });
+
+    expect(result.action).toBe('analyzePerformance');
+    expect(result.period).toBe('14 days');
+    expect(result.analysis).toBe('Performance analysis text');
+    expect(aiMessageMock).toHaveBeenCalledTimes(1);
+
+    // The prompt sent to the AI should contain the substituted display name,
+    // provider, and period from the registered template.
+    const [text] = aiMessageMock.mock.calls[0];
+    expect(text).toContain('Oak Creek News GA4');
+    expect(text).toContain('ga4');
+    expect(text).toContain('14 days');
+  });
+
+  it('defaults the period to "30 days" when not provided', async () => {
+    const property = makeProperty();
+
+    const result = await property.analyzePerformance();
+
+    expect(result.period).toBe('30 days');
+    const [text] = aiMessageMock.mock.calls[0];
+    expect(text).toContain('30 days');
+  });
+
+  it('does NOT pass internal/PII-adjacent fields to the AI provider', async () => {
+    const property = makeProperty();
+
+    await property.analyzePerformance();
+
+    const [text] = aiMessageMock.mock.calls[0];
+    // Provider identifiers and credentials must never leak into prompts.
+    expect(text).not.toContain('properties/123456789');
+    expect(text).not.toContain('G-PRIVATE-MID-1234');
+    expect(text).not.toContain('super-secret-ga4-token');
+    expect(text).not.toContain('private-site.example.com');
+    // The providerMetadata blob may carry account IDs / private keys.
+    expect(text).not.toContain('accounts/9999999');
+    expect(text).not.toContain('do-not-leak');
+  });
+
+  it('passes empty AI options for the default registered prompt (no ai config)', async () => {
+    const property = makeProperty();
+
+    await property.analyzePerformance();
+
+    expect(aiMessageMock).toHaveBeenCalledTimes(1);
+    const [, options] = aiMessageMock.mock.calls[0];
+    expect(options).toEqual({});
+  });
+
+  it('forwards model/temperature/maxTokens from a runtime ai override via promptMessageOptions', () => {
+    // Drive promptMessageOptions directly with a synthetic ResolvedPromptAI
+    // shape — the same helper analyzePerformance() routes through.
+    const options = promptMessageOptions({
+      profile: null,
+      model: 'gpt-test-1',
+      temperature: 0.42,
+      maxTokens: 512,
+      params: { topP: 0.95 },
+    });
+
+    expect(options).toEqual({
+      topP: 0.95,
+      model: 'gpt-test-1',
+      temperature: 0.42,
+      maxTokens: 512,
+    });
+  });
+});

--- a/packages/analytics/src/__tests__/analytics-report-prompt.test.ts
+++ b/packages/analytics/src/__tests__/analytics-report-prompt.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for `AnalyticsReport.analyzeResults()` and
+ * `AnalyticsReport.hasPositiveTrends()` — verifies the smrt-prompts
+ * integration: prompt resolution, variable substitution, and that
+ * internal/PII-adjacent fields (`propertyId`, `lastError`, raw filter
+ * expressions) are NOT passed to the AI provider.
+ *
+ * The AI client is stubbed via a `getAiClient()` override so no network
+ * calls are made.
+ */
+
+import { clearPromptCache } from '@happyvertical/smrt-prompts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AnalyticsReport } from '../models/AnalyticsReport.js';
+import {
+  smrtAnalyticsAnalyzeResultsPrompt,
+  smrtAnalyticsHasPositiveTrendsPrompt,
+} from '../prompts.js';
+import { ReportStatus } from '../types/index.js';
+
+function makeReport(opts: { aiResponse?: string } = {}) {
+  const aiResponse = opts.aiResponse ?? 'Findings, trends, and recommendations';
+  const aiMessageMock = vi.fn().mockResolvedValue(`${aiResponse}  `);
+
+  const report = new AnalyticsReport({
+    name: 'Weekly Traffic Report',
+    description: 'Weekly traffic dashboard',
+    dimensions: JSON.stringify([
+      { name: 'country' },
+      { name: 'deviceCategory' },
+    ]),
+    metrics: JSON.stringify([{ name: 'activeUsers' }, { name: 'sessions' }]),
+    dateRangeStart: '7daysAgo',
+    dateRangeEnd: 'today',
+    rowCount: 42,
+    status: ReportStatus.COMPLETED,
+    resultData: JSON.stringify({
+      rows: [
+        { country: 'US', activeUsers: 1234 },
+        { country: 'CA', activeUsers: 567 },
+      ],
+    }),
+    // Internal/PII-adjacent fields that should NOT reach the AI provider:
+    propertyId: 'analytics-property-uuid-1234',
+    dimensionFilter: JSON.stringify({ field: 'userPseudoId', value: 'PII-99' }),
+    metricFilter: JSON.stringify({ secret: 'do-not-leak' }),
+    lastError: 'INTERNAL: token expired for tenant tenant-secret-9999',
+  });
+  (report as any).getAiClient = async () => ({
+    message: aiMessageMock,
+  });
+  return { report, aiMessageMock };
+}
+
+describe('AnalyticsReport.analyzeResults()', () => {
+  beforeEach(() => {
+    clearPromptCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses the registered prompt key', () => {
+    expect(smrtAnalyticsAnalyzeResultsPrompt.key).toBe(
+      'smrtAnalytics.report.analyzeResults',
+    );
+  });
+
+  it('resolves the registered analyzeResults prompt and returns trimmed analysis', async () => {
+    const { report, aiMessageMock } = makeReport();
+
+    const result = await report.analyzeResults();
+
+    expect(result.action).toBe('analyzeResults');
+    expect(result.analysis).toBe('Findings, trends, and recommendations');
+    // After migration, insights mirrors analysis (the registered template
+    // already structures the response into findings/trends/recommendations).
+    expect(result.insights).toBe(result.analysis);
+    expect(aiMessageMock).toHaveBeenCalledTimes(1);
+
+    const [text] = aiMessageMock.mock.calls[0];
+    expect(text).toContain('Weekly Traffic Report');
+    expect(text).toContain('country');
+    expect(text).toContain('activeUsers');
+    expect(text).toContain('7daysAgo');
+    expect(text).toContain('today');
+    expect(text).toContain('42');
+  });
+
+  it('does NOT pass internal/PII-adjacent fields to the AI provider', async () => {
+    const { report, aiMessageMock } = makeReport();
+
+    await report.analyzeResults();
+
+    const [text] = aiMessageMock.mock.calls[0];
+    // Foreign-key reference and tenant-internal payloads must not leak.
+    expect(text).not.toContain('analytics-property-uuid-1234');
+    expect(text).not.toContain('userPseudoId');
+    expect(text).not.toContain('PII-99');
+    expect(text).not.toContain('tenant-secret-9999');
+    // Internal error strings must not leak (may contain auth tokens).
+    expect(text).not.toContain('INTERNAL: token expired');
+  });
+
+  it('passes empty AI options for the default registered prompt (no ai config)', async () => {
+    const { report, aiMessageMock } = makeReport();
+
+    await report.analyzeResults();
+
+    const [, options] = aiMessageMock.mock.calls[0];
+    expect(options).toEqual({});
+  });
+});
+
+describe('AnalyticsReport.hasPositiveTrends()', () => {
+  beforeEach(() => {
+    clearPromptCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses the registered prompt key', () => {
+    expect(smrtAnalyticsHasPositiveTrendsPrompt.key).toBe(
+      'smrtAnalytics.report.hasPositiveTrends',
+    );
+  });
+
+  it('returns true when the AI response begins with "yes"', async () => {
+    const { report, aiMessageMock } = makeReport({
+      aiResponse: 'Yes — engagement and conversion are both up week over week.',
+    });
+
+    const result = await report.hasPositiveTrends();
+
+    expect(result).toBe(true);
+    expect(aiMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false when the AI response is "no"', async () => {
+    const { report, aiMessageMock } = makeReport({
+      aiResponse: 'No, several metrics are trending downward.',
+    });
+
+    const result = await report.hasPositiveTrends();
+
+    expect(result).toBe(false);
+    expect(aiMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('substitutes metrics and result data into the registered prompt', async () => {
+    const { report, aiMessageMock } = makeReport({ aiResponse: 'Yes' });
+
+    await report.hasPositiveTrends();
+
+    const [text] = aiMessageMock.mock.calls[0];
+    expect(text).toContain('activeUsers');
+    expect(text).toContain('sessions');
+    // The aggregate result rows pass through.
+    expect(text).toContain('1234');
+  });
+
+  it('does NOT pass internal/PII-adjacent fields to the AI provider', async () => {
+    const { report, aiMessageMock } = makeReport({ aiResponse: 'yes' });
+
+    await report.hasPositiveTrends();
+
+    const [text] = aiMessageMock.mock.calls[0];
+    expect(text).not.toContain('analytics-property-uuid-1234');
+    expect(text).not.toContain('userPseudoId');
+    expect(text).not.toContain('PII-99');
+    expect(text).not.toContain('tenant-secret-9999');
+    expect(text).not.toContain('INTERNAL: token expired');
+    // The descriptive report name is not in this leaner classifier prompt.
+    expect(text).not.toContain('Weekly Traffic Report');
+  });
+});

--- a/packages/analytics/src/__tests__/analytics-report-prompt.test.ts
+++ b/packages/analytics/src/__tests__/analytics-report-prompt.test.ts
@@ -103,6 +103,45 @@ describe('AnalyticsReport.analyzeResults()', () => {
     expect(text).not.toContain('INTERNAL: token expired');
   });
 
+  it('FORWARDS `resultData` rows verbatim — caller must de-PII before persisting', async () => {
+    // This test pins the contract that `resultData` is passed through to the
+    // AI provider as opaque aggregate. If a caller persists raw GA4 row-level
+    // data containing PII (e.g. a `userPseudoId` dimension), it WILL reach
+    // the AI provider. The prompts.ts and CLAUDE.md tenancy notes both
+    // document this; the assertion below ensures the contract is intentional
+    // rather than hidden behind a sanitization step nobody implemented.
+    const aiMessageMock = vi.fn().mockResolvedValue('analysis');
+    const report = new AnalyticsReport({
+      name: 'PII test',
+      dimensions: '[]',
+      metrics: '[]',
+      dateRangeStart: '7daysAgo',
+      dateRangeEnd: 'today',
+      rowCount: 1,
+      status: ReportStatus.COMPLETED,
+      // Caller-persisted PII inside resultData rows.
+      resultData: JSON.stringify({
+        rows: [
+          {
+            userPseudoId: 'pii-pseudo-id-leak-9999',
+            activeUsers: 1,
+          },
+        ],
+      }),
+    });
+    (report as any).getAiClient = async () => ({
+      message: aiMessageMock,
+    });
+
+    await report.analyzeResults();
+
+    const [text] = aiMessageMock.mock.calls[0];
+    // Both the field name and its value land in the prompt — that is the
+    // documented contract, NOT a regression to be silently fixed.
+    expect(text).toContain('userPseudoId');
+    expect(text).toContain('pii-pseudo-id-leak-9999');
+  });
+
   it('passes empty AI options for the default registered prompt (no ai config)', async () => {
     const { report, aiMessageMock } = makeReport();
 

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -12,6 +12,9 @@
 // downstream. Must come first so the side effect runs ahead of the class
 // module loads below. See __smrt-register__.ts for issue #1132 context.
 import './__smrt-register__.js';
+// Register prompts at module-load time so consumers and tenants can
+// override them via `resolvePrompt()` without further plumbing.
+import './prompts.js';
 
 // Collections
 export {
@@ -28,6 +31,14 @@ export {
   AnalyticsProperty,
   AnalyticsReport,
 } from './models/index.js';
+// Prompt registrations — re-exported so consumers can reference the keys
+// for tenant-aware overrides via `@happyvertical/smrt-prompts`.
+export {
+  promptMessageOptions,
+  smrtAnalyticsAnalyzePerformancePrompt,
+  smrtAnalyticsAnalyzeResultsPrompt,
+  smrtAnalyticsHasPositiveTrendsPrompt,
+} from './prompts.js';
 // Re-export SDK types for convenience
 export type {
   AnalyticsCapabilities,

--- a/packages/analytics/src/models/AnalyticsProperty.ts
+++ b/packages/analytics/src/models/AnalyticsProperty.ts
@@ -4,6 +4,11 @@
  */
 
 import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { resolvePrompt } from '@happyvertical/smrt-prompts';
+import {
+  promptMessageOptions,
+  smrtAnalyticsAnalyzePerformancePrompt,
+} from '../prompts.js';
 import { AnalyticsPropertyStatus, AnalyticsProvider } from '../types/index.js';
 
 /**
@@ -170,7 +175,16 @@ export class AnalyticsProperty extends SmrtObject {
   }
 
   /**
-   * AI-powered: Analyze property performance
+   * AI-powered: Analyze property performance.
+   *
+   * Uses the `smrtAnalytics.property.analyzePerformance` prompt registered
+   * via `@happyvertical/smrt-prompts`, allowing tenant- or instance-level
+   * overrides of the template, model, and parameters at runtime.
+   *
+   * Only non-PII fields (display name, provider label, requested period)
+   * are sent to the AI provider. Internal identifiers (`id`, `externalId`,
+   * `measurementId`, `apiSecret`, `providerMetadata`) are intentionally
+   * excluded — see `../prompts.ts` for the full exclusion rationale.
    */
   async analyzePerformance(options: { period?: string } = {}): Promise<{
     action: string;
@@ -178,15 +192,35 @@ export class AnalyticsProperty extends SmrtObject {
     analysis: string;
   }> {
     const period = options.period || '30 days';
-    const analysis = await this.do(`
-      Analyze the analytics performance for this property over the last ${period}.
-      Consider: traffic trends, user engagement, conversion patterns.
-      Property: ${this.displayName} (${this.provider})
-    `);
+
+    // Resolve `db` from either the canonical `db` option or its `persistence`
+    // alias so stored prompt overrides are honored on first call before
+    // `getAiClient()` triggers full initialization.
+    const db = (this.options as any).db ?? (this.options as any).persistence;
+
+    const resolvedPrompt = await resolvePrompt(
+      smrtAnalyticsAnalyzePerformancePrompt.key,
+      {
+        db,
+        tenantId: (this as any).tenantId ?? null,
+        variables: {
+          period,
+          propertyDisplayName: this.displayName || '',
+          propertyProvider: this.provider || '',
+        },
+      },
+    );
+
+    const ai = await this.getAiClient();
+    const analysis = await ai.message(
+      resolvedPrompt.text,
+      promptMessageOptions(resolvedPrompt.ai),
+    );
+
     return {
       action: 'analyzePerformance',
       period,
-      analysis,
+      analysis: analysis.trim(),
     };
   }
 

--- a/packages/analytics/src/models/AnalyticsProperty.ts
+++ b/packages/analytics/src/models/AnalyticsProperty.ts
@@ -195,14 +195,23 @@ export class AnalyticsProperty extends SmrtObject {
 
     // Resolve `db` from either the canonical `db` option or its `persistence`
     // alias so stored prompt overrides are honored on first call before
-    // `getAiClient()` triggers full initialization.
-    const db = (this.options as any).db ?? (this.options as any).persistence;
+    // `getAiClient()` triggers full initialization. SmrtObject already types
+    // both options on `SmrtClassOptions` so no `any` cast is needed — that
+    // keeps a misspelt option name surfacing as a TypeScript error rather
+    // than silently falling through.
+    const db = this.options.db ?? this.options.persistence;
 
+    // `AnalyticsProperty` does not declare a `tenantId` field (the model is
+    // intentionally not `@TenantScoped`), but consumers commonly invoke it
+    // inside a `withTenant(...)` block. We deliberately OMIT `tenantId` from
+    // the resolvePrompt options so that the resolver falls back to the
+    // AsyncLocalStorage tenancy context via `getTenantId()`. Passing
+    // `tenantId: null` explicitly would short-circuit that fallback and
+    // silently ignore tenant-specific prompt overrides.
     const resolvedPrompt = await resolvePrompt(
       smrtAnalyticsAnalyzePerformancePrompt.key,
       {
         db,
-        tenantId: (this as any).tenantId ?? null,
         variables: {
           period,
           propertyDisplayName: this.displayName || '',

--- a/packages/analytics/src/models/AnalyticsReport.ts
+++ b/packages/analytics/src/models/AnalyticsReport.ts
@@ -300,14 +300,23 @@ export class AnalyticsReport extends SmrtObject {
 
     // Resolve `db` from either the canonical `db` option or its `persistence`
     // alias so stored prompt overrides are honored on first call before
-    // `getAiClient()` triggers full initialization.
-    const db = (this.options as any).db ?? (this.options as any).persistence;
+    // `getAiClient()` triggers full initialization. SmrtObject already types
+    // both options on `SmrtClassOptions` so no `any` cast is needed — that
+    // keeps a misspelt option name surfacing as a TypeScript error rather
+    // than silently falling through.
+    const db = this.options.db ?? this.options.persistence;
 
+    // `AnalyticsReport` does not declare a `tenantId` field (the model is
+    // intentionally not `@TenantScoped`), but consumers commonly invoke it
+    // inside a `withTenant(...)` block. We deliberately OMIT `tenantId` from
+    // the resolvePrompt options so that the resolver falls back to the
+    // AsyncLocalStorage tenancy context via `getTenantId()`. Passing
+    // `tenantId: null` explicitly would short-circuit that fallback and
+    // silently ignore tenant-specific prompt overrides.
     const resolvedPrompt = await resolvePrompt(
       smrtAnalyticsAnalyzeResultsPrompt.key,
       {
         db,
-        tenantId: (this as any).tenantId ?? null,
         variables: {
           reportName: this.name || '',
           reportDimensions: this.dimensions || '[]',
@@ -347,13 +356,13 @@ export class AnalyticsReport extends SmrtObject {
   async hasPositiveTrends(): Promise<boolean> {
     const resultData = this.getResultData();
 
-    const db = (this.options as any).db ?? (this.options as any).persistence;
+    // See `analyzeResults` above for the typed-options + tenancy-fallback rationale.
+    const db = this.options.db ?? this.options.persistence;
 
     const resolvedPrompt = await resolvePrompt(
       smrtAnalyticsHasPositiveTrendsPrompt.key,
       {
         db,
-        tenantId: (this as any).tenantId ?? null,
         variables: {
           reportMetrics: this.metrics || '[]',
           reportData: JSON.stringify(resultData),

--- a/packages/analytics/src/models/AnalyticsReport.ts
+++ b/packages/analytics/src/models/AnalyticsReport.ts
@@ -279,11 +279,21 @@ export class AnalyticsReport extends SmrtObject {
    * `@happyvertical/smrt-prompts`, allowing tenant- or instance-level
    * overrides of the template, model, and parameters at runtime.
    *
-   * Only non-PII fields (report name, dimension/metric labels which are
-   * provider-schema names, date-range window, row count, and the opaque
-   * `resultData` aggregates) are sent to the AI. Internal identifiers
-   * (`id`, `propertyId`, `tenantId`, `lastError`, raw filter expressions)
-   * are excluded — see `../prompts.ts` for the full exclusion rationale.
+   * Internal identifiers (`id`, `propertyId`, `tenantId`, `lastError`, raw
+   * `dimensionFilter` / `metricFilter` JSON) are excluded from the prompt
+   * variables — see `../prompts.ts` for the exclusion rationale.
+   *
+   * **`resultData` is FORWARDED VERBATIM.** The persisted result rows are
+   * JSON-stringified into the `reportData` variable; this package cannot
+   * strip PII because the row schema is determined by which dimensions /
+   * metrics the caller asked the analytics provider to return. If the
+   * persisted rows contain `userPseudoId`, `clientId`, IP-derived
+   * geolocation, or any other identifier, those fields WILL reach the AI
+   * provider. Callers are responsible for excluding PII-bearing dimensions
+   * before persisting, applying a column allowlist at the call site, or
+   * overriding the prompt template via `PromptOverride`. The forwarding is
+   * pinned by a regression test in
+   * `__tests__/analytics-report-prompt.test.ts`.
    *
    * The previous implementation issued a second freeform `this.do()` call
    * to re-summarize "top 3 insights"; that behaviour is now folded into
@@ -349,9 +359,16 @@ export class AnalyticsReport extends SmrtObject {
    *
    * Uses the `smrtAnalytics.report.hasPositiveTrends` prompt registered
    * via `@happyvertical/smrt-prompts`. Only the metric labels and the
-   * aggregate `resultData` JSON are sent to the AI provider. Boolean
-   * coercion uses the same heuristic as `SmrtObject.is()` (truthy if the
-   * response begins with /yes|true/i).
+   * aggregate `resultData` JSON are sent to the AI provider — though as
+   * with `analyzeResults`, `resultData` is forwarded verbatim and may
+   * carry PII the caller persisted; see `analyzeResults` docstring and
+   * `../prompts.ts`.
+   *
+   * Boolean coercion uses `/^\s*(yes|true)\b/i` against the trimmed
+   * response. The registered prompt template explicitly instructs the
+   * model to begin its answer with the literal word "yes" or "no" so
+   * this regex is reliable; tenant overrides MUST preserve that leading-
+   * word convention or the boolean will silently fall to `false`.
    */
   async hasPositiveTrends(): Promise<boolean> {
     const resultData = this.getResultData();

--- a/packages/analytics/src/models/AnalyticsReport.ts
+++ b/packages/analytics/src/models/AnalyticsReport.ts
@@ -4,6 +4,12 @@
  */
 
 import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { resolvePrompt } from '@happyvertical/smrt-prompts';
+import {
+  promptMessageOptions,
+  smrtAnalyticsAnalyzeResultsPrompt,
+  smrtAnalyticsHasPositiveTrendsPrompt,
+} from '../prompts.js';
 import { ReportFrequency, ReportStatus } from '../types/index.js';
 
 /**
@@ -267,7 +273,23 @@ export class AnalyticsReport extends SmrtObject {
   }
 
   /**
-   * AI-powered: Analyze report results
+   * AI-powered: Analyze report results.
+   *
+   * Uses the `smrtAnalytics.report.analyzeResults` prompt registered via
+   * `@happyvertical/smrt-prompts`, allowing tenant- or instance-level
+   * overrides of the template, model, and parameters at runtime.
+   *
+   * Only non-PII fields (report name, dimension/metric labels which are
+   * provider-schema names, date-range window, row count, and the opaque
+   * `resultData` aggregates) are sent to the AI. Internal identifiers
+   * (`id`, `propertyId`, `tenantId`, `lastError`, raw filter expressions)
+   * are excluded — see `../prompts.ts` for the full exclusion rationale.
+   *
+   * The previous implementation issued a second freeform `this.do()` call
+   * to re-summarize "top 3 insights"; that behaviour is now folded into
+   * the single registered template (which already asks for findings,
+   * trends, and recommendations) — `insights` mirrors `analysis` so the
+   * return shape is preserved without a redundant AI round-trip.
    */
   async analyzeResults(_options: any = {}): Promise<{
     action: string;
@@ -275,45 +297,79 @@ export class AnalyticsReport extends SmrtObject {
     insights: string;
   }> {
     const resultData = this.getResultData();
-    const analysis = await this.do(`
-      Analyze these analytics report results and provide insights:
 
-      Report: ${this.name}
-      Dimensions: ${this.dimensions}
-      Metrics: ${this.metrics}
-      Date Range: ${this.dateRangeStart} to ${this.dateRangeEnd}
-      Row Count: ${this.rowCount}
+    // Resolve `db` from either the canonical `db` option or its `persistence`
+    // alias so stored prompt overrides are honored on first call before
+    // `getAiClient()` triggers full initialization.
+    const db = (this.options as any).db ?? (this.options as any).persistence;
 
-      Data: ${JSON.stringify(resultData, null, 2)}
+    const resolvedPrompt = await resolvePrompt(
+      smrtAnalyticsAnalyzeResultsPrompt.key,
+      {
+        db,
+        tenantId: (this as any).tenantId ?? null,
+        variables: {
+          reportName: this.name || '',
+          reportDimensions: this.dimensions || '[]',
+          reportMetrics: this.metrics || '[]',
+          dateRangeStart: this.dateRangeStart || '',
+          dateRangeEnd: this.dateRangeEnd || '',
+          rowCount: String(this.rowCount),
+          reportData: JSON.stringify(resultData, null, 2),
+        },
+      },
+    );
 
-      Provide:
-      1. Key findings
-      2. Trends or patterns
-      3. Actionable recommendations
-    `);
+    const ai = await this.getAiClient();
+    const analysis = (
+      await ai.message(
+        resolvedPrompt.text,
+        promptMessageOptions(resolvedPrompt.ai),
+      )
+    ).trim();
 
     return {
       action: 'analyzeResults',
       analysis,
-      insights: await this.do(
-        'Summarize the top 3 insights from this report in bullet points',
-      ),
+      insights: analysis,
     };
   }
 
   /**
-   * AI-powered: Check if results show positive trends
+   * AI-powered: Check if results show positive trends.
+   *
+   * Uses the `smrtAnalytics.report.hasPositiveTrends` prompt registered
+   * via `@happyvertical/smrt-prompts`. Only the metric labels and the
+   * aggregate `resultData` JSON are sent to the AI provider. Boolean
+   * coercion uses the same heuristic as `SmrtObject.is()` (truthy if the
+   * response begins with /yes|true/i).
    */
   async hasPositiveTrends(): Promise<boolean> {
     const resultData = this.getResultData();
-    return await this.is(`
-      Based on these report results, are the metrics showing positive trends?
 
-      Metrics: ${this.metrics}
-      Data: ${JSON.stringify(resultData)}
+    const db = (this.options as any).db ?? (this.options as any).persistence;
 
-      Consider: user growth, engagement, conversions as positive indicators.
-    `);
+    const resolvedPrompt = await resolvePrompt(
+      smrtAnalyticsHasPositiveTrendsPrompt.key,
+      {
+        db,
+        tenantId: (this as any).tenantId ?? null,
+        variables: {
+          reportMetrics: this.metrics || '[]',
+          reportData: JSON.stringify(resultData),
+        },
+      },
+    );
+
+    const ai = await this.getAiClient();
+    const response = (
+      await ai.message(
+        resolvedPrompt.text,
+        promptMessageOptions(resolvedPrompt.ai),
+      )
+    ).trim();
+
+    return /^\s*(yes|true)\b/i.test(response);
   }
 }
 

--- a/packages/analytics/src/prompts.ts
+++ b/packages/analytics/src/prompts.ts
@@ -55,9 +55,23 @@ Property: {propertyDisplayName} ({propertyProvider})`,
  * `AnalyticsReport.analyzeResults()` prompt. Surfaces report name, the
  * dimension/metric labels (which are public GA4/Plausible/Matomo schema
  * names — not user data), the date-range window, and the row count plus
- * a JSON-stringified `resultData` blob. Callers should ensure result rows
- * have already been de-PII'd by their analytics provider; we treat them
- * as opaque aggregates for the AI provider.
+ * a JSON-stringified `resultData` blob.
+ *
+ * **`resultData` is forwarded verbatim.** This package does not strip PII
+ * from result rows — it cannot, because the row schema is determined by
+ * the dimensions/metrics the caller asked the analytics provider to
+ * return. If the caller persists rows containing a `userPseudoId`,
+ * `clientId`, IP-derived geolocation, or any other identifier, those
+ * fields WILL reach the AI provider. Either:
+ *
+ *   - exclude PII-bearing dimensions before persisting `resultData`
+ *     (e.g. don't request `userPseudoId` as a GA4 dimension), or
+ *   - apply a column allowlist at the call site before invoking
+ *     `analyzeResults()`, or
+ *   - override the prompt template via `PromptOverride` to redact rows.
+ *
+ * The forwarding contract is pinned by a regression test in
+ * `__tests__/analytics-report-prompt.test.ts`.
  */
 export const smrtAnalyticsAnalyzeResultsPrompt = definePrompt({
   key: 'smrtAnalytics.report.analyzeResults',

--- a/packages/analytics/src/prompts.ts
+++ b/packages/analytics/src/prompts.ts
@@ -8,7 +8,8 @@
  * `prompts.ts`) and `@happyvertical/smrt-content` (see `content-prompts.ts`).
  *
  * PII / internal-field exclusion policy:
- * The variables sent to the AI provider deliberately exclude:
+ *
+ * Variables that this package never forwards to the AI provider:
  *   - `id`, `tenantId`, `propertyId` and other foreign-key/UUID fields —
  *     they identify internal records and provide no analytic value.
  *   - `apiSecret`, `measurementId`, `externalId`, `siteDomain` — these are
@@ -17,15 +18,29 @@
  *     be tenant-private configuration.
  *   - `providerMetadata` — extensible JSON blob that may contain
  *     credentials, account IDs, or other configuration secrets.
- *   - `lastError`, `dimensionFilter`, `metricFilter`, `resultData` raw
- *     payloads — only aggregate counts and computed deltas are passed; the
- *     raw rows can include cookie IDs, user-pseudo-IDs, IP-derived geos,
- *     and other PII the analytics provider returned.
+ *   - `lastError`, raw `dimensionFilter` / `metricFilter` JSON — internal
+ *     error strings (which may contain auth tokens) and filter expressions
+ *     that may reference cookie IDs or user-pseudo-IDs are kept out of the
+ *     prompt variable set.
  *
- * Acceptable variables: human-readable names, time periods, computed
- * aggregates (row counts, totals), and high-level dimension/metric labels.
- * If a downstream tenant needs richer context they can override the
- * template via PromptOverride.
+ * Variables this package DOES forward (potentially carrying PII the caller
+ * persisted):
+ *   - `reportData` (a JSON.stringify of the persisted `resultData`) — this
+ *     is forwarded VERBATIM to the AI in `analyzeResults` and
+ *     `hasPositiveTrends`. The package cannot strip PII because the row
+ *     schema is determined by which dimensions/metrics the caller asked
+ *     the analytics provider to return. If the persisted rows contain
+ *     `userPseudoId`, `clientId`, IP-derived geolocation, or any other
+ *     identifier, those fields WILL reach the AI provider. The forwarding
+ *     is pinned by a regression test in
+ *     `__tests__/analytics-report-prompt.test.ts`. Callers must either
+ *     exclude PII-bearing dimensions before persisting, apply a column
+ *     allowlist at the call site, or override the prompt template via
+ *     `PromptOverride` to redact rows.
+ *
+ * Acceptable variables (always safe): human-readable names, time periods,
+ * computed aggregates (row counts, totals), and high-level dimension/metric
+ * labels (which are public GA4/Plausible/Matomo schema names).
  */
 
 import {
@@ -102,6 +117,15 @@ Provide:
  * variables as `analyzeResults` minus the descriptive name — only the
  * provider-schema metric labels and the aggregate `resultData` payload are
  * needed to decide whether the trend is positive.
+ *
+ * The template explicitly instructs the model to begin its response with
+ * either "yes" or "no" so the boolean coercion in `hasPositiveTrends()`
+ * (`/^\s*(yes|true)\b/i`) is reliable. Without the leading-word
+ * instruction the model commonly answers with prose that happens to
+ * describe positive trends but starts with a sentence like "The
+ * conversion rate is up..." — the parser would then treat that as
+ * `false` despite a positive analysis. Tenants overriding this template
+ * MUST preserve the leading yes/no convention.
  */
 export const smrtAnalyticsHasPositiveTrendsPrompt = definePrompt({
   key: 'smrtAnalytics.report.hasPositiveTrends',
@@ -110,7 +134,11 @@ export const smrtAnalyticsHasPositiveTrendsPrompt = definePrompt({
 Metrics: {reportMetrics}
 Data: {reportData}
 
-Consider: user growth, engagement, conversions as positive indicators.`,
+Consider: user growth, engagement, conversions as positive indicators.
+
+Begin your response with the single word "yes" or "no" (lower case), then
+optionally provide a one-sentence explanation. Tooling parses the leading
+word — "yes" or "true" means positive, anything else means negative.`,
   editable: {
     template: true,
     profile: true,

--- a/packages/analytics/src/prompts.ts
+++ b/packages/analytics/src/prompts.ts
@@ -1,0 +1,122 @@
+/**
+ * Prompt registrations for the @happyvertical/smrt-analytics package.
+ *
+ * Prompts are registered at module-load time via `definePrompt()` so that
+ * tenant-aware overrides can be applied at call time via `resolvePrompt()`.
+ *
+ * Mirrors the pattern used by `@happyvertical/smrt-properties` (see
+ * `prompts.ts`) and `@happyvertical/smrt-content` (see `content-prompts.ts`).
+ *
+ * PII / internal-field exclusion policy:
+ * The variables sent to the AI provider deliberately exclude:
+ *   - `id`, `tenantId`, `propertyId` and other foreign-key/UUID fields —
+ *     they identify internal records and provide no analytic value.
+ *   - `apiSecret`, `measurementId`, `externalId`, `siteDomain` — these are
+ *     provider credentials or platform-specific identifiers (e.g. GA4 API
+ *     secrets, Matomo `idSite`, custom `G-XXXX` measurement IDs) that may
+ *     be tenant-private configuration.
+ *   - `providerMetadata` — extensible JSON blob that may contain
+ *     credentials, account IDs, or other configuration secrets.
+ *   - `lastError`, `dimensionFilter`, `metricFilter`, `resultData` raw
+ *     payloads — only aggregate counts and computed deltas are passed; the
+ *     raw rows can include cookie IDs, user-pseudo-IDs, IP-derived geos,
+ *     and other PII the analytics provider returned.
+ *
+ * Acceptable variables: human-readable names, time periods, computed
+ * aggregates (row counts, totals), and high-level dimension/metric labels.
+ * If a downstream tenant needs richer context they can override the
+ * template via PromptOverride.
+ */
+
+import {
+  definePrompt,
+  type ResolvedPromptAI,
+} from '@happyvertical/smrt-prompts';
+
+/**
+ * `AnalyticsProperty.analyzePerformance()` prompt. Only the human-readable
+ * display name, provider label, and the requested period reach the model;
+ * provider IDs, API secrets, and the providerMetadata blob are excluded.
+ */
+export const smrtAnalyticsAnalyzePerformancePrompt = definePrompt({
+  key: 'smrtAnalytics.property.analyzePerformance',
+  template: `Analyze the analytics performance for this property over the last {period}.
+Consider: traffic trends, user engagement, conversion patterns.
+Property: {propertyDisplayName} ({propertyProvider})`,
+  editable: {
+    template: true,
+    profile: true,
+    model: true,
+    params: true,
+  },
+});
+
+/**
+ * `AnalyticsReport.analyzeResults()` prompt. Surfaces report name, the
+ * dimension/metric labels (which are public GA4/Plausible/Matomo schema
+ * names — not user data), the date-range window, and the row count plus
+ * a JSON-stringified `resultData` blob. Callers should ensure result rows
+ * have already been de-PII'd by their analytics provider; we treat them
+ * as opaque aggregates for the AI provider.
+ */
+export const smrtAnalyticsAnalyzeResultsPrompt = definePrompt({
+  key: 'smrtAnalytics.report.analyzeResults',
+  template: `Analyze these analytics report results and provide insights:
+
+Report: {reportName}
+Dimensions: {reportDimensions}
+Metrics: {reportMetrics}
+Date Range: {dateRangeStart} to {dateRangeEnd}
+Row Count: {rowCount}
+
+Data: {reportData}
+
+Provide:
+1. Key findings
+2. Trends or patterns
+3. Actionable recommendations`,
+  editable: {
+    template: true,
+    profile: true,
+    model: true,
+    params: true,
+  },
+});
+
+/**
+ * `AnalyticsReport.hasPositiveTrends()` boolean classifier prompt. Same
+ * variables as `analyzeResults` minus the descriptive name — only the
+ * provider-schema metric labels and the aggregate `resultData` payload are
+ * needed to decide whether the trend is positive.
+ */
+export const smrtAnalyticsHasPositiveTrendsPrompt = definePrompt({
+  key: 'smrtAnalytics.report.hasPositiveTrends',
+  template: `Based on these report results, are the metrics showing positive trends?
+
+Metrics: {reportMetrics}
+Data: {reportData}
+
+Consider: user growth, engagement, conversions as positive indicators.`,
+  editable: {
+    template: true,
+    profile: true,
+    model: true,
+    params: true,
+  },
+});
+
+/**
+ * Build the message-options object passed to `aiClient.message()` from a
+ * `ResolvedPromptAI` shape. Mirrors the helper in `smrt-properties` and
+ * `smrt-content` so behavior across packages is identical.
+ */
+export function promptMessageOptions(ai: ResolvedPromptAI) {
+  return {
+    ...(ai.params || {}),
+    ...(ai.model ? { model: ai.model } : {}),
+    ...(typeof ai.temperature === 'number'
+      ? { temperature: ai.temperature }
+      : {}),
+    ...(typeof ai.maxTokens === 'number' ? { maxTokens: ai.maxTokens } : {}),
+  };
+}

--- a/packages/analytics/src/svelte/index.ts
+++ b/packages/analytics/src/svelte/index.ts
@@ -1,19 +1,73 @@
 /**
- * Svelte components for analytics dashboards.
+ * Analytics Module Svelte Components
  *
- * @example
- * ```svelte
- * <script>
- *   import { AnalyticsSummary, PropertyInfo, EventsTable } from '@happyvertical/smrt-analytics/svelte';
- * </script>
+ * Optional Svelte UI components for analytics dashboards. Auto-registers
+ * components with `ModuleUIRegistry` on import.
+ *
+ * @example Direct imports
+ * ```typescript
+ * import { AnalyticsSummary, EventsTable } from '@happyvertical/smrt-analytics/svelte';
+ * ```
+ *
+ * @example Registry-based discovery
+ * ```typescript
+ * import { ModuleUIRegistry } from '@happyvertical/smrt-svelte/registry';
+ * import '@happyvertical/smrt-analytics/svelte'; // Auto-registers components
+ *
+ * const Component = ModuleUIRegistry.get('@happyvertical/smrt-analytics', 'analytics-summary');
  * ```
  *
  * @packageDocumentation
  */
 
-export { default as AnalyticsSummary } from './AnalyticsSummary.svelte';
-export { default as EventsTable } from './EventsTable.svelte';
-export { default as PropertyInfo } from './PropertyInfo.svelte';
-export { default as PropertyStatusBadge } from './PropertyStatusBadge.svelte';
-export { default as StatCard } from './StatCard.svelte';
-export { default as TrendBadge } from './TrendBadge.svelte';
+import { ModuleUIRegistry } from '@happyvertical/smrt-svelte/registry';
+import { ANALYTICS_MODULE_META } from '../ui.js';
+import AnalyticsSummary from './AnalyticsSummary.svelte';
+import EventsTable from './EventsTable.svelte';
+import PropertyInfo from './PropertyInfo.svelte';
+import PropertyStatusBadge from './PropertyStatusBadge.svelte';
+import StatCard from './StatCard.svelte';
+import TrendBadge from './TrendBadge.svelte';
+
+// Export components
+export {
+  AnalyticsSummary,
+  EventsTable,
+  PropertyInfo,
+  PropertyStatusBadge,
+  StatCard,
+  TrendBadge,
+};
+
+// Auto-register module and components with ModuleUIRegistry
+ModuleUIRegistry.registerModule(ANALYTICS_MODULE_META);
+ModuleUIRegistry.register(
+  '@happyvertical/smrt-analytics',
+  'analytics-summary',
+  AnalyticsSummary,
+);
+ModuleUIRegistry.register(
+  '@happyvertical/smrt-analytics',
+  'events-table',
+  EventsTable,
+);
+ModuleUIRegistry.register(
+  '@happyvertical/smrt-analytics',
+  'property-info',
+  PropertyInfo,
+);
+ModuleUIRegistry.register(
+  '@happyvertical/smrt-analytics',
+  'property-status-badge',
+  PropertyStatusBadge,
+);
+ModuleUIRegistry.register(
+  '@happyvertical/smrt-analytics',
+  'stat-card',
+  StatCard,
+);
+ModuleUIRegistry.register(
+  '@happyvertical/smrt-analytics',
+  'trend-badge',
+  TrendBadge,
+);

--- a/packages/analytics/src/ui.ts
+++ b/packages/analytics/src/ui.ts
@@ -1,0 +1,100 @@
+/**
+ * Analytics Module UI Slot Declarations
+ *
+ * This file defines the UI extension points for the analytics module.
+ * UI components are implemented in the ./svelte subpath and auto-register
+ * with `ModuleUIRegistry` when that subpath is imported.
+ *
+ * @example Usage
+ * ```typescript
+ * import { ANALYTICS_MODULE_META } from '@happyvertical/smrt-analytics/ui';
+ * console.log(ANALYTICS_MODULE_META.uiSlots);
+ * ```
+ */
+
+import type { ModuleUISlot, SmrtModuleMeta } from '@happyvertical/smrt-types';
+
+/**
+ * Analytics module UI slots
+ */
+export const ANALYTICS_UI_SLOTS: Record<string, ModuleUISlot> = {
+  'analytics-summary': {
+    id: 'analytics-summary',
+    label: 'Analytics Summary',
+    description:
+      'Summary cards for pageviews, users, and trend deltas across today/yesterday',
+    icon: 'bar-chart-3',
+    category: 'display',
+    order: 1,
+    propsInterface: 'AnalyticsSummaryProps',
+  },
+  'events-table': {
+    id: 'events-table',
+    label: 'Events Table',
+    description: 'Tabular display of recent analytics events with filters',
+    icon: 'list',
+    category: 'list',
+    order: 2,
+    propsInterface: 'EventsTableProps',
+  },
+  'property-info': {
+    id: 'property-info',
+    label: 'Property Info',
+    description: 'Display analytics property identifiers and configuration',
+    icon: 'info',
+    category: 'display',
+    order: 3,
+    propsInterface: 'PropertyInfoProps',
+  },
+  'property-status-badge': {
+    id: 'property-status-badge',
+    label: 'Property Status Badge',
+    description: 'Compact status indicator for an analytics property',
+    icon: 'badge',
+    category: 'display',
+    order: 4,
+    propsInterface: 'PropertyStatusBadgeProps',
+  },
+  'stat-card': {
+    id: 'stat-card',
+    label: 'Stat Card',
+    description:
+      'Single-metric card with label, value, optional trend and subtitle',
+    icon: 'trending-up',
+    category: 'display',
+    order: 5,
+    propsInterface: 'StatCardProps',
+  },
+  'trend-badge': {
+    id: 'trend-badge',
+    label: 'Trend Badge',
+    description: 'Up/down/flat trend indicator with percentage delta',
+    icon: 'arrow-up-right',
+    category: 'display',
+    order: 6,
+    propsInterface: 'TrendBadgeProps',
+  },
+};
+
+/**
+ * Analytics module metadata
+ */
+export const ANALYTICS_MODULE_META: SmrtModuleMeta = {
+  name: '@happyvertical/smrt-analytics',
+  displayName: 'Analytics',
+  description:
+    'Analytics integration models for GA4, Plausible, and Matomo with server-side event tracking and AI-powered reporting',
+  uiSlots: ANALYTICS_UI_SLOTS,
+  models: [
+    'AnalyticsProperty',
+    'AnalyticsDataStream',
+    'AnalyticsEvent',
+    'AnalyticsReport',
+  ],
+  collections: [
+    'AnalyticsPropertyCollection',
+    'AnalyticsDataStreamCollection',
+    'AnalyticsEventCollection',
+    'AnalyticsReportCollection',
+  ],
+};

--- a/packages/analytics/vite.config.ts
+++ b/packages/analytics/vite.config.ts
@@ -1,6 +1,6 @@
 import { createPackageConfig } from '../../vite.config.base.js';
 
 export default createPackageConfig('analytics', {
-  entries: ['playground'],
+  entries: ['playground', 'ui'],
   svelte: 'svelte',
 });

--- a/packages/ledgers/CLAUDE.md
+++ b/packages/ledgers/CLAUDE.md
@@ -5,8 +5,22 @@ Double-entry accounting with chart of accounts, journal lifecycle, and balance e
 ## Models
 
 - **Account**: 5 types (asset/liability/equity/revenue/expense). Hierarchical via `parentId`. Debit-normal (asset, expense) vs credit-normal (liability, equity, revenue). Methods: `getAncestors()`, `getFullPath()`, `toTreeNode()`, `getBalance(asOfDate?)`.
-- **Journal**: lifecycle `draft → posted → voided`. **Immutable after posting** (can only void, not edit). `sourceModule`/`sourceRef` for cross-package attribution. Auto-numbered (e.g., "JNL-0001").
+- **Journal**: lifecycle `draft → posted → voided`. **Immutable after posting** (can only void, not edit). `sourceModule`/`sourceRef` for cross-package attribution. Auto-numbered (e.g., "JNL-0001"). `summarize()` is AI-powered via the smrt-prompts registry (see Prompt Registry below).
 - **JournalEntry**: debit XOR credit (not both, validated on save). Multi-currency via `exchangeRate`. Non-negative amounts required.
+
+## Key Methods
+
+- **`Journal.summarize()`**: Generates a natural-language summary via the registered `smrtLedgers.journal.summarize` prompt, resolved through `@happyvertical/smrt-prompts`. Tenants can override the template, model, temperature, or other params via `_smrt_prompt_overrides` without code changes. Only non-PII fields (number, date, description, status, aggregate total, entry count, balanced flag) reach the AI provider.
+
+## Prompt Registry
+
+Registered at module-load time via `definePrompt()` in `src/prompts.ts`. Side-effect imported from `src/index.ts` so consumers automatically see the prompts after importing any export from this package.
+
+| Key | Method | Variables |
+|-----|--------|-----------|
+| `smrtLedgers.journal.summarize` | `Journal.summarize()` | `journalNumber`, `journalDate`, `journalDescription`, `journalStatus`, `journalTotal`, `entryCount`, `journalBalanced` |
+
+PII-conscious variable selection: `tenantId`, `sourceRef` (may reference customer/vendor identifiers), per-entry `accountId`/`id`, and the extensible `metadata` blob are intentionally NOT exposed as prompt variables. Tenants who need richer context should override the template via `PromptOverride` and supply their own variables through a custom call site.
 
 ## Balance Enforcement
 

--- a/packages/ledgers/package.json
+++ b/packages/ledgers/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-prompts": "workspace:*",
     "@happyvertical/smrt-tenancy": "workspace:*"
   },
   "devDependencies": {

--- a/packages/ledgers/src/__tests__/journal-summarize.test.ts
+++ b/packages/ledgers/src/__tests__/journal-summarize.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for `Journal.summarize()` — verifies the smrt-prompts integration:
+ * prompt resolution, variable substitution, trimmed AI output, and that
+ * internal/PII-adjacent fields (id, tenantId, sourceRef, metadata) are NOT
+ * passed to the AI provider.
+ *
+ * The AI client is stubbed via a `getAiClient()` override so no network calls
+ * are made. The `db` plumbing is exercised separately via the smrt-prompts
+ * package's own integration tests; here we focus on Journal-level behavior.
+ *
+ * Mirrors `packages/properties/src/__tests__/summarize.test.ts`.
+ */
+
+import { clearPromptCache } from '@happyvertical/smrt-prompts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Journal } from '../models/Journal.js';
+import { smrtLedgersJournalSummarizePrompt } from '../prompts.js';
+
+describe('Journal.summarize()', () => {
+  let aiMessageMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    aiMessageMock = vi.fn().mockResolvedValue('Generated summary text  ');
+    clearPromptCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makeJournal(opts: ConstructorParameters<typeof Journal>[0] = {}) {
+    const journal = new Journal({
+      number: 'JNL-0001',
+      date: new Date('2026-05-01T00:00:00Z'),
+      description: 'Cash sale of widgets',
+      sourceModule: 'smrt-commerce',
+      status: 'posted',
+      // Internal/PII-adjacent fields that should NOT reach the AI provider:
+      id: 'journal-uuid-1234',
+      sourceRef: 'INV-PRIVATE-9999',
+      tenantId: 'tenant-uuid-9999',
+      metadata: {
+        analyticsId: 'UA-PRIVATE-12345',
+        secretKey: 'do-not-leak',
+      },
+      ...opts,
+    });
+    // Stub the AI client so summarize doesn't reach a real provider.
+    (journal as any).getAiClient = async () => ({
+      message: aiMessageMock,
+    });
+    // Stub aggregate helpers so we don't need a real DB for this focused test.
+    (journal as any).getEntries = async () => [
+      {
+        id: 'entry-uuid-aaaa',
+        accountId: 'account-uuid-cash',
+        debit: 100,
+        credit: 0,
+      },
+      {
+        id: 'entry-uuid-bbbb',
+        accountId: 'account-uuid-revenue',
+        debit: 0,
+        credit: 100,
+      },
+    ];
+    (journal as any).getTotalDebits = async () => 100;
+    (journal as any).getTotalCredits = async () => 100;
+    (journal as any).isBalanced = async () => true;
+    return journal;
+  }
+
+  it('uses the registered prompt key', () => {
+    expect(smrtLedgersJournalSummarizePrompt.key).toBe(
+      'smrtLedgers.journal.summarize',
+    );
+  });
+
+  it('resolves the registered summarize prompt and returns trimmed AI output', async () => {
+    const journal = makeJournal();
+
+    const result = await journal.summarize();
+
+    expect(result).toBe('Generated summary text');
+    expect(aiMessageMock).toHaveBeenCalledTimes(1);
+
+    // The prompt sent to the AI should contain the substituted number,
+    // date, description, status, total, entry count, and balanced flag
+    // from the registered template.
+    const [text] = aiMessageMock.mock.calls[0];
+    expect(text).toContain('JNL-0001');
+    expect(text).toContain('2026-05-01');
+    expect(text).toContain('Cash sale of widgets');
+    expect(text).toContain('posted');
+    expect(text).toContain('$100.00');
+    expect(text).toContain('Entries: 2');
+    expect(text).toContain('Balanced: Yes');
+  });
+
+  it('does NOT pass internal/PII-adjacent fields to the AI provider', async () => {
+    const journal = makeJournal();
+
+    await journal.summarize();
+
+    const [text] = aiMessageMock.mock.calls[0];
+    // Foreign-key references that link to identifying records.
+    expect(text).not.toContain('journal-uuid-1234');
+    expect(text).not.toContain('tenant-uuid-9999');
+    expect(text).not.toContain('INV-PRIVATE-9999');
+    // Per-entry account IDs and entry IDs must not leak via aggregate path.
+    expect(text).not.toContain('entry-uuid-aaaa');
+    expect(text).not.toContain('entry-uuid-bbbb');
+    expect(text).not.toContain('account-uuid-cash');
+    expect(text).not.toContain('account-uuid-revenue');
+    // Extensible metadata may contain analytics IDs, secrets, or other
+    // tenant-private configuration — must not leak into prompts.
+    expect(text).not.toContain('UA-PRIVATE-12345');
+    expect(text).not.toContain('do-not-leak');
+  });
+
+  it('renders Balanced: No when the journal does not balance', async () => {
+    const journal = makeJournal();
+    (journal as any).isBalanced = async () => false;
+    (journal as any).getTotalDebits = async () => 100;
+
+    await journal.summarize();
+
+    const [text] = aiMessageMock.mock.calls[0];
+    expect(text).toContain('Balanced: No');
+  });
+
+  it('passes empty AI options for the default registered prompt (no ai config)', async () => {
+    const journal = makeJournal();
+
+    await journal.summarize();
+
+    expect(aiMessageMock).toHaveBeenCalledTimes(1);
+    // The default registered prompt has no model/temperature/maxTokens/params,
+    // so the options object derived by promptMessageOptions should be empty.
+    const [, options] = aiMessageMock.mock.calls[0];
+    expect(options).toEqual({});
+  });
+
+  it('forwards model/temperature/maxTokens from a runtime ai override to ai.message', async () => {
+    // Drive promptMessageOptions directly with a synthetic ResolvedPromptAI
+    // shape — this exercises the same helper Journal.summarize calls and
+    // documents the contract for tenant overrides that set ai-config fields.
+    const { promptMessageOptions } = await import('../prompts.js');
+
+    const options = promptMessageOptions({
+      profile: null,
+      model: 'gpt-test-1',
+      temperature: 0.42,
+      maxTokens: 256,
+      params: { topP: 0.9 },
+    });
+
+    expect(options).toEqual({
+      topP: 0.9,
+      model: 'gpt-test-1',
+      temperature: 0.42,
+      maxTokens: 256,
+    });
+  });
+});

--- a/packages/ledgers/src/index.ts
+++ b/packages/ledgers/src/index.ts
@@ -64,6 +64,9 @@
 // downstream. Must come first so the side effect runs ahead of the class
 // module loads below. See __smrt-register__.ts for issue #1132 context.
 import './__smrt-register__.js';
+// Register prompts at module-load time so consumers and tenants can
+// override them via `resolvePrompt()` without further plumbing.
+import './prompts.js';
 
 // Export collections
 export { AccountCollection } from './collections/Accounts';
@@ -74,6 +77,13 @@ export { JournalCollection } from './collections/Journals';
 export { Account } from './models/Account';
 export { Journal } from './models/Journal';
 export { JournalEntry } from './models/JournalEntry';
+
+// Export prompt registrations so consumers can reference the key for
+// tenant-aware overrides via `@happyvertical/smrt-prompts`.
+export {
+  promptMessageOptions,
+  smrtLedgersJournalSummarizePrompt,
+} from './prompts';
 
 // Export types
 export type {

--- a/packages/ledgers/src/models/Journal.ts
+++ b/packages/ledgers/src/models/Journal.ts
@@ -274,7 +274,9 @@ export class Journal extends SmrtObject {
           journalDate: this.date.toISOString().split('T')[0],
           journalDescription: this.description || '',
           journalStatus: this.status || '',
-          journalTotal: debits.toFixed(2),
+          // Currency prefix folded into the value rather than the template
+          // — see the `smrtLedgersJournalSummarizePrompt` comment block.
+          journalTotal: `$${debits.toFixed(2)}`,
           entryCount: String(entries.length),
           journalBalanced: balanced ? 'Yes' : 'No',
         },

--- a/packages/ledgers/src/models/Journal.ts
+++ b/packages/ledgers/src/models/Journal.ts
@@ -6,7 +6,12 @@
  */
 
 import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { resolvePrompt } from '@happyvertical/smrt-prompts';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import {
+  promptMessageOptions,
+  smrtLedgersJournalSummarizePrompt,
+} from '../prompts';
 import {
   BALANCE_EPSILON,
   type JournalEntryData,
@@ -231,22 +236,57 @@ export class Journal extends SmrtObject {
   }
 
   /**
-   * Generate a summary of this journal
+   * AI-powered: Generate a summary of this journal.
+   *
+   * Uses the `smrtLedgers.journal.summarize` prompt registered via
+   * `@happyvertical/smrt-prompts`, allowing tenant- or instance-level
+   * overrides of the template, model, and parameters at runtime.
+   *
+   * Only non-PII journal fields (number, date, description, status, balanced
+   * flag) plus aggregate totals and entry count are sent to the AI provider.
+   * Internal foreign-key fields (tenantId, sourceRef, individual entry
+   * account IDs) and the extensible `metadata` blob are intentionally
+   * excluded.
+   *
+   * @returns Generated summary text
    */
   async summarize(): Promise<string> {
     const entries = await this.getEntries();
     const debits = await this.getTotalDebits();
     const balanced = await this.isBalanced();
 
-    return await this.do(
-      `Summarize this accounting journal entry:\n` +
-        `Number: ${this.number}\n` +
-        `Date: ${this.date.toISOString().split('T')[0]}\n` +
-        `Description: ${this.description}\n` +
-        `Status: ${this.status}\n` +
-        `Total: $${debits.toFixed(2)}\n` +
-        `Entries: ${entries.length}\n` +
-        `Balanced: ${balanced ? 'Yes' : 'No'}`,
+    // Resolve `db` from either the canonical `db` option or its `persistence`
+    // alias. SmrtClass maps `persistence → db` lazily during `initialize()`,
+    // so on a freshly-constructed Journal that has not yet been initialized,
+    // `this.options.db` may be undefined while `this.options.persistence` is
+    // set. Falling back here ensures stored app- and tenant-level prompt
+    // overrides in `_smrt_prompt_overrides` are honored on the first call —
+    // before `getAiClient()` triggers full initialization further below.
+    const db = this.options.db ?? this.options.persistence;
+
+    const resolvedPrompt = await resolvePrompt(
+      smrtLedgersJournalSummarizePrompt.key,
+      {
+        db,
+        tenantId: this.tenantId,
+        variables: {
+          journalNumber: this.number || '',
+          journalDate: this.date.toISOString().split('T')[0],
+          journalDescription: this.description || '',
+          journalStatus: this.status || '',
+          journalTotal: debits.toFixed(2),
+          entryCount: String(entries.length),
+          journalBalanced: balanced ? 'Yes' : 'No',
+        },
+      },
     );
+
+    const ai = await this.getAiClient();
+    const response = await ai.message(
+      resolvedPrompt.text,
+      promptMessageOptions(resolvedPrompt.ai),
+    );
+
+    return response.trim();
   }
 }

--- a/packages/ledgers/src/prompts.ts
+++ b/packages/ledgers/src/prompts.ts
@@ -1,0 +1,51 @@
+/**
+ * Prompt registrations for the @happyvertical/smrt-ledgers package.
+ *
+ * Prompts are registered at module-load time via `definePrompt()` so that
+ * tenant-aware overrides can be applied at call time via `resolvePrompt()`.
+ *
+ * Mirrors the pattern used by `@happyvertical/smrt-properties` (see
+ * `prompts.ts`) and `@happyvertical/smrt-content` (see `content-prompts.ts`).
+ */
+
+import {
+  definePrompt,
+  type ResolvedPromptAI,
+} from '@happyvertical/smrt-prompts';
+
+// Journal summarization only uses non-PII journal fields
+// (number, date, description, status, balanced flag) plus aggregate totals
+// and entry count. Internal/foreign-key fields like tenantId, sourceRef,
+// individual entry account IDs, and the extensible `metadata` blob are
+// intentionally NOT passed to the AI provider — they may link to identifying
+// records (customer/vendor IDs via sourceRef) or contain tenant-private
+// configuration. If a downstream tenant needs richer context they can
+// override the template via PromptOverride.
+export const smrtLedgersJournalSummarizePrompt = definePrompt({
+  key: 'smrtLedgers.journal.summarize',
+  template: `Summarize this accounting journal entry:
+Number: {journalNumber}
+Date: {journalDate}
+Description: {journalDescription}
+Status: {journalStatus}
+Total: \${journalTotal}
+Entries: {entryCount}
+Balanced: {journalBalanced}`,
+  editable: {
+    template: true,
+    profile: true,
+    model: true,
+    params: true,
+  },
+});
+
+export function promptMessageOptions(ai: ResolvedPromptAI) {
+  return {
+    ...(ai.params || {}),
+    ...(ai.model ? { model: ai.model } : {}),
+    ...(typeof ai.temperature === 'number'
+      ? { temperature: ai.temperature }
+      : {}),
+    ...(typeof ai.maxTokens === 'number' ? { maxTokens: ai.maxTokens } : {}),
+  };
+}

--- a/packages/ledgers/src/prompts.ts
+++ b/packages/ledgers/src/prompts.ts
@@ -21,6 +21,13 @@ import {
 // records (customer/vendor IDs via sourceRef) or contain tenant-private
 // configuration. If a downstream tenant needs richer context they can
 // override the template via PromptOverride.
+// Note: smrt-prompts substitutes `{token}` placeholders. The currency prefix
+// is folded into the `journalTotal` variable value (e.g. "$100.00") rather
+// than written as a literal `$` in the template — earlier revisions used
+// `\${journalTotal}` (a template-literal escape that renders as the literal
+// `${journalTotal}` at runtime). That technically worked because the regex
+// still matched the inner `{journalTotal}` and produced `$100.00`, but it
+// confused reviewers; folding the prefix into the value avoids the trap.
 export const smrtLedgersJournalSummarizePrompt = definePrompt({
   key: 'smrtLedgers.journal.summarize',
   template: `Summarize this accounting journal entry:
@@ -28,7 +35,7 @@ Number: {journalNumber}
 Date: {journalDate}
 Description: {journalDescription}
 Status: {journalStatus}
-Total: \${journalTotal}
+Total: {journalTotal}
 Entries: {entryCount}
 Balanced: {journalBalanced}`,
   editable: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,7 +283,16 @@ importers:
       '@happyvertical/smrt-prompts':
         specifier: workspace:*
         version: link:../prompts
+      '@happyvertical/smrt-types':
+        specifier: workspace:*
+        version: link:../types
     devDependencies:
+      '@happyvertical/smrt-svelte':
+        specifier: workspace:*
+        version: link:../smrt-svelte
+      '@happyvertical/smrt-tenancy':
+        specifier: workspace:*
+        version: link:../tenancy
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
         version: link:../vitest

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1129,6 +1129,9 @@ importers:
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
+      '@happyvertical/smrt-prompts':
+        specifier: workspace:*
+        version: link:../prompts
       '@happyvertical/smrt-tenancy':
         specifier: workspace:*
         version: link:../tenancy

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
+      '@happyvertical/smrt-prompts':
+        specifier: workspace:*
+        version: link:../prompts
     devDependencies:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
@@ -289,7 +292,7 @@ importers:
         version: 0.73.2
       '@sveltejs/package':
         specifier: ^2.5.7
-        version: 2.5.7(svelte@5.53.5)(typescript@5.9.3)
+        version: 2.5.7(svelte@5.53.12)(typescript@5.9.3)
       '@types/node':
         specifier: 24.10.9
         version: 24.10.9
@@ -297,11 +300,11 @@ importers:
         specifier: 3.3.3
         version: 3.3.3
       svelte:
-        specifier: ^5.0.0
-        version: 5.53.5
+        specifier: ^5.18.0
+        version: 5.53.12
       svelte-check:
         specifier: ^4.3.5
-        version: 4.4.4(picomatch@4.0.3)(svelte@5.53.5)(typescript@5.9.3)
+        version: 4.4.4(picomatch@4.0.3)(svelte@5.53.12)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
Phase 2 alignment for the Business category — sequenced under epic #1191 after Foundation (#1206), Agents & Runtime (#1208), Domain (#1210), and Content & Media (#1212) closed. Tracking: #1214.

## Per-package work

### `commerce`, `products`
Already aligned. No code changes.

### `ads` — `1445c41d`
- Adds a Tenancy section to `packages/ads/CLAUDE.md` mirroring the documented-exception pattern from `packages/secrets/CLAUDE.md`.
- Adds inline comments on `AdDeliveryTier` and `AdFormat`'s `@smrt(...)` blocks documenting why they are deliberately not `@TenantScoped` — both are shared catalog tables (industry-standard IAB dimensions and the package's priority waterfall) that would fragment if tenanted.
- The transactional models (`AdGroup`, `AdVariation`, `AdEvent`) keep their existing `@TenantScoped({ mode: 'optional' })` decorators.
- No model schemas, decorators, or tests changed.

### `affiliates` — `d0ca4919`
- Documents the cross-tenant tenancy model in `packages/affiliates/CLAUDE.md`. The package was already global-by-design (one-line gotcha), but the rationale is now expanded into a dedicated Tenancy section explaining why per-tenant slicing of `Partner`/`Commission`/`Payout` would either duplicate identity or hide payouts owed across tenants.
- Adds inline comments on each `@smrt(...)` block pointing back to the Tenancy section.
- Notes that operators needing tenant-attributed reporting should aggregate via `eventId` joins to smrt-ads, not by adding `@TenantScoped` here.
- No model schemas, decorators, or tests changed.

### `ledgers` — `ccf481d2` (sub-branch `feat/business-ledgers-alignment`)
- Migrates `Journal.summarize()` from inline `this.do()` to the smrt-prompts pattern.
- New `packages/ledgers/src/prompts.ts` registers `smrtLedgers.journal.summarize` (key) via `definePrompt()` with `editable: { template, profile, model, params }`.
- Side-effect import from `index.ts` so registration runs at module load; re-exports the prompt definition for consumer-side overrides.
- `summarize()` now resolves the prompt with `resolvePrompt({ db: this.options.db ?? this.options.persistence, tenantId: this.tenantId, … })` and forwards `promptMessageOptions(resolved.ai)` into `getAiClient().message()` so editable model/params overrides take effect.
- PII-conscious variables: account names, totals, period, entry count. Excluded: `id`, `tenantId`, `sourceRef`, per-entry `accountId`/`id`, the freeform `metadata` blob.
- Adds 6 focused vitest tests (`__tests__/journal-summarize.test.ts`) covering prompt key, variable substitution, PII exclusion, balanced flag rendering, default empty AI options, and runtime ai-override forwarding. All 52/52 ledger tests green.

### `analytics` — `56691110` + `50905c3e` (sub-branch `feat/business-analytics-alignment`)
- Migrates three AI-powered methods from inline `this.do()` to smrt-prompts:
  - `AnalyticsProperty.analyzePerformance()` → key `smrtAnalytics.property.analyzePerformance`
  - `AnalyticsReport.analyzeResults()` → key `smrtAnalytics.report.analyzeResults`
  - `AnalyticsReport.hasPositiveTrends()` → key `smrtAnalytics.report.hasPositiveTrends`
- New `packages/analytics/src/prompts.ts` with `definePrompt()` registrations and a `promptMessageOptions` helper. Side-effect import from `index.ts`.
- Adopts `ModuleUIRegistry`: new `packages/analytics/src/ui.ts` exporting `ANALYTICS_MODULE_META` + `ANALYTICS_UI_SLOTS` (6 slots: `analytics-summary`, `events-table`, `property-info`, `property-status-badge`, `stat-card`, `trend-badge`); `src/svelte/index.ts` registers via `ModuleUIRegistry.registerModule` + per-slot `register`.
- Bumps `peerDependencies.svelte` and `devDependencies.svelte` from `^5.0.0` to `^5.18.0` (matches profiles/content/images).
- Adds `./ui` package.json export with `{ types, import }` only — no `svelte` condition (matches the PR #1213 cleanup).
- 248→254 tests pass per adapter (json/sqlite/postgres) plus 28 intentionally skipped.

#### Review-finding fixes (`50905c3e`)
- **Codex P2**: tenant-context fallback was being short-circuited because the analytics models (no `tenantId` field) were passing `tenantId: null` explicitly. `resolvePrompt` only consults `getTenantId()` from AsyncLocalStorage when `options.tenantId` is undefined; passing `null` silently ignored tenant overrides. All three methods now OMIT `tenantId` from the resolvePrompt options. Pinned by a regression test inspecting the options object.
- **Codex P2**: declared the new UI entry-point dependencies — `@happyvertical/smrt-types` as a direct dependency (used by `./ui`), `@happyvertical/smrt-svelte` as an optional peer (used by `./svelte`). Mirrors the shape used by smrt-images after PR #1213's identical fix.
- **Claude reviewer**: dropped unnecessary `(this.options as any)` casts — `SmrtClassOptions` already types `db` and `persistence`, so casting masked typo risk.
- **Claude reviewer**: tightened the `resultData` forwarding contract. Added a regression test proving `resultData` rows ARE forwarded verbatim (with PII fields intact when caller persists raw GA4 dimensions like `userPseudoId`); reworded `prompts.ts` and `CLAUDE.md` so callers can't mistakenly assume the package strips PII for them.

## Standards

`scripts/check-standards.mjs`: 42 packages, 0 violations.

Relates to epic #1191.