### PR TITLE
[codex] add svelte-check typechecks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,5 +107,6 @@ From [@happyvertical/sdk](https://github.com/happyvertical/sdk): `@happyvertical
 - **Manifest is build-time**: generated once at vitest startup — restart after adding new `@smrt()` classes
 - **ObjectRegistry on globalThis**: singleton via `globalThis.__smrtRegistry*` — survives HMR
 - **No runtime schema creation**: application tables must be prepared explicitly via migrations/tooling; runtime only verifies and fails clearly
+- **Svelte typechecking**: packages with `/svelte` subpaths must run `svelte-check` in `typecheck` after `tsc`; `tsc` alone treats `.svelte` imports as ambient `Component<any>`.
 - **TypeScript & Svelte 5 Performance**: Avoid using inline intersected generic types (like `Asset & { id: string }`) in component `$props()`. It causes infinite-loop-like recursion during type evaluation. Export an explicit interface (e.g., `interface PersistedAsset extends Asset { id: string }`) instead.
 - **Editing `packages/core/src/scanner/*` or `src/schema/generator.ts` requires a rebuild**: the vite-plugin loads these modules from `dist/` deterministically (sniffing `.ts`/`.js` via `import.meta.url` was non-deterministic under tsx and repeatedly broke publishes — see #1139). Run `pnpm build` in core, or keep `pnpm dev` / `pnpm build:watch` running, otherwise consumers won't see your scanner/generator edits reflected in their manifests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,5 +106,6 @@ From [@happyvertical/sdk](https://github.com/happyvertical/sdk): `@happyvertical
 - **Manifest is build-time**: generated once at vitest startup — restart after adding new `@smrt()` classes
 - **ObjectRegistry on globalThis**: singleton via `globalThis.__smrtRegistry*` — survives HMR
 - **Lazy table creation**: tables created on first DB op, not on `initialize()` — safe for SSR
+- **Svelte typechecking**: packages with `/svelte` subpaths must run `svelte-check` in `typecheck` after `tsc`; `tsc` alone treats `.svelte` imports as ambient `Component<any>`.
 - **TypeScript & Svelte 5 Performance**: Avoid using inline intersected generic types (like `Asset & { id: string }`) in component `$props()`. It causes infinite-loop-like recursion during type evaluation. Export an explicit interface (e.g., `interface PersistedAsset extends Asset { id: string }`) instead.
 - **Editing `packages/core/src/scanner/*` or `src/schema/generator.ts` requires a rebuild**: the vite-plugin loads these modules from `dist/` deterministically (sniffing `.ts`/`.js` via `import.meta.url` was non-deterministic under tsx and repeatedly broke publishes — see #1139). Run `pnpm build` in core, or keep `pnpm dev` / `pnpm build:watch` running, otherwise consumers won't see your scanner/generator edits reflected in their manifests.

--- a/docs/content/standards.md
+++ b/docs/content/standards.md
@@ -302,6 +302,7 @@ These are already documented in the root `CLAUDE.md` and `.claude/rules/smrt-pat
 - **`./playground` subpath**: exports the package's playground module for use by `smrt-playground`
 - **Svelte peer**: `svelte: ^5.18.0` (uniform). Drop the `^4.0.0 || ^5.0.0` range.
 - **Build script**: `vite build && svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json`
+- **Typecheck script**: packages with `./svelte` exports must run both TypeScript and Svelte checks, e.g. `tsc --noEmit && svelte-check --tsconfig ./tsconfig.svelte.json`. SvelteKit-backed packages should run `svelte-kit sync` before both the TypeScript and `svelte-check` passes.
 - **`tsconfig.svelte.json`**: extends `tsconfig.package-svelte.json`, includes `ambient.d.ts` and `*.svelte`
 
 ---
@@ -337,6 +338,7 @@ Templates ship a `template/` directory that is copied wholesale by the scaffold 
 - All files referenced in `template/package.json` scripts must actually exist in `template/`
 - `template/README.md` ≥100 lines, explaining the scaffolding flow and runtime parameters
 - CI verifies that `pnpm install && pnpm build` succeeds in each scaffolded template (would have caught the `template-site-static-json` missing-`caelus.ts` bug)
+- Scaffolded SvelteKit templates must ship `typecheck` as a TypeScript pass plus `svelte-check`; otherwise generated projects inherit the `.svelte` ambient typing gap.
 
 ---
 

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -46,6 +46,7 @@
     "clean": "rm -rf dist",
     "dev": "vite dev",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -66,6 +67,7 @@
     "@happyvertical/smrt-core": "workspace:*",
     "@happyvertical/smrt-secrets": "workspace:*",
     "@happyvertical/smrt-tenancy": "workspace:*",
+    "@happyvertical/smrt-types": "workspace:*",
     "@happyvertical/smrt-users": "workspace:*",
     "@happyvertical/utils": "catalog:"
   },

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -34,6 +34,7 @@
     "build": "vite build --mode library && svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json",
     "build:watch": "vite build --mode library --watch",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "clean": "rm -rf dist",
     "dev": "vite dev",
     "prepack": "node ../../scripts/prepack-package.js",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -41,7 +41,7 @@
     "pretest": "[ -f ../cli/dist/index.js ] && node ../cli/dist/index.js test --manifest-only || true",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "typecheck": "svelte-kit sync && tsc -p tsconfig.typecheck.json && svelte-check --tsconfig ./tsconfig.kit.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },
   "dependencies": {

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -37,7 +37,7 @@
     "dev": "npm run build:watch",
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },

--- a/packages/commerce/package.json
+++ b/packages/commerce/package.json
@@ -33,7 +33,7 @@
     "dev": "npm run build:watch",
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -46,6 +46,7 @@
     "test:e2e": "pnpm exec playwright test -c playwright.config.ts",
     "test:e2e:headed": "pnpm exec playwright test -c playwright.config.ts --headed",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.kit.json",
+    "typecheck": "svelte-kit sync && tsc -p tsconfig.typecheck.json && svelte-check --tsconfig ./tsconfig.kit.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },
   "dependencies": {

--- a/packages/content/src/route-loaders.ts
+++ b/packages/content/src/route-loaders.ts
@@ -35,13 +35,18 @@ export function isContentRouteLoadError(
   );
 }
 
-function getItemData<T>(payload: T | { data?: T; result?: T }): T {
-  if (payload && typeof payload === 'object' && 'result' in payload) {
-    return (payload as { result: T }).result;
+function getItemData<T>(payload: unknown): T {
+  if (!payload || typeof payload !== 'object') {
+    return payload as T;
   }
 
-  if (payload && typeof payload === 'object' && 'data' in payload) {
-    return (payload as { data: T }).data;
+  const wrappedPayload = payload as { data?: unknown; result?: unknown };
+  if ('result' in wrappedPayload) {
+    return wrappedPayload.result as T;
+  }
+
+  if ('data' in wrappedPayload) {
+    return wrappedPayload.data as T;
   }
 
   return payload as T;

--- a/packages/content/tsconfig.typecheck.json
+++ b/packages/content/tsconfig.typecheck.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.package-typecheck.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "src/svelte/**/*",
+    "src/routes/**/*",
+    "src/hooks.server.ts",
+    "src/playground.ts",
+    "src/route-module.ts"
+  ]
+}

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -43,7 +43,7 @@
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "echo '⏭️  Skipping events typecheck (use npm run check instead)'",
+    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },
   "peerDependencies": {

--- a/packages/images/package.json
+++ b/packages/images/package.json
@@ -40,6 +40,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.kit.json",
+    "typecheck": "svelte-kit sync && tsc -p tsconfig.typecheck.json && svelte-check --tsconfig ./tsconfig.kit.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },
   "dependencies": {

--- a/packages/images/src/lib/server/smrt-register.ts
+++ b/packages/images/src/lib/server/smrt-register.ts
@@ -13,4 +13,7 @@ import { Image } from '../../image';
 import '../../images';
 
 // Re-register imported objects with explicit package names for bundled runtimes
-ObjectRegistry.register(Image, { packageName: '@happyvertical/smrt-images' });
+ObjectRegistry.register(Image, {
+  name: 'Image',
+  packageName: '@happyvertical/smrt-images',
+});

--- a/packages/images/tsconfig.typecheck.json
+++ b/packages/images/tsconfig.typecheck.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.package-typecheck.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "src/svelte/**/*",
+    "src/routes/**/*",
+    "src/playground.ts",
+    "src/route-module.ts"
+  ]
+}

--- a/packages/images/vite.config.ts
+++ b/packages/images/vite.config.ts
@@ -47,6 +47,14 @@ export default defineConfig(async ({ mode }) => {
     sourceEntry: 'packages/core/src/vite-plugin/index.ts',
     purpose: 'images package Vite config',
   });
+  const { smrtConsumer } = await importWorkspaceModule<
+    typeof import('@happyvertical/smrt-core/consumer-plugin')
+  >({
+    packageName: '@happyvertical/smrt-core/consumer-plugin',
+    distEntry: 'packages/core/dist/consumer-plugin.js',
+    sourceEntry: 'packages/core/src/consumer-plugin/index.ts',
+    purpose: 'images package consumer plugin',
+  });
 
   return {
     resolve: {
@@ -60,6 +68,10 @@ export default defineConfig(async ({ mode }) => {
     },
     plugins: [
       sveltekit(),
+      smrtConsumer({
+        projectRoot: process.cwd(),
+        svelteKit: true,
+      }),
       smrtPlugin({
         include: ['src/**/*.ts'],
         exclude: ['**/*.test.ts', '**/*.spec.ts', 'src/svelte/**/*', 'src/routes/**/*', '**/*.svelte'],

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -53,6 +53,7 @@
     "clean": "rm -rf dist",
     "dev": "vite dev",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -40,7 +40,7 @@
     "pretest": "[ -f ../cli/dist/index.js ] && node ../cli/dist/index.js test --manifest-only || true",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },
   "dependencies": {

--- a/packages/projects/package.json
+++ b/packages/projects/package.json
@@ -34,6 +34,7 @@
     "build": "vite build --mode library && svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json",
     "build:watch": "vite build --mode library --watch",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "clean": "rm -rf dist",
     "dev": "vite dev",
     "prepack": "node ../../scripts/prepack-package.js",

--- a/packages/smrt-playground/package.json
+++ b/packages/smrt-playground/package.json
@@ -31,6 +31,7 @@
     "clean": "rm -rf dist",
     "dev": "npm run build:watch",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."

--- a/packages/smrt-svelte/src/components/workspace/__tests__/context-forwarding-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/context-forwarding-harness.svelte
@@ -24,7 +24,6 @@ interface Props {
 
 const props: Props = $props();
 
-// biome-ignore lint/correctness/noUnusedVariables: noop component
 const NoopBody = (() => null) as never;
 
 const dock = defineToolsDock({
@@ -33,6 +32,8 @@ const dock = defineToolsDock({
 
 let currentContext = $state<ToolsDockContext | null | undefined>(undefined);
 
+// This harness intentionally snapshots the callback during component setup.
+// svelte-ignore state_referenced_locally
 props.onReady({
   dock,
   setContextProp: (next) => {

--- a/packages/smrt-svelte/src/components/workspace/__tests__/harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/harness.svelte
@@ -16,6 +16,10 @@ interface Props {
 }
 
 const props: Props = $props();
+// This harness intentionally snapshots initial options during setup.
+// svelte-ignore state_referenced_locally
 const dock = defineToolsDock(props.options);
+// This harness intentionally snapshots the callback during setup.
+// svelte-ignore state_referenced_locally
 props.onReady(dock);
 </script>

--- a/packages/smrt-svelte/src/components/workspace/__tests__/render-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/render-harness.svelte
@@ -39,9 +39,10 @@ const props: Props = $props();
 // Use a trivial inline component as the tool body; the renderer only checks
 // that ActiveTool is defined and renders a header — the body is irrelevant
 // for these tests.
-// biome-ignore lint/correctness/noUnusedVariables: noop component
 const NoopBody = (() => null) as never;
 
+// This harness intentionally snapshots initial render options during setup.
+// svelte-ignore state_referenced_locally
 const dock = defineToolsDock({
   tools: props.tools.map((t) => ({ ...t, component: NoopBody })),
   fetchAvailability: props.fetchAvailability,

--- a/packages/smrt-svelte/src/components/workspace/__tests__/role-shell-bind-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/role-shell-bind-harness.svelte
@@ -29,12 +29,16 @@ const {
   onReady,
 }: Props = $props();
 
+// This harness intentionally snapshots the initial bindable value.
+// svelte-ignore state_referenced_locally
 let mobileNavOpen = $state(initial);
 
 const content = createRawSnippet(() => ({
   render: () => '<span>content</span>',
 }));
 
+// This harness intentionally snapshots the callback during setup.
+// svelte-ignore state_referenced_locally
 onReady?.({
   setMobileNavOpen: (next: boolean) => {
     mobileNavOpen = next;

--- a/packages/smrt-svelte/src/components/workspace/__tests__/role-shell-switch-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/role-shell-switch-harness.svelte
@@ -19,12 +19,16 @@ interface Props {
 
 const { roles, initialRole, currentPath, onReady }: Props = $props();
 
+// This harness intentionally snapshots the initial role.
+// svelte-ignore state_referenced_locally
 let currentRole = $state(initialRole);
 
 const content = createRawSnippet(() => ({
   render: () => '<span>switch-harness</span>',
 }));
 
+// This harness intentionally snapshots the callback during setup.
+// svelte-ignore state_referenced_locally
 onReady?.({
   setCurrentRole: (id: string) => {
     currentRole = id;

--- a/packages/smrt-svelte/src/components/workspace/__tests__/use-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/use-harness.svelte
@@ -17,5 +17,7 @@ defineToolsDock({
 });
 // useToolsDock reads from the same component init scope's context tree.
 const api = useToolsDock();
+// This harness intentionally snapshots the callback during setup.
+// svelte-ignore state_referenced_locally
 onReady(api);
 </script>

--- a/packages/smrt-svelte/src/components/workspace/__tests__/workspace-shell-bind-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/workspace-shell-bind-harness.svelte
@@ -20,12 +20,16 @@ interface Props {
 
 const { initial = false, onReady }: Props = $props();
 
+// This harness intentionally snapshots the initial bindable value.
+// svelte-ignore state_referenced_locally
 let mobileNavOpen = $state(initial);
 
 const content = createRawSnippet(() => ({
   render: () => '<span>content</span>',
 }));
 
+// This harness intentionally snapshots the callback during setup.
+// svelte-ignore state_referenced_locally
 onReady?.({
   setMobileNavOpen: (next: boolean) => {
     mobileNavOpen = next;

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -40,6 +40,7 @@
     "build": "vite build --mode library && svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json",
     "build:watch": "vite build --mode library --watch",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/template-site-static-json/template/package.json
+++ b/packages/template-site-static-json/template/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "typecheck": "svelte-kit sync && tsc --noEmit && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "init-data": "tsx scripts/init-data.ts",
     "workflow:caelus": "node -e \"console.error('workflow:caelus requires @happyvertical/caelus to ship a CLI bin (tracked upstream). For now invoke the workflow from a script that imports the package directly.'); process.exit(1)\"",

--- a/packages/template-sveltekit/template/package.json
+++ b/packages/template-sveltekit/template/package.json
@@ -7,6 +7,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "typecheck": "svelte-kit sync && tsc --noEmit && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
   },
   "devDependencies": {

--- a/packages/tenancy/package.json
+++ b/packages/tenancy/package.json
@@ -47,6 +47,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },
   "dependencies": {

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -38,7 +38,7 @@
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
     "test:postgres": "DATABASE_URL=${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/test_db} vitest run",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       '@happyvertical/smrt-tenancy':
         specifier: workspace:*
         version: link:../tenancy
+      '@happyvertical/smrt-types':
+        specifier: workspace:*
+        version: link:../types
       '@happyvertical/smrt-users':
         specifier: workspace:*
         version: link:../users

--- a/vite.config.base.ts
+++ b/vite.config.base.ts
@@ -203,7 +203,7 @@ export function createPackageConfig(
         './packages/core/src/utils/import-workspace-module.js'
       );
       const { smrtPlugin: plugin } = await importWorkspaceModule<
-        typeof import('@happyvertical/smrt-core/vite-plugin')
+        typeof import('./packages/core/src/vite-plugin/index.js')
       >({
         packageName: '@happyvertical/smrt-core/vite-plugin',
         distEntry: 'packages/core/dist/vite-plugin.js',


### PR DESCRIPTION
## Summary

- Add `svelte-check` to `typecheck` for packages exporting `/svelte` subpaths and for scaffolded SvelteKit templates.
- Add dedicated SvelteKit package typecheck configs where needed and document the rule in repo docs.
- Fix issues exposed by the stricter checks in agents, content, images, shared Vite config, and smrt-svelte harnesses.

## Why

`tsc` alone treats `.svelte` imports through ambient component types, so Svelte component diagnostics were missing from package typecheck runs.

Fixes #1241.

## Validation

- `pnpm exec turbo typecheck --filter=@happyvertical/smrt-agents --filter=@happyvertical/smrt-analytics --filter=@happyvertical/smrt-assets --filter=@happyvertical/smrt-chat --filter=@happyvertical/smrt-commerce --filter=@happyvertical/smrt-content --filter=@happyvertical/smrt-events --filter=@happyvertical/smrt-images --filter=@happyvertical/smrt-jobs --filter=@happyvertical/smrt-messages --filter=@happyvertical/smrt-projects --filter=@happyvertical/smrt-playground --filter=@happyvertical/smrt-svelte --filter=@happyvertical/smrt-social --filter=@happyvertical/smrt-tenancy --filter=@happyvertical/smrt-users`
- `pnpm --filter @happyvertical/smrt-svelte typecheck`
- `git diff --check`
- pre-push format/workflow hooks