### PR TITLE
feat(smrt-svelte): admin layout shell primitives (workspace subpath)

### DIFF
--- a/packages/smrt-svelte/CLAUDE.md
+++ b/packages/smrt-svelte/CLAUDE.md
@@ -76,3 +76,23 @@ Two theme systems: `src/theme/` (simple ThemeProvider with design tokens) and `s
 
 - `@happyvertical/smrt-types` (shared types)
 - Peer: `svelte` >=5.18.2, `@happyvertical/smrt-agents`, `@happyvertical/smrt-jobs`, `@happyvertical/smrt-profiles`, `@happyvertical/smrt-users` (all optional)
+
+## Workspace shell primitives
+
+The `./workspace` subpath (`src/components/workspace/`) holds admin-shell primitives:
+`WorkspaceShell`, `NavTree`, `Breadcrumbs`, and `ToolsDock` (plus `defineToolsDock` /
+`useToolsDock`). Shared types live in `workspace/types.ts` and are re-exported via the
+subpath barrel.
+
+**Layering**: primitives first (this folder), opinionated wrapper second (`AdminShell` — deferred),
+domain-specific tools live outside the framework in consumer packages.
+
+**Principles**:
+- SvelteKit-agnostic — no `$app/state` or `$app/navigation` imports
+- SSR-safe — guard all `window` / `localStorage` access
+- No token bridges — consume `var(--smrt-color-*)` directly
+- Tool IDs are arbitrary strings (extensible, not an enum)
+
+See epic [happyvertical/smrt#1226](https://github.com/happyvertical/smrt/issues/1226) for context;
+implementations land via #1227 (`WorkspaceShell`), #1228 (`NavTree`/`Breadcrumbs`), and #1229
+(`ToolsDock` + registry).

--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -43,6 +43,12 @@
       "import": "./dist/components/ui/index.js",
       "default": "./dist/components/ui/index.js"
     },
+    "./workspace": {
+      "types": "./dist/components/workspace/index.d.ts",
+      "svelte": "./dist/components/workspace/index.js",
+      "import": "./dist/components/workspace/index.js",
+      "default": "./dist/components/workspace/index.js"
+    },
     "./styles/tokens.css": {
       "default": "./dist/styles/tokens.css"
     },

--- a/packages/smrt-svelte/src/components/workspace/Breadcrumbs.svelte
+++ b/packages/smrt-svelte/src/components/workspace/Breadcrumbs.svelte
@@ -68,7 +68,11 @@ const lastIndex = $derived(crumbs.length - 1);
           <span class="separator" aria-hidden="true">/</span>
         {/if}
         {#if i === lastIndex || !crumb.href}
-          <span class="current" aria-current="page">{crumb.label}</span>
+          <span
+            class="current"
+            aria-current={i === lastIndex ? 'page' : undefined}
+            >{crumb.label}</span
+          >
         {:else}
           <a href={crumb.href} class="crumb-link">{crumb.label}</a>
         {/if}

--- a/packages/smrt-svelte/src/components/workspace/Breadcrumbs.svelte
+++ b/packages/smrt-svelte/src/components/workspace/Breadcrumbs.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+/**
+ * Breadcrumbs — generic breadcrumb trail primitive.
+ *
+ * Two modes:
+ *
+ *  - **Explicit**: pass `items` directly.
+ *  - **Auto**: pass `nav` + `pathname` and the component will walk the
+ *    pathname segments, matching against the nav tree for labels and
+ *    falling back to capitalized segments otherwise. Use `rootCrumb`
+ *    to prepend a site/section identity and `startAfter` to skip a
+ *    pathname prefix (e.g. `'sites/foo'` to ignore the
+ *    `/sites/foo` portion of a per-site path).
+ *
+ * SvelteKit-agnostic: no `$app/*` imports. Consumers supply the
+ * pathname externally.
+ */
+import { deriveCrumbsFromNav } from './breadcrumbs-helpers.js';
+import type { BreadcrumbItem, NavItem } from './types.js';
+
+interface Props {
+  /** Explicit crumbs. When provided, `nav` and `pathname` are ignored. */
+  items?: BreadcrumbItem[];
+  /** Nav tree to derive labels from in auto mode. */
+  nav?: NavItem[];
+  /** Pathname to walk in auto mode. */
+  pathname?: string;
+  /** Optional leading crumb (e.g. site name). Auto mode only. */
+  rootCrumb?: BreadcrumbItem;
+  /** Capitalize fallback labels for unknown segments. Default: true. */
+  capitalize?: boolean;
+  /** Skip pathname segments through this path (e.g. `'sites/foo'`). */
+  startAfter?: string;
+  /** Accessible label for the breadcrumb nav. */
+  'aria-label'?: string;
+}
+
+const {
+  items,
+  nav,
+  pathname,
+  rootCrumb,
+  capitalize = true,
+  startAfter,
+  'aria-label': ariaLabel = 'Breadcrumb',
+}: Props = $props();
+
+const crumbs = $derived.by((): BreadcrumbItem[] => {
+  if (items) return items;
+  if (!nav || pathname == null) {
+    return rootCrumb ? [rootCrumb] : [];
+  }
+  return deriveCrumbsFromNav(pathname, nav, {
+    rootCrumb,
+    startAfter,
+    capitalize,
+  });
+});
+
+const lastIndex = $derived(crumbs.length - 1);
+</script>
+
+<nav class="smrt-breadcrumbs" aria-label={ariaLabel}>
+  <ol class="crumb-list">
+    {#each crumbs as crumb, i (`${i}:${crumb.href ?? crumb.label}`)}
+      <li class="crumb-item">
+        {#if i > 0}
+          <span class="separator" aria-hidden="true">/</span>
+        {/if}
+        {#if i === lastIndex || !crumb.href}
+          <span class="current" aria-current="page">{crumb.label}</span>
+        {:else}
+          <a href={crumb.href} class="crumb-link">{crumb.label}</a>
+        {/if}
+      </li>
+    {/each}
+  </ol>
+</nav>
+
+<style>
+  .smrt-breadcrumbs {
+    width: 100%;
+  }
+
+  .crumb-list {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .crumb-item {
+    display: inline-flex;
+    align-items: center;
+    font-size: 0.875rem;
+    color: var(--smrt-color-on-surface-variant);
+  }
+
+  .separator {
+    margin: 0 0.5rem;
+    color: var(--smrt-color-outline-variant);
+    font-size: 0.75rem;
+  }
+
+  .current {
+    font-weight: 500;
+    color: var(--smrt-color-on-surface);
+  }
+
+  .crumb-link {
+    color: var(--smrt-color-on-surface-variant);
+    text-decoration: none;
+    transition: color 0.15s ease;
+  }
+
+  .crumb-link:hover {
+    color: var(--smrt-color-on-surface);
+    text-decoration: underline;
+  }
+
+  .crumb-link:focus-visible {
+    outline: 2px solid var(--smrt-color-primary);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  @media (max-width: 640px) {
+    .crumb-item {
+      font-size: 0.8125rem;
+    }
+    .separator {
+      margin: 0 0.35rem;
+    }
+  }
+</style>

--- a/packages/smrt-svelte/src/components/workspace/NavTree.svelte
+++ b/packages/smrt-svelte/src/components/workspace/NavTree.svelte
@@ -67,6 +67,25 @@ function checkParentActive(item: NavItem): boolean {
 function checkExpanded(item: NavItem): boolean {
   return isExpandedHelper(item, currentPath, isActive);
 }
+
+/**
+ * In collapsed (icon-rail) mode the children container is hidden, so a
+ * parent whose descendant is active would otherwise lose any visible
+ * "current location" indicator. Promote `parent-active` to `active`
+ * styling in that mode.
+ */
+function checkEffectiveActive(item: NavItem): boolean {
+  if (checkActive(item)) return true;
+  if (collapsed && !!item.children?.length && checkParentActive(item))
+    return true;
+  return false;
+}
+
+/** Stable, HTML-safe id derived from an href for `aria-controls` pairing. */
+function navChildrenId(href: string): string {
+  const slug = href.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
+  return `smrt-nav-children-${slug || 'root'}`;
+}
 </script>
 
 <nav class="smrt-nav-tree" class:collapsed aria-label={ariaLabel}>
@@ -74,9 +93,14 @@ function checkExpanded(item: NavItem): boolean {
     <a
       href={item.href}
       class="nav-item level-1"
-      class:active={checkActive(item) && !item.children?.length}
+      class:active={checkEffectiveActive(item) ||
+        (checkActive(item) && !item.children?.length)}
       class:parent-active={checkParentActive(item) && !!item.children?.length}
       title={collapsed ? item.label : item.description}
+      aria-expanded={item.children?.length ? checkExpanded(item) : undefined}
+      aria-controls={item.children?.length
+        ? navChildrenId(item.href)
+        : undefined}
       onclick={onNavigate}
     >
       <span class="nav-icon-slot" aria-hidden="true">
@@ -105,6 +129,7 @@ function checkExpanded(item: NavItem): boolean {
 
     {#if item.children?.length}
       <div
+        id={navChildrenId(item.href)}
         class="children level-2"
         class:expanded={!collapsed && checkExpanded(item)}
       >
@@ -115,6 +140,12 @@ function checkExpanded(item: NavItem): boolean {
             class:active={checkActive(child) && !child.children?.length}
             class:parent-active={checkParentActive(child) && !!child.children?.length}
             title={child.description}
+            aria-expanded={child.children?.length
+              ? checkExpanded(child)
+              : undefined}
+            aria-controls={child.children?.length
+              ? navChildrenId(child.href)
+              : undefined}
             onclick={onNavigate}
           >
             <span class="nav-icon-slot" aria-hidden="true">
@@ -141,8 +172,9 @@ function checkExpanded(item: NavItem): boolean {
 
           {#if child.children?.length}
             <div
+              id={navChildrenId(child.href)}
               class="children level-3"
-              class:expanded={checkExpanded(child)}
+              class:expanded={!collapsed && checkExpanded(child)}
             >
               {#each child.children as grandchild (grandchild.href)}
                 <a

--- a/packages/smrt-svelte/src/components/workspace/NavTree.svelte
+++ b/packages/smrt-svelte/src/components/workspace/NavTree.svelte
@@ -1,0 +1,322 @@
+<script lang="ts">
+/**
+ * NavTree — 3-level recursive sidebar nav primitive.
+ *
+ * Generic and prop-driven: no `$app/*` imports, no SvelteKit dependency.
+ * Consumers pass `currentPath` (e.g. from `page.url.pathname`) and an
+ * optional `iconComponent` for rendering `NavItem.icon` names. When no
+ * icon component is supplied, the raw `icon` string is rendered as text
+ * (useful for emoji / symbol icons).
+ *
+ * Active-state logic is overridable via `isActive`; the default treats
+ * `currentPath === item.href` or `currentPath.startsWith(item.href + '/')`
+ * as active (unless `item.exact === true`).
+ *
+ * In `collapsed` mode the component renders icon-only chips with a
+ * native `title` tooltip; child rows are hidden unless their parent is
+ * itself active (so the chip can highlight without expanding).
+ */
+import type { Component } from 'svelte';
+import {
+  defaultIsActive,
+  isExpanded as isExpandedHelper,
+  isItemOrChildActive,
+} from './nav-helpers.js';
+import type { NavItem } from './types.js';
+
+interface Props {
+  /** Top-level nav items. Each may have up to two levels of children. */
+  items: NavItem[];
+  /** Current pathname. Required — consumers pass `page.url.pathname` or similar. */
+  currentPath: string;
+  /** Called on link click. Consumers typically close a mobile drawer here. */
+  onNavigate?: () => void;
+  /** Override active-detection. Defaults to `defaultIsActive`. */
+  isActive?: (item: NavItem, currentPath: string) => boolean;
+  /**
+   * Optional icon renderer. If omitted, `item.icon` is rendered as plain
+   * text inside the icon slot — handy for emoji/symbol icons.
+   */
+  iconComponent?: Component<{ name: string; size?: number }>;
+  /** Render in collapsed (icon-only) mode. */
+  collapsed?: boolean;
+  /** Accessible label for the surrounding `<nav>` element. */
+  'aria-label'?: string;
+}
+
+const {
+  items,
+  currentPath,
+  onNavigate,
+  isActive: isActiveProp,
+  iconComponent: IconComponent,
+  collapsed = false,
+  'aria-label': ariaLabel = 'Primary',
+}: Props = $props();
+
+const isActive = $derived(isActiveProp ?? defaultIsActive);
+
+function checkActive(item: NavItem): boolean {
+  return isActive(item, currentPath);
+}
+
+function checkParentActive(item: NavItem): boolean {
+  return isItemOrChildActive(item, currentPath, isActive);
+}
+
+function checkExpanded(item: NavItem): boolean {
+  return isExpandedHelper(item, currentPath, isActive);
+}
+</script>
+
+<nav class="smrt-nav-tree" class:collapsed aria-label={ariaLabel}>
+  {#each items as item (item.href)}
+    <a
+      href={item.href}
+      class="nav-item level-1"
+      class:active={checkActive(item) && !item.children?.length}
+      class:parent-active={checkParentActive(item) && !!item.children?.length}
+      title={collapsed ? item.label : item.description}
+      onclick={onNavigate}
+    >
+      <span class="nav-icon-slot" aria-hidden="true">
+        {#if IconComponent && item.icon}
+          <IconComponent name={item.icon} size={18} />
+        {:else if item.icon}
+          <span class="nav-icon-text">{item.icon}</span>
+        {/if}
+      </span>
+      {#if !collapsed}
+        <span class="nav-label">{item.label}</span>
+        {#if item.badge != null && item.badge !== ''}
+          <span class="nav-badge">{item.badge}</span>
+        {/if}
+        {#if item.children?.length}
+          <span
+            class="nav-chevron"
+            class:expanded={checkExpanded(item)}
+            aria-hidden="true"
+          >
+            ›
+          </span>
+        {/if}
+      {/if}
+    </a>
+
+    {#if item.children?.length}
+      <div
+        class="children level-2"
+        class:expanded={!collapsed && checkExpanded(item)}
+      >
+        {#each item.children as child (child.href)}
+          <a
+            href={child.href}
+            class="nav-item level-2"
+            class:active={checkActive(child) && !child.children?.length}
+            class:parent-active={checkParentActive(child) && !!child.children?.length}
+            title={child.description}
+            onclick={onNavigate}
+          >
+            <span class="nav-icon-slot" aria-hidden="true">
+              {#if IconComponent && child.icon}
+                <IconComponent name={child.icon} size={16} />
+              {:else if child.icon}
+                <span class="nav-icon-text">{child.icon}</span>
+              {/if}
+            </span>
+            <span class="nav-label">{child.label}</span>
+            {#if child.badge != null && child.badge !== ''}
+              <span class="nav-badge">{child.badge}</span>
+            {/if}
+            {#if child.children?.length}
+              <span
+                class="nav-chevron"
+                class:expanded={checkExpanded(child)}
+                aria-hidden="true"
+              >
+                ›
+              </span>
+            {/if}
+          </a>
+
+          {#if child.children?.length}
+            <div
+              class="children level-3"
+              class:expanded={checkExpanded(child)}
+            >
+              {#each child.children as grandchild (grandchild.href)}
+                <a
+                  href={grandchild.href}
+                  class="nav-item level-3"
+                  class:active={checkActive(grandchild)}
+                  title={grandchild.description}
+                  onclick={onNavigate}
+                >
+                  <span class="nav-icon-slot" aria-hidden="true">
+                    {#if IconComponent && grandchild.icon}
+                      <IconComponent name={grandchild.icon} size={15} />
+                    {:else if grandchild.icon}
+                      <span class="nav-icon-text">{grandchild.icon}</span>
+                    {/if}
+                  </span>
+                  <span class="nav-label">{grandchild.label}</span>
+                  {#if grandchild.badge != null && grandchild.badge !== ''}
+                    <span class="nav-badge">{grandchild.badge}</span>
+                  {/if}
+                </a>
+              {/each}
+            </div>
+          {/if}
+        {/each}
+      </div>
+    {/if}
+  {/each}
+</nav>
+
+<style>
+  .smrt-nav-tree {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .nav-item {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    color: var(--smrt-color-on-surface-variant);
+    text-decoration: none;
+    transition:
+      color 0.15s ease,
+      background 0.15s ease,
+      border-color 0.15s ease;
+    border-left: 3px solid transparent;
+  }
+
+  .nav-item:hover {
+    color: var(--smrt-color-on-surface);
+    background: var(--smrt-color-surface-container-high);
+  }
+
+  .nav-item:focus-visible {
+    outline: 2px solid var(--smrt-color-primary);
+    outline-offset: -2px;
+  }
+
+  .nav-item.active {
+    color: var(--smrt-color-on-primary-container);
+    background: var(--smrt-color-primary-container);
+    border-left-color: var(--smrt-color-primary);
+  }
+
+  .nav-item.parent-active {
+    color: var(--smrt-color-on-surface);
+    font-weight: 500;
+  }
+
+  .nav-icon-slot {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    flex-shrink: 0;
+    color: var(--smrt-color-on-surface-variant);
+  }
+
+  .nav-icon-text {
+    font-size: 1rem;
+    line-height: 1;
+  }
+
+  .nav-label {
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .nav-badge {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.25rem;
+    padding: 0 0.4rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    line-height: 1.2;
+    border-radius: 999px;
+    background: var(--smrt-color-secondary-container);
+    color: var(--smrt-color-on-secondary-container);
+  }
+
+  .nav-chevron {
+    flex-shrink: 0;
+    color: var(--smrt-color-on-surface-variant);
+    font-size: 1rem;
+    line-height: 1;
+    transform: rotate(0deg);
+    transition:
+      transform 0.15s ease,
+      color 0.15s ease;
+  }
+
+  .nav-chevron.expanded {
+    transform: rotate(90deg);
+    color: var(--smrt-color-on-surface);
+  }
+
+  /* Level 1 */
+  .nav-item.level-1 {
+    padding: 0.625rem 1rem;
+    font-size: 0.875rem;
+  }
+
+  /* Level 2 */
+  .nav-item.level-2 {
+    padding: 0.5rem 1rem 0.5rem 2.75rem;
+    font-size: 0.8125rem;
+  }
+  .nav-item.level-2 .nav-icon-slot {
+    width: 1rem;
+  }
+  .nav-item.level-2 .nav-icon-text {
+    font-size: 0.875rem;
+  }
+
+  /* Level 3 */
+  .nav-item.level-3 {
+    padding: 0.45rem 1rem 0.45rem 4rem;
+    font-size: 0.78rem;
+  }
+  .nav-item.level-3 .nav-icon-slot {
+    width: 0.95rem;
+  }
+  .nav-item.level-3 .nav-icon-text {
+    font-size: 0.8125rem;
+  }
+
+  /* Children containers — collapsed by default, shown when .expanded */
+  .children {
+    display: none;
+    flex-direction: column;
+  }
+  .children.expanded {
+    display: flex;
+  }
+
+  /* Collapsed (icon-only) mode */
+  .smrt-nav-tree.collapsed .nav-item.level-1 {
+    justify-content: center;
+    padding: 0.625rem 0.5rem;
+  }
+  .smrt-nav-tree.collapsed .nav-label,
+  .smrt-nav-tree.collapsed .nav-chevron,
+  .smrt-nav-tree.collapsed .nav-badge {
+    display: none;
+  }
+  /* In collapsed mode, never show nested children. */
+  .smrt-nav-tree.collapsed .children {
+    display: none;
+  }
+</style>

--- a/packages/smrt-svelte/src/components/workspace/README.md
+++ b/packages/smrt-svelte/src/components/workspace/README.md
@@ -1,0 +1,34 @@
+# workspace/
+
+Upstream admin shell primitives for SMRT consumer apps. These pieces are
+SvelteKit-agnostic, SSR-safe, and carry no domain coupling — they slot into
+any Svelte 5 app that wants a sidebar + topbar + tools-dock layout.
+
+## Tracking
+
+- Epic: [happyvertical/smrt#1226](https://github.com/happyvertical/smrt/issues/1226)
+- Implementers:
+  - `WorkspaceShell` — [#1227](https://github.com/happyvertical/smrt/issues/1227)
+  - `NavTree`, `Breadcrumbs` — [#1228](https://github.com/happyvertical/smrt/issues/1228)
+  - `ToolsDock`, `defineToolsDock`, `useToolsDock` — [#1229](https://github.com/happyvertical/smrt/issues/1229)
+
+## Shared types (this PR)
+
+Exported from `./types.js` via the barrel:
+
+- `NavItem`, `BreadcrumbItem`
+- `ToolDef`, `AvailableTool`, `ToolsDockContext`, `ToolsDockApi`
+
+## Planned component exports
+
+- `WorkspaceShell` (#1227) — outer shell layout primitive
+- `NavTree`, `Breadcrumbs` (#1228) — navigation primitives consuming `NavItem` / `BreadcrumbItem`
+- `ToolsDock` + `defineToolsDock` + `useToolsDock` (#1229) — right-rail tools dock + registry
+
+## Principles
+
+- **SvelteKit-agnostic** — no `$app/state` or `$app/navigation` imports
+- **SSR-safe** — guard all `window` / `localStorage` access
+- **No token bridges** — consume `var(--smrt-color-*)` tokens directly
+- **No domain coupling** — domain-specific tools live in consumer packages
+- **Extensible tool IDs** — tool IDs are arbitrary strings, not an enum

--- a/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
@@ -1,0 +1,750 @@
+<script lang="ts">
+import type { Snippet } from 'svelte';
+
+/**
+ * WorkspaceShell — SvelteKit-agnostic, SSR-safe admin shell primitive.
+ *
+ * A composition of snippet slots that lays out a typical workspace UI: brand
+ * + nav sidebar, sticky topbar, main content, optional right-side inspector
+ * panel and a thin icon rail. The component owns no domain logic — every
+ * visible region (brand, nav, account menu, tools dock, etc.) is provided by
+ * the consumer via Svelte 5 snippets.
+ *
+ * Responsive behavior:
+ * - Desktop (>1240px): sidebar visible, inspector fixed-right when open.
+ * - Tablet (961–1240px): sidebar collapses to icon rail.
+ * - Mobile (≤960px): sidebar becomes a drawer with backdrop; inspector
+ *   becomes a right-side drawer with backdrop.
+ *
+ * Sidebar collapse is controlled — consumer owns persistence. Mobile drawer
+ * state is internal and transient.
+ *
+ * See `@happyvertical/smrt#1227` for the issue tracking this primitive.
+ */
+
+export interface Props {
+  /** Brand/product title shown in the brand snippet area fallback. */
+  title?: string;
+  /** Secondary line under the title. */
+  subtitle?: string;
+  /** Small uppercase eyebrow label rendered above the title. */
+  eyebrow?: string;
+  /** Topbar mode label (e.g. "Local-first mode"). */
+  modeLabel?: string;
+  /** Status keyword that maps to a dot color. */
+  modeStatus?:
+    | 'active'
+    | 'offline'
+    | 'local-only'
+    | 'attention'
+    | (string & {});
+  /** Secondary detail line shown next to the mode badge. */
+  modeDetail?: string;
+  /** Whether the inspector panel/drawer is currently shown. */
+  showInspector?: boolean;
+  /** Invoked when the inspector close button (or Escape) is activated. */
+  onCloseInspector?: () => void;
+  /** Sidebar collapsed state (controlled by consumer). */
+  collapsed?: boolean;
+  /** Invoked when the internal collapse toggle is clicked. */
+  onToggleCollapsed?: () => void;
+  /** Whether to render the collapse toggle at all. Default: true. */
+  collapsible?: boolean;
+  /** Top-left brand area (logo + product name). */
+  brand?: Snippet;
+  /** Main sidebar navigation region. */
+  nav?: Snippet;
+  /** Bottom of sidebar (account menu, tenant switcher, etc.). */
+  sidebarFooter?: Snippet;
+  /** Right side of the top bar. */
+  topbarActions?: Snippet;
+  /** Optional vertical icon rail along the right edge. */
+  inspectorRail?: Snippet;
+  /** Inspector panel content (right side). */
+  inspector?: Snippet;
+  /** Main content. */
+  children: Snippet;
+}
+
+const {
+  title = '',
+  subtitle = '',
+  eyebrow = '',
+  modeLabel = '',
+  modeStatus = '',
+  modeDetail = '',
+  showInspector = false,
+  onCloseInspector,
+  collapsed = false,
+  onToggleCollapsed,
+  collapsible = true,
+  brand,
+  nav,
+  sidebarFooter,
+  topbarActions,
+  inspectorRail,
+  inspector,
+  children,
+}: Props = $props();
+
+let mobileNavOpen = $state(false);
+
+function toggleMobileNav(): void {
+  mobileNavOpen = !mobileNavOpen;
+}
+
+function closeMobileNav(): void {
+  mobileNavOpen = false;
+}
+
+function handleCollapseToggle(): void {
+  onToggleCollapsed?.();
+}
+
+function handleInspectorClose(): void {
+  onCloseInspector?.();
+}
+
+// Escape closes inspector if open. Mounted-only (SSR-safe via $effect).
+$effect(() => {
+  if (typeof window === 'undefined') return;
+
+  function onKeydown(event: KeyboardEvent) {
+    if (event.key !== 'Escape') return;
+    if (mobileNavOpen) {
+      mobileNavOpen = false;
+      return;
+    }
+    if (showInspector && onCloseInspector) {
+      onCloseInspector();
+    }
+  }
+
+  window.addEventListener('keydown', onKeydown);
+  return () => window.removeEventListener('keydown', onKeydown);
+});
+
+const hasInspector = $derived(Boolean(inspector) && showInspector);
+const hasInspectorRail = $derived(Boolean(inspectorRail));
+</script>
+
+<div
+  class="smrt-workspace-shell"
+  class:sidebar-collapsed={collapsed}
+  class:nav-open={mobileNavOpen}
+  class:has-inspector={hasInspector}
+  class:has-inspector-rail={hasInspectorRail}
+>
+  <!-- Mobile sidebar backdrop -->
+  <button
+    class="mobile-backdrop"
+    type="button"
+    aria-label="Close navigation"
+    tabindex={mobileNavOpen ? 0 : -1}
+    onclick={closeMobileNav}
+  ></button>
+
+  <!-- Mobile inspector backdrop -->
+  {#if hasInspector}
+    <button
+      class="inspector-backdrop"
+      type="button"
+      aria-label="Close inspector"
+      onclick={handleInspectorClose}
+    ></button>
+  {/if}
+
+  <aside class="smrt-workspace-sidebar" aria-label="Primary navigation">
+    <div class="brand-row">
+      <div class="brand">
+        {#if brand}
+          {@render brand()}
+        {:else}
+          {#if eyebrow}
+            <span class="eyebrow">{eyebrow}</span>
+          {/if}
+          {#if title}
+            <h1>{title}</h1>
+          {/if}
+          {#if subtitle}
+            <p class="subtitle">{subtitle}</p>
+          {/if}
+        {/if}
+      </div>
+
+      {#if collapsible}
+        <button
+          class="shell-toggle"
+          type="button"
+          onclick={handleCollapseToggle}
+          aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          aria-expanded={!collapsed}
+        >
+          <span class="shell-toggle-glyph" aria-hidden="true">
+            {collapsed ? '›' : '‹'}
+          </span>
+        </button>
+      {/if}
+    </div>
+
+    {#if nav}
+      <nav class="nav-region" aria-label="Workspace navigation">
+        {@render nav()}
+      </nav>
+    {/if}
+
+    {#if sidebarFooter}
+      <div class="sidebar-footer">
+        {@render sidebarFooter()}
+      </div>
+    {/if}
+  </aside>
+
+  <div class="smrt-workspace-main">
+    <header class="smrt-workspace-topbar">
+      <div class="topbar-left">
+        <button
+          class="mobile-menu"
+          type="button"
+          onclick={toggleMobileNav}
+          aria-label={mobileNavOpen ? 'Close navigation' : 'Open navigation'}
+          aria-expanded={mobileNavOpen}
+        >
+          <span aria-hidden="true">≡</span>
+        </button>
+        <div class="topbar-brand">
+          {#if eyebrow}
+            <div class="eyebrow topbar-eyebrow">{eyebrow}</div>
+          {/if}
+          {#if modeLabel}
+            <p class="mode-title">{modeLabel}</p>
+          {/if}
+        </div>
+      </div>
+
+      <div class="topbar-right">
+        {#if topbarActions}
+          <div class="topbar-actions">
+            {@render topbarActions()}
+          </div>
+        {/if}
+        {#if modeLabel || modeStatus}
+          <span
+            class="mode-badge"
+            data-status={modeStatus || 'default'}
+            role="status"
+            aria-live="polite"
+          >
+            <span class="mode-dot" aria-hidden="true"></span>
+            <span class="mode-badge-label">{modeLabel || modeStatus}</span>
+          </span>
+        {/if}
+        {#if modeDetail}
+          <p class="mode-detail">{modeDetail}</p>
+        {/if}
+      </div>
+    </header>
+
+    <div class="smrt-workspace-stage">
+      <main class="smrt-workspace-content">
+        {@render children()}
+      </main>
+
+      {#if hasInspector}
+        <aside class="smrt-workspace-inspector" aria-label="Inspector panel">
+          <div class="inspector-header">
+            <span class="inspector-title">Inspector</span>
+            {#if onCloseInspector}
+              <button
+                class="inspector-close"
+                type="button"
+                onclick={handleInspectorClose}
+                aria-label="Close inspector"
+              >
+                <span aria-hidden="true">×</span>
+              </button>
+            {/if}
+          </div>
+          <div class="inspector-body">
+            {@render inspector!()}
+          </div>
+        </aside>
+      {/if}
+
+      {#if hasInspectorRail}
+        <div class="smrt-workspace-inspector-rail" aria-label="Inspector tools">
+          {@render inspectorRail!()}
+        </div>
+      {/if}
+    </div>
+  </div>
+</div>
+
+<style>
+  .smrt-workspace-shell {
+    --smrt-ws-sidebar-width: 280px;
+    --smrt-ws-sidebar-collapsed-width: 96px;
+    --smrt-ws-inspector-width: min(420px, calc(100vw - var(--smrt-ws-sidebar-width) - 1rem));
+    --smrt-ws-rail-width: 3.25rem;
+    --smrt-ws-topbar-height: 3.75rem;
+    --smrt-ws-page-pad: 1.5rem;
+
+    position: relative;
+    display: grid;
+    grid-template-columns: var(--smrt-ws-sidebar-width) 1fr;
+    min-height: 100vh;
+    min-height: 100dvh;
+    background: var(--smrt-color-surface-container-low, #f8fafc);
+    color: var(--smrt-color-on-surface, #1f2937);
+    isolation: isolate;
+  }
+
+  .smrt-workspace-shell.sidebar-collapsed {
+    grid-template-columns: var(--smrt-ws-sidebar-collapsed-width) 1fr;
+  }
+
+  /* ─── Sidebar ─────────────────────────────────────────── */
+
+  .smrt-workspace-sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    padding: 1.25rem 1rem;
+    background: var(--smrt-color-surface, #ffffff);
+    border-right: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
+    min-width: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    z-index: 20;
+  }
+
+  .brand-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .brand {
+    display: grid;
+    gap: 0.35rem;
+    min-width: 0;
+  }
+
+  .brand :global(h1),
+  .brand h1 {
+    margin: 0;
+    font-size: 1.25rem;
+    line-height: 1.1;
+    color: var(--smrt-color-on-surface, #111827);
+    font-weight: 600;
+  }
+
+  .brand .subtitle {
+    margin: 0;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
+    line-height: 1.4;
+    font-size: 0.9rem;
+  }
+
+  .eyebrow {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
+  }
+
+  .shell-toggle {
+    appearance: none;
+    border: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
+    background: var(--smrt-color-surface-container, #f3f4f6);
+    color: var(--smrt-color-on-surface, #111827);
+    border-radius: var(--smrt-radius-medium, 0.65rem);
+    width: 2rem;
+    height: 2rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    flex-shrink: 0;
+    transition:
+      background-color 150ms ease,
+      color 150ms ease;
+  }
+
+  .shell-toggle:hover {
+    background: var(--smrt-color-surface-container-high, #e5e7eb);
+  }
+
+  .shell-toggle:focus-visible {
+    outline: 2px solid var(--smrt-color-primary, #2563eb);
+    outline-offset: 2px;
+  }
+
+  .shell-toggle-glyph {
+    font-size: 1rem;
+    line-height: 1;
+  }
+
+  .nav-region {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    gap: 0.5rem;
+  }
+
+  .sidebar-footer {
+    margin-top: auto;
+    display: grid;
+    gap: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
+  }
+
+  /* ─── Main column ─────────────────────────────────────── */
+
+  .smrt-workspace-main {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+  }
+
+  .smrt-workspace-topbar {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.85rem;
+    padding: 0.75rem var(--smrt-ws-page-pad);
+    min-height: var(--smrt-ws-topbar-height);
+    background: var(--smrt-color-surface, #ffffff);
+    border-bottom: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
+    box-shadow: var(--smrt-elevation-level1, 0 1px 2px rgb(0 0 0 / 0.05));
+  }
+
+  .topbar-left,
+  .topbar-right {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    min-width: 0;
+  }
+
+  .topbar-right {
+    justify-content: flex-end;
+    flex-wrap: wrap;
+  }
+
+  .topbar-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+  }
+
+  .topbar-brand {
+    display: grid;
+    gap: 0.1rem;
+    min-width: 0;
+  }
+
+  .topbar-eyebrow {
+    color: var(--smrt-color-on-surface-variant, #6b7280);
+  }
+
+  .mode-title,
+  .mode-detail {
+    margin: 0;
+  }
+
+  .mode-title {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--smrt-color-on-surface, #111827);
+  }
+
+  .mode-detail {
+    color: var(--smrt-color-on-surface-variant, #6b7280);
+    max-width: 18rem;
+    text-align: right;
+    font-size: 0.85rem;
+  }
+
+  .mode-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.25rem 0.65rem;
+    border-radius: var(--smrt-radius-full, 999px);
+    border: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
+    background: var(--smrt-color-surface-container, #f3f4f6);
+    color: var(--smrt-color-on-surface, #111827);
+    font-size: 0.78rem;
+    font-weight: 600;
+    line-height: 1;
+    white-space: nowrap;
+  }
+
+  .mode-dot {
+    width: 0.55rem;
+    height: 0.55rem;
+    border-radius: 999px;
+    background: var(--smrt-color-on-surface-variant, #9ca3af);
+    flex-shrink: 0;
+  }
+
+  .mode-badge[data-status='active'] .mode-dot {
+    background: var(--smrt-color-success, #16a34a);
+  }
+  .mode-badge[data-status='offline'] .mode-dot {
+    background: var(--smrt-color-on-surface-variant, #9ca3af);
+  }
+  .mode-badge[data-status='local-only'] .mode-dot {
+    background: var(--smrt-color-primary, #2563eb);
+  }
+  .mode-badge[data-status='attention'] .mode-dot {
+    background: var(--smrt-color-warning, #f59e0b);
+  }
+
+  .mobile-menu {
+    display: none;
+    appearance: none;
+    border: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
+    background: var(--smrt-color-surface, #ffffff);
+    color: var(--smrt-color-on-surface, #111827);
+    border-radius: var(--smrt-radius-medium, 0.65rem);
+    width: 2.35rem;
+    height: 2.35rem;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-size: 1.1rem;
+    line-height: 1;
+  }
+
+  .mobile-menu:focus-visible,
+  .inspector-close:focus-visible {
+    outline: 2px solid var(--smrt-color-primary, #2563eb);
+    outline-offset: 2px;
+  }
+
+  /* ─── Stage / content / inspector ─────────────────────── */
+
+  .smrt-workspace-stage {
+    flex: 1;
+    min-height: 0;
+    position: relative;
+  }
+
+  .smrt-workspace-content {
+    padding: var(--smrt-ws-page-pad);
+    min-width: 0;
+  }
+
+  .smrt-workspace-inspector {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: var(--smrt-ws-inspector-width);
+    display: flex;
+    flex-direction: column;
+    background: var(--smrt-color-surface, #ffffff);
+    border-left: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
+    box-shadow: var(--smrt-elevation-level2, 0 4px 6px -1px rgb(0 0 0 / 0.1));
+    z-index: 22;
+  }
+
+  .inspector-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.85rem 1rem;
+    border-bottom: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
+  }
+
+  .inspector-title {
+    font-weight: 600;
+    color: var(--smrt-color-on-surface, #111827);
+    font-size: 0.95rem;
+  }
+
+  .inspector-close {
+    appearance: none;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
+    border-radius: var(--smrt-radius-medium, 0.5rem);
+    width: 2rem;
+    height: 2rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.25rem;
+    line-height: 1;
+    cursor: pointer;
+    transition:
+      background-color 150ms ease,
+      color 150ms ease;
+  }
+
+  .inspector-close:hover {
+    background: var(--smrt-color-surface-container-high, #e5e7eb);
+    color: var(--smrt-color-on-surface, #111827);
+  }
+
+  .inspector-body {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 1rem;
+  }
+
+  .smrt-workspace-inspector-rail {
+    position: fixed;
+    top: var(--smrt-ws-topbar-height);
+    right: 0;
+    bottom: 0;
+    width: var(--smrt-ws-rail-width);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.75rem 0.25rem;
+    background: var(--smrt-color-surface, #ffffff);
+    border-left: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
+    z-index: 18;
+  }
+
+  /* When both inspector + rail are present, push rail off the panel. */
+  .smrt-workspace-shell.has-inspector.has-inspector-rail .smrt-workspace-inspector-rail {
+    right: var(--smrt-ws-inspector-width);
+  }
+
+  /* Reserve room on the right side so content doesn't slide under panel/rail. */
+  @media (min-width: 961px) {
+    .smrt-workspace-shell.has-inspector .smrt-workspace-content,
+    .smrt-workspace-shell.has-inspector .smrt-workspace-topbar {
+      padding-right: calc(var(--smrt-ws-inspector-width) + 1rem);
+    }
+
+    .smrt-workspace-shell.has-inspector-rail:not(.has-inspector)
+      .smrt-workspace-content,
+    .smrt-workspace-shell.has-inspector-rail:not(.has-inspector)
+      .smrt-workspace-topbar {
+      padding-right: calc(var(--smrt-ws-rail-width) + 1rem);
+    }
+  }
+
+  /* ─── Backdrops (mobile only — hidden otherwise) ──────── */
+
+  .mobile-backdrop,
+  .inspector-backdrop {
+    display: none;
+  }
+
+  /* ─── Tablet — collapse sidebar to icon rail ──────────── */
+
+  @media (max-width: 1240px) and (min-width: 961px) {
+    .smrt-workspace-shell {
+      grid-template-columns: var(--smrt-ws-sidebar-collapsed-width) 1fr;
+    }
+
+    .smrt-workspace-shell .brand-row {
+      justify-content: center;
+    }
+
+    .smrt-workspace-shell .shell-toggle {
+      display: none;
+    }
+
+    .smrt-workspace-shell .brand .subtitle,
+    .smrt-workspace-shell.sidebar-collapsed .brand .subtitle {
+      display: none;
+    }
+  }
+
+  /* ─── Mobile — drawer sidebar, drawer inspector ───────── */
+
+  @media (max-width: 960px) {
+    .smrt-workspace-shell,
+    .smrt-workspace-shell.sidebar-collapsed {
+      grid-template-columns: 1fr;
+    }
+
+    .mobile-menu {
+      display: inline-flex;
+    }
+
+    .shell-toggle {
+      display: none;
+    }
+
+    .smrt-workspace-sidebar {
+      position: fixed;
+      inset: 0 auto 0 0;
+      width: min(320px, calc(100vw - 3rem));
+      transform: translateX(-100%);
+      transition: transform 180ms ease;
+      z-index: 30;
+    }
+
+    .smrt-workspace-shell.nav-open .smrt-workspace-sidebar {
+      transform: translateX(0);
+    }
+
+    .mobile-backdrop {
+      display: block;
+      position: fixed;
+      inset: 0;
+      background: rgba(3, 7, 14, 0.55);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 180ms ease;
+      border: 0;
+      z-index: 25;
+    }
+
+    .smrt-workspace-shell.nav-open .mobile-backdrop {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .smrt-workspace-inspector {
+      width: min(100vw, 420px);
+    }
+
+    .smrt-workspace-shell.has-inspector .smrt-workspace-inspector-rail,
+    .smrt-workspace-shell.has-inspector-rail:not(.has-inspector)
+      .smrt-workspace-inspector-rail {
+      top: 0;
+    }
+
+    .smrt-workspace-shell.has-inspector .smrt-workspace-content,
+    .smrt-workspace-shell.has-inspector .smrt-workspace-topbar,
+    .smrt-workspace-shell.has-inspector-rail:not(.has-inspector)
+      .smrt-workspace-content,
+    .smrt-workspace-shell.has-inspector-rail:not(.has-inspector)
+      .smrt-workspace-topbar {
+      padding-right: var(--smrt-ws-page-pad);
+    }
+
+    .inspector-backdrop {
+      display: block;
+      position: fixed;
+      inset: 0;
+      background: rgba(3, 7, 14, 0.4);
+      border: 0;
+      z-index: 21;
+    }
+
+    .mode-detail {
+      max-width: 100%;
+      text-align: left;
+    }
+  }
+</style>

--- a/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
@@ -42,7 +42,24 @@ export interface Props {
   modeDetail?: string;
   /** Whether the inspector panel/drawer is currently shown. */
   showInspector?: boolean;
-  /** Invoked when the inspector close button (or Escape) is activated. */
+  /**
+   * Label rendered in the inspector header. Defaults to `'Inspector'`.
+   * Consumers may rename to `'Properties'`, `'Details'`, etc.
+   */
+  inspectorTitle?: string;
+  /**
+   * Invoked when the inspector close button (or Escape) is activated.
+   *
+   * Focus restoration: because `showInspector` is a controlled prop, the
+   * consumer owns when the inspector opens and is therefore responsible
+   * for restoring focus to the activating element after close (WCAG
+   * 2.4.3). A common pattern is to capture `document.activeElement`
+   * immediately before flipping `showInspector` to `true`, then call
+   * `.focus()` on it inside this handler.
+   *
+   * The component-owned mobile drawer handles focus restoration
+   * internally — only the inspector is consumer-driven.
+   */
   onCloseInspector?: () => void;
   /** Sidebar collapsed state (controlled by consumer). */
   collapsed?: boolean;
@@ -74,6 +91,7 @@ const {
   modeStatus = '',
   modeDetail = '',
   showInspector = false,
+  inspectorTitle = 'Inspector',
   onCloseInspector,
   collapsed = false,
   onToggleCollapsed,
@@ -88,13 +106,52 @@ const {
 }: Props = $props();
 
 let mobileNavOpen = $state(false);
+/**
+ * Tracks whether the viewport is in the mobile drawer breakpoint
+ * (≤960px). Used to mark the sidebar `inert` when it's slid off-screen
+ * so keyboard users can't tab into invisible nav links. SSR-safe — stays
+ * `false` until mounted, which matches the desktop-first default layout.
+ */
+let isMobileViewport = $state(false);
+/**
+ * Element that held focus when the mobile drawer was opened. We restore
+ * focus to it when the drawer closes (Escape, backdrop click, etc.) to
+ * satisfy WCAG 2.4.3 Focus Order for the component-owned drawer state.
+ * The inspector's open state is consumer-controlled, so focus restoration
+ * for it is documented as a caller responsibility (see `onCloseInspector`).
+ */
+let lastFocusedBeforeMobileNav: HTMLElement | null = null;
 
 function toggleMobileNav(): void {
-  mobileNavOpen = !mobileNavOpen;
+  if (!mobileNavOpen) {
+    // Capture the currently focused element before we open the drawer so
+    // we can return focus to it on close (WCAG 2.4.3).
+    if (typeof document !== 'undefined') {
+      const active = document.activeElement;
+      lastFocusedBeforeMobileNav =
+        active instanceof HTMLElement ? active : null;
+    }
+    mobileNavOpen = true;
+  } else {
+    closeMobileNav();
+  }
 }
 
 function closeMobileNav(): void {
   mobileNavOpen = false;
+  // Restore focus to the element that opened the drawer (the hamburger
+  // button in the default flow). Guarded so SSR/non-DOM environments are
+  // a no-op, and so a detached/removed element doesn't throw.
+  const target = lastFocusedBeforeMobileNav;
+  lastFocusedBeforeMobileNav = null;
+  if (
+    target &&
+    typeof document !== 'undefined' &&
+    document.contains(target) &&
+    typeof target.focus === 'function'
+  ) {
+    target.focus();
+  }
 }
 
 function handleCollapseToggle(): void {
@@ -105,14 +162,15 @@ function handleInspectorClose(): void {
   onCloseInspector?.();
 }
 
-// Escape closes inspector if open. Mounted-only (SSR-safe via $effect).
+// Escape closes mobile drawer (with focus restoration) or inspector if
+// open. Mounted-only (SSR-safe via $effect).
 $effect(() => {
   if (typeof window === 'undefined') return;
 
   function onKeydown(event: KeyboardEvent) {
     if (event.key !== 'Escape') return;
     if (mobileNavOpen) {
-      mobileNavOpen = false;
+      closeMobileNav();
       return;
     }
     if (showInspector && onCloseInspector) {
@@ -124,8 +182,39 @@ $effect(() => {
   return () => window.removeEventListener('keydown', onKeydown);
 });
 
+// Track mobile breakpoint so the sidebar can be marked `inert` while it
+// is slid off-screen. Mirrors the `@media (max-width: 960px)` block.
+$effect(() => {
+  if (typeof window === 'undefined' || !window.matchMedia) return;
+
+  const mql = window.matchMedia('(max-width: 960px)');
+  isMobileViewport = mql.matches;
+
+  function handleChange(event: MediaQueryListEvent) {
+    isMobileViewport = event.matches;
+  }
+
+  // `addEventListener` is the modern API. Older Safari only has
+  // `addListener` — feature-detect to stay compatible.
+  if (typeof mql.addEventListener === 'function') {
+    mql.addEventListener('change', handleChange);
+    return () => mql.removeEventListener('change', handleChange);
+  }
+  // @ts-expect-error legacy MediaQueryList API
+  mql.addListener(handleChange);
+  return () => {
+    // @ts-expect-error legacy MediaQueryList API
+    mql.removeListener(handleChange);
+  };
+});
+
 const hasInspector = $derived(Boolean(inspector) && showInspector);
 const hasInspectorRail = $derived(Boolean(inspectorRail));
+/**
+ * Mark the sidebar `inert` when it's slid off-screen on mobile so keyboard
+ * users can't tab into invisible nav links / footer controls.
+ */
+const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
 </script>
 
 <div
@@ -144,17 +233,30 @@ const hasInspectorRail = $derived(Boolean(inspectorRail));
     onclick={closeMobileNav}
   ></button>
 
-  <!-- Mobile inspector backdrop -->
+  <!--
+    Mobile inspector backdrop. Only renders an interactive button when the
+    consumer provided `onCloseInspector` — otherwise the backdrop would be a
+    focusable no-op. When no close handler is provided we render a passive
+    `<div>` so the visual scrim still appears on mobile.
+  -->
   {#if hasInspector}
-    <button
-      class="inspector-backdrop"
-      type="button"
-      aria-label="Close inspector"
-      onclick={handleInspectorClose}
-    ></button>
+    {#if onCloseInspector}
+      <button
+        class="inspector-backdrop"
+        type="button"
+        aria-label="Close inspector"
+        onclick={handleInspectorClose}
+      ></button>
+    {:else}
+      <div class="inspector-backdrop" aria-hidden="true"></div>
+    {/if}
   {/if}
 
-  <aside class="smrt-workspace-sidebar" aria-label="Primary navigation">
+  <aside
+    class="smrt-workspace-sidebar"
+    aria-label="Primary navigation"
+    inert={sidebarInert}
+  >
     <div class="brand-row">
       <div class="brand">
         {#if brand}
@@ -251,9 +353,14 @@ const hasInspectorRail = $derived(Boolean(inspectorRail));
       </main>
 
       {#if hasInspector}
-        <aside class="smrt-workspace-inspector" aria-label="Inspector panel">
+        <aside
+          class="smrt-workspace-inspector"
+          aria-labelledby="smrt-ws-inspector-title"
+        >
           <div class="inspector-header">
-            <span class="inspector-title">Inspector</span>
+            <span id="smrt-ws-inspector-title" class="inspector-title"
+              >{inspectorTitle}</span
+            >
             {#if onCloseInspector}
               <button
                 class="inspector-close"
@@ -301,6 +408,17 @@ const hasInspectorRail = $derived(Boolean(inspectorRail));
 
   .smrt-workspace-shell.sidebar-collapsed {
     grid-template-columns: var(--smrt-ws-sidebar-collapsed-width) 1fr;
+    /*
+     * When the sidebar is collapsed, recompute the inspector-width clamp
+     * against the collapsed sidebar so narrower desktops with both the
+     * inspector and a collapsed sidebar still fit content. Without this
+     * override, padding-right on `.smrt-workspace-content` would still be
+     * sized as if the sidebar were full-width.
+     */
+    --smrt-ws-inspector-width: min(
+      420px,
+      calc(100vw - var(--smrt-ws-sidebar-collapsed-width) - 1rem)
+    );
   }
 
   /* ─── Sidebar ─────────────────────────────────────────── */
@@ -638,13 +756,36 @@ const hasInspectorRail = $derived(Boolean(inspectorRail));
       .smrt-workspace-topbar {
       padding-right: calc(var(--smrt-ws-rail-width) + 1rem);
     }
+
+    /*
+     * When both the inspector panel AND the icon rail are present, the rail
+     * sits to the left of the panel (see `.has-inspector.has-inspector-rail
+     * .smrt-workspace-inspector-rail` above). Content padding must reserve
+     * room for both, otherwise the rail overlaps the right edge of content
+     * and topbar.
+     */
+    .smrt-workspace-shell.has-inspector.has-inspector-rail
+      .smrt-workspace-content,
+    .smrt-workspace-shell.has-inspector.has-inspector-rail
+      .smrt-workspace-topbar {
+      padding-right: calc(
+        var(--smrt-ws-inspector-width) + var(--smrt-ws-rail-width) + 1rem
+      );
+    }
   }
 
   /* ─── Backdrops (mobile only — hidden otherwise) ──────── */
 
+  /*
+   * Defence-in-depth: `display: none` already hides these on desktop, but a
+   * consumer global like `button { display: flex }` could undo that. Setting
+   * `pointer-events: none` ensures the backdrop can never intercept clicks
+   * on the desktop even if it slips back into the rendering tree.
+   */
   .mobile-backdrop,
   .inspector-backdrop {
     display: none;
+    pointer-events: none;
   }
 
   /* ─── Tablet — collapse sidebar to icon rail ──────────── */
@@ -735,6 +876,7 @@ const hasInspectorRail = $derived(Boolean(inspectorRail));
 
     .inspector-backdrop {
       display: block;
+      pointer-events: auto;
       position: fixed;
       inset: 0;
       background: rgba(3, 7, 14, 0.4);

--- a/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
@@ -274,7 +274,7 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
         {/if}
       </div>
 
-      {#if collapsible}
+      {#if collapsible && onToggleCollapsed}
         <button
           class="shell-toggle"
           type="button"
@@ -355,12 +355,10 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
       {#if hasInspector}
         <aside
           class="smrt-workspace-inspector"
-          aria-labelledby="smrt-ws-inspector-title"
+          aria-label={inspectorTitle}
         >
           <div class="inspector-header">
-            <span id="smrt-ws-inspector-title" class="inspector-title"
-              >{inspectorTitle}</span
-            >
+            <span class="inspector-title">{inspectorTitle}</span>
             {#if onCloseInspector}
               <button
                 class="inspector-close"
@@ -379,7 +377,12 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
       {/if}
 
       {#if hasInspectorRail}
-        <div class="smrt-workspace-inspector-rail" aria-label="Inspector tools">
+        <div
+          class="smrt-workspace-inspector-rail"
+          role="toolbar"
+          aria-label="Inspector tools"
+          aria-orientation="vertical"
+        >
           {@render inspectorRail!()}
         </div>
       {/if}
@@ -855,8 +858,12 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
       pointer-events: auto;
     }
 
-    .smrt-workspace-inspector {
-      width: min(100vw, 420px);
+    /* Override the inspector-width variable on mobile so the rail's right
+     * offset (.has-inspector.has-inspector-rail .smrt-workspace-inspector-rail
+     * uses var(--smrt-ws-inspector-width) for `right`) stays in sync with
+     * the actual rendered inspector width. */
+    .smrt-workspace-shell {
+      --smrt-ws-inspector-width: min(100vw, 420px);
     }
 
     .smrt-workspace-shell.has-inspector .smrt-workspace-inspector-rail,

--- a/packages/smrt-svelte/src/components/workspace/__tests__/WorkspaceShell.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/WorkspaceShell.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Tests for WorkspaceShell — issue happyvertical/smrt#1227.
+ *
+ * Uses Svelte 5's `mount` / `unmount` APIs and `createRawSnippet` to exercise
+ * the component in jsdom without pulling in `@testing-library/svelte` (which
+ * the package doesn't depend on).
+ */
+
+import { createRawSnippet, mount, tick, unmount } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import WorkspaceShell from '../WorkspaceShell.svelte';
+
+function textSnippet(text: string) {
+  return createRawSnippet(() => ({
+    render: () => `<span>${text}</span>`,
+  }));
+}
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  container.remove();
+});
+
+describe('WorkspaceShell', () => {
+  it('renders with only required children prop', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('main content'),
+      },
+    });
+
+    try {
+      expect(container.querySelector('.smrt-workspace-shell')).not.toBeNull();
+      expect(
+        container.querySelector('.smrt-workspace-content')?.textContent,
+      ).toContain('main content');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders the brand snippet when provided', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        brand: textSnippet('MyBrand'),
+      },
+    });
+
+    try {
+      const brand = container.querySelector('.brand');
+      expect(brand?.textContent).toContain('MyBrand');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('falls back to title / subtitle / eyebrow when no brand snippet is given', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        title: 'Workspace',
+        subtitle: 'Engineering',
+        eyebrow: 'SMRT',
+      },
+    });
+
+    try {
+      const brand = container.querySelector('.brand');
+      expect(brand?.textContent).toContain('Workspace');
+      expect(brand?.textContent).toContain('Engineering');
+      expect(brand?.textContent).toContain('SMRT');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders the nav snippet inside an aria-labelled region', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        nav: textSnippet('nav-content'),
+      },
+    });
+
+    try {
+      const navRegion = container.querySelector('nav.nav-region');
+      expect(navRegion).not.toBeNull();
+      expect(navRegion?.getAttribute('aria-label')).toBe(
+        'Workspace navigation',
+      );
+      expect(navRegion?.textContent).toContain('nav-content');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders the sidebar footer snippet when provided', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        sidebarFooter: textSnippet('account-menu'),
+      },
+    });
+
+    try {
+      const footer = container.querySelector('.sidebar-footer');
+      expect(footer?.textContent).toContain('account-menu');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders topbar actions on the right of the top bar', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        topbarActions: textSnippet('action-button'),
+      },
+    });
+
+    try {
+      const actions = container.querySelector('.topbar-actions');
+      expect(actions?.textContent).toContain('action-button');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('does NOT render inspector when showInspector is false', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        inspector: textSnippet('inspector-content'),
+        showInspector: false,
+      },
+    });
+
+    try {
+      expect(container.querySelector('.smrt-workspace-inspector')).toBeNull();
+      const shell = container.querySelector('.smrt-workspace-shell');
+      expect(shell?.classList.contains('has-inspector')).toBe(false);
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders inspector and has-inspector class when showInspector is true', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        inspector: textSnippet('inspector-content'),
+        showInspector: true,
+      },
+    });
+
+    try {
+      const inspector = container.querySelector('.smrt-workspace-inspector');
+      expect(inspector).not.toBeNull();
+      expect(inspector?.textContent).toContain('inspector-content');
+      const shell = container.querySelector('.smrt-workspace-shell');
+      expect(shell?.classList.contains('has-inspector')).toBe(true);
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders inspector close button when onCloseInspector is provided', () => {
+    let closed = false;
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        inspector: textSnippet('inspector-content'),
+        showInspector: true,
+        onCloseInspector: () => {
+          closed = true;
+        },
+      },
+    });
+
+    try {
+      const closeBtn =
+        container.querySelector<HTMLButtonElement>('.inspector-close');
+      expect(closeBtn).not.toBeNull();
+      closeBtn?.click();
+      expect(closed).toBe(true);
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('omits the inspector close button when onCloseInspector is not provided', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        inspector: textSnippet('inspector-content'),
+        showInspector: true,
+      },
+    });
+
+    try {
+      expect(container.querySelector('.inspector-close')).toBeNull();
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders the inspector rail snippet when provided', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        inspectorRail: textSnippet('rail-button'),
+      },
+    });
+
+    try {
+      const rail = container.querySelector('.smrt-workspace-inspector-rail');
+      expect(rail).not.toBeNull();
+      expect(rail?.textContent).toContain('rail-button');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('shows a collapse toggle by default and invokes onToggleCollapsed', () => {
+    let toggles = 0;
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        title: 'Brand',
+        collapsed: false,
+        onToggleCollapsed: () => {
+          toggles += 1;
+        },
+      },
+    });
+
+    try {
+      const toggle =
+        container.querySelector<HTMLButtonElement>('.shell-toggle');
+      expect(toggle).not.toBeNull();
+      expect(toggle?.getAttribute('aria-expanded')).toBe('true');
+      toggle?.click();
+      expect(toggles).toBe(1);
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('hides the collapse toggle when collapsible is false', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        title: 'Brand',
+        collapsible: false,
+      },
+    });
+
+    try {
+      expect(container.querySelector('.shell-toggle')).toBeNull();
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('applies sidebar-collapsed class when collapsed prop is true', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        collapsed: true,
+      },
+    });
+
+    try {
+      const shell = container.querySelector('.smrt-workspace-shell');
+      expect(shell?.classList.contains('sidebar-collapsed')).toBe(true);
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders the mode badge when modeLabel is provided', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        modeLabel: 'Local-first mode',
+        modeStatus: 'local-only',
+      },
+    });
+
+    try {
+      const badge = container.querySelector('.mode-badge');
+      expect(badge).not.toBeNull();
+      expect(badge?.getAttribute('data-status')).toBe('local-only');
+      expect(badge?.textContent).toContain('Local-first mode');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('omits the mode badge when no modeLabel/modeStatus is provided', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      expect(container.querySelector('.mode-badge')).toBeNull();
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('invokes onCloseInspector when Escape is pressed while inspector is open', async () => {
+    let closes = 0;
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        inspector: textSnippet('inspector-content'),
+        showInspector: true,
+        onCloseInspector: () => {
+          closes += 1;
+        },
+      },
+    });
+
+    try {
+      await tick();
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      expect(closes).toBe(1);
+    } finally {
+      unmount(component);
+    }
+  });
+});

--- a/packages/smrt-svelte/src/components/workspace/__tests__/WorkspaceShell.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/WorkspaceShell.test.ts
@@ -356,4 +356,159 @@ describe('WorkspaceShell', () => {
       unmount(component);
     }
   });
+
+  it('renders an interactive button backdrop only when onCloseInspector is set', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        inspector: textSnippet('inspector-content'),
+        showInspector: true,
+        onCloseInspector: () => {},
+      },
+    });
+
+    try {
+      const backdrop = container.querySelector('.inspector-backdrop');
+      expect(backdrop).not.toBeNull();
+      expect(backdrop?.tagName).toBe('BUTTON');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders a non-interactive backdrop when onCloseInspector is omitted', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        inspector: textSnippet('inspector-content'),
+        showInspector: true,
+      },
+    });
+
+    try {
+      const backdrop = container.querySelector('.inspector-backdrop');
+      expect(backdrop).not.toBeNull();
+      expect(backdrop?.tagName).toBe('DIV');
+      expect(backdrop?.getAttribute('aria-hidden')).toBe('true');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders the default "Inspector" header label when inspectorTitle is omitted', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        inspector: textSnippet('inspector-content'),
+        showInspector: true,
+      },
+    });
+
+    try {
+      const title = container.querySelector('.inspector-title');
+      expect(title?.textContent).toBe('Inspector');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('uses a custom inspectorTitle and wires it via aria-labelledby', () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        inspector: textSnippet('inspector-content'),
+        showInspector: true,
+        inspectorTitle: 'Properties',
+      },
+    });
+
+    try {
+      const title = container.querySelector('.inspector-title');
+      expect(title?.textContent).toBe('Properties');
+      const aside = container.querySelector('.smrt-workspace-inspector');
+      const labelledBy = aside?.getAttribute('aria-labelledby');
+      expect(labelledBy).toBeTruthy();
+      // The id pointed at by aria-labelledby must resolve to the title node.
+      const referenced = labelledBy
+        ? container.querySelector(`#${labelledBy}`)
+        : null;
+      expect(referenced).toBe(title);
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('marks the sidebar inert on mobile when the drawer is closed', async () => {
+    const originalMatchMedia = window.matchMedia;
+    // Force the mobile breakpoint so `isMobileViewport` becomes true.
+    window.matchMedia = ((query: string) => ({
+      matches: /max-width:\s*960px/.test(query),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        nav: textSnippet('nav-content'),
+      },
+    });
+
+    try {
+      await tick();
+      const sidebar = container.querySelector('.smrt-workspace-sidebar');
+      // jsdom reflects the `inert` attribute as a boolean property — both
+      // forms are acceptable, the contract is "keyboard tab order skips
+      // the sidebar when it's offscreen".
+      expect(
+        sidebar?.hasAttribute('inert') ||
+          (sidebar as HTMLElement | null)?.inert === true,
+      ).toBe(true);
+    } finally {
+      unmount(component);
+      window.matchMedia = originalMatchMedia;
+    }
+  });
+
+  it('restores focus to the hamburger button when the mobile drawer closes via Escape', async () => {
+    const component = mount(WorkspaceShell, {
+      target: container,
+      props: {
+        children: textSnippet('content'),
+        nav: textSnippet('nav-content'),
+      },
+    });
+
+    try {
+      const hamburger =
+        container.querySelector<HTMLButtonElement>('.mobile-menu');
+      expect(hamburger).not.toBeNull();
+      // Simulate keyboard-driven opening of the drawer.
+      hamburger?.focus();
+      expect(document.activeElement).toBe(hamburger);
+      hamburger?.click();
+      await tick();
+      // Move focus elsewhere as a real drawer interaction would.
+      const elsewhere = document.createElement('button');
+      container.appendChild(elsewhere);
+      elsewhere.focus();
+      expect(document.activeElement).toBe(elsewhere);
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      await tick();
+      expect(document.activeElement).toBe(hamburger);
+    } finally {
+      unmount(component);
+    }
+  });
 });

--- a/packages/smrt-svelte/src/components/workspace/__tests__/WorkspaceShell.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/WorkspaceShell.test.ts
@@ -415,7 +415,10 @@ describe('WorkspaceShell', () => {
     }
   });
 
-  it('uses a custom inspectorTitle and wires it via aria-labelledby', () => {
+  it('uses a custom inspectorTitle and exposes it via aria-label', () => {
+    // The inspector aside uses aria-label (not aria-labelledby with a hard-coded
+    // id) so multiple <WorkspaceShell> instances on the same page can't collide
+    // on duplicate ids — see Copilot review on PR #1232.
     const component = mount(WorkspaceShell, {
       target: container,
       props: {
@@ -430,13 +433,8 @@ describe('WorkspaceShell', () => {
       const title = container.querySelector('.inspector-title');
       expect(title?.textContent).toBe('Properties');
       const aside = container.querySelector('.smrt-workspace-inspector');
-      const labelledBy = aside?.getAttribute('aria-labelledby');
-      expect(labelledBy).toBeTruthy();
-      // The id pointed at by aria-labelledby must resolve to the title node.
-      const referenced = labelledBy
-        ? container.querySelector(`#${labelledBy}`)
-        : null;
-      expect(referenced).toBe(title);
+      expect(aside?.getAttribute('aria-label')).toBe('Properties');
+      expect(aside?.getAttribute('aria-labelledby')).toBeNull();
     } finally {
       unmount(component);
     }

--- a/packages/smrt-svelte/src/components/workspace/__tests__/breadcrumbs-helpers.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/breadcrumbs-helpers.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for Breadcrumbs' pure derivation helpers.
+ *
+ * The Svelte component is a thin renderer over `deriveCrumbsFromNav`,
+ * so testing the helper covers:
+ *  - explicit pass-through (handled in the component layer)
+ *  - auto mode: nav-tree label lookup
+ *  - fallback to capitalized segments for unknown paths
+ *  - `rootCrumb` prepend
+ *  - `startAfter` segment skipping
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  capitalizeSegment,
+  deriveCrumbsFromNav,
+  findLabelInNav,
+} from '../breadcrumbs-helpers.js';
+import type { NavItem } from '../types.js';
+
+const nav: NavItem[] = [
+  {
+    href: '/content',
+    label: 'Content',
+    children: [
+      { href: '/content/articles', label: 'Articles' },
+      {
+        href: '/content/media',
+        label: 'Media library',
+        children: [{ href: '/content/media/images', label: 'Images' }],
+      },
+    ],
+  },
+];
+
+describe('findLabelInNav', () => {
+  it('finds a top-level label', () => {
+    expect(findLabelInNav(nav, '/content')).toBe('Content');
+  });
+
+  it('finds a nested label', () => {
+    expect(findLabelInNav(nav, '/content/media/images')).toBe('Images');
+  });
+
+  it('returns null when not found', () => {
+    expect(findLabelInNav(nav, '/missing')).toBeNull();
+  });
+});
+
+describe('capitalizeSegment', () => {
+  it('uppercases the first letter', () => {
+    expect(capitalizeSegment('articles')).toBe('Articles');
+  });
+
+  it('replaces dashes and underscores with spaces', () => {
+    expect(capitalizeSegment('my-cool-section')).toBe('My cool section');
+    expect(capitalizeSegment('snake_case_thing')).toBe('Snake case thing');
+  });
+
+  it('handles empty input gracefully', () => {
+    expect(capitalizeSegment('')).toBe('');
+  });
+});
+
+describe('deriveCrumbsFromNav', () => {
+  it('builds crumbs from nav matches', () => {
+    const crumbs = deriveCrumbsFromNav('/content/articles', nav);
+    expect(crumbs).toEqual([
+      { label: 'Content', href: '/content' },
+      { label: 'Articles', href: '/content/articles' },
+    ]);
+  });
+
+  it('falls back to capitalized segments for unknown paths', () => {
+    const crumbs = deriveCrumbsFromNav('/content/random-thing', nav);
+    expect(crumbs).toEqual([
+      { label: 'Content', href: '/content' },
+      { label: 'Random thing', href: '/content/random-thing' },
+    ]);
+  });
+
+  it('disables capitalization when capitalize=false', () => {
+    const crumbs = deriveCrumbsFromNav('/content/random-thing', nav, {
+      capitalize: false,
+    });
+    expect(crumbs[1]).toEqual({
+      label: 'random-thing',
+      href: '/content/random-thing',
+    });
+  });
+
+  it('prepends rootCrumb', () => {
+    const crumbs = deriveCrumbsFromNav('/content', nav, {
+      rootCrumb: { label: 'My Site', href: '/' },
+    });
+    expect(crumbs[0]).toEqual({ label: 'My Site', href: '/' });
+    expect(crumbs[1]).toEqual({ label: 'Content', href: '/content' });
+  });
+
+  it('skips segments before startAfter and resolves remaining against nav', () => {
+    const siteNav: NavItem[] = [
+      {
+        href: '/sites/foo/content',
+        label: 'Content',
+        children: [{ href: '/sites/foo/content/articles', label: 'Articles' }],
+      },
+    ];
+    const crumbs = deriveCrumbsFromNav('/sites/foo/content/articles', siteNav, {
+      rootCrumb: { label: 'Foo', href: '/sites/foo' },
+      startAfter: 'sites/foo',
+    });
+    expect(crumbs).toEqual([
+      { label: 'Foo', href: '/sites/foo' },
+      { label: 'Content', href: '/sites/foo/content' },
+      { label: 'Articles', href: '/sites/foo/content/articles' },
+    ]);
+  });
+
+  it('returns only rootCrumb when startAfter is not present in pathname', () => {
+    const crumbs = deriveCrumbsFromNav('/other/path', nav, {
+      rootCrumb: { label: 'Root', href: '/' },
+      startAfter: 'sites/foo',
+    });
+    expect(crumbs).toEqual([{ label: 'Root', href: '/' }]);
+  });
+
+  it('returns an empty array for an empty pathname with no rootCrumb', () => {
+    expect(deriveCrumbsFromNav('', nav)).toEqual([]);
+  });
+
+  it('handles a leading-slash startAfter the same as no leading slash', () => {
+    const siteNav: NavItem[] = [
+      { href: '/sites/foo/content', label: 'Content' },
+    ];
+    const a = deriveCrumbsFromNav('/sites/foo/content', siteNav, {
+      startAfter: '/sites/foo',
+    });
+    const b = deriveCrumbsFromNav('/sites/foo/content', siteNav, {
+      startAfter: 'sites/foo',
+    });
+    expect(a).toEqual(b);
+  });
+});

--- a/packages/smrt-svelte/src/components/workspace/__tests__/breadcrumbs-helpers.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/breadcrumbs-helpers.test.ts
@@ -140,4 +140,24 @@ describe('deriveCrumbsFromNav', () => {
     });
     expect(a).toEqual(b);
   });
+
+  // Regression for #1231: multi-segment startAfter must match the full
+  // contiguous sequence in the pathname, not just the last token. Previous
+  // implementation used `segments.indexOf(lastStartSegment)` which would
+  // find the wrong offset when an earlier segment repeated the last token.
+  it('matches the full contiguous startAfter sequence even when its trailing token appears earlier in the path', () => {
+    const siteNav: NavItem[] = [
+      { href: '/sites/sites/content', label: 'Content' },
+    ];
+    const crumbs = deriveCrumbsFromNav('/sites/sites/content', siteNav, {
+      startAfter: 'sites/sites',
+    });
+    // If the helper anchored on the first `sites`, basePath would be
+    // `/sites` and we'd emit two extra crumbs (`sites`, `content`). The
+    // correct behavior is to anchor on the second `sites` and emit only
+    // the trailing `content` crumb.
+    expect(crumbs).toEqual([
+      { label: 'Content', href: '/sites/sites/content' },
+    ]);
+  });
 });

--- a/packages/smrt-svelte/src/components/workspace/__tests__/context-forwarding-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/context-forwarding-harness.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+/**
+ * Harness for asserting that <ToolsDock>'s `context` prop is forwarded into
+ * the dock instance reactively — including the case where the initial value
+ * is `undefined` and is later populated (async route data), and the case
+ * where the prop changes multiple times after mount.
+ *
+ * Owns a `$state` ref for the current context so that the test can mutate it
+ * post-mount via the `setContextProp` callback exposed via `onReady`.
+ */
+import { defineToolsDock } from '../tools-dock/define-tools-dock.svelte.js';
+import ToolsDock from '../tools-dock/ToolsDock.svelte';
+import type { ToolsDockContext, ToolsDockInstance } from '../types.js';
+
+interface Props {
+  onReady: (api: {
+    dock: ToolsDockInstance;
+    setContextProp: (next: ToolsDockContext | null | undefined) => void;
+  }) => void;
+}
+
+const props: Props = $props();
+
+// biome-ignore lint/correctness/noUnusedVariables: noop component
+const NoopBody = (() => null) as never;
+
+const dock = defineToolsDock({
+  tools: [{ id: 'chat', label: 'Chat', component: NoopBody }],
+});
+
+let currentContext = $state<ToolsDockContext | null | undefined>(undefined);
+
+props.onReady({
+  dock,
+  setContextProp: (next) => {
+    currentContext = next;
+  },
+});
+</script>
+
+<ToolsDock {dock} context={currentContext} />

--- a/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Tests for defineToolsDock factory.
+ *
+ * These tests exercise the reactive API surface directly. Svelte `setContext`
+ * is called inside the factory, but the returned `ToolsDockInstance` is the
+ * subject under test — we don't need a full component tree to verify the
+ * state machine.
+ *
+ * `setContext` only works inside a component init scope, so we invoke the
+ * factory inside Svelte's `mount` (via a thin host component) so that all
+ * `$state` runes wire up correctly.
+ */
+
+import { flushSync, mount, unmount } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  defineToolsDock,
+  ToolsDockInstance,
+} from '../tools-dock/define-tools-dock.svelte.js';
+import type { ToolDef } from '../types.js';
+import HostHarness from './harness.svelte';
+
+const noopTool = {} as ToolDef['component'];
+
+interface HarnessExposed {
+  dock: ToolsDockInstance;
+}
+
+function mountDock(options: Parameters<typeof defineToolsDock>[0]): {
+  dock: ToolsDockInstance;
+  teardown: () => void;
+} {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const exposed: HarnessExposed = {
+    dock: undefined as unknown as ToolsDockInstance,
+  };
+  const component = mount(HostHarness, {
+    target,
+    props: {
+      options,
+      onReady: (dock: ToolsDockInstance) => {
+        exposed.dock = dock;
+      },
+    },
+  });
+  return {
+    dock: exposed.dock,
+    teardown: () => {
+      unmount(component);
+      target.remove();
+    },
+  };
+}
+
+describe('defineToolsDock', () => {
+  let cleanup: Array<() => void> = [];
+
+  beforeEach(() => {
+    cleanup = [];
+    if (typeof window !== 'undefined') {
+      window.localStorage.clear();
+    }
+  });
+
+  afterEach(() => {
+    for (const fn of cleanup.splice(0)) fn();
+  });
+
+  function track<T>(value: { teardown: () => void } & T): T {
+    cleanup.push(value.teardown);
+    return value;
+  }
+
+  it('creates an API with sensible defaults', () => {
+    const { dock } = track(
+      mountDock({
+        tools: [
+          { id: 'chat', label: 'Chat', component: noopTool },
+          { id: 'jobs', label: 'Jobs', component: noopTool },
+        ],
+      }),
+    );
+
+    expect(dock.isOpen).toBe(false);
+    expect(dock.activeTool).toBeNull();
+    expect(dock.layout).toBe('rail');
+    expect(dock.storageKey).toBeNull();
+    expect(dock.availableTools.map((t) => t.id)).toEqual(['chat', 'jobs']);
+  });
+
+  it('open() / close() / toggle() update isOpen and activeTool', () => {
+    const { dock } = track(
+      mountDock({
+        tools: [
+          { id: 'chat', label: 'Chat', component: noopTool },
+          { id: 'jobs', label: 'Jobs', component: noopTool },
+        ],
+      }),
+    );
+
+    dock.open('chat');
+    flushSync();
+    expect(dock.isOpen).toBe(true);
+    expect(dock.activeTool).toBe('chat');
+
+    dock.close();
+    flushSync();
+    expect(dock.isOpen).toBe(false);
+    // activeTool persists so re-opening lands on the same tool.
+    expect(dock.activeTool).toBe('chat');
+
+    dock.toggle('jobs');
+    flushSync();
+    expect(dock.isOpen).toBe(true);
+    expect(dock.activeTool).toBe('jobs');
+
+    // toggle on the same id closes.
+    dock.toggle('jobs');
+    flushSync();
+    expect(dock.isOpen).toBe(false);
+
+    // toggle without id flips just isOpen.
+    dock.toggle();
+    flushSync();
+    expect(dock.isOpen).toBe(true);
+  });
+
+  it('open() on unknown id is a no-op (does not crash, does not open)', () => {
+    const { dock } = track(
+      mountDock({
+        tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+      }),
+    );
+
+    dock.open('does-not-exist');
+    flushSync();
+    expect(dock.isOpen).toBe(false);
+    expect(dock.activeTool).toBeNull();
+  });
+
+  it('respects initialOpen and picks first tool when toggled', () => {
+    const { dock } = track(
+      mountDock({
+        tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        initialOpen: true,
+      }),
+    );
+
+    expect(dock.isOpen).toBe(true);
+    expect(dock.activeTool).toBeNull();
+
+    dock.toggle();
+    flushSync();
+    // First toggle while no tool active selects the first available.
+    // (Was open → now closed; activeTool now set on the next open.)
+    expect(dock.isOpen).toBe(false);
+
+    dock.toggle();
+    flushSync();
+    expect(dock.isOpen).toBe(true);
+    expect(dock.activeTool).toBe('chat');
+  });
+
+  it('setContext updates context and triggers fetchAvailability', async () => {
+    const fetchAvailability = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: 'chat' }])
+      .mockResolvedValueOnce([{ id: 'chat' }, { id: 'jobs' }]);
+
+    const { dock } = track(
+      mountDock({
+        tools: [
+          { id: 'chat', label: 'Chat', component: noopTool },
+          { id: 'jobs', label: 'Jobs', component: noopTool },
+          { id: 'hidden', label: 'Hidden', component: noopTool },
+        ],
+        fetchAvailability,
+      }),
+    );
+
+    // No call yet — fetchAvailability only fires on setContext.
+    expect(fetchAvailability).not.toHaveBeenCalled();
+
+    dock.setContext({ type: 'thing', title: 'A' });
+    // setContext invokes fetchAvailability synchronously; the promise resolves
+    // on the next microtask, so flushSync after a few microtasks is required
+    // for Svelte to settle the resulting state update.
+    expect(fetchAvailability).toHaveBeenCalledTimes(1);
+    await new Promise((r) => setTimeout(r, 0));
+    flushSync();
+    expect(dock.availableTools.map((t) => t.id)).toEqual(['chat']);
+
+    dock.setContext({ type: 'thing', title: 'B' });
+    expect(fetchAvailability).toHaveBeenCalledTimes(2);
+    await new Promise((r) => setTimeout(r, 0));
+    flushSync();
+    expect(dock.availableTools.map((t) => t.id)).toEqual(['chat', 'jobs']);
+  });
+
+  it('drops stale fetchAvailability results (race-safety)', async () => {
+    let resolveFirst: ((v: { id: string }[]) => void) | null = null;
+    let resolveSecond: ((v: { id: string }[]) => void) | null = null;
+
+    const fetchAvailability = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ id: string }[]>((r) => {
+            resolveFirst = r;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ id: string }[]>((r) => {
+            resolveSecond = r;
+          }),
+      );
+
+    const { dock } = track(
+      mountDock({
+        tools: [
+          { id: 'chat', label: 'Chat', component: noopTool },
+          { id: 'jobs', label: 'Jobs', component: noopTool },
+        ],
+        fetchAvailability,
+      }),
+    );
+
+    dock.setContext({ type: 'A' });
+    await Promise.resolve();
+    dock.setContext({ type: 'B' });
+    await Promise.resolve();
+
+    // Resolve the *stale* (first) call after the newer one. Then resolve the
+    // newer one. The stale value must not stomp the fresh value.
+    resolveFirst?.([{ id: 'chat' }]);
+    resolveSecond?.([{ id: 'jobs' }]);
+    await Promise.resolve();
+    await Promise.resolve();
+    flushSync();
+
+    expect(dock.availableTools.map((t) => t.id)).toEqual(['jobs']);
+  });
+
+  it('emit / on / unsubscribe', () => {
+    const { dock } = track(
+      mountDock({
+        tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+      }),
+    );
+
+    const handler = vi.fn();
+    const off = dock.on<{ ok: boolean }>('test', handler);
+    dock.emit('test', { ok: true });
+    expect(handler).toHaveBeenCalledWith({ ok: true });
+
+    off();
+    dock.emit('test', { ok: false });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('emit catches handler errors without dropping later handlers', () => {
+    const { dock } = track(
+      mountDock({
+        tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+      }),
+    );
+
+    const throwing = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const after = vi.fn();
+    dock.on('test', throwing);
+    dock.on('test', after);
+
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => dock.emit('test', null)).not.toThrow();
+    expect(throwing).toHaveBeenCalled();
+    expect(after).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('persists state to localStorage when storageKey provided', () => {
+    const { dock } = track(
+      mountDock({
+        tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        storageKey: 'tdtest:v1',
+      }),
+    );
+
+    dock.open('chat');
+    flushSync();
+    const raw = window.localStorage.getItem('tdtest:v1');
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed).toEqual({ isOpen: true, activeTool: 'chat' });
+  });
+
+  it('hydrates state from localStorage on hydrate()', () => {
+    window.localStorage.setItem(
+      'tdtest:v2',
+      JSON.stringify({ isOpen: true, activeTool: 'jobs' }),
+    );
+
+    const { dock } = track(
+      mountDock({
+        tools: [
+          { id: 'chat', label: 'Chat', component: noopTool },
+          { id: 'jobs', label: 'Jobs', component: noopTool },
+        ],
+        storageKey: 'tdtest:v2',
+      }),
+    );
+
+    dock.hydrate();
+    flushSync();
+    expect(dock.isOpen).toBe(true);
+    expect(dock.activeTool).toBe('jobs');
+  });
+
+  it('hydrate() ignores activeTool that no longer matches a registered tool', () => {
+    window.localStorage.setItem(
+      'tdtest:v3',
+      JSON.stringify({ isOpen: true, activeTool: 'gone' }),
+    );
+
+    const { dock } = track(
+      mountDock({
+        tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        storageKey: 'tdtest:v3',
+      }),
+    );
+
+    dock.hydrate();
+    flushSync();
+    expect(dock.isOpen).toBe(true);
+    expect(dock.activeTool).toBeNull();
+  });
+
+  it('clears activeTool when availability removes the active tool', async () => {
+    let availability: { id: string }[] = [{ id: 'chat' }, { id: 'jobs' }];
+    const fetchAvailability = vi.fn(async () => availability);
+
+    const { dock } = track(
+      mountDock({
+        tools: [
+          { id: 'chat', label: 'Chat', component: noopTool },
+          { id: 'jobs', label: 'Jobs', component: noopTool },
+        ],
+        fetchAvailability,
+      }),
+    );
+
+    dock.setContext({ type: 'a' });
+    await Promise.resolve();
+    await Promise.resolve();
+    flushSync();
+    dock.open('jobs');
+    flushSync();
+    expect(dock.activeTool).toBe('jobs');
+
+    availability = [{ id: 'chat' }];
+    dock.setContext({ type: 'b' });
+    await Promise.resolve();
+    await Promise.resolve();
+    flushSync();
+    expect(dock.availableTools.map((t) => t.id)).toEqual(['chat']);
+    expect(dock.activeTool).toBeNull();
+  });
+});

--- a/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
@@ -338,6 +338,67 @@ describe('defineToolsDock', () => {
     expect(dock.activeTool).toBeNull();
   });
 
+  it('exposes context on the public ToolsDockApi surface', () => {
+    const { dock } = track(
+      mountDock({
+        tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+      }),
+    );
+
+    expect(dock.context).toBeNull();
+    dock.setContext({ type: 'route', title: 'Home' });
+    flushSync();
+    expect(dock.context).toEqual({ type: 'route', title: 'Home' });
+
+    dock.setContext(null);
+    flushSync();
+    expect(dock.context).toBeNull();
+  });
+
+  it('badge: null in availability clears a registered default (not falls back)', async () => {
+    const fetchAvailability = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: 'chat', badge: null }]);
+
+    const { dock } = track(
+      mountDock({
+        tools: [{ id: 'chat', label: 'Chat', badge: 3, component: noopTool }],
+        fetchAvailability,
+      }),
+    );
+
+    dock.setContext({ type: 'a' });
+    await new Promise((r) => setTimeout(r, 0));
+    flushSync();
+
+    // `badge: null` is explicit ("clear it"), not a fallback signal.
+    expect(dock.availableTools[0].badge).toBeNull();
+  });
+
+  it('handles synchronous throws from fetchAvailability without surfacing them', async () => {
+    const fetchAvailability = vi.fn(() => {
+      throw new Error('sync boom');
+    });
+
+    const { dock } = track(
+      mountDock({
+        tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        fetchAvailability: fetchAvailability as unknown as (
+          ctx: import('../types.js').ToolsDockContext | null,
+        ) => Promise<import('../types.js').AvailableTool[]>,
+      }),
+    );
+
+    // The sync throw must be caught by the wrapped promise chain, not
+    // propagate out of setContext to the caller.
+    expect(() => dock.setContext({ type: 'a' })).not.toThrow();
+
+    // The internal `.catch` applies an empty-availability result.
+    await new Promise((r) => setTimeout(r, 0));
+    flushSync();
+    expect(dock.availableTools).toEqual([]);
+  });
+
   it('clears activeTool when availability removes the active tool', async () => {
     let availability: { id: string }[] = [{ id: 'chat' }, { id: 'jobs' }];
     const fetchAvailability = vi.fn(async () => availability);

--- a/packages/smrt-svelte/src/components/workspace/__tests__/harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/harness.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+/**
+ * Test harness — invokes defineToolsDock() inside a component init scope so
+ * setContext() is legal, then passes the returned instance back to the
+ * test via the `onReady` callback prop.
+ */
+import {
+  type DefineToolsDockOptions,
+  defineToolsDock,
+  type ToolsDockInstance,
+} from '../tools-dock/define-tools-dock.svelte.js';
+
+interface Props {
+  options: DefineToolsDockOptions;
+  onReady: (dock: ToolsDockInstance) => void;
+}
+
+const props: Props = $props();
+// eslint-disable-next-line svelte/valid-prop-names-in-kit-pages
+const dock = defineToolsDock(props.options);
+props.onReady(dock);
+</script>

--- a/packages/smrt-svelte/src/components/workspace/__tests__/harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/harness.svelte
@@ -16,7 +16,6 @@ interface Props {
 }
 
 const props: Props = $props();
-// eslint-disable-next-line svelte/valid-prop-names-in-kit-pages
 const dock = defineToolsDock(props.options);
 props.onReady(dock);
 </script>

--- a/packages/smrt-svelte/src/components/workspace/__tests__/index.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/index.test.ts
@@ -1,0 +1,17 @@
+/**
+ * Smoke test: the workspace subpath barrel must export the new
+ * NavTree and Breadcrumbs components (plus existing types).
+ */
+
+import { describe, expect, it } from 'vitest';
+import * as workspace from '../index.js';
+
+describe('workspace barrel', () => {
+  it('exports NavTree', () => {
+    expect(workspace.NavTree).toBeDefined();
+  });
+
+  it('exports Breadcrumbs', () => {
+    expect(workspace.Breadcrumbs).toBeDefined();
+  });
+});

--- a/packages/smrt-svelte/src/components/workspace/__tests__/nav-helpers.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/nav-helpers.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for NavTree's pure active/expanded helpers.
+ *
+ * The Svelte component itself is a thin renderer over these helpers,
+ * so covering the helpers gives us full behavioral coverage of:
+ *  - 1-/2-/3-level active detection
+ *  - `exact` flag
+ *  - `isActive` override
+ *  - expansion (default + descendant-driven)
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  defaultIsActive,
+  isExpanded,
+  isItemOrChildActive,
+} from '../nav-helpers.js';
+import type { NavItem } from '../types.js';
+
+const home: NavItem = {
+  href: '/',
+  label: 'Home',
+  exact: true,
+};
+
+const content: NavItem = {
+  href: '/content',
+  label: 'Content',
+  children: [
+    { href: '/content/articles', label: 'Articles' },
+    {
+      href: '/content/media',
+      label: 'Media',
+      children: [
+        { href: '/content/media/images', label: 'Images' },
+        { href: '/content/media/videos', label: 'Videos' },
+      ],
+    },
+  ],
+};
+
+const settings: NavItem = {
+  href: '/settings',
+  label: 'Settings',
+  defaultExpanded: true,
+  children: [{ href: '/settings/users', label: 'Users' }],
+};
+
+const _allItems: NavItem[] = [home, content, settings];
+
+describe('defaultIsActive', () => {
+  it('matches exact paths', () => {
+    expect(defaultIsActive({ href: '/content', label: '' }, '/content')).toBe(
+      true,
+    );
+  });
+
+  it('matches descendant paths when not exact', () => {
+    expect(
+      defaultIsActive({ href: '/content', label: '' }, '/content/articles'),
+    ).toBe(true);
+  });
+
+  it('respects the exact flag', () => {
+    expect(
+      defaultIsActive({ href: '/', label: '', exact: true }, '/content'),
+    ).toBe(false);
+    expect(defaultIsActive({ href: '/', label: '', exact: true }, '/')).toBe(
+      true,
+    );
+  });
+
+  it('does not match unrelated paths that share a prefix', () => {
+    // '/foo' should not match '/foobar' — the '/' boundary matters.
+    expect(defaultIsActive({ href: '/foo', label: '' }, '/foobar')).toBe(false);
+  });
+});
+
+describe('isItemOrChildActive', () => {
+  it('returns true when the item itself is active', () => {
+    expect(isItemOrChildActive(content, '/content')).toBe(true);
+  });
+
+  it('returns true when a deep descendant is active', () => {
+    expect(isItemOrChildActive(content, '/content/media/images')).toBe(true);
+  });
+
+  it('returns false when neither item nor descendants are active', () => {
+    expect(isItemOrChildActive(content, '/settings/users')).toBe(false);
+  });
+
+  it('honors a custom isActive override', () => {
+    const customIsActive = (item: NavItem, _path: string) =>
+      item.href === '/content/media/videos';
+    expect(isItemOrChildActive(content, '/anything', customIsActive)).toBe(
+      true,
+    );
+  });
+});
+
+describe('isExpanded', () => {
+  it('is false for items without children', () => {
+    expect(isExpanded({ href: '/x', label: '' }, '/x')).toBe(false);
+  });
+
+  it('is true when defaultExpanded is set, regardless of path', () => {
+    expect(isExpanded(settings, '/unrelated')).toBe(true);
+  });
+
+  it('is true when a descendant is active', () => {
+    expect(isExpanded(content, '/content/media/images')).toBe(true);
+  });
+
+  it('is false when no descendant is active and not defaultExpanded', () => {
+    expect(isExpanded(content, '/unrelated')).toBe(false);
+  });
+});

--- a/packages/smrt-svelte/src/components/workspace/__tests__/nav-helpers.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/nav-helpers.test.ts
@@ -74,6 +74,18 @@ describe('defaultIsActive', () => {
     // '/foo' should not match '/foobar' — the '/' boundary matters.
     expect(defaultIsActive({ href: '/foo', label: '' }, '/foobar')).toBe(false);
   });
+
+  // Regression for #1231: the descendant-path fallback used to be
+  // `currentPath.startsWith(item.href + '/')`. For `item.href === '/'`,
+  // that expands to `startsWith('//')`, which never matches a real path —
+  // and even if it did, we don't want every nested route to count the
+  // root item as active by ancestry.
+  it('treats a root-href item as exact-only even without the exact flag', () => {
+    const root: NavItem = { href: '/', label: 'Home' };
+    expect(defaultIsActive(root, '/')).toBe(true);
+    expect(defaultIsActive(root, '/content')).toBe(false);
+    expect(defaultIsActive(root, '/content/articles')).toBe(false);
+  });
 });
 
 describe('isItemOrChildActive', () => {

--- a/packages/smrt-svelte/src/components/workspace/__tests__/render-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/render-harness.svelte
@@ -28,6 +28,8 @@ interface Props {
   setContextOnMount?: ToolsDockContext | null;
   /** Force the dock open after setup (for empty-state assertions). */
   forceOpen?: boolean;
+  /** Pass-through `context` prop to <ToolsDock>. */
+  context?: ToolsDockContext | null;
 }
 
 const props: Props = $props();
@@ -58,4 +60,4 @@ onMount(() => {
 });
 </script>
 
-<ToolsDock {dock} />
+<ToolsDock {dock} context={props.context} />

--- a/packages/smrt-svelte/src/components/workspace/__tests__/render-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/render-harness.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+/**
+ * Render harness — wires defineToolsDock + <ToolsDock> into a single
+ * component so tests can render the actual DOM. Accepts a thin shape that
+ * lets each test express only the behavior it cares about.
+ */
+import { onMount } from 'svelte';
+import { defineToolsDock } from '../tools-dock/define-tools-dock.svelte.js';
+import ToolsDock from '../tools-dock/ToolsDock.svelte';
+import type { AvailableTool, ToolsDockContext } from '../types.js';
+
+interface ToolProp {
+  id: string;
+  label: string;
+  badge?: number | string | null;
+}
+
+interface Props {
+  tools: ToolProp[];
+  fetchAvailability?: (
+    ctx: ToolsDockContext | null,
+  ) => Promise<AvailableTool[]>;
+  initialOpen?: boolean;
+  layout?: 'rail' | 'topbar';
+  /** Activate this tool on mount via dock.open(id). */
+  activateOnMount?: string | null;
+  /** Call dock.setContext(...) on mount. */
+  setContextOnMount?: ToolsDockContext | null;
+  /** Force the dock open after setup (for empty-state assertions). */
+  forceOpen?: boolean;
+}
+
+const props: Props = $props();
+
+// Use a trivial inline component as the tool body; the renderer only checks
+// that ActiveTool is defined and renders a header — the body is irrelevant
+// for these tests.
+// biome-ignore lint/correctness/noUnusedVariables: noop component
+const NoopBody = (() => null) as never;
+
+const dock = defineToolsDock({
+  tools: props.tools.map((t) => ({ ...t, component: NoopBody })),
+  fetchAvailability: props.fetchAvailability,
+  initialOpen: props.initialOpen,
+  layout: props.layout,
+});
+
+onMount(() => {
+  if (props.setContextOnMount !== undefined) {
+    dock.setContext(props.setContextOnMount);
+  }
+  if (props.activateOnMount) {
+    dock.open(props.activateOnMount);
+  }
+  if (props.forceOpen) {
+    dock.open();
+  }
+});
+</script>
+
+<ToolsDock {dock} />

--- a/packages/smrt-svelte/src/components/workspace/__tests__/render-tools-dock.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/render-tools-dock.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for the <ToolsDock> renderer.
+ *
+ * Verifies that rail buttons are rendered for available tools, that clicking
+ * one opens the panel and activates the tool, that the close button closes
+ * the panel, and that the empty state renders when fetchAvailability filters
+ * everything away.
+ */
+
+import { flushSync, mount, unmount } from 'svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import RenderHarness from './render-harness.svelte';
+
+const mountedComponents: Array<ReturnType<typeof mount>> = [];
+
+function render(props: Record<string, unknown>) {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const component = mount(RenderHarness, { target, props });
+  mountedComponents.push(component);
+  flushSync();
+  return target;
+}
+
+afterEach(() => {
+  while (mountedComponents.length > 0) {
+    const c = mountedComponents.pop();
+    if (c) unmount(c);
+  }
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+describe('<ToolsDock> rail layout', () => {
+  it('renders a rail button for every available tool', () => {
+    const target = render({
+      tools: [
+        { id: 'chat', label: 'Chat' },
+        { id: 'jobs', label: 'Jobs' },
+      ],
+    });
+
+    const buttons = target.querySelectorAll('.tools-dock__rail-button');
+    expect(buttons.length).toBe(2);
+    expect(buttons[0].getAttribute('aria-label')).toBe('Chat tool');
+    expect(buttons[1].getAttribute('aria-label')).toBe('Jobs tool');
+  });
+
+  it('opens the panel and marks the active button with aria-current when clicked', () => {
+    const target = render({
+      tools: [
+        { id: 'chat', label: 'Chat' },
+        { id: 'jobs', label: 'Jobs' },
+      ],
+    });
+
+    const chatBtn = target.querySelectorAll<HTMLButtonElement>(
+      '.tools-dock__rail-button',
+    )[0];
+    chatBtn.click();
+    flushSync();
+
+    expect(chatBtn.classList.contains('active')).toBe(true);
+    expect(chatBtn.getAttribute('aria-current')).toBe('true');
+    expect(chatBtn.getAttribute('aria-pressed')).toBe('true');
+
+    // Panel header reflects the active tool.
+    const heading = target.querySelector('.tools-dock__panel-header h3');
+    expect(heading?.textContent).toBe('Chat');
+  });
+
+  it('closes when the close button is clicked', () => {
+    const target = render({
+      tools: [{ id: 'chat', label: 'Chat' }],
+      initialOpen: true,
+      activateOnMount: 'chat',
+    });
+
+    const aside = target.querySelector('.tools-dock--rail');
+    expect(aside?.classList.contains('tools-dock--open')).toBe(true);
+
+    const closeBtn =
+      target.querySelector<HTMLButtonElement>('.tools-dock__close');
+    closeBtn?.click();
+    flushSync();
+
+    expect(aside?.classList.contains('tools-dock--open')).toBe(false);
+  });
+
+  it('renders an empty state when no tools are available', async () => {
+    const target = render({
+      tools: [{ id: 'chat', label: 'Chat' }],
+      // fetchAvailability that returns nothing means no tools surface.
+      fetchAvailability: async () => [],
+      activateOnMount: null,
+      setContextOnMount: { type: 'route' },
+      forceOpen: true,
+    });
+
+    // Wait for the microtask resolving fetchAvailability.
+    await new Promise((r) => setTimeout(r, 0));
+    flushSync();
+
+    const buttons = target.querySelectorAll('.tools-dock__rail-button');
+    expect(buttons.length).toBe(0);
+    // When forced open, the panel body renders the empty state.
+    const empty = target.querySelector('.tools-dock__empty');
+    expect(empty?.textContent).toContain('No tools');
+  });
+});

--- a/packages/smrt-svelte/src/components/workspace/__tests__/render-tools-dock.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/render-tools-dock.test.ts
@@ -7,8 +7,10 @@
  * everything away.
  */
 
-import { flushSync, mount, unmount } from 'svelte';
+import { flushSync, mount, tick, unmount } from 'svelte';
 import { afterEach, describe, expect, it } from 'vitest';
+import type { ToolsDockInstance } from '../tools-dock/define-tools-dock.svelte.js';
+import ContextForwardingHarness from './context-forwarding-harness.svelte';
 import RenderHarness from './render-harness.svelte';
 
 const mountedComponents: Array<ReturnType<typeof mount>> = [];
@@ -47,7 +49,7 @@ describe('<ToolsDock> rail layout', () => {
     expect(buttons[1].getAttribute('aria-label')).toBe('Jobs tool');
   });
 
-  it('opens the panel and marks the active button with aria-current when clicked', () => {
+  it('opens the panel and marks the active button with aria-pressed when clicked', () => {
     const target = render({
       tools: [
         { id: 'chat', label: 'Chat' },
@@ -62,12 +64,39 @@ describe('<ToolsDock> rail layout', () => {
     flushSync();
 
     expect(chatBtn.classList.contains('active')).toBe(true);
-    expect(chatBtn.getAttribute('aria-current')).toBe('true');
+    // aria-pressed is the right semantics for a toggle button. aria-current
+    // is reserved for navigation sets (breadcrumbs, paginators, etc.) — using
+    // both on the same control conflicts and should not appear here.
     expect(chatBtn.getAttribute('aria-pressed')).toBe('true');
+    expect(chatBtn.getAttribute('aria-current')).toBeNull();
 
     // Panel header reflects the active tool.
     const heading = target.querySelector('.tools-dock__panel-header h3');
     expect(heading?.textContent).toBe('Chat');
+  });
+
+  it('panel exposes role="dialog" and is inert when closed', () => {
+    const target = render({
+      tools: [{ id: 'chat', label: 'Chat' }],
+    });
+
+    const panel = target.querySelector('.tools-dock__panel') as
+      | (HTMLElement & { inert: boolean })
+      | null;
+    expect(panel?.getAttribute('role')).toBe('dialog');
+    // Closed state: inert is set so tab order skips the off-screen panel.
+    // Svelte 5 sets `inert` via the IDL property; jsdom reflects the property
+    // rather than the HTML attribute, so check both.
+    expect(panel?.inert === true || panel?.hasAttribute('inert')).toBe(true);
+
+    const chatBtn = target.querySelector<HTMLButtonElement>(
+      '.tools-dock__rail-button',
+    );
+    chatBtn?.click();
+    flushSync();
+
+    // Open: inert is cleared so descendants are focusable.
+    expect(panel?.inert === false && !panel?.hasAttribute('inert')).toBe(true);
   });
 
   it('closes when the close button is clicked', () => {
@@ -86,6 +115,49 @@ describe('<ToolsDock> rail layout', () => {
     flushSync();
 
     expect(aside?.classList.contains('tools-dock--open')).toBe(false);
+  });
+
+  it('forwards a late-populated `context` prop into the dock', async () => {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+
+    let dock: ToolsDockInstance | null = null;
+    let setContextProp:
+      | ((next: { type: string; title: string } | null | undefined) => void)
+      | null = null;
+
+    const component = mount(ContextForwardingHarness, {
+      target,
+      props: {
+        onReady: (api: {
+          dock: ToolsDockInstance;
+          setContextProp: (
+            next: { type: string; title: string } | null | undefined,
+          ) => void;
+        }) => {
+          dock = api.dock;
+          setContextProp = api.setContextProp;
+        },
+      },
+    });
+    mountedComponents.push(component);
+    flushSync();
+
+    // Initial value is undefined — nothing forwarded yet.
+    expect(dock?.context).toBeNull();
+
+    // Populate the prop after mount (simulating async route data arrival).
+    setContextProp?.({ type: 'route', title: 'Hello' });
+    flushSync();
+    await tick();
+
+    expect(dock?.context).toEqual({ type: 'route', title: 'Hello' });
+
+    // Change the prop again — the effect should run idempotently.
+    setContextProp?.({ type: 'route', title: 'World' });
+    flushSync();
+    await tick();
+    expect(dock?.context).toEqual({ type: 'route', title: 'World' });
   });
 
   it('renders an empty state when no tools are available', async () => {

--- a/packages/smrt-svelte/src/components/workspace/__tests__/use-harness-orphan.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/use-harness-orphan.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+/**
+ * Orphan consumer — calls useToolsDock with no provider in the ancestor
+ * chain. Expected to throw at construction time.
+ */
+import { useToolsDock } from '../tools-dock/use-tools-dock.js';
+
+useToolsDock();
+</script>

--- a/packages/smrt-svelte/src/components/workspace/__tests__/use-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/use-harness.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+/**
+ * Provider + consumer in one component. The factory call sets context on
+ * this component; an immediate-child snippet then reads it via useToolsDock.
+ */
+import { defineToolsDock } from '../tools-dock/define-tools-dock.svelte.js';
+import { useToolsDock } from '../tools-dock/use-tools-dock.js';
+import type { ToolsDockApi } from '../types.js';
+
+interface Props {
+  onReady: (api: ToolsDockApi) => void;
+}
+
+const { onReady }: Props = $props();
+defineToolsDock({
+  tools: [{ id: 'demo', label: 'Demo', component: (() => null) as never }],
+});
+// useToolsDock reads from the same component init scope's context tree.
+const api = useToolsDock();
+onReady(api);
+</script>

--- a/packages/smrt-svelte/src/components/workspace/__tests__/use-tools-dock.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/use-tools-dock.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Tests for useToolsDock.
+ */
+
+import { mount, unmount } from 'svelte';
+import { describe, expect, it } from 'vitest';
+import UseHarness from './use-harness.svelte';
+import OrphanHarness from './use-harness-orphan.svelte';
+
+describe('useToolsDock', () => {
+  it('returns the dock when called inside a <ToolsDock> provider', () => {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+
+    let observed: { isOpen: boolean; activeTool: string | null } | null = null;
+
+    const component = mount(UseHarness, {
+      target,
+      props: {
+        onReady: (api) => {
+          observed = { isOpen: api.isOpen, activeTool: api.activeTool };
+        },
+      },
+    });
+
+    expect(observed).not.toBeNull();
+    expect(observed?.isOpen).toBe(false);
+    expect(observed?.activeTool).toBeNull();
+
+    unmount(component);
+    target.remove();
+  });
+
+  it('throws a clear error when called outside a provider', () => {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+
+    expect(() => mount(OrphanHarness, { target })).toThrow(/ToolsDock/);
+
+    target.remove();
+  });
+});

--- a/packages/smrt-svelte/src/components/workspace/breadcrumbs-helpers.ts
+++ b/packages/smrt-svelte/src/components/workspace/breadcrumbs-helpers.ts
@@ -77,15 +77,25 @@ export function deriveCrumbsFromNav(
   let basePath = '';
   if (startAfter) {
     const startSegments = startAfter.split('/').filter(Boolean);
-    const lastStartSegment = startSegments[startSegments.length - 1];
-    if (lastStartSegment !== undefined) {
-      const found = segments.indexOf(lastStartSegment);
-      if (found === -1) {
+    if (startSegments.length > 0) {
+      // Match the full contiguous `startSegments` sequence in `segments`,
+      // not just the last token — otherwise an ambiguous pathname like
+      // `/sites/sites/content` with `startAfter: 'sites/sites'` would
+      // anchor on the first `sites` and build the wrong base path.
+      let matched = false;
+      outer: for (let i = 0; i <= segments.length - startSegments.length; i++) {
+        for (let j = 0; j < startSegments.length; j++) {
+          if (segments[i + j] !== startSegments[j]) continue outer;
+        }
+        startIndex = i + startSegments.length;
+        basePath = `/${segments.slice(0, startIndex).join('/')}`;
+        matched = true;
+        break;
+      }
+      if (!matched) {
         // startAfter not in path → nothing to walk.
         return result;
       }
-      startIndex = found + 1;
-      basePath = `/${segments.slice(0, startIndex).join('/')}`;
     }
   }
 

--- a/packages/smrt-svelte/src/components/workspace/breadcrumbs-helpers.ts
+++ b/packages/smrt-svelte/src/components/workspace/breadcrumbs-helpers.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure helpers for breadcrumb derivation.
+ *
+ * Extracted so the path-walking logic can be unit-tested without rendering
+ * a Svelte component.
+ */
+
+import type { BreadcrumbItem, NavItem } from './types.js';
+
+/**
+ * Walk a nav tree depth-first and return the label of the item whose
+ * `href` matches exactly, or `null` if not found.
+ */
+export function findLabelInNav(items: NavItem[], href: string): string | null {
+  for (const item of items) {
+    if (item.href === href) return item.label;
+    if (item.children?.length) {
+      const label = findLabelInNav(item.children, href);
+      if (label) return label;
+    }
+  }
+  return null;
+}
+
+/**
+ * Default label fallback for unknown segments: capitalize the first letter
+ * and turn dashes/underscores into spaces.
+ */
+export function capitalizeSegment(segment: string): string {
+  if (!segment) return segment;
+  const cleaned = segment.replace(/[-_]/g, ' ');
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
+export interface DeriveCrumbsOptions {
+  /** Optional first crumb (e.g., site identity). */
+  rootCrumb?: BreadcrumbItem;
+  /**
+   * Skip pathname segments until (and including) the given path is matched.
+   * Example: `startAfter: 'sites/foo'` ignores everything up through
+   * `/sites/foo` in the pathname.
+   */
+  startAfter?: string;
+  /** Fall back to capitalized segments for unmatched paths (default: true). */
+  capitalize?: boolean;
+}
+
+/**
+ * Derive a breadcrumb trail from a pathname + nav tree.
+ *
+ * Strategy:
+ *  1. Optionally prepend `rootCrumb`.
+ *  2. Split the pathname into segments.
+ *  3. If `startAfter` is set, locate its trailing segment in the
+ *     pathname and skip everything before/including it. The
+ *     `startAfter` value may include a leading slash or none and
+ *     may be a multi-segment path (e.g. `sites/foo`).
+ *  4. Walk the remaining segments, building cumulative paths; for
+ *     each, try to find a matching nav label, otherwise capitalize.
+ */
+export function deriveCrumbsFromNav(
+  pathname: string,
+  nav: NavItem[],
+  options: DeriveCrumbsOptions = {},
+): BreadcrumbItem[] {
+  const { rootCrumb, startAfter, capitalize = true } = options;
+  const result: BreadcrumbItem[] = [];
+
+  if (rootCrumb) {
+    result.push(rootCrumb);
+  }
+
+  const segments = (pathname || '').split('/').filter(Boolean);
+
+  // Resolve which segment index we start emitting crumbs after.
+  let startIndex = 0;
+  let basePath = '';
+  if (startAfter) {
+    const startSegments = startAfter.split('/').filter(Boolean);
+    const lastStartSegment = startSegments[startSegments.length - 1];
+    if (lastStartSegment !== undefined) {
+      const found = segments.indexOf(lastStartSegment);
+      if (found === -1) {
+        // startAfter not in path → nothing to walk.
+        return result;
+      }
+      startIndex = found + 1;
+      basePath = `/${segments.slice(0, startIndex).join('/')}`;
+    }
+  }
+
+  let currentPath = basePath;
+  for (const segment of segments.slice(startIndex)) {
+    currentPath += `/${segment}`;
+    const label =
+      findLabelInNav(nav, currentPath) ??
+      (capitalize ? capitalizeSegment(segment) : segment);
+    result.push({ label, href: currentPath });
+  }
+
+  return result;
+}

--- a/packages/smrt-svelte/src/components/workspace/index.ts
+++ b/packages/smrt-svelte/src/components/workspace/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @happyvertical/smrt-svelte/workspace
+ *
+ * Workspace shell primitives for admin UIs. See packages/smrt-svelte/CLAUDE.md
+ * for layering principles. Implementations land via #1227, #1228, #1229.
+ */
+
+export type {
+  AvailableTool,
+  BreadcrumbItem,
+  NavItem,
+  ToolDef,
+  ToolsDockApi,
+  ToolsDockContext,
+} from './types.js';
+
+// Component exports land via implementer PRs:
+//   #1227: WorkspaceShell
+//   #1228: NavTree, Breadcrumbs
+//   #1229: ToolsDock, defineToolsDock, useToolsDock

--- a/packages/smrt-svelte/src/components/workspace/index.ts
+++ b/packages/smrt-svelte/src/components/workspace/index.ts
@@ -5,6 +5,8 @@
  * for layering principles. Implementations land via #1227, #1228, #1229.
  */
 
+export { default as Breadcrumbs } from './Breadcrumbs.svelte';
+export { default as NavTree } from './NavTree.svelte';
 export type {
   AvailableTool,
   BreadcrumbItem,
@@ -16,5 +18,4 @@ export type {
 
 // Component exports land via implementer PRs:
 //   #1227: WorkspaceShell
-//   #1228: NavTree, Breadcrumbs
 //   #1229: ToolsDock, defineToolsDock, useToolsDock

--- a/packages/smrt-svelte/src/components/workspace/index.ts
+++ b/packages/smrt-svelte/src/components/workspace/index.ts
@@ -13,8 +13,9 @@ export type {
   ToolsDockApi,
   ToolsDockContext,
 } from './types.js';
+export { default as WorkspaceShell } from './WorkspaceShell.svelte';
 
 // Component exports land via implementer PRs:
-//   #1227: WorkspaceShell
+//   #1227: WorkspaceShell (landed)
 //   #1228: NavTree, Breadcrumbs
 //   #1229: ToolsDock, defineToolsDock, useToolsDock

--- a/packages/smrt-svelte/src/components/workspace/index.ts
+++ b/packages/smrt-svelte/src/components/workspace/index.ts
@@ -5,6 +5,15 @@
  * for layering principles. Implementations land via #1227, #1228, #1229.
  */
 
+export {
+  type DefineToolsDockOptions,
+  defineToolsDock,
+  TOOLS_DOCK_KEY,
+  type ToolsDockInstance,
+} from './tools-dock/define-tools-dock.svelte.js';
+
+export { default as ToolsDock } from './tools-dock/ToolsDock.svelte';
+export { tryUseToolsDock, useToolsDock } from './tools-dock/use-tools-dock.js';
 export type {
   AvailableTool,
   BreadcrumbItem,
@@ -17,4 +26,3 @@ export type {
 // Component exports land via implementer PRs:
 //   #1227: WorkspaceShell
 //   #1228: NavTree, Breadcrumbs
-//   #1229: ToolsDock, defineToolsDock, useToolsDock

--- a/packages/smrt-svelte/src/components/workspace/nav-helpers.ts
+++ b/packages/smrt-svelte/src/components/workspace/nav-helpers.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure helpers for nav state derivation.
+ *
+ * Extracted so the recursive active/expanded logic can be unit-tested
+ * without needing to mount Svelte components.
+ *
+ * No DOM, no Svelte runes, no SvelteKit imports — these are SSR-safe and
+ * deterministic given their inputs.
+ */
+
+import type { NavItem } from './types.js';
+
+/**
+ * Default activeness check for a nav item against a current path.
+ *
+ * - Exact match → active
+ * - `item.exact === true` → only exact match counts
+ * - Otherwise, active when `currentPath` starts with `item.href + '/'`
+ *   (the trailing slash avoids `/foo` matching `/foobar`).
+ */
+export function defaultIsActive(item: NavItem, currentPath: string): boolean {
+  if (item.href === currentPath) return true;
+  if (item.exact) return false;
+  return currentPath.startsWith(`${item.href}/`);
+}
+
+/**
+ * True if the item or any descendant is active under `isActive`.
+ */
+export function isItemOrChildActive(
+  item: NavItem,
+  currentPath: string,
+  isActive: (item: NavItem, currentPath: string) => boolean = defaultIsActive,
+): boolean {
+  if (isActive(item, currentPath)) return true;
+  if (item.children) {
+    for (const child of item.children) {
+      if (isItemOrChildActive(child, currentPath, isActive)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * True when an item's children container should render as expanded.
+ *
+ * Children are expanded when:
+ *  - the item has children, AND
+ *  - one of its descendants is active, OR `item.defaultExpanded` is set.
+ */
+export function isExpanded(
+  item: NavItem,
+  currentPath: string,
+  isActive: (item: NavItem, currentPath: string) => boolean = defaultIsActive,
+): boolean {
+  if (!item.children?.length) return false;
+  if (item.defaultExpanded) return true;
+  return isItemOrChildActive(item, currentPath, isActive);
+}

--- a/packages/smrt-svelte/src/components/workspace/nav-helpers.ts
+++ b/packages/smrt-svelte/src/components/workspace/nav-helpers.ts
@@ -15,12 +15,19 @@ import type { NavItem } from './types.js';
  *
  * - Exact match → active
  * - `item.exact === true` → only exact match counts
+ * - `item.href === '/'` → only matches `currentPath === '/'`; otherwise
+ *   the descendant-path fallback would degrade to `startsWith('//')`
+ *   and never fire (and we don't want every path counting the root as
+ *   active by ancestry).
  * - Otherwise, active when `currentPath` starts with `item.href + '/'`
  *   (the trailing slash avoids `/foo` matching `/foobar`).
  */
 export function defaultIsActive(item: NavItem, currentPath: string): boolean {
   if (item.href === currentPath) return true;
   if (item.exact) return false;
+  // The root href would produce `startsWith('//')`, which never matches a
+  // real path. Treat root as exact-only when not flagged with `exact`.
+  if (item.href === '/') return false;
   return currentPath.startsWith(`${item.href}/`);
 }
 

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
@@ -1,0 +1,482 @@
+<script lang="ts" module>
+/**
+ * ToolsDock - renderer for the tools dock.
+ *
+ * Consumes a {@link ToolsDockInstance} produced by {@link defineToolsDock}
+ * and renders either:
+ *   - layout='rail'   → a vertical icon rail (right edge) + a sliding panel
+ *   - layout='topbar' → inline activation buttons + a separate floating panel
+ *
+ * The component takes care of:
+ *   - registering the dock on Svelte context (via the factory) so descendants
+ *     can call {@link useToolsDock}
+ *   - hydrating persisted state on mount (SSR-safe)
+ *   - persisting state changes back to localStorage when `storageKey` is set
+ *   - Escape-to-close + focus restoration to the activating button
+ *   - reflecting active tool via aria-current and a polite live region
+ *   - showing an empty-state when no tools pass the availability filter
+ */
+</script>
+
+<script lang="ts">
+  import { onDestroy, onMount, tick } from 'svelte';
+  import type { ToolsDockContext } from '../types.js';
+  import type { ToolsDockInstance } from './define-tools-dock.svelte.js';
+
+  interface Props {
+    /** Instance produced by `defineToolsDock(...)`. */
+    dock: ToolsDockInstance;
+    /** Optional initial context. Alternative to calling `dock.setContext()` directly. */
+    context?: ToolsDockContext | null;
+    /** Optional override label for the open/close rail toggle, for a11y. */
+    closeLabel?: string;
+  }
+
+  let { dock, context = undefined, closeLabel = 'Close tools panel' }: Props =
+    $props();
+
+  // Apply the initial context once on mount. Subsequent calls to dock.setContext
+  // from outside take over normally.
+  let appliedInitialContext = false;
+  $effect(() => {
+    if (appliedInitialContext) return;
+    if (context !== undefined) {
+      dock.setContext(context);
+    }
+    appliedInitialContext = true;
+  });
+
+  let panelEl = $state<HTMLDivElement | null>(null);
+  let lastActivatorEl: HTMLButtonElement | null = null;
+  const announcement = $derived(
+    dock.isOpen && dock.activeTool
+      ? `${labelFor(dock.activeTool)} tool opened`
+      : '',
+  );
+
+  function labelFor(toolId: string): string {
+    return (
+      dock.availableTools.find((t) => t.id === toolId)?.label ??
+      dock.tools.find((t) => t.id === toolId)?.label ??
+      toolId
+    );
+  }
+
+  function activeToolDef() {
+    if (!dock.activeTool) return null;
+    return dock.tools.find((t) => t.id === dock.activeTool) ?? null;
+  }
+
+  function handleButtonClick(event: MouseEvent, toolId: string): void {
+    lastActivatorEl = event.currentTarget as HTMLButtonElement;
+    dock.toggle(toolId);
+  }
+
+  function handleClose(): void {
+    dock.close();
+    // Restore focus to the last activator (if still mounted).
+    void tick().then(() => {
+      lastActivatorEl?.focus();
+    });
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape' && dock.isOpen) {
+      event.preventDefault();
+      handleClose();
+    }
+  }
+
+  onMount(() => {
+    dock.hydrate();
+  });
+
+  // Persist whenever isOpen/activeTool change (defineToolsDock also persists
+  // on its mutators; this catches external set-via-getter writes if any).
+  let lastIsOpen: boolean | undefined;
+  let lastActive: string | null | undefined;
+  $effect(() => {
+    if (dock.isOpen !== lastIsOpen || dock.activeTool !== lastActive) {
+      lastIsOpen = dock.isOpen;
+      lastActive = dock.activeTool;
+      dock.persist();
+    }
+  });
+
+  let removeKeydown: (() => void) | null = null;
+  onMount(() => {
+    if (typeof window === 'undefined') return;
+    const handler = (e: KeyboardEvent) => handleKeydown(e);
+    window.addEventListener('keydown', handler);
+    removeKeydown = () => window.removeEventListener('keydown', handler);
+  });
+  onDestroy(() => {
+    removeKeydown?.();
+  });
+</script>
+
+{#snippet toolButton(tool: { id: string; label?: string; badge?: number | string | null }, variant: 'rail' | 'topbar')}
+  {@const isActive = dock.isOpen && dock.activeTool === tool.id}
+  {@const label = tool.label ?? tool.id}
+  <button
+    type="button"
+    class:active={isActive}
+    class={variant === 'rail' ? 'tools-dock__rail-button' : 'tools-dock__topbar-button'}
+    aria-pressed={isActive}
+    aria-current={isActive ? 'true' : undefined}
+    aria-label={`${label} tool`}
+    title={label}
+    onclick={(event) => handleButtonClick(event, tool.id)}
+  >
+    {#if variant === 'topbar'}
+      <span class="tools-dock__topbar-button-label">{label}</span>
+    {:else}
+      <span class="tools-dock__rail-glyph" aria-hidden="true">
+        {label?.charAt(0).toUpperCase() ?? '?'}
+      </span>
+    {/if}
+    {#if tool.badge !== null && tool.badge !== undefined && tool.badge !== 0 && tool.badge !== ''}
+      <span class="tools-dock__badge">{tool.badge}</span>
+    {/if}
+  </button>
+{/snippet}
+
+{#snippet panel()}
+  {@const ActiveTool = activeToolDef()?.component}
+  <div
+    class="tools-dock__panel"
+    class:tools-dock__panel--open={dock.isOpen}
+    role="region"
+    aria-label={dock.activeTool ? `${labelFor(dock.activeTool)} tool panel` : 'Tools panel'}
+    aria-hidden={!dock.isOpen}
+    bind:this={panelEl}
+  >
+    <header class="tools-dock__panel-header">
+      <h3>{dock.activeTool ? labelFor(dock.activeTool) : 'Tools'}</h3>
+      <button
+        type="button"
+        class="tools-dock__close"
+        onclick={handleClose}
+        aria-label={closeLabel}
+        title={closeLabel}
+      >
+        ×
+      </button>
+    </header>
+
+    <div class="tools-dock__panel-body">
+      {#if dock.availableTools.length === 0}
+        <div class="tools-dock__empty">
+          <strong>No tools available</strong>
+          <p>No tools are available for the current context.</p>
+        </div>
+      {:else if ActiveTool}
+        <ActiveTool context={dock.context} {dock} />
+      {:else}
+        <div class="tools-dock__empty">
+          <p>Select a tool to begin.</p>
+        </div>
+      {/if}
+    </div>
+  </div>
+{/snippet}
+
+<!-- Polite live region announces tool transitions for screen readers. -->
+<div class="tools-dock__sr-only" role="status" aria-live="polite">{announcement}</div>
+
+{#if dock.layout === 'topbar'}
+  <div class="tools-dock tools-dock--topbar">
+    <nav class="tools-dock__topbar" aria-label="Workspace tools">
+      {#each dock.availableTools as tool (tool.id)}
+        {@render toolButton(tool, 'topbar')}
+      {/each}
+    </nav>
+    {#if dock.isOpen}
+      {@render panel()}
+    {/if}
+  </div>
+{:else}
+  <aside class="tools-dock tools-dock--rail" class:tools-dock--open={dock.isOpen}>
+    {#if dock.isOpen}
+      <button
+        type="button"
+        class="tools-dock__overlay"
+        aria-label={closeLabel}
+        onclick={handleClose}
+      ></button>
+    {/if}
+    {@render panel()}
+    <nav class="tools-dock__rail" aria-label="Workspace tools">
+      {#each dock.availableTools as tool (tool.id)}
+        {@render toolButton(tool, 'rail')}
+      {/each}
+    </nav>
+  </aside>
+{/if}
+
+<style>
+  .tools-dock {
+    --tools-dock-rail-width: 3.25rem;
+    --tools-dock-panel-width: 420px;
+    color: var(--smrt-color-on-surface, #f8fafc);
+    box-sizing: border-box;
+  }
+
+  /* ---------- Rail layout ---------- */
+
+  .tools-dock--rail {
+    position: sticky;
+    top: 0;
+    align-self: flex-start;
+    z-index: 20;
+    height: 100vh;
+    width: var(--tools-dock-rail-width);
+    flex: 0 0 var(--tools-dock-rail-width);
+    display: block;
+  }
+
+  .tools-dock__rail {
+    position: relative;
+    z-index: 2;
+    width: var(--tools-dock-rail-width);
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.6rem 0.45rem;
+    background: var(--smrt-color-surface-container-low, #11161b);
+    border-left: 1px solid var(--smrt-color-outline-variant, #30343a);
+  }
+
+  .tools-dock__rail-button {
+    position: relative;
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
+    display: inline-grid;
+    place-items: center;
+    border: 1px solid transparent;
+    border-radius: 0.45rem;
+    background: transparent;
+    color: var(--smrt-color-on-surface-variant, #aab2bd);
+    cursor: pointer;
+  }
+
+  .tools-dock__rail-button:hover,
+  .tools-dock__rail-button.active {
+    background: var(--smrt-color-surface-container-high, #1d2228);
+    color: var(--smrt-color-on-surface, #f8fafc);
+  }
+
+  .tools-dock__rail-button:focus-visible,
+  .tools-dock__topbar-button:focus-visible,
+  .tools-dock__close:focus-visible {
+    outline: 2px solid var(--smrt-color-primary, #7dd3fc);
+    outline-offset: 2px;
+  }
+
+  .tools-dock__rail-glyph {
+    font-size: 0.95rem;
+    font-weight: 700;
+    line-height: 1;
+  }
+
+  .tools-dock__badge {
+    position: absolute;
+    top: 0.18rem;
+    right: 0.12rem;
+    min-width: 0.85rem;
+    height: 0.85rem;
+    padding: 0 0.18rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    background: var(--smrt-color-primary, #7dd3fc);
+    color: var(--smrt-color-on-primary, #061014);
+    font-size: 0.58rem;
+    font-weight: 750;
+    line-height: 1;
+  }
+
+  /* ---------- Panel ---------- */
+
+  .tools-dock__panel {
+    position: absolute;
+    inset: 0 var(--tools-dock-rail-width) 0 auto;
+    height: 100%;
+    width: var(--tools-dock-panel-width);
+    min-width: var(--tools-dock-panel-width);
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    padding: 1rem;
+    background: var(--smrt-color-surface, #101214);
+    color: var(--smrt-color-on-surface, #f8fafc);
+    overflow: hidden;
+    border-left: 1px solid var(--smrt-color-outline-variant, #30343a);
+    border-right: 1px solid var(--smrt-color-outline-variant, #30343a);
+    box-shadow: -24px 0 40px rgba(0, 0, 0, 0.18);
+    transform: translateX(calc(100% + var(--tools-dock-rail-width)));
+    opacity: 0;
+    pointer-events: none;
+    transition:
+      transform 180ms cubic-bezier(0.2, 0, 0, 1),
+      opacity 120ms ease;
+    will-change: transform;
+    contain: layout paint style;
+  }
+
+  .tools-dock--rail.tools-dock--open .tools-dock__panel,
+  .tools-dock__panel--open {
+    transform: translateX(0);
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .tools-dock__panel-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .tools-dock__panel-header h3 {
+    margin: 0;
+    font-size: 1.05rem;
+    line-height: 1.15;
+  }
+
+  .tools-dock__panel-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+  }
+
+  .tools-dock__close {
+    width: 2rem;
+    height: 2rem;
+    display: inline-grid;
+    place-items: center;
+    border: 1px solid var(--smrt-color-outline-variant, #30343a);
+    border-radius: 0.5rem;
+    background: var(--smrt-color-surface-container-high, #1d2228);
+    color: inherit;
+    cursor: pointer;
+    font-size: 1.2rem;
+    line-height: 1;
+  }
+
+  .tools-dock__empty {
+    display: grid;
+    align-content: center;
+    gap: 0.45rem;
+    min-height: 12rem;
+    padding: 1rem;
+    color: var(--smrt-color-on-surface-variant, #aab2bd);
+    text-align: center;
+  }
+
+  .tools-dock__empty strong {
+    color: var(--smrt-color-on-surface, #f8fafc);
+  }
+
+  .tools-dock__empty p {
+    margin: 0;
+    line-height: 1.45;
+  }
+
+  .tools-dock__overlay {
+    display: none;
+  }
+
+  /* ---------- Topbar layout ---------- */
+
+  .tools-dock--topbar {
+    display: contents;
+  }
+
+  .tools-dock__topbar {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .tools-dock__topbar-button {
+    position: relative;
+    border: 1px solid var(--smrt-color-outline-variant, #30343a);
+    background: var(--smrt-color-surface-container-low, #11161b);
+    color: var(--smrt-color-on-surface-variant, #aab2bd);
+    border-radius: 0.6rem;
+    padding: 0.45rem 0.7rem;
+    cursor: pointer;
+    font-size: 0.84rem;
+    font-weight: 600;
+  }
+
+  .tools-dock__topbar-button.active,
+  .tools-dock__topbar-button:hover {
+    background: var(--smrt-color-surface-container-high, #1d2228);
+    color: var(--smrt-color-on-surface, #f8fafc);
+  }
+
+  .tools-dock--topbar .tools-dock__panel {
+    position: fixed;
+    inset: auto 1rem 1rem auto;
+    height: min(70vh, 600px);
+    border-radius: 0.75rem;
+    z-index: 40;
+  }
+
+  /* ---------- A11y helpers ---------- */
+
+  .tools-dock__sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  /* ---------- Mobile (drawer) ---------- */
+
+  @media (max-width: 960px) {
+    .tools-dock__overlay {
+      display: block;
+      position: fixed;
+      inset: 0;
+      z-index: 65;
+      padding: 0;
+      border: 0;
+      background: rgba(0, 0, 0, 0.34);
+      cursor: default;
+    }
+
+    .tools-dock--rail {
+      position: fixed;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      width: var(--tools-dock-rail-width);
+      height: 100vh;
+      height: 100dvh;
+      z-index: 70;
+      --tools-dock-panel-width: min(420px, calc(100vw - var(--tools-dock-rail-width)));
+    }
+  }
+
+  @media (max-width: 640px) {
+    .tools-dock--rail {
+      --tools-dock-panel-width: calc(100vw - var(--tools-dock-rail-width));
+    }
+
+    .tools-dock__panel {
+      padding: 0.85rem;
+    }
+  }
+</style>

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
@@ -48,7 +48,6 @@
     }
   });
 
-  let panelEl = $state<HTMLDivElement | null>(null);
   let lastActivatorEl: HTMLButtonElement | null = null;
   const announcement = $derived(
     dock.isOpen && dock.activeTool
@@ -168,7 +167,6 @@
     aria-modal="false"
     aria-hidden={!dock.isOpen}
     inert={!dock.isOpen}
-    bind:this={panelEl}
   >
     <header class="tools-dock__panel-header">
       <h3>{dock.activeTool ? labelFor(dock.activeTool) : 'Tools'}</h3>

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
@@ -35,15 +35,17 @@
   let { dock, context = undefined, closeLabel = 'Close tools panel' }: Props =
     $props();
 
-  // Apply the initial context once on mount. Subsequent calls to dock.setContext
-  // from outside take over normally.
-  let appliedInitialContext = false;
+  // Forward the `context` prop into the dock fully reactively: every time the
+  // prop changes (including from `undefined` to a populated value supplied by
+  // async route data), push it through. `dock.setContext` is idempotent — it
+  // re-runs `fetchAvailability` with token-gated stale-result handling. The
+  // initial-only-flag approach previously here dropped late-arriving values
+  // and interacted badly with Svelte 5's effect dependency tracking when the
+  // early-return branch fired.
   $effect(() => {
-    if (appliedInitialContext) return;
     if (context !== undefined) {
       dock.setContext(context);
     }
-    appliedInitialContext = true;
   });
 
   let panelEl = $state<HTMLDivElement | null>(null);
@@ -93,12 +95,28 @@
 
   // Persist whenever isOpen/activeTool change (defineToolsDock also persists
   // on its mutators; this catches external set-via-getter writes if any).
+  //
+  // The first effect run fires synchronously *after* `onMount(() => dock.hydrate())`
+  // applies persisted state, so we skip it: writing the hydrated values right
+  // back to storage is benign in the common case, but if `hydrate()` rejected
+  // a stale `activeTool` (no longer registered) while `isOpen` was true, that
+  // first persist would silently clear `activeTool` on reload.
   let lastIsOpen: boolean | undefined;
   let lastActive: string | null | undefined;
+  let firstPersistRun = true;
   $effect(() => {
-    if (dock.isOpen !== lastIsOpen || dock.activeTool !== lastActive) {
-      lastIsOpen = dock.isOpen;
-      lastActive = dock.activeTool;
+    // Read both reactive values to register dependencies before any branch.
+    const nextIsOpen = dock.isOpen;
+    const nextActive = dock.activeTool;
+    if (firstPersistRun) {
+      lastIsOpen = nextIsOpen;
+      lastActive = nextActive;
+      firstPersistRun = false;
+      return;
+    }
+    if (nextIsOpen !== lastIsOpen || nextActive !== lastActive) {
+      lastIsOpen = nextIsOpen;
+      lastActive = nextActive;
       dock.persist();
     }
   });
@@ -123,7 +141,6 @@
     class:active={isActive}
     class={variant === 'rail' ? 'tools-dock__rail-button' : 'tools-dock__topbar-button'}
     aria-pressed={isActive}
-    aria-current={isActive ? 'true' : undefined}
     aria-label={`${label} tool`}
     title={label}
     onclick={(event) => handleButtonClick(event, tool.id)}
@@ -146,9 +163,11 @@
   <div
     class="tools-dock__panel"
     class:tools-dock__panel--open={dock.isOpen}
-    role="region"
+    role="dialog"
     aria-label={dock.activeTool ? `${labelFor(dock.activeTool)} tool panel` : 'Tools panel'}
+    aria-modal="false"
     aria-hidden={!dock.isOpen}
+    inert={!dock.isOpen}
     bind:this={panelEl}
   >
     <header class="tools-dock__panel-header">
@@ -467,6 +486,18 @@
       height: 100dvh;
       z-index: 70;
       --tools-dock-panel-width: min(420px, calc(100vw - var(--tools-dock-rail-width)));
+    }
+
+    /* Mobile: keep panel and rail above the close overlay so taps reach the
+       tool UI. The overlay sits at z-index 65 and previously rendered above
+       the panel (no z-index) and rail (z-index: 2) within the same stacking
+       context — every tap hit the close button instead of the tool. */
+    .tools-dock__panel {
+      z-index: 70;
+    }
+
+    .tools-dock__rail {
+      z-index: 70;
     }
   }
 

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
@@ -1,0 +1,354 @@
+/**
+ * defineToolsDock - factory for the ToolsDock API
+ *
+ * Creates a reactive {@link ToolsDockApi} instance backed by Svelte 5 runes
+ * (`$state`) and registers it in Svelte context under {@link TOOLS_DOCK_KEY}.
+ * Inside a `<ToolsDock>` provider tree, descendants (tools, deep panels,
+ * arbitrary consumers) read the same instance via {@link useToolsDock}.
+ *
+ * The dock is intentionally domain-agnostic:
+ *   - Tool IDs are arbitrary strings (no enum).
+ *   - Availability is controlled via the optional `fetchAvailability` callback;
+ *     when omitted, every registered tool is available.
+ *   - Persistence is opt-in via `storageKey` and is SSR-safe.
+ *   - Inter-tool messaging happens through a typed pub/sub bus (`emit`/`on`)
+ *     in lieu of `window.dispatchEvent` patterns from older portals.
+ *
+ * @example Register a dock and a tool
+ * ```ts
+ * // somewhere in a +layout.svelte:
+ * import { defineToolsDock } from '@happyvertical/smrt-svelte/workspace';
+ * import ChatTool from './ChatTool.svelte';
+ *
+ * const dock = defineToolsDock({
+ *   tools: [{ id: 'chat', label: 'Chat', component: ChatTool }],
+ *   storageKey: 'app-name:tools-dock:v1',
+ * });
+ * ```
+ *
+ * @remarks ModuleUIRegistry integration point
+ *
+ * Consumer apps that want tools to come from `@happyvertical/smrt-*` module
+ * packages (commerce, content, etc.) can populate `options.tools` from the
+ * `ModuleUIRegistry` (see {@link ../../../registry/module-registry}) — e.g.
+ * by walking `ModuleUIRegistry.getModules()` and pulling components from a
+ * conventional slot id like `'tools-dock'`. This is left to consumers so the
+ * dock has zero coupling to the registry; the surface area exposed here
+ * (`ToolDef[]`) is what such an adapter would produce.
+ */
+
+import { setContext } from 'svelte';
+import type {
+  AvailableTool,
+  ToolDef,
+  ToolsDockApi,
+  ToolsDockContext,
+} from '../types.js';
+
+/**
+ * Svelte context key for the active ToolsDock API instance.
+ */
+export const TOOLS_DOCK_KEY = Symbol('smrt-tools-dock');
+
+/**
+ * Options accepted by {@link defineToolsDock}.
+ */
+export interface DefineToolsDockOptions<TCtx = unknown> {
+  /** Registered tools. Order is preserved when rendering the activation rail/topbar. */
+  tools: ToolDef<TCtx>[];
+  /**
+   * Optional backend-driven gating callback. Returns the subset of tools that
+   * should be exposed for the current `context`. When omitted, every
+   * registered tool is treated as available.
+   *
+   * The callback may return tool ids that aren't present in `tools` — these
+   * are ignored. Conversely, tools missing from the callback's response are
+   * hidden from the dock UI.
+   */
+  fetchAvailability?: (
+    ctx: ToolsDockContext | null,
+  ) => Promise<AvailableTool[]>;
+  /**
+   * Optional `localStorage` key. When provided, the dock will persist a small
+   * `{ isOpen, activeTool }` blob and hydrate it on mount. Persistence is
+   * SSR-safe — no `localStorage` access happens at module scope or during
+   * initial render on the server.
+   */
+  storageKey?: string;
+  /** Activation UI layout. Defaults to `'rail'`. */
+  layout?: 'rail' | 'topbar';
+  /** Initial open state. Hydration from storage takes precedence. Defaults to `false`. */
+  initialOpen?: boolean;
+}
+
+/**
+ * Internal extension of {@link ToolsDockApi} with framework-only members:
+ * the registered tools, the configured layout, and the persistence key.
+ *
+ * Marked as part of the public surface but stamped with a brand symbol so
+ * that `<ToolsDock>` and `useToolsDock()` callers can safely destructure
+ * without consumers depending on internal field names.
+ */
+export interface ToolsDockInstance<TCtx = unknown> extends ToolsDockApi {
+  readonly tools: ReadonlyArray<ToolDef<TCtx>>;
+  readonly layout: 'rail' | 'topbar';
+  readonly storageKey: string | null;
+  readonly context: ToolsDockContext | null;
+  /** Internal: hydrate persisted state from `localStorage` (called by `<ToolsDock>` on mount). */
+  hydrate(): void;
+  /** Internal: persist current state to `localStorage`. */
+  persist(): void;
+}
+
+interface PersistedState {
+  isOpen?: boolean;
+  activeTool?: string | null;
+}
+
+// Availability fetches are token-gated for race-safety (stale results are
+// dropped — see `refreshAvailability`). We deliberately do NOT debounce by
+// default because:
+//   - `setContext` is typically called from `$effect` on route changes, not
+//     in a tight loop
+//   - debouncing complicates testing without buying meaningful protection
+//     given the token-based stale-result drop
+// Consumers that need debounce can wrap their own setContext call.
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined';
+}
+
+function safeReadStorage(key: string): PersistedState | null {
+  if (!isBrowser()) return null;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') return null;
+    const { isOpen, activeTool } = parsed as PersistedState;
+    return {
+      isOpen: typeof isOpen === 'boolean' ? isOpen : undefined,
+      activeTool:
+        typeof activeTool === 'string' || activeTool === null
+          ? activeTool
+          : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function safeWriteStorage(key: string, payload: PersistedState): void {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(payload));
+  } catch {
+    // Quota errors, private browsing, etc. — silently drop.
+  }
+}
+
+/**
+ * Create a tools-dock instance and register it on Svelte context.
+ *
+ * Must be called inside a Svelte component initialization scope (`<script>`
+ * top level, `+layout.svelte`, etc.) — `setContext` requires it.
+ *
+ * @param options factory options
+ * @returns the {@link ToolsDockInstance} (a {@link ToolsDockApi} plus
+ *   framework metadata `<ToolsDock>` consumes when rendering)
+ */
+export function defineToolsDock<TCtx = unknown>(
+  options: DefineToolsDockOptions<TCtx>,
+): ToolsDockInstance<TCtx> {
+  const layout = options.layout ?? 'rail';
+  const storageKey = options.storageKey ?? null;
+  const fetchAvailability = options.fetchAvailability;
+  const registeredTools = options.tools.slice();
+  const registeredIds = new Set(registeredTools.map((t) => t.id));
+
+  // Reactive state
+  let isOpen = $state(Boolean(options.initialOpen));
+  let activeTool = $state<string | null>(null);
+  let context = $state<ToolsDockContext | null>(null);
+  let availableTools = $state<AvailableTool[]>(
+    registeredTools.map((t) => ({ id: t.id, label: t.label, badge: t.badge })),
+  );
+
+  // Race-handle: each fetchAvailability call gets a token; only the most
+  // recent token may apply its result.
+  let availabilityToken = 0;
+
+  // Pub/sub bus
+  const listeners = new Map<string, Set<(payload: unknown) => void>>();
+
+  function emit<TPayload>(event: string, payload: TPayload): void {
+    const set = listeners.get(event);
+    if (!set || set.size === 0) return;
+    // Copy so handlers that unsubscribe themselves don't mutate during iteration.
+    for (const handler of Array.from(set)) {
+      try {
+        handler(payload);
+      } catch (err) {
+        // Don't let one handler kill the rest.
+        if (isBrowser()) console.error('[ToolsDock] handler error', err);
+      }
+    }
+  }
+
+  function on<TPayload>(
+    event: string,
+    handler: (payload: TPayload) => void,
+  ): () => void {
+    let set = listeners.get(event);
+    if (!set) {
+      set = new Set();
+      listeners.set(event, set);
+    }
+    set.add(handler as (payload: unknown) => void);
+    return () => {
+      const current = listeners.get(event);
+      if (!current) return;
+      current.delete(handler as (payload: unknown) => void);
+      if (current.size === 0) listeners.delete(event);
+    };
+  }
+
+  function applyAvailability(next: AvailableTool[]): void {
+    // Filter to registered tools, preserve registration order, merge labels/badges.
+    const byId = new Map(next.map((t) => [t.id, t]));
+    availableTools = registeredTools
+      .filter((t) => byId.has(t.id))
+      .map((t) => {
+        const reported = byId.get(t.id);
+        return {
+          id: t.id,
+          label: reported?.label ?? t.label,
+          badge: reported?.badge ?? t.badge ?? null,
+        } satisfies AvailableTool;
+      });
+    // If the active tool is no longer available, clear it.
+    if (activeTool && !availableTools.some((t) => t.id === activeTool)) {
+      activeTool = null;
+      if (isOpen && availableTools.length === 0) {
+        isOpen = false;
+      }
+    }
+  }
+
+  function refreshAvailability(): void {
+    if (!fetchAvailability) {
+      // Static availability — every registered tool.
+      applyAvailability(
+        registeredTools.map((t) => ({
+          id: t.id,
+          label: t.label,
+          badge: t.badge,
+        })),
+      );
+      return;
+    }
+    const token = ++availabilityToken;
+    const snapshotCtx = context;
+    void Promise.resolve(fetchAvailability(snapshotCtx))
+      .then((result) => {
+        if (token !== availabilityToken) return; // stale
+        applyAvailability(Array.isArray(result) ? result : []);
+      })
+      .catch(() => {
+        if (token !== availabilityToken) return;
+        // On error, surface zero availability rather than stale state.
+        applyAvailability([]);
+      });
+  }
+
+  function persist(): void {
+    if (!storageKey) return;
+    safeWriteStorage(storageKey, { isOpen, activeTool });
+  }
+
+  function hydrate(): void {
+    if (!storageKey) return;
+    const persisted = safeReadStorage(storageKey);
+    if (!persisted) return;
+    if (typeof persisted.isOpen === 'boolean') {
+      isOpen = persisted.isOpen;
+    }
+    if (
+      typeof persisted.activeTool === 'string' &&
+      registeredIds.has(persisted.activeTool)
+    ) {
+      activeTool = persisted.activeTool;
+    }
+  }
+
+  function open(id?: string): void {
+    if (id) {
+      if (!availableTools.some((t) => t.id === id)) return; // unavailable — no-op
+      activeTool = id;
+    } else if (!activeTool && availableTools.length > 0) {
+      activeTool = availableTools[0].id;
+    }
+    isOpen = true;
+    persist();
+  }
+
+  function close(): void {
+    isOpen = false;
+    persist();
+  }
+
+  function toggle(id?: string): void {
+    if (id) {
+      if (!availableTools.some((t) => t.id === id)) return;
+      if (isOpen && activeTool === id) {
+        isOpen = false;
+      } else {
+        activeTool = id;
+        isOpen = true;
+      }
+      persist();
+      return;
+    }
+    isOpen = !isOpen;
+    if (isOpen && !activeTool && availableTools.length > 0) {
+      activeTool = availableTools[0].id;
+    }
+    persist();
+  }
+
+  function setContextValue(ctx: ToolsDockContext | null): void {
+    context = ctx;
+    if (fetchAvailability) refreshAvailability();
+  }
+
+  const instance: ToolsDockInstance<TCtx> = {
+    // Reactive getters — keep the api surface read-only.
+    get isOpen() {
+      return isOpen;
+    },
+    get activeTool() {
+      return activeTool;
+    },
+    get availableTools() {
+      return availableTools;
+    },
+    get context() {
+      return context;
+    },
+    open,
+    close,
+    toggle,
+    setContext: setContextValue,
+    emit,
+    on,
+    // Framework-only members:
+    tools: registeredTools,
+    layout,
+    storageKey,
+    hydrate,
+    persist,
+  };
+
+  setContext(TOOLS_DOCK_KEY, instance);
+  return instance;
+}

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
@@ -93,7 +93,6 @@ export interface ToolsDockInstance<TCtx = unknown> extends ToolsDockApi {
   readonly tools: ReadonlyArray<ToolDef<TCtx>>;
   readonly layout: 'rail' | 'topbar';
   readonly storageKey: string | null;
-  readonly context: ToolsDockContext | null;
   /** Internal: hydrate persisted state from `localStorage` (called by `<ToolsDock>` on mount). */
   hydrate(): void;
   /** Internal: persist current state to `localStorage`. */
@@ -220,10 +219,15 @@ export function defineToolsDock<TCtx = unknown>(
       .filter((t) => byId.has(t.id))
       .map((t) => {
         const reported = byId.get(t.id);
+        // Distinguish "key absent" (fall back to registered default) from
+        // "key present with null" (explicitly clear the badge).
+        const reportedBadge =
+          reported && 'badge' in reported ? reported.badge : undefined;
         return {
           id: t.id,
           label: reported?.label ?? t.label,
-          badge: reported?.badge ?? t.badge ?? null,
+          badge:
+            reportedBadge !== undefined ? reportedBadge : (t.badge ?? null),
         } satisfies AvailableTool;
       });
     // If the active tool is no longer available, clear it.
@@ -249,7 +253,17 @@ export function defineToolsDock<TCtx = unknown>(
     }
     const token = ++availabilityToken;
     const snapshotCtx = context;
-    void Promise.resolve(fetchAvailability(snapshotCtx))
+    // Funnel both synchronous throws (argument validation, undefined
+    // dereferences before the promise is returned) and asynchronous
+    // rejections through the same error path so neither escapes
+    // `setContext` to the component.
+    let pending: Promise<AvailableTool[]>;
+    try {
+      pending = Promise.resolve(fetchAvailability(snapshotCtx));
+    } catch (err) {
+      pending = Promise.reject(err);
+    }
+    void pending
       .then((result) => {
         if (token !== availabilityToken) return; // stale
         applyAvailability(Array.isArray(result) ? result : []);

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
@@ -236,6 +236,10 @@ export function defineToolsDock<TCtx = unknown>(
       if (isOpen && availableTools.length === 0) {
         isOpen = false;
       }
+      // Persist the cleared state so the factory's persistence guarantees
+      // don't depend on the <ToolsDock> component being mounted to rescue
+      // them via its $effect.
+      persist();
     }
   }
 

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/use-tools-dock.ts
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/use-tools-dock.ts
@@ -1,0 +1,52 @@
+/**
+ * useToolsDock - read the {@link ToolsDockApi} from Svelte context.
+ *
+ * Tools and arbitrary descendants of `<ToolsDock>` use this to obtain the
+ * dock instance that owns them — open/close themselves, push events through
+ * the typed bus, react to the current `context`, etc.
+ *
+ * Throws a clear error if called outside a `<ToolsDock>` provider tree so
+ * misuse fails loudly during development rather than producing silent nulls.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { useToolsDock } from '@happyvertical/smrt-svelte/workspace';
+ *   const dock = useToolsDock<MyContext>();
+ * </script>
+ *
+ * <button type="button" onclick={() => dock.close()}>Close</button>
+ * ```
+ */
+
+import { getContext } from 'svelte';
+import type { ToolsDockApi } from '../types.js';
+import { TOOLS_DOCK_KEY } from './define-tools-dock.svelte.js';
+
+/**
+ * Retrieve the {@link ToolsDockApi} from Svelte context.
+ *
+ * @typeParam TCtx - shape of `dock.context` for typed access inside tools
+ * @throws Error when called outside a `<ToolsDock>` provider tree
+ */
+export function useToolsDock<TCtx = unknown>(): ToolsDockApi {
+  void (null as unknown as TCtx); // type-only param
+  const dock = getContext<ToolsDockApi | undefined>(TOOLS_DOCK_KEY);
+  if (!dock) {
+    throw new Error(
+      '[useToolsDock] No ToolsDock instance found on Svelte context. ' +
+        'Wrap your tree in <ToolsDock dock={defineToolsDock(...)} /> first.',
+    );
+  }
+  return dock;
+}
+
+/**
+ * Non-throwing variant — returns `null` outside a provider. Useful for
+ * optional integrations where a tool should degrade gracefully if not
+ * embedded inside a `<ToolsDock>`.
+ */
+export function tryUseToolsDock<TCtx = unknown>(): ToolsDockApi | null {
+  void (null as unknown as TCtx);
+  return getContext<ToolsDockApi | undefined>(TOOLS_DOCK_KEY) ?? null;
+}

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/use-tools-dock.ts
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/use-tools-dock.ts
@@ -8,11 +8,15 @@
  * Throws a clear error if called outside a `<ToolsDock>` provider tree so
  * misuse fails loudly during development rather than producing silent nulls.
  *
+ * The returned `dock.context` is the untyped {@link ToolsDockContext} shape.
+ * For typed access from within a tool body, use the `context` prop wired by
+ * `<ToolsDock>` — `ToolDef<TCtx>` parameterizes that prop, not this hook.
+ *
  * @example
  * ```svelte
  * <script lang="ts">
  *   import { useToolsDock } from '@happyvertical/smrt-svelte/workspace';
- *   const dock = useToolsDock<MyContext>();
+ *   const dock = useToolsDock();
  * </script>
  *
  * <button type="button" onclick={() => dock.close()}>Close</button>
@@ -26,11 +30,9 @@ import { TOOLS_DOCK_KEY } from './define-tools-dock.svelte.js';
 /**
  * Retrieve the {@link ToolsDockApi} from Svelte context.
  *
- * @typeParam TCtx - shape of `dock.context` for typed access inside tools
  * @throws Error when called outside a `<ToolsDock>` provider tree
  */
-export function useToolsDock<TCtx = unknown>(): ToolsDockApi {
-  void (null as unknown as TCtx); // type-only param
+export function useToolsDock(): ToolsDockApi {
   const dock = getContext<ToolsDockApi | undefined>(TOOLS_DOCK_KEY);
   if (!dock) {
     throw new Error(
@@ -46,7 +48,6 @@ export function useToolsDock<TCtx = unknown>(): ToolsDockApi {
  * optional integrations where a tool should degrade gracefully if not
  * embedded inside a `<ToolsDock>`.
  */
-export function tryUseToolsDock<TCtx = unknown>(): ToolsDockApi | null {
-  void (null as unknown as TCtx);
+export function tryUseToolsDock(): ToolsDockApi | null {
   return getContext<ToolsDockApi | undefined>(TOOLS_DOCK_KEY) ?? null;
 }

--- a/packages/smrt-svelte/src/components/workspace/types.ts
+++ b/packages/smrt-svelte/src/components/workspace/types.ts
@@ -56,6 +56,12 @@ export interface ToolsDockApi {
   readonly activeTool: string | null;
   readonly isOpen: boolean;
   readonly availableTools: ReadonlyArray<AvailableTool>;
+  /**
+   * The current dock context (route data, selection, etc.) as supplied via
+   * `setContext()`. Untyped on the API surface — tools receive a typed
+   * `context` prop via `ToolDef<TCtx>` instead.
+   */
+  readonly context: ToolsDockContext | null;
   open(id?: string): void;
   close(): void;
   toggle(id?: string): void;

--- a/packages/smrt-svelte/src/components/workspace/types.ts
+++ b/packages/smrt-svelte/src/components/workspace/types.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared types for the workspace shell primitives.
+ *
+ * See @happyvertical/smrt#1226 (epic) and #1227 / #1228 / #1229 (implementers).
+ */
+
+import type { Component } from 'svelte';
+
+// ────────────────────────────────────────────────
+// Nav primitives (used by NavTree, Breadcrumbs)
+// ────────────────────────────────────────────────
+
+export interface NavItem {
+  href: string;
+  label: string;
+  icon?: string;
+  description?: string;
+  exact?: boolean;
+  defaultExpanded?: boolean;
+  badge?: number | string | null;
+  children?: NavItem[];
+}
+
+export interface BreadcrumbItem {
+  href?: string;
+  label: string;
+}
+
+// ────────────────────────────────────────────────
+// Tools dock primitives
+// ────────────────────────────────────────────────
+
+export interface ToolDef<TCtx = unknown> {
+  id: string;
+  label: string;
+  icon?: string;
+  component: Component<{ context: TCtx; dock: ToolsDockApi }>;
+  badge?: number | string | null;
+}
+
+export interface AvailableTool {
+  id: string;
+  label?: string;
+  badge?: number | string | null;
+}
+
+export interface ToolsDockContext<TData = Record<string, unknown>> {
+  type: string;
+  title?: string;
+  url?: string;
+  data?: TData;
+  actions?: Record<string, (...args: any[]) => unknown>;
+}
+
+export interface ToolsDockApi {
+  readonly activeTool: string | null;
+  readonly isOpen: boolean;
+  readonly availableTools: ReadonlyArray<AvailableTool>;
+  open(id?: string): void;
+  close(): void;
+  toggle(id?: string): void;
+  setContext(ctx: ToolsDockContext | null): void;
+  emit<TPayload>(event: string, payload: TPayload): void;
+  on<TPayload>(event: string, handler: (payload: TPayload) => void): () => void;
+}

--- a/packages/smrt-svelte/vitest.config.ts
+++ b/packages/smrt-svelte/vitest.config.ts
@@ -8,6 +8,16 @@ export default defineConfig({
   // resolve to the client runtime under jsdom. Without this, `svelte`'s
   // package exports fall through to `default: index-server.js`, which makes
   // `mount(...)` unavailable in tests.
+  //
+  // NOTE: Forcing the `browser` condition globally masks the SSR path. Any
+  // future test in this package that needs to exercise Svelte's server
+  // runtime (e.g. asserting SSR HTML output of a component, or covering
+  // `$effect.root` boundaries that differ between client/server) will need
+  // a scoped override — either a dedicated vitest project (workspace) with
+  // its own `resolve.conditions`, or a path filter on this `conditions`
+  // setting. Until that need arises, keeping `['browser']` everywhere is
+  // the simplest way to keep the client-side workspace primitive tests
+  // green under jsdom.
   resolve: {
     conditions: ['browser'],
   },

--- a/packages/smrt-svelte/vitest.config.ts
+++ b/packages/smrt-svelte/vitest.config.ts
@@ -4,6 +4,13 @@ import { smrtVitestPlugin } from '../vitest/src/index.ts';
 
 export default defineConfig({
   plugins: [smrtVitestPlugin({ verbose: true }), svelte({ hot: false })],
+  // Resolve Svelte's `browser` export condition so that `mount` / `unmount`
+  // resolve to the client runtime under jsdom. Without this, `svelte`'s
+  // package exports fall through to `default: index-server.js`, which makes
+  // `mount(...)` unavailable in tests.
+  resolve: {
+    conditions: ['browser'],
+  },
   test: {
     globals: true,
     environment: 'jsdom',

--- a/packages/smrt-svelte/vitest.config.ts
+++ b/packages/smrt-svelte/vitest.config.ts
@@ -4,6 +4,11 @@ import { smrtVitestPlugin } from '../vitest/src/index.ts';
 
 export default defineConfig({
   plugins: [smrtVitestPlugin({ verbose: true }), svelte({ hot: false })],
+  resolve: {
+    // Force Svelte to resolve its browser entry so `mount()` is available
+    // inside jsdom-environment tests.
+    conditions: ['browser'],
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary

Ships the first phase of [epic #1226](https://github.com/happyvertical/smrt/issues/1226): admin layout shell primitives in `@happyvertical/smrt-svelte`.

Three primitives, exposed at the new `/workspace` subpath:

- **`<WorkspaceShell>`** — SvelteKit-agnostic, SSR-safe shell with snippet slots (`brand`, `nav`, `sidebarFooter`, `topbarActions`, `inspectorRail`, `inspector`, `children`). Composes desktop sidebar / tablet icon-rail / mobile drawer. Configurable inspector title, focus-restoration on close.
- **`<NavTree>` + `<Breadcrumbs>`** — 3-level recursive nav, prop-driven (no `$app/state`); breadcrumbs accept either explicit `items` or auto-derived from `nav` + `pathname`. Helpers (`nav-helpers.ts`, `breadcrumbs-helpers.ts`) hold the pure derivation logic for full test coverage without a renderer.
- **`<ToolsDock>` + `defineToolsDock` + `useToolsDock`** — context-aware tools dock with `rail` and `topbar` layouts. Arbitrary string tool IDs (not enum), optional backend `fetchAvailability`, optional namespaced `storageKey` persistence, typed event bus replacing `window.dispatchEvent`. Inert when closed; focus-restoring on Escape.

## What's in this branch

| PR | What | Tests |
|---|---|---|
| #1227 → [#1232](https://github.com/happyvertical/smrt/pull/1232) | `WorkspaceShell` primitive | +23 |
| #1228 → [#1231](https://github.com/happyvertical/smrt/pull/1231) | `NavTree` + `Breadcrumbs` primitives | +30 |
| #1229 → [#1233](https://github.com/happyvertical/smrt/pull/1233) | `ToolsDock` system | +23 |

**Integrated state**: 118 tests passing in `smrt-svelte` (was 42 on main), build clean.

Each primitive PR went through a deep review pass (claude Opus 4.7 + codex gpt-5.5 xhigh in parallel) before merging here — 22 distinct findings raised, all addressed in fixup commits. Comments on the individual PRs document the findings + resolutions.

## Design principles

Codified in `packages/smrt-svelte/CLAUDE.md`:

- **SvelteKit-agnostic** — no `$app/state`, no SvelteKit imports. Consumer passes `currentPath`, nav data, hrefs, callbacks as props.
- **SSR-safe** — no unguarded `window` / `document` / `localStorage` at module scope.
- **No domain coupling** — dock defines the client-side protocol; consumers supply tool components and the optional availability fetcher.
- **Extensible** — tool IDs are arbitrary strings; aligned with `ModuleUIRegistry` integration point (documented in JSDoc).
- **Direct SMRT tokens** — no bridge variables like Ergot's `--imago-*`. Consumers migrate to direct token usage.
- **Primitives first, wrapper second** — `AdminShell` opinionated wrapper (#1230) is intentionally deferred until both real migrations (ergot #53, anytown site-portal #317) validate the primitive API.

## Test plan

- [ ] Verify CI green on this PR
- [ ] After merge, verify `smrt-svelte` auto-release ships with the new `/workspace` subpath in `package.json` exports
- [ ] Manual: install the released version in a scratch SvelteKit app and import from `@happyvertical/smrt-svelte/workspace`
- [ ] Confirm changeset entry covers the new primitives (single combined entry per the merge-strategy note in #1226)

## Next

- Phase 2: [ergot.io#53](https://github.com/happyvertical/ergot.io/issues/53) — first downstream migration (validates the primitive API)
- Phase 3: [anytown.ai#317](https://github.com/anytown/anytown.ai/issues/317) — site-portal migration (stress-tests the 9-tool dock)
- Phase 4: revisit [#1230](https://github.com/happyvertical/smrt/issues/1230) `AdminShell` only after both migrations land
