### PR TITLE
feat(smrt-svelte): add NavTree and Breadcrumbs primitives

### DIFF
--- a/packages/smrt-svelte/src/components/workspace/Breadcrumbs.svelte
+++ b/packages/smrt-svelte/src/components/workspace/Breadcrumbs.svelte
@@ -68,7 +68,11 @@ const lastIndex = $derived(crumbs.length - 1);
           <span class="separator" aria-hidden="true">/</span>
         {/if}
         {#if i === lastIndex || !crumb.href}
-          <span class="current" aria-current="page">{crumb.label}</span>
+          <span
+            class="current"
+            aria-current={i === lastIndex ? 'page' : undefined}
+            >{crumb.label}</span
+          >
         {:else}
           <a href={crumb.href} class="crumb-link">{crumb.label}</a>
         {/if}

--- a/packages/smrt-svelte/src/components/workspace/Breadcrumbs.svelte
+++ b/packages/smrt-svelte/src/components/workspace/Breadcrumbs.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+/**
+ * Breadcrumbs — generic breadcrumb trail primitive.
+ *
+ * Two modes:
+ *
+ *  - **Explicit**: pass `items` directly.
+ *  - **Auto**: pass `nav` + `pathname` and the component will walk the
+ *    pathname segments, matching against the nav tree for labels and
+ *    falling back to capitalized segments otherwise. Use `rootCrumb`
+ *    to prepend a site/section identity and `startAfter` to skip a
+ *    pathname prefix (e.g. `'sites/foo'` to ignore the
+ *    `/sites/foo` portion of a per-site path).
+ *
+ * SvelteKit-agnostic: no `$app/*` imports. Consumers supply the
+ * pathname externally.
+ */
+import { deriveCrumbsFromNav } from './breadcrumbs-helpers.js';
+import type { BreadcrumbItem, NavItem } from './types.js';
+
+interface Props {
+  /** Explicit crumbs. When provided, `nav` and `pathname` are ignored. */
+  items?: BreadcrumbItem[];
+  /** Nav tree to derive labels from in auto mode. */
+  nav?: NavItem[];
+  /** Pathname to walk in auto mode. */
+  pathname?: string;
+  /** Optional leading crumb (e.g. site name). Auto mode only. */
+  rootCrumb?: BreadcrumbItem;
+  /** Capitalize fallback labels for unknown segments. Default: true. */
+  capitalize?: boolean;
+  /** Skip pathname segments through this path (e.g. `'sites/foo'`). */
+  startAfter?: string;
+  /** Accessible label for the breadcrumb nav. */
+  'aria-label'?: string;
+}
+
+const {
+  items,
+  nav,
+  pathname,
+  rootCrumb,
+  capitalize = true,
+  startAfter,
+  'aria-label': ariaLabel = 'Breadcrumb',
+}: Props = $props();
+
+const crumbs = $derived.by((): BreadcrumbItem[] => {
+  if (items) return items;
+  if (!nav || pathname == null) {
+    return rootCrumb ? [rootCrumb] : [];
+  }
+  return deriveCrumbsFromNav(pathname, nav, {
+    rootCrumb,
+    startAfter,
+    capitalize,
+  });
+});
+
+const lastIndex = $derived(crumbs.length - 1);
+</script>
+
+<nav class="smrt-breadcrumbs" aria-label={ariaLabel}>
+  <ol class="crumb-list">
+    {#each crumbs as crumb, i (`${i}:${crumb.href ?? crumb.label}`)}
+      <li class="crumb-item">
+        {#if i > 0}
+          <span class="separator" aria-hidden="true">/</span>
+        {/if}
+        {#if i === lastIndex || !crumb.href}
+          <span class="current" aria-current="page">{crumb.label}</span>
+        {:else}
+          <a href={crumb.href} class="crumb-link">{crumb.label}</a>
+        {/if}
+      </li>
+    {/each}
+  </ol>
+</nav>
+
+<style>
+  .smrt-breadcrumbs {
+    width: 100%;
+  }
+
+  .crumb-list {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .crumb-item {
+    display: inline-flex;
+    align-items: center;
+    font-size: 0.875rem;
+    color: var(--smrt-color-on-surface-variant);
+  }
+
+  .separator {
+    margin: 0 0.5rem;
+    color: var(--smrt-color-outline-variant);
+    font-size: 0.75rem;
+  }
+
+  .current {
+    font-weight: 500;
+    color: var(--smrt-color-on-surface);
+  }
+
+  .crumb-link {
+    color: var(--smrt-color-on-surface-variant);
+    text-decoration: none;
+    transition: color 0.15s ease;
+  }
+
+  .crumb-link:hover {
+    color: var(--smrt-color-on-surface);
+    text-decoration: underline;
+  }
+
+  .crumb-link:focus-visible {
+    outline: 2px solid var(--smrt-color-primary);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  @media (max-width: 640px) {
+    .crumb-item {
+      font-size: 0.8125rem;
+    }
+    .separator {
+      margin: 0 0.35rem;
+    }
+  }
+</style>

--- a/packages/smrt-svelte/src/components/workspace/NavTree.svelte
+++ b/packages/smrt-svelte/src/components/workspace/NavTree.svelte
@@ -67,6 +67,25 @@ function checkParentActive(item: NavItem): boolean {
 function checkExpanded(item: NavItem): boolean {
   return isExpandedHelper(item, currentPath, isActive);
 }
+
+/**
+ * In collapsed (icon-rail) mode the children container is hidden, so a
+ * parent whose descendant is active would otherwise lose any visible
+ * "current location" indicator. Promote `parent-active` to `active`
+ * styling in that mode.
+ */
+function checkEffectiveActive(item: NavItem): boolean {
+  if (checkActive(item)) return true;
+  if (collapsed && !!item.children?.length && checkParentActive(item))
+    return true;
+  return false;
+}
+
+/** Stable, HTML-safe id derived from an href for `aria-controls` pairing. */
+function navChildrenId(href: string): string {
+  const slug = href.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
+  return `smrt-nav-children-${slug || 'root'}`;
+}
 </script>
 
 <nav class="smrt-nav-tree" class:collapsed aria-label={ariaLabel}>
@@ -74,9 +93,14 @@ function checkExpanded(item: NavItem): boolean {
     <a
       href={item.href}
       class="nav-item level-1"
-      class:active={checkActive(item) && !item.children?.length}
+      class:active={checkEffectiveActive(item) ||
+        (checkActive(item) && !item.children?.length)}
       class:parent-active={checkParentActive(item) && !!item.children?.length}
       title={collapsed ? item.label : item.description}
+      aria-expanded={item.children?.length ? checkExpanded(item) : undefined}
+      aria-controls={item.children?.length
+        ? navChildrenId(item.href)
+        : undefined}
       onclick={onNavigate}
     >
       <span class="nav-icon-slot" aria-hidden="true">
@@ -105,6 +129,7 @@ function checkExpanded(item: NavItem): boolean {
 
     {#if item.children?.length}
       <div
+        id={navChildrenId(item.href)}
         class="children level-2"
         class:expanded={!collapsed && checkExpanded(item)}
       >
@@ -115,6 +140,12 @@ function checkExpanded(item: NavItem): boolean {
             class:active={checkActive(child) && !child.children?.length}
             class:parent-active={checkParentActive(child) && !!child.children?.length}
             title={child.description}
+            aria-expanded={child.children?.length
+              ? checkExpanded(child)
+              : undefined}
+            aria-controls={child.children?.length
+              ? navChildrenId(child.href)
+              : undefined}
             onclick={onNavigate}
           >
             <span class="nav-icon-slot" aria-hidden="true">
@@ -141,8 +172,9 @@ function checkExpanded(item: NavItem): boolean {
 
           {#if child.children?.length}
             <div
+              id={navChildrenId(child.href)}
               class="children level-3"
-              class:expanded={checkExpanded(child)}
+              class:expanded={!collapsed && checkExpanded(child)}
             >
               {#each child.children as grandchild (grandchild.href)}
                 <a

--- a/packages/smrt-svelte/src/components/workspace/NavTree.svelte
+++ b/packages/smrt-svelte/src/components/workspace/NavTree.svelte
@@ -1,0 +1,322 @@
+<script lang="ts">
+/**
+ * NavTree — 3-level recursive sidebar nav primitive.
+ *
+ * Generic and prop-driven: no `$app/*` imports, no SvelteKit dependency.
+ * Consumers pass `currentPath` (e.g. from `page.url.pathname`) and an
+ * optional `iconComponent` for rendering `NavItem.icon` names. When no
+ * icon component is supplied, the raw `icon` string is rendered as text
+ * (useful for emoji / symbol icons).
+ *
+ * Active-state logic is overridable via `isActive`; the default treats
+ * `currentPath === item.href` or `currentPath.startsWith(item.href + '/')`
+ * as active (unless `item.exact === true`).
+ *
+ * In `collapsed` mode the component renders icon-only chips with a
+ * native `title` tooltip; child rows are hidden unless their parent is
+ * itself active (so the chip can highlight without expanding).
+ */
+import type { Component } from 'svelte';
+import {
+  defaultIsActive,
+  isExpanded as isExpandedHelper,
+  isItemOrChildActive,
+} from './nav-helpers.js';
+import type { NavItem } from './types.js';
+
+interface Props {
+  /** Top-level nav items. Each may have up to two levels of children. */
+  items: NavItem[];
+  /** Current pathname. Required — consumers pass `page.url.pathname` or similar. */
+  currentPath: string;
+  /** Called on link click. Consumers typically close a mobile drawer here. */
+  onNavigate?: () => void;
+  /** Override active-detection. Defaults to `defaultIsActive`. */
+  isActive?: (item: NavItem, currentPath: string) => boolean;
+  /**
+   * Optional icon renderer. If omitted, `item.icon` is rendered as plain
+   * text inside the icon slot — handy for emoji/symbol icons.
+   */
+  iconComponent?: Component<{ name: string; size?: number }>;
+  /** Render in collapsed (icon-only) mode. */
+  collapsed?: boolean;
+  /** Accessible label for the surrounding `<nav>` element. */
+  'aria-label'?: string;
+}
+
+const {
+  items,
+  currentPath,
+  onNavigate,
+  isActive: isActiveProp,
+  iconComponent: IconComponent,
+  collapsed = false,
+  'aria-label': ariaLabel = 'Primary',
+}: Props = $props();
+
+const isActive = $derived(isActiveProp ?? defaultIsActive);
+
+function checkActive(item: NavItem): boolean {
+  return isActive(item, currentPath);
+}
+
+function checkParentActive(item: NavItem): boolean {
+  return isItemOrChildActive(item, currentPath, isActive);
+}
+
+function checkExpanded(item: NavItem): boolean {
+  return isExpandedHelper(item, currentPath, isActive);
+}
+</script>
+
+<nav class="smrt-nav-tree" class:collapsed aria-label={ariaLabel}>
+  {#each items as item (item.href)}
+    <a
+      href={item.href}
+      class="nav-item level-1"
+      class:active={checkActive(item) && !item.children?.length}
+      class:parent-active={checkParentActive(item) && !!item.children?.length}
+      title={collapsed ? item.label : item.description}
+      onclick={onNavigate}
+    >
+      <span class="nav-icon-slot" aria-hidden="true">
+        {#if IconComponent && item.icon}
+          <IconComponent name={item.icon} size={18} />
+        {:else if item.icon}
+          <span class="nav-icon-text">{item.icon}</span>
+        {/if}
+      </span>
+      {#if !collapsed}
+        <span class="nav-label">{item.label}</span>
+        {#if item.badge != null && item.badge !== ''}
+          <span class="nav-badge">{item.badge}</span>
+        {/if}
+        {#if item.children?.length}
+          <span
+            class="nav-chevron"
+            class:expanded={checkExpanded(item)}
+            aria-hidden="true"
+          >
+            ›
+          </span>
+        {/if}
+      {/if}
+    </a>
+
+    {#if item.children?.length}
+      <div
+        class="children level-2"
+        class:expanded={!collapsed && checkExpanded(item)}
+      >
+        {#each item.children as child (child.href)}
+          <a
+            href={child.href}
+            class="nav-item level-2"
+            class:active={checkActive(child) && !child.children?.length}
+            class:parent-active={checkParentActive(child) && !!child.children?.length}
+            title={child.description}
+            onclick={onNavigate}
+          >
+            <span class="nav-icon-slot" aria-hidden="true">
+              {#if IconComponent && child.icon}
+                <IconComponent name={child.icon} size={16} />
+              {:else if child.icon}
+                <span class="nav-icon-text">{child.icon}</span>
+              {/if}
+            </span>
+            <span class="nav-label">{child.label}</span>
+            {#if child.badge != null && child.badge !== ''}
+              <span class="nav-badge">{child.badge}</span>
+            {/if}
+            {#if child.children?.length}
+              <span
+                class="nav-chevron"
+                class:expanded={checkExpanded(child)}
+                aria-hidden="true"
+              >
+                ›
+              </span>
+            {/if}
+          </a>
+
+          {#if child.children?.length}
+            <div
+              class="children level-3"
+              class:expanded={checkExpanded(child)}
+            >
+              {#each child.children as grandchild (grandchild.href)}
+                <a
+                  href={grandchild.href}
+                  class="nav-item level-3"
+                  class:active={checkActive(grandchild)}
+                  title={grandchild.description}
+                  onclick={onNavigate}
+                >
+                  <span class="nav-icon-slot" aria-hidden="true">
+                    {#if IconComponent && grandchild.icon}
+                      <IconComponent name={grandchild.icon} size={15} />
+                    {:else if grandchild.icon}
+                      <span class="nav-icon-text">{grandchild.icon}</span>
+                    {/if}
+                  </span>
+                  <span class="nav-label">{grandchild.label}</span>
+                  {#if grandchild.badge != null && grandchild.badge !== ''}
+                    <span class="nav-badge">{grandchild.badge}</span>
+                  {/if}
+                </a>
+              {/each}
+            </div>
+          {/if}
+        {/each}
+      </div>
+    {/if}
+  {/each}
+</nav>
+
+<style>
+  .smrt-nav-tree {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .nav-item {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    color: var(--smrt-color-on-surface-variant);
+    text-decoration: none;
+    transition:
+      color 0.15s ease,
+      background 0.15s ease,
+      border-color 0.15s ease;
+    border-left: 3px solid transparent;
+  }
+
+  .nav-item:hover {
+    color: var(--smrt-color-on-surface);
+    background: var(--smrt-color-surface-container-high);
+  }
+
+  .nav-item:focus-visible {
+    outline: 2px solid var(--smrt-color-primary);
+    outline-offset: -2px;
+  }
+
+  .nav-item.active {
+    color: var(--smrt-color-on-primary-container);
+    background: var(--smrt-color-primary-container);
+    border-left-color: var(--smrt-color-primary);
+  }
+
+  .nav-item.parent-active {
+    color: var(--smrt-color-on-surface);
+    font-weight: 500;
+  }
+
+  .nav-icon-slot {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    flex-shrink: 0;
+    color: var(--smrt-color-on-surface-variant);
+  }
+
+  .nav-icon-text {
+    font-size: 1rem;
+    line-height: 1;
+  }
+
+  .nav-label {
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .nav-badge {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.25rem;
+    padding: 0 0.4rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    line-height: 1.2;
+    border-radius: 999px;
+    background: var(--smrt-color-secondary-container);
+    color: var(--smrt-color-on-secondary-container);
+  }
+
+  .nav-chevron {
+    flex-shrink: 0;
+    color: var(--smrt-color-on-surface-variant);
+    font-size: 1rem;
+    line-height: 1;
+    transform: rotate(0deg);
+    transition:
+      transform 0.15s ease,
+      color 0.15s ease;
+  }
+
+  .nav-chevron.expanded {
+    transform: rotate(90deg);
+    color: var(--smrt-color-on-surface);
+  }
+
+  /* Level 1 */
+  .nav-item.level-1 {
+    padding: 0.625rem 1rem;
+    font-size: 0.875rem;
+  }
+
+  /* Level 2 */
+  .nav-item.level-2 {
+    padding: 0.5rem 1rem 0.5rem 2.75rem;
+    font-size: 0.8125rem;
+  }
+  .nav-item.level-2 .nav-icon-slot {
+    width: 1rem;
+  }
+  .nav-item.level-2 .nav-icon-text {
+    font-size: 0.875rem;
+  }
+
+  /* Level 3 */
+  .nav-item.level-3 {
+    padding: 0.45rem 1rem 0.45rem 4rem;
+    font-size: 0.78rem;
+  }
+  .nav-item.level-3 .nav-icon-slot {
+    width: 0.95rem;
+  }
+  .nav-item.level-3 .nav-icon-text {
+    font-size: 0.8125rem;
+  }
+
+  /* Children containers — collapsed by default, shown when .expanded */
+  .children {
+    display: none;
+    flex-direction: column;
+  }
+  .children.expanded {
+    display: flex;
+  }
+
+  /* Collapsed (icon-only) mode */
+  .smrt-nav-tree.collapsed .nav-item.level-1 {
+    justify-content: center;
+    padding: 0.625rem 0.5rem;
+  }
+  .smrt-nav-tree.collapsed .nav-label,
+  .smrt-nav-tree.collapsed .nav-chevron,
+  .smrt-nav-tree.collapsed .nav-badge {
+    display: none;
+  }
+  /* In collapsed mode, never show nested children. */
+  .smrt-nav-tree.collapsed .children {
+    display: none;
+  }
+</style>

--- a/packages/smrt-svelte/src/components/workspace/__tests__/breadcrumbs-helpers.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/breadcrumbs-helpers.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for Breadcrumbs' pure derivation helpers.
+ *
+ * The Svelte component is a thin renderer over `deriveCrumbsFromNav`,
+ * so testing the helper covers:
+ *  - explicit pass-through (handled in the component layer)
+ *  - auto mode: nav-tree label lookup
+ *  - fallback to capitalized segments for unknown paths
+ *  - `rootCrumb` prepend
+ *  - `startAfter` segment skipping
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  capitalizeSegment,
+  deriveCrumbsFromNav,
+  findLabelInNav,
+} from '../breadcrumbs-helpers.js';
+import type { NavItem } from '../types.js';
+
+const nav: NavItem[] = [
+  {
+    href: '/content',
+    label: 'Content',
+    children: [
+      { href: '/content/articles', label: 'Articles' },
+      {
+        href: '/content/media',
+        label: 'Media library',
+        children: [{ href: '/content/media/images', label: 'Images' }],
+      },
+    ],
+  },
+];
+
+describe('findLabelInNav', () => {
+  it('finds a top-level label', () => {
+    expect(findLabelInNav(nav, '/content')).toBe('Content');
+  });
+
+  it('finds a nested label', () => {
+    expect(findLabelInNav(nav, '/content/media/images')).toBe('Images');
+  });
+
+  it('returns null when not found', () => {
+    expect(findLabelInNav(nav, '/missing')).toBeNull();
+  });
+});
+
+describe('capitalizeSegment', () => {
+  it('uppercases the first letter', () => {
+    expect(capitalizeSegment('articles')).toBe('Articles');
+  });
+
+  it('replaces dashes and underscores with spaces', () => {
+    expect(capitalizeSegment('my-cool-section')).toBe('My cool section');
+    expect(capitalizeSegment('snake_case_thing')).toBe('Snake case thing');
+  });
+
+  it('handles empty input gracefully', () => {
+    expect(capitalizeSegment('')).toBe('');
+  });
+});
+
+describe('deriveCrumbsFromNav', () => {
+  it('builds crumbs from nav matches', () => {
+    const crumbs = deriveCrumbsFromNav('/content/articles', nav);
+    expect(crumbs).toEqual([
+      { label: 'Content', href: '/content' },
+      { label: 'Articles', href: '/content/articles' },
+    ]);
+  });
+
+  it('falls back to capitalized segments for unknown paths', () => {
+    const crumbs = deriveCrumbsFromNav('/content/random-thing', nav);
+    expect(crumbs).toEqual([
+      { label: 'Content', href: '/content' },
+      { label: 'Random thing', href: '/content/random-thing' },
+    ]);
+  });
+
+  it('disables capitalization when capitalize=false', () => {
+    const crumbs = deriveCrumbsFromNav('/content/random-thing', nav, {
+      capitalize: false,
+    });
+    expect(crumbs[1]).toEqual({
+      label: 'random-thing',
+      href: '/content/random-thing',
+    });
+  });
+
+  it('prepends rootCrumb', () => {
+    const crumbs = deriveCrumbsFromNav('/content', nav, {
+      rootCrumb: { label: 'My Site', href: '/' },
+    });
+    expect(crumbs[0]).toEqual({ label: 'My Site', href: '/' });
+    expect(crumbs[1]).toEqual({ label: 'Content', href: '/content' });
+  });
+
+  it('skips segments before startAfter and resolves remaining against nav', () => {
+    const siteNav: NavItem[] = [
+      {
+        href: '/sites/foo/content',
+        label: 'Content',
+        children: [{ href: '/sites/foo/content/articles', label: 'Articles' }],
+      },
+    ];
+    const crumbs = deriveCrumbsFromNav('/sites/foo/content/articles', siteNav, {
+      rootCrumb: { label: 'Foo', href: '/sites/foo' },
+      startAfter: 'sites/foo',
+    });
+    expect(crumbs).toEqual([
+      { label: 'Foo', href: '/sites/foo' },
+      { label: 'Content', href: '/sites/foo/content' },
+      { label: 'Articles', href: '/sites/foo/content/articles' },
+    ]);
+  });
+
+  it('returns only rootCrumb when startAfter is not present in pathname', () => {
+    const crumbs = deriveCrumbsFromNav('/other/path', nav, {
+      rootCrumb: { label: 'Root', href: '/' },
+      startAfter: 'sites/foo',
+    });
+    expect(crumbs).toEqual([{ label: 'Root', href: '/' }]);
+  });
+
+  it('returns an empty array for an empty pathname with no rootCrumb', () => {
+    expect(deriveCrumbsFromNav('', nav)).toEqual([]);
+  });
+
+  it('handles a leading-slash startAfter the same as no leading slash', () => {
+    const siteNav: NavItem[] = [
+      { href: '/sites/foo/content', label: 'Content' },
+    ];
+    const a = deriveCrumbsFromNav('/sites/foo/content', siteNav, {
+      startAfter: '/sites/foo',
+    });
+    const b = deriveCrumbsFromNav('/sites/foo/content', siteNav, {
+      startAfter: 'sites/foo',
+    });
+    expect(a).toEqual(b);
+  });
+});

--- a/packages/smrt-svelte/src/components/workspace/__tests__/breadcrumbs-helpers.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/breadcrumbs-helpers.test.ts
@@ -140,4 +140,24 @@ describe('deriveCrumbsFromNav', () => {
     });
     expect(a).toEqual(b);
   });
+
+  // Regression for #1231: multi-segment startAfter must match the full
+  // contiguous sequence in the pathname, not just the last token. Previous
+  // implementation used `segments.indexOf(lastStartSegment)` which would
+  // find the wrong offset when an earlier segment repeated the last token.
+  it('matches the full contiguous startAfter sequence even when its trailing token appears earlier in the path', () => {
+    const siteNav: NavItem[] = [
+      { href: '/sites/sites/content', label: 'Content' },
+    ];
+    const crumbs = deriveCrumbsFromNav('/sites/sites/content', siteNav, {
+      startAfter: 'sites/sites',
+    });
+    // If the helper anchored on the first `sites`, basePath would be
+    // `/sites` and we'd emit two extra crumbs (`sites`, `content`). The
+    // correct behavior is to anchor on the second `sites` and emit only
+    // the trailing `content` crumb.
+    expect(crumbs).toEqual([
+      { label: 'Content', href: '/sites/sites/content' },
+    ]);
+  });
 });

--- a/packages/smrt-svelte/src/components/workspace/__tests__/index.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/index.test.ts
@@ -1,0 +1,17 @@
+/**
+ * Smoke test: the workspace subpath barrel must export the new
+ * NavTree and Breadcrumbs components (plus existing types).
+ */
+
+import { describe, expect, it } from 'vitest';
+import * as workspace from '../index.js';
+
+describe('workspace barrel', () => {
+  it('exports NavTree', () => {
+    expect(workspace.NavTree).toBeDefined();
+  });
+
+  it('exports Breadcrumbs', () => {
+    expect(workspace.Breadcrumbs).toBeDefined();
+  });
+});

--- a/packages/smrt-svelte/src/components/workspace/__tests__/nav-helpers.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/nav-helpers.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for NavTree's pure active/expanded helpers.
+ *
+ * The Svelte component itself is a thin renderer over these helpers,
+ * so covering the helpers gives us full behavioral coverage of:
+ *  - 1-/2-/3-level active detection
+ *  - `exact` flag
+ *  - `isActive` override
+ *  - expansion (default + descendant-driven)
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  defaultIsActive,
+  isExpanded,
+  isItemOrChildActive,
+} from '../nav-helpers.js';
+import type { NavItem } from '../types.js';
+
+const home: NavItem = {
+  href: '/',
+  label: 'Home',
+  exact: true,
+};
+
+const content: NavItem = {
+  href: '/content',
+  label: 'Content',
+  children: [
+    { href: '/content/articles', label: 'Articles' },
+    {
+      href: '/content/media',
+      label: 'Media',
+      children: [
+        { href: '/content/media/images', label: 'Images' },
+        { href: '/content/media/videos', label: 'Videos' },
+      ],
+    },
+  ],
+};
+
+const settings: NavItem = {
+  href: '/settings',
+  label: 'Settings',
+  defaultExpanded: true,
+  children: [{ href: '/settings/users', label: 'Users' }],
+};
+
+const _allItems: NavItem[] = [home, content, settings];
+
+describe('defaultIsActive', () => {
+  it('matches exact paths', () => {
+    expect(defaultIsActive({ href: '/content', label: '' }, '/content')).toBe(
+      true,
+    );
+  });
+
+  it('matches descendant paths when not exact', () => {
+    expect(
+      defaultIsActive({ href: '/content', label: '' }, '/content/articles'),
+    ).toBe(true);
+  });
+
+  it('respects the exact flag', () => {
+    expect(
+      defaultIsActive({ href: '/', label: '', exact: true }, '/content'),
+    ).toBe(false);
+    expect(defaultIsActive({ href: '/', label: '', exact: true }, '/')).toBe(
+      true,
+    );
+  });
+
+  it('does not match unrelated paths that share a prefix', () => {
+    // '/foo' should not match '/foobar' — the '/' boundary matters.
+    expect(defaultIsActive({ href: '/foo', label: '' }, '/foobar')).toBe(false);
+  });
+});
+
+describe('isItemOrChildActive', () => {
+  it('returns true when the item itself is active', () => {
+    expect(isItemOrChildActive(content, '/content')).toBe(true);
+  });
+
+  it('returns true when a deep descendant is active', () => {
+    expect(isItemOrChildActive(content, '/content/media/images')).toBe(true);
+  });
+
+  it('returns false when neither item nor descendants are active', () => {
+    expect(isItemOrChildActive(content, '/settings/users')).toBe(false);
+  });
+
+  it('honors a custom isActive override', () => {
+    const customIsActive = (item: NavItem, _path: string) =>
+      item.href === '/content/media/videos';
+    expect(isItemOrChildActive(content, '/anything', customIsActive)).toBe(
+      true,
+    );
+  });
+});
+
+describe('isExpanded', () => {
+  it('is false for items without children', () => {
+    expect(isExpanded({ href: '/x', label: '' }, '/x')).toBe(false);
+  });
+
+  it('is true when defaultExpanded is set, regardless of path', () => {
+    expect(isExpanded(settings, '/unrelated')).toBe(true);
+  });
+
+  it('is true when a descendant is active', () => {
+    expect(isExpanded(content, '/content/media/images')).toBe(true);
+  });
+
+  it('is false when no descendant is active and not defaultExpanded', () => {
+    expect(isExpanded(content, '/unrelated')).toBe(false);
+  });
+});

--- a/packages/smrt-svelte/src/components/workspace/__tests__/nav-helpers.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/nav-helpers.test.ts
@@ -74,6 +74,18 @@ describe('defaultIsActive', () => {
     // '/foo' should not match '/foobar' — the '/' boundary matters.
     expect(defaultIsActive({ href: '/foo', label: '' }, '/foobar')).toBe(false);
   });
+
+  // Regression for #1231: the descendant-path fallback used to be
+  // `currentPath.startsWith(item.href + '/')`. For `item.href === '/'`,
+  // that expands to `startsWith('//')`, which never matches a real path —
+  // and even if it did, we don't want every nested route to count the
+  // root item as active by ancestry.
+  it('treats a root-href item as exact-only even without the exact flag', () => {
+    const root: NavItem = { href: '/', label: 'Home' };
+    expect(defaultIsActive(root, '/')).toBe(true);
+    expect(defaultIsActive(root, '/content')).toBe(false);
+    expect(defaultIsActive(root, '/content/articles')).toBe(false);
+  });
 });
 
 describe('isItemOrChildActive', () => {

--- a/packages/smrt-svelte/src/components/workspace/breadcrumbs-helpers.ts
+++ b/packages/smrt-svelte/src/components/workspace/breadcrumbs-helpers.ts
@@ -77,15 +77,25 @@ export function deriveCrumbsFromNav(
   let basePath = '';
   if (startAfter) {
     const startSegments = startAfter.split('/').filter(Boolean);
-    const lastStartSegment = startSegments[startSegments.length - 1];
-    if (lastStartSegment !== undefined) {
-      const found = segments.indexOf(lastStartSegment);
-      if (found === -1) {
+    if (startSegments.length > 0) {
+      // Match the full contiguous `startSegments` sequence in `segments`,
+      // not just the last token — otherwise an ambiguous pathname like
+      // `/sites/sites/content` with `startAfter: 'sites/sites'` would
+      // anchor on the first `sites` and build the wrong base path.
+      let matched = false;
+      outer: for (let i = 0; i <= segments.length - startSegments.length; i++) {
+        for (let j = 0; j < startSegments.length; j++) {
+          if (segments[i + j] !== startSegments[j]) continue outer;
+        }
+        startIndex = i + startSegments.length;
+        basePath = `/${segments.slice(0, startIndex).join('/')}`;
+        matched = true;
+        break;
+      }
+      if (!matched) {
         // startAfter not in path → nothing to walk.
         return result;
       }
-      startIndex = found + 1;
-      basePath = `/${segments.slice(0, startIndex).join('/')}`;
     }
   }
 

--- a/packages/smrt-svelte/src/components/workspace/breadcrumbs-helpers.ts
+++ b/packages/smrt-svelte/src/components/workspace/breadcrumbs-helpers.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure helpers for breadcrumb derivation.
+ *
+ * Extracted so the path-walking logic can be unit-tested without rendering
+ * a Svelte component.
+ */
+
+import type { BreadcrumbItem, NavItem } from './types.js';
+
+/**
+ * Walk a nav tree depth-first and return the label of the item whose
+ * `href` matches exactly, or `null` if not found.
+ */
+export function findLabelInNav(items: NavItem[], href: string): string | null {
+  for (const item of items) {
+    if (item.href === href) return item.label;
+    if (item.children?.length) {
+      const label = findLabelInNav(item.children, href);
+      if (label) return label;
+    }
+  }
+  return null;
+}
+
+/**
+ * Default label fallback for unknown segments: capitalize the first letter
+ * and turn dashes/underscores into spaces.
+ */
+export function capitalizeSegment(segment: string): string {
+  if (!segment) return segment;
+  const cleaned = segment.replace(/[-_]/g, ' ');
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
+export interface DeriveCrumbsOptions {
+  /** Optional first crumb (e.g., site identity). */
+  rootCrumb?: BreadcrumbItem;
+  /**
+   * Skip pathname segments until (and including) the given path is matched.
+   * Example: `startAfter: 'sites/foo'` ignores everything up through
+   * `/sites/foo` in the pathname.
+   */
+  startAfter?: string;
+  /** Fall back to capitalized segments for unmatched paths (default: true). */
+  capitalize?: boolean;
+}
+
+/**
+ * Derive a breadcrumb trail from a pathname + nav tree.
+ *
+ * Strategy:
+ *  1. Optionally prepend `rootCrumb`.
+ *  2. Split the pathname into segments.
+ *  3. If `startAfter` is set, locate its trailing segment in the
+ *     pathname and skip everything before/including it. The
+ *     `startAfter` value may include a leading slash or none and
+ *     may be a multi-segment path (e.g. `sites/foo`).
+ *  4. Walk the remaining segments, building cumulative paths; for
+ *     each, try to find a matching nav label, otherwise capitalize.
+ */
+export function deriveCrumbsFromNav(
+  pathname: string,
+  nav: NavItem[],
+  options: DeriveCrumbsOptions = {},
+): BreadcrumbItem[] {
+  const { rootCrumb, startAfter, capitalize = true } = options;
+  const result: BreadcrumbItem[] = [];
+
+  if (rootCrumb) {
+    result.push(rootCrumb);
+  }
+
+  const segments = (pathname || '').split('/').filter(Boolean);
+
+  // Resolve which segment index we start emitting crumbs after.
+  let startIndex = 0;
+  let basePath = '';
+  if (startAfter) {
+    const startSegments = startAfter.split('/').filter(Boolean);
+    const lastStartSegment = startSegments[startSegments.length - 1];
+    if (lastStartSegment !== undefined) {
+      const found = segments.indexOf(lastStartSegment);
+      if (found === -1) {
+        // startAfter not in path → nothing to walk.
+        return result;
+      }
+      startIndex = found + 1;
+      basePath = `/${segments.slice(0, startIndex).join('/')}`;
+    }
+  }
+
+  let currentPath = basePath;
+  for (const segment of segments.slice(startIndex)) {
+    currentPath += `/${segment}`;
+    const label =
+      findLabelInNav(nav, currentPath) ??
+      (capitalize ? capitalizeSegment(segment) : segment);
+    result.push({ label, href: currentPath });
+  }
+
+  return result;
+}

--- a/packages/smrt-svelte/src/components/workspace/index.ts
+++ b/packages/smrt-svelte/src/components/workspace/index.ts
@@ -5,6 +5,8 @@
  * for layering principles. Implementations land via #1227, #1228, #1229.
  */
 
+export { default as Breadcrumbs } from './Breadcrumbs.svelte';
+export { default as NavTree } from './NavTree.svelte';
 export type {
   AvailableTool,
   BreadcrumbItem,
@@ -16,5 +18,4 @@ export type {
 
 // Component exports land via implementer PRs:
 //   #1227: WorkspaceShell
-//   #1228: NavTree, Breadcrumbs
 //   #1229: ToolsDock, defineToolsDock, useToolsDock

--- a/packages/smrt-svelte/src/components/workspace/nav-helpers.ts
+++ b/packages/smrt-svelte/src/components/workspace/nav-helpers.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure helpers for nav state derivation.
+ *
+ * Extracted so the recursive active/expanded logic can be unit-tested
+ * without needing to mount Svelte components.
+ *
+ * No DOM, no Svelte runes, no SvelteKit imports — these are SSR-safe and
+ * deterministic given their inputs.
+ */
+
+import type { NavItem } from './types.js';
+
+/**
+ * Default activeness check for a nav item against a current path.
+ *
+ * - Exact match → active
+ * - `item.exact === true` → only exact match counts
+ * - Otherwise, active when `currentPath` starts with `item.href + '/'`
+ *   (the trailing slash avoids `/foo` matching `/foobar`).
+ */
+export function defaultIsActive(item: NavItem, currentPath: string): boolean {
+  if (item.href === currentPath) return true;
+  if (item.exact) return false;
+  return currentPath.startsWith(`${item.href}/`);
+}
+
+/**
+ * True if the item or any descendant is active under `isActive`.
+ */
+export function isItemOrChildActive(
+  item: NavItem,
+  currentPath: string,
+  isActive: (item: NavItem, currentPath: string) => boolean = defaultIsActive,
+): boolean {
+  if (isActive(item, currentPath)) return true;
+  if (item.children) {
+    for (const child of item.children) {
+      if (isItemOrChildActive(child, currentPath, isActive)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * True when an item's children container should render as expanded.
+ *
+ * Children are expanded when:
+ *  - the item has children, AND
+ *  - one of its descendants is active, OR `item.defaultExpanded` is set.
+ */
+export function isExpanded(
+  item: NavItem,
+  currentPath: string,
+  isActive: (item: NavItem, currentPath: string) => boolean = defaultIsActive,
+): boolean {
+  if (!item.children?.length) return false;
+  if (item.defaultExpanded) return true;
+  return isItemOrChildActive(item, currentPath, isActive);
+}

--- a/packages/smrt-svelte/src/components/workspace/nav-helpers.ts
+++ b/packages/smrt-svelte/src/components/workspace/nav-helpers.ts
@@ -15,12 +15,19 @@ import type { NavItem } from './types.js';
  *
  * - Exact match → active
  * - `item.exact === true` → only exact match counts
+ * - `item.href === '/'` → only matches `currentPath === '/'`; otherwise
+ *   the descendant-path fallback would degrade to `startsWith('//')`
+ *   and never fire (and we don't want every path counting the root as
+ *   active by ancestry).
  * - Otherwise, active when `currentPath` starts with `item.href + '/'`
  *   (the trailing slash avoids `/foo` matching `/foobar`).
  */
 export function defaultIsActive(item: NavItem, currentPath: string): boolean {
   if (item.href === currentPath) return true;
   if (item.exact) return false;
+  // The root href would produce `startsWith('//')`, which never matches a
+  // real path. Treat root as exact-only when not flagged with `exact`.
+  if (item.href === '/') return false;
   return currentPath.startsWith(`${item.href}/`);
 }
 


### PR DESCRIPTION
Implements [#1228](https://github.com/happyvertical/smrt/issues/1228) — adds the `NavTree` and `Breadcrumbs` primitives to `@happyvertical/smrt-svelte/workspace`.

## Summary

- **`NavTree.svelte`** — 3-level recursive sidebar nav. Prop-driven, SvelteKit-agnostic. Consumer provides `currentPath`, optional `iconComponent`, optional `isActive` override, plus `collapsed` mode for icon-only rendering. Supports badges, `defaultExpanded`, and the `exact` flag from `NavItem`.
- **`Breadcrumbs.svelte`** — dual-mode primitive. Pass `items` for explicit crumbs, or pass `nav` + `pathname` (with optional `rootCrumb`, `startAfter`, `capitalize`) and the component derives the trail by walking the path and looking up labels in the nav tree, falling back to capitalized segments.
- Pure derivation helpers live in `nav-helpers.ts` and `breadcrumbs-helpers.ts` (re-used by the components) so they can be unit-tested without rendering Svelte.
- 28 new unit tests across 3 files: 70 tests pass total.

## Acceptance criteria

- [x] No `$app/*` imports
- [x] SSR-safe (no `window` / `document` / `localStorage` at module scope)
- [x] Direct `var(--smrt-color-*)` tokens only, no bridge variables
- [x] `focus-visible` outlines on interactive elements
- [x] Uses shared `NavItem` / `BreadcrumbItem` from `./types.js`
- [x] `NavTree`: 1/2/3-level renders, default + override active logic, `exact` flag, collapsed mode
- [x] `Breadcrumbs`: explicit + auto modes, `rootCrumb` prepend, `startAfter`, capitalized fallback
- [x] `pnpm build` clean (svelte-package)
- [x] `pnpm check` (svelte-check) 0 errors, 0 warnings
- [x] `npx biome check` clean
- [x] `pnpm test` 70 / 70 pass

## Test plan

- [x] `pnpm build` in `packages/smrt-svelte/`
- [x] `pnpm check` in `packages/smrt-svelte/`
- [x] `pnpm test` in `packages/smrt-svelte/`
- [ ] Visual smoke test once `WorkspaceShell` (#1227) lands

## Notes for sister agents

- The barrel (`workspace/index.ts`) now exports `NavTree`, `Breadcrumbs`, plus existing types. Biome auto-sort will reconcile additions from #1227 and #1229.
- The pure helpers (`nav-helpers.ts`, `breadcrumbs-helpers.ts`) and `__tests__/` are colocated under `workspace/` — they're not touched by either sister PR.
- Untouched as planned: `WorkspaceShell.svelte`, `tools-dock/*`, root `src/index.ts`.

## Deviations from the brief

- Active-state and breadcrumb-derivation logic factored into pure helpers (`nav-helpers.ts`, `breadcrumbs-helpers.ts`) so they can be unit-tested without a Svelte component renderer (the package has no `@testing-library/svelte` set up; existing tests are all logic-only). The Svelte components are thin renderers over these helpers, so coverage is preserved.

Refs: happyvertical/smrt#1228