### PR TITLE
feat(smrt-svelte): add WorkspaceShell primitive

### DIFF
--- a/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
@@ -1,0 +1,750 @@
+<script lang="ts">
+import type { Snippet } from 'svelte';
+
+/**
+ * WorkspaceShell — SvelteKit-agnostic, SSR-safe admin shell primitive.
+ *
+ * A composition of snippet slots that lays out a typical workspace UI: brand
+ * + nav sidebar, sticky topbar, main content, optional right-side inspector
+ * panel and a thin icon rail. The component owns no domain logic — every
+ * visible region (brand, nav, account menu, tools dock, etc.) is provided by
+ * the consumer via Svelte 5 snippets.
+ *
+ * Responsive behavior:
+ * - Desktop (>1240px): sidebar visible, inspector fixed-right when open.
+ * - Tablet (961–1240px): sidebar collapses to icon rail.
+ * - Mobile (≤960px): sidebar becomes a drawer with backdrop; inspector
+ *   becomes a right-side drawer with backdrop.
+ *
+ * Sidebar collapse is controlled — consumer owns persistence. Mobile drawer
+ * state is internal and transient.
+ *
+ * See `@happyvertical/smrt#1227` for the issue tracking this primitive.
+ */
+
+export interface Props {
+  /** Brand/product title shown in the brand snippet area fallback. */
+  title?: string;
+  /** Secondary line under the title. */
+  subtitle?: string;
+  /** Small uppercase eyebrow label rendered above the title. */
+  eyebrow?: string;
+  /** Topbar mode label (e.g. "Local-first mode"). */
+  modeLabel?: string;
+  /** Status keyword that maps to a dot color. */
+  modeStatus?:
+    | 'active'
+    | 'offline'
+    | 'local-only'
+    | 'attention'
+    | (string & {});
+  /** Secondary detail line shown next to the mode badge. */
+  modeDetail?: string;
+  /** Whether the inspector panel/drawer is currently shown. */
+  showInspector?: boolean;
+  /** Invoked when the inspector close button (or Escape) is activated. */
+  onCloseInspector?: () => void;
+  /** Sidebar collapsed state (controlled by consumer). */
+  collapsed?: boolean;
+  /** Invoked when the internal collapse toggle is clicked. */
+  onToggleCollapsed?: () => void;
+  /** Whether to render the collapse toggle at all. Default: true. */
+  collapsible?: boolean;
+  /** Top-left brand area (logo + product name). */
+  brand?: Snippet;
+  /** Main sidebar navigation region. */
+  nav?: Snippet;
+  /** Bottom of sidebar (account menu, tenant switcher, etc.). */
+  sidebarFooter?: Snippet;
+  /** Right side of the top bar. */
+  topbarActions?: Snippet;
+  /** Optional vertical icon rail along the right edge. */
+  inspectorRail?: Snippet;
+  /** Inspector panel content (right side). */
+  inspector?: Snippet;
+  /** Main content. */
+  children: Snippet;
+}
+
+const {
+  title = '',
+  subtitle = '',
+  eyebrow = '',
+  modeLabel = '',
+  modeStatus = '',
+  modeDetail = '',
+  showInspector = false,
+  onCloseInspector,
+  collapsed = false,
+  onToggleCollapsed,
+  collapsible = true,
+  brand,
+  nav,
+  sidebarFooter,
+  topbarActions,
+  inspectorRail,
+  inspector,
+  children,
+}: Props = $props();
+
+let mobileNavOpen = $state(false);
+
+function toggleMobileNav(): void {
+  mobileNavOpen = !mobileNavOpen;
+}
+
+function closeMobileNav(): void {
+  mobileNavOpen = false;
+}
+
+function handleCollapseToggle(): void {
+  onToggleCollapsed?.();
+}
+
+function handleInspectorClose(): void {
+  onCloseInspector?.();
+}
+
+// Escape closes inspector if open. Mounted-only (SSR-safe via $effect).
+$effect(() => {
+  if (typeof window === 'undefined') return;
+
+  function onKeydown(event: KeyboardEvent) {
+    if (event.key !== 'Escape') return;
+    if (mobileNavOpen) {
+      mobileNavOpen = false;
+      return;
+    }
+    if (showInspector && onCloseInspector) {
+      onCloseInspector();
+    }
+  }
+
+  window.addEventListener('keydown', onKeydown);
+  return () => window.removeEventListener('keydown', onKeydown);
+});
+
+const hasInspector = $derived(Boolean(inspector) && showInspector);
+const hasInspectorRail = $derived(Boolean(inspectorRail));
+</script>
+
+<div
+  class="smrt-workspace-shell"
+  class:sidebar-collapsed={collapsed}
+  class:nav-open={mobileNavOpen}
+  class:has-inspector={hasInspector}
+  class:has-inspector-rail={hasInspectorRail}
+>
+  <!-- Mobile sidebar backdrop -->
+  <button
+    class="mobile-backdrop"
+    type="button"
+    aria-label="Close navigation"
+    tabindex={mobileNavOpen ? 0 : -1}
+    onclick={closeMobileNav}
+  ></button>
+
+  <!-- Mobile inspector backdrop -->
+  {#if hasInspector}
+    <button
+      class="inspector-backdrop"
+      type="button"
+      aria-label="Close inspector"
+      onclick={handleInspectorClose}
+    ></button>
+  {/if}
+
+  <aside class="smrt-workspace-sidebar" aria-label="Primary navigation">
+    <div class="brand-row">
+      <div class="brand">
+        {#if brand}
+          {@render brand()}
+        {:else}
+          {#if eyebrow}
+            <span class="eyebrow">{eyebrow}</span>
+          {/if}
+          {#if title}
+            <h1>{title}</h1>
+          {/if}
+          {#if subtitle}
+            <p class="subtitle">{subtitle}</p>
+          {/if}
+        {/if}
+      </div>
+
+      {#if collapsible}
+        <button
+          class="shell-toggle"
+          type="button"
+          onclick={handleCollapseToggle}
+          aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          aria-expanded={!collapsed}
+        >
+          <span class="shell-toggle-glyph" aria-hidden="true">
+            {collapsed ? '›' : '‹'}
+          </span>
+        </button>
+      {/if}
+    </div>
+
+    {#if nav}
+      <nav class="nav-region" aria-label="Workspace navigation">
+        {@render nav()}
+      </nav>
+    {/if}
+
+    {#if sidebarFooter}
+      <div class="sidebar-footer">
+        {@render sidebarFooter()}
+      </div>
+    {/if}
+  </aside>
+
+  <div class="smrt-workspace-main">
+    <header class="smrt-workspace-topbar">
+      <div class="topbar-left">
+        <button
+          class="mobile-menu"
+          type="button"
+          onclick={toggleMobileNav}
+          aria-label={mobileNavOpen ? 'Close navigation' : 'Open navigation'}
+          aria-expanded={mobileNavOpen}
+        >
+          <span aria-hidden="true">≡</span>
+        </button>
+        <div class="topbar-brand">
+          {#if eyebrow}
+            <div class="eyebrow topbar-eyebrow">{eyebrow}</div>
+          {/if}
+          {#if modeLabel}
+            <p class="mode-title">{modeLabel}</p>
+          {/if}
+        </div>
+      </div>
+
+      <div class="topbar-right">
+        {#if topbarActions}
+          <div class="topbar-actions">
+            {@render topbarActions()}
+          </div>
+        {/if}
+        {#if modeLabel || modeStatus}
+          <span
+            class="mode-badge"
+            data-status={modeStatus || 'default'}
+            role="status"
+            aria-live="polite"
+          >
+            <span class="mode-dot" aria-hidden="true"></span>
+            <span class="mode-badge-label">{modeLabel || modeStatus}</span>
+          </span>
+        {/if}
+        {#if modeDetail}
+          <p class="mode-detail">{modeDetail}</p>
+        {/if}
+      </div>
+    </header>
+
+    <div class="smrt-workspace-stage">
+      <main class="smrt-workspace-content">
+        {@render children()}
+      </main>
+
+      {#if hasInspector}
+        <aside class="smrt-workspace-inspector" aria-label="Inspector panel">
+          <div class="inspector-header">
+            <span class="inspector-title">Inspector</span>
+            {#if onCloseInspector}
+              <button
+                class="inspector-close"
+                type="button"
+                onclick={handleInspectorClose}
+                aria-label="Close inspector"
+              >
+                <span aria-hidden="true">×</span>
+              </button>
+            {/if}
+          </div>
+          <div class="inspector-body">
+            {@render inspector!()}
+          </div>
+        </aside>
+      {/if}
+
+      {#if hasInspectorRail}
+        <div class="smrt-workspace-inspector-rail" aria-label="Inspector tools">
+          {@render inspectorRail!()}
+        </div>
+      {/if}
+    </div>
+  </div>
+</div>
+
+<style>
+  .smrt-workspace-shell {
+    --smrt-ws-sidebar-width: 280px;
+    --smrt-ws-sidebar-collapsed-width: 96px;
+    --smrt-ws-inspector-width: min(420px, calc(100vw - var(--smrt-ws-sidebar-width) - 1rem));
+    --smrt-ws-rail-width: 3.25rem;
+    --smrt-ws-topbar-height: 3.75rem;
+    --smrt-ws-page-pad: 1.5rem;
+
+    position: relative;
+    display: grid;
+    grid-template-columns: var(--smrt-ws-sidebar-width) 1fr;
+    min-height: 100vh;
+    min-height: 100dvh;
+    background: var(--smrt-color-surface-container-low, #f8fafc);
+    color: var(--smrt-color-on-surface, #1f2937);
+    isolation: isolate;
+  }
+
+  .smrt-workspace-shell.sidebar-collapsed {
+    grid-template-columns: var(--smrt-ws-sidebar-collapsed-width) 1fr;
+  }
+
+  /* ─── Sidebar ─────────────────────────────────────────── */
+
+  .smrt-workspace-sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    padding: 1.25rem 1rem;
+    background: var(--smrt-color-surface, #ffffff);
+    border-right: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
+    min-width: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    z-index: 20;
+  }
+
+  .brand-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .brand {
+    display: grid;
+    gap: 0.35rem;
+    min-width: 0;
+  }
+
+  .brand :global(h1),
+  .brand h1 {
+    margin: 0;
+    font-size: 1.25rem;
+    line-height: 1.1;
+    color: var(--smrt-color-on-surface, #111827);
+    font-weight: 600;
+  }
+
+  .brand .subtitle {
+    margin: 0;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
+    line-height: 1.4;
+    font-size: 0.9rem;
+  }
+
+  .eyebrow {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
+  }
+
+  .shell-toggle {
+    appearance: none;
+    border: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
+    background: var(--smrt-color-surface-container, #f3f4f6);
+    color: var(--smrt-color-on-surface, #111827);
+    border-radius: var(--smrt-radius-medium, 0.65rem);
+    width: 2rem;
+    height: 2rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    flex-shrink: 0;
+    transition:
+      background-color 150ms ease,
+      color 150ms ease;
+  }
+
+  .shell-toggle:hover {
+    background: var(--smrt-color-surface-container-high, #e5e7eb);
+  }
+
+  .shell-toggle:focus-visible {
+    outline: 2px solid var(--smrt-color-primary, #2563eb);
+    outline-offset: 2px;
+  }
+
+  .shell-toggle-glyph {
+    font-size: 1rem;
+    line-height: 1;
+  }
+
+  .nav-region {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    gap: 0.5rem;
+  }
+
+  .sidebar-footer {
+    margin-top: auto;
+    display: grid;
+    gap: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
+  }
+
+  /* ─── Main column ─────────────────────────────────────── */
+
+  .smrt-workspace-main {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+  }
+
+  .smrt-workspace-topbar {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.85rem;
+    padding: 0.75rem var(--smrt-ws-page-pad);
+    min-height: var(--smrt-ws-topbar-height);
+    background: var(--smrt-color-surface, #ffffff);
+    border-bottom: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
+    box-shadow: var(--smrt-elevation-level1, 0 1px 2px rgb(0 0 0 / 0.05));
+  }
+
+  .topbar-left,
+  .topbar-right {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    min-width: 0;
+  }
+
+  .topbar-right {
+    justify-content: flex-end;
+    flex-wrap: wrap;
+  }
+
+  .topbar-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+  }
+
+  .topbar-brand {
+    display: grid;
+    gap: 0.1rem;
+    min-width: 0;
+  }
+
+  .topbar-eyebrow {
+    color: var(--smrt-color-on-surface-variant, #6b7280);
+  }
+
+  .mode-title,
+  .mode-detail {
+    margin: 0;
+  }
+
+  .mode-title {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--smrt-color-on-surface, #111827);
+  }
+
+  .mode-detail {
+    color: var(--smrt-color-on-surface-variant, #6b7280);
+    max-width: 18rem;
+    text-align: right;
+    font-size: 0.85rem;
+  }
+
+  .mode-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.25rem 0.65rem;
+    border-radius: var(--smrt-radius-full, 999px);
+    border: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
+    background: var(--smrt-color-surface-container, #f3f4f6);
+    color: var(--smrt-color-on-surface, #111827);
+    font-size: 0.78rem;
+    font-weight: 600;
+    line-height: 1;
+    white-space: nowrap;
+  }
+
+  .mode-dot {
+    width: 0.55rem;
+    height: 0.55rem;
+    border-radius: 999px;
+    background: var(--smrt-color-on-surface-variant, #9ca3af);
+    flex-shrink: 0;
+  }
+
+  .mode-badge[data-status='active'] .mode-dot {
+    background: var(--smrt-color-success, #16a34a);
+  }
+  .mode-badge[data-status='offline'] .mode-dot {
+    background: var(--smrt-color-on-surface-variant, #9ca3af);
+  }
+  .mode-badge[data-status='local-only'] .mode-dot {
+    background: var(--smrt-color-primary, #2563eb);
+  }
+  .mode-badge[data-status='attention'] .mode-dot {
+    background: var(--smrt-color-warning, #f59e0b);
+  }
+
+  .mobile-menu {
+    display: none;
+    appearance: none;
+    border: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
+    background: var(--smrt-color-surface, #ffffff);
+    color: var(--smrt-color-on-surface, #111827);
+    border-radius: var(--smrt-radius-medium, 0.65rem);
+    width: 2.35rem;
+    height: 2.35rem;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-size: 1.1rem;
+    line-height: 1;
+  }
+
+  .mobile-menu:focus-visible,
+  .inspector-close:focus-visible {
+    outline: 2px solid var(--smrt-color-primary, #2563eb);
+    outline-offset: 2px;
+  }
+
+  /* ─── Stage / content / inspector ─────────────────────── */
+
+  .smrt-workspace-stage {
+    flex: 1;
+    min-height: 0;
+    position: relative;
+  }
+
+  .smrt-workspace-content {
+    padding: var(--smrt-ws-page-pad);
+    min-width: 0;
+  }
+
+  .smrt-workspace-inspector {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: var(--smrt-ws-inspector-width);
+    display: flex;
+    flex-direction: column;
+    background: var(--smrt-color-surface, #ffffff);
+    border-left: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
+    box-shadow: var(--smrt-elevation-level2, 0 4px 6px -1px rgb(0 0 0 / 0.1));
+    z-index: 22;
+  }
+
+  .inspector-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.85rem 1rem;
+    border-bottom: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
+  }
+
+  .inspector-title {
+    font-weight: 600;
+    color: var(--smrt-color-on-surface, #111827);
+    font-size: 0.95rem;
+  }
+
+  .inspector-close {
+    appearance: none;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
+    border-radius: var(--smrt-radius-medium, 0.5rem);
+    width: 2rem;
+    height: 2rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.25rem;
+    line-height: 1;
+    cursor: pointer;
+    transition:
+      background-color 150ms ease,
+      color 150ms ease;
+  }
+
+  .inspector-close:hover {
+    background: var(--smrt-color-surface-container-high, #e5e7eb);
+    color: var(--smrt-color-on-surface, #111827);
+  }
+
+  .inspector-body {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 1rem;
+  }
+
+  .smrt-workspace-inspector-rail {
+    position: fixed;
+    top: var(--smrt-ws-topbar-height);
+    right: 0;
+    bottom: 0;
+    width: var(--smrt-ws-rail-width);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.75rem 0.25rem;
+    background: var(--smrt-color-surface, #ffffff);
+    border-left: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
+    z-index: 18;
+  }
+
+  /* When both inspector + rail are present, push rail off the panel. */
+  .smrt-workspace-shell.has-inspector.has-inspector-rail .smrt-workspace-inspector-rail {
+    right: var(--smrt-ws-inspector-width);
+  }
+
+  /* Reserve room on the right side so content doesn't slide under panel/rail. */
+  @media (min-width: 961px) {
+    .smrt-workspace-shell.has-inspector .smrt-workspace-content,
+    .smrt-workspace-shell.has-inspector .smrt-workspace-topbar {
+      padding-right: calc(var(--smrt-ws-inspector-width) + 1rem);
+    }
+
+    .smrt-workspace-shell.has-inspector-rail:not(.has-inspector)
+      .smrt-workspace-content,
+    .smrt-workspace-shell.has-inspector-rail:not(.has-inspector)
+      .smrt-workspace-topbar {
+      padding-right: calc(var(--smrt-ws-rail-width) + 1rem);
+    }
+  }
+
+  /* ─── Backdrops (mobile only — hidden otherwise) ──────── */
+
+  .mobile-backdrop,
+  .inspector-backdrop {
+    display: none;
+  }
+
+  /* ─── Tablet — collapse sidebar to icon rail ──────────── */
+
+  @media (max-width: 1240px) and (min-width: 961px) {
+    .smrt-workspace-shell {
+      grid-template-columns: var(--smrt-ws-sidebar-collapsed-width) 1fr;
+    }
+
+    .smrt-workspace-shell .brand-row {
+      justify-content: center;
+    }
+
+    .smrt-workspace-shell .shell-toggle {
+      display: none;
+    }
+
+    .smrt-workspace-shell .brand .subtitle,
+    .smrt-workspace-shell.sidebar-collapsed .brand .subtitle {
+      display: none;
+    }
+  }
+
+  /* ─── Mobile — drawer sidebar, drawer inspector ───────── */
+
+  @media (max-width: 960px) {
+    .smrt-workspace-shell,
+    .smrt-workspace-shell.sidebar-collapsed {
+      grid-template-columns: 1fr;
+    }
+
+    .mobile-menu {
+      display: inline-flex;
+    }
+
+    .shell-toggle {
+      display: none;
+    }
+
+    .smrt-workspace-sidebar {
+      position: fixed;
+      inset: 0 auto 0 0;
+      width: min(320px, calc(100vw - 3rem));
+      transform: translateX(-100%);
+      transition: transform 180ms ease;
+      z-index: 30;
+    }
+
+    .smrt-workspace-shell.nav-open .smrt-workspace-sidebar {
+      transform: translateX(0);
+    }
+
+    .mobile-backdrop {
+      display: block;
+      position: fixed;
+      inset: 0;
+      background: rgba(3, 7, 14, 0.55);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 180ms ease;
+      border: 0;
+      z-index: 25;
+    }
+
+    .smrt-workspace-shell.nav-open .mobile-backdrop {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .smrt-workspace-inspector {
+      width: min(100vw, 420px);
+    }
+
+    .smrt-workspace-shell.has-inspector .smrt-workspace-inspector-rail,
+    .smrt-workspace-shell.has-inspector-rail:not(.has-inspector)
+      .smrt-workspace-inspector-rail {
+      top: 0;
+    }
+
+    .smrt-workspace-shell.has-inspector .smrt-workspace-content,
+    .smrt-workspace-shell.has-inspector .smrt-workspace-topbar,
+    .smrt-workspace-shell.has-inspector-rail:not(.has-inspector)
+      .smrt-workspace-content,
+    .smrt-workspace-shell.has-inspector-rail:not(.has-inspector)
+      .smrt-workspace-topbar {
+      padding-right: var(--smrt-ws-page-pad);
+    }
+
+    .inspector-backdrop {
+      display: block;
+      position: fixed;
+      inset: 0;
+      background: rgba(3, 7, 14, 0.4);
+      border: 0;
+      z-index: 21;
+    }
+
+    .mode-detail {
+      max-width: 100%;
+      text-align: left;
+    }
+  }
+</style>

--- a/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
@@ -42,7 +42,24 @@ export interface Props {
   modeDetail?: string;
   /** Whether the inspector panel/drawer is currently shown. */
   showInspector?: boolean;
-  /** Invoked when the inspector close button (or Escape) is activated. */
+  /**
+   * Label rendered in the inspector header. Defaults to `'Inspector'`.
+   * Consumers may rename to `'Properties'`, `'Details'`, etc.
+   */
+  inspectorTitle?: string;
+  /**
+   * Invoked when the inspector close button (or Escape) is activated.
+   *
+   * Focus restoration: because `showInspector` is a controlled prop, the
+   * consumer owns when the inspector opens and is therefore responsible
+   * for restoring focus to the activating element after close (WCAG
+   * 2.4.3). A common pattern is to capture `document.activeElement`
+   * immediately before flipping `showInspector` to `true`, then call
+   * `.focus()` on it inside this handler.
+   *
+   * The component-owned mobile drawer handles focus restoration
+   * internally — only the inspector is consumer-driven.
+   */
   onCloseInspector?: () => void;
   /** Sidebar collapsed state (controlled by consumer). */
   collapsed?: boolean;
@@ -74,6 +91,7 @@ const {
   modeStatus = '',
   modeDetail = '',
   showInspector = false,
+  inspectorTitle = 'Inspector',
   onCloseInspector,
   collapsed = false,
   onToggleCollapsed,
@@ -88,13 +106,52 @@ const {
 }: Props = $props();
 
 let mobileNavOpen = $state(false);
+/**
+ * Tracks whether the viewport is in the mobile drawer breakpoint
+ * (≤960px). Used to mark the sidebar `inert` when it's slid off-screen
+ * so keyboard users can't tab into invisible nav links. SSR-safe — stays
+ * `false` until mounted, which matches the desktop-first default layout.
+ */
+let isMobileViewport = $state(false);
+/**
+ * Element that held focus when the mobile drawer was opened. We restore
+ * focus to it when the drawer closes (Escape, backdrop click, etc.) to
+ * satisfy WCAG 2.4.3 Focus Order for the component-owned drawer state.
+ * The inspector's open state is consumer-controlled, so focus restoration
+ * for it is documented as a caller responsibility (see `onCloseInspector`).
+ */
+let lastFocusedBeforeMobileNav: HTMLElement | null = null;
 
 function toggleMobileNav(): void {
-  mobileNavOpen = !mobileNavOpen;
+  if (!mobileNavOpen) {
+    // Capture the currently focused element before we open the drawer so
+    // we can return focus to it on close (WCAG 2.4.3).
+    if (typeof document !== 'undefined') {
+      const active = document.activeElement;
+      lastFocusedBeforeMobileNav =
+        active instanceof HTMLElement ? active : null;
+    }
+    mobileNavOpen = true;
+  } else {
+    closeMobileNav();
+  }
 }
 
 function closeMobileNav(): void {
   mobileNavOpen = false;
+  // Restore focus to the element that opened the drawer (the hamburger
+  // button in the default flow). Guarded so SSR/non-DOM environments are
+  // a no-op, and so a detached/removed element doesn't throw.
+  const target = lastFocusedBeforeMobileNav;
+  lastFocusedBeforeMobileNav = null;
+  if (
+    target &&
+    typeof document !== 'undefined' &&
+    document.contains(target) &&
+    typeof target.focus === 'function'
+  ) {
+    target.focus();
+  }
 }
 
 function handleCollapseToggle(): void {
@@ -105,14 +162,15 @@ function handleInspectorClose(): void {
   onCloseInspector?.();
 }
 
-// Escape closes inspector if open. Mounted-only (SSR-safe via $effect).
+// Escape closes mobile drawer (with focus restoration) or inspector if
+// open. Mounted-only (SSR-safe via $effect).
 $effect(() => {
   if (typeof window === 'undefined') return;
 
   function onKeydown(event: KeyboardEvent) {
     if (event.key !== 'Escape') return;
     if (mobileNavOpen) {
-      mobileNavOpen = false;
+      closeMobileNav();
       return;
     }
     if (showInspector && onCloseInspector) {
@@ -124,8 +182,39 @@ $effect(() => {
   return () => window.removeEventListener('keydown', onKeydown);
 });
 
+// Track mobile breakpoint so the sidebar can be marked `inert` while it
+// is slid off-screen. Mirrors the `@media (max-width: 960px)` block.
+$effect(() => {
+  if (typeof window === 'undefined' || !window.matchMedia) return;
+
+  const mql = window.matchMedia('(max-width: 960px)');
+  isMobileViewport = mql.matches;
+
+  function handleChange(event: MediaQueryListEvent) {
+    isMobileViewport = event.matches;
+  }
+
+  // `addEventListener` is the modern API. Older Safari only has
+  // `addListener` — feature-detect to stay compatible.
+  if (typeof mql.addEventListener === 'function') {
+    mql.addEventListener('change', handleChange);
+    return () => mql.removeEventListener('change', handleChange);
+  }
+  // @ts-expect-error legacy MediaQueryList API
+  mql.addListener(handleChange);
+  return () => {
+    // @ts-expect-error legacy MediaQueryList API
+    mql.removeListener(handleChange);
+  };
+});
+
 const hasInspector = $derived(Boolean(inspector) && showInspector);
 const hasInspectorRail = $derived(Boolean(inspectorRail));
+/**
+ * Mark the sidebar `inert` when it's slid off-screen on mobile so keyboard
+ * users can't tab into invisible nav links / footer controls.
+ */
+const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
 </script>
 
 <div
@@ -144,17 +233,30 @@ const hasInspectorRail = $derived(Boolean(inspectorRail));
     onclick={closeMobileNav}
   ></button>
 
-  <!-- Mobile inspector backdrop -->
+  <!--
+    Mobile inspector backdrop. Only renders an interactive button when the
+    consumer provided `onCloseInspector` — otherwise the backdrop would be a
+    focusable no-op. When no close handler is provided we render a passive
+    `<div>` so the visual scrim still appears on mobile.
+  -->
   {#if hasInspector}
-    <button
-      class="inspector-backdrop"
-      type="button"
-      aria-label="Close inspector"
-      onclick={handleInspectorClose}
-    ></button>
+    {#if onCloseInspector}
+      <button
+        class="inspector-backdrop"
+        type="button"
+        aria-label="Close inspector"
+        onclick={handleInspectorClose}
+      ></button>
+    {:else}
+      <div class="inspector-backdrop" aria-hidden="true"></div>
+    {/if}
   {/if}
 
-  <aside class="smrt-workspace-sidebar" aria-label="Primary navigation">
+  <aside
+    class="smrt-workspace-sidebar"
+    aria-label="Primary navigation"
+    inert={sidebarInert}
+  >
     <div class="brand-row">
       <div class="brand">
         {#if brand}
@@ -251,9 +353,14 @@ const hasInspectorRail = $derived(Boolean(inspectorRail));
       </main>
 
       {#if hasInspector}
-        <aside class="smrt-workspace-inspector" aria-label="Inspector panel">
+        <aside
+          class="smrt-workspace-inspector"
+          aria-labelledby="smrt-ws-inspector-title"
+        >
           <div class="inspector-header">
-            <span class="inspector-title">Inspector</span>
+            <span id="smrt-ws-inspector-title" class="inspector-title"
+              >{inspectorTitle}</span
+            >
             {#if onCloseInspector}
               <button
                 class="inspector-close"
@@ -301,6 +408,17 @@ const hasInspectorRail = $derived(Boolean(inspectorRail));
 
   .smrt-workspace-shell.sidebar-collapsed {
     grid-template-columns: var(--smrt-ws-sidebar-collapsed-width) 1fr;
+    /*
+     * When the sidebar is collapsed, recompute the inspector-width clamp
+     * against the collapsed sidebar so narrower desktops with both the
+     * inspector and a collapsed sidebar still fit content. Without this
+     * override, padding-right on `.smrt-workspace-content` would still be
+     * sized as if the sidebar were full-width.
+     */
+    --smrt-ws-inspector-width: min(
+      420px,
+      calc(100vw - var(--smrt-ws-sidebar-collapsed-width) - 1rem)
+    );
   }
 
   /* ─── Sidebar ─────────────────────────────────────────── */
@@ -638,13 +756,36 @@ const hasInspectorRail = $derived(Boolean(inspectorRail));
       .smrt-workspace-topbar {
       padding-right: calc(var(--smrt-ws-rail-width) + 1rem);
     }
+
+    /*
+     * When both the inspector panel AND the icon rail are present, the rail
+     * sits to the left of the panel (see `.has-inspector.has-inspector-rail
+     * .smrt-workspace-inspector-rail` above). Content padding must reserve
+     * room for both, otherwise the rail overlaps the right edge of content
+     * and topbar.
+     */
+    .smrt-workspace-shell.has-inspector.has-inspector-rail
+      .smrt-workspace-content,
+    .smrt-workspace-shell.has-inspector.has-inspector-rail
+      .smrt-workspace-topbar {
+      padding-right: calc(
+        var(--smrt-ws-inspector-width) + var(--smrt-ws-rail-width) + 1rem
+      );
+    }
   }
 
   /* ─── Backdrops (mobile only — hidden otherwise) ──────── */
 
+  /*
+   * Defence-in-depth: `display: none` already hides these on desktop, but a
+   * consumer global like `button { display: flex }` could undo that. Setting
+   * `pointer-events: none` ensures the backdrop can never intercept clicks
+   * on the desktop even if it slips back into the rendering tree.
+   */
   .mobile-backdrop,
   .inspector-backdrop {
     display: none;
+    pointer-events: none;
   }
 
   /* ─── Tablet — collapse sidebar to icon rail ──────────── */
@@ -735,6 +876,7 @@ const hasInspectorRail = $derived(Boolean(inspectorRail));
 
     .inspector-backdrop {
       display: block;
+      pointer-events: auto;
       position: fixed;
       inset: 0;
       background: rgba(3, 7, 14, 0.4);

--- a/packages/smrt-svelte/src/components/workspace/__tests__/WorkspaceShell.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/WorkspaceShell.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Tests for WorkspaceShell — issue happyvertical/smrt#1227.
+ *
+ * Uses Svelte 5's `mount` / `unmount` APIs and `createRawSnippet` to exercise
+ * the component in jsdom without pulling in `@testing-library/svelte` (which
+ * the package doesn't depend on).
+ */
+
+import { createRawSnippet, mount, tick, unmount } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import WorkspaceShell from '../WorkspaceShell.svelte';
+
+function textSnippet(text: string) {
+  return createRawSnippet(() => ({
+    render: () => `<span>${text}</span>`,
+  }));
+}
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  container.remove();
+});
+
+describe('WorkspaceShell', () => {
+  it('renders with only required children prop', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('main content'),
+      },
+    });
+
+    try {
+      expect(container.querySelector('.smrt-workspace-shell')).not.toBeNull();
+      expect(
+        container.querySelector('.smrt-workspace-content')?.textContent,
+      ).toContain('main content');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders the brand snippet when provided', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        brand: textSnippet('MyBrand'),
+      },
+    });
+
+    try {
+      const brand = container.querySelector('.brand');
+      expect(brand?.textContent).toContain('MyBrand');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('falls back to title / subtitle / eyebrow when no brand snippet is given', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        title: 'Workspace',
+        subtitle: 'Engineering',
+        eyebrow: 'SMRT',
+      },
+    });
+
+    try {
+      const brand = container.querySelector('.brand');
+      expect(brand?.textContent).toContain('Workspace');
+      expect(brand?.textContent).toContain('Engineering');
+      expect(brand?.textContent).toContain('SMRT');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders the nav snippet inside an aria-labelled region', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        nav: textSnippet('nav-content'),
+      },
+    });
+
+    try {
+      const navRegion = container.querySelector('nav.nav-region');
+      expect(navRegion).not.toBeNull();
+      expect(navRegion?.getAttribute('aria-label')).toBe(
+        'Workspace navigation',
+      );
+      expect(navRegion?.textContent).toContain('nav-content');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders the sidebar footer snippet when provided', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        sidebarFooter: textSnippet('account-menu'),
+      },
+    });
+
+    try {
+      const footer = container.querySelector('.sidebar-footer');
+      expect(footer?.textContent).toContain('account-menu');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders topbar actions on the right of the top bar', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        topbarActions: textSnippet('action-button'),
+      },
+    });
+
+    try {
+      const actions = container.querySelector('.topbar-actions');
+      expect(actions?.textContent).toContain('action-button');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('does NOT render inspector when showInspector is false', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        inspector: textSnippet('inspector-content'),
+        showInspector: false,
+      },
+    });
+
+    try {
+      expect(container.querySelector('.smrt-workspace-inspector')).toBeNull();
+      const shell = container.querySelector('.smrt-workspace-shell');
+      expect(shell?.classList.contains('has-inspector')).toBe(false);
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders inspector and has-inspector class when showInspector is true', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        inspector: textSnippet('inspector-content'),
+        showInspector: true,
+      },
+    });
+
+    try {
+      const inspector = container.querySelector('.smrt-workspace-inspector');
+      expect(inspector).not.toBeNull();
+      expect(inspector?.textContent).toContain('inspector-content');
+      const shell = container.querySelector('.smrt-workspace-shell');
+      expect(shell?.classList.contains('has-inspector')).toBe(true);
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders inspector close button when onCloseInspector is provided', () => {
+    let closed = false;
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        inspector: textSnippet('inspector-content'),
+        showInspector: true,
+        onCloseInspector: () => {
+          closed = true;
+        },
+      },
+    });
+
+    try {
+      const closeBtn =
+        container.querySelector<HTMLButtonElement>('.inspector-close');
+      expect(closeBtn).not.toBeNull();
+      closeBtn?.click();
+      expect(closed).toBe(true);
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('omits the inspector close button when onCloseInspector is not provided', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        inspector: textSnippet('inspector-content'),
+        showInspector: true,
+      },
+    });
+
+    try {
+      expect(container.querySelector('.inspector-close')).toBeNull();
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders the inspector rail snippet when provided', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        inspectorRail: textSnippet('rail-button'),
+      },
+    });
+
+    try {
+      const rail = container.querySelector('.smrt-workspace-inspector-rail');
+      expect(rail).not.toBeNull();
+      expect(rail?.textContent).toContain('rail-button');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('shows a collapse toggle by default and invokes onToggleCollapsed', () => {
+    let toggles = 0;
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        title: 'Brand',
+        collapsed: false,
+        onToggleCollapsed: () => {
+          toggles += 1;
+        },
+      },
+    });
+
+    try {
+      const toggle =
+        container.querySelector<HTMLButtonElement>('.shell-toggle');
+      expect(toggle).not.toBeNull();
+      expect(toggle?.getAttribute('aria-expanded')).toBe('true');
+      toggle?.click();
+      expect(toggles).toBe(1);
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('hides the collapse toggle when collapsible is false', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        title: 'Brand',
+        collapsible: false,
+      },
+    });
+
+    try {
+      expect(container.querySelector('.shell-toggle')).toBeNull();
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('applies sidebar-collapsed class when collapsed prop is true', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        collapsed: true,
+      },
+    });
+
+    try {
+      const shell = container.querySelector('.smrt-workspace-shell');
+      expect(shell?.classList.contains('sidebar-collapsed')).toBe(true);
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders the mode badge when modeLabel is provided', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        modeLabel: 'Local-first mode',
+        modeStatus: 'local-only',
+      },
+    });
+
+    try {
+      const badge = container.querySelector('.mode-badge');
+      expect(badge).not.toBeNull();
+      expect(badge?.getAttribute('data-status')).toBe('local-only');
+      expect(badge?.textContent).toContain('Local-first mode');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('omits the mode badge when no modeLabel/modeStatus is provided', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      expect(container.querySelector('.mode-badge')).toBeNull();
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('invokes onCloseInspector when Escape is pressed while inspector is open', async () => {
+    let closes = 0;
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        inspector: textSnippet('inspector-content'),
+        showInspector: true,
+        onCloseInspector: () => {
+          closes += 1;
+        },
+      },
+    });
+
+    try {
+      await tick();
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      expect(closes).toBe(1);
+    } finally {
+      unmount(component);
+    }
+  });
+});

--- a/packages/smrt-svelte/src/components/workspace/__tests__/WorkspaceShell.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/WorkspaceShell.test.ts
@@ -356,4 +356,159 @@ describe('WorkspaceShell', () => {
       unmount(component);
     }
   });
+
+  it('renders an interactive button backdrop only when onCloseInspector is set', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        inspector: textSnippet('inspector-content'),
+        showInspector: true,
+        onCloseInspector: () => {},
+      },
+    });
+
+    try {
+      const backdrop = container.querySelector('.inspector-backdrop');
+      expect(backdrop).not.toBeNull();
+      expect(backdrop?.tagName).toBe('BUTTON');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders a non-interactive backdrop when onCloseInspector is omitted', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        inspector: textSnippet('inspector-content'),
+        showInspector: true,
+      },
+    });
+
+    try {
+      const backdrop = container.querySelector('.inspector-backdrop');
+      expect(backdrop).not.toBeNull();
+      expect(backdrop?.tagName).toBe('DIV');
+      expect(backdrop?.getAttribute('aria-hidden')).toBe('true');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders the default "Inspector" header label when inspectorTitle is omitted', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        inspector: textSnippet('inspector-content'),
+        showInspector: true,
+      },
+    });
+
+    try {
+      const title = container.querySelector('.inspector-title');
+      expect(title?.textContent).toBe('Inspector');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('uses a custom inspectorTitle and wires it via aria-labelledby', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        inspector: textSnippet('inspector-content'),
+        showInspector: true,
+        inspectorTitle: 'Properties',
+      },
+    });
+
+    try {
+      const title = container.querySelector('.inspector-title');
+      expect(title?.textContent).toBe('Properties');
+      const aside = container.querySelector('.smrt-workspace-inspector');
+      const labelledBy = aside?.getAttribute('aria-labelledby');
+      expect(labelledBy).toBeTruthy();
+      // The id pointed at by aria-labelledby must resolve to the title node.
+      const referenced = labelledBy
+        ? container.querySelector(`#${labelledBy}`)
+        : null;
+      expect(referenced).toBe(title);
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('marks the sidebar inert on mobile when the drawer is closed', async () => {
+    const originalMatchMedia = window.matchMedia;
+    // Force the mobile breakpoint so `isMobileViewport` becomes true.
+    window.matchMedia = ((query: string) => ({
+      matches: /max-width:\s*960px/.test(query),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        nav: textSnippet('nav-content'),
+      },
+    });
+
+    try {
+      await tick();
+      const sidebar = container.querySelector('.smrt-workspace-sidebar');
+      // jsdom reflects the `inert` attribute as a boolean property — both
+      // forms are acceptable, the contract is "keyboard tab order skips
+      // the sidebar when it's offscreen".
+      expect(
+        sidebar?.hasAttribute('inert') ||
+          (sidebar as HTMLElement | null)?.inert === true,
+      ).toBe(true);
+    } finally {
+      unmount(component);
+      window.matchMedia = originalMatchMedia;
+    }
+  });
+
+  it('restores focus to the hamburger button when the mobile drawer closes via Escape', async () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        nav: textSnippet('nav-content'),
+      },
+    });
+
+    try {
+      const hamburger =
+        container.querySelector<HTMLButtonElement>('.mobile-menu');
+      expect(hamburger).not.toBeNull();
+      // Simulate keyboard-driven opening of the drawer.
+      hamburger?.focus();
+      expect(document.activeElement).toBe(hamburger);
+      hamburger?.click();
+      await tick();
+      // Move focus elsewhere as a real drawer interaction would.
+      const elsewhere = document.createElement('button');
+      container.appendChild(elsewhere);
+      elsewhere.focus();
+      expect(document.activeElement).toBe(elsewhere);
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      await tick();
+      expect(document.activeElement).toBe(hamburger);
+    } finally {
+      unmount(component);
+    }
+  });
 });

--- a/packages/smrt-svelte/src/components/workspace/index.ts
+++ b/packages/smrt-svelte/src/components/workspace/index.ts
@@ -13,8 +13,9 @@ export type {
   ToolsDockApi,
   ToolsDockContext,
 } from './types.js';
+export { default as WorkspaceShell } from './WorkspaceShell.svelte';
 
 // Component exports land via implementer PRs:
-//   #1227: WorkspaceShell
+//   #1227: WorkspaceShell (landed)
 //   #1228: NavTree, Breadcrumbs
 //   #1229: ToolsDock, defineToolsDock, useToolsDock

--- a/packages/smrt-svelte/vitest.config.ts
+++ b/packages/smrt-svelte/vitest.config.ts
@@ -8,6 +8,16 @@ export default defineConfig({
   // resolve to the client runtime under jsdom. Without this, `svelte`'s
   // package exports fall through to `default: index-server.js`, which makes
   // `mount(...)` unavailable in tests.
+  //
+  // NOTE: Forcing the `browser` condition globally masks the SSR path. Any
+  // future test in this package that needs to exercise Svelte's server
+  // runtime (e.g. asserting SSR HTML output of a component, or covering
+  // `$effect.root` boundaries that differ between client/server) will need
+  // a scoped override — either a dedicated vitest project (workspace) with
+  // its own `resolve.conditions`, or a path filter on this `conditions`
+  // setting. Until that need arises, keeping `['browser']` everywhere is
+  // the simplest way to keep the client-side workspace primitive tests
+  // green under jsdom.
   resolve: {
     conditions: ['browser'],
   },

--- a/packages/smrt-svelte/vitest.config.ts
+++ b/packages/smrt-svelte/vitest.config.ts
@@ -4,6 +4,13 @@ import { smrtVitestPlugin } from '../vitest/src/index.ts';
 
 export default defineConfig({
   plugins: [smrtVitestPlugin({ verbose: true }), svelte({ hot: false })],
+  // Resolve Svelte's `browser` export condition so that `mount` / `unmount`
+  // resolve to the client runtime under jsdom. Without this, `svelte`'s
+  // package exports fall through to `default: index-server.js`, which makes
+  // `mount(...)` unavailable in tests.
+  resolve: {
+    conditions: ['browser'],
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary

Lands the `WorkspaceShell` admin shell primitive under
`@happyvertical/smrt-svelte/workspace`, completing the first piece of the
workspace primitives epic ([#1226](https://github.com/happyvertical/smrt/issues/1226))
tracked in [#1227](https://github.com/happyvertical/smrt/issues/1227).

The component is a SvelteKit-agnostic, SSR-safe composition primitive — every
visible region is a Svelte 5 snippet provided by the consumer, no domain
implementation is assumed, and styles consume `var(--smrt-color-*)` tokens
directly (no `--imago-*` bridge).

### What's built

- `packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte` — the
  primitive itself. Snippet slots: `brand`, `nav`, `sidebarFooter`,
  `topbarActions`, `inspectorRail`, `inspector`, `children`. Props per the
  issue brief (`title`, `subtitle`, `eyebrow`, `modeLabel`, `modeStatus`,
  `modeDetail`, `showInspector`, `onCloseInspector`, `collapsed`,
  `onToggleCollapsed`, `collapsible`).
- `__tests__/WorkspaceShell.test.ts` — 17 tests using Svelte 5
  `mount` / `unmount` + `createRawSnippet` (no `@testing-library/svelte`).
- `index.ts` — adds the `WorkspaceShell` export. Biome-sorted.
- `vitest.config.ts` — adds `resolve.conditions: ['browser']` so Svelte's
  package exports resolve `mount` to the client runtime under jsdom. Without
  this, `mount` from `svelte` falls through to the server entry and throws
  `lifecycle_function_unavailable`.

### Behavior

- **Desktop (>1240px)**: sidebar fixed-left, inspector fixed-right, sticky topbar.
- **Tablet (961–1240px)**: sidebar auto-collapses to icon rail.
- **Mobile (≤960px)**: sidebar becomes a drawer with backdrop; inspector becomes
  a right drawer with backdrop.
- Inspector: width `min(420px, calc(100vw - sidebar - 1rem))`, fixed-right,
  internal close button when `onCloseInspector` is provided.
- Sidebar collapse is fully controlled (no `localStorage` writes — consumer
  owns persistence). Mobile drawer open/close is internal transient state.
- Escape closes the inspector (or mobile drawer if open) — guarded with
  `typeof window !== 'undefined'` inside `$effect`.
- Focus-visible outlines on toggle / close / mobile-menu controls.

## Acceptance criteria (from #1227)

- [x] Exported at `@happyvertical/smrt-svelte/workspace`
- [x] Snippet slots only: `brand`, `nav`, `sidebarFooter`, `topbarActions`,
  `children`, `inspector`, optional `inspectorRail`
- [x] No assumed account menu / tenant switcher / topbar / dock implementation
- [x] Uses `var(--smrt-color-*)` tokens directly (no bridge layer)
- [x] SSR-safe: no unguarded `window` / `document` / `localStorage` access
- [x] No `$app/state` / `$app/stores` / SvelteKit navigation imports
- [x] Responsive: desktop / tablet icon-rail / mobile drawer
- [x] Keyboard: focus-visible states, Escape closes inspector
- [x] Documented in `smrt-svelte` CLAUDE.md with the layering note (already
  landed in the scaffold commit `56eec2b8d`)

## Deviations from brief

- **`vitest.config.ts` change**: the brief did not call for editing vitest
  config, but `mount` from `svelte` is otherwise unavailable in jsdom because
  Svelte's package exports `default: ./src/index-server.js`. Adding
  `resolve.conditions: ['browser']` is the smallest possible change and does
  not affect existing tests. Open to alternatives if reviewers prefer.

## Notes for sister agents (#1228 / #1229)

- `index.ts` now also re-exports `WorkspaceShell`. Biome auto-sort ordering
  keeps the type re-exports first, then default exports — merges should be
  trivial.
- The inspector rail is a *snippet slot* in this PR — `#1229`'s `ToolsDock`
  activation buttons will likely be the consumer of the `inspectorRail` slot
  (rail mode) or `topbarActions` slot (topbar mode).
- I did NOT touch `tools-dock/` or add `NavTree.svelte` / `Breadcrumbs.svelte`
  stubs — those belong to your PRs.
- The `mode-badge` styling uses `--smrt-color-success` / `--smrt-color-warning`
  fallback variables (with hex fallbacks if absent from the active theme). If
  you find those tokens are not defined in the current theme presets, we can
  drop the colored mapping and rely on theme/consumer styling.

## Test plan

- [x] `pnpm build` passes (`packages/smrt-svelte`)
- [x] `pnpm test` passes (59/59, including 17 new tests)
- [x] Biome check clean on all touched files
- [ ] Manual verification by a consumer migration (anytown site-portal /
  ergot imago-dashboard) — out of scope for this PR