### PR TITLE
feat(smrt-svelte): add ToolDef iconComponent and dock.refreshAvailability

### DIFF
--- a/packages/smrt-svelte/CLAUDE.md
+++ b/packages/smrt-svelte/CLAUDE.md
@@ -105,10 +105,14 @@ domain-specific tools live outside the framework in consumer packages.
   state. Pair it with `<NavTree onNavigate={() => mobileNavOpen = false} />` to
   close the drawer on navigation without any DOM querying.
 - `ToolDef.iconComponent?: Component` renders a custom icon inside the rail
-  glyph (matches `NavTree`'s `iconComponent` convention). Takes precedence over
-  the `icon: string` fallback and the `label.charAt(0)` last-resort. Pass a
-  thin wrapper around your icon library of choice (lucide-svelte etc.) — avoids
+  glyph (and as a leading glyph in the topbar layout). Matches `NavTree`'s
+  `iconComponent` convention; takes precedence over the `icon: string`
+  fallback and the `label.charAt(0)` last-resort. Pass the icon component
+  from your library of choice (lucide-svelte etc.) directly — avoids
   ambiguous single-letter glyphs in dense docks ("Chat" vs "Claim Audit").
+  The icon component is rendered with no props (`<IconComponent />`); wrap
+  props-bearing icons in a small `.svelte` adapter component if you need
+  to hard-code size or other attributes.
 - `dock.refreshAvailability()` forces a re-run of `fetchAvailability` with the
   current context. `setContext()` short-circuits on strict-equal references, so
   use this when a side-channel event (job-updated websocket, manual refresh

--- a/packages/smrt-svelte/CLAUDE.md
+++ b/packages/smrt-svelte/CLAUDE.md
@@ -104,6 +104,15 @@ domain-specific tools live outside the framework in consumer packages.
 - `WorkspaceShell` exposes `bind:mobileNavOpen` so consumers can lift the drawer
   state. Pair it with `<NavTree onNavigate={() => mobileNavOpen = false} />` to
   close the drawer on navigation without any DOM querying.
+- `ToolDef.iconComponent?: Component` renders a custom icon inside the rail
+  glyph (matches `NavTree`'s `iconComponent` convention). Takes precedence over
+  the `icon: string` fallback and the `label.charAt(0)` last-resort. Pass a
+  thin wrapper around your icon library of choice (lucide-svelte etc.) — avoids
+  ambiguous single-letter glyphs in dense docks ("Chat" vs "Claim Audit").
+- `dock.refreshAvailability()` forces a re-run of `fetchAvailability` with the
+  current context. `setContext()` short-circuits on strict-equal references, so
+  use this when a side-channel event (job-updated websocket, manual refresh
+  button, etc.) signals availability or badges changed without a context change.
 
 See epic [happyvertical/smrt#1226](https://github.com/happyvertical/smrt/issues/1226) for context;
 implementations land via #1227 (`WorkspaceShell`), #1228 (`NavTree`/`Breadcrumbs`), and #1229

--- a/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
@@ -399,6 +399,108 @@ describe('defineToolsDock', () => {
     expect(dock.availableTools).toEqual([]);
   });
 
+  describe('refreshAvailability()', () => {
+    it('re-runs fetchAvailability with the current context', async () => {
+      let availability: { id: string }[] = [{ id: 'chat' }];
+      const fetchAvailability = vi.fn(async () => availability);
+
+      const { dock } = track(
+        mountDock({
+          tools: [
+            { id: 'chat', label: 'Chat', component: noopTool },
+            { id: 'jobs', label: 'Jobs', component: noopTool },
+          ],
+          fetchAvailability,
+        }),
+      );
+
+      const ctx = { type: 'thing', title: 'A' } as const;
+      dock.setContext(ctx);
+      await new Promise((r) => setTimeout(r, 0));
+      flushSync();
+      expect(fetchAvailability).toHaveBeenCalledTimes(1);
+      expect(dock.availableTools.map((t) => t.id)).toEqual(['chat']);
+
+      // Side-channel signal: availability changed without a context change.
+      // setContext(ctx) would short-circuit; refreshAvailability() forces it.
+      availability = [{ id: 'chat' }, { id: 'jobs' }];
+      dock.refreshAvailability();
+      expect(fetchAvailability).toHaveBeenCalledTimes(2);
+      // Called with the same (unchanged) context.
+      expect(fetchAvailability).toHaveBeenLastCalledWith(ctx);
+
+      await new Promise((r) => setTimeout(r, 0));
+      flushSync();
+      // Second fetch's result is reflected in availableTools.
+      expect(dock.availableTools.map((t) => t.id)).toEqual(['chat', 'jobs']);
+    });
+
+    it('resets to all registered tools when no fetchAvailability is configured', () => {
+      const { dock } = track(
+        mountDock({
+          tools: [
+            { id: 'chat', label: 'Chat', component: noopTool },
+            { id: 'jobs', label: 'Jobs', component: noopTool },
+          ],
+        }),
+      );
+
+      expect(dock.availableTools.map((t) => t.id)).toEqual(['chat', 'jobs']);
+      // No-op semantically (all tools were already available), but the
+      // method should not crash without a fetchAvailability callback.
+      expect(() => dock.refreshAvailability()).not.toThrow();
+      flushSync();
+      expect(dock.availableTools.map((t) => t.id)).toEqual(['chat', 'jobs']);
+    });
+
+    it('drops stale results from a prior refreshAvailability call (race-safety)', async () => {
+      let resolveFirst: ((v: { id: string }[]) => void) | null = null;
+      let resolveSecond: ((v: { id: string }[]) => void) | null = null;
+
+      const fetchAvailability = vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<{ id: string }[]>((r) => {
+              resolveFirst = r;
+            }),
+        )
+        .mockImplementationOnce(
+          () =>
+            new Promise<{ id: string }[]>((r) => {
+              resolveSecond = r;
+            }),
+        );
+
+      const { dock } = track(
+        mountDock({
+          tools: [
+            { id: 'chat', label: 'Chat', component: noopTool },
+            { id: 'jobs', label: 'Jobs', component: noopTool },
+          ],
+          fetchAvailability,
+        }),
+      );
+
+      // First call via refreshAvailability (no prior setContext).
+      dock.refreshAvailability();
+      await Promise.resolve();
+      // Second call before the first resolves.
+      dock.refreshAvailability();
+      await Promise.resolve();
+
+      // Resolve stale first AFTER fresh second was requested.
+      resolveFirst?.([{ id: 'chat' }]);
+      resolveSecond?.([{ id: 'jobs' }]);
+      await Promise.resolve();
+      await Promise.resolve();
+      flushSync();
+
+      // Only the most recent result applies.
+      expect(dock.availableTools.map((t) => t.id)).toEqual(['jobs']);
+    });
+  });
+
   it('clears activeTool when availability removes the active tool', async () => {
     let availability: { id: string }[] = [{ id: 'chat' }, { id: 'jobs' }];
     const fetchAvailability = vi.fn(async () => availability);

--- a/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
@@ -453,6 +453,106 @@ describe('defineToolsDock', () => {
       expect(dock.availableTools.map((t) => t.id)).toEqual(['chat', 'jobs']);
     });
 
+    it("emits 'dock:change' when refresh changes only badge values", async () => {
+      // Regression for the badge-only refresh case: a side-channel signal
+      // fires (e.g. a Jobs-count websocket message) and the consumer calls
+      // `refreshAvailability()` to repaint badges. The tool ids haven't
+      // changed and the active tool stays put, but `availableTools` now
+      // carries a different badge — consumers mirroring this into a topbar
+      // count must see a `'dock:change'` event to repaint without polling.
+      let availability: { id: string; badge?: number | null }[] = [
+        { id: 'chat', badge: 0 },
+        { id: 'jobs', badge: 0 },
+      ];
+      const fetchAvailability = vi.fn(async () => availability);
+
+      const { dock } = track(
+        mountDock({
+          tools: [
+            { id: 'chat', label: 'Chat', component: noopTool },
+            { id: 'jobs', label: 'Jobs', component: noopTool },
+          ],
+          fetchAvailability,
+        }),
+      );
+
+      dock.setContext({ type: 'thing' });
+      await new Promise((r) => setTimeout(r, 0));
+      flushSync();
+
+      const handler = vi.fn();
+      dock.on('dock:change', handler);
+
+      // Side-channel update: same tool ids, different badge values.
+      availability = [
+        { id: 'chat', badge: 0 },
+        { id: 'jobs', badge: 7 },
+      ];
+      dock.refreshAvailability();
+      await new Promise((r) => setTimeout(r, 0));
+      flushSync();
+
+      // Exactly one emit reflecting the new badge.
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenLastCalledWith({
+        isOpen: false,
+        activeTool: null,
+        context: { type: 'thing' },
+      });
+      const jobsAfter = dock.availableTools.find((t) => t.id === 'jobs');
+      expect(jobsAfter?.badge).toBe(7);
+
+      // Calling refreshAvailability again with byte-identical results must
+      // NOT emit a second time. The discriminating shape check keeps no-op
+      // refreshes silent so consumer mirrors don't see spurious updates.
+      dock.refreshAvailability();
+      await new Promise((r) => setTimeout(r, 0));
+      flushSync();
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it("emits 'dock:change' when refresh clears the active tool", async () => {
+      // Direct coverage for the active-tool-clear branch of
+      // `applyAvailability` reached via `refreshAvailability()` (rather
+      // than via a `setContext()` → refresh chain).
+      let availability: { id: string }[] = [{ id: 'chat' }, { id: 'jobs' }];
+      const fetchAvailability = vi.fn(async () => availability);
+
+      const { dock } = track(
+        mountDock({
+          tools: [
+            { id: 'chat', label: 'Chat', component: noopTool },
+            { id: 'jobs', label: 'Jobs', component: noopTool },
+          ],
+          fetchAvailability,
+        }),
+      );
+
+      dock.setContext({ type: 'thing' });
+      await new Promise((r) => setTimeout(r, 0));
+      flushSync();
+      dock.open('jobs');
+      flushSync();
+      expect(dock.activeTool).toBe('jobs');
+
+      const handler = vi.fn();
+      dock.on('dock:change', handler);
+
+      // Side-channel availability shrink — 'jobs' is no longer available.
+      availability = [{ id: 'chat' }];
+      dock.refreshAvailability();
+      await new Promise((r) => setTimeout(r, 0));
+      flushSync();
+
+      expect(dock.activeTool).toBeNull();
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenLastCalledWith({
+        isOpen: true,
+        activeTool: null,
+        context: { type: 'thing' },
+      });
+    });
+
     it('drops stale results from a prior refreshAvailability call (race-safety)', async () => {
       let resolveFirst: ((v: { id: string }[]) => void) | null = null;
       let resolveSecond: ((v: { id: string }[]) => void) | null = null;

--- a/packages/smrt-svelte/src/components/workspace/__tests__/render-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/render-harness.svelte
@@ -4,7 +4,7 @@
  * component so tests can render the actual DOM. Accepts a thin shape that
  * lets each test express only the behavior it cares about.
  */
-import { onMount } from 'svelte';
+import { type Component, onMount } from 'svelte';
 import { defineToolsDock } from '../tools-dock/define-tools-dock.svelte.js';
 import ToolsDock from '../tools-dock/ToolsDock.svelte';
 import type { AvailableTool, ToolsDockContext } from '../types.js';
@@ -13,6 +13,8 @@ interface ToolProp {
   id: string;
   label: string;
   badge?: number | string | null;
+  icon?: string;
+  iconComponent?: Component;
 }
 
 interface Props {

--- a/packages/smrt-svelte/src/components/workspace/__tests__/render-tools-dock.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/render-tools-dock.test.ts
@@ -213,6 +213,87 @@ describe('<ToolsDock> rail layout', () => {
     });
   });
 
+  describe('topbar button icon rendering', () => {
+    it('renders ToolDef.iconComponent before the label in topbar layout', () => {
+      const target = render({
+        layout: 'topbar',
+        tools: [{ id: 'chat', label: 'Chat', iconComponent: TestIcon }],
+      });
+
+      const btn = target.querySelector<HTMLButtonElement>(
+        '.tools-dock__topbar-button',
+      );
+      expect(btn).not.toBeNull();
+      const icon = btn?.querySelector('.tools-dock__topbar-button-icon');
+      const label = btn?.querySelector('.tools-dock__topbar-button-label');
+      expect(icon).not.toBeNull();
+      expect(label?.textContent).toBe('Chat');
+      // Icon hosts the test SVG.
+      expect(
+        icon?.querySelector('svg[data-testid="custom-icon"]'),
+      ).not.toBeNull();
+      // Icon precedes the label in document order so screen-magnifier /
+      // visual layout matches reading order.
+      if (icon && label) {
+        expect(
+          icon.compareDocumentPosition(label) &
+            Node.DOCUMENT_POSITION_FOLLOWING,
+        ).toBeTruthy();
+      }
+    });
+
+    it('renders ToolDef.icon string before the label in topbar layout', () => {
+      const target = render({
+        layout: 'topbar',
+        tools: [{ id: 'chat', label: 'Chat', icon: 'X' }],
+      });
+
+      const btn = target.querySelector<HTMLButtonElement>(
+        '.tools-dock__topbar-button',
+      );
+      const icon = btn?.querySelector('.tools-dock__topbar-button-icon');
+      expect(icon?.textContent?.trim()).toBe('X');
+      // No SVG when only the string icon was supplied.
+      expect(icon?.querySelector('svg')).toBeNull();
+    });
+
+    it('omits the icon span entirely when neither iconComponent nor icon is set', () => {
+      const target = render({
+        layout: 'topbar',
+        tools: [{ id: 'chat', label: 'Chat' }],
+      });
+
+      const btn = target.querySelector<HTMLButtonElement>(
+        '.tools-dock__topbar-button',
+      );
+      const icon = btn?.querySelector('.tools-dock__topbar-button-icon');
+      const label = btn?.querySelector('.tools-dock__topbar-button-label');
+      // Topbar buttons stay label-only when no icon is provided — unlike
+      // the rail, where we fall back to the first letter of the label.
+      expect(icon).toBeNull();
+      expect(label?.textContent).toBe('Chat');
+    });
+
+    it('iconComponent takes precedence over icon string in topbar layout', () => {
+      const target = render({
+        layout: 'topbar',
+        tools: [
+          { id: 'chat', label: 'Chat', icon: 'X', iconComponent: TestIcon },
+        ],
+      });
+
+      const btn = target.querySelector<HTMLButtonElement>(
+        '.tools-dock__topbar-button',
+      );
+      const icon = btn?.querySelector('.tools-dock__topbar-button-icon');
+      // SVG wins, the string "X" must not appear.
+      expect(
+        icon?.querySelector('svg[data-testid="custom-icon"]'),
+      ).not.toBeNull();
+      expect(icon?.textContent?.trim()).toBe('');
+    });
+  });
+
   it('renders an empty state when no tools are available', async () => {
     const target = render({
       tools: [{ id: 'chat', label: 'Chat' }],

--- a/packages/smrt-svelte/src/components/workspace/__tests__/render-tools-dock.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/render-tools-dock.test.ts
@@ -12,6 +12,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import type { ToolsDockInstance } from '../tools-dock/define-tools-dock.svelte.js';
 import ContextForwardingHarness from './context-forwarding-harness.svelte';
 import RenderHarness from './render-harness.svelte';
+import TestIcon from './test-icon.svelte';
 
 const mountedComponents: Array<ReturnType<typeof mount>> = [];
 
@@ -158,6 +159,58 @@ describe('<ToolsDock> rail layout', () => {
     flushSync();
     await tick();
     expect(dock?.context).toEqual({ type: 'route', title: 'World' });
+  });
+
+  describe('rail glyph rendering', () => {
+    it('renders ToolDef.iconComponent inside the rail glyph when provided', () => {
+      const target = render({
+        tools: [{ id: 'chat', label: 'Chat', iconComponent: TestIcon }],
+      });
+
+      const glyph = target.querySelector('.tools-dock__rail-glyph');
+      expect(glyph).not.toBeNull();
+      // iconComponent rendered → SVG present, first-letter fallback absent.
+      const svg = glyph?.querySelector('svg[data-testid="custom-icon"]');
+      expect(svg).not.toBeNull();
+      // No stray "C" letter text node — only the icon component.
+      expect(glyph?.textContent?.trim()).toBe('');
+    });
+
+    it('renders ToolDef.icon string when no iconComponent is provided', () => {
+      const target = render({
+        tools: [{ id: 'chat', label: 'Chat', icon: 'X' }],
+      });
+
+      const glyph = target.querySelector('.tools-dock__rail-glyph');
+      expect(glyph?.textContent?.trim()).toBe('X');
+      // No iconComponent rendered.
+      expect(glyph?.querySelector('svg')).toBeNull();
+    });
+
+    it('falls back to label.charAt(0).toUpperCase() when neither iconComponent nor icon is set', () => {
+      const target = render({
+        tools: [{ id: 'chat', label: 'chat' }],
+      });
+
+      const glyph = target.querySelector('.tools-dock__rail-glyph');
+      // First letter, uppercased — existing behaviour preserved.
+      expect(glyph?.textContent?.trim()).toBe('C');
+    });
+
+    it('iconComponent takes precedence over icon string when both are provided', () => {
+      const target = render({
+        tools: [
+          { id: 'chat', label: 'Chat', icon: 'X', iconComponent: TestIcon },
+        ],
+      });
+
+      const glyph = target.querySelector('.tools-dock__rail-glyph');
+      // iconComponent wins; the icon string is not rendered.
+      expect(
+        glyph?.querySelector('svg[data-testid="custom-icon"]'),
+      ).not.toBeNull();
+      expect(glyph?.textContent?.trim()).toBe('');
+    });
   });
 
   it('renders an empty state when no tools are available', async () => {

--- a/packages/smrt-svelte/src/components/workspace/__tests__/test-icon.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/test-icon.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+/**
+ * Trivial icon component used by render-tools-dock tests to verify that
+ * `ToolDef.iconComponent` is rendered inside `.tools-dock__rail-glyph`
+ * instead of the first-letter fallback.
+ */
+</script>
+
+<svg
+  data-testid="custom-icon"
+  width="18"
+  height="18"
+  viewBox="0 0 24 24"
+  aria-hidden="true"
+>
+  <circle cx="12" cy="12" r="10" />
+</svg>

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
@@ -156,6 +156,15 @@
     onclick={(event) => handleButtonClick(event, tool.id)}
   >
     {#if variant === 'topbar'}
+      {#if IconComponent}
+        <span class="tools-dock__topbar-button-icon" aria-hidden="true">
+          <IconComponent />
+        </span>
+      {:else if iconString}
+        <span class="tools-dock__topbar-button-icon" aria-hidden="true">
+          {iconString}
+        </span>
+      {/if}
       <span class="tools-dock__topbar-button-label">{label}</span>
     {:else}
       <span class="tools-dock__rail-glyph" aria-hidden="true">
@@ -439,6 +448,9 @@
 
   .tools-dock__topbar-button {
     position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
     border: 1px solid var(--smrt-color-outline-variant, #30343a);
     background: var(--smrt-color-surface-container-low, #11161b);
     color: var(--smrt-color-on-surface-variant, #aab2bd);
@@ -453,6 +465,17 @@
   .tools-dock__topbar-button:hover {
     background: var(--smrt-color-surface-container-high, #1d2228);
     color: var(--smrt-color-on-surface, #f8fafc);
+  }
+
+  /* Leading glyph in the topbar layout. Sized to match the surrounding
+     text — consumers wanting a different size can wrap their icon
+     component to hard-code dimensions (see ToolDef.iconComponent docs). */
+  .tools-dock__topbar-button-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    font-size: 0.95rem;
   }
 
   .tools-dock--topbar .tools-dock__panel {

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
@@ -72,6 +72,10 @@
     return dock.tools.find((t) => t.id === dock.activeTool) ?? null;
   }
 
+  function toolDefById(id: string) {
+    return dock.tools.find((t) => t.id === id) ?? null;
+  }
+
   function handleButtonClick(event: MouseEvent, toolId: string): void {
     lastActivatorEl = event.currentTarget as HTMLButtonElement;
     dock.toggle(toolId);
@@ -139,6 +143,9 @@
 {#snippet toolButton(tool: { id: string; label?: string; badge?: number | string | null }, variant: 'rail' | 'topbar')}
   {@const isActive = dock.isOpen && dock.activeTool === tool.id}
   {@const label = tool.label ?? tool.id}
+  {@const def = toolDefById(tool.id)}
+  {@const IconComponent = def?.iconComponent}
+  {@const iconString = def?.icon}
   <button
     type="button"
     class:active={isActive}
@@ -152,7 +159,13 @@
       <span class="tools-dock__topbar-button-label">{label}</span>
     {:else}
       <span class="tools-dock__rail-glyph" aria-hidden="true">
-        {label?.charAt(0).toUpperCase() ?? '?'}
+        {#if IconComponent}
+          <IconComponent />
+        {:else if iconString}
+          {iconString}
+        {:else}
+          {label?.charAt(0).toUpperCase() ?? '?'}
+        {/if}
       </span>
     {/if}
     {#if tool.badge !== null && tool.badge !== undefined && tool.badge !== 0 && tool.badge !== ''}

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
@@ -440,6 +440,7 @@ export function defineToolsDock<TCtx = unknown>(
     close,
     toggle,
     setContext: setContextValue,
+    refreshAvailability,
     emit,
     on,
     // Framework-only members:

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
@@ -255,9 +255,38 @@ export function defineToolsDock<TCtx = unknown>(
     emit('dock:change', payload);
   }
 
+  /**
+   * Discriminating comparison of two availability snapshots. Returns true
+   * when the new snapshot differs from the previous one in any user-visible
+   * way (id ordering, badge value, or label). Used by `applyAvailability`
+   * to decide whether to fire a `'dock:change'` event: refreshes that
+   * resolve to byte-identical availability (the common no-op case when a
+   * side-channel signal fires but underlying data didn't change) stay
+   * silent, avoiding spurious work in consumer-side `'dock:change'`
+   * mirrors.
+   *
+   * Both inputs come from `registeredTools.filter(...).map(...)` in the
+   * same registration order, so a positional comparison is sufficient.
+   */
+  function availabilityActuallyChanged(
+    prev: ReadonlyArray<AvailableTool>,
+    next: ReadonlyArray<AvailableTool>,
+  ): boolean {
+    if (prev.length !== next.length) return true;
+    for (let i = 0; i < prev.length; i++) {
+      const a = prev[i];
+      const b = next[i];
+      if (a.id !== b.id) return true;
+      if ((a.badge ?? null) !== (b.badge ?? null)) return true;
+      if ((a.label ?? '') !== (b.label ?? '')) return true;
+    }
+    return false;
+  }
+
   function applyAvailability(next: AvailableTool[]): void {
     // Filter to registered tools, preserve registration order, merge labels/badges.
     const byId = new Map(next.map((t) => [t.id, t]));
+    const prev = availableTools;
     availableTools = registeredTools
       .filter((t) => byId.has(t.id))
       .map((t) => {
@@ -273,6 +302,9 @@ export function defineToolsDock<TCtx = unknown>(
             reportedBadge !== undefined ? reportedBadge : (t.badge ?? null),
         } satisfies AvailableTool;
       });
+
+    let changed = false;
+
     // If the active tool is no longer available, clear it.
     if (activeTool && !availableTools.some((t) => t.id === activeTool)) {
       activeTool = null;
@@ -283,6 +315,19 @@ export function defineToolsDock<TCtx = unknown>(
       // don't depend on the <ToolsDock> component being mounted to rescue
       // them via its $effect.
       persist();
+      changed = true;
+    }
+
+    // Even when the active tool stayed put, the availability set may have
+    // shifted in ways consumers care about (badge counts, label overrides,
+    // tools appearing/disappearing). Emit so consumers mirroring
+    // `availableTools` into their own state (badges in topbars, etc.) see
+    // the update without polling.
+    if (!changed) {
+      changed = availabilityActuallyChanged(prev, availableTools);
+    }
+
+    if (changed) {
       emitChange();
     }
   }

--- a/packages/smrt-svelte/src/components/workspace/types.ts
+++ b/packages/smrt-svelte/src/components/workspace/types.ts
@@ -39,26 +39,33 @@ export interface ToolDef<TCtx = unknown> {
    * of `label` when both are omitted.
    *
    * Note: ambiguous in dense docks (e.g. "Chat" and "Claim Audit" both
-   * collapse to "C"). Provide `iconComponent` for production decks — see
+   * collapse to "C"). Provide `iconComponent` for production docks — see
    * the `iconComponent` field below.
    */
   icon?: string;
   /**
    * Component rendered in the rail layout (and as a leading glyph in the
    * topbar layout) for this tool. Takes precedence over `icon`. Matches
-   * the pattern used by `NavTree` for per-item icons — pass a wrapper
-   * component over your icon library of choice (lucide-svelte etc.).
+   * the pattern used by `NavTree` for per-item icons — pass the icon
+   * component from your library of choice (lucide-svelte etc.) directly,
+   * or a thin `.svelte` wrapper around it.
    *
-   * The component is rendered with no required props; if your icon library
-   * needs sizing, wrap it in a thin component that hard-codes the dimensions
-   * you want (typically ~18px to match `.tools-dock__rail-glyph`).
+   * The component is rendered with no props (`<IconComponent />`); if your
+   * icon library needs sizing, wrap it in a thin `.svelte` component that
+   * hard-codes the dimensions you want (typically ~18px to match
+   * `.tools-dock__rail-glyph`).
    *
    * @example
-   * ```svelte
-   * <script>
-   *   import { MessageSquare } from 'lucide-svelte';
-   *   const ChatIcon = () => MessageSquare; // or a wrapper component
-   * </script>
+   * ```ts
+   * import MessageSquare from 'lucide-svelte/icons/message-square';
+   * import ChatPanel from './ChatPanel.svelte';
+   *
+   * const tool: ToolDef = {
+   *   id: 'chat',
+   *   label: 'Chat',
+   *   iconComponent: MessageSquare,
+   *   component: ChatPanel,
+   * };
    * ```
    */
   iconComponent?: Component;

--- a/packages/smrt-svelte/src/components/workspace/types.ts
+++ b/packages/smrt-svelte/src/components/workspace/types.ts
@@ -33,7 +33,35 @@ export interface BreadcrumbItem {
 export interface ToolDef<TCtx = unknown> {
   id: string;
   label: string;
+  /**
+   * Single-character glyph or emoji rendered in the rail layout when no
+   * `iconComponent` is provided. Defaults to the uppercased first character
+   * of `label` when both are omitted.
+   *
+   * Note: ambiguous in dense docks (e.g. "Chat" and "Claim Audit" both
+   * collapse to "C"). Provide `iconComponent` for production decks — see
+   * the `iconComponent` field below.
+   */
   icon?: string;
+  /**
+   * Component rendered in the rail layout (and as a leading glyph in the
+   * topbar layout) for this tool. Takes precedence over `icon`. Matches
+   * the pattern used by `NavTree` for per-item icons — pass a wrapper
+   * component over your icon library of choice (lucide-svelte etc.).
+   *
+   * The component is rendered with no required props; if your icon library
+   * needs sizing, wrap it in a thin component that hard-codes the dimensions
+   * you want (typically ~18px to match `.tools-dock__rail-glyph`).
+   *
+   * @example
+   * ```svelte
+   * <script>
+   *   import { MessageSquare } from 'lucide-svelte';
+   *   const ChatIcon = () => MessageSquare; // or a wrapper component
+   * </script>
+   * ```
+   */
+  iconComponent?: Component;
   component: Component<{ context: TCtx; dock: ToolsDockApi }>;
   badge?: number | string | null;
 }
@@ -95,6 +123,20 @@ export interface ToolsDockApi {
   close(): void;
   toggle(id?: string): void;
   setContext(ctx: ToolsDockContext | null): void;
+  /**
+   * Force a re-run of the `fetchAvailability` callback with the current
+   * context. Useful when a side-channel event signals that availability or
+   * badges changed without the dock context itself changing (e.g. a job
+   * completes, a content row's status flips, a websocket "updated" event
+   * arrives). `setContext()` short-circuits on strict-equal references so
+   * the only way to refetch with the same context is to call this method.
+   *
+   * If no `fetchAvailability` is configured, this resets `availableTools`
+   * to the full registered set (same behavior as the implicit initial
+   * snapshot). Concurrent / overlapping calls are token-gated — stale
+   * results are dropped, only the latest fetch applies.
+   */
+  refreshAvailability(): void;
   /**
    * Emit an event to all subscribers. The typed overload covers built-in
    * `'dock:*'` events (see {@link ToolsDockEvents}); the stringly-typed


### PR DESCRIPTION
## Summary

Two workspace API additions surfaced by the Phase 3 site-portal migration ([anytown.ai#321](https://github.com/anytown/anytown.ai/pull/321) review). Both unblock clean visual + behavioral parity.

Refs: #1235 (Findings F and U6)

### Finding F — `ToolDef.iconComponent`
- New optional `iconComponent?: Component` field on `ToolDef`. Rendered inside `.tools-dock__rail-glyph` when set, takes precedence over the existing `icon: string` fallback, which itself takes precedence over the `label.charAt(0).toUpperCase()` last-resort.
- Matches `NavTree`'s per-item icon convention (consumers pass a thin wrapper over lucide-svelte etc.).
- Resolves the Phase 3 regression where dense docks (9 tools in anytown's site-portal) collapsed distinct tools to ambiguous single letters ("Chat" + "Claim Audit" both → "C", "Versions" + "Videos" both → "V").

### Finding U6 — `dock.refreshAvailability()`
- New public method on `ToolsDockApi`. Forces a re-run of the configured `fetchAvailability` with the current context.
- `setContext()` short-circuits on strict-equal references, so this is the only path to refetch with an unchanged context (side-channel events like job-completion websockets, "updated" pings, manual refresh buttons).
- Wraps the existing internal `refreshAvailability` already used by `setContext` — same token-gated race-safety, no behavioral surprises.

### Notes on API shape
- For `iconComponent`, chose `Component` over `Snippet | Component`. Simpler runtime, no need to discriminate at render time, and matches `NavTree`. Consumers who want a snippet-based API can wrap one in a tiny component.
- Named the field `iconComponent` (not `icon`) so the existing `icon: string` fallback keeps working unchanged for emoji/single-char users — strict back-compat.

## Test plan

- [x] All existing 137 tests still pass (no regressions)
- [x] 7 new tests added: 4 in `render-tools-dock.test.ts` (iconComponent render, icon string fallback, first-letter fallback, precedence); 3 in `define-tools-dock.test.ts` (refresh with same context, no-fetch fallback path, stale-result race-safety)
- [x] 137 → 144 tests, all passing
- [x] `pnpm typecheck` clean
- [x] `pnpm build` (`svelte-package`) clean — no Snippet-typing surprises
- [x] No SvelteKit deps, SSR-safe, direct SMRT tokens