### PR TITLE
feat(smrt-svelte): add ToolsDock 'change' event and bindable mobileNavOpen

### DIFF
--- a/packages/smrt-svelte/CLAUDE.md
+++ b/packages/smrt-svelte/CLAUDE.md
@@ -94,11 +94,13 @@ domain-specific tools live outside the framework in consumer packages.
 - Tool IDs are arbitrary strings (extensible, not an enum)
 
 **State-mirroring recipes** (issue #1235):
-- `dock.on('change', ({ isOpen, activeTool, context }) => ...)` fires after every
-  `open()`/`close()`/`toggle()`/`setContext()` (and once more if a context change
-  clears the active tool via availability filtering). Use this instead of
+- `dock.on('dock:change', ({ isOpen, activeTool, context }) => ...)` fires after
+  every `open()`/`close()`/`toggle()`/`setContext()` (and once more if a context
+  change clears the active tool via availability filtering). Use this instead of
   threading multiple `$effect`s through every getter to mirror dock state into a
-  workbench store.
+  workbench store. The `'dock:*'` event-name prefix is reserved for built-in
+  dock events; consumer events should pick their own namespace (e.g.
+  `'my-app:foo'`) and use the stringly-typed overloads of `dock.on` / `dock.emit`.
 - `WorkspaceShell` exposes `bind:mobileNavOpen` so consumers can lift the drawer
   state. Pair it with `<NavTree onNavigate={() => mobileNavOpen = false} />` to
   close the drawer on navigation without any DOM querying.

--- a/packages/smrt-svelte/CLAUDE.md
+++ b/packages/smrt-svelte/CLAUDE.md
@@ -93,6 +93,16 @@ domain-specific tools live outside the framework in consumer packages.
 - No token bridges — consume `var(--smrt-color-*)` directly
 - Tool IDs are arbitrary strings (extensible, not an enum)
 
+**State-mirroring recipes** (issue #1235):
+- `dock.on('change', ({ isOpen, activeTool, context }) => ...)` fires after every
+  `open()`/`close()`/`toggle()`/`setContext()` (and once more if a context change
+  clears the active tool via availability filtering). Use this instead of
+  threading multiple `$effect`s through every getter to mirror dock state into a
+  workbench store.
+- `WorkspaceShell` exposes `bind:mobileNavOpen` so consumers can lift the drawer
+  state. Pair it with `<NavTree onNavigate={() => mobileNavOpen = false} />` to
+  close the drawer on navigation without any DOM querying.
+
 See epic [happyvertical/smrt#1226](https://github.com/happyvertical/smrt/issues/1226) for context;
 implementations land via #1227 (`WorkspaceShell`), #1228 (`NavTree`/`Breadcrumbs`), and #1229
 (`ToolsDock` + registry).

--- a/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
@@ -17,9 +17,16 @@ import type { Snippet } from 'svelte';
  *   becomes a right-side drawer with backdrop.
  *
  * Sidebar collapse is controlled — consumer owns persistence. Mobile drawer
- * state is internal and transient.
+ * state defaults to internal/transient but can be lifted via the bindable
+ * `mobileNavOpen` prop (see below) for consumers that need to close the
+ * drawer in response to events the shell doesn't own (e.g. a route change
+ * fired from a nav-tree click). Pair `bind:mobileNavOpen={...}` on the
+ * shell with `<NavTree onNavigate={() => (mobileNavOpen = false)} />`
+ * inside the `nav` snippet to close the drawer on every link click —
+ * no DOM querying required.
  *
- * See `@happyvertical/smrt#1227` for the issue tracking this primitive.
+ * See `@happyvertical/smrt#1227` for the issue tracking this primitive,
+ * and `happyvertical/smrt#1235` for the bindable-drawer follow-up.
  */
 
 export interface Props {
@@ -81,9 +88,19 @@ export interface Props {
   inspector?: Snippet;
   /** Main content. */
   children: Snippet;
+  /**
+   * Mobile drawer open-state. Defaults to `false` and is managed
+   * internally — the hamburger button, backdrop, and Escape key all
+   * toggle it. Consumers who need to close the drawer in response to
+   * events outside the shell (e.g. a nav-link click in their nav
+   * snippet) can lift the state via `bind:mobileNavOpen={...}` and
+   * mutate it directly. SSR-safe — initial value is honored on the
+   * server (the drawer is only visible on the ≤960px breakpoint).
+   */
+  mobileNavOpen?: boolean;
 }
 
-const {
+let {
   title = '',
   subtitle = '',
   eyebrow = '',
@@ -103,9 +120,9 @@ const {
   inspectorRail,
   inspector,
   children,
+  mobileNavOpen = $bindable(false),
 }: Props = $props();
 
-let mobileNavOpen = $state(false);
 /**
  * Tracks whether the viewport is in the mobile drawer breakpoint
  * (≤960px). Used to mark the sidebar `inert` when it's slid off-screen

--- a/packages/smrt-svelte/src/components/workspace/__tests__/WorkspaceShell.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/WorkspaceShell.test.ts
@@ -9,6 +9,7 @@
 import { createRawSnippet, mount, tick, unmount } from 'svelte';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import WorkspaceShell from '../WorkspaceShell.svelte';
+import BindHarness from './workspace-shell-bind-harness.svelte';
 
 function textSnippet(text: string) {
   return createRawSnippet(() => ({
@@ -476,6 +477,129 @@ describe('WorkspaceShell', () => {
       unmount(component);
       window.matchMedia = originalMatchMedia;
     }
+  });
+
+  describe('bindable mobileNavOpen', () => {
+    it('opens the drawer when the bound value flips to true externally', async () => {
+      let controls!: {
+        setMobileNavOpen: (next: boolean) => void;
+        getMobileNavOpen: () => boolean;
+      };
+      const component = mount(BindHarness, {
+        target: container,
+        props: {
+          onReady: (c) => {
+            controls = c;
+          },
+        },
+      });
+
+      try {
+        await tick();
+        const shell = container.querySelector('.smrt-workspace-shell');
+        expect(shell?.classList.contains('nav-open')).toBe(false);
+
+        controls.setMobileNavOpen(true);
+        await tick();
+        expect(shell?.classList.contains('nav-open')).toBe(true);
+        expect(controls.getMobileNavOpen()).toBe(true);
+
+        controls.setMobileNavOpen(false);
+        await tick();
+        expect(shell?.classList.contains('nav-open')).toBe(false);
+        expect(controls.getMobileNavOpen()).toBe(false);
+      } finally {
+        unmount(component);
+      }
+    });
+
+    it('propagates internal hamburger clicks back through bind:', async () => {
+      let controls!: {
+        setMobileNavOpen: (next: boolean) => void;
+        getMobileNavOpen: () => boolean;
+      };
+      const component = mount(BindHarness, {
+        target: container,
+        props: {
+          onReady: (c) => {
+            controls = c;
+          },
+        },
+      });
+
+      try {
+        await tick();
+        expect(controls.getMobileNavOpen()).toBe(false);
+
+        const hamburger =
+          container.querySelector<HTMLButtonElement>('.mobile-menu');
+        expect(hamburger).not.toBeNull();
+        hamburger?.click();
+        await tick();
+        expect(controls.getMobileNavOpen()).toBe(true);
+        // Toggle a second time — closes the drawer.
+        hamburger?.click();
+        await tick();
+        expect(controls.getMobileNavOpen()).toBe(false);
+      } finally {
+        unmount(component);
+      }
+    });
+
+    it('propagates internal backdrop clicks back through bind:', async () => {
+      let controls!: {
+        setMobileNavOpen: (next: boolean) => void;
+        getMobileNavOpen: () => boolean;
+      };
+      const component = mount(BindHarness, {
+        target: container,
+        props: {
+          initial: true,
+          onReady: (c) => {
+            controls = c;
+          },
+        },
+      });
+
+      try {
+        await tick();
+        expect(controls.getMobileNavOpen()).toBe(true);
+
+        const backdrop =
+          container.querySelector<HTMLButtonElement>('.mobile-backdrop');
+        expect(backdrop).not.toBeNull();
+        backdrop?.click();
+        await tick();
+        expect(controls.getMobileNavOpen()).toBe(false);
+      } finally {
+        unmount(component);
+      }
+    });
+
+    it('honors a non-default initial value passed by the consumer', async () => {
+      let controls!: {
+        setMobileNavOpen: (next: boolean) => void;
+        getMobileNavOpen: () => boolean;
+      };
+      const component = mount(BindHarness, {
+        target: container,
+        props: {
+          initial: true,
+          onReady: (c) => {
+            controls = c;
+          },
+        },
+      });
+
+      try {
+        await tick();
+        const shell = container.querySelector('.smrt-workspace-shell');
+        expect(shell?.classList.contains('nav-open')).toBe(true);
+        expect(controls.getMobileNavOpen()).toBe(true);
+      } finally {
+        unmount(component);
+      }
+    });
   });
 
   it('restores focus to the hamburger button when the mobile drawer closes via Escape', async () => {

--- a/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
@@ -429,4 +429,217 @@ describe('defineToolsDock', () => {
     expect(dock.availableTools.map((t) => t.id)).toEqual(['chat']);
     expect(dock.activeTool).toBeNull();
   });
+
+  describe("'change' event", () => {
+    it('does not fire during factory construction', () => {
+      // Subscribing in a separate tick would miss any event fired during the
+      // factory body. To assert "no construction-time emit" we count via a
+      // listener added *before* the factory runs — but the factory's
+      // listener bus is internal, so instead we rely on the fact that
+      // `'change'` is gated by the `ready` flag and verify post-construction
+      // state is clean (no recursive errors etc.) here.
+      const { dock } = track(
+        mountDock({
+          tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+          initialOpen: true,
+        }),
+      );
+
+      // Sanity: initial state reflects options without any emit having fired.
+      expect(dock.isOpen).toBe(true);
+      expect(dock.activeTool).toBeNull();
+    });
+
+    it('fires on open() with the post-update state', () => {
+      const { dock } = track(
+        mountDock({
+          tools: [
+            { id: 'chat', label: 'Chat', component: noopTool },
+            { id: 'jobs', label: 'Jobs', component: noopTool },
+          ],
+        }),
+      );
+
+      const handler = vi.fn();
+      dock.on('change', handler);
+
+      dock.open('chat');
+      flushSync();
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenLastCalledWith({
+        isOpen: true,
+        activeTool: 'chat',
+        context: null,
+      });
+    });
+
+    it('fires on close() with the post-update state', () => {
+      const { dock } = track(
+        mountDock({
+          tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        }),
+      );
+
+      dock.open('chat');
+      flushSync();
+      const handler = vi.fn();
+      dock.on('change', handler);
+
+      dock.close();
+      flushSync();
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenLastCalledWith({
+        // close() leaves activeTool intact so re-opens land on the same tool.
+        isOpen: false,
+        activeTool: 'chat',
+        context: null,
+      });
+    });
+
+    it('fires on toggle() with the post-update state', () => {
+      const { dock } = track(
+        mountDock({
+          tools: [
+            { id: 'chat', label: 'Chat', component: noopTool },
+            { id: 'jobs', label: 'Jobs', component: noopTool },
+          ],
+        }),
+      );
+
+      const handler = vi.fn();
+      dock.on('change', handler);
+
+      dock.toggle('chat');
+      flushSync();
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenLastCalledWith({
+        isOpen: true,
+        activeTool: 'chat',
+        context: null,
+      });
+
+      dock.toggle('chat');
+      flushSync();
+      expect(handler).toHaveBeenCalledTimes(2);
+      expect(handler).toHaveBeenLastCalledWith({
+        isOpen: false,
+        activeTool: 'chat',
+        context: null,
+      });
+
+      dock.toggle();
+      flushSync();
+      expect(handler).toHaveBeenCalledTimes(3);
+      expect(handler).toHaveBeenLastCalledWith({
+        isOpen: true,
+        activeTool: 'chat',
+        context: null,
+      });
+    });
+
+    it('fires on setContext() with the new context', () => {
+      const { dock } = track(
+        mountDock({
+          tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        }),
+      );
+
+      const handler = vi.fn();
+      dock.on('change', handler);
+
+      dock.setContext({ type: 'route', title: 'Home' });
+      flushSync();
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenLastCalledWith({
+        isOpen: false,
+        activeTool: null,
+        context: { type: 'route', title: 'Home' },
+      });
+    });
+
+    it('fires once with cleared state when availability removes the active tool', async () => {
+      let availability: { id: string }[] = [{ id: 'chat' }, { id: 'jobs' }];
+      const fetchAvailability = vi.fn(async () => availability);
+
+      const { dock } = track(
+        mountDock({
+          tools: [
+            { id: 'chat', label: 'Chat', component: noopTool },
+            { id: 'jobs', label: 'Jobs', component: noopTool },
+          ],
+          fetchAvailability,
+        }),
+      );
+
+      dock.setContext({ type: 'a' });
+      await Promise.resolve();
+      await Promise.resolve();
+      flushSync();
+      dock.open('jobs');
+      flushSync();
+      expect(dock.activeTool).toBe('jobs');
+
+      const handler = vi.fn();
+      dock.on('change', handler);
+
+      availability = [{ id: 'chat' }];
+      dock.setContext({ type: 'b' });
+      // setContext emits synchronously …
+      expect(handler).toHaveBeenCalledTimes(1);
+      // … then the async availability refresh resolves, clears the active
+      // tool, and emits a second 'change' with the cleared state.
+      await Promise.resolve();
+      await Promise.resolve();
+      flushSync();
+
+      expect(handler).toHaveBeenCalledTimes(2);
+      expect(handler).toHaveBeenLastCalledWith({
+        isOpen: true,
+        activeTool: null,
+        context: { type: 'b' },
+      });
+    });
+
+    it('stops calling a handler after its unsubscribe function runs', () => {
+      const { dock } = track(
+        mountDock({
+          tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        }),
+      );
+
+      const handler = vi.fn();
+      const off = dock.on('change', handler);
+
+      dock.open('chat');
+      flushSync();
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      off();
+      dock.close();
+      flushSync();
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('payload type is inferred from ToolsDockEvents', () => {
+      const { dock } = track(
+        mountDock({
+          tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        }),
+      );
+
+      // Compile-time check: handler arg should be the `change` payload shape
+      // without an explicit generic.
+      dock.on('change', (e) => {
+        const _isOpen: boolean = e.isOpen;
+        const _activeTool: string | null = e.activeTool;
+        void _isOpen;
+        void _activeTool;
+      });
+
+      // Runtime sanity check that the test compiles & wires.
+      dock.open('chat');
+      flushSync();
+      expect(dock.isOpen).toBe(true);
+    });
+  });
 });

--- a/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
@@ -641,5 +641,155 @@ describe('defineToolsDock', () => {
       flushSync();
       expect(dock.isOpen).toBe(true);
     });
+
+    // ─────────────────────────────────────────────────────────────
+    // Regression tests: no-op state changes must NOT fire 'change'.
+    //
+    // Before this guard, idempotent calls like `dock.open(activeId)` when
+    // already open emitted spurious events. Combined with effects that
+    // call setContext on every prop change, that produced redundant work
+    // (availability refetch) and could amplify into noisy loops when
+    // consumers wired the 'change' event back into upstream state.
+    // ─────────────────────────────────────────────────────────────
+
+    it('does NOT fire on open() when already at that state', () => {
+      const { dock } = track(
+        mountDock({
+          tools: [
+            { id: 'chat', label: 'Chat', component: noopTool },
+            { id: 'jobs', label: 'Jobs', component: noopTool },
+          ],
+        }),
+      );
+
+      dock.open('chat');
+      flushSync();
+
+      const handler = vi.fn();
+      dock.on('change', handler);
+
+      // Same id, already open — no observable state change.
+      dock.open('chat');
+      flushSync();
+      expect(handler).not.toHaveBeenCalled();
+
+      // open() with no id, already open with an active tool — still a no-op.
+      dock.open();
+      flushSync();
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('does NOT fire on close() when already closed', () => {
+      const { dock } = track(
+        mountDock({
+          tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        }),
+      );
+
+      const handler = vi.fn();
+      dock.on('change', handler);
+
+      // Initial state is closed; calling close again must not emit.
+      dock.close();
+      flushSync();
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('does NOT fire on setContext() with the same reference', async () => {
+      const fetchAvailability = vi.fn().mockResolvedValue([{ id: 'chat' }]);
+      const { dock } = track(
+        mountDock({
+          tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+          fetchAvailability,
+        }),
+      );
+
+      const ctx = { type: 'route', title: 'Home' } as const;
+      dock.setContext(ctx);
+      // Initial emit + initial fetchAvailability call.
+      await new Promise((r) => setTimeout(r, 0));
+      flushSync();
+      expect(fetchAvailability).toHaveBeenCalledTimes(1);
+
+      const handler = vi.fn();
+      dock.on('change', handler);
+
+      // Same reference — must short-circuit (no emit, no refetch).
+      dock.setContext(ctx);
+      flushSync();
+      await new Promise((r) => setTimeout(r, 0));
+      flushSync();
+      expect(handler).not.toHaveBeenCalled();
+      expect(fetchAvailability).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT fire on toggle(id) that resolves to the same state', () => {
+      // toggle(sameId) when open+active flips to closed; toggle again
+      // flips back to open+active. Each transition is real, so each emits.
+      // The "no observable change" branch for toggle is hard to trigger
+      // through the API surface alone (toggle always flips at minimum
+      // `isOpen`), so the assertion here is the symmetric one: the emit
+      // counts match the number of real state transitions.
+      const { dock } = track(
+        mountDock({
+          tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        }),
+      );
+
+      const handler = vi.fn();
+      dock.on('change', handler);
+
+      dock.toggle('chat'); // open+active
+      flushSync();
+      dock.toggle('chat'); // close
+      flushSync();
+      expect(handler).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retrigger context-forwarding $effect when state mutates', async () => {
+      // Regression guard for the reactive-read leak in emitChange. Without
+      // `untrack` around the $state reads, an $effect calling
+      // dock.setContext would also depend on isOpen/activeTool/context
+      // (read inside the emitChange invoked by setContext). A subsequent
+      // dock.open() would mutate those, re-run the effect, call setContext
+      // again, etc. Here we verify open() does NOT cause the forwarding
+      // effect's tracked count to grow.
+      const fetchAvailability = vi.fn().mockResolvedValue([{ id: 'chat' }]);
+      const { dock } = track(
+        mountDock({
+          tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+          fetchAvailability,
+        }),
+      );
+
+      // Mount a child component whose $effect mirrors a `currentCtx` $state
+      // into dock.setContext — same pattern <ToolsDock>'s context prop uses.
+      const target = document.createElement('div');
+      document.body.appendChild(target);
+      cleanup.push(() => target.remove());
+
+      // We use the harness pattern: a tiny inline component would require
+      // its own file. Instead, count how many times fetchAvailability runs
+      // after the initial setContext — open() / close() must not cause it
+      // to re-run via a re-triggered forwarding effect.
+      dock.setContext({ type: 'a' });
+      await new Promise((r) => setTimeout(r, 0));
+      flushSync();
+      const initialFetchCount = fetchAvailability.mock.calls.length;
+
+      const handler = vi.fn();
+      dock.on('change', handler);
+
+      dock.open('chat');
+      flushSync();
+      dock.close();
+      flushSync();
+
+      // Two real state transitions → two emits, but the context-forwarding
+      // chain stays quiet: no extra fetchAvailability calls beyond the
+      // initial setContext.
+      expect(handler).toHaveBeenCalledTimes(2);
+      expect(fetchAvailability.mock.calls.length).toBe(initialFetchCount);
+    });
   });
 });

--- a/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
@@ -430,14 +430,14 @@ describe('defineToolsDock', () => {
     expect(dock.activeTool).toBeNull();
   });
 
-  describe("'change' event", () => {
+  describe("'dock:change' event", () => {
     it('does not fire during factory construction', () => {
       // Subscribing in a separate tick would miss any event fired during the
       // factory body. To assert "no construction-time emit" we count via a
       // listener added *before* the factory runs — but the factory's
       // listener bus is internal, so instead we rely on the fact that
-      // `'change'` is gated by the `ready` flag and verify post-construction
-      // state is clean (no recursive errors etc.) here.
+      // `'dock:change'` is gated by the `ready` flag and verify
+      // post-construction state is clean (no recursive errors etc.) here.
       const { dock } = track(
         mountDock({
           tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
@@ -461,7 +461,7 @@ describe('defineToolsDock', () => {
       );
 
       const handler = vi.fn();
-      dock.on('change', handler);
+      dock.on('dock:change', handler);
 
       dock.open('chat');
       flushSync();
@@ -483,7 +483,7 @@ describe('defineToolsDock', () => {
       dock.open('chat');
       flushSync();
       const handler = vi.fn();
-      dock.on('change', handler);
+      dock.on('dock:change', handler);
 
       dock.close();
       flushSync();
@@ -507,7 +507,7 @@ describe('defineToolsDock', () => {
       );
 
       const handler = vi.fn();
-      dock.on('change', handler);
+      dock.on('dock:change', handler);
 
       dock.toggle('chat');
       flushSync();
@@ -545,7 +545,7 @@ describe('defineToolsDock', () => {
       );
 
       const handler = vi.fn();
-      dock.on('change', handler);
+      dock.on('dock:change', handler);
 
       dock.setContext({ type: 'route', title: 'Home' });
       flushSync();
@@ -580,14 +580,14 @@ describe('defineToolsDock', () => {
       expect(dock.activeTool).toBe('jobs');
 
       const handler = vi.fn();
-      dock.on('change', handler);
+      dock.on('dock:change', handler);
 
       availability = [{ id: 'chat' }];
       dock.setContext({ type: 'b' });
       // setContext emits synchronously …
       expect(handler).toHaveBeenCalledTimes(1);
       // … then the async availability refresh resolves, clears the active
-      // tool, and emits a second 'change' with the cleared state.
+      // tool, and emits a second 'dock:change' with the cleared state.
       await Promise.resolve();
       await Promise.resolve();
       flushSync();
@@ -608,7 +608,7 @@ describe('defineToolsDock', () => {
       );
 
       const handler = vi.fn();
-      const off = dock.on('change', handler);
+      const off = dock.on('dock:change', handler);
 
       dock.open('chat');
       flushSync();
@@ -627,9 +627,9 @@ describe('defineToolsDock', () => {
         }),
       );
 
-      // Compile-time check: handler arg should be the `change` payload shape
-      // without an explicit generic.
-      dock.on('change', (e) => {
+      // Compile-time check: handler arg should be the `dock:change` payload
+      // shape without an explicit generic.
+      dock.on('dock:change', (e) => {
         const _isOpen: boolean = e.isOpen;
         const _activeTool: string | null = e.activeTool;
         void _isOpen;
@@ -642,14 +642,44 @@ describe('defineToolsDock', () => {
       expect(dock.isOpen).toBe(true);
     });
 
+    it('non-"dock:*" event names use the stringly-typed overload (e.g. "change" is not reserved)', () => {
+      // After namespacing built-ins under `'dock:*'`, the literal `'change'`
+      // is no longer a key of ToolsDockEvents, so consumers may use it
+      // freely with an explicit payload generic via the stringly-typed
+      // overload.
+      const { dock } = track(
+        mountDock({
+          tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        }),
+      );
+
+      const customHandler = vi.fn();
+      const off = dock.on<{ selected: string }>('change', customHandler);
+      dock.emit<{ selected: string }>('change', { selected: 'row-1' });
+      expect(customHandler).toHaveBeenCalledWith({ selected: 'row-1' });
+
+      // Also confirm a namespaced consumer event works.
+      const appHandler = vi.fn();
+      dock.on<{ id: number }>('app:custom', appHandler);
+      dock.emit<{ id: number }>('app:custom', { id: 42 });
+      expect(appHandler).toHaveBeenCalledWith({ id: 42 });
+
+      // Built-in 'dock:change' must NOT trigger the custom 'change' listener.
+      dock.open('chat');
+      flushSync();
+      expect(customHandler).toHaveBeenCalledTimes(1);
+
+      off();
+    });
+
     // ─────────────────────────────────────────────────────────────
-    // Regression tests: no-op state changes must NOT fire 'change'.
+    // Regression tests: no-op state changes must NOT fire 'dock:change'.
     //
     // Before this guard, idempotent calls like `dock.open(activeId)` when
     // already open emitted spurious events. Combined with effects that
     // call setContext on every prop change, that produced redundant work
     // (availability refetch) and could amplify into noisy loops when
-    // consumers wired the 'change' event back into upstream state.
+    // consumers wired the 'dock:change' event back into upstream state.
     // ─────────────────────────────────────────────────────────────
 
     it('does NOT fire on open() when already at that state', () => {
@@ -666,7 +696,7 @@ describe('defineToolsDock', () => {
       flushSync();
 
       const handler = vi.fn();
-      dock.on('change', handler);
+      dock.on('dock:change', handler);
 
       // Same id, already open — no observable state change.
       dock.open('chat');
@@ -687,7 +717,7 @@ describe('defineToolsDock', () => {
       );
 
       const handler = vi.fn();
-      dock.on('change', handler);
+      dock.on('dock:change', handler);
 
       // Initial state is closed; calling close again must not emit.
       dock.close();
@@ -712,7 +742,7 @@ describe('defineToolsDock', () => {
       expect(fetchAvailability).toHaveBeenCalledTimes(1);
 
       const handler = vi.fn();
-      dock.on('change', handler);
+      dock.on('dock:change', handler);
 
       // Same reference — must short-circuit (no emit, no refetch).
       dock.setContext(ctx);
@@ -737,7 +767,7 @@ describe('defineToolsDock', () => {
       );
 
       const handler = vi.fn();
-      dock.on('change', handler);
+      dock.on('dock:change', handler);
 
       dock.toggle('chat'); // open+active
       flushSync();
@@ -778,7 +808,7 @@ describe('defineToolsDock', () => {
       const initialFetchCount = fetchAvailability.mock.calls.length;
 
       const handler = vi.fn();
-      dock.on('change', handler);
+      dock.on('dock:change', handler);
 
       dock.open('chat');
       flushSync();

--- a/packages/smrt-svelte/src/components/workspace/__tests__/index.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/index.test.ts
@@ -16,11 +16,12 @@ describe('workspace barrel', () => {
     expect(workspace.Breadcrumbs).toBeDefined();
   });
 
-  it('re-exports ToolsDockEvents for declaration merging', () => {
+  it('re-exports ToolsDockEvents for typed dock:* event payloads', () => {
     // Compile-time assertion: the type must be importable from the barrel
-    // so consumers can declaration-merge their own events into it.
+    // so consumers can reference the built-in `'dock:*'` event payloads in
+    // their own typed wrappers / stores.
     // (No runtime export; the `import type` above is the real check.)
-    const _typeCheck: ToolsDockEvents['change'] = {
+    const _typeCheck: ToolsDockEvents['dock:change'] = {
       isOpen: false,
       activeTool: null,
       context: null,

--- a/packages/smrt-svelte/src/components/workspace/__tests__/index.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/index.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import type { ToolsDockEvents } from '../index.js';
 import * as workspace from '../index.js';
 
 describe('workspace barrel', () => {
@@ -13,5 +14,17 @@ describe('workspace barrel', () => {
 
   it('exports Breadcrumbs', () => {
     expect(workspace.Breadcrumbs).toBeDefined();
+  });
+
+  it('re-exports ToolsDockEvents for declaration merging', () => {
+    // Compile-time assertion: the type must be importable from the barrel
+    // so consumers can declaration-merge their own events into it.
+    // (No runtime export; the `import type` above is the real check.)
+    const _typeCheck: ToolsDockEvents['change'] = {
+      isOpen: false,
+      activeTool: null,
+      context: null,
+    };
+    expect(_typeCheck.isOpen).toBe(false);
   });
 });

--- a/packages/smrt-svelte/src/components/workspace/__tests__/workspace-shell-bind-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/workspace-shell-bind-harness.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+/**
+ * Test harness for `bind:mobileNavOpen` on `WorkspaceShell`.
+ *
+ * Exposes the bindable drawer state on the outer `state` object so tests
+ * can observe the consumer-visible value after every interaction. The
+ * `onReady` callback hands back a setter the test can use to drive the
+ * value externally — verifying the two-way binding really is two-way.
+ */
+import { createRawSnippet } from 'svelte';
+import WorkspaceShell from '../WorkspaceShell.svelte';
+
+interface Props {
+  initial?: boolean;
+  onReady?: (controls: {
+    setMobileNavOpen: (next: boolean) => void;
+    getMobileNavOpen: () => boolean;
+  }) => void;
+}
+
+const { initial = false, onReady }: Props = $props();
+
+let mobileNavOpen = $state(initial);
+
+const content = createRawSnippet(() => ({
+  render: () => '<span>content</span>',
+}));
+
+onReady?.({
+  setMobileNavOpen: (next: boolean) => {
+    mobileNavOpen = next;
+  },
+  getMobileNavOpen: () => mobileNavOpen,
+});
+</script>
+
+<WorkspaceShell bind:mobileNavOpen>
+  {@render content()}
+</WorkspaceShell>

--- a/packages/smrt-svelte/src/components/workspace/index.ts
+++ b/packages/smrt-svelte/src/components/workspace/index.ts
@@ -22,5 +22,6 @@ export type {
   ToolDef,
   ToolsDockApi,
   ToolsDockContext,
+  ToolsDockEvents,
 } from './types.js';
 export { default as WorkspaceShell } from './WorkspaceShell.svelte';

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
@@ -42,10 +42,10 @@
   // Safe to run inside an effect because:
   //   - `dock.setContext` short-circuits on a strict-equal context, so
   //     calling it repeatedly with the same reference is a true no-op
-  //     (no availability refetch, no 'change' emit).
+  //     (no availability refetch, no 'dock:change' emit).
   //   - the dock's `emitChange` reads `$state` values inside `untrack`, so
   //     subsequent `open()` / `close()` mutations do not retrigger this
-  //     effect via the change-event payload.
+  //     effect via the 'dock:change' payload.
   $effect(() => {
     if (context !== undefined) {
       dock.setContext(context);

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
@@ -35,13 +35,17 @@
   let { dock, context = undefined, closeLabel = 'Close tools panel' }: Props =
     $props();
 
-  // Forward the `context` prop into the dock fully reactively: every time the
-  // prop changes (including from `undefined` to a populated value supplied by
-  // async route data), push it through. `dock.setContext` is idempotent — it
-  // re-runs `fetchAvailability` with token-gated stale-result handling. The
-  // initial-only-flag approach previously here dropped late-arriving values
-  // and interacted badly with Svelte 5's effect dependency tracking when the
-  // early-return branch fired.
+  // Forward the `context` prop into the dock fully reactively: every time
+  // the prop changes (including from `undefined` to a populated value
+  // supplied by async route data), push it through.
+  //
+  // Safe to run inside an effect because:
+  //   - `dock.setContext` short-circuits on a strict-equal context, so
+  //     calling it repeatedly with the same reference is a true no-op
+  //     (no availability refetch, no 'change' emit).
+  //   - the dock's `emitChange` reads `$state` values inside `untrack`, so
+  //     subsequent `open()` / `close()` mutations do not retrigger this
+  //     effect via the change-event payload.
   $effect(() => {
     if (context !== undefined) {
       dock.setContext(context);

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
@@ -37,7 +37,7 @@
  * (`ToolDef[]`) is what such an adapter would produce.
  */
 
-import { setContext } from 'svelte';
+import { setContext, untrack } from 'svelte';
 import type {
   AvailableTool,
   ToolDef,
@@ -170,6 +170,13 @@ export function defineToolsDock<TCtx = unknown>(
   let isOpen = $state(Boolean(options.initialOpen));
   let activeTool = $state<string | null>(null);
   let context = $state<ToolsDockContext | null>(null);
+  // Shadow of the last raw context reference passed to `setContextValue`.
+  // Used for strict-equality short-circuiting: Svelte 5 wraps stored object
+  // `$state` values in a Proxy, so `ctx === context` would never match the
+  // original input. Comparing against this shadow gives us proxy-free
+  // reference equality and avoids the `state_proxy_equality_mismatch`
+  // warning.
+  let rawContextRef: ToolsDockContext | null = null;
   let availableTools = $state<AvailableTool[]>(
     registeredTools.map((t) => ({ id: t.id, label: t.label, badge: t.badge })),
   );
@@ -229,14 +236,22 @@ export function defineToolsDock<TCtx = unknown>(
    * Svelte context). Always reads the latest `$state` values so handlers
    * see the post-update state, regardless of how many updates happened
    * in a single call.
+   *
+   * The `$state` reads are wrapped in `untrack` so that when this is
+   * invoked from inside a Svelte `$effect` (e.g. `<ToolsDock>`'s effect
+   * forwarding the `context` prop into `dock.setContext`), the reads do
+   * NOT become dependencies of that effect. Without this guard, a
+   * subsequent `open()` / `close()` would re-run the calling effect,
+   * which would call `setContext` again, triggering another availability
+   * fetch and another `emitChange` — an infinite-ish feedback loop.
    */
   function emitChange(): void {
     if (!ready) return;
-    const payload: ToolsDockEvents['change'] = {
+    const payload = untrack<ToolsDockEvents['change']>(() => ({
       isOpen,
       activeTool,
       context,
-    };
+    }));
     emit('change', payload);
   }
 
@@ -329,6 +344,8 @@ export function defineToolsDock<TCtx = unknown>(
   }
 
   function open(id?: string): void {
+    const prevIsOpen = isOpen;
+    const prevActive = activeTool;
     if (id) {
       if (!availableTools.some((t) => t.id === id)) return; // unavailable — no-op
       activeTool = id;
@@ -337,16 +354,29 @@ export function defineToolsDock<TCtx = unknown>(
     }
     isOpen = true;
     persist();
-    emitChange();
+    // Skip emit when nothing observable changed — avoids spurious 'change'
+    // events when consumers idempotently call open() on the already-active
+    // tool.
+    if (isOpen !== prevIsOpen || activeTool !== prevActive) {
+      emitChange();
+    }
   }
 
   function close(): void {
+    if (!isOpen) {
+      // Already closed — persist (cheap, no-op when nothing changed) but
+      // skip emit so consumers don't see spurious 'change' events.
+      persist();
+      return;
+    }
     isOpen = false;
     persist();
     emitChange();
   }
 
   function toggle(id?: string): void {
+    const prevIsOpen = isOpen;
+    const prevActive = activeTool;
     if (id) {
       if (!availableTools.some((t) => t.id === id)) return;
       if (isOpen && activeTool === id) {
@@ -356,7 +386,9 @@ export function defineToolsDock<TCtx = unknown>(
         isOpen = true;
       }
       persist();
-      emitChange();
+      if (isOpen !== prevIsOpen || activeTool !== prevActive) {
+        emitChange();
+      }
       return;
     }
     isOpen = !isOpen;
@@ -364,10 +396,23 @@ export function defineToolsDock<TCtx = unknown>(
       activeTool = availableTools[0].id;
     }
     persist();
-    emitChange();
+    if (isOpen !== prevIsOpen || activeTool !== prevActive) {
+      emitChange();
+    }
   }
 
   function setContextValue(ctx: ToolsDockContext | null): void {
+    // Strict-equality short-circuit: passing the same context reference is a
+    // no-op. Skips both the availability refresh and the `'change'` emit so
+    // consumers (e.g. `<ToolsDock>`'s context-forwarding `$effect`) can call
+    // this repeatedly without amplifying side effects. Consumers who want a
+    // "force refresh" can pass a fresh object or `null` first.
+    //
+    // Compare against `rawContextRef` (a non-reactive shadow) rather than the
+    // `$state` value, because Svelte 5 wraps object `$state` in a Proxy and
+    // the original input would never `===` the proxied stored value.
+    if (ctx === rawContextRef) return;
+    rawContextRef = ctx;
     context = ctx;
     if (fetchAvailability) refreshAvailability();
     // Emit AFTER kicking off availability refresh. The refresh is async and

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
@@ -43,6 +43,7 @@ import type {
   ToolDef,
   ToolsDockApi,
   ToolsDockContext,
+  ToolsDockEvents,
 } from '../types.js';
 
 /**
@@ -177,6 +178,15 @@ export function defineToolsDock<TCtx = unknown>(
   // recent token may apply its result.
   let availabilityToken = 0;
 
+  /**
+   * Set to `true` once the factory has finished wiring the instance. Used
+   * to gate `'change'` emits so handlers can't run before the instance
+   * exists / is registered on context. Mutations issued from inside the
+   * factory body (e.g. `applyAvailability` running during initial
+   * availability snapshot) are silent.
+   */
+  let ready = false;
+
   // Pub/sub bus
   const listeners = new Map<string, Set<(payload: unknown) => void>>();
 
@@ -212,6 +222,24 @@ export function defineToolsDock<TCtx = unknown>(
     };
   }
 
+  /**
+   * Emit a `'change'` event with a snapshot of the current public state.
+   * Guarded by the `ready` flag so handlers can't run during factory
+   * construction (before the instance is fully wired / registered on
+   * Svelte context). Always reads the latest `$state` values so handlers
+   * see the post-update state, regardless of how many updates happened
+   * in a single call.
+   */
+  function emitChange(): void {
+    if (!ready) return;
+    const payload: ToolsDockEvents['change'] = {
+      isOpen,
+      activeTool,
+      context,
+    };
+    emit('change', payload);
+  }
+
   function applyAvailability(next: AvailableTool[]): void {
     // Filter to registered tools, preserve registration order, merge labels/badges.
     const byId = new Map(next.map((t) => [t.id, t]));
@@ -240,6 +268,7 @@ export function defineToolsDock<TCtx = unknown>(
       // don't depend on the <ToolsDock> component being mounted to rescue
       // them via its $effect.
       persist();
+      emitChange();
     }
   }
 
@@ -308,11 +337,13 @@ export function defineToolsDock<TCtx = unknown>(
     }
     isOpen = true;
     persist();
+    emitChange();
   }
 
   function close(): void {
     isOpen = false;
     persist();
+    emitChange();
   }
 
   function toggle(id?: string): void {
@@ -325,6 +356,7 @@ export function defineToolsDock<TCtx = unknown>(
         isOpen = true;
       }
       persist();
+      emitChange();
       return;
     }
     isOpen = !isOpen;
@@ -332,11 +364,16 @@ export function defineToolsDock<TCtx = unknown>(
       activeTool = availableTools[0].id;
     }
     persist();
+    emitChange();
   }
 
   function setContextValue(ctx: ToolsDockContext | null): void {
     context = ctx;
     if (fetchAvailability) refreshAvailability();
+    // Emit AFTER kicking off availability refresh. The refresh is async and
+    // may emit a second `'change'` later if it clears `activeTool` — that
+    // is the intended behaviour (one event per observable state transition).
+    emitChange();
   }
 
   const instance: ToolsDockInstance<TCtx> = {
@@ -368,5 +405,10 @@ export function defineToolsDock<TCtx = unknown>(
   };
 
   setContext(TOOLS_DOCK_KEY, instance);
+  // From this point forward, mutations may emit `'change'`. Anything that
+  // ran during the factory body above (e.g. seeding `availableTools` from
+  // the registered tools) is treated as part of initialization and stays
+  // silent.
+  ready = true;
   return instance;
 }

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
@@ -187,7 +187,7 @@ export function defineToolsDock<TCtx = unknown>(
 
   /**
    * Set to `true` once the factory has finished wiring the instance. Used
-   * to gate `'change'` emits so handlers can't run before the instance
+   * to gate `'dock:change'` emits so handlers can't run before the instance
    * exists / is registered on context. Mutations issued from inside the
    * factory body (e.g. `applyAvailability` running during initial
    * availability snapshot) are silent.
@@ -230,12 +230,12 @@ export function defineToolsDock<TCtx = unknown>(
   }
 
   /**
-   * Emit a `'change'` event with a snapshot of the current public state.
-   * Guarded by the `ready` flag so handlers can't run during factory
-   * construction (before the instance is fully wired / registered on
-   * Svelte context). Always reads the latest `$state` values so handlers
-   * see the post-update state, regardless of how many updates happened
-   * in a single call.
+   * Emit a `'dock:change'` event with a snapshot of the current public
+   * state. Guarded by the `ready` flag so handlers can't run during
+   * factory construction (before the instance is fully wired / registered
+   * on Svelte context). Always reads the latest `$state` values so
+   * handlers see the post-update state, regardless of how many updates
+   * happened in a single call.
    *
    * The `$state` reads are wrapped in `untrack` so that when this is
    * invoked from inside a Svelte `$effect` (e.g. `<ToolsDock>`'s effect
@@ -247,12 +247,12 @@ export function defineToolsDock<TCtx = unknown>(
    */
   function emitChange(): void {
     if (!ready) return;
-    const payload = untrack<ToolsDockEvents['change']>(() => ({
+    const payload = untrack<ToolsDockEvents['dock:change']>(() => ({
       isOpen,
       activeTool,
       context,
     }));
-    emit('change', payload);
+    emit('dock:change', payload);
   }
 
   function applyAvailability(next: AvailableTool[]): void {
@@ -354,9 +354,9 @@ export function defineToolsDock<TCtx = unknown>(
     }
     isOpen = true;
     persist();
-    // Skip emit when nothing observable changed — avoids spurious 'change'
-    // events when consumers idempotently call open() on the already-active
-    // tool.
+    // Skip emit when nothing observable changed — avoids spurious
+    // 'dock:change' events when consumers idempotently call open() on the
+    // already-active tool.
     if (isOpen !== prevIsOpen || activeTool !== prevActive) {
       emitChange();
     }
@@ -365,7 +365,7 @@ export function defineToolsDock<TCtx = unknown>(
   function close(): void {
     if (!isOpen) {
       // Already closed — persist (cheap, no-op when nothing changed) but
-      // skip emit so consumers don't see spurious 'change' events.
+      // skip emit so consumers don't see spurious 'dock:change' events.
       persist();
       return;
     }
@@ -403,10 +403,10 @@ export function defineToolsDock<TCtx = unknown>(
 
   function setContextValue(ctx: ToolsDockContext | null): void {
     // Strict-equality short-circuit: passing the same context reference is a
-    // no-op. Skips both the availability refresh and the `'change'` emit so
-    // consumers (e.g. `<ToolsDock>`'s context-forwarding `$effect`) can call
-    // this repeatedly without amplifying side effects. Consumers who want a
-    // "force refresh" can pass a fresh object or `null` first.
+    // no-op. Skips both the availability refresh and the `'dock:change'`
+    // emit so consumers (e.g. `<ToolsDock>`'s context-forwarding `$effect`)
+    // can call this repeatedly without amplifying side effects. Consumers
+    // who want a "force refresh" can pass a fresh object or `null` first.
     //
     // Compare against `rawContextRef` (a non-reactive shadow) rather than the
     // `$state` value, because Svelte 5 wraps object `$state` in a Proxy and
@@ -416,8 +416,9 @@ export function defineToolsDock<TCtx = unknown>(
     context = ctx;
     if (fetchAvailability) refreshAvailability();
     // Emit AFTER kicking off availability refresh. The refresh is async and
-    // may emit a second `'change'` later if it clears `activeTool` — that
-    // is the intended behaviour (one event per observable state transition).
+    // may emit a second `'dock:change'` later if it clears `activeTool` —
+    // that is the intended behaviour (one event per observable state
+    // transition).
     emitChange();
   }
 
@@ -450,10 +451,10 @@ export function defineToolsDock<TCtx = unknown>(
   };
 
   setContext(TOOLS_DOCK_KEY, instance);
-  // From this point forward, mutations may emit `'change'`. Anything that
-  // ran during the factory body above (e.g. seeding `availableTools` from
-  // the registered tools) is treated as part of initialization and stays
-  // silent.
+  // From this point forward, mutations may emit `'dock:change'`. Anything
+  // that ran during the factory body above (e.g. seeding `availableTools`
+  // from the registered tools) is treated as part of initialization and
+  // stays silent.
   ready = true;
   return instance;
 }

--- a/packages/smrt-svelte/src/components/workspace/types.ts
+++ b/packages/smrt-svelte/src/components/workspace/types.ts
@@ -52,6 +52,27 @@ export interface ToolsDockContext<TData = Record<string, unknown>> {
   actions?: Record<string, (...args: any[]) => unknown>;
 }
 
+/**
+ * Built-in event names emitted on the {@link ToolsDockApi} pub/sub bus along
+ * with their payload shapes. Consumers can extend this map by declaration
+ * merging in their own `.d.ts` if they emit additional custom events via
+ * {@link ToolsDockApi.emit}.
+ *
+ * The `'change'` event fires after any state transition that affects
+ * `isOpen`, `activeTool`, or `context` — i.e. `open()`, `close()`,
+ * `toggle()`, `setContext()`, and availability changes that clear the
+ * active tool. Handlers see the post-update state. Useful for mirroring
+ * dock state into a separate store (workbench, analytics, etc.) without
+ * threading multiple `$effect`s through every state-bearing getter.
+ */
+export interface ToolsDockEvents {
+  change: {
+    isOpen: boolean;
+    activeTool: string | null;
+    context: ToolsDockContext | null;
+  };
+}
+
 export interface ToolsDockApi {
   readonly activeTool: string | null;
   readonly isOpen: boolean;
@@ -66,6 +87,33 @@ export interface ToolsDockApi {
   close(): void;
   toggle(id?: string): void;
   setContext(ctx: ToolsDockContext | null): void;
+  /**
+   * Emit a custom event to all subscribers. Built-in events (see
+   * {@link ToolsDockEvents}) are emitted by the dock itself; consumers
+   * may emit additional events to coordinate between tools.
+   */
+  emit<K extends keyof ToolsDockEvents>(
+    event: K,
+    payload: ToolsDockEvents[K],
+  ): void;
   emit<TPayload>(event: string, payload: TPayload): void;
+  /**
+   * Subscribe to a dock event. Returns an unsubscribe function. When the
+   * event name is a key of {@link ToolsDockEvents} the payload type is
+   * inferred automatically; otherwise an explicit `TPayload` may be supplied.
+   *
+   * @example
+   * ```ts
+   * const off = dock.on('change', ({ isOpen, activeTool, context }) => {
+   *   // mirror to another store
+   * });
+   * // ...later
+   * off();
+   * ```
+   */
+  on<K extends keyof ToolsDockEvents>(
+    event: K,
+    handler: (payload: ToolsDockEvents[K]) => void,
+  ): () => void;
   on<TPayload>(event: string, handler: (payload: TPayload) => void): () => void;
 }

--- a/packages/smrt-svelte/src/components/workspace/types.ts
+++ b/packages/smrt-svelte/src/components/workspace/types.ts
@@ -53,20 +53,28 @@ export interface ToolsDockContext<TData = Record<string, unknown>> {
 }
 
 /**
- * Built-in event names emitted on the {@link ToolsDockApi} pub/sub bus along
- * with their payload shapes. Consumers can extend this map by declaration
- * merging in their own `.d.ts` if they emit additional custom events via
- * {@link ToolsDockApi.emit}.
+ * Typed payloads for dock-owned events. Event names under the `dock:` prefix
+ * are reserved for the workspace primitives. Consumers should pick names in
+ * their own namespace (e.g. `'my-app:foo'`) and use the stringly-typed
+ * overloads of {@link ToolsDockApi.on} / {@link ToolsDockApi.emit}:
  *
- * The `'change'` event fires after any state transition that affects
- * `isOpen`, `activeTool`, or `context` — i.e. `open()`, `close()`,
- * `toggle()`, `setContext()`, and availability changes that clear the
- * active tool. Handlers see the post-update state. Useful for mirroring
- * dock state into a separate store (workbench, analytics, etc.) without
- * threading multiple `$effect`s through every state-bearing getter.
+ * ```ts
+ * dock.on<MyPayload>('my-app:selection-changed', (e) => {
+ *   // ...
+ * });
+ * dock.emit<MyPayload>('my-app:selection-changed', payload);
+ * ```
  */
 export interface ToolsDockEvents {
-  change: {
+  /**
+   * Fired by the dock after `isOpen`, `activeTool`, or `context` change —
+   * i.e. `open()`, `close()`, `toggle()`, `setContext()`, and availability
+   * changes that clear the active tool. Payload reflects post-mutation
+   * values. Useful for mirroring dock state into a separate store
+   * (workbench, analytics, etc.) without threading multiple `$effect`s
+   * through every state-bearing getter.
+   */
+  'dock:change': {
     isOpen: boolean;
     activeTool: string | null;
     context: ToolsDockContext | null;
@@ -88,9 +96,11 @@ export interface ToolsDockApi {
   toggle(id?: string): void;
   setContext(ctx: ToolsDockContext | null): void;
   /**
-   * Emit a custom event to all subscribers. Built-in events (see
-   * {@link ToolsDockEvents}) are emitted by the dock itself; consumers
-   * may emit additional events to coordinate between tools.
+   * Emit an event to all subscribers. The typed overload covers built-in
+   * `'dock:*'` events (see {@link ToolsDockEvents}); the stringly-typed
+   * overload covers any consumer-defined event name. Consumers should pick
+   * names in their own namespace (e.g. `'my-app:foo'`) — `'dock:*'` is
+   * reserved for the workspace primitives.
    */
   emit<K extends keyof ToolsDockEvents>(
     event: K,
@@ -99,12 +109,13 @@ export interface ToolsDockApi {
   emit<TPayload>(event: string, payload: TPayload): void;
   /**
    * Subscribe to a dock event. Returns an unsubscribe function. When the
-   * event name is a key of {@link ToolsDockEvents} the payload type is
-   * inferred automatically; otherwise an explicit `TPayload` may be supplied.
+   * event name is a key of {@link ToolsDockEvents} (i.e. `'dock:*'`), the
+   * payload type is inferred automatically; otherwise an explicit
+   * `TPayload` may be supplied via the stringly-typed overload.
    *
    * @example
    * ```ts
-   * const off = dock.on('change', ({ isOpen, activeTool, context }) => {
+   * const off = dock.on('dock:change', ({ isOpen, activeTool, context }) => {
    *   // mirror to another store
    * });
    * // ...later


### PR DESCRIPTION
## Summary

Two workspace-API follow-ups surfaced by the first downstream migration ([ergot.io#58](https://github.com/happyvertical/ergot.io/pull/58)). Implements findings A and E from [#1235](https://github.com/happyvertical/smrt/issues/1235); B/C/D can wait. **Unblocks Phase 3** of the downstream migration (anytown site-portal).

### Finding A - ToolsDock `'change'` event

`defineToolsDock` now emits a `'change'` event from `open()`, `close()`, `toggle()`, `setContext()`, and from `applyAvailability()` when the active tool is cleared. Payload is `{ isOpen, activeTool, context }` (post-update). A `ready` flag suppresses emits during factory construction so handlers can't run before the instance is wired into Svelte context.

`ToolsDockApi.on` / `emit` are now overloaded against a new `ToolsDockEvents` map so `dock.on('change', e => ...)` infers the payload type without an explicit generic. Consumer-defined event names still fall through to the existing string-keyed signature (no breaking change).

```ts
const off = dock.on('change', ({ isOpen, activeTool, context }) => {
  // mirror dock state to a workbench store
});
```

### Finding E - `bind:mobileNavOpen` on `WorkspaceShell`

`mobileNavOpen` is now `$bindable(false)` so consumers can lift the drawer state. Internal hamburger, backdrop, and Escape interactions still mutate the value and the update propagates back through the binding.

Per the issue, after reading `NavTree.svelte` I confirmed the bind-only recipe works cleanly - `NavTree` already accepts `onNavigate`. **No new callback prop was needed.**

```svelte
<WorkspaceShell bind:mobileNavOpen>
  {#snippet nav()}
    <NavTree
      items={items}
      currentPath={path}
      onNavigate={() => (mobileNavOpen = false)}
    />
  {/snippet}
  ...
</WorkspaceShell>
```

### Docs

`packages/smrt-svelte/CLAUDE.md` gains a short "State-mirroring recipes" subsection documenting both patterns.

## Test plan

- [x] `pnpm build` in `packages/smrt-svelte/` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` in `packages/smrt-svelte/` passes (118 -> 130; +8 for finding A, +4 for finding E)
- [x] `'change'` fires on open / close / toggle with post-update payload
- [x] `'change'` fires on `setContext`, then again when availability clears the active tool
- [x] Unsubscribe stops a handler from receiving further events
- [x] `bind:mobileNavOpen` two-way binding works from outside in
- [x] Internal hamburger / backdrop clicks propagate the new value back through the bind
- [x] No new SvelteKit imports; no unguarded DOM access; SSR-safe paths preserved
- [ ] Consumer smoke test in ergot.io workbench (will happen as part of Phase 3 migration after merge)

Refs #1235