### PR TITLE
Make generated schema migrations atomic

### DIFF
--- a/packages/cli/src/commands/__tests__/db-migrate-atomic.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-atomic.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  autoDiscoverAndLoadMock,
+  committedAppliedMigrations,
+  compareMock,
+  getAllSchemasAsDefinitionsMock,
+  getDatabaseMock,
+  getInitializationOrderMock,
+  getPackageConfigMock,
+  getTableNameMock,
+  migrationAttempts,
+  MockMigrationTracker,
+  MockSchemaComparer,
+  trackerOptions,
+  transactionRolledBack,
+} = vi.hoisted(() => {
+  const migrationAttempts: string[] = [];
+  const committedAppliedMigrations: string[] = [];
+  const trackerOptions: Array<{ useConcurrentIndexes?: boolean }> = [];
+  const transactionRolledBack = { value: false };
+
+  class MockSchemaComparer {
+    compare = compareMock;
+  }
+
+  class MockMigrationTracker {
+    private db: any;
+
+    constructor(options: { db: any; useConcurrentIndexes?: boolean }) {
+      this.db = options.db;
+      trackerOptions.push({
+        useConcurrentIndexes: options.useConcurrentIndexes,
+      });
+    }
+
+    async initialize() {}
+
+    getEngine() {
+      return 'postgres';
+    }
+
+    async apply(definition: { id: string }) {
+      migrationAttempts.push(definition.id);
+
+      if (definition.id === 'add_column_contents_second_column') {
+        return {
+          success: false,
+          applied: false,
+          skipped: false,
+          name: definition.id,
+          checksum: 'bad',
+          execution_time_ms: 1,
+          error: new Error('synthetic failure'),
+        };
+      }
+
+      this.db.appliedMigrations.push(definition.id);
+      return {
+        success: true,
+        applied: true,
+        skipped: false,
+        name: definition.id,
+        checksum: 'ok',
+        execution_time_ms: 1,
+      };
+    }
+  }
+
+  const compareMock = vi.fn();
+
+  return {
+    autoDiscoverAndLoadMock: vi.fn(),
+    committedAppliedMigrations,
+    compareMock,
+    getAllSchemasAsDefinitionsMock: vi.fn(),
+    getDatabaseMock: vi.fn(),
+    getInitializationOrderMock: vi.fn(),
+    getPackageConfigMock: vi.fn(),
+    getTableNameMock: vi.fn(),
+    migrationAttempts,
+    transactionRolledBack,
+    MockMigrationTracker,
+    MockSchemaComparer,
+    trackerOptions,
+  };
+});
+
+vi.mock('../../discovery/index.js', () => ({
+  autoDiscoverAndLoad: autoDiscoverAndLoadMock,
+}));
+
+vi.mock('@happyvertical/smrt-config', () => ({
+  getPackageConfig: getPackageConfigMock,
+}));
+
+vi.mock('@happyvertical/sql', () => ({
+  getDatabase: getDatabaseMock,
+}));
+
+vi.mock('@happyvertical/smrt-core', () => ({
+  ObjectRegistry: {
+    getAllSchemasAsDefinitions: getAllSchemasAsDefinitionsMock,
+    getInitializationOrder: getInitializationOrderMock,
+    getSTIBase: vi.fn(),
+    getTableName: getTableNameMock,
+    getTableStrategy: vi.fn(() => 'cti'),
+  },
+  SchemaComparer: MockSchemaComparer,
+  isQualifiedName: vi.fn((value: string) => value.includes(':')),
+}));
+
+vi.mock('@happyvertical/smrt-core/migrations', () => ({
+  MigrationTracker: MockMigrationTracker,
+  shortChecksum: vi.fn((checksum: string) => checksum),
+}));
+
+describe('db:migrate atomic schema execution', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.exitCode = undefined;
+    migrationAttempts.length = 0;
+    committedAppliedMigrations.length = 0;
+    trackerOptions.length = 0;
+    transactionRolledBack.value = false;
+
+    getPackageConfigMock.mockReturnValue({
+      database: {
+        type: 'postgres',
+        url: 'postgresql://test:test@localhost:5432/test_db',
+      },
+    });
+
+    autoDiscoverAndLoadMock.mockResolvedValue({
+      discovered: [
+        {
+          path: '/tmp/project/.smrt/manifest.json',
+          source: 'project',
+          objectCount: 1,
+        },
+      ],
+      totalObjects: 1,
+    });
+
+    getInitializationOrderMock.mockReturnValue(['Content']);
+    getTableNameMock.mockReturnValue('contents');
+    getAllSchemasAsDefinitionsMock.mockReturnValue({
+      contents: { tableName: 'contents' },
+    });
+    compareMock.mockResolvedValue({
+      added_tables: [],
+      dropped_tables: [],
+      has_changes: true,
+      changes: [
+        {
+          type: 'add_column',
+          table: 'contents',
+          name: 'first_column',
+          column: { type: 'TEXT' },
+          sql: 'ALTER TABLE "contents" ADD COLUMN "first_column" TEXT',
+        },
+        {
+          type: 'add_column',
+          table: 'contents',
+          name: 'second_column',
+          column: { type: 'TEXT' },
+          sql: 'ALTER TABLE "contents" ADD COLUMN "second_column" TEXT',
+        },
+      ],
+    });
+
+    getDatabaseMock.mockResolvedValue({
+      url: 'postgresql://test:test@localhost:5432/test_db',
+      alterTable: {},
+      getTableSchema: vi.fn(),
+      close: vi.fn(),
+      transaction: async (callback: (tx: any) => Promise<void>) => {
+        const tx = {
+          appliedMigrations: [] as string[],
+          query: vi.fn(),
+          tableExists: vi.fn(),
+          url: 'postgresql://test:test@localhost:5432/test_db',
+        };
+
+        try {
+          await callback(tx);
+          committedAppliedMigrations.push(...tx.appliedMigrations);
+        } catch (error) {
+          transactionRolledBack.value = true;
+          throw error;
+        }
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rolls back earlier generated migrations when a later generated migration fails', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { utilityCommands } = await import('../utilities.js');
+
+    await utilityCommands['db:migrate'].handler([], { 'postgres-safe': true });
+
+    expect(migrationAttempts).toEqual([
+      'add_column_contents_first_column',
+      'add_column_contents_second_column',
+    ]);
+    expect(transactionRolledBack.value).toBe(true);
+    expect(committedAppliedMigrations).toEqual([]);
+    expect(
+      trackerOptions.map((options) => options.useConcurrentIndexes),
+    ).toEqual([true, false]);
+    expect(process.exitCode).toBe(1);
+
+    const stdout = logSpy.mock.calls.flat().join('\n');
+    const stderr = errorSpy.mock.calls.flat().join('\n');
+    expect(stdout).not.toContain('Added column contents.first_column');
+    expect(stderr).toContain('atomic schema migration failed');
+    expect(stderr).toContain('Rolled back all schema changes');
+  });
+});

--- a/packages/cli/src/commands/__tests__/db-migrate-atomic.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-atomic.test.ts
@@ -9,7 +9,7 @@ const {
   getInitializationOrderMock,
   getPackageConfigMock,
   getTableNameMock,
-  migrationApplyOptions,
+  migrationApplyAllOptions,
   migrationAttempts,
   MockMigrationTracker,
   MockSchemaComparer,
@@ -17,7 +17,12 @@ const {
   transactionRolledBack,
 } = vi.hoisted(() => {
   const migrationAttempts: string[] = [];
-  const migrationApplyOptions: Array<{ postgresSafe?: boolean }> = [];
+  const migrationApplyAllOptions: Array<{
+    atomic?: boolean;
+    force?: boolean;
+    postgresSafe?: boolean;
+    reconcile?: boolean;
+  }> = [];
   const committedAppliedMigrations: string[] = [];
   const trackerOptions: Array<{ useConcurrentIndexes?: boolean }> = [];
   const transactionRolledBack = { value: false };
@@ -42,36 +47,78 @@ const {
       return 'postgres';
     }
 
-    async apply(
-      definition: { id: string },
-      options: { postgresSafe?: boolean } = {},
+    async applyAll(
+      definitions: Array<{ id: string }>,
+      options: {
+        atomic?: boolean;
+        force?: boolean;
+        onProgress?: (result: any) => void;
+        postgresSafe?: boolean;
+        reconcile?: boolean;
+      } = {},
     ) {
-      migrationAttempts.push(definition.id);
-      migrationApplyOptions.push({
+      migrationApplyAllOptions.push({
+        atomic: options.atomic,
+        force: options.force,
         postgresSafe: options.postgresSafe,
+        reconcile: options.reconcile,
       });
 
-      if (definition.id === 'add_column_contents_second_column') {
-        return {
-          success: false,
-          applied: false,
-          skipped: false,
-          name: definition.id,
-          checksum: 'bad',
-          execution_time_ms: 1,
-          error: new Error('synthetic failure'),
-        };
+      const results: any[] = [];
+      let failedName: string | undefined;
+
+      try {
+        await this.db.transaction(async (tx: any) => {
+          for (const definition of definitions) {
+            migrationAttempts.push(definition.id);
+
+            if (definition.id === 'add_column_contents_second_column') {
+              failedName = definition.id;
+              const failed = {
+                success: false,
+                applied: false,
+                skipped: false,
+                name: definition.id,
+                checksum: 'bad',
+                execution_time_ms: 1,
+                error: new Error('synthetic failure'),
+              };
+              results.push(failed);
+              options.onProgress?.(failed);
+              throw failed.error;
+            }
+
+            tx.appliedMigrations.push(definition.id);
+            const result = {
+              success: true,
+              applied: true,
+              skipped: false,
+              name: definition.id,
+              checksum: 'ok',
+              execution_time_ms: 1,
+            };
+            results.push(result);
+            options.onProgress?.(result);
+          }
+        });
+      } catch {
+        return results.map((result) =>
+          result.success
+            ? {
+                ...result,
+                success: false,
+                applied: false,
+                skipped: false,
+                rolled_back: true,
+                error: new Error(
+                  `Rolled back because migration ${failedName} failed`,
+                ),
+              }
+            : result,
+        );
       }
 
-      this.db.appliedMigrations.push(definition.id);
-      return {
-        success: true,
-        applied: true,
-        skipped: false,
-        name: definition.id,
-        checksum: 'ok',
-        execution_time_ms: 1,
-      };
+      return results;
     }
   }
 
@@ -86,7 +133,7 @@ const {
     getInitializationOrderMock: vi.fn(),
     getPackageConfigMock: vi.fn(),
     getTableNameMock: vi.fn(),
-    migrationApplyOptions,
+    migrationApplyAllOptions,
     migrationAttempts,
     transactionRolledBack,
     MockMigrationTracker,
@@ -129,7 +176,7 @@ describe('db:migrate atomic schema execution', () => {
     vi.resetModules();
     vi.clearAllMocks();
     process.exitCode = undefined;
-    migrationApplyOptions.length = 0;
+    migrationApplyAllOptions.length = 0;
     migrationAttempts.length = 0;
     committedAppliedMigrations.length = 0;
     trackerOptions.length = 0;
@@ -223,16 +270,67 @@ describe('db:migrate atomic schema execution', () => {
     expect(committedAppliedMigrations).toEqual([]);
     expect(
       trackerOptions.map((options) => options.useConcurrentIndexes),
-    ).toEqual([true, false]);
-    expect(
-      migrationApplyOptions.map((options) => options.postgresSafe),
-    ).toEqual([false, false]);
+    ).toEqual([true]);
+    expect(migrationApplyAllOptions).toEqual([
+      {
+        atomic: true,
+        force: false,
+        postgresSafe: false,
+        reconcile: true,
+      },
+    ]);
     expect(process.exitCode).toBe(1);
 
     const stdout = logSpy.mock.calls.flat().join('\n');
     const stderr = errorSpy.mock.calls.flat().join('\n');
-    expect(stdout).not.toContain('Added column contents.first_column');
+    expect(stdout).toContain('Added column contents.first_column');
     expect(stderr).toContain('atomic schema migration failed');
-    expect(stderr).toContain('Rolled back all schema changes');
+    expect(stderr).toContain(
+      'add_column_contents_second_column: synthetic failure',
+    );
+    expect(stderr).toContain('successful steps shown above');
+  });
+
+  it('warns when postgres-safe index operations are folded into the atomic batch', async () => {
+    compareMock.mockResolvedValue({
+      added_tables: [],
+      dropped_tables: [],
+      has_changes: true,
+      changes: [
+        {
+          type: 'add_index',
+          table: 'contents',
+          index: {
+            name: 'contents_first_column_idx',
+            columns: ['first_column'],
+          },
+          sql: 'CREATE INDEX "contents_first_column_idx" ON "contents" ("first_column")',
+        },
+      ],
+    });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { utilityCommands } = await import('../utilities.js');
+
+    await utilityCommands['db:migrate'].handler([], { 'postgres-safe': true });
+
+    expect(warnSpy.mock.calls.flat().join('\n')).toContain(
+      '--postgres-safe requested',
+    );
+    expect(migrationAttempts).toEqual([
+      expect.stringMatching(/^add_index_contents_first_column_idx_/),
+    ]);
+    expect(migrationApplyAllOptions[0]).toMatchObject({
+      atomic: true,
+      postgresSafe: false,
+      reconcile: true,
+    });
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('atomic schema migration failed'),
+    );
+    expect(logSpy.mock.calls.flat().join('\n')).toContain(
+      'Created index contents_first_column_idx on contents',
+    );
   });
 });

--- a/packages/cli/src/commands/__tests__/db-migrate-atomic.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-atomic.test.ts
@@ -9,6 +9,7 @@ const {
   getInitializationOrderMock,
   getPackageConfigMock,
   getTableNameMock,
+  migrationApplyOptions,
   migrationAttempts,
   MockMigrationTracker,
   MockSchemaComparer,
@@ -16,6 +17,7 @@ const {
   transactionRolledBack,
 } = vi.hoisted(() => {
   const migrationAttempts: string[] = [];
+  const migrationApplyOptions: Array<{ postgresSafe?: boolean }> = [];
   const committedAppliedMigrations: string[] = [];
   const trackerOptions: Array<{ useConcurrentIndexes?: boolean }> = [];
   const transactionRolledBack = { value: false };
@@ -40,8 +42,14 @@ const {
       return 'postgres';
     }
 
-    async apply(definition: { id: string }) {
+    async apply(
+      definition: { id: string },
+      options: { postgresSafe?: boolean } = {},
+    ) {
       migrationAttempts.push(definition.id);
+      migrationApplyOptions.push({
+        postgresSafe: options.postgresSafe,
+      });
 
       if (definition.id === 'add_column_contents_second_column') {
         return {
@@ -78,6 +86,7 @@ const {
     getInitializationOrderMock: vi.fn(),
     getPackageConfigMock: vi.fn(),
     getTableNameMock: vi.fn(),
+    migrationApplyOptions,
     migrationAttempts,
     transactionRolledBack,
     MockMigrationTracker,
@@ -120,6 +129,7 @@ describe('db:migrate atomic schema execution', () => {
     vi.resetModules();
     vi.clearAllMocks();
     process.exitCode = undefined;
+    migrationApplyOptions.length = 0;
     migrationAttempts.length = 0;
     committedAppliedMigrations.length = 0;
     trackerOptions.length = 0;
@@ -214,6 +224,9 @@ describe('db:migrate atomic schema execution', () => {
     expect(
       trackerOptions.map((options) => options.useConcurrentIndexes),
     ).toEqual([true, false]);
+    expect(
+      migrationApplyOptions.map((options) => options.postgresSafe),
+    ).toEqual([false, false]);
     expect(process.exitCode).toBe(1);
 
     const stdout = logSpy.mock.calls.flat().join('\n');

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -10,6 +10,7 @@ import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
+  tableExists as coreTableExists,
   isQualifiedName,
   ObjectRegistry,
   SchemaComparer,
@@ -83,10 +84,6 @@ function formatSchemaCommandFailureHeader(
   return fallback;
 }
 
-function getRows(result: unknown): any[] {
-  return Array.isArray(result) ? result : ((result as any)?.rows ?? []);
-}
-
 function createAtomicSchemaMigrationDb(tx: any, dbType: string): any {
   const migrationDb: any = {
     ...tx,
@@ -96,29 +93,8 @@ function createAtomicSchemaMigrationDb(tx: any, dbType: string): any {
   migrationDb.transaction = async <T>(callback: (txDb: any) => Promise<T>) =>
     callback(migrationDb);
 
-  migrationDb.tableExists = async (tableName: string): Promise<boolean> => {
-    if (dbType === 'postgres') {
-      const result = await migrationDb.query(
-        `SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = ? AND table_schema = 'public') as exists`,
-        tableName,
-      );
-      return Boolean(getRows(result)[0]?.exists);
-    }
-
-    if (dbType === 'duckdb') {
-      const result = await migrationDb.query(
-        `SELECT table_name FROM information_schema.tables WHERE table_name = ?`,
-        tableName,
-      );
-      return getRows(result).length > 0;
-    }
-
-    const result = await migrationDb.query(
-      `SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`,
-      tableName,
-    );
-    return getRows(result).length > 0;
-  };
+  migrationDb.tableExists = (tableName: string): Promise<boolean> =>
+    coreTableExists(migrationDb, tableName, dbType);
 
   return migrationDb;
 }
@@ -1565,7 +1541,7 @@ export default testManifest;
                   };
 
                   const result = await batchTracker.apply(migrationDef, {
-                    postgresSafe: options['postgres-safe'] ?? false,
+                    postgresSafe: false,
                     force: options.force ?? false,
                   });
 
@@ -1645,7 +1621,7 @@ export default testManifest;
 
                   // Apply migration - tracker handles checksum validation and idempotency
                   const result = await batchTracker.apply(migrationDef, {
-                    postgresSafe: options['postgres-safe'] ?? false,
+                    postgresSafe: false,
                     force: options.force ?? false,
                     // The diff was computed from the live schema moments earlier, so
                     // missing columns/indexes must be repaired even if a previous

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -83,6 +83,46 @@ function formatSchemaCommandFailureHeader(
   return fallback;
 }
 
+function getRows(result: unknown): any[] {
+  return Array.isArray(result) ? result : ((result as any)?.rows ?? []);
+}
+
+function createAtomicSchemaMigrationDb(tx: any, dbType: string): any {
+  const migrationDb: any = {
+    ...tx,
+    syncSchema: undefined,
+  };
+
+  migrationDb.transaction = async <T>(callback: (txDb: any) => Promise<T>) =>
+    callback(migrationDb);
+
+  migrationDb.tableExists = async (tableName: string): Promise<boolean> => {
+    if (dbType === 'postgres') {
+      const result = await migrationDb.query(
+        `SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = ? AND table_schema = 'public') as exists`,
+        tableName,
+      );
+      return Boolean(getRows(result)[0]?.exists);
+    }
+
+    if (dbType === 'duckdb') {
+      const result = await migrationDb.query(
+        `SELECT table_name FROM information_schema.tables WHERE table_name = ?`,
+        tableName,
+      );
+      return getRows(result).length > 0;
+    }
+
+    const result = await migrationDb.query(
+      `SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`,
+      tableName,
+    );
+    return getRows(result).length > 0;
+  };
+
+  return migrationDb;
+}
+
 /**
  * Index definition type for migration comparison
  */
@@ -1298,7 +1338,7 @@ export default testManifest;
         // This uses the same comparison logic as core (including equivalent index detection)
         const migrations: MigrationAction[] = [];
         const manualInterventions: MigrationAction[] = [];
-        let tableErrorCount = 0;
+        const tableErrorCount = 0;
         const isDryRun = options['dry-run'] ?? false;
         const applySchemaMigrations = shouldApplySchemaMigrations({
           dryRun: isDryRun,
@@ -1335,76 +1375,18 @@ export default testManifest;
           return tableName;
         };
 
-        // Create new tables that don't exist yet
-        if (diff.added_tables.length > 0) {
-          const { ensureSchema } = await import(
-            '@happyvertical/smrt-core/schema/utils'
-          );
-
+        // Preview new tables that don't exist yet. Actual schema changes are
+        // applied below in one transaction with the generated migrations.
+        if (diff.added_tables.length > 0 && isDryRun) {
           for (const schema of diff.added_tables) {
             const className = getClassForTable(schema.tableName);
 
-            if (isDryRun) {
-              const fields = Object.keys(schema.columns).length;
-              console.log(
-                `  📦 ${schema.tableName} (${className}): Would create table (${fields} columns)`,
-              );
-              if (options.verbose && schema.ddl) {
-                console.log(`     ${schema.ddl}`);
-              }
-            } else {
-              try {
-                await ensureSchema(db, className);
-
-                // Track table creation as a migration.
-                // Note: ensureSchema generates and executes its own DDL.
-                // We record schema.ddl (from SchemaComparer) for reference;
-                // it should match what ensureSchema produced.
-                const migrationName = `create_table_${schema.tableName}`;
-                const upSql =
-                  schema.ddl ||
-                  `-- Table created via ensureSchema('${className}')`;
-                const migrationDef = {
-                  id: migrationName,
-                  description: `Create table ${schema.tableName}`,
-                  version: '1.0.0',
-                  up: [upSql],
-                  down: [`DROP TABLE IF EXISTS "${schema.tableName}"`],
-                };
-
-                const result = await tracker.apply(migrationDef, {
-                  postgresSafe: options['postgres-safe'] ?? false,
-                  force: options.force ?? false,
-                });
-
-                if (result.success) {
-                  const fields = Object.keys(schema.columns).length;
-                  console.log(
-                    `  ✓ Created table ${schema.tableName} (${fields} columns, ${shortChecksum(result.checksum)})`,
-                  );
-                } else {
-                  tableErrorCount++;
-                  const errorMsg =
-                    result.error instanceof Error
-                      ? result.error.message
-                      : String(
-                          result.error || 'Unknown migration tracking error',
-                        );
-                  console.error(
-                    `  ✗ Failed to track ${schema.tableName}: ${errorMsg}`,
-                  );
-                }
-              } catch (error) {
-                tableErrorCount++;
-                const errorMsg =
-                  error instanceof Error ? error.message : String(error);
-                console.error(
-                  `  ✗ Failed to create ${schema.tableName}: ${errorMsg}`,
-                );
-                if (options.verbose && error instanceof Error && error.stack) {
-                  console.error(`\n${error.stack}\n`);
-                }
-              }
+            const fields = Object.keys(schema.columns).length;
+            console.log(
+              `  📦 ${schema.tableName} (${className}): Would create table (${fields} columns)`,
+            );
+            if (options.verbose && schema.ddl) {
+              console.log(`     ${schema.ddl}`);
             }
           }
 
@@ -1530,102 +1512,178 @@ export default testManifest;
         let errorCount = 0;
         let stiErrorCount = 0;
 
-        // Only show migration execution header if there are migrations to apply
-        if (applySchemaMigrations && migrations.length > 0) {
-          console.log(`🔨 Applying ${migrations.length} migration(s)...\n`);
+        const schemaChangeCount = diff.added_tables.length + migrations.length;
+
+        // Only show migration execution header if there are schema changes to apply
+        if (applySchemaMigrations && schemaChangeCount > 0) {
+          console.log(
+            `🔨 Applying ${schemaChangeCount} schema change(s) atomically...\n`,
+          );
         }
 
-        if (applySchemaMigrations) {
-          for (const migration of migrations) {
+        if (applySchemaMigrations && schemaChangeCount > 0) {
+          if (!db.transaction) {
+            errorCount++;
+            console.error(
+              '  ✗ atomic schema migration failed: database adapter does not support transactions',
+            );
+          } else {
+            const logLines: string[] = [];
+            let batchSuccessCount = 0;
+            let batchSkippedCount = 0;
+
             try {
-              // Generate a unique migration name based on the action
-              const migrationName =
-                getSyntheticMigrationNameForAction(migration);
-              if (!migrationName) {
-                continue;
-              }
-              let migrationSql: string;
-              let actionDesc: string;
+              await db.transaction(async (tx: any) => {
+                const migrationDb = createAtomicSchemaMigrationDb(tx, dbType);
+                const { ensureSchema } = await import(
+                  '@happyvertical/smrt-core/schema/utils'
+                );
+                const batchTracker = new MigrationTracker({
+                  db: migrationDb,
+                  useConcurrentIndexes: false,
+                });
+                await batchTracker.initialize();
 
-              if (migration.type === 'add_column' && migration.column) {
-                migrationSql = migration.sql || '';
-                actionDesc = `Added column ${migration.tableName}.${migration.column.name}`;
-              } else if (
-                migration.type === 'type_upgrade' &&
-                migration.column
-              ) {
-                migrationSql = migration.sql || '';
-                actionDesc = `Upgraded column ${migration.tableName}.${migration.column.name} from ${migration.mismatch?.actual} to ${migration.mismatch?.expected}`;
-              } else if (migration.type === 'add_index' && migration.index) {
-                migrationSql = migration.sql || '';
-                actionDesc = `Created index ${migration.index.name} on ${migration.tableName}`;
-              } else if (
-                migration.type === 'drop_index' &&
-                migration.indexName
-              ) {
-                migrationSql = migration.sql || '';
-                actionDesc = `Dropped index ${migration.indexName} on ${migration.tableName}`;
-              } else {
-                continue;
-              }
-              const migrationSqlStatements =
-                migration.sqlStatements ?? (migrationSql ? [migrationSql] : []);
+                for (const schema of diff.added_tables) {
+                  const className = getClassForTable(schema.tableName);
+                  await ensureSchema(migrationDb, className);
 
-              // Create migration definition - tracker handles idempotency
-              const migrationDef = {
-                id: migrationName,
-                description:
-                  migration.type === 'add_column'
-                    ? `Add column ${migration.column?.name} to ${migration.tableName}`
-                    : migration.type === 'type_upgrade'
-                      ? `Upgrade column ${migration.column?.name} on ${migration.tableName} from ${migration.mismatch?.actual} to ${migration.mismatch?.expected}`
-                      : migration.type === 'drop_index'
-                        ? `Drop index ${migration.indexName} on ${migration.tableName}`
-                        : `Add index ${migration.index?.name} on ${migration.tableName}`,
-                version: '1.0.0',
-                // Auto-migrations don't carry a DOWN script. For shape-drift
-                // index recreates (drop_index + add_index), this means a
-                // rollback would leave the table without the index entirely.
-                // Issue #1165 — surfaced and accepted: the alternative is
-                // capturing the DB-side index shape we just dropped, which
-                // we don't have the introspection wiring for yet.
-                up: migrationSqlStatements,
-                down: [],
-              };
+                  // Track table creation as a migration.
+                  // Note: ensureSchema generates and executes its own DDL.
+                  // We record schema.ddl (from SchemaComparer) for reference;
+                  // it should match what ensureSchema produced.
+                  const migrationName = `create_table_${schema.tableName}`;
+                  const upSql =
+                    schema.ddl ||
+                    `-- Table created via ensureSchema('${className}')`;
+                  const migrationDef = {
+                    id: migrationName,
+                    description: `Create table ${schema.tableName}`,
+                    version: '1.0.0',
+                    up: [upSql],
+                    down: [`DROP TABLE IF EXISTS "${schema.tableName}"`],
+                  };
 
-              // Apply migration - tracker handles checksum validation and idempotency
-              const result = await tracker.apply(migrationDef, {
-                postgresSafe: options['postgres-safe'] ?? false,
-                force: options.force ?? false,
-                // The diff was computed from the live schema moments earlier, so
-                // missing columns/indexes must be repaired even if a previous
-                // synthetic migration record says "completed".
-                reconcile: true,
-              });
+                  const result = await batchTracker.apply(migrationDef, {
+                    postgresSafe: options['postgres-safe'] ?? false,
+                    force: options.force ?? false,
+                  });
 
-              if (result.success) {
-                // Check if this was already applied (execution_time_ms = 0 means skipped)
-                if (result.execution_time_ms === 0) {
-                  if (options.verbose) {
-                    console.log(
-                      `  ⊙ ${migrationName} already applied (${shortChecksum(result.checksum)})`,
+                  if (!result.success) {
+                    throw (
+                      result.error ||
+                      new Error(`Failed to track ${schema.tableName}`)
                     );
                   }
-                  skippedCount++;
-                } else {
-                  console.log(
-                    `  ✓ ${actionDesc} (${shortChecksum(result.checksum)})`,
+
+                  const fields = Object.keys(schema.columns).length;
+                  logLines.push(
+                    `  ✓ Created table ${schema.tableName} (${fields} columns, ${shortChecksum(result.checksum)})`,
                   );
-                  successCount++;
+                  batchSuccessCount++;
                 }
-              } else if (result.error) {
-                throw result.error;
+
+                for (const migration of migrations) {
+                  // Generate a unique migration name based on the action
+                  const migrationName =
+                    getSyntheticMigrationNameForAction(migration);
+                  if (!migrationName) {
+                    continue;
+                  }
+                  let migrationSql: string;
+                  let actionDesc: string;
+
+                  if (migration.type === 'add_column' && migration.column) {
+                    migrationSql = migration.sql || '';
+                    actionDesc = `Added column ${migration.tableName}.${migration.column.name}`;
+                  } else if (
+                    migration.type === 'type_upgrade' &&
+                    migration.column
+                  ) {
+                    migrationSql = migration.sql || '';
+                    actionDesc = `Upgraded column ${migration.tableName}.${migration.column.name} from ${migration.mismatch?.actual} to ${migration.mismatch?.expected}`;
+                  } else if (
+                    migration.type === 'add_index' &&
+                    migration.index
+                  ) {
+                    migrationSql = migration.sql || '';
+                    actionDesc = `Created index ${migration.index.name} on ${migration.tableName}`;
+                  } else if (
+                    migration.type === 'drop_index' &&
+                    migration.indexName
+                  ) {
+                    migrationSql = migration.sql || '';
+                    actionDesc = `Dropped index ${migration.indexName} on ${migration.tableName}`;
+                  } else {
+                    continue;
+                  }
+                  const migrationSqlStatements =
+                    migration.sqlStatements ??
+                    (migrationSql ? [migrationSql] : []);
+
+                  // Create migration definition - tracker handles idempotency
+                  const migrationDef = {
+                    id: migrationName,
+                    description:
+                      migration.type === 'add_column'
+                        ? `Add column ${migration.column?.name} to ${migration.tableName}`
+                        : migration.type === 'type_upgrade'
+                          ? `Upgrade column ${migration.column?.name} on ${migration.tableName} from ${migration.mismatch?.actual} to ${migration.mismatch?.expected}`
+                          : migration.type === 'drop_index'
+                            ? `Drop index ${migration.indexName} on ${migration.tableName}`
+                            : `Add index ${migration.index?.name} on ${migration.tableName}`,
+                    version: '1.0.0',
+                    // Auto-migrations don't carry a DOWN script. For shape-drift
+                    // index recreates (drop_index + add_index), this means a
+                    // rollback would leave the table without the index entirely.
+                    // Issue #1165 — surfaced and accepted: the alternative is
+                    // capturing the DB-side index shape we just dropped, which
+                    // we don't have the introspection wiring for yet.
+                    up: migrationSqlStatements,
+                    down: [],
+                  };
+
+                  // Apply migration - tracker handles checksum validation and idempotency
+                  const result = await batchTracker.apply(migrationDef, {
+                    postgresSafe: options['postgres-safe'] ?? false,
+                    force: options.force ?? false,
+                    // The diff was computed from the live schema moments earlier, so
+                    // missing columns/indexes must be repaired even if a previous
+                    // synthetic migration record says "completed".
+                    reconcile: true,
+                  });
+
+                  if (!result.success) {
+                    throw result.error || new Error(`${migration.type} failed`);
+                  }
+
+                  // Check if this was already applied (execution_time_ms = 0 means skipped)
+                  if (result.execution_time_ms === 0) {
+                    if (options.verbose) {
+                      logLines.push(
+                        `  ⊙ ${migrationName} already applied (${shortChecksum(result.checksum)})`,
+                      );
+                    }
+                    batchSkippedCount++;
+                  } else {
+                    logLines.push(
+                      `  ✓ ${actionDesc} (${shortChecksum(result.checksum)})`,
+                    );
+                    batchSuccessCount++;
+                  }
+                }
+              });
+
+              for (const line of logLines) {
+                console.log(line);
               }
+              successCount += batchSuccessCount;
+              skippedCount += batchSkippedCount;
             } catch (error) {
               errorCount++;
               const errorMsg =
                 error instanceof Error ? error.message : String(error);
-              console.error(`  ✗ ${migration.type} failed: ${errorMsg}`);
+              console.error(`  ✗ atomic schema migration failed: ${errorMsg}`);
               // Show underlying database error if available
               if (
                 error instanceof Error &&
@@ -1639,6 +1697,9 @@ export default testManifest;
               if (options.verbose && error instanceof Error && error.stack) {
                 console.error(`\n${error.stack}\n`);
               }
+              console.error(
+                '     Rolled back all schema changes from this migration batch.',
+              );
             }
           }
         }
@@ -1811,7 +1872,7 @@ export default testManifest;
         // Data repairs have their own summary printed above.
         if (
           applySchemaMigrations &&
-          (migrations.length > 0 || errorCount > 0 || skippedCount > 0)
+          (schemaChangeCount > 0 || errorCount > 0 || skippedCount > 0)
         ) {
           console.log();
           if (errorCount > 0) {

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -10,11 +10,15 @@ import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
-  tableExists as coreTableExists,
+  generateDDLForEngine,
   isQualifiedName,
   ObjectRegistry,
   SchemaComparer,
 } from '@happyvertical/smrt-core';
+import type {
+  MigrationDefinition,
+  MigrationResult,
+} from '@happyvertical/smrt-core/migrations';
 import type { CLICommand } from '../cli-generator.js';
 import { autoDiscoverAndLoad } from '../discovery/index.js';
 import { configExportCommand } from './config-export.js';
@@ -84,19 +88,37 @@ function formatSchemaCommandFailureHeader(
   return fallback;
 }
 
-function createAtomicSchemaMigrationDb(tx: any, dbType: string): any {
-  const migrationDb: any = {
-    ...tx,
-    syncSchema: undefined,
-  };
+interface SchemaMigrationLogInfo {
+  successMessage: string;
+  skippedMessage?: string;
+}
 
-  migrationDb.transaction = async <T>(callback: (txDb: any) => Promise<T>) =>
-    callback(migrationDb);
+function migrationErrorMessage(error: MigrationResult['error']): string {
+  if (!error) {
+    return 'migration failed';
+  }
 
-  migrationDb.tableExists = (tableName: string): Promise<boolean> =>
-    coreTableExists(migrationDb, tableName, dbType);
+  if (error instanceof Error) {
+    return error.message;
+  }
 
-  return migrationDb;
+  return String(error);
+}
+
+function migrationResultFailure(
+  results: MigrationResult[],
+): MigrationResult | undefined {
+  return (
+    results.find((result) => !result.success && !result.rolled_back) ??
+    results.find((result) => !result.success)
+  );
+}
+
+function migrationResultError(result: MigrationResult): Error {
+  const cause = result.error instanceof Error ? result.error : undefined;
+  return new Error(`${result.name}: ${migrationErrorMessage(result.error)}`, {
+    cause,
+  });
 }
 
 /**
@@ -1498,185 +1520,172 @@ export default testManifest;
         }
 
         if (applySchemaMigrations && schemaChangeCount > 0) {
-          if (!db.transaction) {
-            errorCount++;
-            console.error(
-              '  ✗ atomic schema migration failed: database adapter does not support transactions',
-            );
-          } else {
-            const logLines: string[] = [];
-            let batchSuccessCount = 0;
-            let batchSkippedCount = 0;
+          const migrationDefs: MigrationDefinition[] = [];
+          const migrationLogs = new Map<string, SchemaMigrationLogInfo>();
+          const engine = tracker.getEngine();
 
-            try {
-              await db.transaction(async (tx: any) => {
-                const migrationDb = createAtomicSchemaMigrationDb(tx, dbType);
-                const { ensureSchema } = await import(
-                  '@happyvertical/smrt-core/schema/utils'
-                );
-                const batchTracker = new MigrationTracker({
-                  db: migrationDb,
-                  useConcurrentIndexes: false,
-                });
-                await batchTracker.initialize();
-
-                for (const schema of diff.added_tables) {
-                  const className = getClassForTable(schema.tableName);
-                  await ensureSchema(migrationDb, className);
-
-                  // Track table creation as a migration.
-                  // Note: ensureSchema generates and executes its own DDL.
-                  // We record schema.ddl (from SchemaComparer) for reference;
-                  // it should match what ensureSchema produced.
-                  const migrationName = `create_table_${schema.tableName}`;
-                  const upSql =
-                    schema.ddl ||
-                    `-- Table created via ensureSchema('${className}')`;
-                  const migrationDef = {
-                    id: migrationName,
-                    description: `Create table ${schema.tableName}`,
-                    version: '1.0.0',
-                    up: [upSql],
-                    down: [`DROP TABLE IF EXISTS "${schema.tableName}"`],
-                  };
-
-                  const result = await batchTracker.apply(migrationDef, {
-                    postgresSafe: false,
-                    force: options.force ?? false,
-                  });
-
-                  if (!result.success) {
-                    throw (
-                      result.error ||
-                      new Error(`Failed to track ${schema.tableName}`)
-                    );
-                  }
-
-                  const fields = Object.keys(schema.columns).length;
-                  logLines.push(
-                    `  ✓ Created table ${schema.tableName} (${fields} columns, ${shortChecksum(result.checksum)})`,
-                  );
-                  batchSuccessCount++;
-                }
-
-                for (const migration of migrations) {
-                  // Generate a unique migration name based on the action
-                  const migrationName =
-                    getSyntheticMigrationNameForAction(migration);
-                  if (!migrationName) {
-                    continue;
-                  }
-                  let migrationSql: string;
-                  let actionDesc: string;
-
-                  if (migration.type === 'add_column' && migration.column) {
-                    migrationSql = migration.sql || '';
-                    actionDesc = `Added column ${migration.tableName}.${migration.column.name}`;
-                  } else if (
-                    migration.type === 'type_upgrade' &&
-                    migration.column
-                  ) {
-                    migrationSql = migration.sql || '';
-                    actionDesc = `Upgraded column ${migration.tableName}.${migration.column.name} from ${migration.mismatch?.actual} to ${migration.mismatch?.expected}`;
-                  } else if (
-                    migration.type === 'add_index' &&
-                    migration.index
-                  ) {
-                    migrationSql = migration.sql || '';
-                    actionDesc = `Created index ${migration.index.name} on ${migration.tableName}`;
-                  } else if (
-                    migration.type === 'drop_index' &&
-                    migration.indexName
-                  ) {
-                    migrationSql = migration.sql || '';
-                    actionDesc = `Dropped index ${migration.indexName} on ${migration.tableName}`;
-                  } else {
-                    continue;
-                  }
-                  const migrationSqlStatements =
-                    migration.sqlStatements ??
-                    (migrationSql ? [migrationSql] : []);
-
-                  // Create migration definition - tracker handles idempotency
-                  const migrationDef = {
-                    id: migrationName,
-                    description:
-                      migration.type === 'add_column'
-                        ? `Add column ${migration.column?.name} to ${migration.tableName}`
-                        : migration.type === 'type_upgrade'
-                          ? `Upgrade column ${migration.column?.name} on ${migration.tableName} from ${migration.mismatch?.actual} to ${migration.mismatch?.expected}`
-                          : migration.type === 'drop_index'
-                            ? `Drop index ${migration.indexName} on ${migration.tableName}`
-                            : `Add index ${migration.index?.name} on ${migration.tableName}`,
-                    version: '1.0.0',
-                    // Auto-migrations don't carry a DOWN script. For shape-drift
-                    // index recreates (drop_index + add_index), this means a
-                    // rollback would leave the table without the index entirely.
-                    // Issue #1165 — surfaced and accepted: the alternative is
-                    // capturing the DB-side index shape we just dropped, which
-                    // we don't have the introspection wiring for yet.
-                    up: migrationSqlStatements,
-                    down: [],
-                  };
-
-                  // Apply migration - tracker handles checksum validation and idempotency
-                  const result = await batchTracker.apply(migrationDef, {
-                    postgresSafe: false,
-                    force: options.force ?? false,
-                    // The diff was computed from the live schema moments earlier, so
-                    // missing columns/indexes must be repaired even if a previous
-                    // synthetic migration record says "completed".
-                    reconcile: true,
-                  });
-
-                  if (!result.success) {
-                    throw result.error || new Error(`${migration.type} failed`);
-                  }
-
-                  // Check if this was already applied (execution_time_ms = 0 means skipped)
-                  if (result.execution_time_ms === 0) {
-                    if (options.verbose) {
-                      logLines.push(
-                        `  ⊙ ${migrationName} already applied (${shortChecksum(result.checksum)})`,
-                      );
-                    }
-                    batchSkippedCount++;
-                  } else {
-                    logLines.push(
-                      `  ✓ ${actionDesc} (${shortChecksum(result.checksum)})`,
-                    );
-                    batchSuccessCount++;
-                  }
-                }
-              });
-
-              for (const line of logLines) {
-                console.log(line);
-              }
-              successCount += batchSuccessCount;
-              skippedCount += batchSkippedCount;
-            } catch (error) {
-              errorCount++;
-              const errorMsg =
-                error instanceof Error ? error.message : String(error);
-              console.error(`  ✗ atomic schema migration failed: ${errorMsg}`);
-              // Show underlying database error if available
-              if (
-                error instanceof Error &&
-                'context' in error &&
-                (error as any).context?.originalError
-              ) {
-                console.error(
-                  `     Cause: ${(error as any).context.originalError}`,
-                );
-              }
-              if (options.verbose && error instanceof Error && error.stack) {
-                console.error(`\n${error.stack}\n`);
-              }
-              console.error(
-                '     Rolled back all schema changes from this migration batch.',
+          for (const schema of diff.added_tables) {
+            const ddl = generateDDLForEngine(schema, engine);
+            const createTableSql = ddl.createTable || schema.ddl;
+            if (!createTableSql?.trim()) {
+              throw new Error(
+                `Cannot create table ${schema.tableName}: schema definition has no generated DDL.`,
               );
             }
+
+            const migrationName = `create_table_${schema.tableName}`;
+            const fields = Object.keys(schema.columns).length;
+
+            migrationDefs.push({
+              id: migrationName,
+              description: `Create table ${schema.tableName}`,
+              version: '1.0.0',
+              up: [createTableSql, ...ddl.indexes, ...ddl.triggers],
+              down: [`DROP TABLE IF EXISTS "${schema.tableName}"`],
+            });
+            migrationLogs.set(migrationName, {
+              successMessage: `Created table ${schema.tableName} (${fields} columns)`,
+            });
+          }
+
+          for (const migration of migrations) {
+            const migrationName = getSyntheticMigrationNameForAction(migration);
+            if (!migrationName) {
+              continue;
+            }
+
+            let migrationSql: string;
+            let actionDesc: string;
+
+            if (migration.type === 'add_column' && migration.column) {
+              migrationSql = migration.sql || '';
+              actionDesc = `Added column ${migration.tableName}.${migration.column.name}`;
+            } else if (migration.type === 'type_upgrade' && migration.column) {
+              migrationSql = migration.sql || '';
+              actionDesc = `Upgraded column ${migration.tableName}.${migration.column.name} from ${migration.mismatch?.actual} to ${migration.mismatch?.expected}`;
+            } else if (migration.type === 'add_index' && migration.index) {
+              migrationSql = migration.sql || '';
+              actionDesc = `Created index ${migration.index.name} on ${migration.tableName}`;
+            } else if (migration.type === 'drop_index' && migration.indexName) {
+              migrationSql = migration.sql || '';
+              actionDesc = `Dropped index ${migration.indexName} on ${migration.tableName}`;
+            } else {
+              continue;
+            }
+
+            const migrationSqlStatements =
+              migration.sqlStatements ?? (migrationSql ? [migrationSql] : []);
+
+            migrationDefs.push({
+              id: migrationName,
+              description:
+                migration.type === 'add_column'
+                  ? `Add column ${migration.column?.name} to ${migration.tableName}`
+                  : migration.type === 'type_upgrade'
+                    ? `Upgrade column ${migration.column?.name} on ${migration.tableName} from ${migration.mismatch?.actual} to ${migration.mismatch?.expected}`
+                    : migration.type === 'drop_index'
+                      ? `Drop index ${migration.indexName} on ${migration.tableName}`
+                      : `Add index ${migration.index?.name} on ${migration.tableName}`,
+              version: '1.0.0',
+              // Auto-migrations don't carry a DOWN script. Atomic execution
+              // rolls back the surrounding transaction instead of relying on
+              // per-migration DOWN SQL.
+              up: migrationSqlStatements,
+              down: [],
+            });
+            migrationLogs.set(migrationName, {
+              successMessage: actionDesc,
+              skippedMessage: `${migrationName} already applied`,
+            });
+          }
+
+          if (
+            options['postgres-safe'] &&
+            engine === 'postgres' &&
+            migrations.some(
+              (migration) =>
+                migration.type === 'add_index' ||
+                migration.type === 'drop_index',
+            )
+          ) {
+            console.warn(
+              '⚠️  --postgres-safe requested, but db:migrate applies generated schema changes atomically.',
+            );
+            console.warn(
+              '   Index DDL in this batch will run without CONCURRENTLY so PostgreSQL can roll back the full batch on failure.\n',
+            );
+          }
+
+          try {
+            const results = await tracker.applyAll(migrationDefs, {
+              atomic: true,
+              postgresSafe: false,
+              force: options.force ?? false,
+              // The diff was computed from the live schema moments earlier, so
+              // missing columns/indexes must be repaired even if a previous
+              // synthetic migration record says "completed".
+              reconcile: true,
+              onProgress: (result) => {
+                if (!result.success) {
+                  return;
+                }
+
+                const logInfo = migrationLogs.get(result.name);
+                const checksum = shortChecksum(result.checksum);
+                if (result.execution_time_ms === 0 || result.skipped) {
+                  if (options.verbose) {
+                    console.log(
+                      `  ⊙ ${logInfo?.skippedMessage ?? result.name} (${checksum})`,
+                    );
+                  }
+                  return;
+                }
+
+                console.log(
+                  `  ✓ ${logInfo?.successMessage ?? result.name} (${checksum})`,
+                );
+              },
+            });
+
+            const failed = migrationResultFailure(results);
+            if (failed) {
+              throw migrationResultError(failed);
+            }
+
+            successCount += results.filter(
+              (result) =>
+                result.success &&
+                result.applied !== false &&
+                result.execution_time_ms !== 0,
+            ).length;
+            skippedCount += results.filter(
+              (result) =>
+                result.success &&
+                (result.skipped ||
+                  result.applied === false ||
+                  result.execution_time_ms === 0),
+            ).length;
+          } catch (error) {
+            errorCount++;
+            const errorMsg =
+              error instanceof Error ? error.message : String(error);
+            console.error(`  ✗ atomic schema migration failed: ${errorMsg}`);
+            // Show underlying database error if available
+            if (
+              error instanceof Error &&
+              'context' in error &&
+              (error as any).context?.originalError
+            ) {
+              console.error(
+                `     Cause: ${(error as any).context.originalError}`,
+              );
+            }
+            if (options.verbose && error instanceof Error && error.stack) {
+              console.error(`\n${error.stack}\n`);
+            }
+            console.error(
+              '     Rolled back all schema changes from this migration batch, including any successful steps shown above.',
+            );
           }
         }
 

--- a/packages/core/src/migrations/__tests__/tracker.test.ts
+++ b/packages/core/src/migrations/__tests__/tracker.test.ts
@@ -499,6 +499,78 @@ describe('MigrationTracker', () => {
     });
   });
 
+  describe('applyAll', () => {
+    beforeEach(async () => {
+      await tracker.initialize();
+    });
+
+    it('should roll back prior migrations in an atomic batch when a later migration fails', async () => {
+      const migrations: MigrationDefinition[] = [
+        {
+          id: '0001_atomic_first',
+          description: 'First migration',
+          version: '1.0.0',
+          up: ['CREATE TABLE atomic_first (id TEXT PRIMARY KEY);'],
+          down: [],
+        },
+        {
+          id: '0002_atomic_bad_sql',
+          description: 'Bad SQL',
+          version: '1.0.0',
+          up: ['THIS IS NOT VALID SQL;'],
+          down: [],
+        },
+      ];
+
+      const results = await tracker.applyAll(migrations, { atomic: true });
+
+      expect(results).toHaveLength(2);
+      expect(results[0].success).toBe(false);
+      expect(results[0].error).toBeInstanceOf(Error);
+      expect(String(results[0].error)).toContain(
+        'Rolled back because migration 0002_atomic_bad_sql failed',
+      );
+      expect(results[1].success).toBe(false);
+
+      const tables = await db.query<{ name: string }>(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='atomic_first'`,
+      );
+      expect(tables.rows).toHaveLength(0);
+
+      const history = await tracker.getHistory();
+      expect(history).toHaveLength(0);
+    });
+
+    it('rejects explicit Postgres CONCURRENTLY index DDL before starting an atomic batch', async () => {
+      const postgresTracker = new MigrationTracker({
+        db: {
+          url: 'postgresql://test:test@localhost:5432/test',
+          query: async () => ({ rows: [] }),
+          transaction: async () => {
+            throw new Error('transaction should not start');
+          },
+        } as any,
+      });
+
+      await expect(
+        postgresTracker.applyAll(
+          [
+            {
+              id: '0001_concurrent_index',
+              description: 'Concurrent index',
+              version: '1.0.0',
+              up: [
+                'CREATE INDEX CONCURRENTLY idx_atomic_name ON atomic_first (name);',
+              ],
+              down: [],
+            },
+          ],
+          { atomic: true, postgresSafe: true },
+        ),
+      ).rejects.toThrow(/cannot include CONCURRENTLY index DDL/);
+    });
+  });
+
   describe('rollback', () => {
     beforeEach(async () => {
       await tracker.initialize();

--- a/packages/core/src/migrations/__tests__/tracker.test.ts
+++ b/packages/core/src/migrations/__tests__/tracker.test.ts
@@ -6,7 +6,7 @@
 
 import type { DatabaseProvider } from '@happyvertical/sql';
 import { getDatabase } from '@happyvertical/sql';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MigrationDefinition } from '../../schema/types.js';
 import { MigrationTracker } from '../tracker.js';
 
@@ -21,6 +21,7 @@ describe('MigrationTracker', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     if (db && typeof db.close === 'function') {
       try {
         await db.close();
@@ -526,6 +527,7 @@ describe('MigrationTracker', () => {
 
       expect(results).toHaveLength(2);
       expect(results[0].success).toBe(false);
+      expect(results[0].rolled_back).toBe(true);
       expect(results[0].error).toBeInstanceOf(Error);
       expect(String(results[0].error)).toContain(
         'Rolled back because migration 0002_atomic_bad_sql failed',
@@ -568,6 +570,60 @@ describe('MigrationTracker', () => {
           { atomic: true, postgresSafe: true },
         ),
       ).rejects.toThrow(/cannot include CONCURRENTLY index DDL/);
+    });
+
+    it('rejects explicit Postgres REINDEX CONCURRENTLY DDL before starting an atomic batch', async () => {
+      const postgresTracker = new MigrationTracker({
+        db: {
+          url: 'postgresql://test:test@localhost:5432/test',
+          query: async () => ({ rows: [] }),
+          transaction: async () => {
+            throw new Error('transaction should not start');
+          },
+        } as any,
+      });
+
+      await expect(
+        postgresTracker.applyAll(
+          [
+            {
+              id: '0001_concurrent_reindex',
+              description: 'Concurrent reindex',
+              version: '1.0.0',
+              up: ['REINDEX INDEX CONCURRENTLY idx_atomic_name;'],
+              down: [],
+            },
+          ],
+          { atomic: true },
+        ),
+      ).rejects.toThrow(/cannot include CONCURRENTLY index DDL/);
+    });
+
+    it('reports failed-status persistence errors without hiding the migration failure', async () => {
+      const originalQuery = db.query.bind(db);
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      (db as any).query = async (sql: string, ...params: unknown[]) => {
+        if (sql.includes("SET status = 'failed'")) {
+          throw new Error('failed-status write failed');
+        }
+
+        return originalQuery(sql, ...params);
+      };
+
+      const result = await tracker.apply({
+        id: '0001_bad_sql',
+        description: 'Bad SQL',
+        version: '1.0.0',
+        up: ['THIS IS NOT VALID SQL;'],
+        down: [],
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeInstanceOf(Error);
+      expect(String(result.error)).toContain('Failed to execute raw query');
+      expect(errorSpy.mock.calls.flat().join('\n')).toContain(
+        'Failed to persist failed status for migration 0001_bad_sql: failed-status write failed',
+      );
     });
   });
 

--- a/packages/core/src/migrations/tracker.ts
+++ b/packages/core/src/migrations/tracker.ts
@@ -513,6 +513,7 @@ export class MigrationTracker {
             ...options,
             atomic: false,
             continueOnError: false,
+            postgresSafe: false,
           });
           const failed = results.find((result) => !result.success);
 

--- a/packages/core/src/migrations/tracker.ts
+++ b/packages/core/src/migrations/tracker.ts
@@ -55,6 +55,37 @@ const DEFAULT_OPTIONS = {
   useConcurrentIndexes: true,
 };
 
+class AtomicMigrationRollback extends Error {
+  constructor(
+    public readonly results: MigrationResult[],
+    public readonly failed: MigrationResult,
+  ) {
+    super(`Atomic migration batch failed at ${failed.name}`);
+  }
+}
+
+const CONCURRENT_INDEX_STATEMENT_RE =
+  /(?:CREATE\s+(?:UNIQUE\s+)?INDEX|DROP\s+INDEX)\s+CONCURRENTLY/i;
+
+function findConcurrentIndexStatement(
+  definitions: MigrationDefinition[],
+): { migrationName: string; statement: string } | null {
+  for (const definition of definitions) {
+    const statement = definition.up.find((sql) =>
+      CONCURRENT_INDEX_STATEMENT_RE.test(sql),
+    );
+
+    if (statement) {
+      return {
+        migrationName: definition.id,
+        statement,
+      };
+    }
+  }
+
+  return null;
+}
+
 /**
  * MigrationTracker class
  *
@@ -410,14 +441,24 @@ export class MigrationTracker {
         execution_time_ms: executionTime,
       };
     } catch (error) {
-      // Mark as failed
-      await this.db.query(
-        `UPDATE _smrt_schema_migrations
-         SET status = 'failed', error_message = ?
-         WHERE id = ?`,
-        error instanceof Error ? error.message : String(error),
-        id,
-      );
+      const migrationError =
+        error instanceof Error ? error : new Error(String(error));
+
+      // Mark as failed. In an outer atomic Postgres transaction, a DDL error
+      // aborts the transaction and this status write must be skipped so the
+      // caller can roll back the whole batch while preserving the root error.
+      try {
+        await this.db.query(
+          `UPDATE _smrt_schema_migrations
+           SET status = 'failed', error_message = ?
+           WHERE id = ?`,
+          migrationError.message,
+          id,
+        );
+      } catch {
+        // Preserve the migration failure; status persistence is secondary and
+        // may be impossible until the surrounding transaction rolls back.
+      }
 
       return {
         success: false,
@@ -426,7 +467,7 @@ export class MigrationTracker {
         name: definition.id,
         checksum,
         execution_time_ms: Date.now() - startTime,
-        error: error instanceof Error ? error : new Error(String(error)),
+        error: migrationError,
       };
     }
   }
@@ -438,6 +479,72 @@ export class MigrationTracker {
     definitions: MigrationDefinition[],
     options: ApplyMigrationsOptions = {},
   ): Promise<MigrationResult[]> {
+    if (options.atomic && !options.dryRun) {
+      if (!this.db.transaction) {
+        throw new Error(
+          'Atomic migration batches require a database adapter with transaction support.',
+        );
+      }
+
+      if (this.dbEngine === 'postgres') {
+        const concurrentStatement = findConcurrentIndexStatement(definitions);
+        if (concurrentStatement) {
+          throw new Error(
+            `Atomic migration batch cannot include CONCURRENTLY index DDL in ${concurrentStatement.migrationName}; PostgreSQL forbids CONCURRENTLY inside a transaction.`,
+          );
+        }
+      }
+
+      try {
+        return await this.db.transaction(async (tx) => {
+          const txDb = {
+            ...tx,
+            transaction: async <T>(
+              callback: (transactionDb: DatabaseInterface) => Promise<T>,
+            ) => callback(tx as DatabaseInterface),
+          } as DatabaseInterface;
+          const txTracker = new MigrationTracker({
+            db: txDb,
+            lockTimeout: this.options.lockTimeout,
+            statementTimeout: this.options.statementTimeout,
+            useConcurrentIndexes: false,
+          });
+          const results = await txTracker.applyAll(definitions, {
+            ...options,
+            atomic: false,
+            continueOnError: false,
+          });
+          const failed = results.find((result) => !result.success);
+
+          if (failed) {
+            throw new AtomicMigrationRollback(results, failed);
+          }
+
+          return results;
+        });
+      } catch (error) {
+        if (error instanceof AtomicMigrationRollback) {
+          return error.results.map((result) => {
+            if (!result.success || !result.applied) {
+              return result;
+            }
+
+            return {
+              ...result,
+              success: false,
+              applied: false,
+              skipped: false,
+              error: new Error(
+                `Rolled back because migration ${error.failed.name} failed`,
+              ),
+            };
+          });
+        }
+
+        throw error;
+      }
+    }
+
     const results: MigrationResult[] = [];
     this.currentBatch = await this.getNextBatch();
 

--- a/packages/core/src/migrations/tracker.ts
+++ b/packages/core/src/migrations/tracker.ts
@@ -65,7 +65,7 @@ class AtomicMigrationRollback extends Error {
 }
 
 const CONCURRENT_INDEX_STATEMENT_RE =
-  /(?:CREATE\s+(?:UNIQUE\s+)?INDEX|DROP\s+INDEX)\s+CONCURRENTLY/i;
+  /(?:(?:CREATE\s+(?:UNIQUE\s+)?INDEX|DROP\s+INDEX)\s+CONCURRENTLY|REINDEX(?:\s*\([^)]*\))?\s+(?:INDEX|TABLE|SCHEMA|DATABASE|SYSTEM)\s+CONCURRENTLY)/i;
 
 function findConcurrentIndexStatement(
   definitions: MigrationDefinition[],
@@ -455,9 +455,16 @@ export class MigrationTracker {
           migrationError.message,
           id,
         );
-      } catch {
+      } catch (persistError) {
         // Preserve the migration failure; status persistence is secondary and
         // may be impossible until the surrounding transaction rolls back.
+        const persistMessage =
+          persistError instanceof Error
+            ? persistError.message
+            : String(persistError);
+        console.error(
+          `Failed to persist failed status for migration ${definition.id}: ${persistMessage}`,
+        );
       }
 
       return {
@@ -535,6 +542,7 @@ export class MigrationTracker {
               success: false,
               applied: false,
               skipped: false,
+              rolled_back: true,
               error: new Error(
                 `Rolled back because migration ${error.failed.name} failed`,
               ),
@@ -552,6 +560,7 @@ export class MigrationTracker {
     for (const definition of definitions) {
       const result = await this.apply(definition, options);
       results.push(result);
+      options.onProgress?.(result);
 
       if (!result.success && !options.continueOnError) {
         break;

--- a/packages/core/src/migrations/types.ts
+++ b/packages/core/src/migrations/types.ts
@@ -116,6 +116,8 @@ export type DatabaseEngine = 'sqlite' | 'postgres' | 'duckdb';
  * Options for batch migration application
  */
 export interface ApplyMigrationsOptions {
+  /** Apply the full batch in one transaction and roll back all applied changes on first failure */
+  atomic?: boolean;
   /** Continue applying migrations even if one fails */
   continueOnError?: boolean;
   /** Dry run - don't actually apply migrations */

--- a/packages/core/src/migrations/types.ts
+++ b/packages/core/src/migrations/types.ts
@@ -11,6 +11,7 @@ import type {
   IndexDefinition as SqlIndexDefinition,
   TableSchemaInfo as SqlTableSchemaInfo,
 } from '@happyvertical/sql';
+import type { MigrationResult } from '../schema/types.js';
 
 export type {
   SqlColumnDefinitionWithName,
@@ -138,6 +139,8 @@ export interface ApplyMigrationsOptions {
   reconcile?: boolean;
   /** Use PostgreSQL-safe operations (CONCURRENTLY, lock timeout) */
   postgresSafe?: boolean;
+  /** Called after each migration attempt completes, before the batch continues */
+  onProgress?: (result: MigrationResult) => void;
 }
 
 /**


### PR DESCRIPTION
## Summary
- run generated smrt db:migrate schema changes inside a single transaction instead of committing each generated change independently
- roll back table creation and generated column/index migrations on the first failure, then fail loudly
- add MigrationTracker.applyAll atomic support and preserve the original migration error when Postgres aborts the surrounding transaction

## Why
Anytown dev showed the failure mode: a generated migration failed partway through, but earlier table/column changes remained committed. Flux then blocked the app rollout while the database had partial schema side effects.

## Verification
- pnpm exec biome check packages/core/src/migrations/tracker.ts packages/core/src/migrations/types.ts packages/core/src/migrations/__tests__/tracker.test.ts packages/cli/src/commands/utilities.ts packages/cli/src/commands/__tests__/db-migrate-atomic.test.ts
- pnpm --filter @happyvertical/smrt-core exec vitest run src/migrations/__tests__/tracker.test.ts
- pnpm --filter @happyvertical/smrt-cli exec vitest run src/commands/__tests__/utilities.test.ts src/commands/__tests__/db-migrate-atomic.test.ts
- pnpm --filter @happyvertical/smrt-core typecheck
- pnpm --filter @happyvertical/smrt-cli typecheck
- pnpm --filter @happyvertical/smrt-core build
- pnpm --filter @happyvertical/smrt-cli build
- Postgres smoke: failed atomic batch left no first table behind on local Postgres