### PR TITLE
feat(core)!: ObjectRegistry qualified names canonical (R5-canon)

### DIFF
--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -1026,14 +1026,24 @@ export abstract class Agent extends SmrtObject {
       // Invalidate cached chain so getTableStrategy rebuilds with complete data
       ObjectRegistry.invalidateInheritanceCache(_className);
 
-      // Add STI discriminator filter if this is an STI child class
+      // Add STI discriminator filter if this is an STI child class.
+      // R5-canon: `getSTIBase` returns the qualified name; compare
+      // against the qualified form of `_className` so a query against
+      // an STI BASE doesn't get an unintended `_meta_type` filter that
+      // would hide its descendants.
       const tableStrategy = ObjectRegistry.getTableStrategy(_className);
       if (tableStrategy === 'sti') {
         const stiBase = ObjectRegistry.getSTIBase(_className);
-        if (stiBase && stiBase !== _className) {
+        const classInfo = ObjectRegistry.getClass(_className);
+        const qualifiedClassName =
+          classInfo?.qualifiedName ?? classInfo?.name ?? _className;
+        if (
+          stiBase &&
+          stiBase !== qualifiedClassName &&
+          stiBase !== _className
+        ) {
           // Get the qualified name for this class (e.g., '@happyvertical/praeco:Meeting')
           // This is what's stored in the _meta_type column in the database
-          const classInfo = ObjectRegistry.getClass(_className);
           const metaTypeValue = classInfo?.qualifiedName || _className;
           // Wrap original where clause and add _meta_type filter
           whereClause = `_meta_type = ? AND (${whereClause})`;

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -651,8 +651,17 @@ export default testManifest;
             const tableStrategy = ObjectRegistry.getTableStrategy(className);
             const stiBase = ObjectRegistry.getSTIBase(className);
 
-            // Skip STI children (they share the base class table)
-            if (tableStrategy === 'sti' && stiBase && stiBase !== className) {
+            // R5-canon: `getSTIBase` returns the qualified name; compare
+            // against the qualified form so an STI base isn't
+            // mis-classified as a child.
+            const qualifiedClassName =
+              registered.qualifiedName ?? registered.name ?? className;
+            const isSTIChild =
+              tableStrategy === 'sti' &&
+              !!stiBase &&
+              stiBase !== qualifiedClassName &&
+              stiBase !== className;
+            if (isSTIChild) {
               console.log(
                 `-- Table: ${className} (Base: ${stiBase}, Strategy: STI)`,
               );
@@ -753,9 +762,18 @@ export default testManifest;
           try {
             const tableStrategy = ObjectRegistry.getTableStrategy(className);
             const stiBase = ObjectRegistry.getSTIBase(className);
+            // R5-canon: qualified-to-qualified STI-child detection.
+            const registered = ObjectRegistry.getClass(className);
+            const qualifiedClassName =
+              registered?.qualifiedName ?? registered?.name ?? className;
 
             // Skip STI children (schema already created by base class)
-            if (tableStrategy === 'sti' && stiBase && stiBase !== className) {
+            if (
+              tableStrategy === 'sti' &&
+              stiBase &&
+              stiBase !== qualifiedClassName &&
+              stiBase !== className
+            ) {
               tablesSkipped++;
               if (options.verbose) {
                 console.log(`  ⊙ ${className} (shares table with ${stiBase})`);
@@ -1189,8 +1207,17 @@ export default testManifest;
             const tableName = ObjectRegistry.getTableName(className);
             const tableStrategy = ObjectRegistry.getTableStrategy(className);
             const stiBase = ObjectRegistry.getSTIBase(className);
+            // R5-canon: qualified-to-qualified STI-child detection.
+            const registered = ObjectRegistry.getClass(className);
+            const qualifiedClassName =
+              registered?.qualifiedName ?? registered?.name ?? className;
 
-            if (tableStrategy === 'sti' && stiBase && stiBase !== className) {
+            if (
+              tableStrategy === 'sti' &&
+              stiBase &&
+              stiBase !== qualifiedClassName &&
+              stiBase !== className
+            ) {
               console.log(
                 `  ${i + 1}. ${className} → ${tableName} (STI child of ${stiBase})`,
               );

--- a/packages/content/src/content-sti.test.ts
+++ b/packages/content/src/content-sti.test.ts
@@ -95,7 +95,7 @@ describe('Content STI Support', () => {
       const base = ObjectRegistry.getSTIBase('ContentDocument');
       // ContentDocument inherits STI from Content, so Content is the actual STI base
       // Even though ContentDocument explicitly declares tableStrategy: 'sti', that's redundant
-      expect(base).toBe('Content');
+      expect(base).toBe('@happyvertical/smrt-content:Content');
     });
 
     it('should set _meta_type to ContentDocument', async () => {
@@ -161,7 +161,7 @@ describe('Content STI Support', () => {
     it('should get STI base class', () => {
       const base = ObjectRegistry.getSTIBase('Article');
       // Article inherits STI from Content, so Content is the actual STI base
-      expect(base).toBe('Content');
+      expect(base).toBe('@happyvertical/smrt-content:Content');
     });
 
     it('should set _meta_type to Article', async () => {
@@ -249,12 +249,14 @@ describe('Content STI Support', () => {
       const chain = ObjectRegistry.getInheritanceChain('ContentDocument');
 
       // Should include Content → ContentDocument
-      expect(chain).toContain('Content');
-      expect(chain).toContain('ContentDocument');
+      expect(chain).toContain('@happyvertical/smrt-content:Content');
+      expect(chain).toContain('@happyvertical/smrt-content:ContentDocument');
 
       // ContentDocument should come after Content
-      const contentIdx = chain.indexOf('Content');
-      const docIdx = chain.indexOf('ContentDocument');
+      const contentIdx = chain.indexOf('@happyvertical/smrt-content:Content');
+      const docIdx = chain.indexOf(
+        '@happyvertical/smrt-content:ContentDocument',
+      );
       expect(docIdx).toBeGreaterThan(contentIdx);
     });
 
@@ -262,8 +264,10 @@ describe('Content STI Support', () => {
       const descendants = ObjectRegistry.getDescendants('Content');
 
       // Should include at least ContentDocument and Article
-      expect(descendants).toContain('ContentDocument');
-      expect(descendants).toContain('Article');
+      expect(descendants).toContain(
+        '@happyvertical/smrt-content:ContentDocument',
+      );
+      expect(descendants).toContain('@happyvertical/smrt-content:Article');
     });
   });
 });

--- a/packages/core/src/__tests__/downstream-events-sti-schema.test.ts
+++ b/packages/core/src/__tests__/downstream-events-sti-schema.test.ts
@@ -79,7 +79,10 @@ describe('Downstream events STI schema synthesis', () => {
     const eventClass = ObjectRegistry.findClass('Event');
     expect(eventClass).toBeDefined();
     expect(ObjectRegistry.getTableStrategy('Event')).toBe('sti');
-    expect(ObjectRegistry.getSTIBase('Event')).toBe('Event');
+    // R5-canon: getSTIBase returns qualified names.
+    expect(ObjectRegistry.getSTIBase('Event')).toBe(
+      '@happyvertical/smrt-events:Event',
+    );
 
     // This mirrors a downstream built manifest child: inherited STI metadata
     // is already resolved, but the child still contributes its own fields.
@@ -112,7 +115,10 @@ describe('Downstream events STI schema synthesis', () => {
     );
 
     expect(ObjectRegistry.getTableStrategy('Meeting')).toBe('sti');
-    expect(ObjectRegistry.getSTIBase('Meeting')).toBe('Event');
+    // R5-canon: getSTIBase returns qualified names.
+    expect(ObjectRegistry.getSTIBase('Meeting')).toBe(
+      '@happyvertical/smrt-events:Event',
+    );
 
     const schemas = ObjectRegistry.getAllSchemas();
     expect(schemas.events).toBeDefined();

--- a/packages/core/src/__tests__/hierarchical.test.ts
+++ b/packages/core/src/__tests__/hierarchical.test.ts
@@ -250,37 +250,44 @@ describe('SmrtHierarchical', () => {
 /**
  * Cross-package qualified-name disambiguation
  *
- * Exercises the constructor prototype-chain walk in
- * `_hierarchyCollection`. Two hierarchical classes share the SAME simple
- * name (`CollisionDoc`) but are registered under different package
- * contexts. The constructor identities are unique even though the names
- * collide, so the walk should resolve each instance to ITS package's
- * qualified registration rather than picking whichever registration won
- * the simple-name lookup race.
+ * Two hierarchical classes share the SAME simple name (`CollisionDoc`)
+ * but live in different package contexts. Each instance's
+ * `_hierarchyCollection()` must resolve to ITS own qualified collection
+ * rather than picking whichever registration won the simple-name lookup
+ * race.
  *
- * Pre-PR-#1269 behavior: `_hierarchyCollection` called
- * `ObjectRegistry.getCollection(this.constructor.name)` — the simple
- * name `'CollisionDoc'` — and `findClass` would pick one registration
- * arbitrarily (whichever entry won the classNameMap iteration, or
- * throw on ambiguity).
+ * After R5-canon, the resolution is:
  *
- * Post-PR-#1269 behavior: the constructor reference uniquely identifies
- * the right registration regardless of name collision.
+ *   1. Read `ctor._smrtQualifiedName` (set by the registry at
+ *      registration on every registered class).
+ *   2. Fall back to `ObjectRegistry.getClassByConstructor(ctor)?.
+ *      qualifiedName` when the static isn't present.
+ *   3. Fall back to the simple `ctor.name` only when nothing is
+ *      registered at all.
  *
- * Setting up a true cross-package registry collision in-process is
- * non-trivial (the registry's package-name inference reads stack
- * traces and manifest data), so this suite stubs
- * `ObjectRegistry.getClassByConstructor` to return synthetic
- * registrations keyed by constructor identity, then asserts the
- * qualified name produced by `_hierarchyCollection` matches the
- * constructor that was instantiated. That's exactly the property the
- * fix is supposed to preserve.
+ * The result is passed through `ObjectRegistry.getSTIBase(...)` (which
+ * also returns a qualified name in R5-canon) before reaching
+ * `getCollection`. The whole pipeline is qualified-name-canonical end
+ * to end, so the previous prototype-chain walk workaround (added in
+ * #1269 when `getSTIBase` still returned simple names) is now dead
+ * code and has been removed.
  */
 describe('SmrtHierarchical cross-package qualified-name disambiguation', () => {
-  // Two distinct constructors with the SAME simple `.name`. The
-  // `class CollisionDoc extends SmrtHierarchical {}` expression literal
-  // gives each `const` a class whose `.name === 'CollisionDoc'`, but
-  // the constructors are distinct values in JS — `DocA !== DocB`.
+  // Two distinct constructors with the SAME simple `.name`. The `class
+  // CollisionDoc extends SmrtHierarchical {}` expression literal gives
+  // each `const` a class whose `.name === 'CollisionDoc'`, but the
+  // constructors are distinct values in JS — `DocA !== DocB`.
+  //
+  // Why not exercise the `_smrtQualifiedName` static directly here:
+  // the test environment's manifest stub auto-loads any
+  // `extends SmrtHierarchical` class it finds in the file, then the
+  // registry stamps the static under the test runner's own package
+  // context (`@happyvertical/smrt-core:CollisionDoc`). That stamping
+  // happens lazily on construction and overwrites whatever we set in
+  // beforeEach. So we test the disambiguation property the same way
+  // PR #1269's suite did — via `getClassByConstructor` mocks that
+  // model the WeakMap fallback. The fast-path static read is covered
+  // by `class-registration.ts`'s registration unit (separate suite).
   const DocA = class CollisionDoc extends SmrtHierarchical {
     marker = 'A';
   };
@@ -310,29 +317,42 @@ describe('SmrtHierarchical cross-package qualified-name disambiguation', () => {
   ]);
 
   let getClassByConstructorSpy: ReturnType<typeof vi.spyOn>;
+  let getSTIBaseSpy: ReturnType<typeof vi.spyOn>;
   let getCollectionSpy: ReturnType<typeof vi.spyOn>;
   const getCollectionCalls: string[] = [];
+  const getSTIBaseCalls: string[] = [];
 
   beforeEach(() => {
+    // Strip the auto-registered static so the WeakMap fallback path
+    // (via the spy below) becomes the source of qualified-name
+    // identity for this suite.
+    delete (DocA as any)._smrtQualifiedName;
+    delete (DocB as any)._smrtQualifiedName;
+
     getCollectionCalls.length = 0;
+    getSTIBaseCalls.length = 0;
     getClassByConstructorSpy = vi
       .spyOn(ObjectRegistry, 'getClassByConstructor')
       .mockImplementation(
         (ctor: any) => regByCtor.get(ctor) ?? undefined,
       ) as any;
+    getSTIBaseSpy = vi
+      .spyOn(ObjectRegistry, 'getSTIBase')
+      .mockImplementation((className: string) => {
+        getSTIBaseCalls.push(className);
+        return null;
+      }) as any;
     getCollectionSpy = vi
       .spyOn(ObjectRegistry, 'getCollection')
       .mockImplementation(async (className: string) => {
         getCollectionCalls.push(className);
-        // Return a minimal mock — the test only cares which className
-        // was passed in. Cast as any since SmrtCollection's shape is
-        // larger than what we need here.
         return { tableName: `mock-table-for-${className}` } as any;
       }) as any;
   });
 
   afterEach(() => {
     getClassByConstructorSpy.mockRestore();
+    getSTIBaseSpy.mockRestore();
     getCollectionSpy.mockRestore();
   });
 
@@ -343,67 +363,57 @@ describe('SmrtHierarchical cross-package qualified-name disambiguation', () => {
     await (a as any)._hierarchyCollection();
     await (b as any)._hierarchyCollection();
 
+    // Both `getSTIBase` and `getCollection` see the per-instance
+    // qualified name — never the ambiguous simple `'CollisionDoc'`.
+    expect(getSTIBaseCalls).toEqual([
+      '@test/package-a:CollisionDoc',
+      '@test/package-b:CollisionDoc',
+    ]);
     expect(getCollectionCalls).toEqual([
       '@test/package-a:CollisionDoc',
       '@test/package-b:CollisionDoc',
     ]);
   });
 
-  it('walks past intermediate STI subclasses to the OLDEST STI base', async () => {
-    // `Child extends Mid extends StiRoot extends SmrtHierarchical`.
-    // StiRoot declares tableStrategy:'sti'; the walk should land there
-    // (the OLDEST STI ancestor), NOT on Mid or Child.
-    const StiRoot = class StiBase extends SmrtHierarchical {};
-    const Mid = class StiMid extends StiRoot {};
-    const Child = class StiChild extends Mid {};
-
-    regByCtor.set(StiRoot, {
-      name: 'StiBase',
-      qualifiedName: '@test/sti-pkg:StiBase',
-      config: { tableStrategy: 'sti' },
-    });
-    regByCtor.set(Mid, {
-      name: 'StiMid',
-      qualifiedName: '@test/sti-pkg:StiMid',
-      config: {},
-    });
-    regByCtor.set(Child, {
-      name: 'StiChild',
-      qualifiedName: '@test/sti-pkg:StiChild',
-      config: {},
+  it('routes STI subclasses through the qualified STI base from getSTIBase', async () => {
+    // For an STI subclass, `_hierarchyCollection` calls
+    // `getSTIBase(qualifiedSubclass)` and passes the qualified base
+    // name to `getCollection`. Mock `getSTIBase` to return the base
+    // for DocA only.
+    getSTIBaseSpy.mockImplementation((className: string) => {
+      getSTIBaseCalls.push(className);
+      return className === '@test/package-a:CollisionDoc'
+        ? '@test/package-a:CollisionDocBase'
+        : null;
     });
 
-    const inst = new Child({} as any);
-    await (inst as any)._hierarchyCollection();
+    const a = new DocA({} as any);
+    await (a as any)._hierarchyCollection();
 
-    expect(getCollectionCalls).toEqual(['@test/sti-pkg:StiBase']);
+    expect(getSTIBaseCalls).toEqual(['@test/package-a:CollisionDoc']);
+    // The STI base's qualified name flows into getCollection, NOT the
+    // leaf subclass — that's the property R5-canon guarantees end to
+    // end.
+    expect(getCollectionCalls).toEqual(['@test/package-a:CollisionDocBase']);
   });
 
-  it('terminates cleanly without registry lookups against Function/Object prototypes', async () => {
-    // Constructor that isn't registered anywhere should walk up its
-    // chain (Function.prototype → Object.prototype → null) without
-    // throwing and without the lookup being invoked with Function or
-    // Object themselves (the loop terminates at the prototype-object
-    // boundaries — round-1 review fix).
+  it('falls back to the simple constructor name when nothing is registered', async () => {
+    // Unregistered constructor: no static, no WeakMap entry. The
+    // `regByCtor` map returns undefined for any other class.
+    //
+    // The auto-registration path stamps `_smrtQualifiedName` at
+    // construction time, so we delete it AFTER construction and
+    // immediately before the lookup runs.
     const Unregistered = class UnregisteredDoc extends SmrtHierarchical {};
-    // Deliberately NOT in regByCtor — getClassByConstructor returns
-    // undefined for it.
-
     const inst = new Unregistered({} as any);
+    delete (Unregistered as any)._smrtQualifiedName;
+
     await (inst as any)._hierarchyCollection();
 
-    // collectionClass falls back to `this.constructor.name` since
-    // no registration and no STI base were found. The fix should leave
-    // that fallback path intact.
+    // Lookup receives the bare simple name. `getCollection` will
+    // surface the existing "not found in ObjectRegistry" error in
+    // production; here we just verify the lookup key is the leaf
+    // class name (no static tag, no qualified resolution available).
     expect(getCollectionCalls).toEqual(['UnregisteredDoc']);
-
-    // Sanity: getClassByConstructor was called for the leaf ctor itself,
-    // never for `Function.prototype` or `Object.prototype` (the
-    // termination conditions skip them).
-    const callArgs = getClassByConstructorSpy.mock.calls.map(
-      (c: any[]) => c[0],
-    );
-    expect(callArgs).not.toContain(Function.prototype);
-    expect(callArgs).not.toContain(Object.prototype);
   });
 });

--- a/packages/core/src/__tests__/inheritance-simple.test.ts
+++ b/packages/core/src/__tests__/inheritance-simple.test.ts
@@ -33,8 +33,9 @@ describe('Inheritance Core Functionality', () => {
     console.log('Inheritance chain:', chain);
 
     expect(chain.length).toBeGreaterThan(1);
-    expect(chain).toContain('BaseContent');
-    expect(chain).toContain('ExtendedContent');
+    // R5-canon: getInheritanceChain returns qualified names
+    expect(chain).toContain('@happyvertical/smrt-core:BaseContent');
+    expect(chain).toContain('@happyvertical/smrt-core:ExtendedContent');
   });
 
   it('should get direct fields from BaseContent', () => {

--- a/packages/core/src/__tests__/inheritance.test.ts
+++ b/packages/core/src/__tests__/inheritance.test.ts
@@ -37,11 +37,12 @@ describe('Multi-level Class Inheritance', () => {
       const chain = ObjectRegistry.getInheritanceChain(
         'InheritanceTestBentleyContent',
       );
-      // SmrtObject is excluded from chains (fixed in #265)
+      // SmrtObject is excluded from chains (fixed in #265).
+      // R5-canon: chains return qualified names.
       expect(chain).toEqual([
-        'InheritanceTestContent',
-        'InheritanceTestPraecoContent',
-        'InheritanceTestBentleyContent',
+        '@happyvertical/smrt-core:InheritanceTestContent',
+        '@happyvertical/smrt-core:InheritanceTestPraecoContent',
+        '@happyvertical/smrt-core:InheritanceTestBentleyContent',
       ]);
     });
 
@@ -49,10 +50,11 @@ describe('Multi-level Class Inheritance', () => {
       const chain = ObjectRegistry.getInheritanceChain(
         'InheritanceTestPraecoContent',
       );
-      // SmrtObject is excluded from chains (fixed in #265)
+      // SmrtObject is excluded from chains (fixed in #265).
+      // R5-canon: chains return qualified names.
       expect(chain).toEqual([
-        'InheritanceTestContent',
-        'InheritanceTestPraecoContent',
+        '@happyvertical/smrt-core:InheritanceTestContent',
+        '@happyvertical/smrt-core:InheritanceTestPraecoContent',
       ]);
     });
 
@@ -60,8 +62,11 @@ describe('Multi-level Class Inheritance', () => {
       const chain = ObjectRegistry.getInheritanceChain(
         'InheritanceTestContent',
       );
-      // SmrtObject is excluded from chains (fixed in #265)
-      expect(chain).toEqual(['InheritanceTestContent']);
+      // SmrtObject is excluded from chains (fixed in #265).
+      // R5-canon: chains return qualified names.
+      expect(chain).toEqual([
+        '@happyvertical/smrt-core:InheritanceTestContent',
+      ]);
     });
 
     it('should return empty array for unregistered class', () => {

--- a/packages/core/src/__tests__/issue-265-external-package-manifest.test.ts
+++ b/packages/core/src/__tests__/issue-265-external-package-manifest.test.ts
@@ -79,8 +79,9 @@ describe('Issue #265: External Package Inheritance with Null Manifest', () => {
     // Should still be able to build chain from constructor prototype
     const chain = ObjectRegistry.getInheritanceChain('PraecoTest2');
 
-    // Chain should include the class itself
-    expect(chain).toContain('PraecoTest2');
+    // Chain should include the class itself.
+    // R5-canon: chains return qualified names when class is registered.
+    expect(chain).toContain('@happyvertical/smrt-core:PraecoTest2');
 
     // Chain should NOT include SmrtObject (buildInheritanceChain stops at it)
     expect(chain).not.toContain('SmrtObject');

--- a/packages/core/src/__tests__/issue-693-sti-separate-tablename.test.ts
+++ b/packages/core/src/__tests__/issue-693-sti-separate-tablename.test.ts
@@ -128,12 +128,15 @@ describe('Issue #693: STI subclasses with separate tableName', () => {
     });
 
     it('should find correct STI base class', () => {
-      expect(ObjectRegistry.getSTIBase('Issue693Event')).toBe('Issue693Event');
+      // R5-canon: getSTIBase returns qualified names.
+      expect(ObjectRegistry.getSTIBase('Issue693Event')).toBe(
+        '@happyvertical/smrt-core:Issue693Event',
+      );
       expect(ObjectRegistry.getSTIBase('Issue693Meeting')).toBe(
-        'Issue693Event',
+        '@happyvertical/smrt-core:Issue693Event',
       );
       expect(ObjectRegistry.getSTIBase('Issue693WeatherForecast')).toBe(
-        'Issue693Event',
+        '@happyvertical/smrt-core:Issue693Event',
       );
     });
   });

--- a/packages/core/src/__tests__/issue-703-sti-null-tablename.test.ts
+++ b/packages/core/src/__tests__/issue-703-sti-null-tablename.test.ts
@@ -102,8 +102,9 @@ describe('Issue #703: STI with null tableName from external manifest', () => {
 
   describe('getSTIBase()', () => {
     it('should return STI base class for the base class itself', () => {
+      // R5-canon: getSTIBase returns qualified names.
       const stiBase = ObjectRegistry.getSTIBase('Issue703Event');
-      expect(stiBase).toBe('Issue703Event');
+      expect(stiBase).toBe('test-package:Issue703Event');
     });
 
     it('should find STI base for child class even when tableName is derived (null in manifest)', () => {
@@ -113,15 +114,17 @@ describe('Issue #703: STI with null tableName from external manifest', () => {
       //             parent's tableName 'issue703_events'
       // After fix: getSTIBase('Issue703Meeting') returns 'Issue703Event'
       //            because we find the oldest ancestor with explicit tableStrategy: 'sti'
+      // R5-canon: getSTIBase returns qualified names.
       const stiBase = ObjectRegistry.getSTIBase('Issue703Meeting');
-      expect(stiBase).toBe('Issue703Event');
+      expect(stiBase).toBe('test-package:Issue703Event');
     });
 
     it('should find STI base for child class even when tableName explicitly differs', () => {
       // Even with explicitly different tableName, the STI base should be found
-      // because STI inheritance is determined by tableStrategy, not tableName
+      // because STI inheritance is determined by tableStrategy, not tableName.
+      // R5-canon: getSTIBase returns qualified names.
       const stiBase = ObjectRegistry.getSTIBase('Issue703WeatherForecast');
-      expect(stiBase).toBe('Issue703Event');
+      expect(stiBase).toBe('test-package:Issue703Event');
     });
 
     it('should return null for CTI classes', () => {

--- a/packages/core/src/__tests__/issue-871-circular-inheritance-false-positive.test.ts
+++ b/packages/core/src/__tests__/issue-871-circular-inheritance-false-positive.test.ts
@@ -98,9 +98,15 @@ describe('Issue #871: Circular inheritance false positive', () => {
 
     const chain = ObjectRegistry.getInheritanceChain('Issue871LocalAccount');
 
-    // The chain should use SMRT registered names
-    // Expected: [..., 'Issue871LedgerAccount', 'Issue871LocalAccount']
-    expect(chain).toContain('Issue871LocalAccount');
+    // The chain should use SMRT registered names.
+    // R5-canon: chains return qualified names. The package context may vary,
+    // so accept either bare or qualified form ending with the class name.
+    expect(
+      chain.some(
+        (c) =>
+          c === 'Issue871LocalAccount' || c.endsWith(':Issue871LocalAccount'),
+      ),
+    ).toBe(true);
 
     // Note: The parent might show up as 'Issue871LedgerAccount' or the JS name
     // depending on how the chain is built. The important thing is no circular error.

--- a/packages/core/src/__tests__/issue-951-qualified-keys.test.ts
+++ b/packages/core/src/__tests__/issue-951-qualified-keys.test.ts
@@ -415,7 +415,12 @@ describe('Issue #951: Qualified Names as Primary Keys', () => {
     ).toThrow(ConfigurationError);
   });
 
-  it('should return correct simple names from getDescendants()', () => {
+  // R5-canon switched these methods to return qualified names; updated
+  // expectations accordingly. (The test title was renamed from
+  // "should return correct simple names from getDescendants()" to reflect
+  // the new behavior; the issue's spirit — qualified keys as the canon —
+  // is preserved.)
+  it('should return correct qualified names from getDescendants()', () => {
     @smrt({ tableStrategy: 'sti' })
     class QualifiedBase extends SmrtObject {
       title: string = '';
@@ -427,10 +432,10 @@ describe('Issue #951: Qualified Names as Primary Keys', () => {
     }
 
     const descendants = ObjectRegistry.getDescendants('QualifiedBase');
-    expect(descendants).toContain('QualifiedChild');
+    expect(descendants).toContain('@happyvertical/smrt-core:QualifiedChild');
 
-    // Should not contain qualified keys
-    expect(descendants.some((d) => d.includes(':'))).toBe(false);
+    // Every returned descendant should be a qualified key.
+    expect(descendants.every((d) => d.includes(':'))).toBe(true);
   });
 
   it('should use simple names in getDependencyGraph()', () => {

--- a/packages/core/src/__tests__/sti-registry.test.ts
+++ b/packages/core/src/__tests__/sti-registry.test.ts
@@ -133,7 +133,8 @@ describe('STI Registry Methods', () => {
         title: string = '';
       }
 
-      expect(ObjectRegistry.getSTIBase('Event')).toBe('Event');
+      // R5-canon: getSTIBase returns qualified names.
+      expect(ObjectRegistry.getSTIBase('Event')).toBe('@vitest/runner:Event');
     });
 
     it('should return the parent class when child inherits STI', () => {
@@ -147,8 +148,9 @@ describe('STI Registry Methods', () => {
         roomNumber: string = '';
       }
 
-      expect(ObjectRegistry.getSTIBase('Event')).toBe('Event');
-      expect(ObjectRegistry.getSTIBase('Meeting')).toBe('Event');
+      // R5-canon: getSTIBase returns qualified names.
+      expect(ObjectRegistry.getSTIBase('Event')).toBe('@vitest/runner:Event');
+      expect(ObjectRegistry.getSTIBase('Meeting')).toBe('@vitest/runner:Event');
     });
 
     it('should return the top-most STI base through multiple levels', () => {
@@ -167,9 +169,14 @@ describe('STI Registry Methods', () => {
         homeTeam: string = '';
       }
 
-      expect(ObjectRegistry.getSTIBase('Event')).toBe('Event');
-      expect(ObjectRegistry.getSTIBase('SportingEvent')).toBe('Event');
-      expect(ObjectRegistry.getSTIBase('HockeyGame')).toBe('Event');
+      // R5-canon: getSTIBase returns qualified names.
+      expect(ObjectRegistry.getSTIBase('Event')).toBe('@vitest/runner:Event');
+      expect(ObjectRegistry.getSTIBase('SportingEvent')).toBe(
+        '@vitest/runner:Event',
+      );
+      expect(ObjectRegistry.getSTIBase('HockeyGame')).toBe(
+        '@vitest/runner:Event',
+      );
     });
 
     it('should reject child with explicit CTI override', () => {
@@ -219,9 +226,10 @@ describe('STI Registry Methods', () => {
       }
 
       const descendants = ObjectRegistry.getDescendants('Event');
+      // R5-canon: getDescendants returns qualified names.
       expect(descendants).toHaveLength(2);
-      expect(descendants).toContain('Meeting');
-      expect(descendants).toContain('HockeyGame');
+      expect(descendants).toContain('@vitest/runner:Meeting');
+      expect(descendants).toContain('@vitest/runner:HockeyGame');
     });
 
     it('should return all descendants (direct and indirect)', () => {
@@ -246,15 +254,16 @@ describe('STI Registry Methods', () => {
       }
 
       const eventDescendants = ObjectRegistry.getDescendants('Event');
+      // R5-canon: getDescendants returns qualified names.
       expect(eventDescendants).toHaveLength(3);
-      expect(eventDescendants).toContain('SportingEvent');
-      expect(eventDescendants).toContain('HockeyGame');
-      expect(eventDescendants).toContain('Meeting');
+      expect(eventDescendants).toContain('@vitest/runner:SportingEvent');
+      expect(eventDescendants).toContain('@vitest/runner:HockeyGame');
+      expect(eventDescendants).toContain('@vitest/runner:Meeting');
 
       const sportingDescendants =
         ObjectRegistry.getDescendants('SportingEvent');
       expect(sportingDescendants).toHaveLength(1);
-      expect(sportingDescendants).toContain('HockeyGame');
+      expect(sportingDescendants).toContain('@vitest/runner:HockeyGame');
     });
 
     it('should not include the base class itself', () => {
@@ -284,8 +293,9 @@ describe('STI Registry Methods', () => {
       }
 
       const descendants = ObjectRegistry.getDescendants('BaseClass');
+      // R5-canon: getDescendants returns qualified names.
       expect(descendants).toHaveLength(1);
-      expect(descendants).toContain('ChildClass');
+      expect(descendants).toContain('@vitest/runner:ChildClass');
     });
   });
 
@@ -312,15 +322,18 @@ describe('STI Registry Methods', () => {
       expect(ObjectRegistry.getTableStrategy('HockeyGame')).toBe('sti');
 
       // Verify base
-      expect(ObjectRegistry.getSTIBase('Event')).toBe('Event');
-      expect(ObjectRegistry.getSTIBase('Meeting')).toBe('Event');
-      expect(ObjectRegistry.getSTIBase('HockeyGame')).toBe('Event');
+      // R5-canon: getSTIBase/getDescendants return qualified names.
+      expect(ObjectRegistry.getSTIBase('Event')).toBe('@vitest/runner:Event');
+      expect(ObjectRegistry.getSTIBase('Meeting')).toBe('@vitest/runner:Event');
+      expect(ObjectRegistry.getSTIBase('HockeyGame')).toBe(
+        '@vitest/runner:Event',
+      );
 
       // Verify descendants
       const descendants = ObjectRegistry.getDescendants('Event');
       expect(descendants).toHaveLength(2);
-      expect(descendants).toContain('Meeting');
-      expect(descendants).toContain('HockeyGame');
+      expect(descendants).toContain('@vitest/runner:Meeting');
+      expect(descendants).toContain('@vitest/runner:HockeyGame');
     });
 
     it('should handle mixed CTI and STI hierarchies', () => {
@@ -352,15 +365,20 @@ describe('STI Registry Methods', () => {
       expect(ObjectRegistry.getSTIBase('Product')).toBeNull();
       expect(ObjectRegistry.getSTIBase('Book')).toBeNull();
 
-      // Verify Event hierarchy uses STI
+      // Verify Event hierarchy uses STI.
+      // R5-canon: getSTIBase/getDescendants return qualified names.
       expect(ObjectRegistry.getTableStrategy('Event')).toBe('sti');
       expect(ObjectRegistry.getTableStrategy('Meeting')).toBe('sti');
-      expect(ObjectRegistry.getSTIBase('Event')).toBe('Event');
-      expect(ObjectRegistry.getSTIBase('Meeting')).toBe('Event');
+      expect(ObjectRegistry.getSTIBase('Event')).toBe('@vitest/runner:Event');
+      expect(ObjectRegistry.getSTIBase('Meeting')).toBe('@vitest/runner:Event');
 
       // Verify descendants are isolated
-      expect(ObjectRegistry.getDescendants('Product')).toEqual(['Book']);
-      expect(ObjectRegistry.getDescendants('Event')).toEqual(['Meeting']);
+      expect(ObjectRegistry.getDescendants('Product')).toEqual([
+        '@vitest/runner:Book',
+      ]);
+      expect(ObjectRegistry.getDescendants('Event')).toEqual([
+        '@vitest/runner:Meeting',
+      ]);
     });
   });
 

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -30,10 +30,6 @@ export { config } from './config';
 export * from './errors';
 export { type HierarchyView, SmrtHierarchical } from './hierarchical';
 export {
-  type HierarchyView,
-  SmrtHierarchical,
-} from './hierarchical';
-export {
   type JunctionAttachOptions,
   type JunctionFilterOptions,
   SmrtJunction,

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -271,13 +271,21 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       validFieldNames.add('meta_data');
 
       // Issue #869: For STI classes, also include fields from all ancestor classes
-      // This ensures child class collections can filter by parent class fields
+      // This ensures child class collections can filter by parent class fields.
+      //
+      // R5-canon: inheritanceChain entries are qualified names (when the
+      // registration has one). Compare self against the qualified form;
+      // the framework-base sentinels stay as simple names since they're
+      // never registered. The simple-name `itemClassName` is also checked
+      // as a defensive fall-through for unqualified registrations.
+      const itemQualifiedName = this.getResolvedItemQualifiedName();
       const inheritanceChain =
         ObjectRegistry.getInheritanceChain(itemClassName);
       for (const ancestorName of inheritanceChain) {
         if (
           ancestorName === 'SmrtObject' ||
           ancestorName === 'SmrtClass' ||
+          ancestorName === itemQualifiedName ||
           ancestorName === itemClassName
         ) {
           continue; // Skip framework base classes and self (already included)
@@ -800,9 +808,11 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     const isSTI = tableStrategy === 'sti';
 
     if (isSTI) {
+      // R5-canon: `getSTIBase` returns the qualified name (when available);
+      // compare against the qualified form of the item class to detect a
+      // child collection vs the base itself.
       const stiBase = ObjectRegistry.getSTIBase(itemClassName);
-      // If this is a child collection (not the base), auto-filter by type
-      if (stiBase && stiBase !== itemClassName) {
+      if (stiBase && stiBase !== itemQualifiedName) {
         where = {
           _meta_type: itemQualifiedName,
           ...where,
@@ -924,9 +934,9 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     const isSTI = tableStrategy === 'sti';
 
     if (isSTI) {
+      // R5-canon: qualified-to-qualified comparison.
       const stiBase = ObjectRegistry.getSTIBase(itemClassName);
-      // If this is a child collection (not the base), auto-filter by type
-      if (stiBase && stiBase !== itemClassName) {
+      if (stiBase && stiBase !== itemQualifiedName) {
         where = {
           _meta_type: itemQualifiedName,
           ...(where || {}),
@@ -1874,9 +1884,9 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     const isSTI = tableStrategy === 'sti';
 
     if (isSTI) {
+      // R5-canon: qualified-to-qualified comparison.
       const stiBase = ObjectRegistry.getSTIBase(itemClassName);
-      // If this is a child collection (not the base), auto-filter by type
-      if (stiBase && stiBase !== itemClassName) {
+      if (stiBase && stiBase !== itemQualifiedName) {
         where = {
           _meta_type: itemQualifiedName,
           ...(where || {}),

--- a/packages/core/src/hierarchical.ts
+++ b/packages/core/src/hierarchical.ts
@@ -74,29 +74,20 @@ export class SmrtHierarchical extends SmrtObject {
    * For STI subclasses, queries are issued against the STI base collection
    * so the table/discriminator are correct.
    *
-   * Disambiguates classes that share a simple name across packages
-   * (e.g. two packages both shipping `Document`) by walking the
-   * constructor prototype chain. Constructor identity is unique even
-   * when class names collide, so this is collision-immune end-to-end:
+   * Lookup uses the constructor's qualified name when available — set by
+   * the registry on every registered class as `_smrtQualifiedName` (R5-
+   * canon prep). Then `ObjectRegistry.getSTIBase(...)` returns the
+   * qualified name of the STI base directly (R5-canon main), so the
+   * `getCollection` lookup never collapses to a simple-name ambiguity
+   * even when two packages ship a hierarchical class with the same
+   * simple name. Falls back through `getClassByConstructor` → simple
+   * `this.constructor.name` when the static / WeakMap aren't populated
+   * (rare; `getCollection` then surfaces the existing "not found in
+   * ObjectRegistry" error).
    *
-   * 1. Walk `this.constructor`'s prototype chain. For each ancestor
-   *    constructor, ask `ObjectRegistry.getClassByConstructor()` for
-   *    its registration. Track the OLDEST registration whose decorator
-   *    config declares `tableStrategy: 'sti'` — that's the STI base.
-   * 2. If we found an STI base, use its qualified name as the
-   *    collection lookup key.
-   * 3. Otherwise (non-STI), use this constructor's own qualified
-   *    registration name.
-   * 4. Fall back to the simple `this.constructor.name` only when nothing
-   *    is registered (in which case `getCollection` itself will surface
-   *    the existing "not found in ObjectRegistry" error).
-   *
-   * This finishes the qualified-name disambiguation that the prior
-   * implementation only delivered for non-STI hierarchical classes —
-   * `ObjectRegistry.getSTIBase(simpleName)` returns simple ancestor
-   * names from the inheritance chain map, which collapsed the qualified
-   * lookup back to an ambiguous simple key. Walking the runtime
-   * prototype chain sidesteps that entirely.
+   * The constructor prototype-chain walk that lived here from PR #1269
+   * is gone — the registry now returns qualified names directly so the
+   * walk became dead code.
    */
   protected async _hierarchyCollection(): Promise<SmrtCollection<this>> {
     if (this.constructor === SmrtHierarchical) {
@@ -105,41 +96,25 @@ export class SmrtHierarchical extends SmrtObject {
       );
     }
 
-    // Walk the prototype chain looking for the OLDEST ancestor whose
-    // registered config declares STI. Keep overwriting so we end on the
-    // root-most STI declaration (multi-level STI hierarchies put the
-    // shared table on the OLDEST ancestor — see ObjectRegistry.getSTIBase).
-    //
-    // Terminate at SmrtHierarchical (the typical case for any concrete
-    // subclass) and at `Function.prototype` / `Object.prototype` — those
-    // are what `Object.getPrototypeOf(ctor)` ultimately surfaces at the
-    // top of the chain (not the `Function` / `Object` constructors), so
-    // an explicit check against the prototypes avoids running the
-    // registry lookup on irrelevant non-class objects.
-    let stiBaseRegistration: ReturnType<
-      typeof ObjectRegistry.getClassByConstructor
-    >;
-    let ctor: unknown = this.constructor;
-    while (
-      ctor &&
-      ctor !== SmrtHierarchical &&
-      ctor !== Function.prototype &&
-      ctor !== Object.prototype
-    ) {
-      const reg = ObjectRegistry.getClassByConstructor(ctor as any);
-      if (reg?.config?.tableStrategy === 'sti') {
-        stiBaseRegistration = reg;
-      }
-      ctor = Object.getPrototypeOf(ctor);
-    }
+    // Identity priority:
+    //  1. The constructor's `_smrtQualifiedName` static (set at
+    //     registration, survives HMR / federated-module duplication).
+    //  2. The registry's WeakMap (`getClassByConstructor`) — same value
+    //     as the static when both are populated, but the WeakMap is
+    //     where simple-name fallback lives.
+    //  3. The simple constructor name as a last-ditch fallback.
+    const ctor = this.constructor as typeof SmrtHierarchical & {
+      _smrtQualifiedName?: string;
+    };
+    const tagged = ctor._smrtQualifiedName;
+    const registered = tagged
+      ? undefined
+      : ObjectRegistry.getClassByConstructor(ctor as any);
+    const className =
+      tagged ?? registered?.qualifiedName ?? registered?.name ?? ctor.name;
 
-    const ownRegistration = ObjectRegistry.getClassByConstructor(
-      this.constructor as any,
-    );
-    const resolved = stiBaseRegistration ?? ownRegistration;
-    const collectionClass =
-      resolved?.qualifiedName ?? resolved?.name ?? this.constructor.name;
-
+    const stiBase = ObjectRegistry.getSTIBase(className);
+    const collectionClass = stiBase ?? className;
     return await ObjectRegistry.getCollection<this>(
       collectionClass,
       this.options,

--- a/packages/core/src/registry.test.ts
+++ b/packages/core/src/registry.test.ts
@@ -879,11 +879,15 @@ describe('ObjectRegistry', () => {
       registered.inheritanceChain = undefined;
 
       // getInheritanceChain should not throw, and should return a chain
-      // that includes only the registered classes
+      // that includes only the registered classes.
+      // R5-canon: chains return qualified names. Use endsWith matcher
+      // to tolerate whatever package context the test runner derives.
       const chain = ObjectRegistry.getInheritanceChain('ChildClass');
 
       // Chain should contain at least the child class
-      expect(chain).toContain('ChildClass');
+      expect(
+        chain.some((c) => c === 'ChildClass' || c.endsWith(':ChildClass')),
+      ).toBe(true);
 
       // Since NonExistentParent isn't in any manifest, chain should only have ChildClass
       expect(chain.length).toBe(1);
@@ -898,8 +902,12 @@ describe('ObjectRegistry', () => {
       // Get the inheritance chain
       const chain = ObjectRegistry.getInheritanceChain('TestObject');
 
-      // Should contain TestObject but not SmrtObject
-      expect(chain).toContain('TestObject');
+      // Should contain TestObject but not SmrtObject (framework bases stay
+      // as simple sentinel names; they are never registered).
+      // R5-canon: chains return qualified names for registered classes.
+      expect(
+        chain.some((c) => c === 'TestObject' || c.endsWith(':TestObject')),
+      ).toBe(true);
       expect(chain).not.toContain('SmrtObject');
       expect(chain).not.toContain('SmrtClass');
       expect(chain).not.toContain('SmrtCollection');
@@ -1512,11 +1520,15 @@ describe('ObjectRegistry', () => {
       expect(videoShot).toBeDefined();
       expect(videoShot?.extends).toBe('@happyvertical/smrt-video:Content');
 
-      // Verify getInheritanceChain resolves correctly
+      // Verify getInheritanceChain resolves correctly.
+      // R5-canon: chains return qualified names.
       const chain = ObjectRegistry.getInheritanceChain(
         '@happyvertical/smrt-video:VideoShot',
       );
-      expect(chain).toEqual(['Content', 'VideoShot']);
+      expect(chain).toEqual([
+        '@happyvertical/smrt-video:Content',
+        '@happyvertical/smrt-video:VideoShot',
+      ]);
     });
 
     it('should pass through already-qualified extends names', () => {
@@ -1545,11 +1557,16 @@ describe('ObjectRegistry', () => {
       // Already-qualified extends should pass through unchanged
       expect(meeting?.extends).toBe('@happyvertical/smrt-events:Event');
 
-      // Chain should resolve correctly
+      // Chain should resolve correctly.
+      // R5-canon: chains return qualified names — ancestors keep their
+      // declaring package, child keeps its own.
       const chain = ObjectRegistry.getInheritanceChain(
         '@happyvertical/praeco:Meeting',
       );
-      expect(chain).toEqual(['Event', 'Meeting']);
+      expect(chain).toEqual([
+        '@happyvertical/smrt-events:Event',
+        '@happyvertical/praeco:Meeting',
+      ]);
     });
 
     it('should resolve single-package simple extends without issue', () => {
@@ -1578,10 +1595,14 @@ describe('ObjectRegistry', () => {
       // Same-package parent should be qualified
       expect(dog?.extends).toBe('@happyvertical/smrt-zoo:Animal');
 
+      // R5-canon: chains return qualified names.
       const chain = ObjectRegistry.getInheritanceChain(
         '@happyvertical/smrt-zoo:Dog',
       );
-      expect(chain).toEqual(['Animal', 'Dog']);
+      expect(chain).toEqual([
+        '@happyvertical/smrt-zoo:Animal',
+        '@happyvertical/smrt-zoo:Dog',
+      ]);
     });
 
     it('should not qualify framework base classes (SmrtObject, etc.)', () => {
@@ -1617,10 +1638,11 @@ describe('ObjectRegistry', () => {
       expect(standalone).toBeDefined();
       expect(standalone?.extends).toBeUndefined();
 
+      // R5-canon: chains return qualified names.
       const chain = ObjectRegistry.getInheritanceChain(
         '@happyvertical/smrt-misc:Standalone',
       );
-      expect(chain).toEqual(['Standalone']);
+      expect(chain).toEqual(['@happyvertical/smrt-misc:Standalone']);
     });
   });
 });

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1997,26 +1997,29 @@ export class ObjectRegistry {
   /**
    * Get full inheritance chain for a class
    *
-   * Returns array of class names from base (SmrtObject) to child. Chain
-   * entries are **qualified names** (`@package/name:ClassName`) whenever
-   * the corresponding registration has one — i.e. for every class loaded
-   * via a manifest or `@smrt()` decorator with a package context. Classes
-   * registered without a package (some tests) fall back to their simple
-   * name. The framework-base sentinels (`SmrtObject`, `SmrtClass`,
-   * `SmrtCollection`) are still simple names because they are never
-   * registered.
+   * Returns array of registered ancestor class names from the oldest
+   * registered ancestor down to the input class. Framework base classes
+   * (`SmrtObject`, `SmrtClass`, `SmrtCollection`) are **NOT** included
+   * because they are never registered — the walk terminates one step
+   * before them.
+   *
+   * Chain entries are **qualified names** (`@package/name:ClassName`)
+   * whenever the corresponding registration has one — i.e. for every
+   * class loaded via a manifest or `@smrt()` decorator with a package
+   * context. Classes registered without a package (some tests) fall
+   * back to their simple name.
    *
    * Results are cached globally for performance (~100x faster than re-walking).
    *
    * @param className - Name of the registered class (simple or qualified)
-   * @returns Array of class names from base to child, or empty array if not found
+   * @returns Array of class names from oldest registered ancestor to
+   *   the input class, or empty array if not found
    * @example
    * ```typescript
    * const chain = ObjectRegistry.getInheritanceChain(
    *   '@happyvertical/smrt-content:BentleyContent',
    * );
    * // [
-   * //   'SmrtObject',
    * //   '@happyvertical/smrt-content:Content',
    * //   '@happyvertical/smrt-content:PraecoContent',
    * //   '@happyvertical/smrt-content:BentleyContent',

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -3140,7 +3140,7 @@ export function smrt(config: SmartObjectConfig = {}) {
 
           if (stiBase && stiBase !== itemQualified) {
             // Use STI base's table name
-            const baseReg = ObjectRegistry.findClass(stiBase);
+            const baseReg = ObjectRegistry.getClass(stiBase);
             tableName =
               baseReg?.schema?.tableName ??
               classnameToTablename(baseReg?.name ?? stiBase);
@@ -3217,7 +3217,7 @@ export function smrt(config: SmartObjectConfig = {}) {
             // This is an STI child - use parent's table name. Resolve the
             // qualified stiBaseName to its registration to pick the
             // correct table identifier.
-            const baseReg = ObjectRegistry.findClass(stiBaseName);
+            const baseReg = ObjectRegistry.getClass(stiBaseName);
             tableName =
               baseReg?.schema?.tableName ??
               classnameToTablename(baseReg?.name ?? stiBaseName);
@@ -3244,7 +3244,7 @@ export function smrt(config: SmartObjectConfig = {}) {
           if (stiBaseName) {
             // Use STI base's table name. (R5-canon: see above — qualified
             // stiBaseName resolves to its registration's tableName.)
-            const baseReg = ObjectRegistry.findClass(stiBaseName);
+            const baseReg = ObjectRegistry.getClass(stiBaseName);
             tableName =
               baseReg?.schema?.tableName ??
               classnameToTablename(baseReg?.name ?? stiBaseName);

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1997,15 +1997,30 @@ export class ObjectRegistry {
   /**
    * Get full inheritance chain for a class
    *
-   * Returns array of class names from base (SmrtObject) to child.
+   * Returns array of class names from base (SmrtObject) to child. Chain
+   * entries are **qualified names** (`@package/name:ClassName`) whenever
+   * the corresponding registration has one — i.e. for every class loaded
+   * via a manifest or `@smrt()` decorator with a package context. Classes
+   * registered without a package (some tests) fall back to their simple
+   * name. The framework-base sentinels (`SmrtObject`, `SmrtClass`,
+   * `SmrtCollection`) are still simple names because they are never
+   * registered.
+   *
    * Results are cached globally for performance (~100x faster than re-walking).
    *
-   * @param className - Name of the registered class
+   * @param className - Name of the registered class (simple or qualified)
    * @returns Array of class names from base to child, or empty array if not found
    * @example
    * ```typescript
-   * const chain = ObjectRegistry.getInheritanceChain('BentleyContent');
-   * // ['SmrtObject', 'Content', 'PraecoContent', 'BentleyContent']
+   * const chain = ObjectRegistry.getInheritanceChain(
+   *   '@happyvertical/smrt-content:BentleyContent',
+   * );
+   * // [
+   * //   'SmrtObject',
+   * //   '@happyvertical/smrt-content:Content',
+   * //   '@happyvertical/smrt-content:PraecoContent',
+   * //   '@happyvertical/smrt-content:BentleyContent',
+   * // ]
    * ```
    */
   static getInheritanceChain(className: string): string[] {
@@ -2055,7 +2070,11 @@ export class ObjectRegistry {
       }
       visited.add(current);
 
-      chain.unshift(current.name); // Add at start to build [ancestor, ..., descendant]
+      // R5-canon: emit the qualified name when the registration has one
+      // so chain entries are unambiguous across packages. Falls back to
+      // the simple `current.name` for classes that lack a package context
+      // (some tests, or classes that bypassed manifest registration).
+      chain.unshift(current.qualifiedName ?? current.name); // [ancestor, ..., descendant]
       if (!current.extends) break;
 
       // Skip framework base classes that are never registered
@@ -2692,11 +2711,16 @@ export class ObjectRegistry {
    * with `tableStrategy: 'sti'`. This is the class that owns the shared table.
    *
    * **Returns:**
-   * - The base class name if STI is configured in the hierarchy
-   * - null if the class uses CTI strategy
+   * - The base class's **qualified name** (`@package/name:ClassName`) when
+   *   the registration has one — same convention as
+   *   `getInheritanceChain`. Falls back to the simple name only for
+   *   registrations without a package context (some test classes).
+   * - `null` if the class uses CTI strategy.
+   *
+   * Accepts either a simple or a qualified name on input.
    *
    * @param className - Name of the class to find STI base for
-   * @returns Base class name or null if CTI
+   * @returns Qualified base class name or null if CTI
    * @example
    * ```typescript
    * @smrt({ tableStrategy: 'sti' })
@@ -2705,8 +2729,10 @@ export class ObjectRegistry {
    * @smrt()
    * class Meeting extends Event { }
    *
-   * ObjectRegistry.getSTIBase('Meeting'); // 'Event'
-   * ObjectRegistry.getSTIBase('Event'); // 'Event'
+   * ObjectRegistry.getSTIBase('@happyvertical/smrt-events:Meeting');
+   * // '@happyvertical/smrt-events:Event'
+   * ObjectRegistry.getSTIBase('@happyvertical/smrt-events:Event');
+   * // '@happyvertical/smrt-events:Event'
    * ```
    */
   static getSTIBase(className: string): string | null {
@@ -2726,6 +2752,10 @@ export class ObjectRegistry {
     // 2. registerFromManifest() derives a tableName from class name when null
     // 3. This causes tableName mismatch ('meetings' vs 'events')
     // 4. Instead, find the oldest ancestor with EXPLICIT tableStrategy: 'sti'
+    //
+    // R5-canon: chain entries are qualified names (when the class has a
+    // package context), so the returned STI base is also qualified —
+    // ambiguity across packages with same-simple-name STI roots is gone.
     const chain = ObjectRegistry.getInheritanceChain(className);
 
     // Walk the chain (ordered [root, ..., className]) to find oldest STI base
@@ -2738,13 +2768,15 @@ export class ObjectRegistry {
       if (ancestor.config?.tableStrategy === 'sti') {
         // Found the OLDEST ancestor with explicit STI - this is the base
         // All descendants inherit from this table regardless of their tableName
-        return ancestorName;
+        return ancestor.qualifiedName ?? ancestor.name;
       }
     }
 
     // If no explicit STI ancestor found but we detected STI strategy,
-    // this class is its own STI base (it must have declared tableStrategy: 'sti')
-    return className;
+    // this class is its own STI base (it must have declared tableStrategy: 'sti').
+    // Return its qualified name when available.
+    const self = ObjectRegistry.findClass(className);
+    return self?.qualifiedName ?? self?.name ?? className;
   }
 
   /**
@@ -2758,8 +2790,13 @@ export class ObjectRegistry {
    * - Polymorphic queries: Find all types to instantiate
    * - Documentation: Show class hierarchy
    *
-   * @param className - Name of the base class
-   * @returns Array of descendant class names (direct and indirect)
+   * Accepts either a simple or a qualified name on input. The returned
+   * descendant names are **qualified** (`@package/name:ClassName`) when
+   * the registration has one — same convention as `getInheritanceChain`
+   * and `getSTIBase`.
+   *
+   * @param className - Name of the base class (simple or qualified)
+   * @returns Array of qualified descendant class names (direct and indirect)
    * @example
    * ```typescript
    * @smrt({ tableStrategy: 'sti' })
@@ -2771,19 +2808,31 @@ export class ObjectRegistry {
    * @smrt()
    * class HockeyGame extends Event { }
    *
-   * ObjectRegistry.getDescendants('Event'); // ['Meeting', 'HockeyGame']
+   * ObjectRegistry.getDescendants('@happyvertical/smrt-events:Event');
+   * // [
+   * //   '@happyvertical/smrt-events:Meeting',
+   * //   '@happyvertical/smrt-events:HockeyGame',
+   * // ]
    * ```
    */
   static getDescendants(className: string): string[] {
     const descendants: string[] = [];
 
+    // R5-canon: inheritance chains are emitted with qualified names when
+    // available, so the comparison against `className` must accept either
+    // a qualified or simple input from the caller. Resolve once up-front
+    // to whichever form actually appears in the chain.
+    const target = ObjectRegistry.findClass(className);
+    const targetKey = target?.qualifiedName ?? target?.name ?? className;
+
     // Find all classes that extend the given class
-    // Issue #951: Use simple name for comparison since inheritance chains contain simple names
     for (const [_key, childClass] of ObjectRegistry.classes) {
-      const simpleName = childClass.name || _key;
-      const chain = ObjectRegistry.getInheritanceChain(simpleName);
-      if (chain.includes(className) && simpleName !== className) {
-        descendants.push(simpleName);
+      const childKey = childClass.qualifiedName ?? childClass.name ?? _key;
+      if (childKey === targetKey) continue;
+
+      const chain = ObjectRegistry.getInheritanceChain(childKey);
+      if (chain.includes(targetKey)) {
+        descendants.push(childKey);
       }
     }
 
@@ -3079,9 +3128,22 @@ export function smrt(config: SmartObjectConfig = {}) {
           const itemClassName = itemClass.name;
           const stiBase = ObjectRegistry.getSTIBase(itemClassName);
 
-          if (stiBase && stiBase !== itemClassName) {
+          // R5-canon: `getSTIBase` returns a qualified name. Compare against
+          // the item class's own qualified registration (when present) and
+          // derive the table name from the base's actual registration —
+          // feeding a qualified string straight into `classnameToTablename`
+          // would yield a garbled identifier.
+          const itemReg = ObjectRegistry.getClassByConstructor(
+            itemClass as any,
+          );
+          const itemQualified = itemReg?.qualifiedName ?? itemClassName;
+
+          if (stiBase && stiBase !== itemQualified) {
             // Use STI base's table name
-            tableName = classnameToTablename(stiBase);
+            const baseReg = ObjectRegistry.findClass(stiBase);
+            tableName =
+              baseReg?.schema?.tableName ??
+              classnameToTablename(baseReg?.name ?? stiBase);
           } else if (ObjectRegistry.getTableStrategy(itemClassName) === 'sti') {
             // This is the STI base - use its own table name
             tableName = classnameToTablename(itemClassName);
@@ -3134,6 +3196,12 @@ export function smrt(config: SmartObjectConfig = {}) {
           // 3. Test scenarios without manifest generation
           // Note: This relies on parents being registered first, which is why
           // the manifest check above is preferred (it has correct build-time data).
+          //
+          // R5-canon: `getSTIBase` now returns the qualified name. We
+          // resolve back to the registered class and prefer its actual
+          // `schema.tableName` when present; otherwise fall back to the
+          // simple-name-derived table name. Deriving directly from a
+          // qualified string would produce a garbled identifier.
           let proto = Object.getPrototypeOf(ctor);
           let stiBaseName: string | null = null;
 
@@ -3146,8 +3214,13 @@ export function smrt(config: SmartObjectConfig = {}) {
           }
 
           if (stiBaseName) {
-            // This is an STI child - use parent's table name
-            tableName = classnameToTablename(stiBaseName);
+            // This is an STI child - use parent's table name. Resolve the
+            // qualified stiBaseName to its registration to pick the
+            // correct table identifier.
+            const baseReg = ObjectRegistry.findClass(stiBaseName);
+            tableName =
+              baseReg?.schema?.tableName ??
+              classnameToTablename(baseReg?.name ?? stiBaseName);
           } else {
             // This is the actual STI base - use its own table name
             tableName = classnameToTablename(ctor.name);
@@ -3169,8 +3242,12 @@ export function smrt(config: SmartObjectConfig = {}) {
           }
 
           if (stiBaseName) {
-            // Use STI base's table name
-            tableName = classnameToTablename(stiBaseName);
+            // Use STI base's table name. (R5-canon: see above — qualified
+            // stiBaseName resolves to its registration's tableName.)
+            const baseReg = ObjectRegistry.findClass(stiBaseName);
+            tableName =
+              baseReg?.schema?.tableName ??
+              classnameToTablename(baseReg?.name ?? stiBaseName);
           } else {
             // CTI: Use own table name
             tableName = classnameToTablename(ctor.name);

--- a/packages/core/src/registry/class-registration.ts
+++ b/packages/core/src/registry/class-registration.ts
@@ -420,6 +420,38 @@ function setSmrtTableName(ctor: typeof SmrtObject, tableName: string): void {
   });
 }
 
+/**
+ * Attach the registry's qualified name to the constructor as a static
+ * property. Mirrors the `SMRT_TABLE_NAME` pattern.
+ *
+ * Survives:
+ * - Minification (the property is set on the constructor itself).
+ * - HMR / module duplication / federated-module boundaries where the
+ *   `constructorIndex` WeakMap holds an older constructor identity than
+ *   the one a caller has in hand.
+ *
+ * Acts as a belt-and-suspenders fallback for runtime code that has a
+ * constructor reference and wants its registry identity without going
+ * through a Map lookup (e.g. `SmrtHierarchical._hierarchyCollection`).
+ */
+function setSmrtQualifiedName(
+  ctor: typeof SmrtObject,
+  qualifiedName: string | undefined,
+): void {
+  if (!qualifiedName) return;
+  const existing = Object.getOwnPropertyDescriptor(ctor, '_smrtQualifiedName');
+  if (existing?.value === qualifiedName) {
+    return;
+  }
+
+  Object.defineProperty(ctor, '_smrtQualifiedName', {
+    value: qualifiedName,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
+}
+
 export function register(
   ctor: typeof SmrtObject,
   config: SmartObjectConfig = {},
@@ -472,6 +504,7 @@ export function register(
     existing.schema.tableName = nextTableName;
     existing.constructor = ctor;
     setSmrtTableName(ctor, nextTableName);
+    setSmrtQualifiedName(ctor, existing.qualifiedName);
 
     if (existingKey !== nextKey) {
       const classes = getClasses();
@@ -978,6 +1011,10 @@ export function register(
 
   // Index constructor for O(1) reverse lookups (Issue #713: constructor-based lookup)
   getConstructorIndex().set(ctor, registrationKey);
+  // Stamp the qualified name on the constructor itself as a fallback for
+  // runtime code that has a constructor reference but might hit a
+  // WeakMap miss (HMR / federated modules / multiple-copy edge cases).
+  setSmrtQualifiedName(ctor, qualifiedName);
 
   verboseLog(
     `🎯 Registered smrt object: ${name} (key: ${registrationKey}) with schema for ${schema.tableName} and ${(validators?.length || 0) + (validationRules?.length || 0)} validators/rules`,
@@ -1559,6 +1596,10 @@ export function registerFromManifest(
     extends: qualifiedExtends, // Issue #1004: Pre-computed qualified parent
     visibility, // New: Visibility control for manifest filtering
   });
+  // Tag the synthetic stub constructor with the qualified name so the
+  // same constructor-side identity convention holds for manifest-loaded
+  // classes as well as decorator-registered ones.
+  setSmrtQualifiedName(stubConstructor, qualifiedName);
 
   verboseLog(
     `📦 Registered ${simpleClassName} from manifest (key: ${registrationKey}, ${fields.size} fields, ${methods.size} methods)`,

--- a/packages/core/src/registry/inheritance-resolver.ts
+++ b/packages/core/src/registry/inheritance-resolver.ts
@@ -95,7 +95,10 @@ export function getInheritanceChain(className: string): string[] {
     }
     visited.add(current);
 
-    chain.unshift(current.name); // Add at start to build [ancestor, ..., descendant]
+    // R5-canon: emit qualified names when available, matching the
+    // public `ObjectRegistry.getInheritanceChain` contract. Falls back
+    // to simple name for classes registered without a package context.
+    chain.unshift(current.qualifiedName ?? current.name); // [ancestor, ..., descendant]
     if (!current.extends) break;
 
     // Skip framework base classes that are never registered

--- a/packages/core/src/registry/schema-builder.ts
+++ b/packages/core/src/registry/schema-builder.ts
@@ -180,13 +180,15 @@ export function getAllSchemas(): Record<
     // registerFromManifest() to derive a tableName from class name.
     // For STI subclasses, we need to use the STI base's tableName instead.
     if (!registered.schema?.tableName && registered.extends) {
-      const tableStrategy = ObjectRegistry.getTableStrategy(simpleName);
+      // R5-canon: use the qualified key for STI lookups so colliding
+      // simple names don't resolve to the wrong package's class.
+      // `getTableStrategy` / `getSTIBase` both accept qualified names
+      // via `findClass`'s multi-strategy lookup.
+      const qualifiedName = (registered as any).qualifiedName ?? simpleName;
+      const lookupKey = qualifiedName;
+      const tableStrategy = ObjectRegistry.getTableStrategy(lookupKey);
       if (tableStrategy === 'sti') {
-        const stiBaseName = ObjectRegistry.getSTIBase(simpleName);
-        // R5-canon: getSTIBase returns the qualified name; compare against
-        // the qualified form of this class so an STI base isn't
-        // mis-classified as a subclass.
-        const qualifiedName = (registered as any).qualifiedName ?? simpleName;
+        const stiBaseName = ObjectRegistry.getSTIBase(lookupKey);
         if (stiBaseName && stiBaseName !== qualifiedName) {
           const stiBaseClass = findClass(stiBaseName);
           if (stiBaseClass?.schema?.tableName) {
@@ -215,13 +217,12 @@ export function getAllSchemas(): Record<
       // This ensures all STI subclass columns are merged into the parent table
       // (Issue #693: STI subclasses with separate tableName still serialize to parent table)
       let tableName = registered.schema.tableName;
-      const tableStrategy = ObjectRegistry.getTableStrategy(simpleName);
+      // R5-canon: same qualified-key strategy as the block above.
+      const qualifiedName = (registered as any).qualifiedName ?? simpleName;
+      const lookupKey = qualifiedName;
+      const tableStrategy = ObjectRegistry.getTableStrategy(lookupKey);
       if (tableStrategy === 'sti') {
-        const stiBaseName = ObjectRegistry.getSTIBase(simpleName);
-        // R5-canon: getSTIBase returns the qualified name; compare against
-        // the qualified form of this class so an STI base isn't
-        // mis-classified as a subclass.
-        const qualifiedName = (registered as any).qualifiedName ?? simpleName;
+        const stiBaseName = ObjectRegistry.getSTIBase(lookupKey);
         if (stiBaseName && stiBaseName !== qualifiedName) {
           // This is an STI subclass - use the base class's tableName
           const stiBaseClass = findClass(stiBaseName);
@@ -383,13 +384,15 @@ export function getAllSchemasAsDefinitions(): Record<string, SchemaDefinition> {
 
     // Handle STI subclasses with null tableName from external manifests
     if (!registered.schema?.tableName && registered.extends) {
-      const tableStrategy = ObjectRegistry.getTableStrategy(simpleName);
+      // R5-canon: use the qualified key for STI lookups so colliding
+      // simple names don't resolve to the wrong package's class.
+      // `getTableStrategy` / `getSTIBase` both accept qualified names
+      // via `findClass`'s multi-strategy lookup.
+      const qualifiedName = (registered as any).qualifiedName ?? simpleName;
+      const lookupKey = qualifiedName;
+      const tableStrategy = ObjectRegistry.getTableStrategy(lookupKey);
       if (tableStrategy === 'sti') {
-        const stiBaseName = ObjectRegistry.getSTIBase(simpleName);
-        // R5-canon: getSTIBase returns the qualified name; compare against
-        // the qualified form of this class so an STI base isn't
-        // mis-classified as a subclass.
-        const qualifiedName = (registered as any).qualifiedName ?? simpleName;
+        const stiBaseName = ObjectRegistry.getSTIBase(lookupKey);
         if (stiBaseName && stiBaseName !== qualifiedName) {
           const stiBaseClass = findClass(stiBaseName);
           if (stiBaseClass?.schema?.tableName) {

--- a/packages/core/src/registry/schema-builder.ts
+++ b/packages/core/src/registry/schema-builder.ts
@@ -120,9 +120,14 @@ export function getTableName(name: string): string | undefined {
     return collectionTableName;
   }
 
-  // For STI classes, return the STI base class's table name
+  // For STI classes, return the STI base class's table name.
+  // R5-canon: `getSTIBase` returns the qualified name; resolve `name`
+  // (which may be simple) to its registration's qualified form for the
+  // comparison.
   const stiBase = ObjectRegistry.getSTIBase(name);
-  if (stiBase && stiBase !== name) {
+  const registered = ObjectRegistry.findClass(name);
+  const qualifiedName = registered?.qualifiedName ?? registered?.name ?? name;
+  if (stiBase && stiBase !== qualifiedName) {
     return getSchema(stiBase)?.tableName;
   }
   return getSchema(name)?.tableName;
@@ -178,7 +183,11 @@ export function getAllSchemas(): Record<
       const tableStrategy = ObjectRegistry.getTableStrategy(simpleName);
       if (tableStrategy === 'sti') {
         const stiBaseName = ObjectRegistry.getSTIBase(simpleName);
-        if (stiBaseName && stiBaseName !== simpleName) {
+        // R5-canon: getSTIBase returns the qualified name; compare against
+        // the qualified form of this class so an STI base isn't
+        // mis-classified as a subclass.
+        const qualifiedName = (registered as any).qualifiedName ?? simpleName;
+        if (stiBaseName && stiBaseName !== qualifiedName) {
           const stiBaseClass = findClass(stiBaseName);
           if (stiBaseClass?.schema?.tableName) {
             // Ensure we have a schema object to modify
@@ -209,7 +218,11 @@ export function getAllSchemas(): Record<
       const tableStrategy = ObjectRegistry.getTableStrategy(simpleName);
       if (tableStrategy === 'sti') {
         const stiBaseName = ObjectRegistry.getSTIBase(simpleName);
-        if (stiBaseName && stiBaseName !== simpleName) {
+        // R5-canon: getSTIBase returns the qualified name; compare against
+        // the qualified form of this class so an STI base isn't
+        // mis-classified as a subclass.
+        const qualifiedName = (registered as any).qualifiedName ?? simpleName;
+        if (stiBaseName && stiBaseName !== qualifiedName) {
           // This is an STI subclass - use the base class's tableName
           const stiBaseClass = findClass(stiBaseName);
           if (stiBaseClass?.schema?.tableName) {
@@ -373,7 +386,11 @@ export function getAllSchemasAsDefinitions(): Record<string, SchemaDefinition> {
       const tableStrategy = ObjectRegistry.getTableStrategy(simpleName);
       if (tableStrategy === 'sti') {
         const stiBaseName = ObjectRegistry.getSTIBase(simpleName);
-        if (stiBaseName && stiBaseName !== simpleName) {
+        // R5-canon: getSTIBase returns the qualified name; compare against
+        // the qualified form of this class so an STI base isn't
+        // mis-classified as a subclass.
+        const qualifiedName = (registered as any).qualifiedName ?? simpleName;
+        if (stiBaseName && stiBaseName !== qualifiedName) {
           const stiBaseClass = findClass(stiBaseName);
           if (stiBaseClass?.schema?.tableName) {
             if (!registered.schema) {
@@ -400,7 +417,11 @@ export function getAllSchemasAsDefinitions(): Record<string, SchemaDefinition> {
       const tableStrategy = ObjectRegistry.getTableStrategy(simpleName);
       if (tableStrategy === 'sti') {
         const stiBaseName = ObjectRegistry.getSTIBase(simpleName);
-        if (stiBaseName && stiBaseName !== simpleName) {
+        // R5-canon: getSTIBase returns the qualified name; compare against
+        // the qualified form of this class so an STI base isn't
+        // mis-classified as a subclass.
+        const qualifiedName = (registered as any).qualifiedName ?? simpleName;
+        if (stiBaseName && stiBaseName !== qualifiedName) {
           const stiBaseClass = findClass(stiBaseName);
           if (stiBaseClass?.schema?.tableName) {
             tableName = stiBaseClass.schema.tableName;

--- a/packages/core/src/registry/schema-builder.ts
+++ b/packages/core/src/registry/schema-builder.ts
@@ -125,7 +125,7 @@ export function getTableName(name: string): string | undefined {
   // (which may be simple) to its registration's qualified form for the
   // comparison.
   const stiBase = ObjectRegistry.getSTIBase(name);
-  const registered = ObjectRegistry.findClass(name);
+  const registered = ObjectRegistry.getClass(name);
   const qualifiedName = registered?.qualifiedName ?? registered?.name ?? name;
   if (stiBase && stiBase !== qualifiedName) {
     return getSchema(stiBase)?.tableName;

--- a/packages/core/src/schema/utils.ts
+++ b/packages/core/src/schema/utils.ts
@@ -119,9 +119,13 @@ export async function generateSchema(
       );
     }
 
-    // Only generate schema for the base class (not for children)
-    // Children will use the same table as the base
-    if (className === stiBase) {
+    // Only generate schema for the base class (not for children).
+    // R5-canon: `getSTIBase` returns the qualified name; compare against
+    // the qualified form of this class so an STI base isn't
+    // mis-classified as a subclass and skipped.
+    const qualifiedClassName =
+      registeredClass?.qualifiedName ?? registeredClass?.name ?? className;
+    if (qualifiedClassName === stiBase || className === stiBase) {
       // This is the base class - generate STI schema
       schemaDefinition = await generator.generateSTISchemaFromRegistry(
         className,

--- a/packages/core/src/schema/utils.ts
+++ b/packages/core/src/schema/utils.ts
@@ -187,7 +187,13 @@ export async function ensureSchema(
   const tableStrategy = ObjectRegistry.getTableStrategy(className);
   if (tableStrategy === 'sti') {
     const stiBase = ObjectRegistry.getSTIBase(className);
-    if (stiBase && stiBase !== className) {
+    // R5-canon: `getSTIBase` returns the qualified name. Compare
+    // against the qualified form of `className` so an STI base isn't
+    // mis-classified as a child and recursed on. Falls back to a
+    // simple-name compare for classes without a package context.
+    const qualifiedClassName =
+      registered.qualifiedName ?? registered.name ?? className;
+    if (stiBase && stiBase !== qualifiedClassName && stiBase !== className) {
       await ensureSchema(db, stiBase);
       return;
     }

--- a/packages/core/src/testing/database.ts
+++ b/packages/core/src/testing/database.ts
@@ -204,9 +204,16 @@ export async function getTestDatabase(
   const createdTables = new Set<string>();
 
   for (const className of classNames) {
-    // Skip STI children - their schema is part of the base class table
+    // Skip STI children - their schema is part of the base class table.
+    // R5-canon: `getSTIBase` now returns the qualified name. Compare
+    // against the qualified form of the iteration key so STI base
+    // classes still produce their own table instead of being mis-flagged
+    // as children.
     const stiBase = ObjectRegistry.getSTIBase(className);
-    if (stiBase && stiBase !== className) {
+    const registered = ObjectRegistry.findClass(className);
+    const qualifiedClassName =
+      registered?.qualifiedName ?? registered?.name ?? className;
+    if (stiBase && stiBase !== qualifiedClassName) {
       continue;
     }
 

--- a/packages/core/src/testing/database.ts
+++ b/packages/core/src/testing/database.ts
@@ -210,7 +210,7 @@ export async function getTestDatabase(
     // classes still produce their own table instead of being mis-flagged
     // as children.
     const stiBase = ObjectRegistry.getSTIBase(className);
-    const registered = ObjectRegistry.findClass(className);
+    const registered = ObjectRegistry.getClass(className);
     const qualifiedClassName =
       registered?.qualifiedName ?? registered?.name ?? className;
     if (stiBase && stiBase !== qualifiedClassName) {

--- a/packages/messages/src/__tests__/account-sti.test.ts
+++ b/packages/messages/src/__tests__/account-sti.test.ts
@@ -82,7 +82,7 @@ describe('Account STI Support', () => {
 
     it('should get STI base class', () => {
       const base = ObjectRegistry.getSTIBase('EmailAccount');
-      expect(base).toBe('Account');
+      expect(base).toBe('@happyvertical/smrt-messages:Account');
     });
 
     it('should set _meta_type to EmailAccount', async () => {
@@ -139,7 +139,7 @@ describe('Account STI Support', () => {
 
     it('should get STI base class', () => {
       const base = ObjectRegistry.getSTIBase('SlackAccount');
-      expect(base).toBe('Account');
+      expect(base).toBe('@happyvertical/smrt-messages:Account');
     });
 
     it('should set _meta_type to SlackAccount', async () => {
@@ -177,7 +177,7 @@ describe('Account STI Support', () => {
 
     it('should get STI base class', () => {
       const base = ObjectRegistry.getSTIBase('TwitterAccount');
-      expect(base).toBe('Account');
+      expect(base).toBe('@happyvertical/smrt-messages:Account');
     });
 
     it('should set _meta_type to TwitterAccount', async () => {
@@ -245,20 +245,28 @@ describe('Account STI Support', () => {
     it('should build correct inheritance chain for EmailAccount', () => {
       const chain = ObjectRegistry.getInheritanceChain('EmailAccount');
 
-      expect(chain).toContain('Account');
-      expect(chain).toContain('EmailAccount');
+      expect(chain).toContain('@happyvertical/smrt-messages:Account');
+      expect(chain).toContain('@happyvertical/smrt-messages:EmailAccount');
 
-      const accountIdx = chain.indexOf('Account');
-      const emailAccountIdx = chain.indexOf('EmailAccount');
+      const accountIdx = chain.indexOf('@happyvertical/smrt-messages:Account');
+      const emailAccountIdx = chain.indexOf(
+        '@happyvertical/smrt-messages:EmailAccount',
+      );
       expect(emailAccountIdx).toBeGreaterThan(accountIdx);
     });
 
     it('should get all descendants of Account', () => {
       const descendants = ObjectRegistry.getDescendants('Account');
 
-      expect(descendants).toContain('EmailAccount');
-      expect(descendants).toContain('SlackAccount');
-      expect(descendants).toContain('TwitterAccount');
+      expect(descendants).toContain(
+        '@happyvertical/smrt-messages:EmailAccount',
+      );
+      expect(descendants).toContain(
+        '@happyvertical/smrt-messages:SlackAccount',
+      );
+      expect(descendants).toContain(
+        '@happyvertical/smrt-messages:TwitterAccount',
+      );
     });
   });
 });

--- a/packages/messages/src/__tests__/message-sti.test.ts
+++ b/packages/messages/src/__tests__/message-sti.test.ts
@@ -88,7 +88,7 @@ describe('Message STI Support', () => {
 
     it('should get STI base class', () => {
       const base = ObjectRegistry.getSTIBase('Email');
-      expect(base).toBe('Message');
+      expect(base).toBe('@happyvertical/smrt-messages:Message');
     });
 
     it('should set _meta_type to Email', async () => {
@@ -170,7 +170,7 @@ describe('Message STI Support', () => {
 
     it('should get STI base class', () => {
       const base = ObjectRegistry.getSTIBase('Tweet');
-      expect(base).toBe('Message');
+      expect(base).toBe('@happyvertical/smrt-messages:Message');
     });
 
     it('should set _meta_type to Tweet', async () => {
@@ -244,7 +244,7 @@ describe('Message STI Support', () => {
 
     it('should get STI base class', () => {
       const base = ObjectRegistry.getSTIBase('SlackMessage');
-      expect(base).toBe('Message');
+      expect(base).toBe('@happyvertical/smrt-messages:Message');
     });
 
     it('should set _meta_type to SlackMessage', async () => {
@@ -344,20 +344,22 @@ describe('Message STI Support', () => {
     it('should build correct inheritance chain for Email', () => {
       const chain = ObjectRegistry.getInheritanceChain('Email');
 
-      expect(chain).toContain('Message');
-      expect(chain).toContain('Email');
+      expect(chain).toContain('@happyvertical/smrt-messages:Message');
+      expect(chain).toContain('@happyvertical/smrt-messages:Email');
 
-      const messageIdx = chain.indexOf('Message');
-      const emailIdx = chain.indexOf('Email');
+      const messageIdx = chain.indexOf('@happyvertical/smrt-messages:Message');
+      const emailIdx = chain.indexOf('@happyvertical/smrt-messages:Email');
       expect(emailIdx).toBeGreaterThan(messageIdx);
     });
 
     it('should get all descendants of Message', () => {
       const descendants = ObjectRegistry.getDescendants('Message');
 
-      expect(descendants).toContain('Email');
-      expect(descendants).toContain('Tweet');
-      expect(descendants).toContain('SlackMessage');
+      expect(descendants).toContain('@happyvertical/smrt-messages:Email');
+      expect(descendants).toContain('@happyvertical/smrt-messages:Tweet');
+      expect(descendants).toContain(
+        '@happyvertical/smrt-messages:SlackMessage',
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

R5-canon in the [relationships-v2](https://github.com/happyvertical/smrt/tree/feat/relationships-v2) workstream. Makes qualified names (`@package/name:ClassName`) the canonical identifier throughout `ObjectRegistry`'s internal lookups. Eliminates the cross-package simple-name collision risk that PR [#1269](https://github.com/happyvertical/smrt/pull/1269) had to work around with a constructor prototype-chain walk inside `SmrtHierarchical._hierarchyCollection`.

After this lands, that walk is dead code and is removed.

## Commits

1. **`498e60a75`** `chore(core): de-duplicate SmrtHierarchical browser-entry export` — one-line merge-artifact cleanup (PR [#1269](https://github.com/happyvertical/smrt/pull/1269) and PR [#1272](https://github.com/happyvertical/smrt/pull/1272) both added the same export; collapsed to one statement).
2. **`413e53d13`** `feat(core): stamp qualified name on registered constructors (R5-canon prep)` — purely additive. Mirrors `setSmrtTableName`'s pattern: a new `setSmrtQualifiedName(ctor, qualifiedName)` helper called at three registration insertion points in `class-registration.ts` (decorator new-class, upsert path, `registerFromManifest` stub constructor). Survives HMR / federated-module duplication / WeakMap eviction.
3. **`f19552c0c`** `feat(core)!: ObjectRegistry inheritance/STI lookups return qualified names (R5-canon main)` — the breaking change:
   - `ObjectRegistry.getInheritanceChain(name)` returns qualified names (falls back to simple for unregistered classes).
   - `ObjectRegistry.getSTIBase(name)` returns the qualified name of the STI base.
   - `ObjectRegistry.getDescendants(name)` returns qualified descendant names; accepts either input form.
   - Updates 14 files across `collection.ts`, `object.ts`, `registry.ts`, `registry/schema-builder.ts`, `testing/database.ts`, and test assertions in core / messages / content.
4. **`e70dbd4cd`** `refactor(core): simplify SmrtHierarchical._hierarchyCollection (R5-canon main)` — drops the #1269 prototype-chain walk + fixes `schema/utils.ts:generateSchema()`'s STI-base classifier + swaps 5 private `findClass` callers to public `getClass` + reworks the cross-package-disambiguation test suite for the new shape.
5. **`722b8d909`** `fix(core,cli,agents): round-1 review fixups for R5-canon` — four more qualified-vs-simple comparison sites caught by codex + claude reviewers in parallel: `schema/utils.ts:ensureSchema`, `registry/inheritance-resolver.ts:getInheritanceChain` (module-level), 3 sites in `cli/src/commands/utilities.ts` (db:setup STI-child-skip), and 1 in `agents/src/agent.ts` (interest-query STI discriminator filter).

## Test pass

- **Full repo**: 88/88 tests, 49/49 typecheck
- **Core suite**: 1711 passing (up from 1708; new disambiguation tests added)
- **All R3 packages** (places, events, tags, facts, assets/folders, accounts, zones): green

## What this enables

- **Multi-package class name collisions are now safe**. Two packages both shipping a `Document` class (a hierarchical, an STI base, anything) route correctly because the registry's internal lookups carry the qualified name end to end.
- **`SmrtHierarchical._hierarchyCollection` is back to a one-line lookup**. The prototype-chain walk that PR #1269 added becomes dead code and is removed. Resolution order:
  1. `Constructor._smrtQualifiedName` static (set at registration; survives HMR / module duplication).
  2. `ObjectRegistry.getClassByConstructor(ctor)?.qualifiedName` (WeakMap fallback).
  3. Simple `Constructor.name` (last-resort fallback).

## Deferred (not introduced by this PR)

Codex flagged two pre-existing R3-B issues that R5-canon didn't introduce and aren't blocking:

1. The committed `packages/tags/src/manifest/manifest.json` still has `extends: "SmrtObject"` for Tag (should be `SmrtHierarchical`) and a few other stale entries from R3-B's partial regeneration. Build regenerates the runtime manifest correctly; the committed fallback is the only stale copy.
2. `TagCollection.mergeTag(fromSlug, toSlug, context?)` doesn't scope its `TagAliasCollection` query by context, so calling with an explicit context can still rewrite aliases for the same slug in OTHER contexts.

Both filed as known follow-ups; will land separately.

## Test plan

- [x] `npm test` — full repo green (88/88 turbo tasks)
- [x] `npm run typecheck` — clean (49/49)
- [x] Disambiguation suite in [packages/core/src/__tests__/hierarchical.test.ts](packages/core/src/__tests__/hierarchical.test.ts) — 3 focused tests stub `getClassByConstructor`/`getSTIBase`/`getCollection` and verify the qualified name produced by `_hierarchyCollection` matches the constructor that was instantiated (the property the fix is supposed to preserve).
- [ ] Smoke test in ergot.io / anytown.ai — Phase B, gated on user signal.