### PR TITLE
[codex] Expose content editor primitives

### DIFF
--- a/.changeset/content-editor-primitives.md
+++ b/.changeset/content-editor-primitives.md
@@ -1,0 +1,11 @@
+---
+"@happyvertical/smrt-core": minor
+---
+
+### Features
+
+- Export composable content editor primitives from `@happyvertical/smrt-content/svelte`.
+
+### Release Notes
+
+- Uses the next minor release because `@happyvertical/smrt-content@0.24.18` was already published from a side branch before these source changes landed on `main`.

--- a/.changeset/content-editor-primitives.md
+++ b/.changeset/content-editor-primitives.md
@@ -1,5 +1,5 @@
 ---
-"@happyvertical/smrt-core": minor
+"@happyvertical/smrt-content": minor
 ---
 
 ### Features

--- a/packages/content/CLAUDE.md
+++ b/packages/content/CLAUDE.md
@@ -74,10 +74,10 @@ Three strategies via ThumbnailGenerator:
 - **static-map**: requires `metadata.latitude`/`longitude` (via `@happyvertical/geo`)
 - **ai-generate**: AI image generation (dynamic import of `@happyvertical/ai`)
 
-## Svelte Components (19 total)
+## Svelte Components
 
 ### Content Management
-`ContentList`, `ContentEditor`, `GovernedContentEditor`, `ContentAgentChat`, `ArticleCard`, `ArticleList`, `ImageThumbnail`, `Markdown`
+`ContentList`, `ContentEditor`, `GovernedContentEditor`, `ContentAgentChat`, `ContentTitleField`, `ContentStatusFields`, `ContentMetadataFields`, `ContentReferencesPanel`, `ContentImageBrowser`, `ContentReviewStatusTray`, `ArticleCard`, `ArticleList`, `ImageThumbnail`, `Markdown`
 
 ### Governance
 `ContentGovernanceManager`, `ContentGovernancePanel`, `ContentGovernancePolicyEditor`, `ContentGovernanceProfileEditor`, `ContentGovernanceAssignmentEditor`, `ContentTransparencyReport`

--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -412,10 +412,17 @@ startup and seeds sample content (3 items) for immediate testing.
 | `ContentEditor` | `content`, `contentId`, `onSave`, `onCancel` | Full content editor with metadata, assets, references |
 | `GovernedContentEditor` | `content`, `contentId`, `onSave`, `onCancel` | Editor with integrated governance panel and review controls |
 | `ContentAgentChat` | `contentId`, `apiBasePath` | AI chat sidebar for content with thread management |
+| `ContentTitleField`, `ContentStatusFields`, `ContentMetadataFields`, `ContentReferencesPanel`, `ContentImageBrowser` | focused field/section props | Composable editor primitives for application-owned layouts |
+| `ContentReviewStatusTray` | `items`, `activeId`, `open`, `onSelect` | Compact review status tray for inline review drawers |
 | `ArticleCard` | `article` | Card display for an article |
 | `ArticleList` | `articles` | List of article cards |
 | `ImageThumbnail` | `src`, `alt` | Thumbnail image display |
 | `Markdown` | `source` | Markdown renderer |
+
+Applications that compose their own article editor can use
+`createContentEditorState`, `getContentEditorAssetImageSource`, and
+`resolveContentEditorImageSelection` to share the same form normalization,
+thumbnail selection, and save payload behavior as the package editors.
 
 ### Governance
 

--- a/packages/content/src/svelte/components/ContentReviewStatusTray.svelte
+++ b/packages/content/src/svelte/components/ContentReviewStatusTray.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+export type ContentReviewStatusTone =
+  | 'neutral'
+  | 'danger'
+  | 'warning'
+  | 'success';
+export type ContentReviewStatusIcon = 'content' | 'facts' | 'safety' | 'custom';
+
+export interface ContentReviewStatusTrayItem {
+  id: string;
+  icon: ContentReviewStatusIcon;
+  label: string;
+  tone: ContentReviewStatusTone;
+  status: string;
+}
+
+export interface Props {
+  items?: ContentReviewStatusTrayItem[];
+  activeId?: string | null;
+  open?: boolean;
+  label?: string;
+  onSelect?: (item: ContentReviewStatusTrayItem) => void;
+}
+
+let {
+  items = [],
+  activeId = null,
+  open = false,
+  label = 'Review status',
+  onSelect = undefined,
+}: Props = $props();
+</script>
+
+{#snippet trayIcon(icon: ContentReviewStatusIcon)}
+  {#if icon === 'content'}
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M9 11l2 2 4-4"></path>
+      <path d="M8 5h8"></path>
+      <path d="M8 19h8"></path>
+      <path d="M5 7h14"></path>
+      <path d="M5 17h14"></path>
+    </svg>
+  {:else if icon === 'facts'}
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z"></path>
+      <path d="M14 2v6h6"></path>
+      <path d="M9 15h6"></path>
+      <path d="M9 11h2"></path>
+    </svg>
+  {:else if icon === 'safety'}
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10Z"></path>
+      <path d="m9 12 2 2 4-4"></path>
+    </svg>
+  {:else}
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="m12 3 1.8 4.2L18 9l-4.2 1.8L12 15l-1.8-4.2L6 9l4.2-1.8Z"></path>
+      <path d="m5 15 .9 2.1L8 18l-2.1.9L5 21l-.9-2.1L2 18l2.1-.9Z"></path>
+      <path d="m19 14 .9 2.1L22 17l-2.1.9L19 20l-.9-2.1L16 17l2.1-.9Z"></path>
+    </svg>
+  {/if}
+{/snippet}
+
+{#if items.length > 0}
+  <div class="content-review-status-tray" role="tablist" aria-label={label}>
+    {#each items as item (item.id)}
+      <button
+        type="button"
+        role="tab"
+        aria-selected={activeId === item.id && open}
+        class={`tray-button tray-button--${item.tone}`}
+        class:active={activeId === item.id && open}
+        title={`${item.label}: ${item.status}`}
+        onclick={() => onSelect?.(item)}
+      >
+        {@render trayIcon(item.icon)}
+        <span class="tray-button__indicator" aria-hidden="true"></span>
+        <span class="sr-only">{item.label}: {item.status}</span>
+      </button>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .content-review-status-tray {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    min-height: 2.5rem;
+  }
+
+  .tray-button {
+    position: relative;
+    display: inline-grid;
+    place-items: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border: 1px solid var(--smrt-color-outline-variant);
+    border-radius: 0.55rem;
+    background: var(--smrt-color-surface-container-low);
+    color: var(--smrt-color-on-surface-variant);
+    cursor: pointer;
+    padding: 0;
+  }
+
+  .tray-button:hover,
+  .tray-button.active {
+    background: var(--smrt-color-surface-container);
+    color: var(--smrt-color-on-surface);
+  }
+
+  .tray-button svg {
+    width: 1.15rem;
+    height: 1.15rem;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.9;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .tray-button__indicator {
+    position: absolute;
+    right: 0.35rem;
+    bottom: 0.35rem;
+    width: 0.45rem;
+    height: 0.45rem;
+    border-radius: 999px;
+    background: var(--smrt-color-outline);
+  }
+
+  .tray-button--danger .tray-button__indicator {
+    background: var(--smrt-color-error);
+  }
+
+  .tray-button--warning .tray-button__indicator {
+    background: var(--smrt-color-tertiary, #d97706);
+  }
+
+  .tray-button--success .tray-button__indicator {
+    background: var(--smrt-color-primary);
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+  }
+</style>

--- a/packages/content/src/svelte/components/ContentReviewStatusTray.svelte
+++ b/packages/content/src/svelte/components/ContentReviewStatusTray.svelte
@@ -62,12 +62,11 @@ let {
 {/snippet}
 
 {#if items.length > 0}
-  <div class="content-review-status-tray" role="tablist" aria-label={label}>
+  <div class="content-review-status-tray" role="group" aria-label={label}>
     {#each items as item (item.id)}
       <button
         type="button"
-        role="tab"
-        aria-selected={activeId === item.id && open}
+        aria-pressed={activeId === item.id && open}
         class={`tray-button tray-button--${item.tone}`}
         class:active={activeId === item.id && open}
         title={`${item.label}: ${item.status}`}

--- a/packages/content/src/svelte/components/ContentTitleField.svelte
+++ b/packages/content/src/svelte/components/ContentTitleField.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+export interface Props {
+  value?: string;
+  placeholder?: string;
+  required?: boolean;
+  onChange?: (value: string) => void;
+}
+
+let {
+  value = '',
+  placeholder = 'Title',
+  required = false,
+  onChange = undefined,
+}: Props = $props();
+</script>
+
+<input
+  class="content-title-field"
+  type="text"
+  {placeholder}
+  {required}
+  value={value || ''}
+  oninput={(event) => onChange?.(event.currentTarget.value)}
+/>
+
+<style>
+  .content-title-field {
+    width: 100%;
+    box-sizing: border-box;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    color: var(--smrt-color-on-surface);
+    font: inherit;
+    font-size: clamp(1.45rem, 1.1rem + 1vw, 2rem);
+    font-weight: 720;
+    line-height: 1.12;
+    letter-spacing: 0;
+    padding: 0;
+  }
+
+  .content-title-field::placeholder {
+    color: color-mix(in srgb, var(--smrt-color-on-surface-variant) 70%, transparent);
+  }
+
+  .content-title-field:focus {
+    outline: none;
+  }
+</style>

--- a/packages/content/src/svelte/components/ContentTitleField.svelte
+++ b/packages/content/src/svelte/components/ContentTitleField.svelte
@@ -46,4 +46,9 @@ let {
   .content-title-field:focus {
     outline: none;
   }
+
+  .content-title-field:focus-visible {
+    outline: 2px solid var(--smrt-color-primary, #005ac1);
+    outline-offset: 0.35rem;
+  }
 </style>

--- a/packages/content/src/svelte/components/content-editor-building-blocks.test.ts
+++ b/packages/content/src/svelte/components/content-editor-building-blocks.test.ts
@@ -11,6 +11,7 @@ vi.mock('@happyvertical/smrt-images/svelte', async () => ({
 import ContentImageBrowser from './ContentImageBrowser.svelte';
 import ContentMetadataFields from './ContentMetadataFields.svelte';
 import ContentReferencesPanel from './ContentReferencesPanel.svelte';
+import ContentReviewStatusTray from './ContentReviewStatusTray.svelte';
 import ContentStatusFields from './ContentStatusFields.svelte';
 
 const mountedComponents: Array<ReturnType<typeof mount>> = [];
@@ -174,5 +175,46 @@ describe('content editor building block components', () => {
       '[data-testid="image-uploader-stub"]',
     ) as HTMLElement | null;
     expect(uploader?.dataset.apiBaseUrl).toBe('/tenant/api/v1');
+  });
+
+  it('represents review tray items as pressed buttons, not tabs', () => {
+    const onSelect = vi.fn();
+    const target = renderComponent(ContentReviewStatusTray, {
+      activeId: 'facts',
+      open: true,
+      items: [
+        {
+          id: 'content',
+          icon: 'content',
+          label: 'Content',
+          tone: 'neutral',
+          status: 'Ready',
+        },
+        {
+          id: 'facts',
+          icon: 'facts',
+          label: 'Facts',
+          tone: 'warning',
+          status: 'Review needed',
+        },
+      ],
+      onSelect,
+    });
+
+    expect(target.querySelector('[role="tablist"]')).toBeNull();
+    expect(target.querySelector('[role="tab"]')).toBeNull();
+    expect(target.querySelector('[role="group"]')).toBeTruthy();
+
+    const buttons = Array.from(target.querySelectorAll('button'));
+    expect(
+      buttons.map((button) => button.getAttribute('aria-pressed')),
+    ).toEqual(['false', 'true']);
+
+    buttons[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    flushSync();
+
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'facts' }),
+    );
   });
 });

--- a/packages/content/src/svelte/components/content-editor-building-blocks.test.ts
+++ b/packages/content/src/svelte/components/content-editor-building-blocks.test.ts
@@ -177,11 +177,12 @@ describe('content editor building block components', () => {
     expect(uploader?.dataset.apiBaseUrl).toBe('/tenant/api/v1');
   });
 
-  it('represents review tray items as pressed buttons, not tabs', () => {
+  it('renders accessible review tray buttons and invokes selection', () => {
     const onSelect = vi.fn();
     const target = renderComponent(ContentReviewStatusTray, {
       activeId: 'facts',
       open: true,
+      label: 'Editorial checks',
       items: [
         {
           id: 'content',
@@ -203,12 +204,23 @@ describe('content editor building block components', () => {
 
     expect(target.querySelector('[role="tablist"]')).toBeNull();
     expect(target.querySelector('[role="tab"]')).toBeNull();
-    expect(target.querySelector('[role="group"]')).toBeTruthy();
+    expect(
+      target.querySelector('[role="group"]')?.getAttribute('aria-label'),
+    ).toBe('Editorial checks');
 
     const buttons = Array.from(target.querySelectorAll('button'));
+    expect(buttons).toHaveLength(2);
+    expect(buttons.map((button) => button.getAttribute('title'))).toEqual([
+      'Content: Ready',
+      'Facts: Review needed',
+    ]);
     expect(
       buttons.map((button) => button.getAttribute('aria-pressed')),
     ).toEqual(['false', 'true']);
+    expect(buttons.map((button) => button.textContent?.trim())).toEqual([
+      'Content: Ready',
+      'Facts: Review needed',
+    ]);
 
     buttons[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
     flushSync();

--- a/packages/content/src/svelte/content-editor-media.ts
+++ b/packages/content/src/svelte/content-editor-media.ts
@@ -1,0 +1,79 @@
+import type { ImageLike } from '@happyvertical/smrt-images/svelte';
+import { joinApiUrl, normalizeApiBaseUrl } from './api.js';
+import type { ContentEditorAsset } from './content-editor-form.js';
+
+export function getContentEditorAssetImageSource(
+  asset: ContentEditorAsset | Record<string, unknown>,
+): string {
+  return String(
+    asset?.sourceUri ||
+      asset?.thumbnailUri ||
+      asset?.thumbnailUrl ||
+      asset?.deliveryUrl ||
+      asset?.url ||
+      asset?.src ||
+      '',
+  );
+}
+
+export function readContentEditorFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (event) => resolve(event.target?.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}
+
+export async function createContentEditorImageRecord(
+  apiBaseUrl: string,
+  input: {
+    name: string;
+    sourceUri: string;
+    mimeType: string;
+  },
+): Promise<ContentEditorAsset | null> {
+  const response = await fetch(
+    joinApiUrl(normalizeApiBaseUrl(apiBaseUrl), '/images'),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+
+  const payload = await response.json();
+  return (payload?.data ?? payload) as ContentEditorAsset | null;
+}
+
+export async function resolveContentEditorImageSelection(
+  apiBaseUrl: string,
+  selected: ImageLike | File | string,
+): Promise<ContentEditorAsset | null> {
+  if (selected && typeof selected === 'object' && 'id' in selected) {
+    return selected as ContentEditorAsset;
+  }
+
+  if (selected instanceof File) {
+    return createContentEditorImageRecord(apiBaseUrl, {
+      name: selected.name || 'Uploaded Image',
+      sourceUri: await readContentEditorFileAsDataUrl(selected),
+      mimeType: selected.type || 'image/png',
+    });
+  }
+
+  if (typeof selected === 'string') {
+    const parsedUrl = new URL(selected);
+    return createContentEditorImageRecord(apiBaseUrl, {
+      name: parsedUrl.pathname.split('/').pop() || 'External Image',
+      sourceUri: selected,
+      mimeType: 'image/jpeg',
+    });
+  }
+
+  return null;
+}

--- a/packages/content/src/svelte/content-editor-media.ts
+++ b/packages/content/src/svelte/content-editor-media.ts
@@ -25,6 +25,36 @@ export function readContentEditorFileAsDataUrl(file: File): Promise<string> {
   });
 }
 
+export function getContentEditorMimeTypeFromPath(pathname: string): string {
+  const extension = pathname.split('.').pop()?.toLowerCase() ?? '';
+  switch (extension) {
+    case 'avif':
+      return 'image/avif';
+    case 'gif':
+      return 'image/gif';
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg';
+    case 'png':
+      return 'image/png';
+    case 'svg':
+      return 'image/svg+xml';
+    case 'webp':
+      return 'image/webp';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+function getMimeTypeFromUrl(parsedUrl: URL): string {
+  if (parsedUrl.protocol === 'data:') {
+    const [, mimeType] = parsedUrl.href.match(/^data:([^;,]+)/) ?? [];
+    return mimeType || 'application/octet-stream';
+  }
+
+  return getContentEditorMimeTypeFromPath(parsedUrl.pathname);
+}
+
 export async function createContentEditorImageRecord(
   apiBaseUrl: string,
   input: {
@@ -67,11 +97,17 @@ export async function resolveContentEditorImageSelection(
   }
 
   if (typeof selected === 'string') {
-    const parsedUrl = new URL(selected);
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(selected);
+    } catch {
+      return null;
+    }
+
     return createContentEditorImageRecord(apiBaseUrl, {
       name: parsedUrl.pathname.split('/').pop() || 'External Image',
       sourceUri: selected,
-      mimeType: 'image/jpeg',
+      mimeType: getMimeTypeFromUrl(parsedUrl),
     });
   }
 

--- a/packages/content/src/svelte/content-editor-primitives.test.ts
+++ b/packages/content/src/svelte/content-editor-primitives.test.ts
@@ -1,8 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  type ContentEditorFieldChange,
   createContentEditorState,
   getContentEditorAssetImageSource,
+  resolveContentEditorImageSelection,
 } from './index';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('content editor primitives', () => {
   it('creates editable form state from initial content', () => {
@@ -46,6 +52,43 @@ describe('content editor primitives', () => {
     expect(editor.showUndoBanner).toBe(false);
   });
 
+  it('preserves non-string field values through field update undo', () => {
+    const editor = createContentEditorState({
+      content: {
+        tags: ['council'],
+        thumbnailAssetId: null,
+      },
+    });
+
+    editor.applyFieldUpdates({
+      tags: ['budget', 'capital-plan'],
+      thumbnailAssetId: 'asset-2',
+    });
+
+    expect(editor.form.tags).toEqual(['budget', 'capital-plan']);
+    expect(editor.form.thumbnailAssetId).toBe('asset-2');
+
+    editor.undoLastFieldUpdate();
+
+    expect(editor.form.tags).toEqual(['council']);
+    expect(editor.form.thumbnailAssetId).toBeNull();
+  });
+
+  it('skips incompatible non-string field updates', () => {
+    const editor = createContentEditorState({
+      content: {
+        tags: ['council'],
+      },
+    });
+
+    editor.applyFieldUpdates({
+      tags: 'budget',
+    } as unknown as ContentEditorFieldChange);
+
+    expect(editor.form.tags).toEqual(['council']);
+    expect(editor.undoDepth).toBe(0);
+  });
+
   it('manages editor assets and thumbnail selection', () => {
     const editor = createContentEditorState();
 
@@ -76,5 +119,46 @@ describe('content editor primitives', () => {
         src: 'https://example.com/src.jpg',
       }),
     ).toBe('https://example.com/src.jpg');
+  });
+
+  it('returns null for invalid string image selections', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    await expect(
+      resolveContentEditorImageSelection('/api/v1', 'not a url'),
+    ).resolves.toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('uses the URL extension when creating image records from strings', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: {
+            id: 'asset-1',
+          },
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      ),
+    );
+
+    await expect(
+      resolveContentEditorImageSelection(
+        '/api/v1',
+        'https://example.com/photos/hero.webp?width=1200',
+      ),
+    ).resolves.toEqual({ id: 'asset-1' });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    const body = JSON.parse(String(init?.body));
+    expect(body).toMatchObject({
+      name: 'hero.webp',
+      sourceUri: 'https://example.com/photos/hero.webp?width=1200',
+      mimeType: 'image/webp',
+    });
   });
 });

--- a/packages/content/src/svelte/content-editor-primitives.test.ts
+++ b/packages/content/src/svelte/content-editor-primitives.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createContentEditorState,
+  getContentEditorAssetImageSource,
+} from './index';
+
+describe('content editor primitives', () => {
+  it('creates editable form state from initial content', () => {
+    const editor = createContentEditorState({
+      content: {
+        title: 'Council update',
+        body: '<p>Draft</p>',
+        bodyFormat: 'html',
+        referenceIds: ['ref-1'],
+        assetIds: ['asset-1'],
+        assets: [{ id: 'asset-1', sourceUri: 'https://example.com/image.jpg' }],
+      },
+    });
+
+    expect(editor.form.title).toBe('Council update');
+    expect(editor.snapshot.referenceIds).toEqual(['ref-1']);
+    expect('assets' in editor.savePayload).toBe(false);
+  });
+
+  it('tracks assistant field updates and restores them with undo', () => {
+    const editor = createContentEditorState({
+      content: {
+        title: 'Original title',
+        description: 'Original deck',
+      },
+    });
+
+    editor.applyFieldUpdates({
+      title: 'Updated title',
+      description: 'Updated deck',
+    });
+
+    expect(editor.form.title).toBe('Updated title');
+    expect(editor.lastAppliedFields).toEqual(['title', 'description']);
+    expect(editor.showUndoBanner).toBe(true);
+
+    editor.undoLastFieldUpdate();
+
+    expect(editor.form.title).toBe('Original title');
+    expect(editor.form.description).toBe('Original deck');
+    expect(editor.showUndoBanner).toBe(false);
+  });
+
+  it('manages editor assets and thumbnail selection', () => {
+    const editor = createContentEditorState();
+
+    editor.addAsset({
+      id: 'asset-1',
+      sourceUri: 'https://example.com/image.jpg',
+    });
+
+    expect(editor.form.assetIds).toEqual(['asset-1']);
+    expect(editor.form.thumbnailAssetId).toBe('asset-1');
+
+    editor.removeAsset('asset-1');
+
+    expect(editor.form.assetIds).toEqual([]);
+    expect(editor.form.thumbnailAssetId).toBeNull();
+  });
+
+  it('resolves preview sources from common asset fields', () => {
+    expect(
+      getContentEditorAssetImageSource({
+        thumbnailUrl: 'https://example.com/thumb.jpg',
+        url: 'https://example.com/full.jpg',
+      }),
+    ).toBe('https://example.com/thumb.jpg');
+
+    expect(
+      getContentEditorAssetImageSource({
+        src: 'https://example.com/src.jpg',
+      }),
+    ).toBe('https://example.com/src.jpg');
+  });
+});

--- a/packages/content/src/svelte/content-editor-state.svelte.ts
+++ b/packages/content/src/svelte/content-editor-state.svelte.ts
@@ -1,0 +1,140 @@
+import type { ImageLike } from '@happyvertical/smrt-images/svelte';
+import type { ContentEditorAssistantFields } from '../content-editor-assistant.js';
+import {
+  type ContentEditorAsset,
+  type ContentEditorFormData,
+  type ContentEditorInitialContent,
+  getContentEditorInitialFormData,
+  getContentEditorSavePayload,
+  getContentEditorSnapshot,
+} from './content-editor-form.js';
+
+export interface CreateContentEditorStateOptions {
+  content?: ContentEditorInitialContent | null;
+}
+
+export type ContentEditorFieldChange = Partial<ContentEditorFormData> &
+  Record<string, unknown>;
+
+export class ContentEditorState {
+  private _form = $state<ContentEditorFormData>(
+    getContentEditorInitialFormData(undefined),
+  );
+  private _fieldUndoStack = $state<Record<string, string>[]>([]);
+  private _lastAppliedFields = $state<string[]>([]);
+  private _showUndoBanner = $state(false);
+
+  constructor(options: CreateContentEditorStateOptions = {}) {
+    this.reset(options.content);
+  }
+
+  get form() {
+    return this._form;
+  }
+
+  get snapshot() {
+    return getContentEditorSnapshot(this._form);
+  }
+
+  get savePayload() {
+    return getContentEditorSavePayload(this._form);
+  }
+
+  get showUndoBanner() {
+    return this._showUndoBanner;
+  }
+
+  get lastAppliedFields() {
+    return this._lastAppliedFields;
+  }
+
+  get undoDepth() {
+    return this._fieldUndoStack.length;
+  }
+
+  reset(content?: ContentEditorInitialContent | null) {
+    this._form = getContentEditorInitialFormData(content);
+    this._fieldUndoStack = [];
+    this._lastAppliedFields = [];
+    this._showUndoBanner = false;
+  }
+
+  update(change: ContentEditorFieldChange) {
+    this._form = {
+      ...this._form,
+      ...change,
+    };
+  }
+
+  applyFieldUpdates(fields: ContentEditorAssistantFields) {
+    const oldValues: Record<string, string> = {};
+
+    for (const key of Object.keys(fields)) {
+      oldValues[key] = String(this._form[key] ?? '');
+      this._form[key] = fields[key];
+    }
+
+    this._fieldUndoStack = [...this._fieldUndoStack, oldValues];
+    this._lastAppliedFields = Object.keys(fields);
+    this._showUndoBanner = true;
+  }
+
+  undoLastFieldUpdate() {
+    if (this._fieldUndoStack.length === 0) {
+      return;
+    }
+
+    const oldValues = this._fieldUndoStack[this._fieldUndoStack.length - 1];
+    this._fieldUndoStack = this._fieldUndoStack.slice(0, -1);
+
+    for (const [key, value] of Object.entries(oldValues)) {
+      this._form[key] = value;
+    }
+
+    this._lastAppliedFields = Object.keys(oldValues);
+    if (this._fieldUndoStack.length === 0) {
+      this._showUndoBanner = false;
+    }
+  }
+
+  setReferenceIds(referenceIds: string[]) {
+    this._form.referenceIds = [...referenceIds];
+  }
+
+  addAsset(asset: ContentEditorAsset | ImageLike | Record<string, unknown>) {
+    const assetId = typeof asset.id === 'string' ? asset.id : '';
+    if (!assetId) {
+      return;
+    }
+
+    if (!this._form.assetIds.includes(assetId)) {
+      this._form.assetIds = [...this._form.assetIds, assetId];
+      this._form.assets = [...this._form.assets, asset as ContentEditorAsset];
+    }
+
+    if (!this._form.thumbnailAssetId) {
+      this._form.thumbnailAssetId = assetId;
+    }
+  }
+
+  removeAsset(assetId: string) {
+    this._form.assetIds = this._form.assetIds.filter((id) => id !== assetId);
+    this._form.assets = this._form.assets.filter(
+      (asset) => asset.id !== assetId,
+    );
+
+    if (this._form.thumbnailAssetId === assetId) {
+      this._form.thumbnailAssetId = null;
+    }
+  }
+
+  setThumbnailAsset(assetId: string | null) {
+    this._form.thumbnailAssetId = assetId;
+  }
+}
+
+export function createContentEditorState(
+  options: CreateContentEditorStateOptions = {},
+) {
+  return new ContentEditorState(options);
+}

--- a/packages/content/src/svelte/content-editor-state.svelte.ts
+++ b/packages/content/src/svelte/content-editor-state.svelte.ts
@@ -1,5 +1,4 @@
 import type { ImageLike } from '@happyvertical/smrt-images/svelte';
-import type { ContentEditorAssistantFields } from '../content-editor-assistant.js';
 import {
   type ContentEditorAsset,
   type ContentEditorFormData,
@@ -16,11 +15,61 @@ export interface CreateContentEditorStateOptions {
 export type ContentEditorFieldChange = Partial<ContentEditorFormData> &
   Record<string, unknown>;
 
+type FieldUndoSnapshot = Record<string, unknown>;
+
+function cloneFieldValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return [...value];
+  }
+
+  if (value && typeof value === 'object') {
+    return { ...(value as Record<string, unknown>) };
+  }
+
+  return value;
+}
+
+function normalizeFieldUpdateValue(
+  currentValue: unknown,
+  newValue: unknown,
+): { ok: true; value: unknown } | { ok: false } {
+  if (Array.isArray(currentValue)) {
+    return Array.isArray(newValue)
+      ? { ok: true, value: [...newValue] }
+      : { ok: false };
+  }
+
+  if (currentValue === null) {
+    return newValue == null || typeof newValue === 'string'
+      ? { ok: true, value: newValue ?? null }
+      : { ok: false };
+  }
+
+  switch (typeof currentValue) {
+    case 'string':
+      return { ok: true, value: newValue == null ? '' : String(newValue) };
+    case 'number': {
+      const numberValue = Number(newValue);
+      return Number.isFinite(numberValue)
+        ? { ok: true, value: numberValue }
+        : { ok: false };
+    }
+    case 'boolean':
+      return typeof newValue === 'boolean'
+        ? { ok: true, value: newValue }
+        : { ok: false };
+    case 'undefined':
+      return { ok: true, value: cloneFieldValue(newValue) };
+    default:
+      return { ok: true, value: cloneFieldValue(newValue) };
+  }
+}
+
 export class ContentEditorState {
   private _form = $state<ContentEditorFormData>(
     getContentEditorInitialFormData(undefined),
   );
-  private _fieldUndoStack = $state<Record<string, string>[]>([]);
+  private _fieldUndoStack = $state<FieldUndoSnapshot[]>([]);
   private _lastAppliedFields = $state<string[]>([]);
   private _showUndoBanner = $state(false);
 
@@ -66,16 +115,30 @@ export class ContentEditorState {
     };
   }
 
-  applyFieldUpdates(fields: ContentEditorAssistantFields) {
-    const oldValues: Record<string, string> = {};
+  applyFieldUpdates(fields: ContentEditorFieldChange) {
+    const oldValues: FieldUndoSnapshot = {};
+    const appliedFields: string[] = [];
 
     for (const key of Object.keys(fields)) {
-      oldValues[key] = String(this._form[key] ?? '');
-      this._form[key] = fields[key];
+      const normalized = normalizeFieldUpdateValue(
+        this._form[key],
+        fields[key],
+      );
+      if (!normalized.ok) {
+        continue;
+      }
+
+      oldValues[key] = cloneFieldValue(this._form[key]);
+      this._form[key] = normalized.value;
+      appliedFields.push(key);
+    }
+
+    if (appliedFields.length === 0) {
+      return;
     }
 
     this._fieldUndoStack = [...this._fieldUndoStack, oldValues];
-    this._lastAppliedFields = Object.keys(fields);
+    this._lastAppliedFields = appliedFields;
     this._showUndoBanner = true;
   }
 

--- a/packages/content/src/svelte/index.ts
+++ b/packages/content/src/svelte/index.ts
@@ -36,7 +36,9 @@ import ContentImageChooser from './components/ContentImageChooser.svelte';
 import ContentList from './components/ContentList.svelte';
 import ContentMetadataFields from './components/ContentMetadataFields.svelte';
 import ContentReferencesPanel from './components/ContentReferencesPanel.svelte';
+import ContentReviewStatusTray from './components/ContentReviewStatusTray.svelte';
 import ContentStatusFields from './components/ContentStatusFields.svelte';
+import ContentTitleField from './components/ContentTitleField.svelte';
 import ContentTransparencyReport from './components/ContentTransparencyReport.svelte';
 import ContentTransparencyTool from './components/ContentTransparencyTool.svelte';
 import ContentVersionsTool from './components/ContentVersionsTool.svelte';
@@ -83,7 +85,9 @@ export {
   ContentList,
   ContentMetadataFields,
   ContentReferencesPanel,
+  ContentReviewStatusTray,
   ContentStatusFields,
+  ContentTitleField,
   ContentTransparencyReport,
   ContentTransparencyTool,
   ContentVersionsTool,
@@ -108,6 +112,7 @@ export type ArticleCardProps = ComponentProps<typeof ArticleCard>;
 export type ArticleListProps = ComponentProps<typeof ArticleList>;
 export type ContentAgentChatProps = ComponentProps<typeof ContentAgentChat>;
 export type ContentBodyEditorProps = ComponentProps<typeof ContentBodyEditor>;
+export type { ContentBodyEditorChange } from './components/ContentBodyEditor.svelte';
 export type ContentBodyRendererProps = ComponentProps<
   typeof ContentBodyRenderer
 >;
@@ -136,9 +141,18 @@ export type ContentMetadataFieldsProps = ComponentProps<
 export type ContentReferencesPanelProps = ComponentProps<
   typeof ContentReferencesPanel
 >;
+export type ContentReviewStatusTrayProps = ComponentProps<
+  typeof ContentReviewStatusTray
+>;
+export type {
+  ContentReviewStatusIcon,
+  ContentReviewStatusTone,
+  ContentReviewStatusTrayItem,
+} from './components/ContentReviewStatusTray.svelte';
 export type ContentStatusFieldsProps = ComponentProps<
   typeof ContentStatusFields
 >;
+export type ContentTitleFieldProps = ComponentProps<typeof ContentTitleField>;
 export type ContentListProps = ComponentProps<typeof ContentList>;
 export type ContentContributionFormProps = ComponentProps<
   typeof ContentContributionForm
@@ -240,6 +254,20 @@ export {
   getContentEditorSnapshot,
   normalizePublishDate,
 } from './content-editor-form.js';
+export {
+  createContentEditorImageRecord,
+  getContentEditorAssetImageSource,
+  readContentEditorFileAsDataUrl,
+  resolveContentEditorImageSelection,
+} from './content-editor-media.js';
+export type {
+  ContentEditorFieldChange,
+  CreateContentEditorStateOptions,
+} from './content-editor-state.svelte.js';
+export {
+  ContentEditorState,
+  createContentEditorState,
+} from './content-editor-state.svelte.js';
 export type {
   ContentRouteId,
   ContentRouteKey,


### PR DESCRIPTION
## Summary

This lands the source-side fix for the content editor exports that Anytown PR 312 needed from `@happyvertical/smrt-content/svelte`.

- adds exported composable editor primitives: `ContentTitleField`, `ContentReviewStatusTray`, `createContentEditorState`, and image selection/source helpers
- preserves the existing `ContentEditor` and `GovernedContentEditor` exports for compatibility
- adds regression coverage for shared editor state, undo behavior, asset tracking, and preview source resolution
- documents the primitives in the content package README/CLAUDE notes

## Release note

`@happyvertical/smrt-content@0.24.18` was already published from a side branch before these source changes landed on `main`. This PR includes an explicit minor changeset so the next official release uses a fresh version instead of attempting to reuse that package version. The existing publish workflow already corrects 0.x fixed-group major output back to a 0.x minor release.

## Validation

- `pnpm --filter @happyvertical/smrt-prompts build`
- `pnpm --dir packages/content test`
- `pnpm --dir packages/content check`
- `pnpm --dir packages/content build && pnpm --dir packages/content verify:pack`
- `pnpm exec biome check packages/content/CLAUDE.md packages/content/README.md packages/content/src/svelte/index.ts packages/content/src/svelte/content-editor-primitives.test.ts packages/content/src/svelte/content-editor-media.ts packages/content/src/svelte/content-editor-state.svelte.ts packages/content/src/svelte/components/ContentReviewStatusTray.svelte packages/content/src/svelte/components/ContentTitleField.svelte`

The first `packages/content check` failed before `@happyvertical/smrt-prompts` was built in the fresh worktree; after building that workspace dependency, it passed with 0 Svelte errors.