### PR TITLE
feat(smrt-svelte): add ToolsDock system

### DIFF
--- a/packages/smrt-svelte/src/components/workspace/__tests__/context-forwarding-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/context-forwarding-harness.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+/**
+ * Harness for asserting that <ToolsDock>'s `context` prop is forwarded into
+ * the dock instance reactively — including the case where the initial value
+ * is `undefined` and is later populated (async route data), and the case
+ * where the prop changes multiple times after mount.
+ *
+ * Owns a `$state` ref for the current context so that the test can mutate it
+ * post-mount via the `setContextProp` callback exposed via `onReady`.
+ */
+import { defineToolsDock } from '../tools-dock/define-tools-dock.svelte.js';
+import ToolsDock from '../tools-dock/ToolsDock.svelte';
+import type { ToolsDockContext, ToolsDockInstance } from '../types.js';
+
+interface Props {
+  onReady: (api: {
+    dock: ToolsDockInstance;
+    setContextProp: (next: ToolsDockContext | null | undefined) => void;
+  }) => void;
+}
+
+const props: Props = $props();
+
+// biome-ignore lint/correctness/noUnusedVariables: noop component
+const NoopBody = (() => null) as never;
+
+const dock = defineToolsDock({
+  tools: [{ id: 'chat', label: 'Chat', component: NoopBody }],
+});
+
+let currentContext = $state<ToolsDockContext | null | undefined>(undefined);
+
+props.onReady({
+  dock,
+  setContextProp: (next) => {
+    currentContext = next;
+  },
+});
+</script>
+
+<ToolsDock {dock} context={currentContext} />

--- a/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Tests for defineToolsDock factory.
+ *
+ * These tests exercise the reactive API surface directly. Svelte `setContext`
+ * is called inside the factory, but the returned `ToolsDockInstance` is the
+ * subject under test — we don't need a full component tree to verify the
+ * state machine.
+ *
+ * `setContext` only works inside a component init scope, so we invoke the
+ * factory inside Svelte's `mount` (via a thin host component) so that all
+ * `$state` runes wire up correctly.
+ */
+
+import { flushSync, mount, unmount } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  defineToolsDock,
+  ToolsDockInstance,
+} from '../tools-dock/define-tools-dock.svelte.js';
+import type { ToolDef } from '../types.js';
+import HostHarness from './harness.svelte';
+
+const noopTool = {} as ToolDef['component'];
+
+interface HarnessExposed {
+  dock: ToolsDockInstance;
+}
+
+function mountDock(options: Parameters<typeof defineToolsDock>[0]): {
+  dock: ToolsDockInstance;
+  teardown: () => void;
+} {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const exposed: HarnessExposed = {
+    dock: undefined as unknown as ToolsDockInstance,
+  };
+  const component = mount(HostHarness, {
+    target,
+    props: {
+      options,
+      onReady: (dock: ToolsDockInstance) => {
+        exposed.dock = dock;
+      },
+    },
+  });
+  return {
+    dock: exposed.dock,
+    teardown: () => {
+      unmount(component);
+      target.remove();
+    },
+  };
+}
+
+describe('defineToolsDock', () => {
+  let cleanup: Array<() => void> = [];
+
+  beforeEach(() => {
+    cleanup = [];
+    if (typeof window !== 'undefined') {
+      window.localStorage.clear();
+    }
+  });
+
+  afterEach(() => {
+    for (const fn of cleanup.splice(0)) fn();
+  });
+
+  function track<T>(value: { teardown: () => void } & T): T {
+    cleanup.push(value.teardown);
+    return value;
+  }
+
+  it('creates an API with sensible defaults', () => {
+    const { dock } = track(
+      mountDock({
+        tools: [
+          { id: 'chat', label: 'Chat', component: noopTool },
+          { id: 'jobs', label: 'Jobs', component: noopTool },
+        ],
+      }),
+    );
+
+    expect(dock.isOpen).toBe(false);
+    expect(dock.activeTool).toBeNull();
+    expect(dock.layout).toBe('rail');
+    expect(dock.storageKey).toBeNull();
+    expect(dock.availableTools.map((t) => t.id)).toEqual(['chat', 'jobs']);
+  });
+
+  it('open() / close() / toggle() update isOpen and activeTool', () => {
+    const { dock } = track(
+      mountDock({
+        tools: [
+          { id: 'chat', label: 'Chat', component: noopTool },
+          { id: 'jobs', label: 'Jobs', component: noopTool },
+        ],
+      }),
+    );
+
+    dock.open('chat');
+    flushSync();
+    expect(dock.isOpen).toBe(true);
+    expect(dock.activeTool).toBe('chat');
+
+    dock.close();
+    flushSync();
+    expect(dock.isOpen).toBe(false);
+    // activeTool persists so re-opening lands on the same tool.
+    expect(dock.activeTool).toBe('chat');
+
+    dock.toggle('jobs');
+    flushSync();
+    expect(dock.isOpen).toBe(true);
+    expect(dock.activeTool).toBe('jobs');
+
+    // toggle on the same id closes.
+    dock.toggle('jobs');
+    flushSync();
+    expect(dock.isOpen).toBe(false);
+
+    // toggle without id flips just isOpen.
+    dock.toggle();
+    flushSync();
+    expect(dock.isOpen).toBe(true);
+  });
+
+  it('open() on unknown id is a no-op (does not crash, does not open)', () => {
+    const { dock } = track(
+      mountDock({
+        tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+      }),
+    );
+
+    dock.open('does-not-exist');
+    flushSync();
+    expect(dock.isOpen).toBe(false);
+    expect(dock.activeTool).toBeNull();
+  });
+
+  it('respects initialOpen and picks first tool when toggled', () => {
+    const { dock } = track(
+      mountDock({
+        tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        initialOpen: true,
+      }),
+    );
+
+    expect(dock.isOpen).toBe(true);
+    expect(dock.activeTool).toBeNull();
+
+    dock.toggle();
+    flushSync();
+    // First toggle while no tool active selects the first available.
+    // (Was open → now closed; activeTool now set on the next open.)
+    expect(dock.isOpen).toBe(false);
+
+    dock.toggle();
+    flushSync();
+    expect(dock.isOpen).toBe(true);
+    expect(dock.activeTool).toBe('chat');
+  });
+
+  it('setContext updates context and triggers fetchAvailability', async () => {
+    const fetchAvailability = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: 'chat' }])
+      .mockResolvedValueOnce([{ id: 'chat' }, { id: 'jobs' }]);
+
+    const { dock } = track(
+      mountDock({
+        tools: [
+          { id: 'chat', label: 'Chat', component: noopTool },
+          { id: 'jobs', label: 'Jobs', component: noopTool },
+          { id: 'hidden', label: 'Hidden', component: noopTool },
+        ],
+        fetchAvailability,
+      }),
+    );
+
+    // No call yet — fetchAvailability only fires on setContext.
+    expect(fetchAvailability).not.toHaveBeenCalled();
+
+    dock.setContext({ type: 'thing', title: 'A' });
+    // setContext invokes fetchAvailability synchronously; the promise resolves
+    // on the next microtask, so flushSync after a few microtasks is required
+    // for Svelte to settle the resulting state update.
+    expect(fetchAvailability).toHaveBeenCalledTimes(1);
+    await new Promise((r) => setTimeout(r, 0));
+    flushSync();
+    expect(dock.availableTools.map((t) => t.id)).toEqual(['chat']);
+
+    dock.setContext({ type: 'thing', title: 'B' });
+    expect(fetchAvailability).toHaveBeenCalledTimes(2);
+    await new Promise((r) => setTimeout(r, 0));
+    flushSync();
+    expect(dock.availableTools.map((t) => t.id)).toEqual(['chat', 'jobs']);
+  });
+
+  it('drops stale fetchAvailability results (race-safety)', async () => {
+    let resolveFirst: ((v: { id: string }[]) => void) | null = null;
+    let resolveSecond: ((v: { id: string }[]) => void) | null = null;
+
+    const fetchAvailability = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ id: string }[]>((r) => {
+            resolveFirst = r;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ id: string }[]>((r) => {
+            resolveSecond = r;
+          }),
+      );
+
+    const { dock } = track(
+      mountDock({
+        tools: [
+          { id: 'chat', label: 'Chat', component: noopTool },
+          { id: 'jobs', label: 'Jobs', component: noopTool },
+        ],
+        fetchAvailability,
+      }),
+    );
+
+    dock.setContext({ type: 'A' });
+    await Promise.resolve();
+    dock.setContext({ type: 'B' });
+    await Promise.resolve();
+
+    // Resolve the *stale* (first) call after the newer one. Then resolve the
+    // newer one. The stale value must not stomp the fresh value.
+    resolveFirst?.([{ id: 'chat' }]);
+    resolveSecond?.([{ id: 'jobs' }]);
+    await Promise.resolve();
+    await Promise.resolve();
+    flushSync();
+
+    expect(dock.availableTools.map((t) => t.id)).toEqual(['jobs']);
+  });
+
+  it('emit / on / unsubscribe', () => {
+    const { dock } = track(
+      mountDock({
+        tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+      }),
+    );
+
+    const handler = vi.fn();
+    const off = dock.on<{ ok: boolean }>('test', handler);
+    dock.emit('test', { ok: true });
+    expect(handler).toHaveBeenCalledWith({ ok: true });
+
+    off();
+    dock.emit('test', { ok: false });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('emit catches handler errors without dropping later handlers', () => {
+    const { dock } = track(
+      mountDock({
+        tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+      }),
+    );
+
+    const throwing = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const after = vi.fn();
+    dock.on('test', throwing);
+    dock.on('test', after);
+
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => dock.emit('test', null)).not.toThrow();
+    expect(throwing).toHaveBeenCalled();
+    expect(after).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('persists state to localStorage when storageKey provided', () => {
+    const { dock } = track(
+      mountDock({
+        tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        storageKey: 'tdtest:v1',
+      }),
+    );
+
+    dock.open('chat');
+    flushSync();
+    const raw = window.localStorage.getItem('tdtest:v1');
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed).toEqual({ isOpen: true, activeTool: 'chat' });
+  });
+
+  it('hydrates state from localStorage on hydrate()', () => {
+    window.localStorage.setItem(
+      'tdtest:v2',
+      JSON.stringify({ isOpen: true, activeTool: 'jobs' }),
+    );
+
+    const { dock } = track(
+      mountDock({
+        tools: [
+          { id: 'chat', label: 'Chat', component: noopTool },
+          { id: 'jobs', label: 'Jobs', component: noopTool },
+        ],
+        storageKey: 'tdtest:v2',
+      }),
+    );
+
+    dock.hydrate();
+    flushSync();
+    expect(dock.isOpen).toBe(true);
+    expect(dock.activeTool).toBe('jobs');
+  });
+
+  it('hydrate() ignores activeTool that no longer matches a registered tool', () => {
+    window.localStorage.setItem(
+      'tdtest:v3',
+      JSON.stringify({ isOpen: true, activeTool: 'gone' }),
+    );
+
+    const { dock } = track(
+      mountDock({
+        tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        storageKey: 'tdtest:v3',
+      }),
+    );
+
+    dock.hydrate();
+    flushSync();
+    expect(dock.isOpen).toBe(true);
+    expect(dock.activeTool).toBeNull();
+  });
+
+  it('clears activeTool when availability removes the active tool', async () => {
+    let availability: { id: string }[] = [{ id: 'chat' }, { id: 'jobs' }];
+    const fetchAvailability = vi.fn(async () => availability);
+
+    const { dock } = track(
+      mountDock({
+        tools: [
+          { id: 'chat', label: 'Chat', component: noopTool },
+          { id: 'jobs', label: 'Jobs', component: noopTool },
+        ],
+        fetchAvailability,
+      }),
+    );
+
+    dock.setContext({ type: 'a' });
+    await Promise.resolve();
+    await Promise.resolve();
+    flushSync();
+    dock.open('jobs');
+    flushSync();
+    expect(dock.activeTool).toBe('jobs');
+
+    availability = [{ id: 'chat' }];
+    dock.setContext({ type: 'b' });
+    await Promise.resolve();
+    await Promise.resolve();
+    flushSync();
+    expect(dock.availableTools.map((t) => t.id)).toEqual(['chat']);
+    expect(dock.activeTool).toBeNull();
+  });
+});

--- a/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
@@ -338,6 +338,67 @@ describe('defineToolsDock', () => {
     expect(dock.activeTool).toBeNull();
   });
 
+  it('exposes context on the public ToolsDockApi surface', () => {
+    const { dock } = track(
+      mountDock({
+        tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+      }),
+    );
+
+    expect(dock.context).toBeNull();
+    dock.setContext({ type: 'route', title: 'Home' });
+    flushSync();
+    expect(dock.context).toEqual({ type: 'route', title: 'Home' });
+
+    dock.setContext(null);
+    flushSync();
+    expect(dock.context).toBeNull();
+  });
+
+  it('badge: null in availability clears a registered default (not falls back)', async () => {
+    const fetchAvailability = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: 'chat', badge: null }]);
+
+    const { dock } = track(
+      mountDock({
+        tools: [{ id: 'chat', label: 'Chat', badge: 3, component: noopTool }],
+        fetchAvailability,
+      }),
+    );
+
+    dock.setContext({ type: 'a' });
+    await new Promise((r) => setTimeout(r, 0));
+    flushSync();
+
+    // `badge: null` is explicit ("clear it"), not a fallback signal.
+    expect(dock.availableTools[0].badge).toBeNull();
+  });
+
+  it('handles synchronous throws from fetchAvailability without surfacing them', async () => {
+    const fetchAvailability = vi.fn(() => {
+      throw new Error('sync boom');
+    });
+
+    const { dock } = track(
+      mountDock({
+        tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        fetchAvailability: fetchAvailability as unknown as (
+          ctx: import('../types.js').ToolsDockContext | null,
+        ) => Promise<import('../types.js').AvailableTool[]>,
+      }),
+    );
+
+    // The sync throw must be caught by the wrapped promise chain, not
+    // propagate out of setContext to the caller.
+    expect(() => dock.setContext({ type: 'a' })).not.toThrow();
+
+    // The internal `.catch` applies an empty-availability result.
+    await new Promise((r) => setTimeout(r, 0));
+    flushSync();
+    expect(dock.availableTools).toEqual([]);
+  });
+
   it('clears activeTool when availability removes the active tool', async () => {
     let availability: { id: string }[] = [{ id: 'chat' }, { id: 'jobs' }];
     const fetchAvailability = vi.fn(async () => availability);

--- a/packages/smrt-svelte/src/components/workspace/__tests__/harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/harness.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+/**
+ * Test harness — invokes defineToolsDock() inside a component init scope so
+ * setContext() is legal, then passes the returned instance back to the
+ * test via the `onReady` callback prop.
+ */
+import {
+  type DefineToolsDockOptions,
+  defineToolsDock,
+  type ToolsDockInstance,
+} from '../tools-dock/define-tools-dock.svelte.js';
+
+interface Props {
+  options: DefineToolsDockOptions;
+  onReady: (dock: ToolsDockInstance) => void;
+}
+
+const props: Props = $props();
+// eslint-disable-next-line svelte/valid-prop-names-in-kit-pages
+const dock = defineToolsDock(props.options);
+props.onReady(dock);
+</script>

--- a/packages/smrt-svelte/src/components/workspace/__tests__/render-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/render-harness.svelte
@@ -28,6 +28,8 @@ interface Props {
   setContextOnMount?: ToolsDockContext | null;
   /** Force the dock open after setup (for empty-state assertions). */
   forceOpen?: boolean;
+  /** Pass-through `context` prop to <ToolsDock>. */
+  context?: ToolsDockContext | null;
 }
 
 const props: Props = $props();
@@ -58,4 +60,4 @@ onMount(() => {
 });
 </script>
 
-<ToolsDock {dock} />
+<ToolsDock {dock} context={props.context} />

--- a/packages/smrt-svelte/src/components/workspace/__tests__/render-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/render-harness.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+/**
+ * Render harness — wires defineToolsDock + <ToolsDock> into a single
+ * component so tests can render the actual DOM. Accepts a thin shape that
+ * lets each test express only the behavior it cares about.
+ */
+import { onMount } from 'svelte';
+import { defineToolsDock } from '../tools-dock/define-tools-dock.svelte.js';
+import ToolsDock from '../tools-dock/ToolsDock.svelte';
+import type { AvailableTool, ToolsDockContext } from '../types.js';
+
+interface ToolProp {
+  id: string;
+  label: string;
+  badge?: number | string | null;
+}
+
+interface Props {
+  tools: ToolProp[];
+  fetchAvailability?: (
+    ctx: ToolsDockContext | null,
+  ) => Promise<AvailableTool[]>;
+  initialOpen?: boolean;
+  layout?: 'rail' | 'topbar';
+  /** Activate this tool on mount via dock.open(id). */
+  activateOnMount?: string | null;
+  /** Call dock.setContext(...) on mount. */
+  setContextOnMount?: ToolsDockContext | null;
+  /** Force the dock open after setup (for empty-state assertions). */
+  forceOpen?: boolean;
+}
+
+const props: Props = $props();
+
+// Use a trivial inline component as the tool body; the renderer only checks
+// that ActiveTool is defined and renders a header — the body is irrelevant
+// for these tests.
+// biome-ignore lint/correctness/noUnusedVariables: noop component
+const NoopBody = (() => null) as never;
+
+const dock = defineToolsDock({
+  tools: props.tools.map((t) => ({ ...t, component: NoopBody })),
+  fetchAvailability: props.fetchAvailability,
+  initialOpen: props.initialOpen,
+  layout: props.layout,
+});
+
+onMount(() => {
+  if (props.setContextOnMount !== undefined) {
+    dock.setContext(props.setContextOnMount);
+  }
+  if (props.activateOnMount) {
+    dock.open(props.activateOnMount);
+  }
+  if (props.forceOpen) {
+    dock.open();
+  }
+});
+</script>
+
+<ToolsDock {dock} />

--- a/packages/smrt-svelte/src/components/workspace/__tests__/render-tools-dock.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/render-tools-dock.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for the <ToolsDock> renderer.
+ *
+ * Verifies that rail buttons are rendered for available tools, that clicking
+ * one opens the panel and activates the tool, that the close button closes
+ * the panel, and that the empty state renders when fetchAvailability filters
+ * everything away.
+ */
+
+import { flushSync, mount, unmount } from 'svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import RenderHarness from './render-harness.svelte';
+
+const mountedComponents: Array<ReturnType<typeof mount>> = [];
+
+function render(props: Record<string, unknown>) {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const component = mount(RenderHarness, { target, props });
+  mountedComponents.push(component);
+  flushSync();
+  return target;
+}
+
+afterEach(() => {
+  while (mountedComponents.length > 0) {
+    const c = mountedComponents.pop();
+    if (c) unmount(c);
+  }
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+describe('<ToolsDock> rail layout', () => {
+  it('renders a rail button for every available tool', () => {
+    const target = render({
+      tools: [
+        { id: 'chat', label: 'Chat' },
+        { id: 'jobs', label: 'Jobs' },
+      ],
+    });
+
+    const buttons = target.querySelectorAll('.tools-dock__rail-button');
+    expect(buttons.length).toBe(2);
+    expect(buttons[0].getAttribute('aria-label')).toBe('Chat tool');
+    expect(buttons[1].getAttribute('aria-label')).toBe('Jobs tool');
+  });
+
+  it('opens the panel and marks the active button with aria-current when clicked', () => {
+    const target = render({
+      tools: [
+        { id: 'chat', label: 'Chat' },
+        { id: 'jobs', label: 'Jobs' },
+      ],
+    });
+
+    const chatBtn = target.querySelectorAll<HTMLButtonElement>(
+      '.tools-dock__rail-button',
+    )[0];
+    chatBtn.click();
+    flushSync();
+
+    expect(chatBtn.classList.contains('active')).toBe(true);
+    expect(chatBtn.getAttribute('aria-current')).toBe('true');
+    expect(chatBtn.getAttribute('aria-pressed')).toBe('true');
+
+    // Panel header reflects the active tool.
+    const heading = target.querySelector('.tools-dock__panel-header h3');
+    expect(heading?.textContent).toBe('Chat');
+  });
+
+  it('closes when the close button is clicked', () => {
+    const target = render({
+      tools: [{ id: 'chat', label: 'Chat' }],
+      initialOpen: true,
+      activateOnMount: 'chat',
+    });
+
+    const aside = target.querySelector('.tools-dock--rail');
+    expect(aside?.classList.contains('tools-dock--open')).toBe(true);
+
+    const closeBtn =
+      target.querySelector<HTMLButtonElement>('.tools-dock__close');
+    closeBtn?.click();
+    flushSync();
+
+    expect(aside?.classList.contains('tools-dock--open')).toBe(false);
+  });
+
+  it('renders an empty state when no tools are available', async () => {
+    const target = render({
+      tools: [{ id: 'chat', label: 'Chat' }],
+      // fetchAvailability that returns nothing means no tools surface.
+      fetchAvailability: async () => [],
+      activateOnMount: null,
+      setContextOnMount: { type: 'route' },
+      forceOpen: true,
+    });
+
+    // Wait for the microtask resolving fetchAvailability.
+    await new Promise((r) => setTimeout(r, 0));
+    flushSync();
+
+    const buttons = target.querySelectorAll('.tools-dock__rail-button');
+    expect(buttons.length).toBe(0);
+    // When forced open, the panel body renders the empty state.
+    const empty = target.querySelector('.tools-dock__empty');
+    expect(empty?.textContent).toContain('No tools');
+  });
+});

--- a/packages/smrt-svelte/src/components/workspace/__tests__/render-tools-dock.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/render-tools-dock.test.ts
@@ -7,8 +7,10 @@
  * everything away.
  */
 
-import { flushSync, mount, unmount } from 'svelte';
+import { flushSync, mount, tick, unmount } from 'svelte';
 import { afterEach, describe, expect, it } from 'vitest';
+import type { ToolsDockInstance } from '../tools-dock/define-tools-dock.svelte.js';
+import ContextForwardingHarness from './context-forwarding-harness.svelte';
 import RenderHarness from './render-harness.svelte';
 
 const mountedComponents: Array<ReturnType<typeof mount>> = [];
@@ -47,7 +49,7 @@ describe('<ToolsDock> rail layout', () => {
     expect(buttons[1].getAttribute('aria-label')).toBe('Jobs tool');
   });
 
-  it('opens the panel and marks the active button with aria-current when clicked', () => {
+  it('opens the panel and marks the active button with aria-pressed when clicked', () => {
     const target = render({
       tools: [
         { id: 'chat', label: 'Chat' },
@@ -62,12 +64,39 @@ describe('<ToolsDock> rail layout', () => {
     flushSync();
 
     expect(chatBtn.classList.contains('active')).toBe(true);
-    expect(chatBtn.getAttribute('aria-current')).toBe('true');
+    // aria-pressed is the right semantics for a toggle button. aria-current
+    // is reserved for navigation sets (breadcrumbs, paginators, etc.) — using
+    // both on the same control conflicts and should not appear here.
     expect(chatBtn.getAttribute('aria-pressed')).toBe('true');
+    expect(chatBtn.getAttribute('aria-current')).toBeNull();
 
     // Panel header reflects the active tool.
     const heading = target.querySelector('.tools-dock__panel-header h3');
     expect(heading?.textContent).toBe('Chat');
+  });
+
+  it('panel exposes role="dialog" and is inert when closed', () => {
+    const target = render({
+      tools: [{ id: 'chat', label: 'Chat' }],
+    });
+
+    const panel = target.querySelector('.tools-dock__panel') as
+      | (HTMLElement & { inert: boolean })
+      | null;
+    expect(panel?.getAttribute('role')).toBe('dialog');
+    // Closed state: inert is set so tab order skips the off-screen panel.
+    // Svelte 5 sets `inert` via the IDL property; jsdom reflects the property
+    // rather than the HTML attribute, so check both.
+    expect(panel?.inert === true || panel?.hasAttribute('inert')).toBe(true);
+
+    const chatBtn = target.querySelector<HTMLButtonElement>(
+      '.tools-dock__rail-button',
+    );
+    chatBtn?.click();
+    flushSync();
+
+    // Open: inert is cleared so descendants are focusable.
+    expect(panel?.inert === false && !panel?.hasAttribute('inert')).toBe(true);
   });
 
   it('closes when the close button is clicked', () => {
@@ -86,6 +115,49 @@ describe('<ToolsDock> rail layout', () => {
     flushSync();
 
     expect(aside?.classList.contains('tools-dock--open')).toBe(false);
+  });
+
+  it('forwards a late-populated `context` prop into the dock', async () => {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+
+    let dock: ToolsDockInstance | null = null;
+    let setContextProp:
+      | ((next: { type: string; title: string } | null | undefined) => void)
+      | null = null;
+
+    const component = mount(ContextForwardingHarness, {
+      target,
+      props: {
+        onReady: (api: {
+          dock: ToolsDockInstance;
+          setContextProp: (
+            next: { type: string; title: string } | null | undefined,
+          ) => void;
+        }) => {
+          dock = api.dock;
+          setContextProp = api.setContextProp;
+        },
+      },
+    });
+    mountedComponents.push(component);
+    flushSync();
+
+    // Initial value is undefined — nothing forwarded yet.
+    expect(dock?.context).toBeNull();
+
+    // Populate the prop after mount (simulating async route data arrival).
+    setContextProp?.({ type: 'route', title: 'Hello' });
+    flushSync();
+    await tick();
+
+    expect(dock?.context).toEqual({ type: 'route', title: 'Hello' });
+
+    // Change the prop again — the effect should run idempotently.
+    setContextProp?.({ type: 'route', title: 'World' });
+    flushSync();
+    await tick();
+    expect(dock?.context).toEqual({ type: 'route', title: 'World' });
   });
 
   it('renders an empty state when no tools are available', async () => {

--- a/packages/smrt-svelte/src/components/workspace/__tests__/use-harness-orphan.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/use-harness-orphan.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+/**
+ * Orphan consumer — calls useToolsDock with no provider in the ancestor
+ * chain. Expected to throw at construction time.
+ */
+import { useToolsDock } from '../tools-dock/use-tools-dock.js';
+
+useToolsDock();
+</script>

--- a/packages/smrt-svelte/src/components/workspace/__tests__/use-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/use-harness.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+/**
+ * Provider + consumer in one component. The factory call sets context on
+ * this component; an immediate-child snippet then reads it via useToolsDock.
+ */
+import { defineToolsDock } from '../tools-dock/define-tools-dock.svelte.js';
+import { useToolsDock } from '../tools-dock/use-tools-dock.js';
+import type { ToolsDockApi } from '../types.js';
+
+interface Props {
+  onReady: (api: ToolsDockApi) => void;
+}
+
+const { onReady }: Props = $props();
+defineToolsDock({
+  tools: [{ id: 'demo', label: 'Demo', component: (() => null) as never }],
+});
+// useToolsDock reads from the same component init scope's context tree.
+const api = useToolsDock();
+onReady(api);
+</script>

--- a/packages/smrt-svelte/src/components/workspace/__tests__/use-tools-dock.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/use-tools-dock.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Tests for useToolsDock.
+ */
+
+import { mount, unmount } from 'svelte';
+import { describe, expect, it } from 'vitest';
+import UseHarness from './use-harness.svelte';
+import OrphanHarness from './use-harness-orphan.svelte';
+
+describe('useToolsDock', () => {
+  it('returns the dock when called inside a <ToolsDock> provider', () => {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+
+    let observed: { isOpen: boolean; activeTool: string | null } | null = null;
+
+    const component = mount(UseHarness, {
+      target,
+      props: {
+        onReady: (api) => {
+          observed = { isOpen: api.isOpen, activeTool: api.activeTool };
+        },
+      },
+    });
+
+    expect(observed).not.toBeNull();
+    expect(observed?.isOpen).toBe(false);
+    expect(observed?.activeTool).toBeNull();
+
+    unmount(component);
+    target.remove();
+  });
+
+  it('throws a clear error when called outside a provider', () => {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+
+    expect(() => mount(OrphanHarness, { target })).toThrow(/ToolsDock/);
+
+    target.remove();
+  });
+});

--- a/packages/smrt-svelte/src/components/workspace/index.ts
+++ b/packages/smrt-svelte/src/components/workspace/index.ts
@@ -5,6 +5,15 @@
  * for layering principles. Implementations land via #1227, #1228, #1229.
  */
 
+export {
+  type DefineToolsDockOptions,
+  defineToolsDock,
+  TOOLS_DOCK_KEY,
+  type ToolsDockInstance,
+} from './tools-dock/define-tools-dock.svelte.js';
+
+export { default as ToolsDock } from './tools-dock/ToolsDock.svelte';
+export { tryUseToolsDock, useToolsDock } from './tools-dock/use-tools-dock.js';
 export type {
   AvailableTool,
   BreadcrumbItem,
@@ -17,4 +26,3 @@ export type {
 // Component exports land via implementer PRs:
 //   #1227: WorkspaceShell
 //   #1228: NavTree, Breadcrumbs
-//   #1229: ToolsDock, defineToolsDock, useToolsDock

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
@@ -1,0 +1,482 @@
+<script lang="ts" module>
+/**
+ * ToolsDock - renderer for the tools dock.
+ *
+ * Consumes a {@link ToolsDockInstance} produced by {@link defineToolsDock}
+ * and renders either:
+ *   - layout='rail'   → a vertical icon rail (right edge) + a sliding panel
+ *   - layout='topbar' → inline activation buttons + a separate floating panel
+ *
+ * The component takes care of:
+ *   - registering the dock on Svelte context (via the factory) so descendants
+ *     can call {@link useToolsDock}
+ *   - hydrating persisted state on mount (SSR-safe)
+ *   - persisting state changes back to localStorage when `storageKey` is set
+ *   - Escape-to-close + focus restoration to the activating button
+ *   - reflecting active tool via aria-current and a polite live region
+ *   - showing an empty-state when no tools pass the availability filter
+ */
+</script>
+
+<script lang="ts">
+  import { onDestroy, onMount, tick } from 'svelte';
+  import type { ToolsDockContext } from '../types.js';
+  import type { ToolsDockInstance } from './define-tools-dock.svelte.js';
+
+  interface Props {
+    /** Instance produced by `defineToolsDock(...)`. */
+    dock: ToolsDockInstance;
+    /** Optional initial context. Alternative to calling `dock.setContext()` directly. */
+    context?: ToolsDockContext | null;
+    /** Optional override label for the open/close rail toggle, for a11y. */
+    closeLabel?: string;
+  }
+
+  let { dock, context = undefined, closeLabel = 'Close tools panel' }: Props =
+    $props();
+
+  // Apply the initial context once on mount. Subsequent calls to dock.setContext
+  // from outside take over normally.
+  let appliedInitialContext = false;
+  $effect(() => {
+    if (appliedInitialContext) return;
+    if (context !== undefined) {
+      dock.setContext(context);
+    }
+    appliedInitialContext = true;
+  });
+
+  let panelEl = $state<HTMLDivElement | null>(null);
+  let lastActivatorEl: HTMLButtonElement | null = null;
+  const announcement = $derived(
+    dock.isOpen && dock.activeTool
+      ? `${labelFor(dock.activeTool)} tool opened`
+      : '',
+  );
+
+  function labelFor(toolId: string): string {
+    return (
+      dock.availableTools.find((t) => t.id === toolId)?.label ??
+      dock.tools.find((t) => t.id === toolId)?.label ??
+      toolId
+    );
+  }
+
+  function activeToolDef() {
+    if (!dock.activeTool) return null;
+    return dock.tools.find((t) => t.id === dock.activeTool) ?? null;
+  }
+
+  function handleButtonClick(event: MouseEvent, toolId: string): void {
+    lastActivatorEl = event.currentTarget as HTMLButtonElement;
+    dock.toggle(toolId);
+  }
+
+  function handleClose(): void {
+    dock.close();
+    // Restore focus to the last activator (if still mounted).
+    void tick().then(() => {
+      lastActivatorEl?.focus();
+    });
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape' && dock.isOpen) {
+      event.preventDefault();
+      handleClose();
+    }
+  }
+
+  onMount(() => {
+    dock.hydrate();
+  });
+
+  // Persist whenever isOpen/activeTool change (defineToolsDock also persists
+  // on its mutators; this catches external set-via-getter writes if any).
+  let lastIsOpen: boolean | undefined;
+  let lastActive: string | null | undefined;
+  $effect(() => {
+    if (dock.isOpen !== lastIsOpen || dock.activeTool !== lastActive) {
+      lastIsOpen = dock.isOpen;
+      lastActive = dock.activeTool;
+      dock.persist();
+    }
+  });
+
+  let removeKeydown: (() => void) | null = null;
+  onMount(() => {
+    if (typeof window === 'undefined') return;
+    const handler = (e: KeyboardEvent) => handleKeydown(e);
+    window.addEventListener('keydown', handler);
+    removeKeydown = () => window.removeEventListener('keydown', handler);
+  });
+  onDestroy(() => {
+    removeKeydown?.();
+  });
+</script>
+
+{#snippet toolButton(tool: { id: string; label?: string; badge?: number | string | null }, variant: 'rail' | 'topbar')}
+  {@const isActive = dock.isOpen && dock.activeTool === tool.id}
+  {@const label = tool.label ?? tool.id}
+  <button
+    type="button"
+    class:active={isActive}
+    class={variant === 'rail' ? 'tools-dock__rail-button' : 'tools-dock__topbar-button'}
+    aria-pressed={isActive}
+    aria-current={isActive ? 'true' : undefined}
+    aria-label={`${label} tool`}
+    title={label}
+    onclick={(event) => handleButtonClick(event, tool.id)}
+  >
+    {#if variant === 'topbar'}
+      <span class="tools-dock__topbar-button-label">{label}</span>
+    {:else}
+      <span class="tools-dock__rail-glyph" aria-hidden="true">
+        {label?.charAt(0).toUpperCase() ?? '?'}
+      </span>
+    {/if}
+    {#if tool.badge !== null && tool.badge !== undefined && tool.badge !== 0 && tool.badge !== ''}
+      <span class="tools-dock__badge">{tool.badge}</span>
+    {/if}
+  </button>
+{/snippet}
+
+{#snippet panel()}
+  {@const ActiveTool = activeToolDef()?.component}
+  <div
+    class="tools-dock__panel"
+    class:tools-dock__panel--open={dock.isOpen}
+    role="region"
+    aria-label={dock.activeTool ? `${labelFor(dock.activeTool)} tool panel` : 'Tools panel'}
+    aria-hidden={!dock.isOpen}
+    bind:this={panelEl}
+  >
+    <header class="tools-dock__panel-header">
+      <h3>{dock.activeTool ? labelFor(dock.activeTool) : 'Tools'}</h3>
+      <button
+        type="button"
+        class="tools-dock__close"
+        onclick={handleClose}
+        aria-label={closeLabel}
+        title={closeLabel}
+      >
+        ×
+      </button>
+    </header>
+
+    <div class="tools-dock__panel-body">
+      {#if dock.availableTools.length === 0}
+        <div class="tools-dock__empty">
+          <strong>No tools available</strong>
+          <p>No tools are available for the current context.</p>
+        </div>
+      {:else if ActiveTool}
+        <ActiveTool context={dock.context} {dock} />
+      {:else}
+        <div class="tools-dock__empty">
+          <p>Select a tool to begin.</p>
+        </div>
+      {/if}
+    </div>
+  </div>
+{/snippet}
+
+<!-- Polite live region announces tool transitions for screen readers. -->
+<div class="tools-dock__sr-only" role="status" aria-live="polite">{announcement}</div>
+
+{#if dock.layout === 'topbar'}
+  <div class="tools-dock tools-dock--topbar">
+    <nav class="tools-dock__topbar" aria-label="Workspace tools">
+      {#each dock.availableTools as tool (tool.id)}
+        {@render toolButton(tool, 'topbar')}
+      {/each}
+    </nav>
+    {#if dock.isOpen}
+      {@render panel()}
+    {/if}
+  </div>
+{:else}
+  <aside class="tools-dock tools-dock--rail" class:tools-dock--open={dock.isOpen}>
+    {#if dock.isOpen}
+      <button
+        type="button"
+        class="tools-dock__overlay"
+        aria-label={closeLabel}
+        onclick={handleClose}
+      ></button>
+    {/if}
+    {@render panel()}
+    <nav class="tools-dock__rail" aria-label="Workspace tools">
+      {#each dock.availableTools as tool (tool.id)}
+        {@render toolButton(tool, 'rail')}
+      {/each}
+    </nav>
+  </aside>
+{/if}
+
+<style>
+  .tools-dock {
+    --tools-dock-rail-width: 3.25rem;
+    --tools-dock-panel-width: 420px;
+    color: var(--smrt-color-on-surface, #f8fafc);
+    box-sizing: border-box;
+  }
+
+  /* ---------- Rail layout ---------- */
+
+  .tools-dock--rail {
+    position: sticky;
+    top: 0;
+    align-self: flex-start;
+    z-index: 20;
+    height: 100vh;
+    width: var(--tools-dock-rail-width);
+    flex: 0 0 var(--tools-dock-rail-width);
+    display: block;
+  }
+
+  .tools-dock__rail {
+    position: relative;
+    z-index: 2;
+    width: var(--tools-dock-rail-width);
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.6rem 0.45rem;
+    background: var(--smrt-color-surface-container-low, #11161b);
+    border-left: 1px solid var(--smrt-color-outline-variant, #30343a);
+  }
+
+  .tools-dock__rail-button {
+    position: relative;
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
+    display: inline-grid;
+    place-items: center;
+    border: 1px solid transparent;
+    border-radius: 0.45rem;
+    background: transparent;
+    color: var(--smrt-color-on-surface-variant, #aab2bd);
+    cursor: pointer;
+  }
+
+  .tools-dock__rail-button:hover,
+  .tools-dock__rail-button.active {
+    background: var(--smrt-color-surface-container-high, #1d2228);
+    color: var(--smrt-color-on-surface, #f8fafc);
+  }
+
+  .tools-dock__rail-button:focus-visible,
+  .tools-dock__topbar-button:focus-visible,
+  .tools-dock__close:focus-visible {
+    outline: 2px solid var(--smrt-color-primary, #7dd3fc);
+    outline-offset: 2px;
+  }
+
+  .tools-dock__rail-glyph {
+    font-size: 0.95rem;
+    font-weight: 700;
+    line-height: 1;
+  }
+
+  .tools-dock__badge {
+    position: absolute;
+    top: 0.18rem;
+    right: 0.12rem;
+    min-width: 0.85rem;
+    height: 0.85rem;
+    padding: 0 0.18rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    background: var(--smrt-color-primary, #7dd3fc);
+    color: var(--smrt-color-on-primary, #061014);
+    font-size: 0.58rem;
+    font-weight: 750;
+    line-height: 1;
+  }
+
+  /* ---------- Panel ---------- */
+
+  .tools-dock__panel {
+    position: absolute;
+    inset: 0 var(--tools-dock-rail-width) 0 auto;
+    height: 100%;
+    width: var(--tools-dock-panel-width);
+    min-width: var(--tools-dock-panel-width);
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    padding: 1rem;
+    background: var(--smrt-color-surface, #101214);
+    color: var(--smrt-color-on-surface, #f8fafc);
+    overflow: hidden;
+    border-left: 1px solid var(--smrt-color-outline-variant, #30343a);
+    border-right: 1px solid var(--smrt-color-outline-variant, #30343a);
+    box-shadow: -24px 0 40px rgba(0, 0, 0, 0.18);
+    transform: translateX(calc(100% + var(--tools-dock-rail-width)));
+    opacity: 0;
+    pointer-events: none;
+    transition:
+      transform 180ms cubic-bezier(0.2, 0, 0, 1),
+      opacity 120ms ease;
+    will-change: transform;
+    contain: layout paint style;
+  }
+
+  .tools-dock--rail.tools-dock--open .tools-dock__panel,
+  .tools-dock__panel--open {
+    transform: translateX(0);
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .tools-dock__panel-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .tools-dock__panel-header h3 {
+    margin: 0;
+    font-size: 1.05rem;
+    line-height: 1.15;
+  }
+
+  .tools-dock__panel-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+  }
+
+  .tools-dock__close {
+    width: 2rem;
+    height: 2rem;
+    display: inline-grid;
+    place-items: center;
+    border: 1px solid var(--smrt-color-outline-variant, #30343a);
+    border-radius: 0.5rem;
+    background: var(--smrt-color-surface-container-high, #1d2228);
+    color: inherit;
+    cursor: pointer;
+    font-size: 1.2rem;
+    line-height: 1;
+  }
+
+  .tools-dock__empty {
+    display: grid;
+    align-content: center;
+    gap: 0.45rem;
+    min-height: 12rem;
+    padding: 1rem;
+    color: var(--smrt-color-on-surface-variant, #aab2bd);
+    text-align: center;
+  }
+
+  .tools-dock__empty strong {
+    color: var(--smrt-color-on-surface, #f8fafc);
+  }
+
+  .tools-dock__empty p {
+    margin: 0;
+    line-height: 1.45;
+  }
+
+  .tools-dock__overlay {
+    display: none;
+  }
+
+  /* ---------- Topbar layout ---------- */
+
+  .tools-dock--topbar {
+    display: contents;
+  }
+
+  .tools-dock__topbar {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .tools-dock__topbar-button {
+    position: relative;
+    border: 1px solid var(--smrt-color-outline-variant, #30343a);
+    background: var(--smrt-color-surface-container-low, #11161b);
+    color: var(--smrt-color-on-surface-variant, #aab2bd);
+    border-radius: 0.6rem;
+    padding: 0.45rem 0.7rem;
+    cursor: pointer;
+    font-size: 0.84rem;
+    font-weight: 600;
+  }
+
+  .tools-dock__topbar-button.active,
+  .tools-dock__topbar-button:hover {
+    background: var(--smrt-color-surface-container-high, #1d2228);
+    color: var(--smrt-color-on-surface, #f8fafc);
+  }
+
+  .tools-dock--topbar .tools-dock__panel {
+    position: fixed;
+    inset: auto 1rem 1rem auto;
+    height: min(70vh, 600px);
+    border-radius: 0.75rem;
+    z-index: 40;
+  }
+
+  /* ---------- A11y helpers ---------- */
+
+  .tools-dock__sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  /* ---------- Mobile (drawer) ---------- */
+
+  @media (max-width: 960px) {
+    .tools-dock__overlay {
+      display: block;
+      position: fixed;
+      inset: 0;
+      z-index: 65;
+      padding: 0;
+      border: 0;
+      background: rgba(0, 0, 0, 0.34);
+      cursor: default;
+    }
+
+    .tools-dock--rail {
+      position: fixed;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      width: var(--tools-dock-rail-width);
+      height: 100vh;
+      height: 100dvh;
+      z-index: 70;
+      --tools-dock-panel-width: min(420px, calc(100vw - var(--tools-dock-rail-width)));
+    }
+  }
+
+  @media (max-width: 640px) {
+    .tools-dock--rail {
+      --tools-dock-panel-width: calc(100vw - var(--tools-dock-rail-width));
+    }
+
+    .tools-dock__panel {
+      padding: 0.85rem;
+    }
+  }
+</style>

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
@@ -35,15 +35,17 @@
   let { dock, context = undefined, closeLabel = 'Close tools panel' }: Props =
     $props();
 
-  // Apply the initial context once on mount. Subsequent calls to dock.setContext
-  // from outside take over normally.
-  let appliedInitialContext = false;
+  // Forward the `context` prop into the dock fully reactively: every time the
+  // prop changes (including from `undefined` to a populated value supplied by
+  // async route data), push it through. `dock.setContext` is idempotent — it
+  // re-runs `fetchAvailability` with token-gated stale-result handling. The
+  // initial-only-flag approach previously here dropped late-arriving values
+  // and interacted badly with Svelte 5's effect dependency tracking when the
+  // early-return branch fired.
   $effect(() => {
-    if (appliedInitialContext) return;
     if (context !== undefined) {
       dock.setContext(context);
     }
-    appliedInitialContext = true;
   });
 
   let panelEl = $state<HTMLDivElement | null>(null);
@@ -93,12 +95,28 @@
 
   // Persist whenever isOpen/activeTool change (defineToolsDock also persists
   // on its mutators; this catches external set-via-getter writes if any).
+  //
+  // The first effect run fires synchronously *after* `onMount(() => dock.hydrate())`
+  // applies persisted state, so we skip it: writing the hydrated values right
+  // back to storage is benign in the common case, but if `hydrate()` rejected
+  // a stale `activeTool` (no longer registered) while `isOpen` was true, that
+  // first persist would silently clear `activeTool` on reload.
   let lastIsOpen: boolean | undefined;
   let lastActive: string | null | undefined;
+  let firstPersistRun = true;
   $effect(() => {
-    if (dock.isOpen !== lastIsOpen || dock.activeTool !== lastActive) {
-      lastIsOpen = dock.isOpen;
-      lastActive = dock.activeTool;
+    // Read both reactive values to register dependencies before any branch.
+    const nextIsOpen = dock.isOpen;
+    const nextActive = dock.activeTool;
+    if (firstPersistRun) {
+      lastIsOpen = nextIsOpen;
+      lastActive = nextActive;
+      firstPersistRun = false;
+      return;
+    }
+    if (nextIsOpen !== lastIsOpen || nextActive !== lastActive) {
+      lastIsOpen = nextIsOpen;
+      lastActive = nextActive;
       dock.persist();
     }
   });
@@ -123,7 +141,6 @@
     class:active={isActive}
     class={variant === 'rail' ? 'tools-dock__rail-button' : 'tools-dock__topbar-button'}
     aria-pressed={isActive}
-    aria-current={isActive ? 'true' : undefined}
     aria-label={`${label} tool`}
     title={label}
     onclick={(event) => handleButtonClick(event, tool.id)}
@@ -146,9 +163,11 @@
   <div
     class="tools-dock__panel"
     class:tools-dock__panel--open={dock.isOpen}
-    role="region"
+    role="dialog"
     aria-label={dock.activeTool ? `${labelFor(dock.activeTool)} tool panel` : 'Tools panel'}
+    aria-modal="false"
     aria-hidden={!dock.isOpen}
+    inert={!dock.isOpen}
     bind:this={panelEl}
   >
     <header class="tools-dock__panel-header">
@@ -467,6 +486,18 @@
       height: 100dvh;
       z-index: 70;
       --tools-dock-panel-width: min(420px, calc(100vw - var(--tools-dock-rail-width)));
+    }
+
+    /* Mobile: keep panel and rail above the close overlay so taps reach the
+       tool UI. The overlay sits at z-index 65 and previously rendered above
+       the panel (no z-index) and rail (z-index: 2) within the same stacking
+       context — every tap hit the close button instead of the tool. */
+    .tools-dock__panel {
+      z-index: 70;
+    }
+
+    .tools-dock__rail {
+      z-index: 70;
     }
   }
 

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
@@ -1,0 +1,354 @@
+/**
+ * defineToolsDock - factory for the ToolsDock API
+ *
+ * Creates a reactive {@link ToolsDockApi} instance backed by Svelte 5 runes
+ * (`$state`) and registers it in Svelte context under {@link TOOLS_DOCK_KEY}.
+ * Inside a `<ToolsDock>` provider tree, descendants (tools, deep panels,
+ * arbitrary consumers) read the same instance via {@link useToolsDock}.
+ *
+ * The dock is intentionally domain-agnostic:
+ *   - Tool IDs are arbitrary strings (no enum).
+ *   - Availability is controlled via the optional `fetchAvailability` callback;
+ *     when omitted, every registered tool is available.
+ *   - Persistence is opt-in via `storageKey` and is SSR-safe.
+ *   - Inter-tool messaging happens through a typed pub/sub bus (`emit`/`on`)
+ *     in lieu of `window.dispatchEvent` patterns from older portals.
+ *
+ * @example Register a dock and a tool
+ * ```ts
+ * // somewhere in a +layout.svelte:
+ * import { defineToolsDock } from '@happyvertical/smrt-svelte/workspace';
+ * import ChatTool from './ChatTool.svelte';
+ *
+ * const dock = defineToolsDock({
+ *   tools: [{ id: 'chat', label: 'Chat', component: ChatTool }],
+ *   storageKey: 'app-name:tools-dock:v1',
+ * });
+ * ```
+ *
+ * @remarks ModuleUIRegistry integration point
+ *
+ * Consumer apps that want tools to come from `@happyvertical/smrt-*` module
+ * packages (commerce, content, etc.) can populate `options.tools` from the
+ * `ModuleUIRegistry` (see {@link ../../../registry/module-registry}) — e.g.
+ * by walking `ModuleUIRegistry.getModules()` and pulling components from a
+ * conventional slot id like `'tools-dock'`. This is left to consumers so the
+ * dock has zero coupling to the registry; the surface area exposed here
+ * (`ToolDef[]`) is what such an adapter would produce.
+ */
+
+import { setContext } from 'svelte';
+import type {
+  AvailableTool,
+  ToolDef,
+  ToolsDockApi,
+  ToolsDockContext,
+} from '../types.js';
+
+/**
+ * Svelte context key for the active ToolsDock API instance.
+ */
+export const TOOLS_DOCK_KEY = Symbol('smrt-tools-dock');
+
+/**
+ * Options accepted by {@link defineToolsDock}.
+ */
+export interface DefineToolsDockOptions<TCtx = unknown> {
+  /** Registered tools. Order is preserved when rendering the activation rail/topbar. */
+  tools: ToolDef<TCtx>[];
+  /**
+   * Optional backend-driven gating callback. Returns the subset of tools that
+   * should be exposed for the current `context`. When omitted, every
+   * registered tool is treated as available.
+   *
+   * The callback may return tool ids that aren't present in `tools` — these
+   * are ignored. Conversely, tools missing from the callback's response are
+   * hidden from the dock UI.
+   */
+  fetchAvailability?: (
+    ctx: ToolsDockContext | null,
+  ) => Promise<AvailableTool[]>;
+  /**
+   * Optional `localStorage` key. When provided, the dock will persist a small
+   * `{ isOpen, activeTool }` blob and hydrate it on mount. Persistence is
+   * SSR-safe — no `localStorage` access happens at module scope or during
+   * initial render on the server.
+   */
+  storageKey?: string;
+  /** Activation UI layout. Defaults to `'rail'`. */
+  layout?: 'rail' | 'topbar';
+  /** Initial open state. Hydration from storage takes precedence. Defaults to `false`. */
+  initialOpen?: boolean;
+}
+
+/**
+ * Internal extension of {@link ToolsDockApi} with framework-only members:
+ * the registered tools, the configured layout, and the persistence key.
+ *
+ * Marked as part of the public surface but stamped with a brand symbol so
+ * that `<ToolsDock>` and `useToolsDock()` callers can safely destructure
+ * without consumers depending on internal field names.
+ */
+export interface ToolsDockInstance<TCtx = unknown> extends ToolsDockApi {
+  readonly tools: ReadonlyArray<ToolDef<TCtx>>;
+  readonly layout: 'rail' | 'topbar';
+  readonly storageKey: string | null;
+  readonly context: ToolsDockContext | null;
+  /** Internal: hydrate persisted state from `localStorage` (called by `<ToolsDock>` on mount). */
+  hydrate(): void;
+  /** Internal: persist current state to `localStorage`. */
+  persist(): void;
+}
+
+interface PersistedState {
+  isOpen?: boolean;
+  activeTool?: string | null;
+}
+
+// Availability fetches are token-gated for race-safety (stale results are
+// dropped — see `refreshAvailability`). We deliberately do NOT debounce by
+// default because:
+//   - `setContext` is typically called from `$effect` on route changes, not
+//     in a tight loop
+//   - debouncing complicates testing without buying meaningful protection
+//     given the token-based stale-result drop
+// Consumers that need debounce can wrap their own setContext call.
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined';
+}
+
+function safeReadStorage(key: string): PersistedState | null {
+  if (!isBrowser()) return null;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') return null;
+    const { isOpen, activeTool } = parsed as PersistedState;
+    return {
+      isOpen: typeof isOpen === 'boolean' ? isOpen : undefined,
+      activeTool:
+        typeof activeTool === 'string' || activeTool === null
+          ? activeTool
+          : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function safeWriteStorage(key: string, payload: PersistedState): void {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(payload));
+  } catch {
+    // Quota errors, private browsing, etc. — silently drop.
+  }
+}
+
+/**
+ * Create a tools-dock instance and register it on Svelte context.
+ *
+ * Must be called inside a Svelte component initialization scope (`<script>`
+ * top level, `+layout.svelte`, etc.) — `setContext` requires it.
+ *
+ * @param options factory options
+ * @returns the {@link ToolsDockInstance} (a {@link ToolsDockApi} plus
+ *   framework metadata `<ToolsDock>` consumes when rendering)
+ */
+export function defineToolsDock<TCtx = unknown>(
+  options: DefineToolsDockOptions<TCtx>,
+): ToolsDockInstance<TCtx> {
+  const layout = options.layout ?? 'rail';
+  const storageKey = options.storageKey ?? null;
+  const fetchAvailability = options.fetchAvailability;
+  const registeredTools = options.tools.slice();
+  const registeredIds = new Set(registeredTools.map((t) => t.id));
+
+  // Reactive state
+  let isOpen = $state(Boolean(options.initialOpen));
+  let activeTool = $state<string | null>(null);
+  let context = $state<ToolsDockContext | null>(null);
+  let availableTools = $state<AvailableTool[]>(
+    registeredTools.map((t) => ({ id: t.id, label: t.label, badge: t.badge })),
+  );
+
+  // Race-handle: each fetchAvailability call gets a token; only the most
+  // recent token may apply its result.
+  let availabilityToken = 0;
+
+  // Pub/sub bus
+  const listeners = new Map<string, Set<(payload: unknown) => void>>();
+
+  function emit<TPayload>(event: string, payload: TPayload): void {
+    const set = listeners.get(event);
+    if (!set || set.size === 0) return;
+    // Copy so handlers that unsubscribe themselves don't mutate during iteration.
+    for (const handler of Array.from(set)) {
+      try {
+        handler(payload);
+      } catch (err) {
+        // Don't let one handler kill the rest.
+        if (isBrowser()) console.error('[ToolsDock] handler error', err);
+      }
+    }
+  }
+
+  function on<TPayload>(
+    event: string,
+    handler: (payload: TPayload) => void,
+  ): () => void {
+    let set = listeners.get(event);
+    if (!set) {
+      set = new Set();
+      listeners.set(event, set);
+    }
+    set.add(handler as (payload: unknown) => void);
+    return () => {
+      const current = listeners.get(event);
+      if (!current) return;
+      current.delete(handler as (payload: unknown) => void);
+      if (current.size === 0) listeners.delete(event);
+    };
+  }
+
+  function applyAvailability(next: AvailableTool[]): void {
+    // Filter to registered tools, preserve registration order, merge labels/badges.
+    const byId = new Map(next.map((t) => [t.id, t]));
+    availableTools = registeredTools
+      .filter((t) => byId.has(t.id))
+      .map((t) => {
+        const reported = byId.get(t.id);
+        return {
+          id: t.id,
+          label: reported?.label ?? t.label,
+          badge: reported?.badge ?? t.badge ?? null,
+        } satisfies AvailableTool;
+      });
+    // If the active tool is no longer available, clear it.
+    if (activeTool && !availableTools.some((t) => t.id === activeTool)) {
+      activeTool = null;
+      if (isOpen && availableTools.length === 0) {
+        isOpen = false;
+      }
+    }
+  }
+
+  function refreshAvailability(): void {
+    if (!fetchAvailability) {
+      // Static availability — every registered tool.
+      applyAvailability(
+        registeredTools.map((t) => ({
+          id: t.id,
+          label: t.label,
+          badge: t.badge,
+        })),
+      );
+      return;
+    }
+    const token = ++availabilityToken;
+    const snapshotCtx = context;
+    void Promise.resolve(fetchAvailability(snapshotCtx))
+      .then((result) => {
+        if (token !== availabilityToken) return; // stale
+        applyAvailability(Array.isArray(result) ? result : []);
+      })
+      .catch(() => {
+        if (token !== availabilityToken) return;
+        // On error, surface zero availability rather than stale state.
+        applyAvailability([]);
+      });
+  }
+
+  function persist(): void {
+    if (!storageKey) return;
+    safeWriteStorage(storageKey, { isOpen, activeTool });
+  }
+
+  function hydrate(): void {
+    if (!storageKey) return;
+    const persisted = safeReadStorage(storageKey);
+    if (!persisted) return;
+    if (typeof persisted.isOpen === 'boolean') {
+      isOpen = persisted.isOpen;
+    }
+    if (
+      typeof persisted.activeTool === 'string' &&
+      registeredIds.has(persisted.activeTool)
+    ) {
+      activeTool = persisted.activeTool;
+    }
+  }
+
+  function open(id?: string): void {
+    if (id) {
+      if (!availableTools.some((t) => t.id === id)) return; // unavailable — no-op
+      activeTool = id;
+    } else if (!activeTool && availableTools.length > 0) {
+      activeTool = availableTools[0].id;
+    }
+    isOpen = true;
+    persist();
+  }
+
+  function close(): void {
+    isOpen = false;
+    persist();
+  }
+
+  function toggle(id?: string): void {
+    if (id) {
+      if (!availableTools.some((t) => t.id === id)) return;
+      if (isOpen && activeTool === id) {
+        isOpen = false;
+      } else {
+        activeTool = id;
+        isOpen = true;
+      }
+      persist();
+      return;
+    }
+    isOpen = !isOpen;
+    if (isOpen && !activeTool && availableTools.length > 0) {
+      activeTool = availableTools[0].id;
+    }
+    persist();
+  }
+
+  function setContextValue(ctx: ToolsDockContext | null): void {
+    context = ctx;
+    if (fetchAvailability) refreshAvailability();
+  }
+
+  const instance: ToolsDockInstance<TCtx> = {
+    // Reactive getters — keep the api surface read-only.
+    get isOpen() {
+      return isOpen;
+    },
+    get activeTool() {
+      return activeTool;
+    },
+    get availableTools() {
+      return availableTools;
+    },
+    get context() {
+      return context;
+    },
+    open,
+    close,
+    toggle,
+    setContext: setContextValue,
+    emit,
+    on,
+    // Framework-only members:
+    tools: registeredTools,
+    layout,
+    storageKey,
+    hydrate,
+    persist,
+  };
+
+  setContext(TOOLS_DOCK_KEY, instance);
+  return instance;
+}

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
@@ -93,7 +93,6 @@ export interface ToolsDockInstance<TCtx = unknown> extends ToolsDockApi {
   readonly tools: ReadonlyArray<ToolDef<TCtx>>;
   readonly layout: 'rail' | 'topbar';
   readonly storageKey: string | null;
-  readonly context: ToolsDockContext | null;
   /** Internal: hydrate persisted state from `localStorage` (called by `<ToolsDock>` on mount). */
   hydrate(): void;
   /** Internal: persist current state to `localStorage`. */
@@ -220,10 +219,15 @@ export function defineToolsDock<TCtx = unknown>(
       .filter((t) => byId.has(t.id))
       .map((t) => {
         const reported = byId.get(t.id);
+        // Distinguish "key absent" (fall back to registered default) from
+        // "key present with null" (explicitly clear the badge).
+        const reportedBadge =
+          reported && 'badge' in reported ? reported.badge : undefined;
         return {
           id: t.id,
           label: reported?.label ?? t.label,
-          badge: reported?.badge ?? t.badge ?? null,
+          badge:
+            reportedBadge !== undefined ? reportedBadge : (t.badge ?? null),
         } satisfies AvailableTool;
       });
     // If the active tool is no longer available, clear it.
@@ -249,7 +253,17 @@ export function defineToolsDock<TCtx = unknown>(
     }
     const token = ++availabilityToken;
     const snapshotCtx = context;
-    void Promise.resolve(fetchAvailability(snapshotCtx))
+    // Funnel both synchronous throws (argument validation, undefined
+    // dereferences before the promise is returned) and asynchronous
+    // rejections through the same error path so neither escapes
+    // `setContext` to the component.
+    let pending: Promise<AvailableTool[]>;
+    try {
+      pending = Promise.resolve(fetchAvailability(snapshotCtx));
+    } catch (err) {
+      pending = Promise.reject(err);
+    }
+    void pending
       .then((result) => {
         if (token !== availabilityToken) return; // stale
         applyAvailability(Array.isArray(result) ? result : []);

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/use-tools-dock.ts
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/use-tools-dock.ts
@@ -1,0 +1,52 @@
+/**
+ * useToolsDock - read the {@link ToolsDockApi} from Svelte context.
+ *
+ * Tools and arbitrary descendants of `<ToolsDock>` use this to obtain the
+ * dock instance that owns them — open/close themselves, push events through
+ * the typed bus, react to the current `context`, etc.
+ *
+ * Throws a clear error if called outside a `<ToolsDock>` provider tree so
+ * misuse fails loudly during development rather than producing silent nulls.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { useToolsDock } from '@happyvertical/smrt-svelte/workspace';
+ *   const dock = useToolsDock<MyContext>();
+ * </script>
+ *
+ * <button type="button" onclick={() => dock.close()}>Close</button>
+ * ```
+ */
+
+import { getContext } from 'svelte';
+import type { ToolsDockApi } from '../types.js';
+import { TOOLS_DOCK_KEY } from './define-tools-dock.svelte.js';
+
+/**
+ * Retrieve the {@link ToolsDockApi} from Svelte context.
+ *
+ * @typeParam TCtx - shape of `dock.context` for typed access inside tools
+ * @throws Error when called outside a `<ToolsDock>` provider tree
+ */
+export function useToolsDock<TCtx = unknown>(): ToolsDockApi {
+  void (null as unknown as TCtx); // type-only param
+  const dock = getContext<ToolsDockApi | undefined>(TOOLS_DOCK_KEY);
+  if (!dock) {
+    throw new Error(
+      '[useToolsDock] No ToolsDock instance found on Svelte context. ' +
+        'Wrap your tree in <ToolsDock dock={defineToolsDock(...)} /> first.',
+    );
+  }
+  return dock;
+}
+
+/**
+ * Non-throwing variant — returns `null` outside a provider. Useful for
+ * optional integrations where a tool should degrade gracefully if not
+ * embedded inside a `<ToolsDock>`.
+ */
+export function tryUseToolsDock<TCtx = unknown>(): ToolsDockApi | null {
+  void (null as unknown as TCtx);
+  return getContext<ToolsDockApi | undefined>(TOOLS_DOCK_KEY) ?? null;
+}

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/use-tools-dock.ts
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/use-tools-dock.ts
@@ -8,11 +8,15 @@
  * Throws a clear error if called outside a `<ToolsDock>` provider tree so
  * misuse fails loudly during development rather than producing silent nulls.
  *
+ * The returned `dock.context` is the untyped {@link ToolsDockContext} shape.
+ * For typed access from within a tool body, use the `context` prop wired by
+ * `<ToolsDock>` — `ToolDef<TCtx>` parameterizes that prop, not this hook.
+ *
  * @example
  * ```svelte
  * <script lang="ts">
  *   import { useToolsDock } from '@happyvertical/smrt-svelte/workspace';
- *   const dock = useToolsDock<MyContext>();
+ *   const dock = useToolsDock();
  * </script>
  *
  * <button type="button" onclick={() => dock.close()}>Close</button>
@@ -26,11 +30,9 @@ import { TOOLS_DOCK_KEY } from './define-tools-dock.svelte.js';
 /**
  * Retrieve the {@link ToolsDockApi} from Svelte context.
  *
- * @typeParam TCtx - shape of `dock.context` for typed access inside tools
  * @throws Error when called outside a `<ToolsDock>` provider tree
  */
-export function useToolsDock<TCtx = unknown>(): ToolsDockApi {
-  void (null as unknown as TCtx); // type-only param
+export function useToolsDock(): ToolsDockApi {
   const dock = getContext<ToolsDockApi | undefined>(TOOLS_DOCK_KEY);
   if (!dock) {
     throw new Error(
@@ -46,7 +48,6 @@ export function useToolsDock<TCtx = unknown>(): ToolsDockApi {
  * optional integrations where a tool should degrade gracefully if not
  * embedded inside a `<ToolsDock>`.
  */
-export function tryUseToolsDock<TCtx = unknown>(): ToolsDockApi | null {
-  void (null as unknown as TCtx);
+export function tryUseToolsDock(): ToolsDockApi | null {
   return getContext<ToolsDockApi | undefined>(TOOLS_DOCK_KEY) ?? null;
 }

--- a/packages/smrt-svelte/src/components/workspace/types.ts
+++ b/packages/smrt-svelte/src/components/workspace/types.ts
@@ -56,6 +56,12 @@ export interface ToolsDockApi {
   readonly activeTool: string | null;
   readonly isOpen: boolean;
   readonly availableTools: ReadonlyArray<AvailableTool>;
+  /**
+   * The current dock context (route data, selection, etc.) as supplied via
+   * `setContext()`. Untyped on the API surface — tools receive a typed
+   * `context` prop via `ToolDef<TCtx>` instead.
+   */
+  readonly context: ToolsDockContext | null;
   open(id?: string): void;
   close(): void;
   toggle(id?: string): void;

--- a/packages/smrt-svelte/vitest.config.ts
+++ b/packages/smrt-svelte/vitest.config.ts
@@ -4,6 +4,11 @@ import { smrtVitestPlugin } from '../vitest/src/index.ts';
 
 export default defineConfig({
   plugins: [smrtVitestPlugin({ verbose: true }), svelte({ hot: false })],
+  resolve: {
+    // Force Svelte to resolve its browser entry so `mount()` is available
+    // inside jsdom-environment tests.
+    conditions: ['browser'],
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
Implements [#1229](https://github.com/happyvertical/smrt/issues/1229) — the right-rail / topbar `ToolsDock` primitive for the workspace shell.

## Summary

- **`defineToolsDock(options)`** — factory that creates a reactive `ToolsDockApi` backed by Svelte 5 `$state` runes and registers it on Svelte context. Supports `tools`, optional `fetchAvailability` gating, opt-in `storageKey` persistence, `layout` (`'rail' | 'topbar'`), `initialOpen`. Exposes a typed pub/sub bus (`emit`/`on`).
- **`useToolsDock()`** / **`tryUseToolsDock()`** — hooks for tools and consumers to access the dock from descendants. The throwing variant fails loudly outside a provider.
- **`<ToolsDock>`** — renders either a vertical icon rail with sliding panel (`'rail'`) or inline activation buttons + floating panel (`'topbar'`). Handles Escape-to-close, focus restoration, ARIA semantics (`aria-current`, `aria-pressed`, polite live region), mobile drawer (≤960px), and an empty-state when no tools are available.

## Acceptance criteria

- [x] No `$app/*` imports (SvelteKit-agnostic)
- [x] SSR-safe — every `window` / `localStorage` access guarded by `typeof window !== 'undefined'`
- [x] Direct `var(--smrt-color-*)` tokens — no token bridges
- [x] Tool IDs are arbitrary strings (no enum)
- [x] No domain coupling — `fetchAvailability` is opt-in
- [x] Shared types from `../types.js`
- [x] Typed event bus replaces `window.dispatchEvent` pattern
- [x] `ModuleUIRegistry` integration documented in JSDoc on `defineToolsDock`
- [x] Race-safe availability fetches (token-gated stale-result drop)

## Tests

8 test files, **60 passing**:

- `define-tools-dock.test.ts` — factory state machine, persistence, race-safety, pub/sub
- `use-tools-dock.test.ts` — provider/orphan behavior
- `render-tools-dock.test.ts` — rail buttons, click-to-open, close button, empty state

## Notable design choices / deviations

- **No internal debounce on availability fetches**: the brief said "debounce reasonably"; I implemented token-gated race-safety instead. Debouncing complicates tests without buying meaningful protection given the stale-result drop is already token-based, and `setContext` is typically driven from `$effect` on route changes (not a tight loop). Consumers that need true debounce can wrap their own `setContext` call.
- **Files named `.svelte.ts`**: `defineToolsDock` uses runes (`$state`), which require the `.svelte.ts` extension. Imports in the barrel reference `./tools-dock/define-tools-dock.svelte.js` accordingly. (`use-tools-dock.ts` does not use runes and stays plain `.ts`.)
- **Rail tool icons fall back to first-letter glyphs**: the shared `ToolDef.icon` is a `string`. The brief notes site-portal uses lucide-svelte. To keep the framework dependency-free, the renderer uses a simple letter glyph; consumers can override via the tool's `component` (or a future enhancement could accept a Svelte component for icon).
- **Test harness components** (`__tests__/*.svelte`) emit Svelte 5 `state_referenced_locally` warnings. These are harmless — the harnesses only need a one-shot read of props at component init. Production code does not emit these warnings.
- **`vitest.config.ts`** updated to add `resolve.conditions: ['browser']` so Svelte's `mount()` is available under jsdom (matched the pattern used by `packages/content/vitest.config.ts`).

## Sister-agent note

- Edits in `workspace/index.ts` are a single append block (`ToolsDock`, `defineToolsDock`, `useToolsDock`, plus the `TOOLS_DOCK_KEY` symbol and types). Biome auto-sorts, so merges with #1227 / #1228 should be trivial.
- Did not touch `WorkspaceShell.svelte`, `NavTree.svelte`, `Breadcrumbs.svelte`, the root `src/index.ts`, or any other smrt package.

## Test plan
- [ ] Manual: drop a `defineToolsDock(...) + <ToolsDock dock={...}>` into a SvelteKit `+layout.svelte` and verify rail/topbar layouts render
- [ ] Manual: verify Escape closes panel and focus returns to the activator
- [ ] Manual: verify mobile drawer at ≤960px viewport width
- [ ] Manual: verify `storageKey` persists state across reloads
- [ ] CI: `pnpm build && pnpm test` in `packages/smrt-svelte/`

Refs: #1229