### PR TITLE
fix(content): keep contribution workflow status separate from intake decision

### DIFF
--- a/packages/content/src/svelte/components/ContentContributionInbox.svelte
+++ b/packages/content/src/svelte/components/ContentContributionInbox.svelte
@@ -39,6 +39,18 @@ const selectedContribution = $derived(
     null,
 );
 
+function workflowStatus(
+  contribution: ContentContributionData | null | undefined,
+) {
+  return contribution?.status || 'submitted';
+}
+
+function approveActionLabel(contribution: ContentContributionData) {
+  return workflowStatus(contribution) === 'approved'
+    ? 'Promote'
+    : 'Approve and promote';
+}
+
 $effect(() => {
   note = selectedContribution?.editorNotes || '';
   targetStatus = 'draft';
@@ -67,7 +79,7 @@ $effect(() => {
           >
             <strong>{contribution.title || contribution.contributionTypeKey || 'Untitled submission'}</strong>
             <span>{contribution.contributorName || contribution.contributorEmail || 'Unknown contributor'}</span>
-            <span class="pill">{contribution.status || 'submitted'}</span>
+            <span class="pill">{workflowStatus(contribution)}</span>
           </button>
         {/each}
       </div>
@@ -79,7 +91,7 @@ $effect(() => {
               <h4>{selectedContribution.title || 'Untitled submission'}</h4>
               <p>{selectedContribution.contributorName || selectedContribution.contributorEmail || 'Unknown contributor'}</p>
             </div>
-            <span class="pill">{selectedContribution.intakeDecision || selectedContribution.status || 'submitted'}</span>
+            <span class="pill">{workflowStatus(selectedContribution)}</span>
           </header>
 
           {#if selectedContribution.body}
@@ -101,6 +113,12 @@ $effect(() => {
               <dt>Promoted content</dt>
               <dd>{selectedContribution.promotedContentId || 'Not promoted yet'}</dd>
             </div>
+            {#if selectedContribution.intakeDecision}
+              <div>
+                <dt>Intake decision</dt>
+                <dd>{selectedContribution.intakeDecision}</dd>
+              </div>
+            {/if}
           </dl>
 
           <label>
@@ -125,7 +143,7 @@ $effect(() => {
                     note,
                   })}
               >
-                Approve
+                {approveActionLabel(selectedContribution)}
               </button>
             {/if}
 

--- a/packages/content/src/svelte/components/ContentContributionInbox.test.ts
+++ b/packages/content/src/svelte/components/ContentContributionInbox.test.ts
@@ -31,6 +31,79 @@ afterEach(() => {
 });
 
 describe('ContentContributionInbox', () => {
+  it('keeps intake decision separate from the primary workflow status', () => {
+    const target = renderInbox({
+      contributions: [
+        {
+          id: 'contribution-1',
+          title: 'Letter',
+          contributorEmail: 'reader@example.com',
+          status: 'submitted',
+          intakeDecision: 'accepted',
+        },
+      ],
+    });
+
+    const pills = Array.from(target.querySelectorAll('.pill')).map((pill) =>
+      pill.textContent?.trim(),
+    );
+
+    expect(pills).toContain('submitted');
+    expect(pills.filter((text) => text === 'submitted')).toHaveLength(2);
+    expect(pills).not.toContain('accepted');
+    expect(target.textContent).toContain('Intake decision');
+    expect(target.textContent).toContain('accepted');
+  });
+
+  it('labels submitted contribution approval as approve and promote', () => {
+    const target = renderInbox({
+      contributions: [
+        {
+          id: 'contribution-1',
+          title: 'Letter',
+          contributorEmail: 'reader@example.com',
+          status: 'submitted',
+          intakeDecision: 'accepted',
+        },
+      ],
+      onApprove: vi.fn(),
+    });
+
+    const buttons = Array.from(target.querySelectorAll('button'));
+
+    expect(
+      buttons.some(
+        (button) => button.textContent?.trim() === 'Approve and promote',
+      ),
+    ).toBe(true);
+  });
+
+  it('labels already approved contribution approval as promote', () => {
+    const target = renderInbox({
+      contributions: [
+        {
+          id: 'contribution-1',
+          title: 'Letter',
+          contributorEmail: 'reader@example.com',
+          status: 'approved',
+          intakeDecision: 'accepted',
+        },
+      ],
+      onApprove: vi.fn(),
+    });
+
+    const buttons = Array.from(target.querySelectorAll('button'));
+
+    expect(
+      buttons.some((button) => button.textContent?.trim() === 'Promote'),
+    ).toBe(true);
+    expect(
+      buttons.some(
+        (button) => button.textContent?.trim() === 'Approve and promote',
+      ),
+    ).toBe(false);
+  });
+
   it('emits approve and request-changes actions with the current note', () => {
     const onApprove = vi.fn();
     const onRequestChanges = vi.fn();
@@ -59,7 +132,9 @@ describe('ContentContributionInbox', () => {
     select.dispatchEvent(new Event('change', { bubbles: true }));
 
     const buttons = Array.from(target.querySelectorAll('button'));
-    buttons.find((button) => button.textContent?.includes('Approve'))?.click();
+    buttons
+      .find((button) => button.textContent?.includes('Approve and promote'))
+      ?.click();
     buttons
       .find((button) => button.textContent?.includes('Request changes'))
       ?.click();


### PR DESCRIPTION
## Summary

- Keep the contribution inbox primary status pill tied to workflow status instead of intake decision.
- Show the intake decision separately in the contribution details.
- Adjust approval button labels so submitted items read "Approve and promote" while already approved items read "Promote".

## Context

Supports downstream happyvertical/anytown.ai#375 by keeping editorial workflow state separate from intake review decisions.

## Validation

- pnpm --filter @happyvertical/smrt-content exec vitest run src/svelte/components/ContentContributionInbox.test.ts
