### PR TITLE
fix(content): reset governance tool state on content changes

### DIFF
--- a/packages/content/src/svelte/components/ContentClaimAuditTool.svelte
+++ b/packages/content/src/svelte/components/ContentClaimAuditTool.svelte
@@ -58,16 +58,27 @@ $effect(() => {
   if (!savedContentId) {
     loadedContentId = null;
     factAudit = null;
+    busy = false;
+    error = null;
+    notice = null;
+    selectedClaimIds = [];
     onFactAuditChange?.(null);
     return;
   }
 
   if (savedContentId !== loadedContentId) {
     loadedContentId = savedContentId;
-    void loadFactAudit();
+    factAudit = null;
+    error = null;
+    notice = null;
+    selectedClaimIds = [];
+    void loadFactAudit(savedContentId);
   }
 });
 
+export async function refresh() {
+  await loadFactAudit(savedContentId);
+}
 function getClaimId(claim: FactAuditClaimData): string | null {
   return typeof claim.id === 'string' && claim.id.length > 0 ? claim.id : null;
 }
@@ -86,61 +97,78 @@ function toggleClaimSelection(claim: FactAuditClaimData) {
     : [...selectedClaimIds, claimId];
 }
 
-async function loadFactAudit() {
-  if (!savedContentId) return;
+async function loadFactAudit(contentIdToLoad = savedContentId) {
+  if (!contentIdToLoad) return;
 
   busy = true;
   error = null;
 
   try {
-    const response = await client.contents.getFactAudit(savedContentId);
+    const response = await client.contents.getFactAudit(contentIdToLoad);
+    if (savedContentId !== contentIdToLoad) return;
     factAudit = response.data;
     onFactAuditChange?.(response.data);
   } catch (err: any) {
+    if (savedContentId !== contentIdToLoad) return;
     error = err.message || 'Failed to load claim audit';
   } finally {
-    busy = false;
+    if (savedContentId === contentIdToLoad) {
+      busy = false;
+    }
   }
 }
 
 async function repairFactAudit() {
   if (!savedContentId || busy) return;
 
+  const contentIdToRepair = savedContentId;
   busy = true;
   error = null;
   notice = null;
 
   try {
-    const response = await client.contents.repairFactAudit(savedContentId);
+    const response = await client.contents.repairFactAudit(contentIdToRepair);
+    if (savedContentId !== contentIdToRepair) return;
     factAudit = response.data;
     notice = `Fact audit repaired: ${response.data.counts.total} claim(s) checked.`;
     onFactAuditChange?.(response.data);
   } catch (err: any) {
+    if (savedContentId !== contentIdToRepair) return;
     error = err.message || 'Failed to repair fact audit';
   } finally {
-    busy = false;
+    if (savedContentId === contentIdToRepair) {
+      busy = false;
+    }
   }
 }
 
 async function recheckFactClaims(claimIds: string[]) {
   if (!savedContentId || busy || claimIds.length === 0) return;
 
+  const contentIdToRecheck = savedContentId;
   busy = true;
   error = null;
   notice = null;
 
   try {
-    const response = await client.contents.recheckFactClaims(savedContentId, {
-      claimFactIds: claimIds,
-    });
+    const response = await client.contents.recheckFactClaims(
+      contentIdToRecheck,
+      {
+        claimFactIds: claimIds,
+      },
+    );
+    if (savedContentId !== contentIdToRecheck) return;
     factAudit = response.data;
     notice = `Rechecked ${claimIds.length} claim${claimIds.length === 1 ? '' : 's'} against current evidence.`;
     selectedClaimIds = selectedClaimIds.filter((id) => !claimIds.includes(id));
     onFactAuditChange?.(response.data);
   } catch (err: any) {
+    if (savedContentId !== contentIdToRecheck) return;
     error = err.message || 'Failed to recheck claim support';
   } finally {
-    busy = false;
+    if (savedContentId === contentIdToRecheck) {
+      busy = false;
+    }
   }
 }
 </script>

--- a/packages/content/src/svelte/components/ContentCorrectionsTool.svelte
+++ b/packages/content/src/svelte/components/ContentCorrectionsTool.svelte
@@ -35,17 +35,34 @@ let correctedFactText = $state('');
 let correctionPublicNote = $state('');
 let publishCorrection = $state(true);
 
+function resetCorrectionDraft() {
+  correctionSummary = '';
+  correctionFactId = '';
+  correctedFactText = '';
+  correctionPublicNote = '';
+  publishCorrection = true;
+}
+
 $effect(() => {
   if (!savedContentId) {
     loadedContentId = null;
     corrections = [];
     facts = [];
+    busy = false;
+    error = null;
+    notice = null;
+    resetCorrectionDraft();
     return;
   }
 
   if (savedContentId !== loadedContentId) {
     loadedContentId = savedContentId;
-    void loadCorrections();
+    corrections = [];
+    facts = [];
+    error = null;
+    notice = null;
+    resetCorrectionDraft();
+    void loadCorrections(savedContentId);
   }
 });
 
@@ -79,36 +96,41 @@ function getCorrectionProvenanceCopy(correction: ContentCorrectionData) {
   return null;
 }
 
-async function loadCorrections() {
-  if (!savedContentId) return;
+async function loadCorrections(contentIdToLoad = savedContentId) {
+  if (!contentIdToLoad) return;
 
   busy = true;
   error = null;
 
   try {
     const [correctionsResponse, factsResponse] = await Promise.all([
-      client.contents.getCorrections(savedContentId),
-      client.contents.getFacts(savedContentId, defaultRelationship),
+      client.contents.getCorrections(contentIdToLoad),
+      client.contents.getFacts(contentIdToLoad, defaultRelationship),
     ]);
+    if (savedContentId !== contentIdToLoad) return;
     corrections = correctionsResponse.data;
     facts = factsResponse.data.facts || [];
     onCorrectionsChange?.(correctionsResponse.data);
   } catch (err: any) {
+    if (savedContentId !== contentIdToLoad) return;
     error = err.message || 'Failed to load corrections';
   } finally {
-    busy = false;
+    if (savedContentId === contentIdToLoad) {
+      busy = false;
+    }
   }
 }
 
 async function issueCorrection() {
-  if (!savedContentId) return;
+  if (!savedContentId || busy) return;
 
+  const contentIdToCorrect = savedContentId;
   busy = true;
   error = null;
   notice = null;
 
   try {
-    await client.contents.issueCorrection(savedContentId, {
+    await client.contents.issueCorrection(contentIdToCorrect, {
       summary: correctionSummary,
       factId: correctionFactId || undefined,
       correctedFactText: correctedFactText || undefined,
@@ -116,17 +138,18 @@ async function issueCorrection() {
       publish: publishCorrection,
     });
 
-    correctionSummary = '';
-    correctedFactText = '';
-    correctionPublicNote = '';
-    publishCorrection = true;
+    if (savedContentId !== contentIdToCorrect) return;
+    resetCorrectionDraft();
 
     notice = 'Correction issued.';
-    await loadCorrections();
+    await loadCorrections(contentIdToCorrect);
   } catch (err: any) {
+    if (savedContentId !== contentIdToCorrect) return;
     error = err.message || 'Failed to issue correction';
   } finally {
-    busy = false;
+    if (savedContentId === contentIdToCorrect) {
+      busy = false;
+    }
   }
 }
 </script>

--- a/packages/content/src/svelte/components/ContentGovernanceTools.test.ts
+++ b/packages/content/src/svelte/components/ContentGovernanceTools.test.ts
@@ -1,0 +1,516 @@
+// @vitest-environment jsdom
+
+import { flushSync, mount, unmount } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const clientMocks = vi.hoisted(() => ({
+  createClient: vi.fn(),
+  browseFacts: vi.fn(),
+  getFacts: vi.fn(),
+  getReviews: vi.fn(),
+  getCorrections: vi.fn(),
+  getVersions: vi.fn(),
+  getGovernanceState: vi.fn(),
+  getGovernanceDefinitions: vi.fn(),
+  getFactAudit: vi.fn(),
+  getTransparencyPreview: vi.fn(),
+  getPublishedTransparency: vi.fn(),
+  issueCorrection: vi.fn(),
+  createVersion: vi.fn(),
+  restoreVersion: vi.fn(),
+  repairFactAudit: vi.fn(),
+  recheckFactClaims: vi.fn(),
+}));
+
+vi.mock('../../mock-smrt-client', () => ({
+  createClient: clientMocks.createClient,
+}));
+
+import ContentClaimAuditTool from './ContentClaimAuditTool.svelte';
+import ContentCorrectionsTool from './ContentCorrectionsTool.svelte';
+import ContentTransparencyTool from './ContentTransparencyTool.svelte';
+import ContentVersionsTool from './ContentVersionsTool.svelte';
+
+const mountedComponents: Array<ReturnType<typeof mount>> = [];
+
+function renderComponent(Component: any, props: Record<string, any> = {}) {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+
+  const component = mount(Component, {
+    target,
+    props,
+  });
+
+  mountedComponents.push(component);
+  flushSync();
+
+  return { target, component };
+}
+
+function findButton(target: HTMLElement, text: string) {
+  const button = Array.from(target.querySelectorAll('button')).find(
+    (candidate) => candidate.textContent?.trim() === text,
+  );
+
+  if (!button) {
+    throw new Error(`Button not found: ${text}`);
+  }
+
+  return button as HTMLButtonElement;
+}
+
+function setInputValue(
+  element: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement,
+  value: string,
+  eventName = 'input',
+) {
+  element.value = value;
+  element.dispatchEvent(new Event(eventName, { bubbles: true }));
+  flushSync();
+}
+
+function emptyFactAudit() {
+  return {
+    counts: {
+      total: 0,
+      supported: 0,
+      unsupported: 0,
+      contradicted: 0,
+      needs_review: 0,
+    },
+    claims: [],
+    resourceClaims: [],
+    warnings: [],
+    generatedBy: 'content.factAudit',
+    latestAuditRunId: null,
+  };
+}
+
+function governanceState(overrides: Record<string, any> = {}) {
+  return {
+    isGoverned: true,
+    factLinkingEnabled: true,
+    transparencyEnabled: true,
+    publicationProfileKey: 'publication',
+    correctionProfileKey: null,
+    enforcePublishReadiness: false,
+    defaultFactRelationship: 'supports',
+    reviewPolicies: [],
+    availableProfiles: [],
+    assignment: null,
+    reviewProfiles: [],
+    ...overrides,
+  };
+}
+
+function governanceDefinitions() {
+  return {
+    effective: {
+      policies: [],
+      profiles: [],
+      assignments: [],
+    },
+    persisted: {
+      policies: [],
+      profiles: [],
+      assignments: [],
+    },
+  };
+}
+
+function transparencySnapshot(overrides: Record<string, any> = {}) {
+  return {
+    generatedAt: '2026-05-10T12:00:00.000Z',
+    snapshotKind: 'preview',
+    contentId: 'content-1',
+    currentContentStatus: 'draft',
+    publicationProfileKey: 'publication',
+    publicationVersion: null,
+    generation: {
+      aiAssisted: true,
+      publicPrompt: 'Explain how the article was produced.',
+      model: 'test-model',
+    },
+    factsUsed: [
+      {
+        id: 'fact-1',
+        textRefined: 'Council approved the project.',
+        relationship: 'supports',
+        sources: [],
+      },
+    ],
+    linkedFacts: [],
+    otherExtractedFacts: [],
+    references: [
+      {
+        id: 'ref-1',
+        title: 'Meeting minutes',
+        url: 'https://example.com/minutes',
+        originalUrl: null,
+        type: 'document',
+        source: 'manual',
+        usedFactIds: ['fact-1'],
+        extractedFacts: [],
+      },
+    ],
+    reviews: [],
+    reviewProfiles: [],
+    corrections: [{ id: 'correction-1' }],
+    versionHistory: [],
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  clientMocks.createClient.mockImplementation(() => ({
+    contents: {
+      browseFacts: clientMocks.browseFacts,
+      getFacts: clientMocks.getFacts,
+      getReviews: clientMocks.getReviews,
+      getCorrections: clientMocks.getCorrections,
+      getVersions: clientMocks.getVersions,
+      getGovernanceState: clientMocks.getGovernanceState,
+      getGovernanceDefinitions: clientMocks.getGovernanceDefinitions,
+      getFactAudit: clientMocks.getFactAudit,
+      getTransparencyPreview: clientMocks.getTransparencyPreview,
+      getPublishedTransparency: clientMocks.getPublishedTransparency,
+      issueCorrection: clientMocks.issueCorrection,
+      createVersion: clientMocks.createVersion,
+      restoreVersion: clientMocks.restoreVersion,
+      repairFactAudit: clientMocks.repairFactAudit,
+      recheckFactClaims: clientMocks.recheckFactClaims,
+    },
+  }));
+
+  clientMocks.browseFacts.mockResolvedValue({ data: [] });
+  clientMocks.getFacts.mockResolvedValue({
+    data: {
+      factIds: [],
+      facts: [],
+      factLinks: [],
+    },
+  });
+  clientMocks.getReviews.mockResolvedValue({ data: [] });
+  clientMocks.getCorrections.mockResolvedValue({ data: [] });
+  clientMocks.getVersions.mockResolvedValue({ data: [] });
+  clientMocks.getGovernanceState.mockResolvedValue({
+    data: governanceState(),
+  });
+  clientMocks.getGovernanceDefinitions.mockResolvedValue({
+    data: governanceDefinitions(),
+  });
+  clientMocks.getFactAudit.mockResolvedValue({ data: emptyFactAudit() });
+  clientMocks.getTransparencyPreview.mockResolvedValue({ data: null });
+  clientMocks.getPublishedTransparency.mockResolvedValue({ data: null });
+  clientMocks.issueCorrection.mockResolvedValue({
+    data: {
+      id: 'correction-new',
+      summary: 'Correction issued.',
+    },
+  });
+  clientMocks.createVersion.mockResolvedValue({
+    data: {
+      id: 'version-new',
+      version: 2,
+      kind: 'manual',
+    },
+  });
+  clientMocks.restoreVersion.mockResolvedValue({
+    data: {
+      id: 'content-1',
+    },
+  });
+  clientMocks.repairFactAudit.mockResolvedValue({ data: emptyFactAudit() });
+  clientMocks.recheckFactClaims.mockResolvedValue({ data: emptyFactAudit() });
+});
+
+afterEach(() => {
+  while (mountedComponents.length > 0) {
+    const component = mountedComponents.pop();
+    if (component) {
+      unmount(component);
+    }
+  }
+
+  document.body.innerHTML = '';
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('ContentClaimAuditTool component', () => {
+  it('shows an empty state for unsaved content without loading claims', () => {
+    const { target } = renderComponent(ContentClaimAuditTool, {
+      contentId: 'new',
+    });
+
+    expect(target.textContent).toContain(
+      'Save this content to audit article claims against evidence.',
+    );
+    expect(clientMocks.getFactAudit).not.toHaveBeenCalled();
+  });
+
+  it('loads claims and enables selected claim rechecks', async () => {
+    clientMocks.getFactAudit.mockResolvedValue({
+      data: {
+        ...emptyFactAudit(),
+        counts: {
+          total: 1,
+          supported: 0,
+          unsupported: 1,
+          contradicted: 0,
+          needs_review: 0,
+        },
+        claims: [
+          {
+            id: 'claim-1',
+            supportStatus: 'unsupported',
+            fact: {
+              id: 'claim-1',
+              textRefined: 'Council approved the project.',
+            },
+            claimQuote: 'Council approved the project.',
+            rationale: 'No supporting evidence was found.',
+            evidence: [],
+          },
+        ],
+      },
+    });
+
+    const { target } = renderComponent(ContentClaimAuditTool, {
+      contentId: 'content-1',
+    });
+
+    await vi.waitFor(() => {
+      expect(target.textContent).toContain('Unsupported article claims');
+      expect(target.textContent).toContain('Council approved the project.');
+    });
+
+    expect(findButton(target, 'Recheck selected (0)').disabled).toBe(true);
+
+    const checkbox = target.querySelector(
+      'input[type="checkbox"]',
+    ) as HTMLInputElement;
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+    flushSync();
+
+    const recheckButton = findButton(target, 'Recheck selected (1)');
+    expect(recheckButton.disabled).toBe(false);
+    recheckButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    await vi.waitFor(() =>
+      expect(clientMocks.recheckFactClaims).toHaveBeenCalledWith('content-1', {
+        claimFactIds: ['claim-1'],
+      }),
+    );
+  });
+});
+
+describe('ContentCorrectionsTool component', () => {
+  it('shows an empty state for unsaved content without loading corrections', () => {
+    const { target } = renderComponent(ContentCorrectionsTool, {
+      contentId: 'new',
+    });
+
+    expect(target.textContent).toContain(
+      'Save this content to issue corrections.',
+    );
+    expect(clientMocks.getCorrections).not.toHaveBeenCalled();
+  });
+
+  it('loads corrections and refreshes after issuing a valid correction', async () => {
+    clientMocks.getCorrections.mockResolvedValue({
+      data: [
+        {
+          id: 'correction-1',
+          correctionType: 'correction',
+          status: 'published',
+          summary: 'Original correction',
+          publishedAt: '2026-05-10T12:00:00.000Z',
+        },
+      ],
+    });
+    clientMocks.getFacts.mockResolvedValue({
+      data: {
+        factIds: ['fact-1'],
+        facts: [
+          {
+            id: 'fact-1',
+            textRefined: 'Original fact',
+          },
+        ],
+        factLinks: [],
+      },
+    });
+
+    const { target } = renderComponent(ContentCorrectionsTool, {
+      contentId: 'content-1',
+    });
+
+    await vi.waitFor(() =>
+      expect(target.textContent).toContain('Original correction'),
+    );
+
+    const issueButton = findButton(target, 'Issue correction');
+    expect(issueButton.disabled).toBe(true);
+
+    setInputValue(
+      target.querySelector(
+        'input[placeholder="What was wrong?"]',
+      ) as HTMLInputElement,
+      'Correct the project status.',
+    );
+
+    expect(findButton(target, 'Issue correction').disabled).toBe(false);
+    findButton(target, 'Issue correction').dispatchEvent(
+      new MouseEvent('click', { bubbles: true }),
+    );
+
+    await vi.waitFor(() => {
+      expect(clientMocks.issueCorrection).toHaveBeenCalledWith('content-1', {
+        summary: 'Correct the project status.',
+        factId: 'fact-1',
+        correctedFactText: undefined,
+        publicNote: undefined,
+        publish: true,
+      });
+      expect(clientMocks.getCorrections).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+describe('ContentVersionsTool component', () => {
+  it('disables snapshot creation for unsaved content', () => {
+    const { target } = renderComponent(ContentVersionsTool, {
+      contentId: 'new',
+    });
+
+    expect(target.textContent).toContain(
+      'Save this content to manage versions.',
+    );
+    expect(findButton(target, 'Create snapshot').disabled).toBe(true);
+    expect(clientMocks.getVersions).not.toHaveBeenCalled();
+  });
+
+  it('loads versions and refreshes after confirming a restore', async () => {
+    vi.stubGlobal(
+      'confirm',
+      vi.fn(() => true),
+    );
+    clientMocks.getVersions.mockResolvedValue({
+      data: [
+        {
+          id: 'version-3',
+          version: 3,
+          kind: 'manual',
+          summary: 'Ready to publish',
+          createdAt: '2026-05-10T12:00:00.000Z',
+        },
+      ],
+    });
+
+    const { target } = renderComponent(ContentVersionsTool, {
+      contentId: 'content-1',
+    });
+
+    await vi.waitFor(() => {
+      expect(clientMocks.getVersions).toHaveBeenCalledWith('content-1');
+      expect(target.textContent).toContain('v3');
+      expect(target.textContent).toContain('Ready to publish');
+    });
+
+    findButton(target, 'Restore').dispatchEvent(
+      new MouseEvent('click', { bubbles: true }),
+    );
+
+    await vi.waitFor(() => {
+      expect(clientMocks.restoreVersion).toHaveBeenCalledWith('content-1', 3);
+      expect(clientMocks.getVersions).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+describe('ContentTransparencyTool component', () => {
+  it('shows an empty state for unsaved content without loading transparency', () => {
+    const { target } = renderComponent(ContentTransparencyTool, {
+      contentId: 'new',
+    });
+
+    expect(target.textContent).toContain(
+      'Save this content to preview the public transparency breakdown.',
+    );
+    expect(clientMocks.getGovernanceState).not.toHaveBeenCalled();
+  });
+
+  it('shows the disabled-state copy when transparency is not enabled', async () => {
+    clientMocks.getGovernanceState.mockResolvedValue({
+      data: governanceState({ transparencyEnabled: false }),
+    });
+
+    const { target } = renderComponent(ContentTransparencyTool, {
+      contentId: 'content-1',
+    });
+
+    await vi.waitFor(() =>
+      expect(target.textContent).toContain(
+        'Public transparency snapshots are not enabled for this governed content type.',
+      ),
+    );
+  });
+
+  it('shows loading copy before rendering preview and published snapshots', async () => {
+    const preview = deferred<{ data: any }>();
+    clientMocks.getTransparencyPreview.mockReturnValue(preview.promise);
+    clientMocks.getPublishedTransparency.mockResolvedValue({
+      data: transparencySnapshot({
+        snapshotKind: 'published',
+        publicationVersion: {
+          id: 'version-4',
+          version: 4,
+          kind: 'publication',
+          summary: 'Published snapshot',
+          createdAt: '2026-05-10T12:30:00.000Z',
+        },
+        versionHistory: [
+          {
+            id: 'version-4',
+            version: 4,
+            kind: 'publication',
+            summary: 'Published snapshot',
+            createdAt: '2026-05-10T12:30:00.000Z',
+            provenance: {},
+          },
+        ],
+      }),
+    });
+
+    const { target } = renderComponent(ContentTransparencyTool, {
+      contentId: 'content-1',
+    });
+
+    await vi.waitFor(() =>
+      expect(target.textContent).toContain('Loading transparency...'),
+    );
+
+    preview.resolve({
+      data: transparencySnapshot(),
+    });
+
+    await vi.waitFor(() => {
+      expect(target.textContent).toContain('Current preview');
+      expect(target.textContent).toContain('Meeting minutes');
+      expect(target.textContent).toContain('Latest published snapshot');
+      expect(target.textContent).toContain('v4');
+    });
+  });
+});

--- a/packages/content/src/svelte/components/ContentTransparencyTool.svelte
+++ b/packages/content/src/svelte/components/ContentTransparencyTool.svelte
@@ -36,13 +36,19 @@ $effect(() => {
     governanceState = null;
     transparencyPreview = null;
     publishedTransparency = null;
+    busy = false;
+    error = null;
     onGovernanceStateChange?.(null);
     return;
   }
 
   if (savedContentId !== loadedContentId) {
     loadedContentId = savedContentId;
-    void loadTransparency();
+    governanceState = null;
+    transparencyPreview = null;
+    publishedTransparency = null;
+    error = null;
+    void loadTransparency(savedContentId);
   }
 });
 
@@ -58,8 +64,8 @@ function getReferenceLabel(reference: {
   return reference.title || reference.url || 'Untitled reference';
 }
 
-async function loadTransparency() {
-  if (!savedContentId) return;
+async function loadTransparency(contentIdToLoad = savedContentId) {
+  if (!contentIdToLoad) return;
 
   busy = true;
   error = null;
@@ -70,18 +76,22 @@ async function loadTransparency() {
       transparencyPreviewResponse,
       publishedTransparencyResponse,
     ] = await Promise.all([
-      client.contents.getGovernanceState(savedContentId),
-      client.contents.getTransparencyPreview(savedContentId),
-      client.contents.getPublishedTransparency(savedContentId),
+      client.contents.getGovernanceState(contentIdToLoad),
+      client.contents.getTransparencyPreview(contentIdToLoad),
+      client.contents.getPublishedTransparency(contentIdToLoad),
     ]);
+    if (savedContentId !== contentIdToLoad) return;
     governanceState = governanceResponse.data;
     transparencyPreview = transparencyPreviewResponse.data;
     publishedTransparency = publishedTransparencyResponse.data;
     onGovernanceStateChange?.(governanceResponse.data);
   } catch (err: any) {
+    if (savedContentId !== contentIdToLoad) return;
     error = err.message || 'Failed to load transparency';
   } finally {
-    busy = false;
+    if (savedContentId === contentIdToLoad) {
+      busy = false;
+    }
   }
 }
 </script>

--- a/packages/content/src/svelte/components/ContentVersionsTool.svelte
+++ b/packages/content/src/svelte/components/ContentVersionsTool.svelte
@@ -30,12 +30,18 @@ $effect(() => {
   if (!savedContentId) {
     loadedContentId = null;
     versions = [];
+    busy = false;
+    error = null;
+    notice = null;
     return;
   }
 
   if (savedContentId !== loadedContentId) {
     loadedContentId = savedContentId;
-    void refreshVersions();
+    versions = [];
+    error = null;
+    notice = null;
+    void refreshVersions(savedContentId);
   }
 });
 
@@ -62,41 +68,50 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
   return null;
 }
 
-async function refreshVersions() {
-  if (!savedContentId) return;
+async function refreshVersions(contentIdToLoad = savedContentId) {
+  if (!contentIdToLoad) return;
 
   busy = true;
   error = null;
 
   try {
-    const response = await client.contents.getVersions(savedContentId);
+    const response = await client.contents.getVersions(contentIdToLoad);
+    if (savedContentId !== contentIdToLoad) return;
     versions = response.data;
     onVersionsChange?.(response.data);
   } catch (err: any) {
+    if (savedContentId !== contentIdToLoad) return;
     error = err.message || 'Failed to load versions';
   } finally {
-    busy = false;
+    if (savedContentId === contentIdToLoad) {
+      busy = false;
+    }
   }
 }
 
 async function createSnapshot() {
   if (!savedContentId) return;
 
+  const contentIdToSnapshot = savedContentId;
   busy = true;
   error = null;
   notice = null;
 
   try {
-    await client.contents.createVersion(savedContentId, {
+    await client.contents.createVersion(contentIdToSnapshot, {
       kind: 'manual',
       summary: 'Manual editorial snapshot',
     });
+    if (savedContentId !== contentIdToSnapshot) return;
     notice = 'Snapshot created.';
-    await refreshVersions();
+    await refreshVersions(contentIdToSnapshot);
   } catch (err: any) {
+    if (savedContentId !== contentIdToSnapshot) return;
     error = err.message || 'Failed to create version snapshot';
   } finally {
-    busy = false;
+    if (savedContentId === contentIdToSnapshot) {
+      busy = false;
+    }
   }
 }
 
@@ -107,18 +122,23 @@ async function restoreVersion(versionNumber: number) {
     return;
   }
 
+  const contentIdToRestore = savedContentId;
   busy = true;
   error = null;
   notice = null;
 
   try {
-    await client.contents.restoreVersion(savedContentId, versionNumber);
+    await client.contents.restoreVersion(contentIdToRestore, versionNumber);
+    if (savedContentId !== contentIdToRestore) return;
     notice = `Restored version ${versionNumber}.`;
-    await refreshVersions();
+    await refreshVersions(contentIdToRestore);
   } catch (err: any) {
+    if (savedContentId !== contentIdToRestore) return;
     error = err.message || 'Failed to restore version';
   } finally {
-    busy = false;
+    if (savedContentId === contentIdToRestore) {
+      busy = false;
+    }
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- Follow-up to #1220 after it merged before these review fixes landed.
- Reset governance tool busy/error/notice/form state when content changes or is unsaved.
- Guard async governance tool responses/actions against stale content IDs.
- Add component tests covering stale state resets and stale async responses.

## Verification
- pnpm exec biome check --write packages/content/src/svelte/components/ContentClaimAuditTool.svelte packages/content/src/svelte/components/ContentCorrectionsTool.svelte packages/content/src/svelte/components/ContentTransparencyTool.svelte packages/content/src/svelte/components/ContentVersionsTool.svelte packages/content/src/svelte/components/ContentGovernanceTools.test.ts
- pnpm --filter @happyvertical/smrt-content exec vitest run src/svelte/components/ContentGovernanceTools.test.ts src/svelte/components/ContentGovernancePanel.test.ts
- pnpm --filter @happyvertical/smrt-content check