### PR TITLE
feat(smrt-svelte): add dock availability gate composer (server-side)

### DIFF
--- a/packages/smrt-svelte/CLAUDE.md
+++ b/packages/smrt-svelte/CLAUDE.md
@@ -177,6 +177,15 @@ Convention: `<prefix>:<identifier>` (e.g. `permission:articles.publish`,
 evaluator per prefix, throws on unknown prefixes (loud-fail beats silent-leak),
 AND semantics across a tool's gates. Node-safe, no Svelte imports.
 
+The framework does NOT ship built-in evaluators — every prefix the dock sees
+must have a caller-supplied evaluator in the map (otherwise composition
+throws). `permission:` and `feature:` are recommended conventions for
+ecosystem cohesion (consumers typically wire `PermissionResolver` from
+smrt-users and `FeatureResolver` from smrt-features as those evaluators), but
+they're not reserved — apps may pick any namespace. App-specific gates
+should use a dedicated namespace (e.g. `myapp:`) to avoid colliding with
+future built-ins.
+
 Recommended pattern: in the consumer's `+server.ts` endpoint that backs
 `fetchAvailability`, wrap `PermissionResolver` (smrt-users) and `FeatureResolver`
 (smrt-features) as evaluators and pass them in. Tools without `gates` stay

--- a/packages/smrt-svelte/CLAUDE.md
+++ b/packages/smrt-svelte/CLAUDE.md
@@ -167,3 +167,19 @@ whatever set their app needs. Use this for role-based admin dashboards; use
 See epic [happyvertical/smrt#1226](https://github.com/happyvertical/smrt/issues/1226) for context;
 implementations land via #1227 (`WorkspaceShell`), #1228 (`NavTree`/`Breadcrumbs`), and #1229
 (`ToolsDock` + registry).
+
+### Dock availability gates (server-side)
+
+`ToolDef.gates?: string[]` declares the gates a tool must pass to be visible.
+Convention: `<prefix>:<identifier>` (e.g. `permission:articles.publish`,
+`feature:video-tools`, `myapp:show-jobs`). `composeDockAvailability` from
+`@happyvertical/smrt-svelte/workspace/server` evaluates them — register one
+evaluator per prefix, throws on unknown prefixes (loud-fail beats silent-leak),
+AND semantics across a tool's gates. Node-safe, no Svelte imports.
+
+Recommended pattern: in the consumer's `+server.ts` endpoint that backs
+`fetchAvailability`, wrap `PermissionResolver` (smrt-users) and `FeatureResolver`
+(smrt-features) as evaluators and pass them in. Tools without `gates` stay
+unconditionally visible (back-compat). Anytown's hand-coded
+`apps/dashboard/src/lib/server/content-tool-dock.ts` is a candidate for
+migration in a follow-up.

--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -49,6 +49,11 @@
       "import": "./dist/components/workspace/index.js",
       "default": "./dist/components/workspace/index.js"
     },
+    "./workspace/server": {
+      "types": "./dist/components/workspace/server/index.d.ts",
+      "import": "./dist/components/workspace/server/index.js",
+      "default": "./dist/components/workspace/server/index.js"
+    },
     "./styles/tokens.css": {
       "default": "./dist/styles/tokens.css"
     },

--- a/packages/smrt-svelte/src/components/workspace/server/__tests__/compose-availability.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/server/__tests__/compose-availability.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Tests for the server-side dock availability gate composer
+ * (happyvertical/smrt#1226 Phase 4c).
+ *
+ * Covers:
+ *  - tools without `gates` are unconditionally included (back-compat)
+ *  - single passing / failing gate
+ *  - AND semantics across multiple gates
+ *  - sync and async evaluators
+ *  - unknown-prefix error message (loud-fail)
+ *  - context pass-through
+ *  - edge cases (empty arrays / maps)
+ *  - label / badge passthrough into AvailableTool
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { composeDockAvailability } from '../compose-availability.js';
+import type {
+  GatedToolSummary,
+  GateEvaluationContext,
+  GateEvaluator,
+} from '../types.js';
+
+const alwaysTrue: GateEvaluator = () => true;
+const alwaysFalse: GateEvaluator = () => false;
+const asyncTrue: GateEvaluator = async () => true;
+const asyncFalse: GateEvaluator = async () => false;
+
+describe('composeDockAvailability', () => {
+  it('includes tools without a `gates` field unconditionally', async () => {
+    const result = await composeDockAvailability({
+      tools: [{ id: 'chat', label: 'Chat' }],
+      context: {},
+      evaluators: {},
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('chat');
+  });
+
+  it('includes tools with an empty `gates` array unconditionally', async () => {
+    const result = await composeDockAvailability({
+      tools: [{ id: 'chat', label: 'Chat', gates: [] }],
+      context: {},
+      evaluators: {},
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('chat');
+  });
+
+  it('includes a tool whose single gate evaluates to true', async () => {
+    const result = await composeDockAvailability({
+      tools: [{ id: 'video', label: 'Video', gates: ['feature:video-tools'] }],
+      context: {},
+      evaluators: { feature: alwaysTrue },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('video');
+  });
+
+  it('excludes a tool whose single gate evaluates to false', async () => {
+    const result = await composeDockAvailability({
+      tools: [{ id: 'video', label: 'Video', gates: ['feature:video-tools'] }],
+      context: {},
+      evaluators: { feature: alwaysFalse },
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('requires ALL gates to pass (AND semantics)', async () => {
+    const result = await composeDockAvailability({
+      tools: [
+        {
+          id: 'restricted',
+          label: 'Restricted',
+          gates: ['permission:foo', 'feature:bar'],
+        },
+      ],
+      context: {},
+      evaluators: { permission: alwaysTrue, feature: alwaysFalse },
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('includes a tool only when EVERY gate passes', async () => {
+    const result = await composeDockAvailability({
+      tools: [
+        {
+          id: 'allowed',
+          label: 'Allowed',
+          gates: ['permission:foo', 'feature:bar'],
+        },
+      ],
+      context: {},
+      evaluators: { permission: alwaysTrue, feature: asyncTrue },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('allowed');
+  });
+
+  it('accepts sync evaluators that return a plain boolean', async () => {
+    const result = await composeDockAvailability({
+      tools: [{ id: 't', label: 'T', gates: ['x:y'] }],
+      context: {},
+      evaluators: { x: (_id, _ctx) => true },
+    });
+    expect(result).toHaveLength(1);
+  });
+
+  it('accepts async evaluators that return a Promise<boolean>', async () => {
+    const result = await composeDockAvailability({
+      tools: [{ id: 't', label: 'T', gates: ['x:y'] }],
+      context: {},
+      evaluators: { x: async () => true },
+    });
+    expect(result).toHaveLength(1);
+  });
+
+  it('throws with a clear message when a gate prefix has no evaluator', async () => {
+    await expect(
+      composeDockAvailability({
+        tools: [
+          { id: 'video', label: 'Video', gates: ['feature:video-tools'] },
+        ],
+        context: {},
+        evaluators: { permission: alwaysTrue },
+      }),
+    ).rejects.toThrow(
+      /No evaluator registered for gate prefix "feature".*tool "video".*gate "feature:video-tools".*Available prefixes: permission/,
+    );
+  });
+
+  it('reports `(none)` for available prefixes when the evaluators map is empty', async () => {
+    await expect(
+      composeDockAvailability({
+        tools: [
+          { id: 'video', label: 'Video', gates: ['feature:video-tools'] },
+        ],
+        context: {},
+        evaluators: {},
+      }),
+    ).rejects.toThrow(/Available prefixes: \(none\)/);
+  });
+
+  it('passes the supplied `context` through to each evaluator', async () => {
+    const ctx: GateEvaluationContext = { userId: 'u-1', tenantId: 't-1' };
+    const permission = vi.fn(() => true);
+    const feature = vi.fn(() => true);
+
+    await composeDockAvailability({
+      tools: [
+        {
+          id: 'tool',
+          label: 'Tool',
+          gates: ['permission:articles.publish', 'feature:video-tools'],
+        },
+      ],
+      context: ctx,
+      evaluators: { permission, feature },
+    });
+
+    expect(permission).toHaveBeenCalledWith('permission:articles.publish', ctx);
+    expect(feature).toHaveBeenCalledWith('feature:video-tools', ctx);
+  });
+
+  it('returns an empty array for an empty `tools` input', async () => {
+    const result = await composeDockAvailability({
+      tools: [],
+      context: {},
+      evaluators: {},
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('handles an empty `evaluators` map fine when no tools have gates', async () => {
+    const result = await composeDockAvailability({
+      tools: [
+        { id: 'a', label: 'A' },
+        { id: 'b', label: 'B' },
+      ],
+      context: {},
+      evaluators: {},
+    });
+    expect(result.map((t) => t.id)).toEqual(['a', 'b']);
+  });
+
+  it('passes through `label` and `badge` from the tool def to AvailableTool', async () => {
+    const tools: GatedToolSummary[] = [
+      { id: 'inbox', label: 'Inbox', badge: 3 },
+      { id: 'tasks', label: 'Tasks', badge: 'new' },
+      { id: 'plain', label: 'Plain' }, // no badge
+    ];
+
+    const result = await composeDockAvailability({
+      tools,
+      context: {},
+      evaluators: {},
+    });
+
+    expect(result).toEqual([
+      { id: 'inbox', label: 'Inbox', badge: 3 },
+      { id: 'tasks', label: 'Tasks', badge: 'new' },
+      { id: 'plain', label: 'Plain', badge: null },
+    ]);
+  });
+
+  it('defaults a missing `label` to an empty string in the AvailableTool result', async () => {
+    const result = await composeDockAvailability({
+      tools: [{ id: 'no-label' } as GatedToolSummary],
+      context: {},
+      evaluators: {},
+    });
+    expect(result[0]).toEqual({ id: 'no-label', label: '', badge: null });
+  });
+
+  it('filters a mixed input correctly (gated + ungated, pass + fail)', async () => {
+    const result = await composeDockAvailability({
+      tools: [
+        { id: 'always', label: 'Always' },
+        { id: 'allowed', label: 'Allowed', gates: ['permission:foo'] },
+        { id: 'denied', label: 'Denied', gates: ['permission:bar'] },
+        { id: 'flagged', label: 'Flagged', gates: ['feature:on'] },
+      ],
+      context: { userId: 'u-1' },
+      evaluators: {
+        permission: async (id) => id === 'permission:foo',
+        feature: asyncTrue,
+      },
+    });
+
+    expect(result.map((t) => t.id)).toEqual(['always', 'allowed', 'flagged']);
+  });
+
+  it('still throws on unknown prefix even when other gates on the same tool would have passed', async () => {
+    await expect(
+      composeDockAvailability({
+        tools: [
+          {
+            id: 'mixed',
+            label: 'Mixed',
+            gates: ['permission:ok', 'mystery:??'],
+          },
+        ],
+        context: {},
+        evaluators: { permission: alwaysTrue },
+      }),
+    ).rejects.toThrow(/gate "mystery:\?\?"/);
+  });
+
+  it('treats async evaluator rejections as errors (does not swallow)', async () => {
+    await expect(
+      composeDockAvailability({
+        tools: [{ id: 't', label: 'T', gates: ['boom:bar'] }],
+        context: {},
+        evaluators: {
+          boom: async () => {
+            throw new Error('evaluator exploded');
+          },
+        },
+      }),
+    ).rejects.toThrow('evaluator exploded');
+  });
+
+  it('respects falsy results from async evaluators (excludes the tool)', async () => {
+    const result = await composeDockAvailability({
+      tools: [{ id: 't', label: 'T', gates: ['x:y'] }],
+      context: {},
+      evaluators: { x: asyncFalse },
+    });
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/smrt-svelte/src/components/workspace/server/__tests__/compose-availability.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/server/__tests__/compose-availability.test.ts
@@ -187,7 +187,7 @@ describe('composeDockAvailability', () => {
     const tools: GatedToolSummary[] = [
       { id: 'inbox', label: 'Inbox', badge: 3 },
       { id: 'tasks', label: 'Tasks', badge: 'new' },
-      { id: 'plain', label: 'Plain' }, // no badge
+      { id: 'plain', label: 'Plain' }, // no badge → omitted in output
     ];
 
     const result = await composeDockAvailability({
@@ -199,17 +199,42 @@ describe('composeDockAvailability', () => {
     expect(result).toEqual([
       { id: 'inbox', label: 'Inbox', badge: 3 },
       { id: 'tasks', label: 'Tasks', badge: 'new' },
-      { id: 'plain', label: 'Plain', badge: null },
+      { id: 'plain', label: 'Plain' },
     ]);
   });
 
-  it('defaults a missing `label` to an empty string in the AvailableTool result', async () => {
+  it('omits a missing `label` from the AvailableTool result (lets the dock fall back)', async () => {
     const result = await composeDockAvailability({
       tools: [{ id: 'no-label' } as GatedToolSummary],
       context: {},
       evaluators: {},
     });
-    expect(result[0]).toEqual({ id: 'no-label', label: '', badge: null });
+    // No `label` key at all — `defineToolsDock.applyAvailability` falls
+    // back to the registered ToolDef metadata.
+    expect(result[0]).toEqual({ id: 'no-label' });
+    expect(result[0]).not.toHaveProperty('label');
+    expect(result[0]).not.toHaveProperty('badge');
+  });
+
+  it('omits `badge` when the tool def has no badge (no implicit clear)', async () => {
+    const result = await composeDockAvailability({
+      tools: [{ id: 'chat', label: 'Chat', gates: [] }],
+      context: {},
+      evaluators: {},
+    });
+    // The dock treats `badge: null` as an explicit clear of the
+    // registered default badge. Absence must remain absence.
+    expect(result[0]).toEqual({ id: 'chat', label: 'Chat' });
+    expect(result[0]).not.toHaveProperty('badge');
+  });
+
+  it('preserves explicit `badge: null` when the caller does set it', async () => {
+    const result = await composeDockAvailability({
+      tools: [{ id: 'reset', label: 'Reset', badge: null }],
+      context: {},
+      evaluators: {},
+    });
+    expect(result[0]).toEqual({ id: 'reset', label: 'Reset', badge: null });
   });
 
   it('filters a mixed input correctly (gated + ungated, pass + fail)', async () => {
@@ -267,5 +292,75 @@ describe('composeDockAvailability', () => {
       evaluators: { x: asyncFalse },
     });
     expect(result).toEqual([]);
+  });
+
+  // Regression: a gate prefix that names an inherited `Object.prototype`
+  // property (e.g. `constructor`, `toString`, `hasOwnProperty`, `valueOf`,
+  // `__proto__`) MUST NOT bypass the unknown-prefix fail-loud path. Prior
+  // to the fix, `evaluators[prefix]` resolved to a built-in function and
+  // got invoked, returning a truthy value and silently passing the gate.
+  it('throws on prototype-key gate prefixes (constructor, toString, hasOwnProperty, valueOf, __proto__)', async () => {
+    const evaluators = { permission: () => true };
+    for (const prefix of [
+      'constructor',
+      'toString',
+      'hasOwnProperty',
+      'valueOf',
+      '__proto__',
+    ]) {
+      await expect(
+        composeDockAvailability({
+          tools: [{ id: 'x', label: 'X', gates: [`${prefix}:any`] }],
+          context: {},
+          evaluators,
+        }),
+      ).rejects.toThrow(/No evaluator registered for gate prefix/);
+    }
+  });
+
+  it('throws when an evaluator entry is not a function', async () => {
+    await expect(
+      composeDockAvailability({
+        tools: [{ id: 'x', label: 'X', gates: ['permission:any'] }],
+        context: {},
+        evaluators: {
+          // Intentional non-function evaluator — should fail loud.
+          permission: 'not-a-function',
+        } as unknown as Parameters<
+          typeof composeDockAvailability
+        >[0]['evaluators'],
+      }),
+    ).rejects.toThrow(/No evaluator registered/);
+  });
+
+  // Regression for the TCtx generic parameterization (issue 1242 fix #5).
+  // Verifies the typed-context flow compiles end-to-end: the evaluator
+  // receives a typed `ctx` (string fields, not `unknown`) without a cast.
+  it('preserves the caller-supplied context type through to evaluators (TCtx generic)', async () => {
+    interface MyContext extends GateEvaluationContext {
+      userId: string;
+      tenantId: string;
+    }
+
+    let observedUserId: string | undefined;
+    let observedTenantId: string | undefined;
+
+    const result = await composeDockAvailability<MyContext>({
+      tools: [{ id: 't', label: 'T', gates: ['permission:articles.publish'] }],
+      context: { userId: 'u-1', tenantId: 't-1' },
+      evaluators: {
+        permission: (gateId, ctx) => {
+          // No cast required — ctx.userId and ctx.tenantId are typed string.
+          observedUserId = ctx.userId;
+          observedTenantId = ctx.tenantId;
+          const [, slug] = gateId.split(':', 2);
+          return slug === 'articles.publish';
+        },
+      },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(observedUserId).toBe('u-1');
+    expect(observedTenantId).toBe('t-1');
   });
 });

--- a/packages/smrt-svelte/src/components/workspace/server/__tests__/compose-availability.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/server/__tests__/compose-availability.test.ts
@@ -363,4 +363,91 @@ describe('composeDockAvailability', () => {
     expect(observedUserId).toBe('u-1');
     expect(observedTenantId).toBe('t-1');
   });
+
+  // Regression: an interface-style context (no string index signature) must
+  // be accepted by `TCtx`. The round-1 fixup parameterized
+  // `TCtx extends Record<string, unknown>`, which rejected interfaces under
+  // strict TS — the same trap we hit with `TActions` in #1239. The
+  // self-mapped constraint `{ [K in keyof TCtx]: unknown }` accepts
+  // interfaces without forcing the consumer to add an index signature.
+  //
+  // The compile-time guard lives in
+  // `./__tests__/typed-context-fixture/typed-context.ts` — see the JSDoc
+  // there. The runtime check below confirms the same interface-style
+  // context round-trips through evaluators at runtime.
+  it('accepts an interface-style TCtx (no string index signature)', async () => {
+    interface InterfaceContext {
+      userId: string;
+      tenantId: string;
+    }
+
+    let observedUserId: string | undefined;
+
+    const result = await composeDockAvailability<InterfaceContext>({
+      tools: [{ id: 't', label: 'T', gates: ['permission:any'] }],
+      context: { userId: 'u-1', tenantId: 't-1' },
+      evaluators: {
+        permission: (_gateId, ctx) => {
+          // No cast — ctx.userId is typed string.
+          observedUserId = ctx.userId;
+          return true;
+        },
+      },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(observedUserId).toBe('u-1');
+  });
+
+  // Regression for fix #2 of round-3: `.every(Boolean)` fails OPEN for
+  // truthy non-booleans. `Boolean('false')`, `Boolean({})`, `Boolean([])`
+  // are all true, so an untyped evaluator returning a wrapped object, a
+  // sentinel string, or a number would silently grant access. The composer
+  // now uses strict `=== true`.
+  it('fails closed on truthy non-boolean evaluator returns', async () => {
+    // Evaluators MUST return boolean per the type, but consumers in plain
+    // JS or with untyped wrappers can slip non-boolean returns through.
+    // Verify that truthy non-booleans don't grant access.
+    const cases: Array<{ id: string; evaluator: GateEvaluator }> = [
+      {
+        id: 'string-true',
+        evaluator: () => 'true' as unknown as boolean,
+      },
+      {
+        id: 'object',
+        evaluator: () => ({ allowed: false }) as unknown as boolean,
+      },
+      {
+        id: 'array',
+        evaluator: () => [] as unknown as boolean,
+      },
+      {
+        id: 'number-1',
+        evaluator: () => 1 as unknown as boolean,
+      },
+      {
+        id: 'falsestring',
+        evaluator: () => 'false' as unknown as boolean,
+      },
+    ];
+
+    for (const { id, evaluator } of cases) {
+      const result = await composeDockAvailability({
+        tools: [{ id, label: id, gates: ['permission:any'] }],
+        context: {},
+        evaluators: { permission: evaluator },
+      });
+      // fail-closed: gate doesn't pass
+      expect(result).toEqual([]);
+    }
+  });
+
+  it('passes only on literal `true` (not truthy values)', async () => {
+    const result = await composeDockAvailability({
+      tools: [{ id: 'pass-true', label: 'Pass', gates: ['permission:any'] }],
+      context: {},
+      evaluators: { permission: () => true },
+    });
+    expect(result).toEqual([{ id: 'pass-true', label: 'Pass' }]);
+  });
 });

--- a/packages/smrt-svelte/src/components/workspace/server/__tests__/typed-context-fixture.ts
+++ b/packages/smrt-svelte/src/components/workspace/server/__tests__/typed-context-fixture.ts
@@ -1,0 +1,129 @@
+/**
+ * Compile-time regression fixture for the `TCtx` generic on
+ * `composeDockAvailability` / `ComposeDockAvailabilityOptions` /
+ * `GateEvaluator`.
+ *
+ * This is the contract round-3 of PR #1242 is restoring:
+ *
+ *   - `TCtx` must accept an INTERFACE (no string index signature). The
+ *     round-1 fixup tightened the constraint to
+ *     `TCtx extends Record<string, unknown>`, which silently rejected
+ *     interface-style contexts — the same trap Copilot caught with
+ *     `TActions` in PR #1239. The constraint is now a self-mapped
+ *     `{ [K in keyof TCtx]: unknown }` (matching the `TActions` pattern in
+ *     `../../types.ts`).
+ *
+ *   - The default `TCtx = GateEvaluationContext` must keep existing
+ *     untyped call sites compiling unchanged.
+ *
+ *   - The factory's `<TCtx>` generic must flow through to each evaluator
+ *     so `ctx.fieldName` is typed without a cast at the evaluator call
+ *     site.
+ *
+ * Lives in a `.ts` file (NOT `.test.ts`) so:
+ *   - `tsc --noEmit` (the package's `typecheck` script, run in CI via
+ *     `pnpm turbo run typecheck`) does include it — the package's
+ *     `tsconfig.svelte.json` includes `src/** /*.ts` and excludes only
+ *     `**\/*.test.ts` and `**\/*.spec.ts`.
+ *   - Vitest does NOT execute it (no `.test.ts` suffix), so the
+ *     `_assertInterfaceTCtx*` symbols below never run — their bodies must
+ *     just compile.
+ *
+ * Mirrors the same pattern as
+ * `../../__tests__/typed-tool-fixture/register-typed-tool.ts` (PR #1239).
+ */
+
+import { composeDockAvailability } from '../compose-availability.js';
+import type {
+  ComposeDockAvailabilityOptions,
+  GatedToolSummary,
+  GateEvaluationContext,
+  GateEvaluator,
+} from '../types.js';
+
+/**
+ * Interface-style context — no string index signature. Under a bare
+ * `Record<string, unknown>` constraint this fails to satisfy `TCtx`
+ * (TS2344). Under the self-mapped `{ [K in keyof TCtx]: unknown }`
+ * constraint it's accepted.
+ */
+interface MyInterfaceContext {
+  userId: string;
+  tenantId: string;
+}
+
+/**
+ * Type-only assertion: an `Options` literal parameterized over an
+ * interface-style context must compile, and the evaluator must receive a
+ * typed `ctx` (no cast) with the consumer's field types.
+ *
+ * If `TCtx` ever tightens back to `Record<string, unknown>`, this
+ * declaration fails with TS2344 ("Type 'MyInterfaceContext' does not
+ * satisfy the constraint 'Record<string, unknown>'").
+ */
+export const _assertInterfaceTCtxOptions: ComposeDockAvailabilityOptions<MyInterfaceContext> =
+  {
+    tools: [],
+    context: { userId: 'u-1', tenantId: 't-1' },
+    evaluators: {
+      permission: (gateId, ctx) => {
+        // No cast required — ctx.userId / ctx.tenantId are typed `string`.
+        const _userId: string = ctx.userId;
+        const _tenantId: string = ctx.tenantId;
+        return gateId.startsWith('permission:');
+      },
+    },
+  };
+
+/**
+ * Type-only assertion: `GateEvaluator<MyInterfaceContext>` accepts an
+ * interface. Same regression as above, but exercised through the
+ * `GateEvaluator` alias directly (which `ComposeDockAvailabilityOptions`
+ * indexes into via `evaluators`).
+ */
+export const _assertInterfaceTCtxEvaluator: GateEvaluator<
+  MyInterfaceContext
+> = (gateId, ctx) => {
+  const _: string = ctx.userId;
+  return gateId === 'permission:any';
+};
+
+/**
+ * Type-only assertion: the `composeDockAvailability<TCtx>` factory
+ * accepts an interface-style `TCtx` and threads it through to evaluators
+ * without erasure. Never called at runtime — its body just has to
+ * compile.
+ */
+export async function _assertInterfaceTCtxFactoryFlow(): Promise<void> {
+  const tools: ReadonlyArray<GatedToolSummary> = [
+    { id: 't', label: 'T', gates: ['permission:any'] },
+  ];
+  await composeDockAvailability<MyInterfaceContext>({
+    tools,
+    context: { userId: 'u-1', tenantId: 't-1' },
+    evaluators: {
+      permission: (_gateId, ctx) => {
+        // TYPED: ctx.userId is `string`, not `unknown`. If the factory
+        // dropped its generic on the evaluator signature, the next line
+        // would only compile as `unknown`.
+        const _userId: string = ctx.userId;
+        return true;
+      },
+    },
+  });
+}
+
+/**
+ * Type-only assertion: the untyped (back-compat) call site must still
+ * compile with no generic argument and resolve `TCtx` to the default
+ * `GateEvaluationContext` (`Record<string, unknown>`). If the default
+ * ever drifted, every existing untyped consumer would break.
+ */
+export async function _assertUntypedDefaultTCtx(): Promise<void> {
+  const ctx: GateEvaluationContext = { foo: 'bar' };
+  await composeDockAvailability({
+    tools: [{ id: 't', label: 'T' }],
+    context: ctx,
+    evaluators: {},
+  });
+}

--- a/packages/smrt-svelte/src/components/workspace/server/compose-availability.ts
+++ b/packages/smrt-svelte/src/components/workspace/server/compose-availability.ts
@@ -1,0 +1,104 @@
+/**
+ * Server-side dock availability gate composer.
+ *
+ * Consumer's `fetchAvailability` endpoint calls `composeDockAvailability`
+ * with the registered tools, a caller-supplied context, and a map of
+ * gate evaluators (typically wrapping `PermissionResolver` from
+ * smrt-users and `FeatureResolver` from smrt-features). It returns the
+ * filtered `AvailableTool[]` the dock's client-side `fetchAvailability`
+ * resolves to.
+ *
+ * Server-side by design: no Svelte / DOM imports, no client-only state.
+ * See happyvertical/smrt#1226 (Phase 4c) and #1235 for the registry
+ * audit that motivated this server-first pattern.
+ */
+
+import type { AvailableTool } from '../types.js';
+import type { ComposeDockAvailabilityOptions } from './types.js';
+
+/**
+ * Compose the `availableTools` list for a tools dock by evaluating each
+ * tool's `gates` against the provided evaluators. Tools where ALL gates
+ * resolve to `true` are included (AND semantics).
+ *
+ * Tools without `gates` (or with an empty `gates` array) are
+ * unconditionally included — gating is opt-in, existing tool definitions
+ * keep working.
+ *
+ * Throws if a gate's prefix doesn't match any registered evaluator —
+ * misconfiguration should fail loudly, not silently leak tools to users
+ * who shouldn't see them.
+ *
+ * Gate evaluation is parallel within a tool and across tools (`Promise.all`
+ * fan-out), so a slow evaluator on one gate doesn't block unrelated tools.
+ *
+ * @example
+ * ```ts
+ * import { composeDockAvailability } from '@happyvertical/smrt-svelte/workspace/server';
+ * import { PermissionResolver } from '@happyvertical/smrt-users';
+ * import { FeatureResolver } from '@happyvertical/smrt-features';
+ *
+ * const available = await composeDockAvailability({
+ *   tools: [
+ *     { id: 'governance', label: 'Claim Audit', gates: ['permission:content.governance.view'] },
+ *     { id: 'video-gen',  label: 'Video',       gates: ['feature:video-tools'] },
+ *     { id: 'chat',       label: 'Chat' }, // no gates → always visible
+ *   ],
+ *   context: { userId: 'user-1', tenantId: 'tenant-1' },
+ *   evaluators: {
+ *     permission: async (gateId, ctx) => {
+ *       const [, slug] = gateId.split(':', 2);
+ *       return permissionResolver.hasPermission(
+ *         ctx.userId as string,
+ *         ctx.tenantId as string,
+ *         slug,
+ *       );
+ *     },
+ *     feature: async (gateId, ctx) => {
+ *       const [, key] = gateId.split(':', 2);
+ *       return featureResolver.isEnabled(key, { tenantId: ctx.tenantId as string });
+ *     },
+ *   },
+ * });
+ * // → AvailableTool[] filtered by gates
+ * ```
+ */
+export async function composeDockAvailability(
+  options: ComposeDockAvailabilityOptions,
+): Promise<AvailableTool[]> {
+  const { tools, context, evaluators } = options;
+
+  const evaluations = await Promise.all(
+    tools.map(async (tool) => {
+      if (!tool.gates || tool.gates.length === 0) {
+        return tool; // no gates → visible
+      }
+
+      const gateResults = await Promise.all(
+        tool.gates.map(async (gateId) => {
+          const prefix = gateId.split(':', 1)[0];
+          const evaluator = evaluators[prefix];
+          if (!evaluator) {
+            const availablePrefixes =
+              Object.keys(evaluators).join(', ') || '(none)';
+            throw new Error(
+              `[composeDockAvailability] No evaluator registered for gate prefix "${prefix}" ` +
+                `(tool "${tool.id}", gate "${gateId}"). Available prefixes: ${availablePrefixes}.`,
+            );
+          }
+          return evaluator(gateId, context);
+        }),
+      );
+
+      return gateResults.every(Boolean) ? tool : null;
+    }),
+  );
+
+  return evaluations
+    .filter((t): t is NonNullable<typeof t> => t !== null)
+    .map((tool) => ({
+      id: tool.id,
+      label: tool.label ?? '',
+      badge: tool.badge ?? null,
+    }));
+}

--- a/packages/smrt-svelte/src/components/workspace/server/compose-availability.ts
+++ b/packages/smrt-svelte/src/components/workspace/server/compose-availability.ts
@@ -73,7 +73,7 @@ import type {
  * ```
  */
 export async function composeDockAvailability<
-  TCtx extends GateEvaluationContext = GateEvaluationContext,
+  TCtx extends { [K in keyof TCtx]: unknown } = GateEvaluationContext,
 >(options: ComposeDockAvailabilityOptions<TCtx>): Promise<AvailableTool[]> {
   const { tools, context, evaluators } = options;
 
@@ -107,11 +107,12 @@ export async function composeDockAvailability<
         }),
       );
 
-      // every(Boolean) is intentional: coerces resolved values truthily.
-      // GateEvaluator is typed boolean, but truthy coercion ensures
-      // fail-closed behavior for any untyped evaluator that returns
-      // void/undefined.
-      return gateResults.every(Boolean) ? tool : null;
+      // Strict equality: only literal `true` passes a gate. Any non-boolean
+      // return value (string, object, undefined, etc.) fails-closed —
+      // defensive against untyped evaluators that return wrapped objects or
+      // sentinel strings instead of plain booleans. `Boolean(...)` would
+      // pass `'false'`, `{}`, `[]`, and any truthy garbage, fail-OPEN.
+      return gateResults.every((result) => result === true) ? tool : null;
     }),
   );
 

--- a/packages/smrt-svelte/src/components/workspace/server/compose-availability.ts
+++ b/packages/smrt-svelte/src/components/workspace/server/compose-availability.ts
@@ -14,7 +14,10 @@
  */
 
 import type { AvailableTool } from '../types.js';
-import type { ComposeDockAvailabilityOptions } from './types.js';
+import type {
+  ComposeDockAvailabilityOptions,
+  GateEvaluationContext,
+} from './types.js';
 
 /**
  * Compose the `availableTools` list for a tools dock by evaluating each
@@ -34,11 +37,21 @@ import type { ComposeDockAvailabilityOptions } from './types.js';
  *
  * @example
  * ```ts
- * import { composeDockAvailability } from '@happyvertical/smrt-svelte/workspace/server';
+ * import {
+ *   composeDockAvailability,
+ *   type GateEvaluationContext,
+ * } from '@happyvertical/smrt-svelte/workspace/server';
  * import { PermissionResolver } from '@happyvertical/smrt-users';
  * import { FeatureResolver } from '@happyvertical/smrt-features';
  *
- * const available = await composeDockAvailability({
+ * // Caller narrows the context shape so evaluators get typed access
+ * // without casts:
+ * interface MyContext extends GateEvaluationContext {
+ *   userId: string;
+ *   tenantId: string;
+ * }
+ *
+ * const available = await composeDockAvailability<MyContext>({
  *   tools: [
  *     { id: 'governance', label: 'Claim Audit', gates: ['permission:content.governance.view'] },
  *     { id: 'video-gen',  label: 'Video',       gates: ['feature:video-tools'] },
@@ -48,24 +61,20 @@ import type { ComposeDockAvailabilityOptions } from './types.js';
  *   evaluators: {
  *     permission: async (gateId, ctx) => {
  *       const [, slug] = gateId.split(':', 2);
- *       return permissionResolver.hasPermission(
- *         ctx.userId as string,
- *         ctx.tenantId as string,
- *         slug,
- *       );
+ *       return permissionResolver.hasPermission(ctx.userId, ctx.tenantId, slug);
  *     },
  *     feature: async (gateId, ctx) => {
  *       const [, key] = gateId.split(':', 2);
- *       return featureResolver.isEnabled(key, { tenantId: ctx.tenantId as string });
+ *       return featureResolver.isEnabled(key, { tenantId: ctx.tenantId });
  *     },
  *   },
  * });
  * // → AvailableTool[] filtered by gates
  * ```
  */
-export async function composeDockAvailability(
-  options: ComposeDockAvailabilityOptions,
-): Promise<AvailableTool[]> {
+export async function composeDockAvailability<
+  TCtx extends GateEvaluationContext = GateEvaluationContext,
+>(options: ComposeDockAvailabilityOptions<TCtx>): Promise<AvailableTool[]> {
   const { tools, context, evaluators } = options;
 
   const evaluations = await Promise.all(
@@ -77,8 +86,16 @@ export async function composeDockAvailability(
       const gateResults = await Promise.all(
         tool.gates.map(async (gateId) => {
           const prefix = gateId.split(':', 1)[0];
-          const evaluator = evaluators[prefix];
-          if (!evaluator) {
+          // Use Object.hasOwn() + a function-type guard so a gate like
+          // `constructor:foo` or `toString:foo` doesn't resolve to an
+          // inherited `Object.prototype` property and silently pass — the
+          // contract is fail-loud on unknown prefix. The function-type
+          // check is belt-and-suspenders: a consumer that accidentally
+          // wires a non-function evaluator should also throw here.
+          const evaluator = Object.hasOwn(evaluators, prefix)
+            ? evaluators[prefix]
+            : undefined;
+          if (typeof evaluator !== 'function') {
             const availablePrefixes =
               Object.keys(evaluators).join(', ') || '(none)';
             throw new Error(
@@ -90,15 +107,25 @@ export async function composeDockAvailability(
         }),
       );
 
+      // every(Boolean) is intentional: coerces resolved values truthily.
+      // GateEvaluator is typed boolean, but truthy coercion ensures
+      // fail-closed behavior for any untyped evaluator that returns
+      // void/undefined.
       return gateResults.every(Boolean) ? tool : null;
     }),
   );
 
   return evaluations
     .filter((t): t is NonNullable<typeof t> => t !== null)
-    .map((tool) => ({
-      id: tool.id,
-      label: tool.label ?? '',
-      badge: tool.badge ?? null,
-    }));
+    .map((tool) => {
+      // Preserve absence: omitting `label` / `badge` here lets
+      // `defineToolsDock.applyAvailability` fall back to the registered
+      // `ToolDef` metadata. Materializing `label: ''` would blank the rail
+      // button, and `badge: null` would explicitly clear any registered
+      // default badge.
+      const out: AvailableTool = { id: tool.id };
+      if (tool.label !== undefined) out.label = tool.label;
+      if (tool.badge !== undefined) out.badge = tool.badge;
+      return out;
+    });
 }

--- a/packages/smrt-svelte/src/components/workspace/server/index.ts
+++ b/packages/smrt-svelte/src/components/workspace/server/index.ts
@@ -1,0 +1,19 @@
+/**
+ * @happyvertical/smrt-svelte/workspace/server
+ *
+ * Server-only utilities for the workspace shell — currently the dock
+ * availability gate composer (Phase 4c per happyvertical/smrt#1226).
+ *
+ * Node-safe: no Svelte component imports, no browser-only APIs. Import
+ * this subpath from `+server.ts` endpoints, REST handlers, or anywhere
+ * else outside the client bundle.
+ */
+
+export { composeDockAvailability } from './compose-availability.js';
+export type {
+  AvailableTool,
+  ComposeDockAvailabilityOptions,
+  GatedToolSummary,
+  GateEvaluationContext,
+  GateEvaluator,
+} from './types.js';

--- a/packages/smrt-svelte/src/components/workspace/server/types.ts
+++ b/packages/smrt-svelte/src/components/workspace/server/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Types for the server-side dock availability gate composer.
+ *
+ * See `compose-availability.ts` for the runtime utility and
+ * happyvertical/smrt#1226 (Phase 4c) / #1235 for design context.
+ *
+ * This module is intentionally Node-safe — no Svelte component imports,
+ * no `window`/`document`, no browser-only APIs — so consumers can call it
+ * from server endpoints (`+server.ts`, REST handlers, etc.).
+ */
+
+import type { AvailableTool, ToolDef } from '../types.js';
+
+/**
+ * Context passed to each gate evaluator. Consumer-defined keys (userId,
+ * tenantId, contentId, etc.) carry the data evaluators need to resolve
+ * a gate to a boolean. The composer doesn't introspect this — it's a
+ * pass-through.
+ */
+export type GateEvaluationContext = Record<string, unknown>;
+
+/**
+ * Resolves a gate ID to a boolean (visible / not visible). May be async
+ * (DB query, network call, permission resolver). Sync evaluators that
+ * return a plain boolean are also fine.
+ *
+ * @param gateId Full gate id, including the prefix (e.g. `'permission:articles.publish'`).
+ *               Evaluators typically split on `:` to extract the identifier.
+ * @param context The caller-supplied context blob (see {@link GateEvaluationContext}).
+ */
+export type GateEvaluator = (
+  gateId: string,
+  context: GateEvaluationContext,
+) => Promise<boolean> | boolean;
+
+/**
+ * Tool definition shape required by `composeDockAvailability`. A subset of
+ * the full {@link ToolDef} that drops Svelte-specific fields (`component`,
+ * `iconComponent`) so the composer stays server-side-safe. Consumers
+ * typically derive this from their registered `ToolDef[]` by picking the
+ * fields they want to surface in `availableTools`.
+ */
+export interface GatedToolSummary {
+  id: string;
+  label?: string;
+  badge?: number | string | null;
+  gates?: string[];
+}
+
+/**
+ * Options for {@link composeDockAvailability}.
+ */
+export interface ComposeDockAvailabilityOptions {
+  /** Registered tools (or a subset thereof — typically derived from `ToolDef[]`). */
+  tools: ReadonlyArray<GatedToolSummary>;
+  /**
+   * Caller-supplied context (userId, tenantId, contentId, etc.). Passed
+   * through unchanged to each evaluator. The composer doesn't inspect it.
+   */
+  context: GateEvaluationContext;
+  /**
+   * Map of gate-prefix → evaluator. The prefix is the part of the gate ID
+   * before the first `:`. e.g., `'permission'`, `'feature'`, `'myapp'`.
+   *
+   * Tools whose gates reference an unregistered prefix throw at composition
+   * time — misconfiguration should fail loudly, not silently leak tools.
+   */
+  evaluators: Record<string, GateEvaluator>;
+}
+
+// Re-export AvailableTool so consumers can pull both the composer
+// signature and the return-element type from this server subpath without
+// reaching into the Svelte-aware barrel.
+export type { AvailableTool };

--- a/packages/smrt-svelte/src/components/workspace/server/types.ts
+++ b/packages/smrt-svelte/src/components/workspace/server/types.ts
@@ -28,12 +28,20 @@ export type GateEvaluationContext = Record<string, unknown>;
  * to context fields without casting. Defaults to the permissive
  * `GateEvaluationContext` so existing call sites keep compiling.
  *
+ * The constraint is a self-mapped `{ [K in keyof TCtx]: unknown }` rather
+ * than `Record<string, unknown>`. This accepts interface-style consumer
+ * contexts without an explicit string index signature — the same trap
+ * Copilot flagged on `TActions` in #1239. A bare `Record<string, unknown>`
+ * constraint rejects interfaces (which have no index signature) under
+ * strict TS, forcing consumers to use type aliases or add
+ * `[key: string]: unknown`.
+ *
  * @param gateId Full gate id, including the prefix (e.g. `'permission:articles.publish'`).
  *               Evaluators typically split on `:` to extract the identifier.
  * @param context The caller-supplied context blob (see {@link GateEvaluationContext}).
  */
 export type GateEvaluator<
-  TCtx extends GateEvaluationContext = GateEvaluationContext,
+  TCtx extends { [K in keyof TCtx]: unknown } = GateEvaluationContext,
 > = (gateId: string, context: TCtx) => Promise<boolean> | boolean;
 
 /**
@@ -58,9 +66,13 @@ export interface GatedToolSummary {
  * permissive `GateEvaluationContext` so existing call sites keep
  * compiling.
  *
+ * The constraint is a self-mapped `{ [K in keyof TCtx]: unknown }` so
+ * interface-style contexts (no string index signature) are accepted —
+ * see the doc on {@link GateEvaluator} for the rationale.
+ *
  * @example
  * ```ts
- * interface MyContext extends GateEvaluationContext {
+ * interface MyContext {
  *   userId: string;
  *   tenantId: string;
  * }
@@ -79,7 +91,7 @@ export interface GatedToolSummary {
  * ```
  */
 export interface ComposeDockAvailabilityOptions<
-  TCtx extends GateEvaluationContext = GateEvaluationContext,
+  TCtx extends { [K in keyof TCtx]: unknown } = GateEvaluationContext,
 > {
   /** Registered tools (or a subset thereof — typically derived from `ToolDef[]`). */
   tools: ReadonlyArray<GatedToolSummary>;

--- a/packages/smrt-svelte/src/components/workspace/server/types.ts
+++ b/packages/smrt-svelte/src/components/workspace/server/types.ts
@@ -24,14 +24,17 @@ export type GateEvaluationContext = Record<string, unknown>;
  * (DB query, network call, permission resolver). Sync evaluators that
  * return a plain boolean are also fine.
  *
+ * Generic over the caller's context shape so evaluators get typed access
+ * to context fields without casting. Defaults to the permissive
+ * `GateEvaluationContext` so existing call sites keep compiling.
+ *
  * @param gateId Full gate id, including the prefix (e.g. `'permission:articles.publish'`).
  *               Evaluators typically split on `:` to extract the identifier.
  * @param context The caller-supplied context blob (see {@link GateEvaluationContext}).
  */
-export type GateEvaluator = (
-  gateId: string,
-  context: GateEvaluationContext,
-) => Promise<boolean> | boolean;
+export type GateEvaluator<
+  TCtx extends GateEvaluationContext = GateEvaluationContext,
+> = (gateId: string, context: TCtx) => Promise<boolean> | boolean;
 
 /**
  * Tool definition shape required by `composeDockAvailability`. A subset of
@@ -49,15 +52,42 @@ export interface GatedToolSummary {
 
 /**
  * Options for {@link composeDockAvailability}.
+ *
+ * Generic over the caller's context shape (`TCtx`) so evaluators get
+ * typed access to context fields without casting. Defaults to the
+ * permissive `GateEvaluationContext` so existing call sites keep
+ * compiling.
+ *
+ * @example
+ * ```ts
+ * interface MyContext extends GateEvaluationContext {
+ *   userId: string;
+ *   tenantId: string;
+ * }
+ *
+ * await composeDockAvailability<MyContext>({
+ *   tools: [...],
+ *   context: { userId: 'u-1', tenantId: 't-1' },
+ *   evaluators: {
+ *     permission: async (gateId, ctx) => {
+ *       // ctx.userId and ctx.tenantId are typed `string` — no cast needed
+ *       const [, slug] = gateId.split(':', 2);
+ *       return resolver.hasPermission(ctx.userId, ctx.tenantId, slug);
+ *     },
+ *   },
+ * });
+ * ```
  */
-export interface ComposeDockAvailabilityOptions {
+export interface ComposeDockAvailabilityOptions<
+  TCtx extends GateEvaluationContext = GateEvaluationContext,
+> {
   /** Registered tools (or a subset thereof — typically derived from `ToolDef[]`). */
   tools: ReadonlyArray<GatedToolSummary>;
   /**
    * Caller-supplied context (userId, tenantId, contentId, etc.). Passed
    * through unchanged to each evaluator. The composer doesn't inspect it.
    */
-  context: GateEvaluationContext;
+  context: TCtx;
   /**
    * Map of gate-prefix → evaluator. The prefix is the part of the gate ID
    * before the first `:`. e.g., `'permission'`, `'feature'`, `'myapp'`.
@@ -65,7 +95,7 @@ export interface ComposeDockAvailabilityOptions {
    * Tools whose gates reference an unregistered prefix throw at composition
    * time — misconfiguration should fail loudly, not silently leak tools.
    */
-  evaluators: Record<string, GateEvaluator>;
+  evaluators: Record<string, GateEvaluator<TCtx>>;
 }
 
 // Re-export AvailableTool so consumers can pull both the composer

--- a/packages/smrt-svelte/src/components/workspace/types.ts
+++ b/packages/smrt-svelte/src/components/workspace/types.ts
@@ -150,22 +150,25 @@ export interface ToolDef {
    * Optional gate IDs that must all evaluate to true for the tool to be
    * visible. Convention: `<subsystem>:<identifier>`, e.g.:
    *
-   *   - `'permission:articles.publish'`
-   *   - `'feature:video-tools'`
-   *   - `'user-pref:show-jobs'`
+   *   - `'permission:articles.publish'` (consumer wires a `PermissionResolver` as the `permission` evaluator)
+   *   - `'feature:video-tools'`        (consumer wires a `FeatureResolver` as the `feature` evaluator)
+   *   - `'myapp:my-custom-gate'`       (consumer wires their own evaluator)
    *
    * Gates are evaluated server-side via `composeDockAvailability` from
    * `@happyvertical/smrt-svelte/workspace/server`. Each gate's prefix
-   * (text before the `:`) selects which evaluator handles it; tools with
-   * unknown prefixes throw at composition time (loud-fail beats
-   * silent-leak).
+   * (text before the `:`) selects the evaluator from the caller-supplied
+   * map. The framework does NOT ship built-in evaluators — consumers
+   * register evaluators for every prefix they use. Tools with unknown
+   * prefixes throw at composition time (loud-fail beats silent-leak).
    *
-   * Reserved prefixes (used by built-in evaluators):
-   *   - `permission:` — RBAC, via smrt-users
-   *   - `feature:` — feature flags, via smrt-features (if available)
+   * Recommended prefix conventions for ecosystem cohesion (not enforced —
+   * the framework treats every prefix as caller-defined):
+   *   - `permission:` for RBAC checks (typically wraps smrt-users)
+   *   - `feature:` for feature flags (typically wraps smrt-features)
+   *   - `user-pref:` for per-user UI settings
    *
-   * Consumer-defined prefixes (e.g., `myapp:`) are fine; consumer must
-   * register the evaluator.
+   * Consumers writing their own gates should pick an app-specific
+   * namespace (e.g., `myapp:`) to avoid colliding with future built-ins.
    */
   gates?: string[];
 }

--- a/packages/smrt-svelte/src/components/workspace/types.ts
+++ b/packages/smrt-svelte/src/components/workspace/types.ts
@@ -146,6 +146,28 @@ export interface ToolDef {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   component: Component<any>;
   badge?: number | string | null;
+  /**
+   * Optional gate IDs that must all evaluate to true for the tool to be
+   * visible. Convention: `<subsystem>:<identifier>`, e.g.:
+   *
+   *   - `'permission:articles.publish'`
+   *   - `'feature:video-tools'`
+   *   - `'user-pref:show-jobs'`
+   *
+   * Gates are evaluated server-side via `composeDockAvailability` from
+   * `@happyvertical/smrt-svelte/workspace/server`. Each gate's prefix
+   * (text before the `:`) selects which evaluator handles it; tools with
+   * unknown prefixes throw at composition time (loud-fail beats
+   * silent-leak).
+   *
+   * Reserved prefixes (used by built-in evaluators):
+   *   - `permission:` — RBAC, via smrt-users
+   *   - `feature:` — feature flags, via smrt-features (if available)
+   *
+   * Consumer-defined prefixes (e.g., `myapp:`) are fine; consumer must
+   * register the evaluator.
+   */
+  gates?: string[];
 }
 
 export interface AvailableTool {


### PR DESCRIPTION
## Summary

Phase 4c of the workspace shell epic ([#1226](https://github.com/happyvertical/smrt/issues/1226)). Implements the server-first design from the registry audit ([#1235](https://github.com/happyvertical/smrt/issues/1235)): a reusable server-only utility that filters a registered tool list by evaluating declarative gates against a caller-supplied map of evaluators.

- New `ToolDef.gates?: string[]` field (optional, back-compat). Convention `<subsystem>:<identifier>` (e.g. `permission:articles.publish`, `feature:video-tools`, `myapp:show-jobs`).
- New `./workspace/server` subpath exporting `composeDockAvailability`. Node-safe — no Svelte, no `window`/`document`, no browser-only APIs. Safe to import from `+server.ts`.
- Evaluators are a `Record<prefix, GateEvaluator>` map. Sync or async. AND semantics across a tool's gates. Parallel evaluation within and across tools.
- Unknown gate prefix throws with a clear message naming the tool, the gate, and the registered prefixes — loud-fail beats silent-leak.
- No new package deps; no changes to the dock's client surface — the dock still consumes `availableTools` from the same `fetchAvailability` endpoint.

### Worked example

```ts
// +server.ts
import { composeDockAvailability } from '@happyvertical/smrt-svelte/workspace/server';
import { PermissionResolver } from '@happyvertical/smrt-users';
import { FeatureResolver } from '@happyvertical/smrt-features';

export async function POST({ locals, request }) {
  const ctx = await request.json();
  const available = await composeDockAvailability({
    tools: REGISTERED_TOOLS, // pick { id, label, badge, gates } off each ToolDef
    context: { userId: locals.user.id, tenantId: locals.tenant.id, ...ctx },
    evaluators: {
      permission: async (gateId, ctx) => {
        const [, slug] = gateId.split(':', 2);
        return permissionResolver.hasPermission(
          ctx.userId as string,
          ctx.tenantId as string,
          slug,
        );
      },
      feature: async (gateId, ctx) => {
        const [, key] = gateId.split(':', 2);
        return featureResolver.isEnabled(key, { tenantId: ctx.tenantId as string });
      },
    },
  });
  return Response.json({ tools: available });
}
```

### Design notes

- Server-first per #1235. Neither `smrt-users` nor `smrt-features` has a `/svelte` subpath today, and the registry audit concluded that adding client-side gate hooks before there's a concrete use case would be premature. The dock's client surface is unchanged.
- Evaluator map (vs array): one evaluator per prefix, indexed by `gateId.split(':')[0]`. Faster lookup, simpler caller wiring (`{ permission: ..., feature: ... }` reads cleanly), and the prefix-routing convention is enforced by the data structure rather than by string matching at each evaluator.
- `GatedToolSummary` is intentionally a subset of `ToolDef` — it drops `component`/`iconComponent` so the composer module never has to touch a Svelte type, which keeps the `./workspace/server` subpath usable from any Node environment.

### Anytown follow-up

Anytown's hand-coded `apps/dashboard/src/lib/server/content-tool-dock.ts` is a candidate for migration in a follow-up — out of scope here so we land the framework primitive cleanly first.

## Test plan

- [x] `pnpm build` in `packages/smrt-svelte/` — clean
- [x] `pnpm test` in `packages/smrt-svelte/` — 211 passed (15 files), incl. 19 new composer tests
- [x] `pnpm typecheck` (`tsc --noEmit` + `svelte-check`) — 0 errors
- [x] `pnpm verify:pack` — new `./workspace/server` export resolves to `dist/components/workspace/server/index.{d.ts,js}`
- [x] Server output verified Node-safe (no Svelte / DOM imports outside comments)

Refs: happyvertical/smrt#1226 (epic) - happyvertical/smrt#1235 (registry audit)