### PR TITLE
[codex] Skip object registration for collection entries

### DIFF
--- a/packages/cli/src/commands/__tests__/generate-register.test.ts
+++ b/packages/cli/src/commands/__tests__/generate-register.test.ts
@@ -182,6 +182,24 @@ describe('generate-register', () => {
           extends: 'SmrtCollection',
           visibility: 'public',
         },
+        LegacyWidgetCollection: {
+          className: 'LegacyWidgetCollection',
+          exportName: 'LegacyWidgetCollection',
+          packageName: '@happyvertical/pkg',
+          qualifiedName: '@happyvertical/pkg:LegacyWidgetCollection',
+          collection: 'legacy_widgets',
+          extendsTypeArg: 'Widget',
+          visibility: 'public',
+        },
+        SpecializedWidgetCollection: {
+          className: 'SpecializedWidgetCollection',
+          exportName: 'SpecializedWidgetCollection',
+          packageName: '@happyvertical/pkg',
+          qualifiedName: '@happyvertical/pkg:SpecializedWidgetCollection',
+          collection: 'specialized_widgets',
+          extends: 'WidgetCollection',
+          visibility: 'public',
+        },
       },
     });
 
@@ -194,9 +212,21 @@ describe('generate-register', () => {
       "import { WidgetCollection } from '@happyvertical/pkg';",
     );
     expect(content).toContain(
+      "import { LegacyWidgetCollection } from '@happyvertical/pkg';",
+    );
+    expect(content).toContain(
+      "import { SpecializedWidgetCollection } from '@happyvertical/pkg';",
+    );
+    expect(content).toContain(
       'ObjectRegistry.register(Widget, { name: "Widget", packageName: "@happyvertical/pkg" });',
     );
     expect(content).not.toContain('ObjectRegistry.register(WidgetCollection');
+    expect(content).not.toContain(
+      'ObjectRegistry.register(LegacyWidgetCollection',
+    );
+    expect(content).not.toContain(
+      'ObjectRegistry.register(SpecializedWidgetCollection',
+    );
   });
 
   it('filters out test-visibility objects', async () => {

--- a/packages/cli/src/commands/__tests__/generate-register.test.ts
+++ b/packages/cli/src/commands/__tests__/generate-register.test.ts
@@ -152,6 +152,53 @@ describe('generate-register', () => {
     );
   });
 
+  it('imports collection entries without registering them as objects', async () => {
+    mockedAutoDiscover.mockResolvedValue({
+      discovered: [
+        {
+          path: '/fake/pkg/manifest.json',
+          source: 'package',
+          packageName: '@happyvertical/pkg',
+        },
+      ],
+    } as any);
+
+    mockedLoadManifest.mockResolvedValue({
+      objects: {
+        Widget: {
+          className: 'Widget',
+          exportName: 'Widget',
+          packageName: '@happyvertical/pkg',
+          qualifiedName: '@happyvertical/pkg:Widget',
+          collection: 'widgets',
+          visibility: 'public',
+        },
+        WidgetCollection: {
+          className: 'WidgetCollection',
+          exportName: 'WidgetCollection',
+          packageName: '@happyvertical/pkg',
+          qualifiedName: '@happyvertical/pkg:WidgetCollection',
+          collection: 'widgets',
+          extends: 'SmrtCollection',
+          visibility: 'public',
+        },
+      },
+    });
+
+    await handler([], { 'output-path': outputPath });
+
+    const content = await readFile(outputPath, 'utf-8');
+
+    expect(content).toContain("import { Widget } from '@happyvertical/pkg';");
+    expect(content).toContain(
+      "import { WidgetCollection } from '@happyvertical/pkg';",
+    );
+    expect(content).toContain(
+      'ObjectRegistry.register(Widget, { name: "Widget", packageName: "@happyvertical/pkg" });',
+    );
+    expect(content).not.toContain('ObjectRegistry.register(WidgetCollection');
+  });
+
   it('filters out test-visibility objects', async () => {
     mockedAutoDiscover.mockResolvedValue({
       discovered: [

--- a/packages/cli/src/commands/__tests__/generate-register.test.ts
+++ b/packages/cli/src/commands/__tests__/generate-register.test.ts
@@ -220,12 +220,21 @@ describe('generate-register', () => {
     expect(content).toContain(
       'ObjectRegistry.register(Widget, { name: "Widget", packageName: "@happyvertical/pkg" });',
     );
+    expect(content).toContain(
+      "console.log('[smrt:register] Registered 1 external object');",
+    );
     expect(content).not.toContain('ObjectRegistry.register(WidgetCollection');
     expect(content).not.toContain(
       'ObjectRegistry.register(LegacyWidgetCollection',
     );
     expect(content).not.toContain(
       'ObjectRegistry.register(SpecializedWidgetCollection',
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('with 4 external entries (1 registered object)'),
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      '   - @happyvertical/pkg (1 registered object, 4 imported entries)',
     );
   });
 

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -348,8 +348,12 @@ export const generateCommands: Record<string, CLICommand> = {
         // Build imports and registrations from external packages
         const imports: string[] = [];
         const registrations: string[] = [];
-        let externalObjectCount = 0;
-        const packageSummary: Record<string, number> = {};
+        let importedEntryCount = 0;
+        let registeredObjectCount = 0;
+        const packageSummary: Record<
+          string,
+          { importedEntries: number; registeredObjects: number }
+        > = {};
 
         // Track seen objects to deduplicate across packages.
         // When packages re-export classes from dependencies, the same object
@@ -363,41 +367,67 @@ export const generateCommands: Record<string, CLICommand> = {
 
           // packageName is guaranteed to exist due to filter above
           const packageName = manifestInfo.packageName as string;
-          let packageObjectCount = 0;
+          let packageImportedEntryCount = 0;
+          let packageRegisteredObjectCount = 0;
+          const manifestObjects = manifestData.objects as Record<string, any>;
+          const manifestObjectLookup = new Map<string, any>();
+          for (const [key, objectDef] of Object.entries(manifestObjects)) {
+            const candidate = objectDef as any;
+            const lookupKeys = [
+              key,
+              key.includes(':') ? key.split(':').pop() : undefined,
+              candidate.qualifiedName,
+              candidate.className,
+              candidate.exportName,
+            ];
+
+            for (const lookupKey of lookupKeys) {
+              if (lookupKey && !manifestObjectLookup.has(lookupKey)) {
+                manifestObjectLookup.set(lookupKey, candidate);
+              }
+            }
+          }
+
+          const collectionClassMemo = new WeakMap<object, boolean>();
           const isCollectionClass = (
             def: any,
             seen = new Set<string>(),
           ): boolean => {
+            if (!def || typeof def !== 'object') {
+              return false;
+            }
+
+            const cached = collectionClassMemo.get(def);
+            if (cached !== undefined) {
+              return cached;
+            }
+
             if (
               def?.extends === 'SmrtCollection' ||
               def?.extendsTypeArg !== undefined
             ) {
+              collectionClassMemo.set(def, true);
               return true;
             }
 
-            const parentName = def?.extends;
+            const parentName = def?.extendsQualified || def?.extends;
             if (!parentName || seen.has(parentName)) {
+              collectionClassMemo.set(def, false);
               return false;
             }
             seen.add(parentName);
 
-            const parentDef = Object.entries(manifestData.objects).find(
-              ([key, value]) => {
-                const candidate = value as any;
-                return (
-                  key === parentName ||
-                  key.endsWith(`:${parentName}`) ||
-                  candidate.className === parentName ||
-                  candidate.exportName === parentName
-                );
-              },
-            )?.[1] as any;
+            const parentDef = manifestObjectLookup.get(parentName);
+            const isCollection = parentDef
+              ? isCollectionClass(parentDef, seen)
+              : false;
+            collectionClassMemo.set(def, isCollection);
 
-            return parentDef ? isCollectionClass(parentDef, seen) : false;
+            return isCollection;
           };
 
           for (const [objectName, objectDef] of Object.entries(
-            manifestData.objects,
+            manifestObjects,
           )) {
             const def = objectDef as any;
 
@@ -441,10 +471,10 @@ export const generateCommands: Record<string, CLICommand> = {
             } else {
               imports.push(`import { ${exportName} } from '${importPath}';`);
             }
+            importedEntryCount++;
+            packageImportedEntryCount++;
 
             if (isCollectionClass(def)) {
-              externalObjectCount++;
-              packageObjectCount++;
               continue;
             }
 
@@ -464,17 +494,25 @@ export const generateCommands: Record<string, CLICommand> = {
               );
             }
 
-            externalObjectCount++;
-            packageObjectCount++;
+            registeredObjectCount++;
+            packageRegisteredObjectCount++;
           }
 
-          packageSummary[packageName] = packageObjectCount;
+          packageSummary[packageName] = {
+            importedEntries: packageImportedEntryCount,
+            registeredObjects: packageRegisteredObjectCount,
+          };
         }
 
-        if (externalObjectCount === 0) {
-          console.warn('⚠️ No external objects found in any package');
+        if (importedEntryCount === 0) {
+          console.warn('⚠️ No external entries found in any package');
           return;
         }
+
+        const registeredObjectLabel =
+          registeredObjectCount === 1 ? 'object' : 'objects';
+        const importedEntryLabel =
+          importedEntryCount === 1 ? 'entry' : 'entries';
 
         // Generate file content
         const content = `/**
@@ -494,7 +532,7 @@ ${registrations.join('\n')}
 
 export function registerAll() {
   // Objects are already registered during module evaluation
-  console.log('[smrt:register] Registered ${externalObjectCount} external objects');
+  console.log('[smrt:register] Registered ${registeredObjectCount} external ${registeredObjectLabel}');
 }
 `;
 
@@ -514,11 +552,17 @@ export function registerAll() {
 
         // Report results
         console.log(
-          `✅ Generated ${outputPath} with ${externalObjectCount} external objects\n`,
+          `✅ Generated ${outputPath} with ${importedEntryCount} external ${importedEntryLabel} (${registeredObjectCount} registered ${registeredObjectLabel})\n`,
         );
         console.log('📦 Packages included:');
-        for (const [pkg, count] of Object.entries(packageSummary)) {
-          console.log(`   - ${pkg} (${count} objects)`);
+        for (const [pkg, counts] of Object.entries(packageSummary)) {
+          const packageRegisteredLabel =
+            counts.registeredObjects === 1 ? 'object' : 'objects';
+          const packageImportedLabel =
+            counts.importedEntries === 1 ? 'entry' : 'entries';
+          console.log(
+            `   - ${pkg} (${counts.registeredObjects} registered ${packageRegisteredLabel}, ${counts.importedEntries} imported ${packageImportedLabel})`,
+          );
         }
         console.log();
 

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -401,6 +401,7 @@ export const generateCommands: Record<string, CLICommand> = {
             const registrationName =
               def.className || objectName.split(':').pop() || objectName;
             const registrationPackageName = def.packageName || packageName;
+            const isCollectionClass = def.extends === 'SmrtCollection';
 
             // Generate import statement
             if (hasCollection && collectionExportName) {
@@ -409,6 +410,12 @@ export const generateCommands: Record<string, CLICommand> = {
               );
             } else {
               imports.push(`import { ${exportName} } from '${importPath}';`);
+            }
+
+            if (isCollectionClass) {
+              externalObjectCount++;
+              packageObjectCount++;
+              continue;
             }
 
             // Generate registration calls. Keep the class name and package name

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -364,6 +364,37 @@ export const generateCommands: Record<string, CLICommand> = {
           // packageName is guaranteed to exist due to filter above
           const packageName = manifestInfo.packageName as string;
           let packageObjectCount = 0;
+          const isCollectionClass = (
+            def: any,
+            seen = new Set<string>(),
+          ): boolean => {
+            if (
+              def?.extends === 'SmrtCollection' ||
+              def?.extendsTypeArg !== undefined
+            ) {
+              return true;
+            }
+
+            const parentName = def?.extends;
+            if (!parentName || seen.has(parentName)) {
+              return false;
+            }
+            seen.add(parentName);
+
+            const parentDef = Object.entries(manifestData.objects).find(
+              ([key, value]) => {
+                const candidate = value as any;
+                return (
+                  key === parentName ||
+                  key.endsWith(`:${parentName}`) ||
+                  candidate.className === parentName ||
+                  candidate.exportName === parentName
+                );
+              },
+            )?.[1] as any;
+
+            return parentDef ? isCollectionClass(parentDef, seen) : false;
+          };
 
           for (const [objectName, objectDef] of Object.entries(
             manifestData.objects,
@@ -401,7 +432,6 @@ export const generateCommands: Record<string, CLICommand> = {
             const registrationName =
               def.className || objectName.split(':').pop() || objectName;
             const registrationPackageName = def.packageName || packageName;
-            const isCollectionClass = def.extends === 'SmrtCollection';
 
             // Generate import statement
             if (hasCollection && collectionExportName) {
@@ -412,7 +442,7 @@ export const generateCommands: Record<string, CLICommand> = {
               imports.push(`import { ${exportName} } from '${importPath}';`);
             }
 
-            if (isCollectionClass) {
+            if (isCollectionClass(def)) {
               externalObjectCount++;
               packageObjectCount++;
               continue;

--- a/packages/core/src/consumer-plugin/index.test.ts
+++ b/packages/core/src/consumer-plugin/index.test.ts
@@ -106,6 +106,9 @@ describe('smrtConsumer registration generation', () => {
       'ObjectRegistry.register(ExternalThing, { name: "ExternalThing", packageName: "@test/pkg" });',
     );
     expect(content).toContain(
+      "console.log('[smrt:register] Registered 1 external object');",
+    );
+    expect(content).toContain(
       "import { ExternalThingCollection } from '@test/pkg';",
     );
     expect(content).toContain(

--- a/packages/core/src/consumer-plugin/index.test.ts
+++ b/packages/core/src/consumer-plugin/index.test.ts
@@ -50,6 +50,15 @@ describe('smrtConsumer registration generation', () => {
             methods: {},
             decoratorConfig: {},
           },
+          ExternalThingCollection: {
+            className: 'ExternalThingCollection',
+            exportName: 'ExternalThingCollection',
+            collection: 'externalthings',
+            extends: 'SmrtCollection',
+            fields: {},
+            methods: {},
+            decoratorConfig: {},
+          },
         },
       }),
     );
@@ -77,6 +86,12 @@ describe('smrtConsumer registration generation', () => {
     const content = readFileSync(registerPath, 'utf-8');
     expect(content).toContain(
       'ObjectRegistry.register(ExternalThing, { name: "ExternalThing", packageName: "@test/pkg" });',
+    );
+    expect(content).toContain(
+      "import { ExternalThingCollection } from '@test/pkg';",
+    );
+    expect(content).not.toContain(
+      'ObjectRegistry.register(ExternalThingCollection',
     );
   });
 });

--- a/packages/core/src/consumer-plugin/index.test.ts
+++ b/packages/core/src/consumer-plugin/index.test.ts
@@ -59,6 +59,24 @@ describe('smrtConsumer registration generation', () => {
             methods: {},
             decoratorConfig: {},
           },
+          LegacyThingCollection: {
+            className: 'LegacyThingCollection',
+            exportName: 'LegacyThingCollection',
+            collection: 'legacythings',
+            extendsTypeArg: 'ExternalThing',
+            fields: {},
+            methods: {},
+            decoratorConfig: {},
+          },
+          SpecializedThingCollection: {
+            className: 'SpecializedThingCollection',
+            exportName: 'SpecializedThingCollection',
+            collection: 'specializedthings',
+            extends: 'ExternalThingCollection',
+            fields: {},
+            methods: {},
+            decoratorConfig: {},
+          },
         },
       }),
     );
@@ -90,8 +108,20 @@ describe('smrtConsumer registration generation', () => {
     expect(content).toContain(
       "import { ExternalThingCollection } from '@test/pkg';",
     );
+    expect(content).toContain(
+      "import { LegacyThingCollection } from '@test/pkg';",
+    );
+    expect(content).toContain(
+      "import { SpecializedThingCollection } from '@test/pkg';",
+    );
     expect(content).not.toContain(
       'ObjectRegistry.register(ExternalThingCollection',
+    );
+    expect(content).not.toContain(
+      'ObjectRegistry.register(LegacyThingCollection',
+    );
+    expect(content).not.toContain(
+      'ObjectRegistry.register(SpecializedThingCollection',
     );
   });
 });

--- a/packages/core/src/consumer-plugin/index.ts
+++ b/packages/core/src/consumer-plugin/index.ts
@@ -373,6 +373,9 @@ async function generateRegistrationFile(
   const registrations: string[] = [];
   let externalObjectCount = 0;
 
+  const isCollectionClass = (def: any): boolean =>
+    def?.extends === 'SmrtCollection';
+
   for (const [objectName, objectDef] of Object.entries(manifest.objects)) {
     const def = objectDef as any;
 
@@ -395,6 +398,11 @@ async function generateRegistrationFile(
       );
     } else {
       imports.push(`import { ${exportName} } from '${importPath}';`);
+    }
+
+    if (isCollectionClass(def)) {
+      externalObjectCount++;
+      continue;
     }
 
     // Generate registration calls

--- a/packages/core/src/consumer-plugin/index.ts
+++ b/packages/core/src/consumer-plugin/index.ts
@@ -371,36 +371,63 @@ async function generateRegistrationFile(
   // Build import statements and registrations
   const imports: string[] = [];
   const registrations: string[] = [];
-  let externalObjectCount = 0;
+  let importedEntryCount = 0;
+  let registeredObjectCount = 0;
+
+  const manifestObjects = manifest.objects as Record<string, any>;
+  const manifestObjectLookup = new Map<string, any>();
+  for (const [key, def] of Object.entries(manifestObjects)) {
+    const candidate = def as any;
+    const lookupKeys = [
+      key,
+      key.includes(':') ? key.split(':').pop() : undefined,
+      candidate.qualifiedName,
+      candidate.className,
+      candidate.exportName,
+    ];
+
+    for (const lookupKey of lookupKeys) {
+      if (lookupKey && !manifestObjectLookup.has(lookupKey)) {
+        manifestObjectLookup.set(lookupKey, candidate);
+      }
+    }
+  }
+
+  const collectionClassMemo = new WeakMap<object, boolean>();
 
   const isCollectionClass = (def: any, seen = new Set<string>()): boolean => {
+    if (!def || typeof def !== 'object') {
+      return false;
+    }
+
+    const cached = collectionClassMemo.get(def);
+    if (cached !== undefined) {
+      return cached;
+    }
+
     if (
       def?.extends === 'SmrtCollection' ||
       def?.extendsTypeArg !== undefined
     ) {
+      collectionClassMemo.set(def, true);
       return true;
     }
 
-    const parentName = def?.extends;
+    const parentName = def?.extendsQualified || def?.extends;
     if (!parentName || seen.has(parentName)) {
+      collectionClassMemo.set(def, false);
       return false;
     }
     seen.add(parentName);
 
-    const parentDef = Object.entries(manifest.objects).find(([key, value]) => {
-      const candidate = value as any;
-      return (
-        key === parentName ||
-        key.endsWith(`:${parentName}`) ||
-        candidate.className === parentName ||
-        candidate.exportName === parentName
-      );
-    })?.[1] as any;
+    const parentDef = manifestObjectLookup.get(parentName);
+    const isCollection = parentDef ? isCollectionClass(parentDef, seen) : false;
+    collectionClassMemo.set(def, isCollection);
 
-    return parentDef ? isCollectionClass(parentDef, seen) : false;
+    return isCollection;
   };
 
-  for (const [objectName, objectDef] of Object.entries(manifest.objects)) {
+  for (const [objectName, objectDef] of Object.entries(manifestObjects)) {
     const def = objectDef as any;
 
     // Skip local objects (they're imported from local entry point)
@@ -423,9 +450,9 @@ async function generateRegistrationFile(
     } else {
       imports.push(`import { ${exportName} } from '${importPath}';`);
     }
+    importedEntryCount++;
 
     if (isCollectionClass(def)) {
-      externalObjectCount++;
       continue;
     }
 
@@ -445,14 +472,17 @@ async function generateRegistrationFile(
       );
     }
 
-    externalObjectCount++;
+    registeredObjectCount++;
   }
 
-  // Skip generation if no external objects
-  if (externalObjectCount === 0) {
-    console.log('[smrt:consumer] No external objects - skipping register.js');
+  // Skip generation if no external entries
+  if (importedEntryCount === 0) {
+    console.log('[smrt:consumer] No external entries - skipping register.js');
     return;
   }
+
+  const registeredObjectLabel =
+    registeredObjectCount === 1 ? 'object' : 'objects';
 
   // Generate file content
   const content = `/**
@@ -472,7 +502,7 @@ ${registrations.join('\n')}
 
 export function registerAll() {
   // Objects are already registered during module evaluation
-  console.log('[smrt:register] Registered ${externalObjectCount} external objects');
+  console.log('[smrt:register] Registered ${registeredObjectCount} external ${registeredObjectLabel}');
 }
 `;
 
@@ -485,7 +515,7 @@ export function registerAll() {
   fs.writeFileSync(registerPath, content, 'utf-8');
 
   console.log(
-    `[smrt:consumer] Generated .smrt/register.js with ${externalObjectCount} external objects`,
+    `[smrt:consumer] Generated .smrt/register.js with ${importedEntryCount} external entries (${registeredObjectCount} registered ${registeredObjectLabel})`,
   );
 }
 

--- a/packages/core/src/consumer-plugin/index.ts
+++ b/packages/core/src/consumer-plugin/index.ts
@@ -373,8 +373,32 @@ async function generateRegistrationFile(
   const registrations: string[] = [];
   let externalObjectCount = 0;
 
-  const isCollectionClass = (def: any): boolean =>
-    def?.extends === 'SmrtCollection';
+  const isCollectionClass = (def: any, seen = new Set<string>()): boolean => {
+    if (
+      def?.extends === 'SmrtCollection' ||
+      def?.extendsTypeArg !== undefined
+    ) {
+      return true;
+    }
+
+    const parentName = def?.extends;
+    if (!parentName || seen.has(parentName)) {
+      return false;
+    }
+    seen.add(parentName);
+
+    const parentDef = Object.entries(manifest.objects).find(([key, value]) => {
+      const candidate = value as any;
+      return (
+        key === parentName ||
+        key.endsWith(`:${parentName}`) ||
+        candidate.className === parentName ||
+        candidate.exportName === parentName
+      );
+    })?.[1] as any;
+
+    return parentDef ? isCollectionClass(parentDef, seen) : false;
+  };
 
   for (const [objectName, objectDef] of Object.entries(manifest.objects)) {
     const def = objectDef as any;


### PR DESCRIPTION
## Summary

- skip `ObjectRegistry.register()` for manifest entries that are `SmrtCollection` classes in the consumer registration generator
- keep importing collection entries so decorators and side effects still run
- add regression coverage for both `smrtConsumer()` and `smrt generate-register`

## Why

Consumer package manifests include collection classes as standalone entries. The generated `.smrt/register.js` imported those collection classes and then tried to register them as `SmrtObject` classes, which makes downstream `svelte-check` fail because `ObjectRegistry.register()` is object-only.

## Validation

- `pnpm --filter @happyvertical/smrt-core exec vitest run src/consumer-plugin/index.test.ts`
- `pnpm --filter @happyvertical/smrt-cli exec vitest run src/commands/__tests__/generate-register.test.ts`
- `git push` pre-push hooks: format-check and workflow validation

Note: broader package typecheck in this fresh worktree is blocked until sibling workspace packages such as `smrt-types` and `smrt-config` are built; the focused tests above exercise the touched generators.
