### PR TITLE
[codex] Add native contribution form contracts

### DIFF
--- a/packages/content/src/svelte/components/ContentContributionForm.svelte
+++ b/packages/content/src/svelte/components/ContentContributionForm.svelte
@@ -95,6 +95,9 @@ function handleFileChange(event: Event) {
 
 function handleSubmit(event: SubmitEvent) {
   if (!onSubmit) {
+    if (!action?.trim()) {
+      event.preventDefault();
+    }
     return;
   }
 

--- a/packages/content/src/svelte/components/ContentContributionForm.svelte
+++ b/packages/content/src/svelte/components/ContentContributionForm.svelte
@@ -19,7 +19,8 @@ export interface Props {
   initial?: Partial<ContentContributionData>;
   showContributorFields?: boolean;
   submitLabel?: string;
-  onSubmit: (payload: ContentContributionFormSubmitData) => void;
+  action?: string;
+  onSubmit?: (payload: ContentContributionFormSubmitData) => void;
   onCancel?: () => void;
 }
 
@@ -28,6 +29,7 @@ let {
   initial = {},
   showContributorFields = true,
   submitLabel = 'Submit contribution',
+  action = undefined,
   onSubmit,
   onCancel = undefined,
 }: Props = $props();
@@ -91,7 +93,12 @@ function handleFileChange(event: Event) {
   draft.files = Array.from(target.files || []);
 }
 
-function handleSubmit() {
+function handleSubmit(event: SubmitEvent) {
+  if (!onSubmit) {
+    return;
+  }
+
+  event.preventDefault();
   onSubmit({
     typeKey: draft.typeKey,
     contributorEmail: draft.contributorEmail || undefined,
@@ -106,16 +113,16 @@ function handleSubmit() {
 
 <form
   class="contribution-form"
-  onsubmit={(event) => {
-    event.preventDefault();
-    handleSubmit();
-  }}
+  method="post"
+  enctype="multipart/form-data"
+  {action}
+  onsubmit={handleSubmit}
 >
   <h3>Submit a contribution</h3>
 
   <label>
     Contribution type
-    <select bind:value={draft.typeKey} required>
+    <select name="typeKey" bind:value={draft.typeKey} required>
       {#each types.filter((type) => type.enabled !== false) as type (type.key)}
         <option value={type.key}>{type.label}</option>
       {/each}
@@ -126,34 +133,35 @@ function handleSubmit() {
     <div class="grid">
       <label>
         Email
-        <input type="email" bind:value={draft.contributorEmail} required />
+        <input name="contributorEmail" type="email" bind:value={draft.contributorEmail} required />
       </label>
       <label>
         Name
-        <input type="text" bind:value={draft.contributorName} />
+        <input name="contributorName" type="text" bind:value={draft.contributorName} />
       </label>
     </div>
   {/if}
 
   <label>
     Title
-    <input type="text" bind:value={draft.title} />
+    <input name="title" type="text" bind:value={draft.title} />
   </label>
 
   <label>
     Description
-    <textarea bind:value={draft.description} rows="2"></textarea>
+    <textarea name="description" bind:value={draft.description} rows="2"></textarea>
   </label>
 
   <label>
     Body
-    <textarea bind:value={draft.body} rows="8"></textarea>
+    <textarea name="body" bind:value={draft.body} rows="8"></textarea>
   </label>
 
   {#if activeType?.allowFiles !== false}
     <label>
       Attach files
       <input
+        name="files"
         type="file"
         multiple
         onchange={handleFileChange}

--- a/packages/content/src/svelte/components/ContentContributionForm.test.ts
+++ b/packages/content/src/svelte/components/ContentContributionForm.test.ts
@@ -165,4 +165,19 @@ describe('ContentContributionForm', () => {
 
     expect(event.defaultPrevented).toBe(false);
   });
+
+  it('prevents native submission when neither callback nor action is provided', () => {
+    const target = renderForm({
+      types: [
+        { key: 'letter', label: 'Letter', enabled: true, allowFiles: true },
+      ],
+    });
+
+    const form = target.querySelector('form') as HTMLFormElement;
+    const event = new Event('submit', { bubbles: true, cancelable: true });
+
+    form.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
 });

--- a/packages/content/src/svelte/components/ContentContributionForm.test.ts
+++ b/packages/content/src/svelte/components/ContentContributionForm.test.ts
@@ -19,7 +19,7 @@ function renderForm(props: Record<string, any>) {
 }
 
 function setValue(
-  element: HTMLInputElement | HTMLTextAreaElement,
+  element: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement,
   value: string,
 ) {
   element.value = value;
@@ -86,5 +86,83 @@ describe('ContentContributionForm', () => {
         files: [file],
       }),
     );
+  });
+
+  it('exposes a native POST form contract for contribution fields', () => {
+    const target = renderForm({
+      types: [
+        { key: 'letter', label: 'Letter', enabled: true, allowFiles: true },
+        { key: 'news-tip', label: 'News tip', enabled: true, allowFiles: true },
+      ],
+      action: '/contentcontributions/submit',
+    });
+
+    const form = target.querySelector('form') as HTMLFormElement;
+    const typeSelect = target.querySelector(
+      'select[name="typeKey"]',
+    ) as HTMLSelectElement;
+    const emailInput = target.querySelector(
+      'input[name="contributorEmail"]',
+    ) as HTMLInputElement;
+    const contributorNameInput = target.querySelector(
+      'input[name="contributorName"]',
+    ) as HTMLInputElement;
+    const titleInput = target.querySelector(
+      'input[name="title"]',
+    ) as HTMLInputElement;
+    const descriptionTextarea = target.querySelector(
+      'textarea[name="description"]',
+    ) as HTMLTextAreaElement;
+    const bodyTextarea = target.querySelector(
+      'textarea[name="body"]',
+    ) as HTMLTextAreaElement;
+    const fileInput = target.querySelector(
+      'input[name="files"]',
+    ) as HTMLInputElement;
+
+    expect(form.method).toBe('post');
+    expect(form.enctype).toBe('multipart/form-data');
+    expect(form.getAttribute('action')).toBe('/contentcontributions/submit');
+
+    setValue(typeSelect, 'news-tip');
+    setValue(emailInput, 'reader@example.com');
+    setValue(contributorNameInput, 'Reader');
+    setValue(titleInput, 'Letter title');
+    setValue(descriptionTextarea, 'Short description');
+    setValue(bodyTextarea, 'Longer body text');
+
+    const file = new File(['hello'], 'photo.jpg', { type: 'image/jpeg' });
+    Object.defineProperty(fileInput, 'files', {
+      value: [file],
+      configurable: true,
+    });
+
+    const formData = new FormData(form);
+
+    expect(Object.fromEntries(formData.entries())).toMatchObject({
+      typeKey: 'news-tip',
+      contributorEmail: 'reader@example.com',
+      contributorName: 'Reader',
+      title: 'Letter title',
+      description: 'Short description',
+      body: 'Longer body text',
+    });
+    expect(formData.getAll('files')).toEqual([file]);
+  });
+
+  it('allows native form submission when no submit callback is provided', () => {
+    const target = renderForm({
+      types: [
+        { key: 'letter', label: 'Letter', enabled: true, allowFiles: true },
+      ],
+      action: '/contentcontributions/submit',
+    });
+
+    const form = target.querySelector('form') as HTMLFormElement;
+    const event = new Event('submit', { bubbles: true, cancelable: true });
+
+    form.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
   });
 });

--- a/packages/content/src/svelte/components/ContentContributionInbox.svelte
+++ b/packages/content/src/svelte/components/ContentContributionInbox.svelte
@@ -5,6 +5,7 @@ export interface Props {
   contributions?: ContentContributionData[];
   selectedId?: string | null;
   emptyMessage?: string;
+  workflowFormAction?: string;
   onSelect?: (contribution: ContentContributionData) => void;
   onApprove?: (
     contribution: ContentContributionData,
@@ -24,6 +25,7 @@ let {
   contributions = [],
   selectedId = null,
   emptyMessage = 'No contributions need review right now.',
+  workflowFormAction = undefined,
   onSelect = undefined,
   onApprove = undefined,
   onRequestChanges = undefined,
@@ -38,6 +40,9 @@ const selectedContribution = $derived(
     contributions[0] ||
     null,
 );
+const canSubmitWorkflow = $derived(
+  !workflowFormAction || Boolean(selectedContribution?.id),
+);
 
 function workflowStatus(
   contribution: ContentContributionData | null | undefined,
@@ -49,6 +54,45 @@ function approveActionLabel(contribution: ContentContributionData) {
   return workflowStatus(contribution) === 'approved'
     ? 'Promote'
     : 'Approve and promote';
+}
+
+function handleWorkflowSubmit(event: SubmitEvent) {
+  const submitter = event.submitter as HTMLButtonElement | null;
+  const intent = submitter?.value;
+  const shouldHandleWithCallback =
+    Boolean(selectedContribution) &&
+    ((intent === 'approve' && Boolean(onApprove)) ||
+      (intent === 'request-changes' && Boolean(onRequestChanges)) ||
+      (intent === 'reject' && Boolean(onReject)));
+
+  if (!workflowFormAction || shouldHandleWithCallback) {
+    event.preventDefault();
+  }
+
+  if (intent === 'approve' && onApprove && selectedContribution) {
+    onApprove(selectedContribution, {
+      targetStatus,
+      note,
+    });
+    return;
+  }
+
+  if (
+    intent === 'request-changes' &&
+    onRequestChanges &&
+    selectedContribution
+  ) {
+    onRequestChanges(selectedContribution, {
+      note,
+    });
+    return;
+  }
+
+  if (intent === 'reject' && onReject && selectedContribution) {
+    onReject(selectedContribution, {
+      note,
+    });
+  }
 }
 
 $effect(() => {
@@ -121,58 +165,64 @@ $effect(() => {
             {/if}
           </dl>
 
-          <label>
-            Editorial note
-            <textarea bind:value={note} rows="4"></textarea>
-          </label>
-
-          <div class="actions">
-            {#if onApprove}
-              <label class="inline">
-                Promote to
-                <select bind:value={targetStatus}>
-                  <option value="draft">draft</option>
-                  <option value="review">review</option>
-                </select>
-              </label>
-              <button
-                type="button"
-                onclick={() =>
-                  onApprove?.(selectedContribution, {
-                    targetStatus,
-                    note,
-                  })}
-              >
-                {approveActionLabel(selectedContribution)}
-              </button>
+          <form
+            method="post"
+            action={workflowFormAction}
+            onsubmit={handleWorkflowSubmit}
+          >
+            {#if selectedContribution.id}
+              <input type="hidden" name="contributionId" value={selectedContribution.id} />
             {/if}
 
-            {#if onRequestChanges}
-              <button
-                type="button"
-                class="secondary"
-                onclick={() =>
-                  onRequestChanges?.(selectedContribution, {
-                    note,
-                  })}
-              >
-                Request changes
-              </button>
-            {/if}
+            <label>
+              Editorial note
+              <textarea name="editorNote" bind:value={note} rows="4"></textarea>
+            </label>
 
-            {#if onReject}
-              <button
-                type="button"
-                class="danger"
-                onclick={() =>
-                  onReject?.(selectedContribution, {
-                    note,
-                  })}
-              >
-                Reject
-              </button>
-            {/if}
-          </div>
+            <div class="actions">
+              {#if onApprove || workflowFormAction}
+                <label class="inline">
+                  Promote to
+                  <select name="targetStatus" bind:value={targetStatus}>
+                    <option value="draft">draft</option>
+                    <option value="review">review</option>
+                  </select>
+                </label>
+                <button
+                  type="submit"
+                  name="intent"
+                  value="approve"
+                  disabled={!canSubmitWorkflow}
+                >
+                  {approveActionLabel(selectedContribution)}
+                </button>
+              {/if}
+
+              {#if onRequestChanges || workflowFormAction}
+                <button
+                  type="submit"
+                  name="intent"
+                  value="request-changes"
+                  class="secondary"
+                  disabled={!canSubmitWorkflow}
+                >
+                  Request changes
+                </button>
+              {/if}
+
+              {#if onReject || workflowFormAction}
+                <button
+                  type="submit"
+                  name="intent"
+                  value="reject"
+                  class="danger"
+                  disabled={!canSubmitWorkflow}
+                >
+                  Reject
+                </button>
+              {/if}
+            </div>
+          </form>
         </article>
       {/if}
     </div>
@@ -183,7 +233,8 @@ $effect(() => {
   .inbox,
   .inbox__header,
   .inbox__layout,
-  .inbox__detail {
+  .inbox__detail,
+  .inbox__detail form {
     display: grid;
     gap: 1rem;
   }

--- a/packages/content/src/svelte/components/ContentContributionInbox.svelte
+++ b/packages/content/src/svelte/components/ContentContributionInbox.svelte
@@ -34,6 +34,8 @@ let {
 
 let note = $state('');
 let targetStatus = $state<'draft' | 'review'>('draft');
+const workflowIntents = ['approve', 'request-changes', 'reject'] as const;
+type WorkflowIntent = (typeof workflowIntents)[number];
 
 const selectedContribution = $derived(
   contributions.find((item) => item.id === selectedId) ||
@@ -56,16 +58,26 @@ function approveActionLabel(contribution: ContentContributionData) {
     : 'Approve and promote';
 }
 
+function isWorkflowIntent(
+  intent: string | undefined,
+): intent is WorkflowIntent {
+  return workflowIntents.includes(intent as WorkflowIntent);
+}
+
 function handleWorkflowSubmit(event: SubmitEvent) {
   const submitter = event.submitter as HTMLButtonElement | null;
   const intent = submitter?.value;
+  const hasNativeWorkflowTarget =
+    Boolean(workflowFormAction) &&
+    Boolean(selectedContribution?.id) &&
+    isWorkflowIntent(intent);
   const shouldHandleWithCallback =
     Boolean(selectedContribution) &&
     ((intent === 'approve' && Boolean(onApprove)) ||
       (intent === 'request-changes' && Boolean(onRequestChanges)) ||
       (intent === 'reject' && Boolean(onReject)));
 
-  if (!workflowFormAction || shouldHandleWithCallback) {
+  if (!hasNativeWorkflowTarget || shouldHandleWithCallback) {
     event.preventDefault();
   }
 

--- a/packages/content/src/svelte/components/ContentContributionInbox.test.ts
+++ b/packages/content/src/svelte/components/ContentContributionInbox.test.ts
@@ -104,9 +104,148 @@ describe('ContentContributionInbox', () => {
     ).toBe(false);
   });
 
-  it('emits approve and request-changes actions with the current note', () => {
+  it('renders workflow controls as a native POST form when an action is provided', () => {
+    const target = renderInbox({
+      workflowFormAction: '?/reviewContribution',
+      contributions: [
+        {
+          id: 'contribution-1',
+          title: 'Letter',
+          contributorEmail: 'reader@example.com',
+          status: 'submitted',
+          intakeDecision: 'accepted',
+          revisionCount: 1,
+        },
+      ],
+    });
+
+    const form = target.querySelector('form') as HTMLFormElement;
+    const buttons = Array.from(form.querySelectorAll('button'));
+
+    expect(form).toBeTruthy();
+    expect(form.method).toBe('post');
+    expect(form.getAttribute('action')).toBe('?/reviewContribution');
+    expect(
+      form.querySelector('input[name="contributionId"]')?.getAttribute('value'),
+    ).toBe('contribution-1');
+    expect(form.querySelector('textarea[name="editorNote"]')).toBeTruthy();
+    expect(form.querySelector('select[name="targetStatus"]')).toBeTruthy();
+    expect(buttons.map((button) => button.type)).toEqual([
+      'submit',
+      'submit',
+      'submit',
+    ]);
+    expect(buttons.map((button) => button.getAttribute('name'))).toEqual([
+      'intent',
+      'intent',
+      'intent',
+    ]);
+    expect(buttons.map((button) => button.getAttribute('value'))).toEqual([
+      'approve',
+      'request-changes',
+      'reject',
+    ]);
+  });
+
+  it('allows native workflow form submission when no callback is registered', () => {
+    const target = renderInbox({
+      workflowFormAction: '?/reviewContribution',
+      contributions: [
+        {
+          id: 'contribution-1',
+          title: 'Letter',
+          contributorEmail: 'reader@example.com',
+          status: 'submitted',
+        },
+      ],
+    });
+
+    const form = target.querySelector('form') as HTMLFormElement;
+    const button = form.querySelector(
+      'button[value="approve"]',
+    ) as HTMLButtonElement;
+    const event = new Event('submit', {
+      bubbles: true,
+      cancelable: true,
+    }) as SubmitEvent;
+    Object.defineProperty(event, 'submitter', {
+      value: button,
+      configurable: true,
+    });
+
+    form.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('prevents browser submission when a workflow callback handles the intent', () => {
+    const onApprove = vi.fn();
+    const target = renderInbox({
+      workflowFormAction: '?/reviewContribution',
+      contributions: [
+        {
+          id: 'contribution-1',
+          title: 'Letter',
+          contributorEmail: 'reader@example.com',
+          status: 'submitted',
+        },
+      ],
+      onApprove,
+    });
+
+    const form = target.querySelector('form') as HTMLFormElement;
+    const button = form.querySelector(
+      'button[value="approve"]',
+    ) as HTMLButtonElement;
+    const event = new Event('submit', {
+      bubbles: true,
+      cancelable: true,
+    }) as SubmitEvent;
+    Object.defineProperty(event, 'submitter', {
+      value: button,
+      configurable: true,
+    });
+
+    form.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onApprove).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'contribution-1' }),
+      {
+        targetStatus: 'draft',
+        note: '',
+      },
+    );
+  });
+
+  it('disables native workflow buttons when the selected contribution has no id', () => {
+    const target = renderInbox({
+      workflowFormAction: '?/reviewContribution',
+      contributions: [
+        {
+          id: '',
+          title: 'Letter',
+          contributorEmail: 'reader@example.com',
+          status: 'submitted',
+        },
+      ],
+    });
+
+    const form = target.querySelector('form') as HTMLFormElement;
+    const buttons = Array.from(form.querySelectorAll('button'));
+
+    expect(form.querySelector('input[name="contributionId"]')).toBeNull();
+    expect(buttons.map((button) => button.disabled)).toEqual([
+      true,
+      true,
+      true,
+    ]);
+  });
+
+  it('emits approve, request-changes, and reject actions with the current note', () => {
     const onApprove = vi.fn();
     const onRequestChanges = vi.fn();
+    const onReject = vi.fn();
 
     const target = renderInbox({
       contributions: [
@@ -121,6 +260,7 @@ describe('ContentContributionInbox', () => {
       ],
       onApprove,
       onRequestChanges,
+      onReject,
     });
 
     const textarea = target.querySelector('textarea') as HTMLTextAreaElement;
@@ -138,6 +278,7 @@ describe('ContentContributionInbox', () => {
     buttons
       .find((button) => button.textContent?.includes('Request changes'))
       ?.click();
+    buttons.find((button) => button.textContent?.includes('Reject'))?.click();
 
     expect(onApprove).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'contribution-1' }),
@@ -147,6 +288,12 @@ describe('ContentContributionInbox', () => {
       },
     );
     expect(onRequestChanges).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'contribution-1' }),
+      {
+        note: 'Please tighten the opening.',
+      },
+    );
+    expect(onReject).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'contribution-1' }),
       {
         note: 'Please tighten the opening.',

--- a/packages/content/src/svelte/components/ContentContributionInbox.test.ts
+++ b/packages/content/src/svelte/components/ContentContributionInbox.test.ts
@@ -178,6 +178,30 @@ describe('ContentContributionInbox', () => {
     expect(event.defaultPrevented).toBe(false);
   });
 
+  it('prevents native workflow form submission when no intent is provided', () => {
+    const target = renderInbox({
+      workflowFormAction: '?/reviewContribution',
+      contributions: [
+        {
+          id: 'contribution-1',
+          title: 'Letter',
+          contributorEmail: 'reader@example.com',
+          status: 'submitted',
+        },
+      ],
+    });
+
+    const form = target.querySelector('form') as HTMLFormElement;
+    const event = new Event('submit', {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    form.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
   it('prevents browser submission when a workflow callback handles the intent', () => {
     const onApprove = vi.fn();
     const target = renderInbox({
@@ -240,6 +264,19 @@ describe('ContentContributionInbox', () => {
       true,
       true,
     ]);
+
+    const event = new Event('submit', {
+      bubbles: true,
+      cancelable: true,
+    }) as SubmitEvent;
+    Object.defineProperty(event, 'submitter', {
+      value: buttons[0],
+      configurable: true,
+    });
+
+    form.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
   });
 
   it('emits approve, request-changes, and reject actions with the current note', () => {


### PR DESCRIPTION
## Summary
- Add native POST contract support to `ContentContributionForm`, including `action`, named fields, multipart encoding, and native fallback when no callback is provided.
- Add `workflowFormAction` support to `ContentContributionInbox` for server-side review actions while preserving existing callback behavior.
- Add regression tests for FormData fields, file uploads, native submit fallback, callback precedence, and missing contribution ids.

## Why
Downstream SvelteKit apps need these generated SMRT content components to expose real browser form contracts. Without this, app-level actions cannot reliably receive form fields or uploaded files.

## Validation
- `pnpm --dir /Users/will/.codex/worktrees/smrt-content-contribution-form-contract/packages/content test ContentContributionForm.test.ts ContentContributionInbox.test.ts`
- `pnpm --dir /Users/will/.codex/worktrees/smrt-content-contribution-form-contract/packages/content check`
- `git diff --check`
- `pnpm exec biome check --write --unsafe --no-errors-on-unmatched packages/content/src/svelte/components/ContentContributionForm.svelte packages/content/src/svelte/components/ContentContributionForm.test.ts packages/content/src/svelte/components/ContentContributionInbox.svelte packages/content/src/svelte/components/ContentContributionInbox.test.ts`
- Pre-push hook: Biome format check and workflow validation passed