### PR TITLE
feat(smrt-svelte): land deferred workspace ergonomics (typed context, granular events)

### DIFF
--- a/packages/smrt-svelte/CLAUDE.md
+++ b/packages/smrt-svelte/CLAUDE.md
@@ -94,29 +94,37 @@ domain-specific tools live outside the framework in consumer packages.
 - Tool IDs are arbitrary strings (extensible, not an enum)
 
 **State-mirroring recipes** (issue #1235):
-- `dock.on('dock:change', ({ isOpen, activeTool, context }) => ...)` fires after
-  every `open()`/`close()`/`toggle()`/`setContext()` (and once more if a context
-  change clears the active tool via availability filtering). Use this instead of
-  threading multiple `$effect`s through every getter to mirror dock state into a
-  workbench store. The `'dock:*'` event-name prefix is reserved for built-in
-  dock events; consumer events should pick their own namespace (e.g.
-  `'my-app:foo'`) and use the stringly-typed overloads of `dock.on` / `dock.emit`.
+- Dock events. `'dock:state-changed'` fires on `open()`/`close()`/`toggle()` and
+  on availability-driven `activeTool` clears (payload: `{ isOpen, activeTool }`).
+  `'dock:context-changed'` fires on `setContext()` with a different reference
+  (payload: `{ context }`). Legacy `'dock:change'` (payload: `{ isOpen, activeTool, context }`)
+  still fires on every observable transition (incl. badge-only availability
+  refresh) for back-compat with consumers mirroring `availableTools` — it's
+  `@deprecated`; prefer the granular pair. The `'dock:*'` prefix is reserved
+  for built-ins; consumer events should pick a different namespace.
 - `WorkspaceShell` exposes `bind:mobileNavOpen` so consumers can lift the drawer
   state. Pair it with `<NavTree onNavigate={() => mobileNavOpen = false} />` to
   close the drawer on navigation without any DOM querying.
-- `ToolDef.iconComponent?: Component` renders a custom icon inside the rail
-  glyph (and as a leading glyph in the topbar layout). Matches `NavTree`'s
-  `iconComponent` convention; takes precedence over the `icon: string`
-  fallback and the `label.charAt(0)` last-resort. Pass the icon component
-  from your library of choice (lucide-svelte etc.) directly — avoids
-  ambiguous single-letter glyphs in dense docks ("Chat" vs "Claim Audit").
-  The icon component is rendered with no props (`<IconComponent />`); wrap
-  props-bearing icons in a small `.svelte` adapter component if you need
-  to hard-code size or other attributes.
+- `ToolDef.iconComponent?: Component` renders a custom icon (lucide-svelte etc.)
+  inside the rail glyph (and as a leading glyph in topbar layout). Takes
+  precedence over `icon: string`, then `label.charAt(0)` as last resort.
 - `dock.refreshAvailability()` forces a re-run of `fetchAvailability` with the
-  current context. `setContext()` short-circuits on strict-equal references, so
-  use this when a side-channel event (job-updated websocket, manual refresh
-  button, etc.) signals availability or badges changed without a context change.
+  current context. `setContext()` short-circuits on strict-equal references —
+  use refresh when a side-channel event (websocket, button) signals availability
+  or badges changed without a context change.
+- Typed `defineToolsDock<TData, TActions>`. The factory's two generics flow
+  into `fetchAvailability`'s `ctx` param and through `ToolsDockContext<TData, TActions>`
+  for tool components. Inside a tool, type `context` locally:
+  `let { context }: { context: ToolsDockContext<MyData, MyActions> | null } = $props();`.
+  `context?.actions?.foo()` is then fully typed — no per-consumer redeclaration.
+  `ToolDef` itself is no longer generic (stored as a homogeneous `ToolDef[]`);
+  the consumer-side cast at registration is gone, the typed surface lives on
+  the component's `context` prop instead.
+- Layout positioning. `<ToolsDock layout='topbar'>` renders its own
+  `position: fixed` panel — **do not also use `<WorkspaceShell>`'s `inspector`
+  snippet** in that mode (the two panels overlap with no z-index coordination).
+  `'rail'` layout is safe to compose alongside `inspector` — its panel sits
+  inside the dock's own aside.
 
 ### RoleShell
 

--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -89,7 +89,7 @@
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },
   "keywords": [

--- a/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
@@ -84,7 +84,22 @@ export interface Props {
   topbarActions?: Snippet;
   /** Optional vertical icon rail along the right edge. */
   inspectorRail?: Snippet;
-  /** Inspector panel content (right side). */
+  /**
+   * Inspector panel content (right side). Rendered into a `position: fixed`
+   * panel anchored to the right edge — z-index `22` on desktop, `22` on
+   * mobile (with a `21` scrim).
+   *
+   * **Positioning conflict**: do NOT use this snippet simultaneously with
+   * `<ToolsDock layout='topbar'>`. In topbar mode, the dock owns its own
+   * `position: fixed` panel anchored to the bottom-right (z-index `40`)
+   * with no z-index coordination against the shell's inspector — both
+   * panels will visibly overlap and compete for clicks. Pick one:
+   *   - For consumer-driven inspector content → use this snippet only,
+   *     and use `<ToolsDock layout='rail'>` (the rail layout renders its
+   *     panel inside its own aside, no positioning conflict)
+   *   - For tools-dock-driven content → leave this snippet unused and
+   *     render `<ToolsDock layout='topbar'>` inside `topbarActions`
+   */
   inspector?: Snippet;
   /** Main content. */
   children: Snippet;

--- a/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
@@ -227,15 +227,15 @@ $effect(() => {
   }
 
   // `addEventListener` is the modern API. Older Safari only has
-  // `addListener` — feature-detect to stay compatible.
+  // `addListener` — feature-detect to stay compatible. The deprecated
+  // `addListener`/`removeListener` methods are typed in current lib.dom.d.ts,
+  // so no `@ts-expect-error` is needed.
   if (typeof mql.addEventListener === 'function') {
     mql.addEventListener('change', handleChange);
     return () => mql.removeEventListener('change', handleChange);
   }
-  // @ts-expect-error legacy MediaQueryList API
   mql.addListener(handleChange);
   return () => {
-    // @ts-expect-error legacy MediaQueryList API
     mql.removeListener(handleChange);
   };
 });

--- a/packages/smrt-svelte/src/components/workspace/__tests__/context-forwarding-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/context-forwarding-harness.svelte
@@ -8,9 +8,12 @@
  * Owns a `$state` ref for the current context so that the test can mutate it
  * post-mount via the `setContextProp` callback exposed via `onReady`.
  */
-import { defineToolsDock } from '../tools-dock/define-tools-dock.svelte.js';
+import {
+  defineToolsDock,
+  type ToolsDockInstance,
+} from '../tools-dock/define-tools-dock.svelte.js';
 import ToolsDock from '../tools-dock/ToolsDock.svelte';
-import type { ToolsDockContext, ToolsDockInstance } from '../types.js';
+import type { ToolsDockContext } from '../types.js';
 
 interface Props {
   onReady: (api: {

--- a/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
@@ -1024,4 +1024,300 @@ describe('defineToolsDock', () => {
       expect(fetchAvailability.mock.calls.length).toBe(initialFetchCount);
     });
   });
+
+  // ─────────────────────────────────────────────────────────────
+  // Granular events: 'dock:state-changed' and 'dock:context-changed'
+  // split the legacy 'dock:change' so consumers can subscribe to just
+  // the slice they care about. The legacy event still fires (back-compat).
+  // ─────────────────────────────────────────────────────────────
+
+  describe("'dock:state-changed' event", () => {
+    it('fires on open() / close() / toggle() with state-only payload', () => {
+      const { dock } = track(
+        mountDock({
+          tools: [
+            { id: 'chat', label: 'Chat', component: noopTool },
+            { id: 'jobs', label: 'Jobs', component: noopTool },
+          ],
+        }),
+      );
+
+      const handler = vi.fn();
+      dock.on('dock:state-changed', handler);
+
+      dock.open('chat');
+      flushSync();
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenLastCalledWith({
+        isOpen: true,
+        activeTool: 'chat',
+      });
+
+      dock.close();
+      flushSync();
+      expect(handler).toHaveBeenCalledTimes(2);
+      expect(handler).toHaveBeenLastCalledWith({
+        isOpen: false,
+        activeTool: 'chat',
+      });
+
+      dock.toggle('jobs');
+      flushSync();
+      expect(handler).toHaveBeenCalledTimes(3);
+      expect(handler).toHaveBeenLastCalledWith({
+        isOpen: true,
+        activeTool: 'jobs',
+      });
+    });
+
+    it('does NOT fire on setContext() (context-only mutation)', () => {
+      const { dock } = track(
+        mountDock({
+          tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        }),
+      );
+
+      const handler = vi.fn();
+      dock.on('dock:state-changed', handler);
+
+      dock.setContext({ type: 'route', title: 'Home' });
+      flushSync();
+      // setContext alone does not change isOpen/activeTool — must stay silent.
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('fires when availability clears the active tool', async () => {
+      let availability: { id: string }[] = [{ id: 'chat' }, { id: 'jobs' }];
+      const fetchAvailability = vi.fn(async () => availability);
+
+      const { dock } = track(
+        mountDock({
+          tools: [
+            { id: 'chat', label: 'Chat', component: noopTool },
+            { id: 'jobs', label: 'Jobs', component: noopTool },
+          ],
+          fetchAvailability,
+        }),
+      );
+
+      dock.setContext({ type: 'a' });
+      await new Promise((r) => setTimeout(r, 0));
+      flushSync();
+      dock.open('jobs');
+      flushSync();
+
+      const handler = vi.fn();
+      dock.on('dock:state-changed', handler);
+
+      // Availability shrink → 'jobs' is no longer available, activeTool clears.
+      availability = [{ id: 'chat' }];
+      dock.refreshAvailability();
+      await new Promise((r) => setTimeout(r, 0));
+      flushSync();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenLastCalledWith({
+        isOpen: true,
+        activeTool: null,
+      });
+    });
+
+    it('does NOT fire on no-op open() / close() / toggle()', () => {
+      const { dock } = track(
+        mountDock({
+          tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        }),
+      );
+
+      dock.open('chat');
+      flushSync();
+
+      const handler = vi.fn();
+      dock.on('dock:state-changed', handler);
+
+      dock.open('chat'); // already open + active
+      flushSync();
+      dock.close();
+      flushSync();
+      dock.close(); // already closed
+      flushSync();
+
+      // One observable transition (open → close), so exactly one emit.
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT fire on badge-only availability refresh', async () => {
+      // Pure badge churn: no state change, no context change. The legacy
+      // 'dock:change' event still fires (for back-compat consumers
+      // mirroring availableTools), but 'dock:state-changed' stays silent.
+      let availability: { id: string; badge?: number | null }[] = [
+        { id: 'chat', badge: 0 },
+      ];
+      const fetchAvailability = vi.fn(async () => availability);
+
+      const { dock } = track(
+        mountDock({
+          tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+          fetchAvailability,
+        }),
+      );
+
+      dock.setContext({ type: 'a' });
+      await new Promise((r) => setTimeout(r, 0));
+      flushSync();
+
+      const stateHandler = vi.fn();
+      dock.on('dock:state-changed', stateHandler);
+
+      availability = [{ id: 'chat', badge: 7 }];
+      dock.refreshAvailability();
+      await new Promise((r) => setTimeout(r, 0));
+      flushSync();
+
+      expect(stateHandler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("'dock:context-changed' event", () => {
+    it('fires on setContext() with a different reference', () => {
+      const { dock } = track(
+        mountDock({
+          tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        }),
+      );
+
+      const handler = vi.fn();
+      dock.on('dock:context-changed', handler);
+
+      const ctx = { type: 'route', title: 'Home' } as const;
+      dock.setContext(ctx);
+      flushSync();
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenLastCalledWith({ context: ctx });
+
+      dock.setContext(null);
+      flushSync();
+      expect(handler).toHaveBeenCalledTimes(2);
+      expect(handler).toHaveBeenLastCalledWith({ context: null });
+    });
+
+    it('does NOT fire on open() / close() / toggle() (state-only mutations)', () => {
+      const { dock } = track(
+        mountDock({
+          tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        }),
+      );
+
+      const handler = vi.fn();
+      dock.on('dock:context-changed', handler);
+
+      dock.open('chat');
+      flushSync();
+      dock.close();
+      flushSync();
+      dock.toggle('chat');
+      flushSync();
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('does NOT fire on setContext() with the same reference', () => {
+      const { dock } = track(
+        mountDock({
+          tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        }),
+      );
+
+      const ctx = { type: 'route' } as const;
+      dock.setContext(ctx);
+      flushSync();
+
+      const handler = vi.fn();
+      dock.on('dock:context-changed', handler);
+
+      dock.setContext(ctx); // same reference — no-op-guarded
+      flushSync();
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('does NOT fire on a badge-only availability refresh', async () => {
+      let availability: { id: string; badge?: number | null }[] = [
+        { id: 'chat', badge: 0 },
+      ];
+      const fetchAvailability = vi.fn(async () => availability);
+
+      const { dock } = track(
+        mountDock({
+          tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+          fetchAvailability,
+        }),
+      );
+
+      dock.setContext({ type: 'a' });
+      await new Promise((r) => setTimeout(r, 0));
+      flushSync();
+
+      const handler = vi.fn();
+      dock.on('dock:context-changed', handler);
+
+      availability = [{ id: 'chat', badge: 7 }];
+      dock.refreshAvailability();
+      await new Promise((r) => setTimeout(r, 0));
+      flushSync();
+
+      // Context didn't change — badge refresh stays silent on this event.
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("'dock:change' event continues to fire (back-compat)", () => {
+    it('fires on state, context, and badge-only availability transitions', async () => {
+      // Use a fetchAvailability that yields the same shape the dock seeded
+      // from the registered tools (no badge), so the post-setContext
+      // availability application is a no-op and we can count emits cleanly.
+      const fetchAvailability = vi
+        .fn()
+        .mockResolvedValue([{ id: 'chat' }] as { id: string }[]);
+
+      const { dock } = track(
+        mountDock({
+          tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+          fetchAvailability,
+        }),
+      );
+
+      const legacyHandler = vi.fn();
+      dock.on('dock:change', legacyHandler);
+
+      // 1. setContext → 1 synchronous emit. The async availability fetch
+      //    resolves to the same shape the registered tools already had
+      //    (id='chat', no badge), so applyAvailability sees no change and
+      //    does NOT emit a second time.
+      dock.setContext({ type: 'a' });
+      flushSync();
+      await new Promise((r) => setTimeout(r, 0));
+      flushSync();
+      expect(legacyHandler).toHaveBeenCalledTimes(1);
+
+      // 2. open() → 1 more emit (state change).
+      dock.open('chat');
+      flushSync();
+      expect(legacyHandler).toHaveBeenCalledTimes(2);
+
+      // 3. badge-only availability refresh → 1 more emit. This is the
+      //    back-compat slice: granular 'dock:state-changed' and
+      //    'dock:context-changed' stay silent, but legacy mirrors of
+      //    availableTools still see the update via 'dock:change'.
+      fetchAvailability.mockResolvedValueOnce([{ id: 'chat', badge: 5 }]);
+      dock.refreshAvailability();
+      await new Promise((r) => setTimeout(r, 0));
+      flushSync();
+      expect(legacyHandler).toHaveBeenCalledTimes(3);
+
+      // 4. close() → 1 more emit (state change).
+      dock.close();
+      flushSync();
+      expect(legacyHandler).toHaveBeenCalledTimes(4);
+    });
+  });
 });

--- a/packages/smrt-svelte/src/components/workspace/__tests__/typed-tool-fixture.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/typed-tool-fixture.test.ts
@@ -1,17 +1,40 @@
 /**
  * Regression tests for the typed-tool component pattern documented on
- * `ToolDef.component` and `ToolsDockContext`. The static type checks live
- * in `typed-tool-fixture/register-typed-tool.ts` — those files only need
- * to compile under `tsc --noEmit` to prove the documented pattern works.
- * This test verifies the runtime side: the typed component registers
- * cleanly, the dock activates it, and `dock.setContext` accepts both the
- * typed and untyped action shapes.
+ * `ToolDef.component` and `ToolsDockContext`.
  *
- * If the type fixture ever stops compiling, `pnpm typecheck` (and CI) will
- * fail before this file runs — that's the load-bearing assertion. The
- * runtime test below guards against accidental regressions in the
+ * The static type checks live in `typed-tool-fixture/register-typed-tool.ts`
+ * and `typed-tool-fixture/TypedTool.svelte`. They split across two checkers:
+ *
+ * - `tsc --noEmit` (the package's `typecheck` script, run in CI via
+ *   `pnpm turbo run typecheck`) catches the regressions that live in the
+ *   `.ts` files:
+ *     * The factory `<TData, TActions>` generics flow into
+ *       `ToolsDockApi.setContext` / `ToolsDockApi.context`. If they ever
+ *       erase back to the default shape, the `_assertTypedDockFlow`
+ *       function in `register-typed-tool.ts` fails to compile.
+ *     * The `TActions` constraint accepts interface-style action maps
+ *       (no string index signature). If it ever tightens back to
+ *       `Record<string, ...>`, the `typedContext` / `untypedContext`
+ *       literals fail to compile.
+ *
+ * - `svelte-check` (the package's `check` script, run in CI via
+ *   `pnpm turbo run check`) catches the regression that lives in the
+ *   `.svelte` file:
+ *     * `ToolDef.component` is typed `Component<any>` so a tool component
+ *       declaring a narrower `context` prop is assignable at registration.
+ *       Under `tsc --noEmit` alone, `.svelte` imports resolve to
+ *       `Component<any>` via the ambient `declare module '*.svelte'`
+ *       declaration — so the registration-site assertion in
+ *       `register-typed-tool.ts` would compile regardless of what
+ *       `ToolDef.component` actually demands. Only `svelte-check` actually
+ *       resolves `TypedTool.svelte`'s real prop shape and exercises the
+ *       contravariant assignment, which is why the `check` script is part
+ *       of CI alongside `typecheck`.
+ *
+ * The runtime test below guards against accidental regressions in the
  * `ToolDef` storage shape itself (e.g. registering a component that ends
- * up unreachable because of a runtime type assertion).
+ * up unreachable because of a runtime type assertion) and exercises the
+ * round-trip of typed / untyped context shapes through `dock.setContext`.
  */
 
 import { flushSync, mount, unmount } from 'svelte';

--- a/packages/smrt-svelte/src/components/workspace/__tests__/typed-tool-fixture.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/typed-tool-fixture.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Regression tests for the typed-tool component pattern documented on
+ * `ToolDef.component` and `ToolsDockContext`. The static type checks live
+ * in `typed-tool-fixture/register-typed-tool.ts` — those files only need
+ * to compile under `tsc --noEmit` to prove the documented pattern works.
+ * This test verifies the runtime side: the typed component registers
+ * cleanly, the dock activates it, and `dock.setContext` accepts both the
+ * typed and untyped action shapes.
+ *
+ * If the type fixture ever stops compiling, `pnpm typecheck` (and CI) will
+ * fail before this file runs — that's the load-bearing assertion. The
+ * runtime test below guards against accidental regressions in the
+ * `ToolDef` storage shape itself (e.g. registering a component that ends
+ * up unreachable because of a runtime type assertion).
+ */
+
+import { flushSync, mount, unmount } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ToolsDockInstance } from '../tools-dock/define-tools-dock.svelte.js';
+import HostHarness from './harness.svelte';
+import {
+  typedContext,
+  typedOptions,
+  untypedContext,
+} from './typed-tool-fixture/register-typed-tool.js';
+
+interface HarnessExposed {
+  dock: ToolsDockInstance;
+}
+
+function mountTypedDock(): {
+  dock: ToolsDockInstance;
+  teardown: () => void;
+} {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const exposed: HarnessExposed = {
+    dock: undefined as unknown as ToolsDockInstance,
+  };
+  const component = mount(HostHarness, {
+    target,
+    props: {
+      options: typedOptions,
+      onReady: (dock: ToolsDockInstance) => {
+        exposed.dock = dock;
+      },
+    },
+  });
+  return {
+    dock: exposed.dock,
+    teardown: () => {
+      unmount(component);
+      target.remove();
+    },
+  };
+}
+
+describe('typed-tool fixture (regression guard for PR #1239 review)', () => {
+  let cleanup: Array<() => void> = [];
+
+  beforeEach(() => {
+    cleanup = [];
+  });
+
+  afterEach(() => {
+    for (const fn of cleanup.splice(0)) fn();
+  });
+
+  it('accepts a tool component with a narrowed context prop type', () => {
+    const { dock, teardown } = mountTypedDock();
+    cleanup.push(teardown);
+
+    // The fixture registered TypedTool, whose `context` prop is
+    // `ToolsDockContext<MyData, MyActions> | null`. If ToolDef.component's
+    // type contravariantly required the wider base context, this
+    // registration would not have compiled — which `pnpm typecheck` catches
+    // first. At runtime, we just need to confirm the tool is registered
+    // and reachable.
+    expect(dock.availableTools.map((t) => t.id)).toEqual(['typed']);
+
+    dock.open('typed');
+    flushSync();
+    expect(dock.isOpen).toBe(true);
+    expect(dock.activeTool).toBe('typed');
+  });
+
+  it('accepts the typed context shape via setContext()', () => {
+    const { dock, teardown } = mountTypedDock();
+    cleanup.push(teardown);
+
+    dock.setContext(typedContext);
+    flushSync();
+    // The context round-trips with the typed action shape intact at runtime
+    // (the dock erases the generic but does not mutate the value).
+    expect(dock.context?.data).toEqual({
+      siteSlug: 'demo',
+      contentId: 'demo-1',
+    });
+    // The action is callable — the runtime keeps reference identity.
+    expect(typeof dock.context?.actions?.triggerSave).toBe('function');
+  });
+
+  it('accepts the untyped (back-compat) context shape via setContext()', () => {
+    const { dock, teardown } = mountTypedDock();
+    cleanup.push(teardown);
+
+    // `untypedContext` uses the default `ToolsDockContext` (no generic
+    // arguments). If the default `TActions` were the prior
+    // `Record<string, never>`, this `actions: { triggerSave }` would have
+    // been rejected at typecheck time — the regression Copilot flagged.
+    dock.setContext(untypedContext);
+    flushSync();
+    expect(typeof dock.context?.actions?.triggerSave).toBe('function');
+  });
+});

--- a/packages/smrt-svelte/src/components/workspace/__tests__/typed-tool-fixture/TypedTool.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/typed-tool-fixture/TypedTool.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+/**
+ * Fixture for the typed tool-component pattern documented on
+ * `ToolDef.component`. The dock erases tool-specific types at registration,
+ * but the tool component itself locally annotates `context` with the
+ * narrowed `ToolsDockContext<TData, TActions>` shape — see
+ * `register-typed-tool.ts` for the registration site that must accept this
+ * component without a cast.
+ *
+ * If any of the type assertions below fail at `svelte-check` / `tsc` time,
+ * either the `ToolDef.component` erasure relaxation or the
+ * `ToolsDockContext` action-map constraint regressed.
+ */
+import type { ToolsDockApi, ToolsDockContext } from '../../types.js';
+import type { MyActions, MyData } from './typed-tool-types.js';
+
+let {
+  context,
+  dock,
+}: {
+  context: ToolsDockContext<MyData, MyActions> | null;
+  dock: ToolsDockApi;
+} = $props();
+
+// These reads must compile — they exercise the typed `data` / `actions`
+// surface that motivated the U3/U4/U5 work.
+const slug = $derived(context?.data?.siteSlug ?? '');
+const onSave = () => context?.actions?.triggerSave();
+const onReview = () => context?.actions?.triggerReview('manual');
+
+// Dock reference must still be usable.
+const isOpen = $derived(dock.isOpen);
+</script>
+
+<section data-tool="typed-tool" data-slug={slug} data-open={isOpen}>
+  <button type="button" onclick={onSave}>Save</button>
+  <button type="button" onclick={onReview}>Review</button>
+</section>

--- a/packages/smrt-svelte/src/components/workspace/__tests__/typed-tool-fixture/register-typed-tool.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/typed-tool-fixture/register-typed-tool.ts
@@ -1,0 +1,74 @@
+/**
+ * Registration site for the typed-tool fixture. This file is the contract
+ * the workspace ergonomics PR (#1239) is restoring:
+ *
+ *   - `TypedTool.svelte` declares its own typed `context` prop of shape
+ *     `ToolsDockContext<MyData, MyActions> | null`.
+ *   - It must be assignable to `ToolDef.component` without a registration-
+ *     site cast.
+ *   - `defineToolsDock<MyData, MyActions>(...)` must accept an interface
+ *     `MyActions` (no string index signature) under the factory generic.
+ *   - `dock.setContext({ actions: { triggerSave } })` must still compile
+ *     with no generic arguments (back-compat for the untyped pattern).
+ *
+ * If TypeScript ever rejects this file under strict checks, the regression
+ * from review thread #1239/PRRT_kwDOQDruXs6CbBcK has returned.
+ */
+
+import type {
+  DefineToolsDockOptions,
+  ToolDef,
+  ToolsDockApi,
+  ToolsDockContext,
+} from '../../index.js';
+import TypedTool from './TypedTool.svelte';
+import type { MyActions, MyData } from './typed-tool-types.js';
+
+/** Type-only export: a tool registry that uses the typed component. */
+export const typedTool: ToolDef = {
+  id: 'typed',
+  label: 'Typed',
+  // ↳ TypedTool's `context` prop is narrower than the base
+  //   `ToolsDockContext | null`. Under strict prop variance this would be
+  //   rejected if `ToolDef.component` were typed as
+  //   `Component<{ context: ToolsDockContext | null; dock: ToolsDockApi }>`.
+  component: TypedTool,
+};
+
+/** Type-only export: options that pass the typed action map through. */
+export const typedOptions: DefineToolsDockOptions<MyData, MyActions> = {
+  tools: [typedTool],
+};
+
+/**
+ * Type-only export: a typed context literal. This must compile under the
+ * relaxed `TActions extends { [K in keyof TActions]: (...args: any[]) => any }`
+ * constraint — `MyActions` is an interface (no string index signature) and
+ * would fail a `Record<string, ...>` constraint.
+ */
+export const typedContext: ToolsDockContext<MyData, MyActions> = {
+  type: 'route',
+  data: { siteSlug: 'demo', contentId: 'demo-1' },
+  actions: {
+    triggerSave: () => undefined,
+    triggerReview: (_kind: string) => undefined,
+  },
+};
+
+/**
+ * Type-only export: the untyped (back-compat) setContext shape — passing
+ * `actions` with no factory generic. This caught a previous regression
+ * where `TActions = Record<string, never>` defaulted the action map to
+ * "no keys", rejecting `{ triggerSave }` outright.
+ */
+export const untypedContext: ToolsDockContext = {
+  type: 'route',
+  actions: {
+    triggerSave: () => undefined,
+  },
+};
+
+/** Type-only assertion: typed instance preserves the action shape. */
+export type _AssertTypedActions = ToolsDockApi['context'] extends infer C
+  ? C
+  : never;

--- a/packages/smrt-svelte/src/components/workspace/__tests__/typed-tool-fixture/register-typed-tool.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/typed-tool-fixture/register-typed-tool.ts
@@ -5,21 +5,32 @@
  *   - `TypedTool.svelte` declares its own typed `context` prop of shape
  *     `ToolsDockContext<MyData, MyActions> | null`.
  *   - It must be assignable to `ToolDef.component` without a registration-
- *     site cast.
+ *     site cast — but this assertion is only meaningful under
+ *     `svelte-check`. Under `tsc --noEmit`, `.svelte` imports resolve to
+ *     `Component<any>` via the ambient `declare module '*.svelte'`
+ *     declaration, so the assignment compiles regardless of what
+ *     `ToolDef.component` is typed as. CI runs both `typecheck` and `check`
+ *     (which invokes `svelte-check`) for this reason — see the JSDoc on
+ *     `../typed-tool-fixture.test.ts` for the full split.
  *   - `defineToolsDock<MyData, MyActions>(...)` must accept an interface
  *     `MyActions` (no string index signature) under the factory generic.
  *   - `dock.setContext({ actions: { triggerSave } })` must still compile
  *     with no generic arguments (back-compat for the untyped pattern).
+ *   - The factory's `<TData, TActions>` generics must flow through to the
+ *     returned `ToolsDockInstance<TData, TActions>` — see
+ *     `_assertTypedDockFlow` below for the load-bearing assertion.
  *
  * If TypeScript ever rejects this file under strict checks, the regression
  * from review thread #1239/PRRT_kwDOQDruXs6CbBcK has returned.
  */
 
-import type {
-  DefineToolsDockOptions,
-  ToolDef,
-  ToolsDockApi,
-  ToolsDockContext,
+import {
+  type DefineToolsDockOptions,
+  defineToolsDock,
+  type ToolDef,
+  type ToolsDockApi,
+  type ToolsDockContext,
+  type ToolsDockInstance,
 } from '../../index.js';
 import TypedTool from './TypedTool.svelte';
 import type { MyActions, MyData } from './typed-tool-types.js';
@@ -72,3 +83,56 @@ export const untypedContext: ToolsDockContext = {
 export type _AssertTypedActions = ToolsDockApi['context'] extends infer C
   ? C
   : never;
+
+/**
+ * Type-only fixture: exercises the end-to-end generic flow on the public
+ * surface returned by `defineToolsDock<TData, TActions>(...)`. This is the
+ * regression Codex flagged in PR #1239 round-2 — the factory accepts the
+ * generics but erases them on the return type, so `dock.setContext(...)` and
+ * `dock.context?.data` fall back to the default-typed shape.
+ *
+ * The function below is never called at runtime. Its body has to compile,
+ * which is the load-bearing assertion: if `ToolsDockApi` / `ToolsDockInstance`
+ * ever stop parameterizing their `context` / `setContext` signatures, the
+ * lines marked TYPED below would fail to assign `MyData` / `MyActions` into
+ * the default-typed shape (no string index signature).
+ *
+ * Lives inline rather than at module scope because `defineToolsDock` calls
+ * `setContext`, which is only legal inside a component init scope.
+ */
+export function _assertTypedDockFlow(): ToolsDockInstance<MyData, MyActions> {
+  const typedDock = defineToolsDock<MyData, MyActions>({
+    tools: [typedTool],
+    fetchAvailability: async (ctx) => {
+      // TYPED: `ctx?.data?.siteSlug` must be `string | undefined`, not
+      // `unknown`. If the factory dropped its generics on the callback
+      // signature, the next line would only compile as `unknown`.
+      const _siteSlug: string | undefined = ctx?.data?.siteSlug;
+      const _save: (() => void) | undefined = ctx?.actions?.triggerSave;
+      return [];
+    },
+  });
+
+  // TYPED: `setContext` accepts the narrowed context with no manual cast.
+  // Pre-fix this assignment failed because `ToolsDockApi.setContext` was
+  // typed to receive only the default-generic `ToolsDockContext`, whose
+  // `actions` slot expected `Record<string, (...args: any[]) => unknown>` —
+  // `MyActions` (an interface, no string index signature) was rejected.
+  typedDock.setContext({
+    type: 'route',
+    data: { siteSlug: 'demo', contentId: 'demo-1' },
+    actions: {
+      triggerSave: () => undefined,
+      triggerReview: (_kind: string) => undefined,
+    },
+  });
+
+  // TYPED: reading typed properties off the public `context` surface must
+  // resolve to the consumer's shapes, not `Record<string, unknown>` /
+  // `Record<string, (...args: any[]) => unknown>`.
+  const _slug: string | undefined = typedDock.context?.data?.siteSlug;
+  const _action: (() => void) | undefined =
+    typedDock.context?.actions?.triggerSave;
+
+  return typedDock;
+}

--- a/packages/smrt-svelte/src/components/workspace/__tests__/typed-tool-fixture/typed-tool-types.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/typed-tool-fixture/typed-tool-types.ts
@@ -1,0 +1,16 @@
+/**
+ * Type-only fixtures for the typed tool-component pattern. Lives in a
+ * `.ts` file (not `.svelte`) so the types can be imported cleanly from
+ * both the component and the registration site without relying on
+ * Svelte's `<script context="module">` re-export semantics.
+ */
+
+export interface MyData {
+  siteSlug: string;
+  contentId: string;
+}
+
+export interface MyActions {
+  triggerSave(): void;
+  triggerReview(kind: string): void;
+}

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
@@ -5,7 +5,16 @@
  * Consumes a {@link ToolsDockInstance} produced by {@link defineToolsDock}
  * and renders either:
  *   - layout='rail'   → a vertical icon rail (right edge) + a sliding panel
- *   - layout='topbar' → inline activation buttons + a separate floating panel
+ *     contained inside the dock's own aside (no fixed positioning at the
+ *     viewport level — safe to compose alongside `<WorkspaceShell>`'s
+ *     `inspector` snippet).
+ *   - layout='topbar' → inline activation buttons + a SEPARATE floating
+ *     `position: fixed` panel anchored to the bottom-right (z-index `40`).
+ *     **Do not also use `<WorkspaceShell>`'s `inspector` snippet in this
+ *     mode** — the shell renders its own `position: fixed` inspector with
+ *     no z-index coordination against the dock, and the two panels will
+ *     visibly overlap. Render `<ToolsDock layout='topbar'>` inside the
+ *     shell's `topbarActions` snippet and leave `inspector` unused.
  *
  * The component takes care of:
  *   - registering the dock on Svelte context (via the factory) so descendants

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
@@ -53,10 +53,29 @@ export const TOOLS_DOCK_KEY = Symbol('smrt-tools-dock');
 
 /**
  * Options accepted by {@link defineToolsDock}.
+ *
+ * `TData` types the shape of `context.data` passed through `setContext()` /
+ * `fetchAvailability` — narrow it at the factory site to get a typed
+ * `ctx.data` inside the availability callback without manual casts.
+ * Defaults to `Record<string, unknown>` so existing callers keep compiling.
+ *
+ * `TActions` types the shape of `context.actions` and flows the same way.
+ * Defaults to `Record<string, never>` so callers who don't pass actions get
+ * a strict (empty) action surface instead of `any`.
+ *
+ * Tools themselves are stored as `ToolDef[]` (the generics are erased at
+ * registration). Inside a tool component, type the prop locally — see the
+ * JSDoc on {@link ToolDef.component} for the recommended pattern.
  */
-export interface DefineToolsDockOptions<TCtx = unknown> {
+export interface DefineToolsDockOptions<
+  TData = Record<string, unknown>,
+  TActions extends Record<string, (...args: any[]) => any> = Record<
+    string,
+    never
+  >,
+> {
   /** Registered tools. Order is preserved when rendering the activation rail/topbar. */
-  tools: ToolDef<TCtx>[];
+  tools: ToolDef[];
   /**
    * Optional backend-driven gating callback. Returns the subset of tools that
    * should be exposed for the current `context`. When omitted, every
@@ -65,9 +84,13 @@ export interface DefineToolsDockOptions<TCtx = unknown> {
    * The callback may return tool ids that aren't present in `tools` — these
    * are ignored. Conversely, tools missing from the callback's response are
    * hidden from the dock UI.
+   *
+   * The `ctx` parameter is typed against the factory's `TData` / `TActions`
+   * generics — narrow them at the factory site for typed access to
+   * `ctx.data` / `ctx.actions` here without manual casts.
    */
   fetchAvailability?: (
-    ctx: ToolsDockContext | null,
+    ctx: ToolsDockContext<TData, TActions> | null,
   ) => Promise<AvailableTool[]>;
   /**
    * Optional `localStorage` key. When provided, the dock will persist a small
@@ -76,7 +99,21 @@ export interface DefineToolsDockOptions<TCtx = unknown> {
    * initial render on the server.
    */
   storageKey?: string;
-  /** Activation UI layout. Defaults to `'rail'`. */
+  /**
+   * Activation UI layout. Defaults to `'rail'`.
+   *
+   * - `'rail'`: vertical icon rail with the panel contained inside the
+   *   dock's own aside. Safe to compose alongside `<WorkspaceShell>`'s
+   *   `inspector` snippet — they don't fight for positioning.
+   * - `'topbar'`: inline activation buttons with a SEPARATE
+   *   `position: fixed` panel anchored to the bottom-right of the
+   *   viewport. **Do not also use `<WorkspaceShell>`'s `inspector`
+   *   snippet in this mode** — the shell renders its own
+   *   `position: fixed` inspector with no z-index coordination, and the
+   *   two panels will visibly overlap. Render `<ToolsDock layout='topbar'>`
+   *   inside the shell's `topbarActions` snippet and leave the inspector
+   *   slot unused.
+   */
   layout?: 'rail' | 'topbar';
   /** Initial open state. Hydration from storage takes precedence. Defaults to `false`. */
   initialOpen?: boolean;
@@ -90,8 +127,8 @@ export interface DefineToolsDockOptions<TCtx = unknown> {
  * that `<ToolsDock>` and `useToolsDock()` callers can safely destructure
  * without consumers depending on internal field names.
  */
-export interface ToolsDockInstance<TCtx = unknown> extends ToolsDockApi {
-  readonly tools: ReadonlyArray<ToolDef<TCtx>>;
+export interface ToolsDockInstance extends ToolsDockApi {
+  readonly tools: ReadonlyArray<ToolDef>;
   readonly layout: 'rail' | 'topbar';
   readonly storageKey: string | null;
   /** Internal: hydrate persisted state from `localStorage` (called by `<ToolsDock>` on mount). */
@@ -157,9 +194,13 @@ function safeWriteStorage(key: string, payload: PersistedState): void {
  * @returns the {@link ToolsDockInstance} (a {@link ToolsDockApi} plus
  *   framework metadata `<ToolsDock>` consumes when rendering)
  */
-export function defineToolsDock<TCtx = unknown>(
-  options: DefineToolsDockOptions<TCtx>,
-): ToolsDockInstance<TCtx> {
+export function defineToolsDock<
+  TData = Record<string, unknown>,
+  TActions extends Record<string, (...args: any[]) => any> = Record<
+    string,
+    never
+  >,
+>(options: DefineToolsDockOptions<TData, TActions>): ToolsDockInstance {
   const layout = options.layout ?? 'rail';
   const storageKey = options.storageKey ?? null;
   const fetchAvailability = options.fetchAvailability;
@@ -230,12 +271,11 @@ export function defineToolsDock<TCtx = unknown>(
   }
 
   /**
-   * Emit a `'dock:change'` event with a snapshot of the current public
-   * state. Guarded by the `ready` flag so handlers can't run during
-   * factory construction (before the instance is fully wired / registered
-   * on Svelte context). Always reads the latest `$state` values so
-   * handlers see the post-update state, regardless of how many updates
-   * happened in a single call.
+   * Emit the appropriate dock-owned change events. Guarded by the `ready`
+   * flag so handlers can't run during factory construction (before the
+   * instance is fully wired / registered on Svelte context). Always reads
+   * the latest `$state` values so handlers see the post-update state,
+   * regardless of how many updates happened in a single call.
    *
    * The `$state` reads are wrapped in `untrack` so that when this is
    * invoked from inside a Svelte `$effect` (e.g. `<ToolsDock>`'s effect
@@ -243,16 +283,44 @@ export function defineToolsDock<TCtx = unknown>(
    * NOT become dependencies of that effect. Without this guard, a
    * subsequent `open()` / `close()` would re-run the calling effect,
    * which would call `setContext` again, triggering another availability
-   * fetch and another `emitChange` — an infinite-ish feedback loop.
+   * fetch and another emit — an infinite-ish feedback loop.
+   *
+   * Three events fan out from a single call, each gated by what actually
+   * changed:
+   *   - `'dock:state-changed'` — fired when `stateChanged` is true (open /
+   *     close / toggle / availability cleared the active tool)
+   *   - `'dock:context-changed'` — fired when `contextChanged` is true
+   *     (`setContext` saw a different reference)
+   *   - `'dock:change'` — legacy event, fired whenever this is called.
+   *     Stays for back-compat; consumers should prefer the granular pair.
+   *
+   * Callers that only see a badge/label refresh (no state or context
+   * change) still funnel through here so the legacy `'dock:change'`
+   * subscribers see badge updates — but `stateChanged` / `contextChanged`
+   * both stay `false`, keeping the granular events silent.
    */
-  function emitChange(): void {
+  function emitChange(opts: {
+    stateChanged: boolean;
+    contextChanged: boolean;
+  }): void {
     if (!ready) return;
-    const payload = untrack<ToolsDockEvents['dock:change']>(() => ({
+    const snapshot = untrack(() => ({
       isOpen,
       activeTool,
       context,
     }));
-    emit('dock:change', payload);
+    if (opts.stateChanged) {
+      emit<ToolsDockEvents['dock:state-changed']>('dock:state-changed', {
+        isOpen: snapshot.isOpen,
+        activeTool: snapshot.activeTool,
+      });
+    }
+    if (opts.contextChanged) {
+      emit<ToolsDockEvents['dock:context-changed']>('dock:context-changed', {
+        context: snapshot.context,
+      });
+    }
+    emit<ToolsDockEvents['dock:change']>('dock:change', snapshot);
   }
 
   /**
@@ -303,7 +371,8 @@ export function defineToolsDock<TCtx = unknown>(
         } satisfies AvailableTool;
       });
 
-    let changed = false;
+    let stateChanged = false;
+    let anyChange = false;
 
     // If the active tool is no longer available, clear it.
     if (activeTool && !availableTools.some((t) => t.id === activeTool)) {
@@ -315,7 +384,8 @@ export function defineToolsDock<TCtx = unknown>(
       // don't depend on the <ToolsDock> component being mounted to rescue
       // them via its $effect.
       persist();
-      changed = true;
+      stateChanged = true;
+      anyChange = true;
     }
 
     // Even when the active tool stayed put, the availability set may have
@@ -323,12 +393,16 @@ export function defineToolsDock<TCtx = unknown>(
     // tools appearing/disappearing). Emit so consumers mirroring
     // `availableTools` into their own state (badges in topbars, etc.) see
     // the update without polling.
-    if (!changed) {
-      changed = availabilityActuallyChanged(prev, availableTools);
+    if (!anyChange) {
+      anyChange = availabilityActuallyChanged(prev, availableTools);
     }
 
-    if (changed) {
-      emitChange();
+    if (anyChange) {
+      // Pure badge/label refresh (no `stateChanged`, no context change)
+      // still fires the legacy `'dock:change'` event for back-compat with
+      // consumers mirroring `availableTools` — but stays silent on the
+      // granular pair, which is the point of the U2 split.
+      emitChange({ stateChanged, contextChanged: false });
     }
   }
 
@@ -345,7 +419,11 @@ export function defineToolsDock<TCtx = unknown>(
       return;
     }
     const token = ++availabilityToken;
-    const snapshotCtx = context;
+    // Internally we store `context` as the default-generic shape; the
+    // factory's `TData` / `TActions` only constrain the public callback
+    // signature. Cast at the call boundary to thread the consumer's narrowed
+    // type through without polluting the runtime store with the generic.
+    const snapshotCtx = context as ToolsDockContext<TData, TActions> | null;
     // Funnel both synchronous throws (argument validation, undefined
     // dereferences before the promise is returned) and asynchronous
     // rejections through the same error path so neither escapes
@@ -403,7 +481,7 @@ export function defineToolsDock<TCtx = unknown>(
     // 'dock:change' events when consumers idempotently call open() on the
     // already-active tool.
     if (isOpen !== prevIsOpen || activeTool !== prevActive) {
-      emitChange();
+      emitChange({ stateChanged: true, contextChanged: false });
     }
   }
 
@@ -416,7 +494,7 @@ export function defineToolsDock<TCtx = unknown>(
     }
     isOpen = false;
     persist();
-    emitChange();
+    emitChange({ stateChanged: true, contextChanged: false });
   }
 
   function toggle(id?: string): void {
@@ -432,7 +510,7 @@ export function defineToolsDock<TCtx = unknown>(
       }
       persist();
       if (isOpen !== prevIsOpen || activeTool !== prevActive) {
-        emitChange();
+        emitChange({ stateChanged: true, contextChanged: false });
       }
       return;
     }
@@ -442,7 +520,7 @@ export function defineToolsDock<TCtx = unknown>(
     }
     persist();
     if (isOpen !== prevIsOpen || activeTool !== prevActive) {
-      emitChange();
+      emitChange({ stateChanged: true, contextChanged: false });
     }
   }
 
@@ -461,13 +539,15 @@ export function defineToolsDock<TCtx = unknown>(
     context = ctx;
     if (fetchAvailability) refreshAvailability();
     // Emit AFTER kicking off availability refresh. The refresh is async and
-    // may emit a second `'dock:change'` later if it clears `activeTool` —
-    // that is the intended behaviour (one event per observable state
-    // transition).
-    emitChange();
+    // may emit a second event later if it clears `activeTool` — that is
+    // the intended behaviour (one event per observable state transition).
+    // `contextChanged: true` fires `'dock:context-changed'`; `stateChanged`
+    // stays false here because `setContext` itself doesn't touch isOpen/
+    // activeTool (the async availability refresh handles that).
+    emitChange({ stateChanged: false, contextChanged: true });
   }
 
-  const instance: ToolsDockInstance<TCtx> = {
+  const instance: ToolsDockInstance = {
     // Reactive getters — keep the api surface read-only.
     get isOpen() {
       return isOpen;

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
@@ -127,11 +127,19 @@ export interface DefineToolsDockOptions<
  * Internal extension of {@link ToolsDockApi} with framework-only members:
  * the registered tools, the configured layout, and the persistence key.
  *
- * Marked as part of the public surface but stamped with a brand symbol so
- * that `<ToolsDock>` and `useToolsDock()` callers can safely destructure
- * without consumers depending on internal field names.
+ * Mirrors the same `<TData, TActions>` generics as {@link ToolsDockApi} so
+ * the narrowed `context` / `setContext()` signatures from
+ * `defineToolsDock<TData, TActions>(...)` flow through to consumers that
+ * hold the returned instance directly. Defaults preserve back-compat for
+ * untyped callers (`defineToolsDock({...})`).
  */
-export interface ToolsDockInstance extends ToolsDockApi {
+export interface ToolsDockInstance<
+  TData = Record<string, unknown>,
+  TActions extends { [K in keyof TActions]: (...args: any[]) => any } = Record<
+    string,
+    (...args: any[]) => unknown
+  >,
+> extends ToolsDockApi<TData, TActions> {
   readonly tools: ReadonlyArray<ToolDef>;
   readonly layout: 'rail' | 'topbar';
   readonly storageKey: string | null;
@@ -204,7 +212,9 @@ export function defineToolsDock<
     string,
     (...args: any[]) => unknown
   >,
->(options: DefineToolsDockOptions<TData, TActions>): ToolsDockInstance {
+>(
+  options: DefineToolsDockOptions<TData, TActions>,
+): ToolsDockInstance<TData, TActions> {
   const layout = options.layout ?? 'rail';
   const storageKey = options.storageKey ?? null;
   const fetchAvailability = options.fetchAvailability;
@@ -539,7 +549,9 @@ export function defineToolsDock<
     }
   }
 
-  function setContextValue(ctx: ToolsDockContext | null): void {
+  function setContextValue(
+    ctx: ToolsDockContext<TData, TActions> | null,
+  ): void {
     // Strict-equality short-circuit: passing the same context reference is a
     // no-op. Skips both the availability refresh and the `'dock:change'`
     // emit so consumers (e.g. `<ToolsDock>`'s context-forwarding `$effect`)
@@ -549,9 +561,15 @@ export function defineToolsDock<
     // Compare against `rawContextRef` (a non-reactive shadow) rather than the
     // `$state` value, because Svelte 5 wraps object `$state` in a Proxy and
     // the original input would never `===` the proxied stored value.
-    if (ctx === rawContextRef) return;
-    rawContextRef = ctx;
-    context = ctx;
+    //
+    // Internally the `context` `$state` is typed as the default
+    // `ToolsDockContext` so the runtime store stays generic-erased — the
+    // narrowed type only lives on the public boundary (this function
+    // signature and the `instance.context` getter).
+    const erased = ctx as ToolsDockContext | null;
+    if (erased === rawContextRef) return;
+    rawContextRef = erased;
+    context = erased;
     if (fetchAvailability) refreshAvailability();
     // Emit AFTER kicking off availability refresh. The refresh is async and
     // may emit a second event later if it clears `activeTool` — that is
@@ -562,7 +580,7 @@ export function defineToolsDock<
     emitChange({ stateChanged: false, contextChanged: true });
   }
 
-  const instance: ToolsDockInstance = {
+  const instance: ToolsDockInstance<TData, TActions> = {
     // Reactive getters — keep the api surface read-only.
     get isOpen() {
       return isOpen;
@@ -573,8 +591,15 @@ export function defineToolsDock<
     get availableTools() {
       return availableTools;
     },
+    // Internal `context` `$state` is typed as the default-generic shape so
+    // the runtime store stays homogeneous. Cast at the public boundary —
+    // structurally a `ToolsDockContext<TData, TActions>` IS a
+    // `ToolsDockContext<defaults>` (the generics flow covariantly through
+    // the field shapes); the cast threads the consumer's narrowed type
+    // through to the API surface without forcing the internal store to
+    // carry the generic.
     get context() {
-      return context;
+      return context as ToolsDockContext<TData, TActions> | null;
     },
     open,
     close,

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
@@ -60,8 +60,12 @@ export const TOOLS_DOCK_KEY = Symbol('smrt-tools-dock');
  * Defaults to `Record<string, unknown>` so existing callers keep compiling.
  *
  * `TActions` types the shape of `context.actions` and flows the same way.
- * Defaults to `Record<string, never>` so callers who don't pass actions get
- * a strict (empty) action surface instead of `any`.
+ * Defaults to `Record<string, (...args: any[]) => unknown>` so the untyped
+ * `dock.setContext({ actions: { triggerSave() {} } })` pattern keeps
+ * compiling without a generic argument. The constraint is a self-mapped
+ * `{ [K in keyof TActions]: (...args: any[]) => any }` so interface-style
+ * action maps (without a string index signature) satisfy the bound —
+ * see the JSDoc on {@link ToolsDockContext} for rationale.
  *
  * Tools themselves are stored as `ToolDef[]` (the generics are erased at
  * registration). Inside a tool component, type the prop locally — see the
@@ -69,9 +73,9 @@ export const TOOLS_DOCK_KEY = Symbol('smrt-tools-dock');
  */
 export interface DefineToolsDockOptions<
   TData = Record<string, unknown>,
-  TActions extends Record<string, (...args: any[]) => any> = Record<
+  TActions extends { [K in keyof TActions]: (...args: any[]) => any } = Record<
     string,
-    never
+    (...args: any[]) => unknown
   >,
 > {
   /** Registered tools. Order is preserved when rendering the activation rail/topbar. */
@@ -196,9 +200,9 @@ function safeWriteStorage(key: string, payload: PersistedState): void {
  */
 export function defineToolsDock<
   TData = Record<string, unknown>,
-  TActions extends Record<string, (...args: any[]) => any> = Record<
+  TActions extends { [K in keyof TActions]: (...args: any[]) => any } = Record<
     string,
-    never
+    (...args: any[]) => unknown
   >,
 >(options: DefineToolsDockOptions<TData, TActions>): ToolsDockInstance {
   const layout = options.layout ?? 'rail';
@@ -374,7 +378,18 @@ export function defineToolsDock<
     let stateChanged = false;
     let anyChange = false;
 
-    // If the active tool is no longer available, clear it.
+    // If the active tool is no longer available, clear it. Auto-close policy:
+    //
+    // - If the available set is now empty, close the dock too (nothing left
+    //   to show — leaving `isOpen: true, activeTool: null` would render a
+    //   floating empty panel in the topbar layout).
+    // - If other tools remain, the dock stays open with `activeTool: null`.
+    //   Consumers see the cleared state via `'dock:state-changed'` and can
+    //   decide what to do (auto-pick the first remaining tool via
+    //   `dock.open(availableTools[0].id)`, or surface a "select a tool"
+    //   hint). The primitive stays policy-free — there's no universally
+    //   correct auto-selection (the previously-active tool's adjacency to
+    //   any specific replacement is consumer-specific).
     if (activeTool && !availableTools.some((t) => t.id === activeTool)) {
       activeTool = null;
       if (isOpen && availableTools.length === 0) {

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/use-tools-dock.ts
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/use-tools-dock.ts
@@ -8,9 +8,12 @@
  * Throws a clear error if called outside a `<ToolsDock>` provider tree so
  * misuse fails loudly during development rather than producing silent nulls.
  *
- * The returned `dock.context` is the untyped {@link ToolsDockContext} shape.
- * For typed access from within a tool body, use the `context` prop wired by
- * `<ToolsDock>` — `ToolDef<TCtx>` parameterizes that prop, not this hook.
+ * The returned `dock.context` is the default {@link ToolsDockContext} shape.
+ * For typed access from within a tool body, the recommended pattern is to
+ * type the component's own `context` prop locally — see the JSDoc on
+ * {@link ToolDef.component} for an example. (`ToolDef` deliberately erases
+ * its context generic at registration time so the dock can store tools as
+ * a single homogeneous `ToolDef[]`.)
  *
  * @example
  * ```svelte

--- a/packages/smrt-svelte/src/components/workspace/types.ts
+++ b/packages/smrt-svelte/src/components/workspace/types.ts
@@ -62,7 +62,7 @@ export interface RoleConfig {
 // Tools dock primitives
 // ────────────────────────────────────────────────
 
-export interface ToolDef<TCtx = unknown> {
+export interface ToolDef {
   id: string;
   label: string;
   /**
@@ -101,7 +101,42 @@ export interface ToolDef<TCtx = unknown> {
    * ```
    */
   iconComponent?: Component;
-  component: Component<{ context: TCtx; dock: ToolsDockApi }>;
+  /**
+   * Panel component rendered when this tool is active. Receives the dock's
+   * current `context` (typed as `ToolsDockContext | null` here so the dock
+   * surface stays honest about the type erasure that happens at registration
+   * time) and the dock API.
+   *
+   * Tools that want typed access to `context.data` / `context.actions`
+   * should locally type their own props inside the component, e.g.
+   *
+   * ```svelte
+   * <script lang="ts">
+   *   import type { ToolsDockApi, ToolsDockContext } from
+   *     '@happyvertical/smrt-svelte/workspace';
+   *
+   *   interface MyData { siteSlug: string; contentId: string }
+   *   interface MyActions { triggerSave(): void }
+   *
+   *   let { context, dock }: {
+   *     context: ToolsDockContext<MyData, MyActions> | null;
+   *     dock: ToolsDockApi;
+   *   } = $props();
+   * </script>
+   * ```
+   *
+   * A previous version of this API carried a `<TCtx>` generic on `ToolDef`
+   * that flowed into the `context` prop. In practice it was always erased
+   * at registration (the dock stores tools as `ToolDef[]`), so consumers
+   * cast at the registration site and re-declared the prop shape inside
+   * the component anyway. The honest API surface is `context: ToolsDockContext | null` —
+   * consumers thread their typed shape via the per-component prop
+   * annotation shown above.
+   */
+  component: Component<{
+    context: ToolsDockContext | null;
+    dock: ToolsDockApi;
+  }>;
   badge?: number | string | null;
 }
 
@@ -111,12 +146,47 @@ export interface AvailableTool {
   badge?: number | string | null;
 }
 
-export interface ToolsDockContext<TData = Record<string, unknown>> {
+/**
+ * Context blob the dock surfaces to tools and `fetchAvailability`. Both
+ * generics default so existing call sites keep compiling:
+ *
+ * - `TData` types the shape of `data` (route data, selection, etc.).
+ *   Defaults to `Record<string, unknown>`.
+ * - `TActions` types the shape of `actions` — the host-supplied callback
+ *   map tools may invoke to reach back into the page (`triggerSave`,
+ *   `openDialog`, etc.). Defaults to `Record<string, never>` so callers
+ *   who don't pass actions get an empty action surface instead of `any`.
+ *
+ * Recommended consumer pattern: thread these generics into the tool
+ * component's own `context` prop so `context?.actions?.foo()` is fully
+ * typed without a cast.
+ *
+ * ```ts
+ * interface MyData { siteSlug: string; contentId: string }
+ * interface MyActions { triggerSave: () => void; openReview: (kind: string) => void }
+ *
+ * // factory site:
+ * const dock = defineToolsDock<MyData, MyActions>({ ... });
+ *
+ * // tool component:
+ * let { context }: {
+ *   context: ToolsDockContext<MyData, MyActions> | null;
+ * } = $props();
+ * context?.actions?.triggerSave(); // typed
+ * ```
+ */
+export interface ToolsDockContext<
+  TData = Record<string, unknown>,
+  TActions extends Record<string, (...args: any[]) => any> = Record<
+    string,
+    never
+  >,
+> {
   type: string;
   title?: string;
   url?: string;
   data?: TData;
-  actions?: Record<string, (...args: any[]) => unknown>;
+  actions?: TActions;
 }
 
 /**
@@ -134,12 +204,40 @@ export interface ToolsDockContext<TData = Record<string, unknown>> {
  */
 export interface ToolsDockEvents {
   /**
+   * Fired when `isOpen` or `activeTool` changes — i.e. `open()`, `close()`,
+   * `toggle()`, and availability-driven `activeTool` clears.
+   * Does NOT fire when only `context` changes (use `'dock:context-changed'`
+   * for that). Payload reflects post-mutation values, no-op-guarded by the
+   * same equality checks as the mutators.
+   *
+   * Useful for consumers that mirror only the open/active surface (a
+   * workbench panel, a route guard) and don't care about context refreshes.
+   */
+  'dock:state-changed': {
+    isOpen: boolean;
+    activeTool: string | null;
+  };
+  /**
+   * Fired only when `context` changes (via `setContext()` with a different
+   * reference). Does NOT fire on `open()` / `close()` / `toggle()`.
+   * No-op-guarded — same-reference `setContext` calls stay silent.
+   *
+   * Useful for consumers that mirror only the context (analytics, server
+   * sync) and don't care about open/close transitions.
+   */
+  'dock:context-changed': {
+    context: ToolsDockContext | null;
+  };
+  /**
    * Fired by the dock after `isOpen`, `activeTool`, or `context` change —
    * i.e. `open()`, `close()`, `toggle()`, `setContext()`, and availability
-   * changes that clear the active tool. Payload reflects post-mutation
-   * values. Useful for mirroring dock state into a separate store
-   * (workbench, analytics, etc.) without threading multiple `$effect`s
-   * through every state-bearing getter.
+   * changes that clear the active tool or shift visible badges. Payload
+   * reflects post-mutation values.
+   *
+   * @deprecated Prefer `'dock:state-changed'` / `'dock:context-changed'`
+   * for finer-grained subscriptions — they let consumers ignore the slice
+   * of change they don't care about. `'dock:change'` continues to fire
+   * (back-compat) and may be removed in a future major.
    */
   'dock:change': {
     isOpen: boolean;
@@ -154,8 +252,10 @@ export interface ToolsDockApi {
   readonly availableTools: ReadonlyArray<AvailableTool>;
   /**
    * The current dock context (route data, selection, etc.) as supplied via
-   * `setContext()`. Untyped on the API surface — tools receive a typed
-   * `context` prop via `ToolDef<TCtx>` instead.
+   * `setContext()`. Default-typed on the API surface — tools that want
+   * typed access to `context.data` / `context.actions` should locally
+   * annotate their own `context` prop with `ToolsDockContext<TData, TActions>`
+   * (see the JSDoc on {@link ToolDef.component}).
    */
   readonly context: ToolsDockContext | null;
   open(id?: string): void;

--- a/packages/smrt-svelte/src/components/workspace/types.ts
+++ b/packages/smrt-svelte/src/components/workspace/types.ts
@@ -103,9 +103,7 @@ export interface ToolDef {
   iconComponent?: Component;
   /**
    * Panel component rendered when this tool is active. Receives the dock's
-   * current `context` (typed as `ToolsDockContext | null` here so the dock
-   * surface stays honest about the type erasure that happens at registration
-   * time) and the dock API.
+   * current `context` and the dock API.
    *
    * Tools that want typed access to `context.data` / `context.actions`
    * should locally type their own props inside the component, e.g.
@@ -125,18 +123,28 @@ export interface ToolDef {
    * </script>
    * ```
    *
+   * The dock erases tool-specific types at registration (tools are stored
+   * as a homogeneous `ToolDef[]`), so the props type is intentionally
+   * `Component<any>`. Svelte component props are checked contravariantly,
+   * which means a hard-coded `Component<{ context: ToolsDockContext | null; ... }>`
+   * slot would reject any component declaring a narrower
+   * `context: ToolsDockContext<MyData, MyActions> | null` prop — defeating
+   * the point of letting consumers type the prop locally. Erasing here
+   * means the per-component prop annotation shown above compiles without
+   * a registration-site cast.
+   *
    * A previous version of this API carried a `<TCtx>` generic on `ToolDef`
    * that flowed into the `context` prop. In practice it was always erased
-   * at registration (the dock stores tools as `ToolDef[]`), so consumers
-   * cast at the registration site and re-declared the prop shape inside
-   * the component anyway. The honest API surface is `context: ToolsDockContext | null` —
-   * consumers thread their typed shape via the per-component prop
-   * annotation shown above.
+   * at registration, so consumers cast at the registration site and
+   * re-declared the prop shape inside the component anyway. The current
+   * shape preserves the typed-context ergonomics while removing both the
+   * useless generic and the registration-site cast.
    */
-  component: Component<{
-    context: ToolsDockContext | null;
-    dock: ToolsDockApi;
-  }>;
+  // Registration is intentionally type-erased; see JSDoc above. The `any`
+  // here is load-bearing — see Copilot/codex/claude review threads on PR
+  // #1239 for the contravariance rationale.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  component: Component<any>;
   badge?: number | string | null;
 }
 
@@ -154,8 +162,18 @@ export interface AvailableTool {
  *   Defaults to `Record<string, unknown>`.
  * - `TActions` types the shape of `actions` — the host-supplied callback
  *   map tools may invoke to reach back into the page (`triggerSave`,
- *   `openDialog`, etc.). Defaults to `Record<string, never>` so callers
- *   who don't pass actions get an empty action surface instead of `any`.
+ *   `openDialog`, etc.). Defaults to a permissive
+ *   `Record<string, (...args: any[]) => unknown>` so the untyped pattern
+ *   `dock.setContext({ actions: { triggerSave() {} } })` keeps compiling
+ *   without a generic argument.
+ *
+ * The constraint is a self-mapped
+ * `{ [K in keyof TActions]: (...args: any[]) => any }` rather than
+ * `Record<string, ...>`. This accepts interface-style action maps without
+ * an explicit string index signature — the common pattern Copilot flagged
+ * in the original PR review. A bare `Record<string, ...>` constraint
+ * rejects interfaces (which have no index signature) under strict TS,
+ * forcing consumers to use type aliases or add `[key: string]: ...`.
  *
  * Recommended consumer pattern: thread these generics into the tool
  * component's own `context` prop so `context?.actions?.foo()` is fully
@@ -163,7 +181,7 @@ export interface AvailableTool {
  *
  * ```ts
  * interface MyData { siteSlug: string; contentId: string }
- * interface MyActions { triggerSave: () => void; openReview: (kind: string) => void }
+ * interface MyActions { triggerSave(): void; openReview(kind: string): void }
  *
  * // factory site:
  * const dock = defineToolsDock<MyData, MyActions>({ ... });
@@ -177,9 +195,9 @@ export interface AvailableTool {
  */
 export interface ToolsDockContext<
   TData = Record<string, unknown>,
-  TActions extends Record<string, (...args: any[]) => any> = Record<
+  TActions extends { [K in keyof TActions]: (...args: any[]) => any } = Record<
     string,
-    never
+    (...args: any[]) => unknown
   >,
 > {
   type: string;
@@ -224,6 +242,21 @@ export interface ToolsDockEvents {
    *
    * Useful for consumers that mirror only the context (analytics, server
    * sync) and don't care about open/close transitions.
+   *
+   * The payload uses the default-typed `ToolsDockContext`; the dock's
+   * event registry is shared across all `ToolsDockApi` instances and can't
+   * flow the factory's `<TData, TActions>` through to per-instance
+   * subscribers. Consumers that want typed access should either:
+   *
+   * 1. Cast at the handler site:
+   *    ```ts
+   *    dock.on('dock:context-changed', ({ context }) => {
+   *      const typed = context as ToolsDockContext<MyData, MyActions> | null;
+   *      // ... typed.data?.siteSlug
+   *    });
+   *    ```
+   * 2. Use `dock.context` inside a `$derived` — that read is typed by the
+   *    factory's `<TData, TActions>` generics on the returned instance.
    */
   'dock:context-changed': {
     context: ToolsDockContext | null;

--- a/packages/smrt-svelte/src/components/workspace/types.ts
+++ b/packages/smrt-svelte/src/components/workspace/types.ts
@@ -279,22 +279,59 @@ export interface ToolsDockEvents {
   };
 }
 
-export interface ToolsDockApi {
+/**
+ * Public reactive API for a tools dock instance. Two generics carry through
+ * from the factory site so `dock.context` and `dock.setContext()` flow with
+ * the consumer's narrowed types:
+ *
+ * - `TData` types the shape of `context.data`. Defaults to
+ *   `Record<string, unknown>`.
+ * - `TActions` types the shape of `context.actions`. Defaults to
+ *   `Record<string, (...args: any[]) => unknown>` so the untyped pattern
+ *   `dock.setContext({ actions: { triggerSave() {} } })` keeps compiling
+ *   without a generic argument.
+ *
+ * The constraint mirrors {@link ToolsDockContext} — a self-mapped
+ * `{ [K in keyof TActions]: (...args: any[]) => any }` — so interface-style
+ * action maps satisfy the bound without requiring a string index signature.
+ *
+ * @example
+ * ```ts
+ * interface MyData { siteSlug: string }
+ * interface MyActions { triggerSave(): void }
+ *
+ * const dock = defineToolsDock<MyData, MyActions>({ tools: [...] });
+ *
+ * // typed:
+ * dock.setContext({
+ *   type: 'route',
+ *   data: { siteSlug: 'demo' },
+ *   actions: { triggerSave() {} },
+ * });
+ * const slug: string | undefined = dock.context?.data?.siteSlug;
+ * ```
+ */
+export interface ToolsDockApi<
+  TData = Record<string, unknown>,
+  TActions extends { [K in keyof TActions]: (...args: any[]) => any } = Record<
+    string,
+    (...args: any[]) => unknown
+  >,
+> {
   readonly activeTool: string | null;
   readonly isOpen: boolean;
   readonly availableTools: ReadonlyArray<AvailableTool>;
   /**
    * The current dock context (route data, selection, etc.) as supplied via
-   * `setContext()`. Default-typed on the API surface — tools that want
-   * typed access to `context.data` / `context.actions` should locally
-   * annotate their own `context` prop with `ToolsDockContext<TData, TActions>`
-   * (see the JSDoc on {@link ToolDef.component}).
+   * `setContext()`. Typed against the factory's `<TData, TActions>` generics —
+   * narrow them at the `defineToolsDock<TData, TActions>(...)` call site for
+   * typed access without a cast.
    */
-  readonly context: ToolsDockContext | null;
+  readonly context: ToolsDockContext<TData, TActions> | null;
   open(id?: string): void;
   close(): void;
   toggle(id?: string): void;
-  setContext(ctx: ToolsDockContext | null): void;
+  setContext(ctx: ToolsDockContext<TData, TActions> | null): void;
   /**
    * Force a re-run of the `fetchAvailability` callback with the current
    * context. Useful when a side-channel event signals that availability or


### PR DESCRIPTION
Closes the deferred items on issue [#1235](https://github.com/happyvertical/smrt/issues/1235) — the workspace API follow-ups from the first two downstream migrations (Phase 1 ergot.io, Phase 3 anytown.ai). Five findings, one commit.

## Summary

- **B — `defineToolsDock<TCtx>` generic ergonomics.** Drop the erased `<TCtx>` parameter from `ToolDef`. Tools are stored as a homogeneous `ToolDef[]`; the honest API surface is `context: ToolsDockContext | null`. Consumers who want typed `context.data` / `context.actions` annotate their tool component's own `context` prop locally — the cast at registration is gone. This is the only observable breaking-ish change. In practice consumers were already casting, so the API surface is now just *honest* about it.
- **C — topbar + inspector positioning docs.** JSDoc-only fix on `<WorkspaceShell>`'s `inspector` snippet and `<ToolsDock>`'s `layout` option documenting the unsupported overlap when both are used in `topbar` mode (both fixed-positioned, no z-index coordination).
- **U2 — split `'dock:context-changed'` from `'dock:state-changed'`.** Two new granular events:
  - `'dock:state-changed'` fires only on `open()` / `close()` / `toggle()` and on availability-driven active-tool clears. Payload: `{ isOpen, activeTool }`.
  - `'dock:context-changed'` fires only on `setContext()` with a different reference. Payload: `{ context }`.
  - Legacy `'dock:change'` continues to fire on all observable transitions (incl. badge-only refresh) for back-compat — marked `@deprecated`, slated for removal in a future major. Same no-op guards as before; `untrack` around the snapshot reads preserves the reactive-leak fix from #1236.
- **U3 — `TData` threaded into `fetchAvailability`.** `defineToolsDock<TData, TActions>` flows the factory generics into `fetchAvailability(ctx)` — no more manual `ctx.data as MyShape` casts.
- **U4/U5 — typed `actions` ergonomics.** Parameterize `ToolsDockContext<TData, TActions>` with a defaulted `TActions extends Record<string, (...args: any[]) => any>`. Consumers type their action map once at the factory site and call `context?.actions?.foo()` from tools without per-consumer re-declaration. Closes the drift the site-portal migration's `AssistantContext` redefinition created.

## Backwards-compat strategy

- `'dock:change'` stays. It now coexists with the granular pair (and fires alongside them on every transition). Consumers can adopt the new events at their own pace.
- `ToolsDockContext` and `defineToolsDock` generics are added with defaults that match prior behavior; existing call sites compile unchanged.
- The one observable change is B: `ToolDef<T>` is now `ToolDef`. No in-repo consumers used the parameterized form; the cast at registration is gone.

## Cross-finding interactions

- B and U3 use intentionally different generic names. B drops `<TCtx>` from `ToolDef`. U3/U4 add `<TData, TActions>` to `defineToolsDock` and `ToolsDockContext`. They don't conflict — the factory generics flow into `fetchAvailability` and into the tool component's prop annotation; `ToolDef` itself stays generic-free.
- U2's three event names share `emitChange()`'s `untrack` snapshot. A single mutation produces at most one of each granular event plus one legacy `dock:change` — no extra reactive deps, no infinite-loop risk.

## Test plan

- [x] `pnpm build` in `packages/smrt-svelte/` — succeeds
- [x] `pnpm test` — 160/160 pass (150 prior + 10 new for U2's fire/no-fire matrix)
- [x] `pnpm typecheck` — clean
- [x] `biome check` on the workspace folder — clean (only pre-existing warnings in test harnesses)

Refs: happyvertical/smrt issue 1235