### PR TITLE
feat(smrt-svelte): add RoleShell primitive for multi-role admin shells

### DIFF
--- a/packages/smrt-svelte/CLAUDE.md
+++ b/packages/smrt-svelte/CLAUDE.md
@@ -118,6 +118,30 @@ domain-specific tools live outside the framework in consumer packages.
   use this when a side-channel event (job-updated websocket, manual refresh
   button, etc.) signals availability or badges changed without a context change.
 
+### RoleShell
+
+Opinionated thin wrapper for multi-role admin shells. Pass a `RoleConfig[]` list
+and the current role id; renders `<WorkspaceShell>` + `<NavTree>` + `<Breadcrumbs>`
+wired together. Role colors flow through as `--smrt-role-color` CSS custom property.
+
+```svelte
+<RoleShell
+  roles={ROLE_CONFIGS}
+  currentRole={currentRole}
+  currentPath={page.url.pathname}
+  bind:mobileNavOpen
+>
+  {#snippet sidebarFooter()}
+    <AccountMenu user={data.user} />
+  {/snippet}
+  <Outlet />
+</RoleShell>
+```
+
+The shell intentionally doesn't know about specific role IDs — consumers pick
+whatever set their app needs. Use this for role-based admin dashboards; use
+`<WorkspaceShell>` directly for non-role apps.
+
 See epic [happyvertical/smrt#1226](https://github.com/happyvertical/smrt/issues/1226) for context;
 implementations land via #1227 (`WorkspaceShell`), #1228 (`NavTree`/`Breadcrumbs`), and #1229
 (`ToolsDock` + registry).

--- a/packages/smrt-svelte/CLAUDE.md
+++ b/packages/smrt-svelte/CLAUDE.md
@@ -125,18 +125,32 @@ and the current role id; renders `<WorkspaceShell>` + `<NavTree>` + `<Breadcrumb
 wired together. Role colors flow through as `--smrt-role-color` CSS custom property.
 
 ```svelte
+<script lang="ts">
+  import { page } from '$app/state';
+  import { RoleShell } from '@happyvertical/smrt-svelte/workspace';
+  import AccountMenu from '$lib/AccountMenu.svelte';
+  import { ROLE_CONFIGS } from '$lib/roles';
+
+  let { data, children } = $props();
+  let mobileNavOpen = $state(false);
+</script>
+
 <RoleShell
   roles={ROLE_CONFIGS}
-  currentRole={currentRole}
+  currentRole={data.currentRole}
   currentPath={page.url.pathname}
   bind:mobileNavOpen
 >
   {#snippet sidebarFooter()}
     <AccountMenu user={data.user} />
   {/snippet}
-  <Outlet />
+  {@render children?.()}
 </RoleShell>
 ```
+
+The `{@render children?.()}` call is the Svelte 5 idiom for rendering a
+layout's child route content — replace with the equivalent slot/render call
+for your framework if you're not using SvelteKit's `+layout.svelte` flow.
 
 The shell intentionally doesn't know about specific role IDs — consumers pick
 whatever set their app needs. Use this for role-based admin dashboards; use

--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -115,7 +115,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@happyvertical/smrt-types": "workspace:*"
+    "@happyvertical/smrt-types": "workspace:*",
+    "esm-env": "^1.2.2"
   },
   "peerDependencies": {
     "@happyvertical/smrt-agents": "workspace:*",

--- a/packages/smrt-svelte/src/components/workspace/RoleShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/RoleShell.svelte
@@ -14,14 +14,24 @@
  * SvelteKit imports. Consumers pass `currentPath` explicitly (typically
  * from `page.url.pathname`).
  *
+ * **Missing-role behaviour**: in development a thrown error makes the
+ * misconfiguration loud and immediate. In production we fall back to the
+ * first role in `roles[]` (or, if `roles[]` is empty, a synthetic empty
+ * role) so a brief mismatch — role-switch race, SSR hydration with stale
+ * data, an empty array before data loads — degrades to a harmless empty
+ * shell instead of crashing the component tree. Svelte 5 has no built-in
+ * error boundary, so a hard throw inside `$derived.by` would unmount the
+ * whole shell. See `happyvertical/smrt#1238` review feedback.
+ *
  * See `happyvertical/smrt#1226` (Phase 4b) for design notes. The
  * SmrtObject-aware piece was originally scoped here but has been
  * deferred — this primitive is intentionally cheap and low-blast-radius.
  */
-import type { Snippet } from 'svelte';
+import { DEV } from 'esm-env';
+import type { Component, Snippet } from 'svelte';
 import Breadcrumbs from './Breadcrumbs.svelte';
 import NavTree from './NavTree.svelte';
-import type { RoleConfig } from './types.js';
+import type { BreadcrumbItem, NavItem, RoleConfig } from './types.js';
 import WorkspaceShell from './WorkspaceShell.svelte';
 
 interface Props {
@@ -35,22 +45,78 @@ interface Props {
   title?: string;
   /** Optional: override the shell subtitle; defaults to the current role's description. */
   subtitle?: string;
-  /** Optional: brand snippet — passes through to `WorkspaceShell`. */
+  /** Optional: small uppercase eyebrow label rendered above the title — passes through to `WorkspaceShell`. */
+  eyebrow?: string;
+  /** Optional: topbar mode label — passes through. */
+  modeLabel?: string;
+  /** Optional: topbar mode status — passes through. */
+  modeStatus?:
+    | 'active'
+    | 'offline'
+    | 'local-only'
+    | 'attention'
+    | (string & {});
+  /** Optional: topbar mode detail — passes through. */
+  modeDetail?: string;
+  /** Optional: sidebar collapsed state — passes through to `WorkspaceShell`. */
+  collapsed?: boolean;
+  /** Optional: sidebar collapse handler — passes through to `WorkspaceShell`. */
+  onToggleCollapsed?: () => void;
+  /** Optional: whether the collapse toggle should render — passes through. */
+  collapsible?: boolean;
+  /** Optional: whether the inspector panel is currently shown — passes through. */
+  showInspector?: boolean;
+  /** Optional: inspector header label — passes through. */
+  inspectorTitle?: string;
+  /** Optional: inspector close handler — passes through. */
+  onCloseInspector?: () => void;
+  /** Optional: brand snippet — passes through to `WorkspaceShell`. When omitted, the default brand renders `role.icon` (if any) alongside the resolved title/subtitle. */
   brand?: Snippet;
   /** Optional: sidebar footer (account menu, tenant switcher) — passes through. */
   sidebarFooter?: Snippet;
   /** Optional: topbar actions — passes through. */
   topbarActions?: Snippet;
-  /** Optional: inspector panel — passes through. */
+  /** Optional: inspector panel — passes through. Inspector content only renders when `showInspector` is also true. */
   inspector?: Snippet;
   /** Optional: inspector rail — passes through. */
   inspectorRail?: Snippet;
   /** Required: main content. */
   children: Snippet;
-  /** Optional: bind mobile drawer state for external control. */
+  /**
+   * Mobile drawer open state — bindable via Svelte 5 `$bindable`. Pass as
+   * `bind:mobileNavOpen={...}` to control externally (e.g. close the drawer
+   * after a route change). Defaults to `false`.
+   */
   mobileNavOpen?: boolean;
   /** Optional: show breadcrumbs (default: true). */
   showBreadcrumbs?: boolean;
+  /**
+   * Optional: override the breadcrumb's root crumb. Defaults to
+   * `{ label: role.label, href: '/' + role.id }`. Set this when the shell
+   * is mounted under a prefix (e.g. `/dashboard/[role]/...`,
+   * `/t/:slug/admin`) so the root crumb points at a real route.
+   */
+  rootCrumb?: BreadcrumbItem;
+  /**
+   * Optional: pathname prefix to skip when auto-walking breadcrumbs.
+   * Forwarded to `<Breadcrumbs startAfter={...}>` — useful when the shell
+   * is mounted under e.g. `/dashboard/[role]` and you don't want the
+   * `dashboard` segment to render an extra fallback crumb.
+   */
+  breadcrumbStartAfter?: string;
+  /**
+   * Optional: icon renderer for `NavItem.icon` values, forwarded to the
+   * inner `<NavTree>`. Pass an icon component (lucide-svelte etc.) when
+   * your nav configs use icon *names* rather than emoji glyphs.
+   */
+  navIconComponent?: Component<{ name: string; size?: number }>;
+  /**
+   * Optional: extra side-effect to run after a nav link click. The shell
+   * always closes the mobile drawer on navigation; this callback fires
+   * after that internal close so consumers can layer in analytics,
+   * router-store updates, etc. without losing the drawer behaviour.
+   */
+  onNavigate?: () => void;
 }
 
 let {
@@ -59,7 +125,20 @@ let {
   currentPath,
   title,
   subtitle,
-  brand,
+  eyebrow,
+  modeLabel,
+  modeStatus,
+  modeDetail,
+  collapsed,
+  onToggleCollapsed,
+  collapsible,
+  showInspector,
+  inspectorTitle,
+  onCloseInspector,
+  // Renamed locally so the snippet block below can declare `{#snippet brand()}`
+  // without shadowing the prop (which would cause `{@render brand()}` to
+  // recurse into the new snippet instead of the consumer-supplied one).
+  brand: consumerBrand,
   sidebarFooter,
   topbarActions,
   inspector,
@@ -67,21 +146,45 @@ let {
   children,
   mobileNavOpen = $bindable(false),
   showBreadcrumbs = true,
+  rootCrumb,
+  breadcrumbStartAfter,
+  navIconComponent,
+  onNavigate,
 }: Props = $props();
 
-const role = $derived.by(() => {
+/**
+ * Stable empty fallback used when `roles[]` is empty *and* we're in
+ * production. Constructed once so identity comparisons stay stable across
+ * derivations.
+ */
+const EMPTY_ROLE: RoleConfig = {
+  id: '',
+  label: '',
+  sections: [] as NavItem[],
+};
+
+const role = $derived.by((): RoleConfig => {
   const found = roles.find((r) => r.id === currentRole);
-  if (!found) {
+  if (found) return found;
+  // Dev: fail loud so misconfiguration is caught in test/dev. Prod: fall
+  // back so a brief mismatch (role-switch race, SSR with stale data,
+  // empty array before data loads) degrades to an empty shell rather
+  // than crashing the entire component tree. Svelte 5 has no error
+  // boundary, so a throw inside $derived.by would unmount the shell.
+  if (DEV) {
     throw new Error(
       `[RoleShell] No role found for id "${currentRole}". ` +
         `Available role ids: ${roles.map((r) => r.id).join(', ') || '(none)'}.`,
     );
   }
-  return found;
+  return roles[0] ?? EMPTY_ROLE;
 });
 
 const resolvedTitle = $derived(title ?? role.label);
 const resolvedSubtitle = $derived(subtitle ?? role.description ?? '');
+const resolvedRootCrumb = $derived(
+  rootCrumb ?? { label: role.label, href: `/${role.id}` },
+);
 /**
  * Set the role-color CSS custom property on the shell wrapper when the
  * role config supplies one. Consumer stylesheets can read this via
@@ -92,26 +195,59 @@ const resolvedSubtitle = $derived(subtitle ?? role.description ?? '');
 const wrapperStyle = $derived(
   role.color ? `--smrt-role-color: ${role.color};` : undefined,
 );
+
+function handleNavigate(): void {
+  // Always close the mobile drawer on nav click — this is the behaviour
+  // consumers historically wired up by hand. The optional `onNavigate`
+  // prop lets them layer in additional side-effects (analytics, store
+  // updates, etc.) without losing the close.
+  mobileNavOpen = false;
+  onNavigate?.();
+}
 </script>
 
 <div class="smrt-role-shell" data-role-id={role.id} style={wrapperStyle}>
   <WorkspaceShell
     title={resolvedTitle}
     subtitle={resolvedSubtitle}
-    {brand}
+    {eyebrow}
+    {modeLabel}
+    {modeStatus}
+    {modeDetail}
+    {collapsed}
+    {onToggleCollapsed}
+    {collapsible}
+    {showInspector}
+    {inspectorTitle}
+    {onCloseInspector}
     {sidebarFooter}
     {topbarActions}
     {inspector}
     {inspectorRail}
     bind:mobileNavOpen
   >
+    {#snippet brand()}
+      {#if consumerBrand}
+        {@render consumerBrand()}
+      {:else}
+        {#if role.icon}
+          <span class="smrt-role-shell-icon" aria-hidden="true">{role.icon}</span>
+        {/if}
+        {#if resolvedTitle}
+          <h1>{resolvedTitle}</h1>
+        {/if}
+        {#if resolvedSubtitle}
+          <p class="subtitle">{resolvedSubtitle}</p>
+        {/if}
+      {/if}
+    {/snippet}
+
     {#snippet nav()}
       <NavTree
         items={role.sections}
         {currentPath}
-        onNavigate={() => {
-          mobileNavOpen = false;
-        }}
+        iconComponent={navIconComponent}
+        onNavigate={handleNavigate}
       />
     {/snippet}
 
@@ -119,7 +255,8 @@ const wrapperStyle = $derived(
       <Breadcrumbs
         nav={role.sections}
         pathname={currentPath}
-        rootCrumb={{ label: role.label, href: `/${role.id}` }}
+        rootCrumb={resolvedRootCrumb}
+        startAfter={breadcrumbStartAfter}
       />
     {/if}
     {@render children()}
@@ -135,5 +272,19 @@ const wrapperStyle = $derived(
    */
   .smrt-role-shell {
     display: contents;
+  }
+
+  /*
+   * The default brand snippet renders the role icon as a leading glyph.
+   * Sized to match `<h1>` line-height so the icon stays vertically aligned
+   * with the title baseline. Consumer-provided `brand` snippets bypass
+   * this entirely.
+   */
+  .smrt-role-shell-icon {
+    display: inline-block;
+    margin-right: 0.4rem;
+    font-size: 1.1rem;
+    line-height: 1;
+    color: var(--smrt-role-color, var(--smrt-color-on-surface, #111827));
   }
 </style>

--- a/packages/smrt-svelte/src/components/workspace/RoleShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/RoleShell.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+/**
+ * RoleShell — opinionated thin wrapper around `WorkspaceShell`, `NavTree`,
+ * and `Breadcrumbs` for multi-role admin dashboards.
+ *
+ * Lifts the `RoleConfig`-driven render pattern that's been duplicated in
+ * downstream apps (notably anytown.ai's dashboard) into the framework. Pass
+ * a list of `RoleConfig`s + the currently active role id; the shell looks
+ * up the role and wires its sections into the sidebar nav and breadcrumb
+ * trail. Optional `color` on the role propagates as a `--smrt-role-color`
+ * CSS custom property so consumer CSS can theme child components.
+ *
+ * Pure render layer — no SmrtObject coupling, no manifest access, no
+ * SvelteKit imports. Consumers pass `currentPath` explicitly (typically
+ * from `page.url.pathname`).
+ *
+ * See `happyvertical/smrt#1226` (Phase 4b) for design notes. The
+ * SmrtObject-aware piece was originally scoped here but has been
+ * deferred — this primitive is intentionally cheap and low-blast-radius.
+ */
+import type { Snippet } from 'svelte';
+import Breadcrumbs from './Breadcrumbs.svelte';
+import NavTree from './NavTree.svelte';
+import type { RoleConfig } from './types.js';
+import WorkspaceShell from './WorkspaceShell.svelte';
+
+interface Props {
+  /** All available roles. Looked up by `id`. */
+  roles: RoleConfig[];
+  /** Currently active role's id. The shell renders that role's config. */
+  currentRole: string;
+  /** Current pathname (consumer provides; SvelteKit-agnostic). */
+  currentPath: string;
+  /** Optional: override the shell title; defaults to the current role's label. */
+  title?: string;
+  /** Optional: override the shell subtitle; defaults to the current role's description. */
+  subtitle?: string;
+  /** Optional: brand snippet — passes through to `WorkspaceShell`. */
+  brand?: Snippet;
+  /** Optional: sidebar footer (account menu, tenant switcher) — passes through. */
+  sidebarFooter?: Snippet;
+  /** Optional: topbar actions — passes through. */
+  topbarActions?: Snippet;
+  /** Optional: inspector panel — passes through. */
+  inspector?: Snippet;
+  /** Optional: inspector rail — passes through. */
+  inspectorRail?: Snippet;
+  /** Required: main content. */
+  children: Snippet;
+  /** Optional: bind mobile drawer state for external control. */
+  mobileNavOpen?: boolean;
+  /** Optional: show breadcrumbs (default: true). */
+  showBreadcrumbs?: boolean;
+}
+
+let {
+  roles,
+  currentRole,
+  currentPath,
+  title,
+  subtitle,
+  brand,
+  sidebarFooter,
+  topbarActions,
+  inspector,
+  inspectorRail,
+  children,
+  mobileNavOpen = $bindable(false),
+  showBreadcrumbs = true,
+}: Props = $props();
+
+const role = $derived.by(() => {
+  const found = roles.find((r) => r.id === currentRole);
+  if (!found) {
+    throw new Error(
+      `[RoleShell] No role found for id "${currentRole}". ` +
+        `Available role ids: ${roles.map((r) => r.id).join(', ') || '(none)'}.`,
+    );
+  }
+  return found;
+});
+
+const resolvedTitle = $derived(title ?? role.label);
+const resolvedSubtitle = $derived(subtitle ?? role.description ?? '');
+/**
+ * Set the role-color CSS custom property on the shell wrapper when the
+ * role config supplies one. Consumer stylesheets can read this via
+ * `var(--smrt-role-color)` (e.g. to recolor active-nav highlights). When
+ * omitted the wrapper renders no inline style, which keeps the DOM tidy
+ * for SSR snapshots.
+ */
+const wrapperStyle = $derived(
+  role.color ? `--smrt-role-color: ${role.color};` : undefined,
+);
+</script>
+
+<div class="smrt-role-shell" data-role-id={role.id} style={wrapperStyle}>
+  <WorkspaceShell
+    title={resolvedTitle}
+    subtitle={resolvedSubtitle}
+    {brand}
+    {sidebarFooter}
+    {topbarActions}
+    {inspector}
+    {inspectorRail}
+    bind:mobileNavOpen
+  >
+    {#snippet nav()}
+      <NavTree
+        items={role.sections}
+        {currentPath}
+        onNavigate={() => {
+          mobileNavOpen = false;
+        }}
+      />
+    {/snippet}
+
+    {#if showBreadcrumbs}
+      <Breadcrumbs
+        nav={role.sections}
+        pathname={currentPath}
+        rootCrumb={{ label: role.label, href: `/${role.id}` }}
+      />
+    {/if}
+    {@render children()}
+  </WorkspaceShell>
+</div>
+
+<style>
+  /*
+   * Display: contents lets the WorkspaceShell drive the grid/layout while
+   * still giving us a single DOM node to hang `--smrt-role-color` off.
+   * The wrapper element exists purely to scope the custom property; it
+   * never participates in layout.
+   */
+  .smrt-role-shell {
+    display: contents;
+  }
+</style>

--- a/packages/smrt-svelte/src/components/workspace/RoleShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/RoleShell.svelte
@@ -99,9 +99,12 @@ interface Props {
   rootCrumb?: BreadcrumbItem;
   /**
    * Optional: pathname prefix to skip when auto-walking breadcrumbs.
-   * Forwarded to `<Breadcrumbs startAfter={...}>` — useful when the shell
-   * is mounted under e.g. `/dashboard/[role]` and you don't want the
-   * `dashboard` segment to render an extra fallback crumb.
+   * Forwarded to `<Breadcrumbs startAfter={...}>`. Defaults to `role.id`
+   * so a pathname like `/super/tenants` doesn't render a duplicate
+   * `Super` crumb alongside the `rootCrumb`. Override when the shell is
+   * mounted under a deeper prefix (e.g. `'dashboard/super'` for
+   * `/dashboard/[role]/...`), or pass an empty string to opt out of the
+   * default skip entirely.
    */
   breadcrumbStartAfter?: string;
   /**
@@ -186,6 +189,21 @@ const resolvedRootCrumb = $derived(
   rootCrumb ?? { label: role.label, href: `/${role.id}` },
 );
 /**
+ * Default the breadcrumb's `startAfter` skip-prefix to the role id when
+ * the consumer doesn't supply one. Without this, the auto-walk on a
+ * pathname like `/super/tenants` produces `Super Admin / Super /
+ * Tenants` — the `rootCrumb` already represents the role, so the bare
+ * `/super` segment becomes a duplicate fallback crumb. Skipping
+ * through `role.id` collapses that.
+ *
+ * Consumers mounting the shell under a different prefix (e.g.
+ * `/dashboard/[role]/...`) still need to pass an explicit
+ * `breadcrumbStartAfter='dashboard/super'` — the default only covers
+ * the simpler `/[role]/...` case. Passing an empty string opts out:
+ * `??` preserves it because empty string is not nullish.
+ */
+const resolvedBreadcrumbStartAfter = $derived(breadcrumbStartAfter ?? role.id);
+/**
  * Set the role-color CSS custom property on the shell wrapper when the
  * role config supplies one. Consumer stylesheets can read this via
  * `var(--smrt-role-color)` (e.g. to recolor active-nav highlights). When
@@ -248,6 +266,7 @@ function handleNavigate(): void {
         {currentPath}
         iconComponent={navIconComponent}
         onNavigate={handleNavigate}
+        collapsed={collapsed ?? false}
       />
     {/snippet}
 
@@ -256,7 +275,7 @@ function handleNavigate(): void {
         nav={role.sections}
         pathname={currentPath}
         rootCrumb={resolvedRootCrumb}
-        startAfter={breadcrumbStartAfter}
+        startAfter={resolvedBreadcrumbStartAfter}
       />
     {/if}
     {@render children()}

--- a/packages/smrt-svelte/src/components/workspace/__tests__/RoleShell.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/RoleShell.test.ts
@@ -429,6 +429,150 @@ describe('RoleShell', () => {
     }
   });
 
+  it('defaults breadcrumbStartAfter to role.id so the role segment is not duplicated', () => {
+    // Regression for happyvertical/smrt#1238 round-3: without a default
+    // skip, the auto-walk on `/super/tenants` produced `Super Admin /
+    // Super / Tenants` (the rootCrumb already represents the role, then
+    // the `/super` segment becomes a duplicate fallback crumb).
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super/tenants',
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      const crumbs = container.querySelector('.smrt-breadcrumbs');
+      const labels = Array.from(
+        crumbs?.querySelectorAll('.crumb-item') ?? [],
+      ).map((el) => (el.textContent ?? '').trim());
+
+      expect(labels[0]).toContain('Super Admin');
+      // The duplicate `Super` crumb must NOT appear.
+      expect(labels.some((l) => l === 'Super' || l === '/ Super')).toBe(false);
+      // The Tenants crumb still renders.
+      expect(labels.some((l) => l.includes('Tenants'))).toBe(true);
+      // And the total trail is exactly 2: rootCrumb + Tenants.
+      expect(labels.length).toBe(2);
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('respects an explicit breadcrumbStartAfter override for deeper prefixes', () => {
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/dashboard/super/tenants',
+        rootCrumb: { label: 'Dashboard', href: '/dashboard' },
+        breadcrumbStartAfter: 'dashboard/super',
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      const crumbs = container.querySelector('.smrt-breadcrumbs');
+      const labels = Array.from(
+        crumbs?.querySelectorAll('.crumb-item') ?? [],
+      ).map((el) => (el.textContent ?? '').trim());
+      // Explicit override skips `dashboard/super`, leaving Dashboard (root)
+      // + Tenants — the role-id default is not used.
+      expect(labels[0]).toContain('Dashboard');
+      expect(labels.some((l) => l.includes('Tenants'))).toBe(true);
+      expect(labels.length).toBe(2);
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('opts out of the default startAfter when an empty string is passed', () => {
+    // `??` preserves empty string (it is not nullish), so consumers can
+    // explicitly disable the default skip and render the full path walk.
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super/tenants',
+        breadcrumbStartAfter: '',
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      const crumbs = container.querySelector('.smrt-breadcrumbs');
+      const labels = Array.from(
+        crumbs?.querySelectorAll('.crumb-item') ?? [],
+      ).map((el) => (el.textContent ?? '').trim());
+      // With the default skip disabled, the `super` segment renders as a
+      // fallback crumb: Super Admin (root) / Super / Tenants. We use
+      // anchor hrefs to disambiguate from the rootCrumb (`/super`) since
+      // the rendered text contents include leading separator glyphs.
+      expect(labels.length).toBe(3);
+      expect(labels[0]).toContain('Super Admin');
+      const links = Array.from(
+        crumbs?.querySelectorAll<HTMLAnchorElement>('.crumb-link') ?? [],
+      );
+      const hrefs = links.map((a) => a.getAttribute('href'));
+      // Both `/super` (from rootCrumb) and `/super` (fallback walk) collapse
+      // to the same href — assert the middle text content shows `Super`.
+      expect(labels[1]).toContain('Super');
+      expect(hrefs).toContain('/super');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('propagates collapsed to the inner NavTree', () => {
+    // Regression for happyvertical/smrt#1238 round-3: WorkspaceShell
+    // switches to the 96px collapsed rail when `collapsed={true}` but
+    // RoleShell previously forgot to forward the flag to NavTree, so
+    // labels/badges rendered full-size and overflowed the rail.
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super',
+        collapsed: true,
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      const navTree = container.querySelector('.smrt-nav-tree');
+      expect(navTree).not.toBeNull();
+      expect(navTree?.classList.contains('collapsed')).toBe(true);
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders the NavTree in its expanded state when collapsed is omitted or false', () => {
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super',
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      const navTree = container.querySelector('.smrt-nav-tree');
+      expect(navTree).not.toBeNull();
+      expect(navTree?.classList.contains('collapsed')).toBe(false);
+    } finally {
+      unmount(component);
+    }
+  });
+
   it('uses rootCrumb override when provided', () => {
     const component = mount(RoleShell, {
       target: container,

--- a/packages/smrt-svelte/src/components/workspace/__tests__/RoleShell.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/RoleShell.test.ts
@@ -1,0 +1,453 @@
+/**
+ * Tests for RoleShell — issue happyvertical/smrt#1226 (Phase 4b).
+ *
+ * Verifies the thin RoleConfig-driven wrapper composes WorkspaceShell +
+ * NavTree + Breadcrumbs correctly, propagates the role color as a CSS
+ * custom property, and surfaces the bindable mobile-drawer state.
+ */
+
+import { createRawSnippet, mount, tick, unmount } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import RoleShell from '../RoleShell.svelte';
+import type { RoleConfig } from '../types.js';
+import BindHarness from './role-shell-bind-harness.svelte';
+
+function textSnippet(text: string) {
+  return createRawSnippet(() => ({
+    render: () => `<span>${text}</span>`,
+  }));
+}
+
+const superRole: RoleConfig = {
+  id: 'super',
+  label: 'Super Admin',
+  description: 'Cross-network operations',
+  icon: '⌘',
+  color: 'blue',
+  sections: [
+    {
+      href: '/super/tenants',
+      label: 'Tenants',
+      icon: '◌',
+      description: 'Tenant hierarchy',
+    },
+    {
+      href: '/super/users',
+      label: 'Users',
+      icon: '◎',
+      description: 'Global user directory',
+    },
+  ],
+};
+
+const advertiserRole: RoleConfig = {
+  id: 'advertiser',
+  label: 'Advertiser',
+  description: 'Self-service ad management',
+  icon: '📢',
+  color: 'purple',
+  sections: [
+    {
+      href: '/advertiser',
+      label: 'Overview',
+      icon: '◉',
+    },
+    {
+      href: '/advertiser/campaigns',
+      label: 'Campaigns',
+      icon: '▣',
+    },
+  ],
+};
+
+const ROLES: RoleConfig[] = [superRole, advertiserRole];
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  container.remove();
+});
+
+describe('RoleShell', () => {
+  it("renders the current role's label as the WorkspaceShell title", () => {
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super/tenants',
+        children: textSnippet('main content'),
+      },
+    });
+
+    try {
+      const brand = container.querySelector('.brand');
+      expect(brand?.textContent).toContain('Super Admin');
+      expect(brand?.textContent).toContain('Cross-network operations');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it("renders the current role's sections in the nav tree", () => {
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super/tenants',
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      const navItems = container.querySelectorAll('.smrt-nav-tree .nav-item');
+      const labels = Array.from(navItems).map((el) => el.textContent ?? '');
+      // The nav-item textContent includes the icon glyph + label, so match
+      // with substring contains rather than strict equality.
+      expect(labels.some((l) => l.includes('Tenants'))).toBe(true);
+      expect(labels.some((l) => l.includes('Users'))).toBe(true);
+      // Should NOT render the other role's sections.
+      expect(labels.some((l) => l.includes('Campaigns'))).toBe(false);
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('throws a descriptive error when currentRole does not match any role.id', () => {
+    expect(() =>
+      mount(RoleShell, {
+        target: container,
+        props: {
+          roles: ROLES,
+          currentRole: 'nonexistent',
+          currentPath: '/',
+          children: textSnippet('content'),
+        },
+      }),
+    ).toThrow(/No role found for id "nonexistent"/);
+  });
+
+  it('sets --smrt-role-color CSS custom property when role.color is provided', () => {
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super',
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      const wrapper = container.querySelector<HTMLElement>('.smrt-role-shell');
+      expect(wrapper).not.toBeNull();
+      // The style attribute on the wrapper sets the custom property; we
+      // assert on the inline style string rather than computed style
+      // because jsdom's CSS engine doesn't always resolve custom props.
+      expect(wrapper?.getAttribute('style')).toContain('--smrt-role-color');
+      expect(wrapper?.getAttribute('style')).toContain('blue');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('omits the --smrt-role-color style when role.color is not set', () => {
+    const colorlessRoles: RoleConfig[] = [
+      {
+        id: 'plain',
+        label: 'Plain',
+        sections: [{ href: '/plain', label: 'Home' }],
+      },
+    ];
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: colorlessRoles,
+        currentRole: 'plain',
+        currentPath: '/plain',
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      const wrapper = container.querySelector<HTMLElement>('.smrt-role-shell');
+      expect(wrapper?.getAttribute('style')).toBeNull();
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('uses the title override when provided', () => {
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super',
+        title: 'Custom Title',
+        subtitle: 'Custom Subtitle',
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      const brand = container.querySelector('.brand');
+      expect(brand?.textContent).toContain('Custom Title');
+      expect(brand?.textContent).toContain('Custom Subtitle');
+      expect(brand?.textContent).not.toContain('Super Admin');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders breadcrumbs by default with the role label as root', () => {
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super/tenants',
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      const crumbs = container.querySelector('.smrt-breadcrumbs');
+      expect(crumbs).not.toBeNull();
+      // The first crumb is the rootCrumb (role label).
+      const items = crumbs?.querySelectorAll('.crumb-item');
+      expect(items?.[0]?.textContent).toContain('Super Admin');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('hides breadcrumbs when showBreadcrumbs is false', () => {
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super/tenants',
+        showBreadcrumbs: false,
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      expect(container.querySelector('.smrt-breadcrumbs')).toBeNull();
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('passes through the brand snippet to WorkspaceShell', () => {
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super',
+        brand: textSnippet('MyBrand'),
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      const brand = container.querySelector('.brand');
+      expect(brand?.textContent).toContain('MyBrand');
+      // The brand snippet should override the default title rendering.
+      expect(brand?.textContent).not.toContain('Super Admin');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('passes through the sidebarFooter and topbarActions snippets', () => {
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super',
+        sidebarFooter: textSnippet('account-menu'),
+        topbarActions: textSnippet('action-button'),
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      const footer = container.querySelector('.sidebar-footer');
+      expect(footer?.textContent).toContain('account-menu');
+      const actions = container.querySelector('.topbar-actions');
+      expect(actions?.textContent).toContain('action-button');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('passes through the inspector and inspectorRail snippets', () => {
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super',
+        inspectorRail: textSnippet('rail-button'),
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      const rail = container.querySelector('.smrt-workspace-inspector-rail');
+      expect(rail?.textContent).toContain('rail-button');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('exposes data-role-id on the wrapper', () => {
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'advertiser',
+        currentPath: '/advertiser',
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      const wrapper = container.querySelector('.smrt-role-shell');
+      expect(wrapper?.getAttribute('data-role-id')).toBe('advertiser');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  describe('bindable mobileNavOpen', () => {
+    it('reflects external state changes into the WorkspaceShell drawer class', async () => {
+      let controls!: {
+        setMobileNavOpen: (next: boolean) => void;
+        getMobileNavOpen: () => boolean;
+      };
+      const component = mount(BindHarness, {
+        target: container,
+        props: {
+          roles: ROLES,
+          currentRole: 'super',
+          currentPath: '/super',
+          onReady: (c) => {
+            controls = c;
+          },
+        },
+      });
+
+      try {
+        await tick();
+        const shell = container.querySelector('.smrt-workspace-shell');
+        expect(shell?.classList.contains('nav-open')).toBe(false);
+
+        controls.setMobileNavOpen(true);
+        await tick();
+        expect(shell?.classList.contains('nav-open')).toBe(true);
+        expect(controls.getMobileNavOpen()).toBe(true);
+
+        controls.setMobileNavOpen(false);
+        await tick();
+        expect(shell?.classList.contains('nav-open')).toBe(false);
+      } finally {
+        unmount(component);
+      }
+    });
+
+    it('closes the drawer when a nav link is clicked', async () => {
+      let controls!: {
+        setMobileNavOpen: (next: boolean) => void;
+        getMobileNavOpen: () => boolean;
+      };
+      const component = mount(BindHarness, {
+        target: container,
+        props: {
+          roles: ROLES,
+          currentRole: 'super',
+          currentPath: '/super',
+          initial: true,
+          onReady: (c) => {
+            controls = c;
+          },
+        },
+      });
+
+      try {
+        await tick();
+        expect(controls.getMobileNavOpen()).toBe(true);
+
+        const navLink = container.querySelector<HTMLAnchorElement>(
+          '.smrt-nav-tree .nav-item',
+        );
+        expect(navLink).not.toBeNull();
+        // Prevent jsdom from actually navigating away while clicking.
+        navLink?.addEventListener('click', (e) => e.preventDefault());
+        navLink?.click();
+        await tick();
+        expect(controls.getMobileNavOpen()).toBe(false);
+      } finally {
+        unmount(component);
+      }
+    });
+  });
+
+  it('re-renders with the new role sections when currentRole changes', async () => {
+    let setCurrentRole!: (id: string) => void;
+
+    // Build a small switcher harness inline using a wrapper component is
+    // overkill — instead, drive currentRole via component prop updates.
+    // Svelte 5's `mount` returns the component instance; reassignments
+    // happen via $state in a parent, so we use a tiny inline harness.
+    const Harness = (await import('./role-shell-switch-harness.svelte'))
+      .default;
+
+    const component = mount(Harness, {
+      target: container,
+      props: {
+        roles: ROLES,
+        initialRole: 'super',
+        currentPath: '/super',
+        onReady: (controls: { setCurrentRole: (id: string) => void }) => {
+          setCurrentRole = controls.setCurrentRole;
+        },
+      },
+    });
+
+    try {
+      await tick();
+      let labels = Array.from(
+        container.querySelectorAll('.smrt-nav-tree .nav-item'),
+      ).map((el) => el.textContent ?? '');
+      expect(labels.some((l) => l.includes('Tenants'))).toBe(true);
+      expect(labels.some((l) => l.includes('Campaigns'))).toBe(false);
+
+      setCurrentRole('advertiser');
+      await tick();
+      labels = Array.from(
+        container.querySelectorAll('.smrt-nav-tree .nav-item'),
+      ).map((el) => el.textContent ?? '');
+      expect(labels.some((l) => l.includes('Campaigns'))).toBe(true);
+      expect(labels.some((l) => l.includes('Tenants'))).toBe(false);
+
+      // role-color should have changed too.
+      const wrapper = container.querySelector<HTMLElement>('.smrt-role-shell');
+      expect(wrapper?.getAttribute('style')).toContain('purple');
+      expect(wrapper?.getAttribute('data-role-id')).toBe('advertiser');
+    } finally {
+      unmount(component);
+    }
+  });
+});

--- a/packages/smrt-svelte/src/components/workspace/__tests__/RoleShell.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/RoleShell.test.ts
@@ -119,7 +119,16 @@ describe('RoleShell', () => {
     }
   });
 
-  it('throws a descriptive error when currentRole does not match any role.id', () => {
+  it('throws a descriptive error in dev when currentRole does not match any role.id', async () => {
+    // vitest runs with NODE_ENV=test which `esm-env` treats as
+    // development (DEV === true), so the dev-throw branch fires here.
+    // In production builds (`NODE_ENV=production`), the shell falls back
+    // to `roles[0]` rather than crashing — see the DEV check inside
+    // RoleShell's `$derived.by`. The fallback path is statically
+    // wired against esm-env's resolution and can't be cleanly faked in
+    // vitest, so we only assert the loud-error contract here.
+    const { DEV } = await import('esm-env');
+    expect(DEV).toBe(true);
     expect(() =>
       mount(RoleShell, {
         target: container,
@@ -292,7 +301,7 @@ describe('RoleShell', () => {
     }
   });
 
-  it('passes through the inspector and inspectorRail snippets', () => {
+  it('passes through the inspectorRail snippet', () => {
     const component = mount(RoleShell, {
       target: container,
       props: {
@@ -307,6 +316,257 @@ describe('RoleShell', () => {
     try {
       const rail = container.querySelector('.smrt-workspace-inspector-rail');
       expect(rail?.textContent).toContain('rail-button');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders the inspector snippet only when showInspector is true', () => {
+    // The inspector passthrough requires both the snippet AND
+    // `showInspector` because WorkspaceShell gates rendering on the latter.
+    // Regression for happyvertical/smrt#1238 — the original RoleShell
+    // forwarded only the snippet, making the inspector silently
+    // un-renderable through this wrapper.
+    const componentHidden = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super',
+        inspector: textSnippet('inspector-body'),
+        children: textSnippet('content'),
+      },
+    });
+    try {
+      expect(container.querySelector('.smrt-workspace-inspector')).toBeNull();
+    } finally {
+      unmount(componentHidden);
+    }
+
+    // Mount a second instance with showInspector: true into the same
+    // container — the inspector should now render.
+    const componentShown = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super',
+        inspector: textSnippet('inspector-body'),
+        showInspector: true,
+        children: textSnippet('content'),
+      },
+    });
+    try {
+      const inspector = container.querySelector(
+        '.smrt-workspace-inspector .inspector-body',
+      );
+      expect(inspector?.textContent).toContain('inspector-body');
+    } finally {
+      unmount(componentShown);
+    }
+  });
+
+  it('forwards collapsed + onToggleCollapsed to WorkspaceShell', () => {
+    let toggled = 0;
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super',
+        collapsed: true,
+        onToggleCollapsed: () => {
+          toggled += 1;
+        },
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      // The collapse state surfaces as a class on the shell root.
+      const shell = container.querySelector('.smrt-workspace-shell');
+      expect(shell?.classList.contains('sidebar-collapsed')).toBe(true);
+
+      // The toggle button only renders when `onToggleCollapsed` is provided —
+      // clicking it should invoke our callback.
+      const toggle =
+        container.querySelector<HTMLButtonElement>('.shell-toggle');
+      expect(toggle).not.toBeNull();
+      toggle?.click();
+      expect(toggled).toBe(1);
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('forwards mode/eyebrow props to the WorkspaceShell topbar', () => {
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super',
+        eyebrow: 'EYE',
+        modeLabel: 'Local-first mode',
+        modeStatus: 'local-only',
+        modeDetail: 'detail line',
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      const topbar = container.querySelector('.smrt-workspace-topbar');
+      expect(topbar?.textContent).toContain('Local-first mode');
+      expect(topbar?.textContent).toContain('detail line');
+      const badge = topbar?.querySelector<HTMLElement>('.mode-badge');
+      expect(badge?.dataset.status).toBe('local-only');
+      // The eyebrow appears in the topbar's eyebrow slot.
+      expect(topbar?.querySelector('.topbar-eyebrow')?.textContent).toContain(
+        'EYE',
+      );
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('uses rootCrumb override when provided', () => {
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/dashboard/super/tenants',
+        rootCrumb: { label: 'Dashboard', href: '/dashboard' },
+        breadcrumbStartAfter: 'dashboard',
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      const crumbs = container.querySelector('.smrt-breadcrumbs');
+      expect(crumbs).not.toBeNull();
+      const first = crumbs?.querySelector<HTMLAnchorElement>(
+        '.crumb-item:first-child .crumb-link',
+      );
+      expect(first?.textContent).toBe('Dashboard');
+      expect(first?.getAttribute('href')).toBe('/dashboard');
+      // With startAfter=dashboard, the auto-walk skips the `dashboard`
+      // prefix and the resulting trail should NOT contain a duplicate
+      // `Dashboard` fallback crumb.
+      const labels = Array.from(
+        crumbs?.querySelectorAll('.crumb-item') ?? [],
+      ).map((el) => el.textContent ?? '');
+      const dashboardCrumbs = labels.filter((l) => l.includes('Dashboard'));
+      expect(dashboardCrumbs.length).toBe(1);
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('renders role.icon in the default brand area when no brand snippet is provided', () => {
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super',
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      const icon = container.querySelector('.smrt-role-shell-icon');
+      expect(icon).not.toBeNull();
+      // RoleConfig.icon is a string glyph — render as text content.
+      expect(icon?.textContent).toContain('⌘');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('omits role.icon when a consumer brand snippet is provided', () => {
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super',
+        brand: textSnippet('CustomBrand'),
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      expect(container.querySelector('.smrt-role-shell-icon')).toBeNull();
+      const brand = container.querySelector('.brand');
+      expect(brand?.textContent).toContain('CustomBrand');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('forwards navIconComponent to the inner NavTree', async () => {
+    // Use a tiny stub component so we can assert the icon-rendering branch
+    // fired. NavTree renders `<IconComponent name=... size=... />` in the
+    // icon slot when this prop is provided.
+    const TestIcon = (await import('./test-icon.svelte')).default;
+    const component = mount(RoleShell, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super',
+        navIconComponent: TestIcon,
+        children: textSnippet('content'),
+      },
+    });
+
+    try {
+      const iconStub = container.querySelector(
+        '.smrt-nav-tree [data-testid="custom-icon"]',
+      );
+      expect(iconStub).not.toBeNull();
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('invokes the composed onNavigate callback alongside closing the drawer', async () => {
+    let called = 0;
+    let controls!: {
+      setMobileNavOpen: (next: boolean) => void;
+      getMobileNavOpen: () => boolean;
+    };
+    const component = mount(BindHarness, {
+      target: container,
+      props: {
+        roles: ROLES,
+        currentRole: 'super',
+        currentPath: '/super',
+        initial: true,
+        onNavigate: () => {
+          called += 1;
+        },
+        onReady: (c) => {
+          controls = c;
+        },
+      },
+    });
+
+    try {
+      await tick();
+      expect(controls.getMobileNavOpen()).toBe(true);
+
+      const navLink = container.querySelector<HTMLAnchorElement>(
+        '.smrt-nav-tree .nav-item',
+      );
+      navLink?.addEventListener('click', (e) => e.preventDefault());
+      navLink?.click();
+      await tick();
+
+      // The internal close still fires AND the consumer callback ran.
+      expect(controls.getMobileNavOpen()).toBe(false);
+      expect(called).toBe(1);
     } finally {
       unmount(component);
     }

--- a/packages/smrt-svelte/src/components/workspace/__tests__/index.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/index.test.ts
@@ -16,6 +16,10 @@ describe('workspace barrel', () => {
     expect(workspace.Breadcrumbs).toBeDefined();
   });
 
+  it('exports RoleShell', () => {
+    expect(workspace.RoleShell).toBeDefined();
+  });
+
   it('re-exports ToolsDockEvents for typed dock:* event payloads', () => {
     // Compile-time assertion: the type must be importable from the barrel
     // so consumers can reference the built-in `'dock:*'` event payloads in

--- a/packages/smrt-svelte/src/components/workspace/__tests__/role-shell-bind-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/role-shell-bind-harness.svelte
@@ -13,6 +13,7 @@ interface Props {
   currentRole: string;
   currentPath?: string;
   initial?: boolean;
+  onNavigate?: () => void;
   onReady?: (controls: {
     setMobileNavOpen: (next: boolean) => void;
     getMobileNavOpen: () => boolean;
@@ -24,6 +25,7 @@ const {
   currentRole,
   currentPath = '/',
   initial = false,
+  onNavigate,
   onReady,
 }: Props = $props();
 
@@ -41,6 +43,12 @@ onReady?.({
 });
 </script>
 
-<RoleShell {roles} {currentRole} {currentPath} bind:mobileNavOpen>
+<RoleShell
+  {roles}
+  {currentRole}
+  {currentPath}
+  {onNavigate}
+  bind:mobileNavOpen
+>
   {@render content()}
 </RoleShell>

--- a/packages/smrt-svelte/src/components/workspace/__tests__/role-shell-bind-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/role-shell-bind-harness.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+/**
+ * Test harness for `bind:mobileNavOpen` on `RoleShell`. Mirrors the
+ * `workspace-shell-bind-harness` pattern — exposes the bindable drawer
+ * state so tests can drive and observe it from outside the component.
+ */
+import { createRawSnippet } from 'svelte';
+import RoleShell from '../RoleShell.svelte';
+import type { RoleConfig } from '../types.js';
+
+interface Props {
+  roles: RoleConfig[];
+  currentRole: string;
+  currentPath?: string;
+  initial?: boolean;
+  onReady?: (controls: {
+    setMobileNavOpen: (next: boolean) => void;
+    getMobileNavOpen: () => boolean;
+  }) => void;
+}
+
+const {
+  roles,
+  currentRole,
+  currentPath = '/',
+  initial = false,
+  onReady,
+}: Props = $props();
+
+let mobileNavOpen = $state(initial);
+
+const content = createRawSnippet(() => ({
+  render: () => '<span>content</span>',
+}));
+
+onReady?.({
+  setMobileNavOpen: (next: boolean) => {
+    mobileNavOpen = next;
+  },
+  getMobileNavOpen: () => mobileNavOpen,
+});
+</script>
+
+<RoleShell {roles} {currentRole} {currentPath} bind:mobileNavOpen>
+  {@render content()}
+</RoleShell>

--- a/packages/smrt-svelte/src/components/workspace/__tests__/role-shell-switch-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/role-shell-switch-harness.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+/**
+ * Test harness for verifying RoleShell re-renders when `currentRole` changes.
+ *
+ * Exposes a `setCurrentRole` setter via the `onReady` callback so the test
+ * can flip the active role from the outside, then assert the rendered nav
+ * tree + role color update accordingly.
+ */
+import { createRawSnippet } from 'svelte';
+import RoleShell from '../RoleShell.svelte';
+import type { RoleConfig } from '../types.js';
+
+interface Props {
+  roles: RoleConfig[];
+  initialRole: string;
+  currentPath: string;
+  onReady?: (controls: { setCurrentRole: (id: string) => void }) => void;
+}
+
+const { roles, initialRole, currentPath, onReady }: Props = $props();
+
+let currentRole = $state(initialRole);
+
+const content = createRawSnippet(() => ({
+  render: () => '<span>switch-harness</span>',
+}));
+
+onReady?.({
+  setCurrentRole: (id: string) => {
+    currentRole = id;
+  },
+});
+</script>
+
+<RoleShell {roles} {currentRole} {currentPath}>
+  {@render content()}
+</RoleShell>

--- a/packages/smrt-svelte/src/components/workspace/index.ts
+++ b/packages/smrt-svelte/src/components/workspace/index.ts
@@ -7,6 +7,7 @@
 
 export { default as Breadcrumbs } from './Breadcrumbs.svelte';
 export { default as NavTree } from './NavTree.svelte';
+export { default as RoleShell } from './RoleShell.svelte';
 export {
   type DefineToolsDockOptions,
   defineToolsDock,
@@ -19,6 +20,7 @@ export type {
   AvailableTool,
   BreadcrumbItem,
   NavItem,
+  RoleConfig,
   ToolDef,
   ToolsDockApi,
   ToolsDockContext,

--- a/packages/smrt-svelte/src/components/workspace/types.ts
+++ b/packages/smrt-svelte/src/components/workspace/types.ts
@@ -26,6 +26,38 @@ export interface BreadcrumbItem {
   label: string;
 }
 
+/**
+ * Configuration for a single role in a multi-role admin shell. The role
+ * determines which navigation sections are shown, the display label, and
+ * an optional color identifier consumers can use to theme the shell.
+ *
+ * Role IDs are arbitrary strings — the framework doesn't know about specific
+ * roles. Consumers pick whatever set fits their app (e.g. 'super', 'admin',
+ * 'tenant-owner', 'editor').
+ *
+ * See `RoleShell` for the renderer that consumes this config and
+ * `happyvertical/smrt#1226` (Phase 4b) for design context.
+ */
+export interface RoleConfig {
+  /** Stable role identifier. */
+  id: string;
+  /** Display label (e.g. "Super Admin"). */
+  label: string;
+  /** Optional subtitle / description. */
+  description?: string;
+  /** Optional icon string/glyph for the role's header area. */
+  icon?: string;
+  /**
+   * Optional color identifier. Rendered as a CSS custom property
+   * `--smrt-role-color: <value>` on the shell root so consumer CSS can
+   * theme child components. Pick a semantic name your design system
+   * understands (e.g. 'blue', 'success', 'primary').
+   */
+  color?: string;
+  /** Navigation sections shown for this role. Same shape as NavItem[]. */
+  sections: NavItem[];
+}
+
 // ────────────────────────────────────────────────
 // Tools dock primitives
 // ────────────────────────────────────────────────

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1834,6 +1834,9 @@ importers:
       chrono-node:
         specifier: ^2.9.0
         version: 2.9.0
+      esm-env:
+        specifier: ^1.2.2
+        version: 1.2.2
     devDependencies:
       '@sveltejs/package':
         specifier: ^2.5.7
@@ -3210,6 +3213,11 @@ packages:
     peerDependencies:
       jimp: '>=1.6.1'
       sharp: '>=0.34.5'
+    peerDependenciesMeta:
+      jimp:
+        optional: true
+      sharp:
+        optional: true
 
   '@happyvertical/jobs@0.73.4':
     resolution: {integrity: sha512-D9aj+L58Tdb+goonsyFPwPXSr7BTJNI2Igdinqh8pW9rmBcf1Duw2J/UEMp7iCcA3orH0+F9K/r9RpQEL5wYUQ==, tarball: https://npm.pkg.github.com/download/@happyvertical/jobs/0.73.4/606e8efd07bda9ac850a3fb2daec4813d2be13ec}
@@ -3219,6 +3227,15 @@ packages:
       '@google-cloud/tasks': '>=4.1.0'
       bull: '>=4.16.5'
       bullmq: '>=5.76.0'
+    peerDependenciesMeta:
+      '@aws-sdk/client-sqs':
+        optional: true
+      '@google-cloud/tasks':
+        optional: true
+      bull:
+        optional: true
+      bullmq:
+        optional: true
 
   '@happyvertical/json@0.73.4':
     resolution: {integrity: sha512-gmphofmTXSA4GqfFneOzXMWQs5m1kbp4p5SiALugfIARMFlMOVJHyLZu3XgkmrpYK4lYSM7Xkm+0RpnW8SBG5g==, tarball: https://npm.pkg.github.com/download/@happyvertical/json/0.73.4/6ba3d08348b0310aef112d4a4b36bd79273d7c7b}
@@ -3228,6 +3245,9 @@ packages:
     hasBin: true
     peerDependencies:
       '@sentry/node': '>=10.49.0'
+    peerDependenciesMeta:
+      '@sentry/node':
+        optional: true
 
   '@happyvertical/messages@0.73.4':
     resolution: {integrity: sha512-I5yYNY2x/umgxsYGC7p2M/B8K4skAIHE3tn6Q/xC8qulDpzMKvn4GnICYypdN+oFSycAVWFGRqvTI+WwI87RWQ==, tarball: https://npm.pkg.github.com/download/@happyvertical/messages/0.73.4/eaada4556956b7bf0b4d9cbf93672ea31957b3e6}
@@ -10950,16 +10970,18 @@ snapshots:
   '@happyvertical/images@0.73.4(jimp@1.6.1)(sharp@0.34.5)':
     dependencies:
       '@resvg/resvg-js': 2.6.2
-      jimp: 1.6.1
       satori: 0.26.0
+    optionalDependencies:
+      jimp: 1.6.1
       sharp: 0.34.5
 
   '@happyvertical/jobs@0.73.4(@aws-sdk/client-sqs@3.1038.0)(@google-cloud/tasks@6.2.1)(bull@4.16.5)(bullmq@5.76.4)':
     dependencies:
-      '@aws-sdk/client-sqs': 3.1038.0
-      '@google-cloud/tasks': 6.2.1
       '@happyvertical/sql': 0.73.4
       '@happyvertical/utils': 0.73.4
+    optionalDependencies:
+      '@aws-sdk/client-sqs': 3.1038.0
+      '@google-cloud/tasks': 6.2.1
       bull: 4.16.5
       bullmq: 5.76.4
     transitivePeerDependencies:
@@ -10973,6 +10995,7 @@ snapshots:
   '@happyvertical/logger@0.73.4(@sentry/node@10.51.0)':
     dependencies:
       '@happyvertical/utils': 0.73.4
+    optionalDependencies:
       '@sentry/node': 10.51.0
 
   '@happyvertical/messages@0.73.4(@sentry/node@10.51.0)':


### PR DESCRIPTION
## Summary

Implements Phase 4b of #1226 — a thin `<RoleShell>` primitive in `@happyvertical/smrt-svelte/workspace` that consumes a `RoleConfig[]` + active role id and renders `<WorkspaceShell>` + `<NavTree>` + `<Breadcrumbs>` wired together.

This lifts the role-driven render pattern duplicated in anytown.ai's dashboard (`apps/dashboard/src/lib/dashboard/{config,types,roles}.ts` + the inline `+layout.svelte` shell) into the framework. Pure render layer — no SmrtObject coupling, no SvelteKit imports, SSR-safe.

## How it differs from the original AdminShell brief

The SmrtObject-aware piece originally scoped under `<AdminShell>` (#1230) is being deferred. This PR ships only the cheap, low-blast-radius slice the user asked for: a `RoleConfig`-driven wrapper around the existing primitives. No manifest access, no class metadata, no decorator awareness — just configuration in, rendered shell out.

## Design choices

- **`RoleConfig` lives in `workspace/types.ts`** next to `NavItem` and reuses `NavItem[]` for `sections` rather than introducing a parallel section type — keeps the type surface small.
- **Role IDs are arbitrary strings.** No enum, no registry — consumers pick whatever set fits their app (`'super' | 'admin' | 'tenant-owner' | 'editor'`, etc.).
- **`--smrt-role-color` propagation via `display: contents` wrapper.** The wrapper element sets the CSS custom property as an inline `style` and is otherwise transparent to layout — CSS-cascade reaches every descendant inside `<WorkspaceShell>` without the shell needing a new prop, and consumers can recolor active nav links etc. via `var(--smrt-role-color)`.
- **Fail loud on missing roles.** Looking up `currentRole` against `roles` throws a descriptive error including the available ids — silent fallbacks make broken role wiring hard to debug.
- **`bind:mobileNavOpen` passthrough.** Mirrors the recipe documented for `<WorkspaceShell>` so the same drawer-closing-on-navigation pattern works without DOM querying.

## Tests

17 new tests in `RoleShell.test.ts` cover title/subtitle/sections rendering, the descriptive throw on unknown role, color propagation (present + absent), title override, breadcrumb rendering + `showBreadcrumbs={false}`, snippet passthroughs (brand/sidebarFooter/topbarActions/inspectorRail), `data-role-id`, bindable mobile-nav state (external set + nav-click close), and re-rendering when `currentRole` changes (sections + color + `data-role-id` all update).

## Test plan

- [x] `pnpm build` in `packages/smrt-svelte/` succeeds
- [x] `pnpm test` — all 166 tests pass (149 existing + 17 new RoleShell)
- [x] `pnpm typecheck` clean
- [x] biome check clean
- [x] svelte-autofixer reports no issues on `RoleShell.svelte`

Refs: #1226 (Phase 4b)