### PR TITLE
feat(content): expose governance dock tools

### DIFF
--- a/packages/content/src/svelte/components/ContentClaimAuditTool.svelte
+++ b/packages/content/src/svelte/components/ContentClaimAuditTool.svelte
@@ -1,0 +1,409 @@
+<script lang="ts">
+import type {
+  FactAuditClaimData,
+  FactAuditStateData,
+} from '../../mock-smrt-client';
+import { createClient } from '../../mock-smrt-client';
+import { normalizeApiBaseUrl } from '../api';
+
+export interface Props {
+  apiBaseUrl?: string;
+  contentId: string;
+  onFactAuditChange?: (state: FactAuditStateData | null) => void;
+}
+
+let {
+  apiBaseUrl = '/api/v1',
+  contentId,
+  onFactAuditChange = undefined,
+}: Props = $props();
+
+const client = $derived(createClient(normalizeApiBaseUrl(apiBaseUrl)));
+const savedContentId = $derived(
+  contentId && contentId !== 'new' ? contentId : null,
+);
+
+let factAudit = $state<FactAuditStateData | null>(null);
+let busy = $state(false);
+let error = $state<string | null>(null);
+let notice = $state<string | null>(null);
+let selectedClaimIds = $state<string[]>([]);
+let loadedContentId = $state<string | null>(null);
+
+const factAuditGroups = $derived({
+  contradicted:
+    factAudit?.claims.filter(
+      (claim) => claim.supportStatus === 'contradicted',
+    ) || [],
+  unsupported:
+    factAudit?.claims.filter(
+      (claim) => claim.supportStatus === 'unsupported',
+    ) || [],
+  needs_review:
+    factAudit?.claims.filter(
+      (claim) => claim.supportStatus === 'needs_review',
+    ) || [],
+  supported:
+    factAudit?.claims.filter((claim) => claim.supportStatus === 'supported') ||
+    [],
+});
+const actionableWarnings = $derived(
+  (factAudit?.warnings ?? []).filter(
+    (warning) => !/^Asset .+ has no extracted text\.$/.test(warning.trim()),
+  ),
+);
+const selectedClaimCount = $derived(selectedClaimIds.length);
+
+$effect(() => {
+  if (!savedContentId) {
+    loadedContentId = null;
+    factAudit = null;
+    onFactAuditChange?.(null);
+    return;
+  }
+
+  if (savedContentId !== loadedContentId) {
+    loadedContentId = savedContentId;
+    void loadFactAudit();
+  }
+});
+
+function getClaimId(claim: FactAuditClaimData): string | null {
+  return typeof claim.id === 'string' && claim.id.length > 0 ? claim.id : null;
+}
+
+function isClaimSelected(claim: FactAuditClaimData): boolean {
+  const claimId = getClaimId(claim);
+  return Boolean(claimId && selectedClaimIds.includes(claimId));
+}
+
+function toggleClaimSelection(claim: FactAuditClaimData) {
+  const claimId = getClaimId(claim);
+  if (!claimId) return;
+
+  selectedClaimIds = selectedClaimIds.includes(claimId)
+    ? selectedClaimIds.filter((id) => id !== claimId)
+    : [...selectedClaimIds, claimId];
+}
+
+async function loadFactAudit() {
+  if (!savedContentId) return;
+
+  busy = true;
+  error = null;
+
+  try {
+    const response = await client.contents.getFactAudit(savedContentId);
+    factAudit = response.data;
+    onFactAuditChange?.(response.data);
+  } catch (err: any) {
+    error = err.message || 'Failed to load claim audit';
+  } finally {
+    busy = false;
+  }
+}
+
+async function repairFactAudit() {
+  if (!savedContentId || busy) return;
+
+  busy = true;
+  error = null;
+  notice = null;
+
+  try {
+    const response = await client.contents.repairFactAudit(savedContentId);
+    factAudit = response.data;
+    notice = `Fact audit repaired: ${response.data.counts.total} claim(s) checked.`;
+    onFactAuditChange?.(response.data);
+  } catch (err: any) {
+    error = err.message || 'Failed to repair fact audit';
+  } finally {
+    busy = false;
+  }
+}
+
+async function recheckFactClaims(claimIds: string[]) {
+  if (!savedContentId || busy || claimIds.length === 0) return;
+
+  busy = true;
+  error = null;
+  notice = null;
+
+  try {
+    const response = await client.contents.recheckFactClaims(savedContentId, {
+      claimFactIds: claimIds,
+    });
+    factAudit = response.data;
+    notice = `Rechecked ${claimIds.length} claim${claimIds.length === 1 ? '' : 's'} against current evidence.`;
+    selectedClaimIds = selectedClaimIds.filter((id) => !claimIds.includes(id));
+    onFactAuditChange?.(response.data);
+  } catch (err: any) {
+    error = err.message || 'Failed to recheck claim support';
+  } finally {
+    busy = false;
+  }
+}
+</script>
+
+<div class="governance-tool">
+  {#if error}
+    <p class="tool-error">{error}</p>
+  {/if}
+
+  {#if notice}
+    <p class="tool-notice">{notice}</p>
+  {/if}
+
+  {#if !savedContentId}
+    <p class="empty-copy">Save this content to audit article claims against evidence.</p>
+  {:else}
+    <div class="claim-audit-toolbar">
+      <div class="claim-audit-counts">
+        <span><strong>{factAudit?.counts.total ?? 0}</strong> article claims</span>
+        <span><strong>{factAudit?.counts.supported ?? 0}</strong> supported</span>
+        <span><strong>{factAudit?.counts.unsupported ?? 0}</strong> unsupported</span>
+        <span><strong>{factAudit?.counts.contradicted ?? 0}</strong> contradicted</span>
+        <span><strong>{factAudit?.counts.needs_review ?? 0}</strong> review</span>
+      </div>
+      <button
+        type="button"
+        class="secondary-button"
+        disabled={busy || selectedClaimCount === 0}
+        onclick={() => void recheckFactClaims(selectedClaimIds)}
+      >
+        {busy ? 'Checking...' : `Recheck selected (${selectedClaimCount})`}
+      </button>
+      <button
+        type="button"
+        class="secondary-button"
+        disabled={busy}
+        onclick={() => void repairFactAudit()}
+      >
+        {busy ? 'Working...' : 'Repair audit'}
+      </button>
+    </div>
+    <p class="empty-copy">
+      Article claims are statements made by this draft. A supported claim has linked source evidence from the references; unsupported means the audit has not found that supporting evidence yet.
+    </p>
+
+    {#if actionableWarnings.length}
+      <div class="tool-warning">
+        {#each actionableWarnings as warning}
+          <p>{warning}</p>
+        {/each}
+      </div>
+    {/if}
+
+    {#if !factAudit || factAudit.counts.total === 0}
+      <p class="empty-copy">No article claim audit has been generated yet.</p>
+    {:else}
+      {#each [
+        ['contradicted', 'Contradicted'],
+        ['unsupported', 'Unsupported'],
+        ['needs_review', 'Needs review'],
+        ['supported', 'Supported']
+      ] as group}
+        {@const groupKey = group[0] as keyof typeof factAuditGroups}
+        {@const groupClaims = factAuditGroups[groupKey]}
+        {#if groupClaims.length > 0}
+          <div class="tool-list">
+            <div class="section-caption">{group[1]} article claims</div>
+            {#each groupClaims as claim (claim.id ?? claim.claimQuote ?? claim.fact.textRefined)}
+              <details class="tool-card">
+                <summary>
+                  <label class="claim-audit-select">
+                    <input
+                      type="checkbox"
+                      checked={isClaimSelected(claim)}
+                      disabled={!getClaimId(claim)}
+                      onchange={() => toggleClaimSelection(claim)}
+                    />
+                  </label>
+                  <span class={`pill pill--${claim.supportStatus === 'supported' ? 'passed' : claim.supportStatus === 'contradicted' ? 'failed' : 'flagged'}`}>
+                    {claim.supportStatus.replace('_', ' ')}
+                  </span>
+                  <strong>{claim.fact.textRefined || claim.claimQuote || claim.id}</strong>
+                </summary>
+                <div class="tool-card-body">
+                  <div class="claim-audit-actions">
+                    <button
+                      type="button"
+                      class="secondary-button"
+                      disabled={busy || !getClaimId(claim)}
+                      onclick={() => {
+                        const claimId = getClaimId(claim);
+                        if (claimId) void recheckFactClaims([claimId]);
+                      }}
+                    >
+                      Recheck support
+                    </button>
+                  </div>
+                  {#if claim.claimQuote}
+                    <p><strong>Article claim:</strong> {claim.claimQuote}</p>
+                  {/if}
+                  {#if claim.rationale}
+                    <p><strong>Support assessment:</strong> {claim.rationale}</p>
+                  {/if}
+                  {#if claim.matchedFacts?.length}
+                    <div class="tool-list">
+                      <div class="section-caption">Based on source evidence</div>
+                      {#each claim.matchedFacts as matched (matched.fact.id ?? matched.fact.textRefined)}
+                        <div class="tool-card nested">
+                          <strong>Source claim: {matched.fact.textRefined || matched.fact.textRaw || matched.fact.id}</strong>
+                          {#each matched.evidence ?? [] as evidence (evidence.id ?? evidence.evidenceKey)}
+                            <span>
+                              {evidence.sourceTitle || 'Source'}
+                              {#if evidence.locator}
+                                · {evidence.locator}
+                              {/if}
+                              {#if evidence.quote}
+                                · {evidence.quote}
+                              {/if}
+                            </span>
+                          {/each}
+                        </div>
+                      {/each}
+                    </div>
+                  {:else}
+                    <p><strong>Based on:</strong> No supporting source evidence linked.</p>
+                  {/if}
+                </div>
+              </details>
+            {/each}
+          </div>
+        {/if}
+      {/each}
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .governance-tool,
+  .tool-list,
+  .tool-card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .claim-audit-toolbar,
+  .claim-audit-counts {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .claim-audit-toolbar {
+    justify-content: space-between;
+  }
+
+  .claim-audit-counts,
+  .empty-copy,
+  .section-caption,
+  .tool-card span {
+    color: var(--smrt-color-on-surface-variant);
+    font-size: 0.85rem;
+  }
+
+  .tool-card {
+    border: 1px solid var(--smrt-color-outline-variant);
+    border-radius: 0.65rem;
+    background: var(--smrt-color-surface);
+    padding: 0.75rem;
+  }
+
+  .tool-card.nested {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .tool-card summary {
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
+
+  .tool-card p,
+  .tool-warning p {
+    margin: 0;
+  }
+
+  .tool-card-body {
+    padding-top: 0.75rem;
+  }
+
+  .claim-audit-actions {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .claim-audit-select {
+    display: inline-flex;
+    line-height: 1;
+  }
+
+  .secondary-button {
+    border-radius: 0.5rem;
+    padding: 0.65rem 0.85rem;
+    border: 1px solid var(--smrt-color-outline-variant);
+    background: var(--smrt-color-surface);
+    color: var(--smrt-color-on-surface);
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  .secondary-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.65;
+  }
+
+  .pill {
+    border-radius: 999px;
+    padding: 0.2rem 0.55rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: capitalize;
+  }
+
+  .pill--passed {
+    background: rgba(22, 163, 74, 0.14);
+    color: #166534;
+  }
+
+  .pill--flagged {
+    background: rgba(245, 158, 11, 0.16);
+    color: #92400e;
+  }
+
+  .pill--failed {
+    background: rgba(220, 38, 38, 0.14);
+    color: #991b1b;
+  }
+
+  .tool-error,
+  .tool-notice,
+  .tool-warning {
+    margin: 0;
+    border-radius: 0.6rem;
+    padding: 0.75rem 0.9rem;
+    font-size: 0.9rem;
+  }
+
+  .tool-error {
+    background: rgba(220, 38, 38, 0.1);
+    color: #991b1b;
+  }
+
+  .tool-notice {
+    background: rgba(37, 99, 235, 0.1);
+    color: #1d4ed8;
+  }
+
+  .tool-warning {
+    background: rgba(245, 158, 11, 0.12);
+    color: #92400e;
+  }
+</style>

--- a/packages/content/src/svelte/components/ContentCorrectionsTool.svelte
+++ b/packages/content/src/svelte/components/ContentCorrectionsTool.svelte
@@ -1,0 +1,334 @@
+<script lang="ts">
+import type { ContentCorrectionData, FactData } from '../../mock-smrt-client';
+import { createClient } from '../../mock-smrt-client';
+import { normalizeApiBaseUrl } from '../api';
+
+export interface Props {
+  apiBaseUrl?: string;
+  contentId: string;
+  defaultRelationship?: string;
+  onCorrectionsChange?: (corrections: ContentCorrectionData[]) => void;
+}
+
+let {
+  apiBaseUrl = '/api/v1',
+  contentId,
+  defaultRelationship = 'supports',
+  onCorrectionsChange = undefined,
+}: Props = $props();
+
+const client = $derived(createClient(normalizeApiBaseUrl(apiBaseUrl)));
+const savedContentId = $derived(
+  contentId && contentId !== 'new' ? contentId : null,
+);
+
+let corrections = $state<ContentCorrectionData[]>([]);
+let facts = $state<FactData[]>([]);
+let busy = $state(false);
+let error = $state<string | null>(null);
+let notice = $state<string | null>(null);
+let loadedContentId = $state<string | null>(null);
+
+let correctionSummary = $state('');
+let correctionFactId = $state('');
+let correctedFactText = $state('');
+let correctionPublicNote = $state('');
+let publishCorrection = $state(true);
+
+$effect(() => {
+  if (!savedContentId) {
+    loadedContentId = null;
+    corrections = [];
+    facts = [];
+    return;
+  }
+
+  if (savedContentId !== loadedContentId) {
+    loadedContentId = savedContentId;
+    void loadCorrections();
+  }
+});
+
+$effect(() => {
+  if (facts.length === 0) {
+    correctionFactId = '';
+    return;
+  }
+
+  const factIds = facts
+    .map((fact) => fact.id)
+    .filter((id): id is string => Boolean(id));
+
+  if (!correctionFactId || !factIds.includes(correctionFactId)) {
+    correctionFactId = factIds[0] ?? '';
+  }
+});
+
+function formatTimestamp(value: string | null | undefined) {
+  if (!value) return 'Not published';
+  return new Date(value).toLocaleString();
+}
+
+function getCorrectionProvenanceCopy(correction: ContentCorrectionData) {
+  const metadata = correction.metadata || {};
+
+  if (metadata.draftVersionNumber) {
+    return `Auto-created draft v${metadata.draftVersionNumber} for editorial follow-up.`;
+  }
+
+  return null;
+}
+
+async function loadCorrections() {
+  if (!savedContentId) return;
+
+  busy = true;
+  error = null;
+
+  try {
+    const [correctionsResponse, factsResponse] = await Promise.all([
+      client.contents.getCorrections(savedContentId),
+      client.contents.getFacts(savedContentId, defaultRelationship),
+    ]);
+    corrections = correctionsResponse.data;
+    facts = factsResponse.data.facts || [];
+    onCorrectionsChange?.(correctionsResponse.data);
+  } catch (err: any) {
+    error = err.message || 'Failed to load corrections';
+  } finally {
+    busy = false;
+  }
+}
+
+async function issueCorrection() {
+  if (!savedContentId) return;
+
+  busy = true;
+  error = null;
+  notice = null;
+
+  try {
+    await client.contents.issueCorrection(savedContentId, {
+      summary: correctionSummary,
+      factId: correctionFactId || undefined,
+      correctedFactText: correctedFactText || undefined,
+      publicNote: correctionPublicNote || undefined,
+      publish: publishCorrection,
+    });
+
+    correctionSummary = '';
+    correctedFactText = '';
+    correctionPublicNote = '';
+    publishCorrection = true;
+
+    notice = 'Correction issued.';
+    await loadCorrections();
+  } catch (err: any) {
+    error = err.message || 'Failed to issue correction';
+  } finally {
+    busy = false;
+  }
+}
+</script>
+
+<div class="governance-tool">
+  {#if error}
+    <p class="tool-error">{error}</p>
+  {/if}
+
+  {#if notice}
+    <p class="tool-notice">{notice}</p>
+  {/if}
+
+  {#if !savedContentId}
+    <p class="empty-copy">Save this content to issue corrections.</p>
+  {:else}
+    <label class="workflow-field">
+      Summary
+      <input
+        type="text"
+        bind:value={correctionSummary}
+        placeholder="What was wrong?"
+      />
+    </label>
+
+    <label class="workflow-field">
+      Related fact
+      <select bind:value={correctionFactId}>
+        <option value="">General correction</option>
+        {#each facts as fact (fact.id)}
+          <option value={fact.id ?? ''}>{fact.textRefined}</option>
+        {/each}
+      </select>
+    </label>
+
+    <label class="workflow-field">
+      Corrected fact text
+      <textarea
+        rows="4"
+        bind:value={correctedFactText}
+        placeholder="Provide the corrected claim or wording"
+      ></textarea>
+    </label>
+
+    <label class="workflow-field">
+      Public note
+      <textarea
+        rows="3"
+        bind:value={correctionPublicNote}
+        placeholder="Optional public-facing correction note"
+      ></textarea>
+    </label>
+
+    <label class="checkbox-row">
+      <input type="checkbox" bind:checked={publishCorrection} />
+      Publish immediately
+    </label>
+
+    <button
+      type="button"
+      disabled={busy || correctionSummary.trim().length === 0}
+      onclick={() => void issueCorrection()}
+    >
+      {busy ? 'Issuing correction...' : 'Issue correction'}
+    </button>
+
+    <div class="tool-list">
+      <div class="section-caption">Published history</div>
+      {#if corrections.length === 0}
+        <p class="empty-copy">No corrections issued.</p>
+      {:else}
+        {#each corrections as correction (correction.id ?? `${correction.correctionType}-${correction.createdAt}`)}
+          <div class="tool-card">
+            <div class="tool-card-header">
+              <strong>{correction.correctionType}</strong>
+              <span class={`pill pill--${correction.status}`}>{correction.status}</span>
+            </div>
+            <p>{correction.summary}</p>
+            <span>{formatTimestamp(correction.publishedAt)}</span>
+            {#if getCorrectionProvenanceCopy(correction)}
+              <span>{getCorrectionProvenanceCopy(correction)}</span>
+            {/if}
+          </div>
+        {/each}
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .governance-tool,
+  .tool-list,
+  .workflow-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .workflow-field {
+    color: var(--smrt-color-on-surface-variant);
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+
+  .workflow-field input,
+  .workflow-field textarea,
+  .workflow-field select {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.75rem;
+    border-radius: 0.5rem;
+    border: 1px solid var(--smrt-color-outline);
+    background: var(--smrt-color-surface);
+    color: var(--smrt-color-on-surface);
+    font-family: inherit;
+  }
+
+  button {
+    border: none;
+    border-radius: 0.5rem;
+    padding: 0.7rem 0.95rem;
+    background: var(--smrt-color-primary);
+    color: var(--smrt-color-on-primary, white);
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  button:disabled {
+    cursor: not-allowed;
+    opacity: 0.65;
+  }
+
+  .tool-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    background: var(--smrt-color-surface);
+    border: 1px solid var(--smrt-color-outline-variant);
+    border-radius: 0.75rem;
+    padding: 0.85rem;
+  }
+
+  .tool-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .tool-card span,
+  .empty-copy,
+  .section-caption {
+    color: var(--smrt-color-on-surface-variant);
+    font-size: 0.85rem;
+  }
+
+  .tool-card p {
+    margin: 0;
+  }
+
+  .checkbox-row {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    color: var(--smrt-color-on-surface);
+  }
+
+  .pill {
+    border-radius: 999px;
+    padding: 0.2rem 0.55rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: capitalize;
+  }
+
+  .pill--published,
+  .pill--neutral {
+    background: rgba(59, 130, 246, 0.14);
+    color: #1d4ed8;
+  }
+
+  .pill--draft,
+  .pill--retracted {
+    background: rgba(220, 38, 38, 0.14);
+    color: #991b1b;
+  }
+
+  .tool-error,
+  .tool-notice {
+    margin: 0;
+    border-radius: 0.6rem;
+    padding: 0.75rem 0.9rem;
+    font-size: 0.9rem;
+  }
+
+  .tool-error {
+    background: rgba(220, 38, 38, 0.1);
+    color: #991b1b;
+  }
+
+  .tool-notice {
+    background: rgba(37, 99, 235, 0.1);
+    color: #1d4ed8;
+  }
+</style>

--- a/packages/content/src/svelte/components/ContentGovernanceTool.svelte
+++ b/packages/content/src/svelte/components/ContentGovernanceTool.svelte
@@ -3,14 +3,13 @@ import type {
   ContentGovernanceStateData,
   FactAuditStateData,
 } from '../../mock-smrt-client';
-import ContentGovernancePanel, {
-  type ContentGovernancePanelSection,
-} from './ContentGovernancePanel.svelte';
+import ContentClaimAuditTool from './ContentClaimAuditTool.svelte';
+import ContentCorrectionsTool from './ContentCorrectionsTool.svelte';
+import ContentTransparencyTool from './ContentTransparencyTool.svelte';
+import ContentVersionsTool from './ContentVersionsTool.svelte';
 
 export type ContentGovernanceToolSection =
   | 'claimAudit'
-  | 'facts'
-  | 'reviews'
   | 'corrections'
   | 'versions'
   | 'transparency';
@@ -30,29 +29,28 @@ let {
   onGovernanceStateChange = undefined,
   onFactAuditChange = undefined,
 }: Props = $props();
-
-const allPanelSections: ContentGovernancePanelSection[] = [
-  'factAudit',
-  'facts',
-  'reviews',
-  'transparency',
-  'corrections',
-  'versions',
-];
-
-const panelSection = $derived<ContentGovernancePanelSection>(
-  section === 'claimAudit' ? 'factAudit' : section,
-);
-const hiddenSections = $derived(
-  allPanelSections.filter((candidate) => candidate !== panelSection),
-);
 </script>
 
-<ContentGovernancePanel
-  {apiBaseUrl}
-  {contentId}
-  {hiddenSections}
-  showFactCatalog={section === 'facts'}
-  {onGovernanceStateChange}
-  {onFactAuditChange}
-/>
+{#if section === 'claimAudit'}
+  <ContentClaimAuditTool
+    {apiBaseUrl}
+    {contentId}
+    {onFactAuditChange}
+  />
+{:else if section === 'corrections'}
+  <ContentCorrectionsTool
+    {apiBaseUrl}
+    {contentId}
+  />
+{:else if section === 'versions'}
+  <ContentVersionsTool
+    {apiBaseUrl}
+    {contentId}
+  />
+{:else if section === 'transparency'}
+  <ContentTransparencyTool
+    {apiBaseUrl}
+    {contentId}
+    {onGovernanceStateChange}
+  />
+{/if}

--- a/packages/content/src/svelte/components/ContentTransparencyTool.svelte
+++ b/packages/content/src/svelte/components/ContentTransparencyTool.svelte
@@ -1,0 +1,300 @@
+<script lang="ts">
+import type {
+  ContentGovernanceStateData,
+  ContentTransparencyData,
+} from '../../mock-smrt-client';
+import { createClient } from '../../mock-smrt-client';
+import { normalizeApiBaseUrl } from '../api';
+
+export interface Props {
+  apiBaseUrl?: string;
+  contentId: string;
+  onGovernanceStateChange?: (state: ContentGovernanceStateData | null) => void;
+}
+
+let {
+  apiBaseUrl = '/api/v1',
+  contentId,
+  onGovernanceStateChange = undefined,
+}: Props = $props();
+
+const client = $derived(createClient(normalizeApiBaseUrl(apiBaseUrl)));
+const savedContentId = $derived(
+  contentId && contentId !== 'new' ? contentId : null,
+);
+
+let governanceState = $state<ContentGovernanceStateData | null>(null);
+let transparencyPreview = $state<ContentTransparencyData | null>(null);
+let publishedTransparency = $state<ContentTransparencyData | null>(null);
+let busy = $state(false);
+let error = $state<string | null>(null);
+let loadedContentId = $state<string | null>(null);
+
+$effect(() => {
+  if (!savedContentId) {
+    loadedContentId = null;
+    governanceState = null;
+    transparencyPreview = null;
+    publishedTransparency = null;
+    onGovernanceStateChange?.(null);
+    return;
+  }
+
+  if (savedContentId !== loadedContentId) {
+    loadedContentId = savedContentId;
+    void loadTransparency();
+  }
+});
+
+function formatTimestamp(value: string | null | undefined) {
+  if (!value) return 'Not published';
+  return new Date(value).toLocaleString();
+}
+
+function getReferenceLabel(reference: {
+  title?: string | null;
+  url?: string | null;
+}) {
+  return reference.title || reference.url || 'Untitled reference';
+}
+
+async function loadTransparency() {
+  if (!savedContentId) return;
+
+  busy = true;
+  error = null;
+
+  try {
+    const [
+      governanceResponse,
+      transparencyPreviewResponse,
+      publishedTransparencyResponse,
+    ] = await Promise.all([
+      client.contents.getGovernanceState(savedContentId),
+      client.contents.getTransparencyPreview(savedContentId),
+      client.contents.getPublishedTransparency(savedContentId),
+    ]);
+    governanceState = governanceResponse.data;
+    transparencyPreview = transparencyPreviewResponse.data;
+    publishedTransparency = publishedTransparencyResponse.data;
+    onGovernanceStateChange?.(governanceResponse.data);
+  } catch (err: any) {
+    error = err.message || 'Failed to load transparency';
+  } finally {
+    busy = false;
+  }
+}
+</script>
+
+<div class="governance-tool">
+  {#if error}
+    <p class="tool-error">{error}</p>
+  {/if}
+
+  {#if !savedContentId}
+    <p class="empty-copy">Save this content to preview the public transparency breakdown.</p>
+  {:else if busy && !transparencyPreview}
+    <p class="empty-copy">Loading transparency...</p>
+  {:else if governanceState && !governanceState.transparencyEnabled}
+    <p class="empty-copy">Public transparency snapshots are not enabled for this governed content type.</p>
+  {:else if !transparencyPreview}
+    <p class="empty-copy">No transparency preview is available yet.</p>
+  {:else}
+    <p class="section-caption">
+      The preview below reflects the latest saved article state. The published snapshot stays frozen until the next successful publication.
+    </p>
+
+    <div class="transparency-stats">
+      <div class="transparency-stat">
+        <strong>{transparencyPreview.factsUsed.length}</strong>
+        <span>Facts used</span>
+      </div>
+      <div class="transparency-stat">
+        <strong>{transparencyPreview.references.length}</strong>
+        <span>References</span>
+      </div>
+      <div class="transparency-stat">
+        <strong>{transparencyPreview.otherExtractedFacts.length}</strong>
+        <span>Other extracted facts</span>
+      </div>
+      <div class="transparency-stat">
+        <strong>{transparencyPreview.corrections.length}</strong>
+        <span>Public corrections</span>
+      </div>
+    </div>
+
+    <div class="transparency-card">
+      <div class="tool-card-header">
+        <strong>Current preview</strong>
+        <span class="pill pill--neutral">{transparencyPreview.snapshotKind}</span>
+      </div>
+      <span>
+        {#if transparencyPreview.generation.publicPrompt}
+          Public prompt is set for publication.
+        {:else}
+          No public prompt is exposed yet.
+        {/if}
+      </span>
+      {#if transparencyPreview.generation.publicPrompt}
+        <p class="transparency-card-prompt">
+          {transparencyPreview.generation.publicPrompt}
+        </p>
+      {/if}
+
+      <div class="tool-list">
+        <div class="tool-list-section">
+          <div class="section-caption">Facts used in the article</div>
+          {#if transparencyPreview.factsUsed.length === 0}
+            <p class="empty-copy">No used facts will be shown publicly yet.</p>
+          {:else}
+            {#each transparencyPreview.factsUsed.slice(0, 3) as fact (fact.id ?? fact.textRefined ?? fact.textRaw)}
+              <div class="transparency-list-item">
+                <strong>{fact.textRefined || fact.textRaw || fact.id}</strong>
+                <span>
+                  {fact.relationship || 'linked'}
+                  {#if fact.sources && fact.sources.length > 0}
+                    · {fact.sources.length} source(s)
+                  {/if}
+                </span>
+              </div>
+            {/each}
+          {/if}
+        </div>
+
+        <div class="tool-list-section">
+          <div class="section-caption">Source material</div>
+          {#if transparencyPreview.references.length === 0}
+            <p class="empty-copy">No references will be shown publicly yet.</p>
+          {:else}
+            {#each transparencyPreview.references.slice(0, 3) as reference (reference.id ?? reference.url ?? reference.title)}
+              <div class="transparency-list-item">
+                <strong>{getReferenceLabel(reference)}</strong>
+                <span>
+                  {reference.usedFactIds.length} used fact(s) · {reference.extractedFacts.length} extracted fact(s)
+                </span>
+              </div>
+            {/each}
+          {/if}
+        </div>
+      </div>
+    </div>
+
+    <div class="transparency-card">
+      <div class="tool-card-header">
+        <strong>Latest published snapshot</strong>
+        {#if publishedTransparency?.publicationVersion?.version !== null && publishedTransparency?.publicationVersion?.version !== undefined}
+          <span class="pill pill--passed">v{publishedTransparency.publicationVersion.version}</span>
+        {/if}
+      </div>
+
+      {#if publishedTransparency}
+        <span>
+          Published {formatTimestamp(publishedTransparency.publicationVersion?.createdAt || publishedTransparency.generatedAt)}
+        </span>
+        <span>
+          {publishedTransparency.versionHistory.length} timeline event(s) and {publishedTransparency.corrections.length} public correction(s)
+        </span>
+      {:else}
+        <p class="empty-copy">
+          No published transparency snapshot yet. Publish this article to freeze one for the built site.
+        </p>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .governance-tool,
+  .tool-list,
+  .tool-list-section,
+  .transparency-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .transparency-stats {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
+
+  .transparency-stat,
+  .transparency-card,
+  .transparency-list-item {
+    background: var(--smrt-color-surface);
+    border: 1px solid var(--smrt-color-outline-variant);
+    border-radius: 0.75rem;
+  }
+
+  .transparency-stat {
+    padding: 0.8rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .transparency-card {
+    padding: 0.9rem;
+  }
+
+  .tool-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .transparency-list-item {
+    padding: 0.7rem 0.8rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+
+  .transparency-card span,
+  .transparency-list-item span,
+  .transparency-stat span,
+  .empty-copy,
+  .section-caption {
+    color: var(--smrt-color-on-surface-variant);
+    font-size: 0.85rem;
+  }
+
+  .transparency-card-prompt,
+  .empty-copy {
+    margin: 0;
+  }
+
+  .transparency-card-prompt {
+    color: var(--smrt-color-on-surface-variant);
+    white-space: pre-wrap;
+  }
+
+  .pill {
+    border-radius: 999px;
+    padding: 0.2rem 0.55rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: capitalize;
+  }
+
+  .pill--passed {
+    background: rgba(22, 163, 74, 0.14);
+    color: #166534;
+  }
+
+  .pill--neutral {
+    background: rgba(59, 130, 246, 0.14);
+    color: #1d4ed8;
+  }
+
+  .tool-error {
+    margin: 0;
+    border-radius: 0.6rem;
+    padding: 0.75rem 0.9rem;
+    background: rgba(220, 38, 38, 0.1);
+    color: #991b1b;
+    font-size: 0.9rem;
+  }
+</style>

--- a/packages/content/src/svelte/components/ContentVersionsTool.svelte
+++ b/packages/content/src/svelte/components/ContentVersionsTool.svelte
@@ -1,0 +1,267 @@
+<script lang="ts">
+import type { ContentVersionData } from '../../mock-smrt-client';
+import { createClient } from '../../mock-smrt-client';
+import { normalizeApiBaseUrl } from '../api';
+
+export interface Props {
+  apiBaseUrl?: string;
+  contentId: string;
+  onVersionsChange?: (versions: ContentVersionData[]) => void;
+}
+
+let {
+  apiBaseUrl = '/api/v1',
+  contentId,
+  onVersionsChange = undefined,
+}: Props = $props();
+
+const client = $derived(createClient(normalizeApiBaseUrl(apiBaseUrl)));
+const savedContentId = $derived(
+  contentId && contentId !== 'new' ? contentId : null,
+);
+
+let versions = $state<ContentVersionData[]>([]);
+let busy = $state(false);
+let error = $state<string | null>(null);
+let notice = $state<string | null>(null);
+let loadedContentId = $state<string | null>(null);
+
+$effect(() => {
+  if (!savedContentId) {
+    loadedContentId = null;
+    versions = [];
+    return;
+  }
+
+  if (savedContentId !== loadedContentId) {
+    loadedContentId = savedContentId;
+    void refreshVersions();
+  }
+});
+
+function formatTimestamp(value: string | null | undefined) {
+  if (!value) return 'Not published';
+  return new Date(value).toLocaleString();
+}
+
+function getVersionProvenanceCopy(version: ContentVersionData) {
+  const metadata = version.metadata || {};
+
+  if (metadata.sourceCorrectionVersionNumber) {
+    return `Generated from correction version v${metadata.sourceCorrectionVersionNumber}.`;
+  }
+
+  if (metadata.policyKey) {
+    return `Created from the ${metadata.policyKey} review flow.`;
+  }
+
+  if (version.kind === 'publication') {
+    return 'Frozen public transparency snapshot.';
+  }
+
+  return null;
+}
+
+async function refreshVersions() {
+  if (!savedContentId) return;
+
+  busy = true;
+  error = null;
+
+  try {
+    const response = await client.contents.getVersions(savedContentId);
+    versions = response.data;
+    onVersionsChange?.(response.data);
+  } catch (err: any) {
+    error = err.message || 'Failed to load versions';
+  } finally {
+    busy = false;
+  }
+}
+
+async function createSnapshot() {
+  if (!savedContentId) return;
+
+  busy = true;
+  error = null;
+  notice = null;
+
+  try {
+    await client.contents.createVersion(savedContentId, {
+      kind: 'manual',
+      summary: 'Manual editorial snapshot',
+    });
+    notice = 'Snapshot created.';
+    await refreshVersions();
+  } catch (err: any) {
+    error = err.message || 'Failed to create version snapshot';
+  } finally {
+    busy = false;
+  }
+}
+
+async function restoreVersion(versionNumber: number) {
+  if (!savedContentId) return;
+
+  if (!confirm(`Restore content version ${versionNumber}?`)) {
+    return;
+  }
+
+  busy = true;
+  error = null;
+  notice = null;
+
+  try {
+    await client.contents.restoreVersion(savedContentId, versionNumber);
+    notice = `Restored version ${versionNumber}.`;
+    await refreshVersions();
+  } catch (err: any) {
+    error = err.message || 'Failed to restore version';
+  } finally {
+    busy = false;
+  }
+}
+</script>
+
+<div class="governance-tool">
+  <div class="tool-toolbar">
+    <button
+      type="button"
+      class="secondary-button"
+      disabled={busy || !savedContentId}
+      onclick={() => void createSnapshot()}
+    >
+      {busy ? 'Working...' : 'Create snapshot'}
+    </button>
+  </div>
+
+  {#if error}
+    <p class="tool-error">{error}</p>
+  {/if}
+
+  {#if notice}
+    <p class="tool-notice">{notice}</p>
+  {/if}
+
+  {#if !savedContentId}
+    <p class="empty-copy">Save this content to manage versions.</p>
+  {:else if versions.length === 0}
+    <p class="empty-copy">No versions saved yet.</p>
+  {:else}
+    <div class="tool-list">
+      {#each versions as version (version.id ?? `version-${version.version ?? 0}`)}
+        <div class="tool-card">
+          <div class="tool-card-header">
+            <strong>v{version.version}</strong>
+            <span class="pill pill--neutral">{version.kind}</span>
+          </div>
+          <p>{version.summary || 'Snapshot saved'}</p>
+          {#if getVersionProvenanceCopy(version)}
+            <span>{getVersionProvenanceCopy(version)}</span>
+          {/if}
+          <div class="tool-card-footer">
+            <span>{formatTimestamp(version.createdAt)}</span>
+            <button
+              type="button"
+              class="secondary-button"
+              disabled={busy || version.version === null || version.version === undefined}
+              onclick={() => {
+                if (version.version !== null && version.version !== undefined) {
+                  void restoreVersion(version.version);
+                }
+              }}
+            >
+              Restore
+            </button>
+          </div>
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .governance-tool,
+  .tool-list,
+  .tool-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .tool-toolbar,
+  .tool-card-header,
+  .tool-card-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .tool-toolbar {
+    justify-content: flex-end;
+  }
+
+  .tool-card {
+    background: var(--smrt-color-surface);
+    border: 1px solid var(--smrt-color-outline-variant);
+    border-radius: 0.75rem;
+    padding: 0.85rem;
+  }
+
+  .tool-card p {
+    margin: 0;
+  }
+
+  .tool-card span,
+  .empty-copy {
+    color: var(--smrt-color-on-surface-variant);
+    font-size: 0.85rem;
+  }
+
+  .secondary-button {
+    border-radius: 0.5rem;
+    padding: 0.65rem 0.85rem;
+    border: 1px solid var(--smrt-color-outline-variant);
+    background: var(--smrt-color-surface);
+    color: var(--smrt-color-on-surface);
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  .secondary-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.65;
+  }
+
+  .pill {
+    border-radius: 999px;
+    padding: 0.2rem 0.55rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: capitalize;
+  }
+
+  .pill--neutral {
+    background: rgba(59, 130, 246, 0.14);
+    color: #1d4ed8;
+  }
+
+  .tool-error,
+  .tool-notice {
+    margin: 0;
+    border-radius: 0.6rem;
+    padding: 0.75rem 0.9rem;
+    font-size: 0.9rem;
+  }
+
+  .tool-error {
+    background: rgba(220, 38, 38, 0.1);
+    color: #991b1b;
+  }
+
+  .tool-notice {
+    background: rgba(37, 99, 235, 0.1);
+    color: #1d4ed8;
+  }
+</style>

--- a/packages/content/src/svelte/components/GovernedContentEditor.svelte
+++ b/packages/content/src/svelte/components/GovernedContentEditor.svelte
@@ -36,6 +36,7 @@ export interface Props {
   hideActions?: boolean;
   hideChat?: boolean;
   showFactCatalog?: boolean;
+  showGovernancePanel?: boolean;
   onAssistantContextChange?: ContentEditorAssistantContextChange;
   onSave: (data: GovernedContentEditorSaveData) => void;
   onCancel: () => void;
@@ -58,6 +59,7 @@ let {
   hideActions = false,
   hideChat = false,
   showFactCatalog = false,
+  showGovernancePanel = true,
   onAssistantContextChange = undefined,
   onSave,
   onCancel,
@@ -325,24 +327,26 @@ function handleSave(data: ContentData) {
     onCancel={onCancel}
   />
 
-  <ContentGovernancePanel
-    bind:this={governancePanel}
-    {apiBaseUrl}
-    contentId={resolvedContentId}
-    draftType={draftContent?.type || content?.type}
-    draftVariant={draftContent?.variant || content?.variant}
-    selectedFactIds={selectedFactIds}
-    selectedFacts={selectedFacts}
-    defaultRelationship={defaultRelationship}
-    reviewProfileKey={activeReviewProfileKey}
-    customReviewLabel={customReviewLabel}
-    customReviewInstructions={customReviewInstructions}
-    customReviewPolicyKey={customReviewPolicyKey}
-    {showFactCatalog}
-    onFactsChange={handleFactsChange}
-    onGovernanceStateChange={handleGovernanceStateChange}
-    onFactAuditChange={handleFactAuditChange}
-  />
+  {#if showGovernancePanel}
+    <ContentGovernancePanel
+      bind:this={governancePanel}
+      {apiBaseUrl}
+      contentId={resolvedContentId}
+      draftType={draftContent?.type || content?.type}
+      draftVariant={draftContent?.variant || content?.variant}
+      selectedFactIds={selectedFactIds}
+      selectedFacts={selectedFacts}
+      defaultRelationship={defaultRelationship}
+      reviewProfileKey={activeReviewProfileKey}
+      customReviewLabel={customReviewLabel}
+      customReviewInstructions={customReviewInstructions}
+      customReviewPolicyKey={customReviewPolicyKey}
+      {showFactCatalog}
+      onFactsChange={handleFactsChange}
+      onGovernanceStateChange={handleGovernanceStateChange}
+      onFactAuditChange={handleFactAuditChange}
+    />
+  {/if}
 </div>
 
 <style>

--- a/packages/content/src/svelte/index.ts
+++ b/packages/content/src/svelte/index.ts
@@ -16,11 +16,13 @@ import ArticleCard from './components/ArticleCard.svelte';
 import ArticleList from './components/ArticleList.svelte';
 import ContentBodyEditor from './components/ContentBodyEditor.svelte';
 import ContentBodyRenderer from './components/ContentBodyRenderer.svelte';
+import ContentClaimAuditTool from './components/ContentClaimAuditTool.svelte';
 import ContentContributionForm from './components/ContentContributionForm.svelte';
 import ContentContributionInbox from './components/ContentContributionInbox.svelte';
 import ContentContributionPortal from './components/ContentContributionPortal.svelte';
 import ContentContributionTypeManager from './components/ContentContributionTypeManager.svelte';
 import ContentContributorManager from './components/ContentContributorManager.svelte';
+import ContentCorrectionsTool from './components/ContentCorrectionsTool.svelte';
 import ContentEditor from './components/ContentEditor.svelte';
 import ContentGovernanceAssignmentEditor from './components/ContentGovernanceAssignmentEditor.svelte';
 import ContentGovernanceManager from './components/ContentGovernanceManager.svelte';
@@ -35,6 +37,8 @@ import ContentMetadataFields from './components/ContentMetadataFields.svelte';
 import ContentReferencesPanel from './components/ContentReferencesPanel.svelte';
 import ContentStatusFields from './components/ContentStatusFields.svelte';
 import ContentTransparencyReport from './components/ContentTransparencyReport.svelte';
+import ContentTransparencyTool from './components/ContentTransparencyTool.svelte';
+import ContentVersionsTool from './components/ContentVersionsTool.svelte';
 import GovernedContentEditor from './components/GovernedContentEditor.svelte';
 import Markdown from './components/Markdown.svelte';
 import ContentContributionsRoute from './routes/ContentContributionsRoute.svelte';
@@ -56,11 +60,13 @@ import {
 export {
   ArticleCard,
   ArticleList,
+  ContentClaimAuditTool,
   ContentContributionForm,
   ContentContributionInbox,
   ContentContributionPortal,
   ContentContributionTypeManager,
   ContentContributorManager,
+  ContentCorrectionsTool,
   ContentBodyEditor,
   ContentBodyRenderer,
   ContentEditor,
@@ -77,6 +83,8 @@ export {
   ContentReferencesPanel,
   ContentStatusFields,
   ContentTransparencyReport,
+  ContentTransparencyTool,
+  ContentVersionsTool,
   ContentContributionsRoute,
   ContentFactsRoute,
   ContentGovernanceRoute,
@@ -106,6 +114,18 @@ export type ContentImageChooserProps = ComponentProps<
 >;
 export type ContentImageBrowserProps = ComponentProps<
   typeof ContentImageBrowser
+>;
+export type ContentClaimAuditToolProps = ComponentProps<
+  typeof ContentClaimAuditTool
+>;
+export type ContentCorrectionsToolProps = ComponentProps<
+  typeof ContentCorrectionsTool
+>;
+export type ContentTransparencyToolProps = ComponentProps<
+  typeof ContentTransparencyTool
+>;
+export type ContentVersionsToolProps = ComponentProps<
+  typeof ContentVersionsTool
 >;
 export type ContentMetadataFieldsProps = ComponentProps<
   typeof ContentMetadataFields


### PR DESCRIPTION
## Summary

- Add standalone SMRT content governance dock components for Claim Audit, Corrections, Versions, and Transparency
- Update `ContentGovernanceTool` to compose those components directly instead of rendering the full governance panel with hidden sections
- Add a `showGovernancePanel` switch to `GovernedContentEditor` so apps can keep the editor focused while moving secondary workflows into their own dock/tools

## Why

Anytown is moving secondary article workflows into a right-side Tool Dock. The previous bridge relied on `hiddenSections`, which meant every dock tool was still the large governance panel with most of it hidden. Since Anytown is the current consumer, we can expose the better API now: purpose-built components per workflow.

## Validation

- `pnpm --filter @happyvertical/smrt-content build`
- `git diff --check HEAD~1..HEAD`
