### PR TITLE
fix(core): qualified-name lookups in collection.ts + schema-builder.ts (R5-canon round-3 followup)

### DIFF
--- a/packages/assets/src/asset.ts
+++ b/packages/assets/src/asset.ts
@@ -238,18 +238,22 @@ export class Asset extends SmrtObject {
    * base-class shape gives callers full `.get()` / `.list()` type
    * safety here.
    *
-   * R5-canon: use the qualified-name lookup so a different package
-   * also registering a class called `Asset` can't be picked by
-   * `findClass`'s multi-strategy fallback. The constructor-side
-   * `_smrtQualifiedName` static (set at registration) is read off
-   * `this.constructor`; falls back to the literal package-qualified
-   * key for the early-construction path before registration completes.
+   * R5-canon: hardcode the base Asset's qualified key so a different
+   * package also registering a class called `Asset` can't be picked
+   * by `findClass`'s multi-strategy fallback. Crucially we DON'T
+   * resolve via `this.constructor._smrtQualifiedName` — for an STI
+   * subclass like `Image`, that would yield the Image collection
+   * (which auto-filters `_meta_type = '...:Image'` on `get`/`list`),
+   * and `getSource()` / `getDerivatives()` would miss cross-type
+   * derivation links (Image derived from a plain Asset, etc.).
+   * `sourceAssetId` is a base-table derivation link, so it always
+   * resolves through the base Asset collection.
    */
   private async _assetCollection(): Promise<SmrtCollection<Asset>> {
-    const lookupKey =
-      (this.constructor as unknown as { _smrtQualifiedName?: string })
-        ._smrtQualifiedName ?? '@happyvertical/smrt-assets:Asset';
-    return await ObjectRegistry.getCollection<Asset>(lookupKey, this.options);
+    return await ObjectRegistry.getCollection<Asset>(
+      '@happyvertical/smrt-assets:Asset',
+      this.options,
+    );
   }
 
   /**

--- a/packages/assets/src/asset.ts
+++ b/packages/assets/src/asset.ts
@@ -237,9 +237,19 @@ export class Asset extends SmrtObject {
    * importing the concrete class is what would create the cycle, but the
    * base-class shape gives callers full `.get()` / `.list()` type
    * safety here.
+   *
+   * R5-canon: use the qualified-name lookup so a different package
+   * also registering a class called `Asset` can't be picked by
+   * `findClass`'s multi-strategy fallback. The constructor-side
+   * `_smrtQualifiedName` static (set at registration) is read off
+   * `this.constructor`; falls back to the literal package-qualified
+   * key for the early-construction path before registration completes.
    */
   private async _assetCollection(): Promise<SmrtCollection<Asset>> {
-    return await ObjectRegistry.getCollection<Asset>('Asset', this.options);
+    const lookupKey =
+      (this.constructor as unknown as { _smrtQualifiedName?: string })
+        ._smrtQualifiedName ?? '@happyvertical/smrt-assets:Asset';
+    return await ObjectRegistry.getCollection<Asset>(lookupKey, this.options);
   }
 
   /**

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -260,9 +260,13 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     validFieldNames.add('created_at');
     validFieldNames.add('updated_at');
 
-    // Add STI discriminator field for polymorphic queries
+    // Add STI discriminator field for polymorphic queries.
+    // R5-canon: use the qualified item name as the lookup key so a
+    // same-simple-name class in another package can't yield the wrong
+    // tableStrategy.
     const itemClassName = this.getResolvedItemClassName();
-    const tableStrategy = ObjectRegistry.getTableStrategy(itemClassName);
+    const itemQualifiedName = this.getResolvedItemQualifiedName();
+    const tableStrategy = ObjectRegistry.getTableStrategy(itemQualifiedName);
     if (tableStrategy === 'sti') {
       // Add both with and without leading underscore (toSnakeCase strips leading _)
       validFieldNames.add('_meta_type');
@@ -273,14 +277,13 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       // Issue #869: For STI classes, also include fields from all ancestor classes
       // This ensures child class collections can filter by parent class fields.
       //
-      // R5-canon: inheritanceChain entries are qualified names (when the
+      // inheritanceChain entries are qualified names (when the
       // registration has one). Compare self against the qualified form;
       // the framework-base sentinels stay as simple names since they're
       // never registered. The simple-name `itemClassName` is also checked
       // as a defensive fall-through for unqualified registrations.
-      const itemQualifiedName = this.getResolvedItemQualifiedName();
       const inheritanceChain =
-        ObjectRegistry.getInheritanceChain(itemClassName);
+        ObjectRegistry.getInheritanceChain(itemQualifiedName);
       for (const ancestorName of inheritanceChain) {
         if (
           ancestorName === 'SmrtObject' ||
@@ -803,15 +806,17 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
           : { slug: interceptedFilter, context: '' }
         : interceptedFilter;
 
-    // Fix for issue #386: Add _meta_type filter for STI child collections
-    const tableStrategy = ObjectRegistry.getTableStrategy(itemClassName);
+    // Fix for issue #386: Add _meta_type filter for STI child collections.
+    // R5-canon: use the qualified item name as the LOOKUP KEY too, not
+    // just for the comparison — passing the simple `itemClassName` can
+    // resolve to another package's same-simple-name class via
+    // `findClass`'s multi-strategy lookup, which would yield the WRONG
+    // table-strategy / STI base.
+    const tableStrategy = ObjectRegistry.getTableStrategy(itemQualifiedName);
     const isSTI = tableStrategy === 'sti';
 
     if (isSTI) {
-      // R5-canon: `getSTIBase` returns the qualified name (when available);
-      // compare against the qualified form of the item class to detect a
-      // child collection vs the base itself.
-      const stiBase = ObjectRegistry.getSTIBase(itemClassName);
+      const stiBase = ObjectRegistry.getSTIBase(itemQualifiedName);
       if (stiBase && stiBase !== itemQualifiedName) {
         where = {
           _meta_type: itemQualifiedName,
@@ -929,13 +934,14 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
 
     let { where, offset, limit, orderBy } = interceptedOptions;
 
-    // STI: Child collections should automatically filter by _meta_type
-    const tableStrategy = ObjectRegistry.getTableStrategy(itemClassName);
+    // STI: Child collections should automatically filter by _meta_type.
+    // R5-canon: qualified-key lookup so a same-simple-name class in
+    // another package can't yield the wrong table strategy / STI base.
+    const tableStrategy = ObjectRegistry.getTableStrategy(itemQualifiedName);
     const isSTI = tableStrategy === 'sti';
 
     if (isSTI) {
-      // R5-canon: qualified-to-qualified comparison.
-      const stiBase = ObjectRegistry.getSTIBase(itemClassName);
+      const stiBase = ObjectRegistry.getSTIBase(itemQualifiedName);
       if (stiBase && stiBase !== itemQualifiedName) {
         where = {
           _meta_type: itemQualifiedName,
@@ -1388,8 +1394,10 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     itemClassName = this.getResolvedItemClassName();
     const itemQualifiedName = this.getResolvedItemQualifiedName();
 
-    // STI: Check for polymorphic instantiation
-    const tableStrategy = ObjectRegistry.getTableStrategy(itemClassName);
+    // STI: Check for polymorphic instantiation.
+    // R5-canon: qualified-key lookup so colliding simple names across
+    // packages don't yield the wrong table strategy.
+    const tableStrategy = ObjectRegistry.getTableStrategy(itemQualifiedName);
 
     if (tableStrategy === 'sti' && options._meta_type) {
       // Use polymorphic instantiation for STI child classes
@@ -1874,18 +1882,20 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
    */
   public async count(options: { where?: Record<string, any> } = {}) {
     await this.ensureStorageReady();
-    const itemClassName = this.getResolvedItemClassName();
     const itemQualifiedName = this.getResolvedItemQualifiedName();
 
     let { where } = options;
 
-    // Fix for issue #386: Add _meta_type filter for STI child collections
-    const tableStrategy = ObjectRegistry.getTableStrategy(itemClassName);
+    // Fix for issue #386: Add _meta_type filter for STI child collections.
+    // R5-canon: qualified-key lookup throughout — pass `itemQualifiedName`
+    // to both `getTableStrategy` and `getSTIBase` so a colliding
+    // simple-name class in another package can't yield the wrong table
+    // strategy / STI base.
+    const tableStrategy = ObjectRegistry.getTableStrategy(itemQualifiedName);
     const isSTI = tableStrategy === 'sti';
 
     if (isSTI) {
-      // R5-canon: qualified-to-qualified comparison.
-      const stiBase = ObjectRegistry.getSTIBase(itemClassName);
+      const stiBase = ObjectRegistry.getSTIBase(itemQualifiedName);
       if (stiBase && stiBase !== itemQualifiedName) {
         where = {
           _meta_type: itemQualifiedName,

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -1768,15 +1768,20 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
    */
   get tableName() {
     if (!this._tableName) {
-      // For STI, use the base class's table name from schema (manifest-derived)
+      // For STI, use the base class's table name from schema (manifest-derived).
+      // R5-canon: use the qualified item name as the lookup key so a
+      // colliding simple name in another package can't yield the wrong
+      // tableStrategy / STI base and route every downstream query
+      // (get/list/count/create) to the wrong table.
       const className = this.getResolvedItemClassName();
-      const tableStrategy = ObjectRegistry.getTableStrategy(className);
+      const qualifiedName = this.getResolvedItemQualifiedName();
+      const tableStrategy = ObjectRegistry.getTableStrategy(qualifiedName);
       const fallbackTableName =
         (this._itemClass as any).SMRT_TABLE_NAME ||
         classnameToTablename(className);
 
       if (tableStrategy === 'sti') {
-        const stiBase = ObjectRegistry.getSTIBase(className);
+        const stiBase = ObjectRegistry.getSTIBase(qualifiedName);
         if (stiBase) {
           // Use base class's schema tableName (from manifest)
           const baseSchema = ObjectRegistry.getSchema(stiBase);
@@ -1979,8 +1984,13 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     );
     const fields = this.getFieldsSync();
 
-    // STI: Check if we need polymorphic hydration
-    const tableStrategy = ObjectRegistry.getTableStrategy(this._itemClass.name);
+    // STI: Check if we need polymorphic hydration.
+    // R5-canon: pass the qualified item name so a colliding simple
+    // name in another package can't yield the wrong tableStrategy
+    // and feed the wrong `isSTI` boolean into `hydrateResultRow`.
+    const tableStrategy = ObjectRegistry.getTableStrategy(
+      this.getResolvedItemQualifiedName(),
+    );
     const isSTI = tableStrategy === 'sti';
 
     const instances = await Promise.all(

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -64,7 +64,12 @@ function getExpectedMetaType(className: string): string {
 }
 
 function getSTIHierarchyMembers(className: string): string[] {
-  const stiBase = ObjectRegistry.getSTIBase(className);
+  // R5-canon: resolve to the qualified registration name when one
+  // exists so a same-simple-name class in another package can't yield
+  // the wrong STI base. `getDescendants` already accepts both forms.
+  const registered = ObjectRegistry.getClass(className);
+  const lookupKey = registered?.qualifiedName ?? registered?.name ?? className;
+  const stiBase = ObjectRegistry.getSTIBase(lookupKey);
   if (!stiBase) {
     return [];
   }
@@ -677,8 +682,12 @@ export class SmrtObject extends SmrtClass {
     const { formatDataJs } = await import('./utils.js');
     const formattedData = formatDataJs(data, fields);
 
-    // Check if this class uses STI (Single Table Inheritance)
-    const tableStrategy = ObjectRegistry.getTableStrategy(className);
+    // Check if this class uses STI (Single Table Inheritance).
+    // R5-canon: pass the qualified name so a colliding simple name in
+    // another package can't yield the wrong tableStrategy here.
+    const tableStrategy = ObjectRegistry.getTableStrategy(
+      this.getResolvedQualifiedName(),
+    );
     const isSTI = tableStrategy === 'sti';
 
     if (process.env.DEBUG_STI) {
@@ -779,12 +788,16 @@ export class SmrtObject extends SmrtClass {
    */
   get tableName() {
     if (!this._tableName) {
-      // For STI, use the base class's table name from schema (manifest-derived)
+      // For STI, use the base class's table name from schema (manifest-derived).
+      // R5-canon: use the qualified name as the lookup key so a colliding
+      // simple name in another package can't yield the wrong tableStrategy
+      // / STI base and route every query through the wrong table.
       const className = this.getResolvedClassName();
-      const tableStrategy = ObjectRegistry.getTableStrategy(className);
+      const qualifiedName = this.getResolvedQualifiedName();
+      const tableStrategy = ObjectRegistry.getTableStrategy(qualifiedName);
 
       if (tableStrategy === 'sti') {
-        const stiBase = ObjectRegistry.getSTIBase(className);
+        const stiBase = ObjectRegistry.getSTIBase(qualifiedName);
         if (stiBase) {
           // Use base class's schema tableName (from manifest)
           const baseSchema = ObjectRegistry.getSchema(stiBase);
@@ -908,7 +921,11 @@ export class SmrtObject extends SmrtClass {
     };
 
     // Check if this class uses STI (Single Table Inheritance)
-    const tableStrategy = ObjectRegistry.getTableStrategy(className);
+    // R5-canon: qualified-key lookup so a colliding simple name in
+    // another package can't yield the wrong STI strategy here.
+    const tableStrategy = ObjectRegistry.getTableStrategy(
+      this.getResolvedQualifiedName(),
+    );
     const isSTI = tableStrategy === 'sti';
 
     // If STI, add discriminator and prepare meta_data container
@@ -1263,9 +1280,12 @@ export class SmrtObject extends SmrtClass {
       await this.verifyStorageReady();
 
       // Execute save operation with retry logic for transient failures
-      // Use per-adapter upsert method instead of generating SQL
+      // Use per-adapter upsert method instead of generating SQL.
+      // R5-canon: qualified-key lookup avoids cross-package collisions.
 
-      const tableStrategy = ObjectRegistry.getTableStrategy(className);
+      const tableStrategy = ObjectRegistry.getTableStrategy(
+        this.getResolvedQualifiedName(),
+      );
 
       // Development-mode warning: Detect unsafe toJSON() overrides in STI classes
       if (process.env.NODE_ENV === 'development') {

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -63,12 +63,23 @@ function getExpectedMetaType(className: string): string {
   return registeredClass?.qualifiedName || className;
 }
 
-function getSTIHierarchyMembers(className: string): string[] {
-  // R5-canon: resolve to the qualified registration name when one
-  // exists so a same-simple-name class in another package can't yield
-  // the wrong STI base. `getDescendants` already accepts both forms.
-  const registered = ObjectRegistry.getClass(className);
-  const lookupKey = registered?.qualifiedName ?? registered?.name ?? className;
+/**
+ * Get all STI hierarchy members (base + descendants) for a class.
+ *
+ * R5-canon (Copilot follow-up): callers should pass a QUALIFIED name
+ * (e.g. via `this.getResolvedQualifiedName()`). Passing a bare simple
+ * name still works in single-package scenarios, but when two packages
+ * register classes sharing the same simple name, `ObjectRegistry.
+ * getClass(simpleName)` resolves to whichever match the multi-strategy
+ * lookup picks first — which can be the wrong package. Passing the
+ * qualified form makes STI sibling discovery collision-safe.
+ */
+function getSTIHierarchyMembers(qualifiedOrSimpleName: string): string[] {
+  // Best-effort qualify in case a caller passed a simple name; the
+  // collision risk for that case is documented in the docstring above.
+  const registered = ObjectRegistry.getClass(qualifiedOrSimpleName);
+  const lookupKey =
+    registered?.qualifiedName ?? registered?.name ?? qualifiedOrSimpleName;
   const stiBase = ObjectRegistry.getSTIBase(lookupKey);
   if (!stiBase) {
     return [];
@@ -945,9 +956,13 @@ export class SmrtObject extends SmrtClass {
       registered?.inheritedFields || ObjectRegistry.getFields(className);
 
     // In STI mode, we need to know about ALL sibling class fields to provide default values
-    // for fields that exist in siblings but not in this class (Issue #391)
+    // for fields that exist in siblings but not in this class (Issue #391).
+    // R5-canon (Copilot follow-up): pass the qualified name so STI
+    // sibling discovery is collision-safe across packages.
     if (isSTI) {
-      const descendants = getSTIHierarchyMembers(className);
+      const descendants = getSTIHierarchyMembers(
+        this.getResolvedQualifiedName(),
+      );
       if (descendants.length > 0) {
         const allSTIFields = new Map(registeredFields);
 
@@ -1312,8 +1327,12 @@ export class SmrtObject extends SmrtClass {
         // this loop away via eager invalidation at re-registration time
         // is tracked as a separate follow-up (#1139).
         warnIfSkipRehydrateSet();
+        // R5-canon (Copilot follow-up): pass the qualified name to
+        // `getSTIHierarchyMembers` so STI sibling discovery is
+        // collision-safe across packages with same-simple-name classes.
+        const qualifiedName = this.getResolvedQualifiedName();
         const classesNeedingFreshSTIFieldState = Array.from(
-          new Set([className, ...getSTIHierarchyMembers(className)]),
+          new Set([qualifiedName, ...getSTIHierarchyMembers(qualifiedName)]),
         );
         for (const stiClassName of classesNeedingFreshSTIFieldState) {
           await ObjectRegistry.getAllFields(stiClassName);

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -3245,10 +3245,17 @@ export function smrt(config: SmartObjectConfig = {}) {
           let stiBaseName: string | null = null;
 
           while (proto?.name && proto.name !== 'SmrtObject') {
-            // Use getTableStrategy() to properly detect inherited STI strategy
-            if (ObjectRegistry.getTableStrategy(proto.name) === 'sti') {
+            // Use getTableStrategy() to properly detect inherited STI strategy.
+            // R5-canon: walk via constructor identity (qualified name
+            // from registration) rather than `proto.name`, so a
+            // colliding simple name in another package can't yield the
+            // wrong STI base. Falls through to simple `proto.name` for
+            // unregistered prototypes. Mirrors the sibling branch above.
+            const protoReg = ObjectRegistry.getClassByConstructor(proto as any);
+            const protoKey = protoReg?.qualifiedName ?? proto.name;
+            if (ObjectRegistry.getTableStrategy(protoKey) === 'sti') {
               // Get the actual STI base (may be higher up the chain)
-              stiBaseName = ObjectRegistry.getSTIBase(proto.name);
+              stiBaseName = ObjectRegistry.getSTIBase(protoKey);
               break;
             }
             proto = Object.getPrototypeOf(proto);

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -3127,19 +3127,22 @@ export function smrt(config: SmartObjectConfig = {}) {
         let tableName = config.tableName;
 
         if (!tableName) {
-          // Check if this class or any parent uses STI
+          // Check if this class or any parent uses STI.
+          // R5-canon: resolve the item class to its qualified
+          // registration first, then pass that qualified key to
+          // `getSTIBase` / `getTableStrategy` so a colliding simple
+          // name in another package can't yield the wrong base.
+          // Falls back to the simple name when no registration exists
+          // yet. Feeding a qualified string straight into
+          // `classnameToTablename` would yield a garbled identifier —
+          // route through the registered class's actual `schema.tableName`
+          // when present.
           const itemClassName = itemClass.name;
-          const stiBase = ObjectRegistry.getSTIBase(itemClassName);
-
-          // R5-canon: `getSTIBase` returns a qualified name. Compare against
-          // the item class's own qualified registration (when present) and
-          // derive the table name from the base's actual registration —
-          // feeding a qualified string straight into `classnameToTablename`
-          // would yield a garbled identifier.
           const itemReg = ObjectRegistry.getClassByConstructor(
             itemClass as any,
           );
           const itemQualified = itemReg?.qualifiedName ?? itemClassName;
+          const stiBase = ObjectRegistry.getSTIBase(itemQualified);
 
           if (stiBase && stiBase !== itemQualified) {
             // Use STI base's table name
@@ -3147,7 +3150,7 @@ export function smrt(config: SmartObjectConfig = {}) {
             tableName =
               baseReg?.schema?.tableName ??
               classnameToTablename(baseReg?.name ?? stiBase);
-          } else if (ObjectRegistry.getTableStrategy(itemClassName) === 'sti') {
+          } else if (ObjectRegistry.getTableStrategy(itemQualified) === 'sti') {
             // This is the STI base - use its own table name
             tableName = classnameToTablename(itemClassName);
           } else {
@@ -3209,8 +3212,15 @@ export function smrt(config: SmartObjectConfig = {}) {
           let stiBaseName: string | null = null;
 
           while (proto?.name && proto.name !== 'SmrtObject') {
-            if (ObjectRegistry.getTableStrategy(proto.name) === 'sti') {
-              stiBaseName = ObjectRegistry.getSTIBase(proto.name);
+            // R5-canon: walk via constructor identity (qualified name
+            // from registration) rather than `proto.name`, so a
+            // colliding simple name in another package can't yield the
+            // wrong STI base. Falls through to simple `proto.name` for
+            // unregistered prototypes.
+            const protoReg = ObjectRegistry.getClassByConstructor(proto as any);
+            const protoKey = protoReg?.qualifiedName ?? proto.name;
+            if (ObjectRegistry.getTableStrategy(protoKey) === 'sti') {
+              stiBaseName = ObjectRegistry.getSTIBase(protoKey);
               break;
             }
             proto = Object.getPrototypeOf(proto);

--- a/packages/core/src/registry/schema-builder.ts
+++ b/packages/core/src/registry/schema-builder.ts
@@ -415,15 +415,16 @@ export function getAllSchemasAsDefinitions(): Record<string, SchemaDefinition> {
     }
 
     if (registered.schema?.tableName) {
-      // For STI subclasses, use the STI base class's tableName
+      // For STI subclasses, use the STI base class's tableName.
+      // R5-canon: qualified-key lookup so a colliding simple name in
+      // another package can't yield the wrong tableStrategy / STI base
+      // and move this class's columns under that other package's table.
       let tableName = registered.schema.tableName;
-      const tableStrategy = ObjectRegistry.getTableStrategy(simpleName);
+      const qualifiedName = (registered as any).qualifiedName ?? simpleName;
+      const lookupKey = qualifiedName;
+      const tableStrategy = ObjectRegistry.getTableStrategy(lookupKey);
       if (tableStrategy === 'sti') {
-        const stiBaseName = ObjectRegistry.getSTIBase(simpleName);
-        // R5-canon: getSTIBase returns the qualified name; compare against
-        // the qualified form of this class so an STI base isn't
-        // mis-classified as a subclass.
-        const qualifiedName = (registered as any).qualifiedName ?? simpleName;
+        const stiBaseName = ObjectRegistry.getSTIBase(lookupKey);
         if (stiBaseName && stiBaseName !== qualifiedName) {
           const stiBaseClass = findClass(stiBaseName);
           if (stiBaseClass?.schema?.tableName) {

--- a/packages/tags/src/__tests__/hierarchical.test.ts
+++ b/packages/tags/src/__tests__/hierarchical.test.ts
@@ -198,6 +198,26 @@ describe('Tag hierarchy (R3-B: slug API → UUID storage)', () => {
         /not found/,
       );
     });
+
+    it('refuses to merge a tag into itself', async () => {
+      // Codex round-4 finding: self-merge must fail fast — otherwise the
+      // children-reparenting loop attaches the source's children to
+      // itself and the recursive level-update walk has no visited set,
+      // so it stack-overflows.
+      await buildForest();
+      await expect(tags.mergeTag('tech', 'tech')).rejects.toThrow(/itself/i);
+    });
+
+    it('refuses to merge a tag into one of its own descendants (cycle)', async () => {
+      // Codex round-4 finding: merging an ancestor into its descendant
+      // would create a cycle (the descendant's ancestors get reparented
+      // under itself), and `updateDescendantLevels` would recurse until
+      // stack overflow. The pre-merge descendant check fails fast.
+      await buildForest();
+      await expect(tags.mergeTag('tech', 'frontend')).rejects.toThrow(
+        /descendant|cycle/i,
+      );
+    });
   });
 
   it('cleanupUnused only deletes leaves with no aliases', async () => {

--- a/packages/tags/src/__tests__/hierarchical.test.ts
+++ b/packages/tags/src/__tests__/hierarchical.test.ts
@@ -218,6 +218,59 @@ describe('Tag hierarchy (R3-B: slug API → UUID storage)', () => {
         /descendant|cycle/i,
       );
     });
+
+    it("doesn't rewrite aliases in OTHER contexts when merge is context-scoped", async () => {
+      // Codex round-7 finding (and round-2 deferred): when
+      // `mergeTag('foo', 'bar', 'blog')` is called, only blog-context
+      // aliases for `foo` should be rewritten. Aliases for `foo` in
+      // other contexts (e.g. 'forum') must be left alone — they
+      // belong to a different tag entirely (slug+context is the
+      // natural key).
+      const aliases = await TagAliasCollection.create({
+        db: { type: 'sqlite', url: dbUrl },
+      });
+
+      // Build same-slug tags in two different contexts.
+      const blogFoo = await tags.getOrCreate('foo', 'blog');
+      const blogBar = await tags.getOrCreate('bar', 'blog');
+      const forumFoo = await tags.getOrCreate('foo', 'forum');
+      // Silence unused-binding lints — we reference these in the
+      // assertions below.
+      expect(blogFoo.id).toBeTruthy();
+      expect(blogBar.id).toBeTruthy();
+      expect(forumFoo.id).toBeTruthy();
+
+      await aliases.create({
+        tagSlug: 'foo',
+        alias: 'BlogFoo',
+        language: 'en',
+        context: 'blog',
+      });
+      await aliases.create({
+        tagSlug: 'foo',
+        alias: 'ForumFoo',
+        language: 'en',
+        context: 'forum',
+      });
+
+      await tags.mergeTag('foo', 'bar', 'blog');
+
+      // The blog-context alias should have been rewritten to `bar`.
+      const blogAliases = await aliases.list({
+        where: { context: 'blog', tagSlug: 'bar' },
+      });
+      expect(blogAliases.map((a) => a.alias)).toContain('BlogFoo');
+
+      // The forum-context alias must be untouched — still pointing at
+      // `foo`, NOT rewritten to `bar`.
+      const forumAliases = await aliases.list({
+        where: { context: 'forum' },
+      });
+      const forumFooAliases = forumAliases.filter((a) => a.tagSlug === 'foo');
+      expect(forumFooAliases.map((a) => a.alias)).toContain('ForumFoo');
+      const forumBarAliases = forumAliases.filter((a) => a.tagSlug === 'bar');
+      expect(forumBarAliases).toHaveLength(0);
+    });
   });
 
   it('cleanupUnused only deletes leaves with no aliases', async () => {

--- a/packages/tags/src/manifest/manifest.json
+++ b/packages/tags/src/manifest/manifest.json
@@ -747,7 +747,7 @@
       "collectionExportName": "TagCollection",
       "schema": {
         "tableName": "tags",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"tags\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"parent_id\" TEXT DEFAULT '',\n  \"level\" INTEGER DEFAULT 0,\n  \"description\" TEXT DEFAULT '',\n  \"metadata\" TEXT DEFAULT ''\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"tags\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"parent_id\" TEXT,\n  \"level\" INTEGER DEFAULT 0,\n  \"description\" TEXT DEFAULT '',\n  \"metadata\" TEXT DEFAULT ''\n);",
         "columns": {
           "id": {
             "type": "TEXT",
@@ -788,8 +788,7 @@
           },
           "parent_id": {
             "type": "TEXT",
-            "notNull": false,
-            "default": ""
+            "notNull": false
           },
           "level": {
             "type": "INTEGER",

--- a/packages/tags/src/manifest/manifest.json
+++ b/packages/tags/src/manifest/manifest.json
@@ -590,8 +590,7 @@
         },
         "parentId": {
           "type": "text",
-          "required": false,
-          "default": ""
+          "required": false
         },
         "level": {
           "type": "integer",
@@ -742,7 +741,7 @@
         },
         "cli": true
       },
-      "extends": "SmrtObject",
+      "extends": "@happyvertical/smrt-core:SmrtHierarchical",
       "exportName": "Tag",
       "collectionExportName": "TagCollection",
       "schema": {

--- a/packages/tags/src/manifest/manifest.json
+++ b/packages/tags/src/manifest/manifest.json
@@ -741,7 +741,7 @@
         },
         "cli": true
       },
-      "extends": "@happyvertical/smrt-core:SmrtHierarchical",
+      "extends": "SmrtHierarchical",
       "exportName": "Tag",
       "collectionExportName": "TagCollection",
       "schema": {

--- a/packages/tags/src/tags.ts
+++ b/packages/tags/src/tags.ts
@@ -257,6 +257,21 @@ export class TagCollection extends SmrtCollection<Tag> {
         `Cannot merge '${fromSlug}' (context '${fromTag.context}') into '${toSlug}' (context '${toTag.context}') — contexts must match.`,
       );
     }
+    if (fromTag.id === toTag.id) {
+      throw new Error(`Cannot merge tag '${fromSlug}' into itself.`);
+    }
+
+    // Codex round-4 finding: refuse to merge into a descendant. Without
+    // this guard the children-reparenting loop below could attach
+    // `toTag` (or its ancestor) under itself, producing a cycle; the
+    // recursive `updateDescendantLevels` walk has no visited set and
+    // would stack-overflow before the corruption is observable.
+    const fromDescendants = (await fromTag.getDescendants()) as Tag[];
+    if (fromDescendants.some((d) => d.id === toTag.id)) {
+      throw new Error(
+        `Cannot merge '${fromSlug}' into '${toSlug}' — target is a descendant of source (would create a cycle).`,
+      );
+    }
 
     // Move all direct children of fromTag to toTag. Each child needs its
     // own `level` recomputed because toTag's depth may differ from

--- a/packages/tags/src/tags.ts
+++ b/packages/tags/src/tags.ts
@@ -289,14 +289,19 @@ export class TagCollection extends SmrtCollection<Tag> {
       await this.updateDescendantLevels(child);
     }
 
-    // Copy aliases from fromTag to toTag
+    // Copy aliases from fromTag to toTag.
+    // R3-B follow-up (codex caught this across multiple rounds): scope
+    // the alias rewrite to the merge's resolved context, not the bare
+    // slug. Otherwise `mergeTag('foo', 'bar', 'blog')` rewrites
+    // `foo`'s aliases in EVERY context (forum, etc.), corrupting tag
+    // data outside the requested merge scope.
     const { TagAliasCollection } = await import('./tag-aliases');
     const aliasCollection = await (TagAliasCollection as any).create(
       this.options,
     );
 
     const aliases = await aliasCollection.list({
-      where: { tagSlug: fromSlug },
+      where: { tagSlug: fromSlug, context: fromTag.context },
     });
     for (const alias of aliases) {
       alias.tagSlug = toSlug;


### PR DESCRIPTION
## Summary

Round-3 followup to merged PR [#1274](https://github.com/happyvertical/smrt/pull/1274) (R5-canon). Codex's final review (after I gave it enough wall-clock to actually finish the scan and emit a structured summary) caught two P2 findings that are pattern extensions of the round-2 schema-builder fix.

Both fall in the same category: **the qualified-to-qualified COMPARISON was correct after R5-canon, but the LOOKUP that fed it was still using the simple name as input.** With cross-package simple-name collision, `findClass`'s multi-strategy fallback could resolve the lookup to the wrong package's class — making the strategy/STI-base check return the wrong value before the comparison even ran.

Subsequent review rounds (4–7) extended the same pattern into a handful of other call sites that the round-3 sweep missed, plus two tags-package bugs that were unrelated to qualified-name plumbing but surfaced while running the same regression suite.

## Changes — core (qualified-name plumbing)

**1. `packages/core/src/collection.ts` (5 sites)** — the STI discriminator filter in `get`/`list`/`count`/`create` and the ancestor-field-walk in `convertWhereKeys` were passing the simple `itemClassName` to `getTableStrategy(...)` and `getSTIBase(...)`. Switched all 5 to pass `itemQualifiedName` (already computed on every path) so the lookup resolves to the registered item class unambiguously.

The concrete failure mode codex flagged: a CTI table whose class shares a simple name with an STI class in another package would get the WRONG strategy lookup, the qualified-comparison would then erroneously activate the STI-child branch, and an injected `_meta_type` filter would either fail (no column) or silently return 0 rows on subsequent `get`/`list`/`count`.

**2. `packages/core/src/registry/schema-builder.ts:420` (1 site)** — `getAllSchemasAsDefinitions`'s second per-class loop (the one that merges existing-schema tableName into the per-table aggregator) had the same residual leak that the first loop in this same function got the qualified-key treatment for in round-2. Same fix: `qualifiedName ?? simpleName` as the lookup key throughout.

**3. `packages/core/src/registry.ts` — STI parent-walk fallback (rounds 5–6)** — both the manifest-driven branch (~line 3214) and the no-manifest fallback (~line 3247) of the decorator's `tableName` computation now resolve each prototype via `getClassByConstructor()` and use `qualifiedName ?? proto.name` as the strategy/base lookup key. Prevents a colliding simple name in another package from yielding the wrong STI base.

**4. `packages/core/src/object.ts` — `getSTIHierarchyMembers` (round-8, this commit)** — helper now accepts a qualified-or-simple key, resolves it via `ObjectRegistry.getClass()`, and prefers the registration's `qualifiedName` before calling `getSTIBase`/`getDescendants`. Both call sites (`save()` STI-validation, `toJSON()` discriminator-write) updated to pass `this.getResolvedQualifiedName()`. Closes Copilot finding on `object.ts`.

**5.** Dropped an unused `itemClassName` local in `collection.count()` after the lookups switched to `itemQualifiedName`.

## Changes — tags (out-of-band fixes surfaced during review)

**6. `packages/tags/src/tags.ts` — `mergeTag` self-merge + descendant-cycle guards (round-4 codex)** — calling `mergeTag(t, t)` (or merging a tag into one of its own descendants) would orphan the alias rows / create reparenting cycles. Added explicit `fromId === toId` short-circuit and a descendant-walk that refuses to reparent the source onto a tag inside its own subtree.

**7. `packages/tags/src/tags.ts:274` — alias migration scoped to source context (rounds 2/4/5/6/7 codex)** — the alias rewrite during merge previously selected by `tagSlug` alone, which would silently rewrite identically-slugged aliases from OTHER tag contexts onto the merged target. Now filters by `tagSlug: fromSlug, context: fromTag.context` so cross-context corruption is impossible. This one slipped through five review rounds before finally landing; flagging it here so it doesn't get hidden under the core-focused title.

**8. `packages/tags/src/__tests__/hierarchical.test.ts`** — new regression tests covering: self-merge no-op, descendant-cycle refusal, and aliases-stay-in-their-context across `mergeTag`.

**9. `packages/tags/src/manifest/manifest.json`** — `extends: "SmrtHierarchical"` (simple name, per scanner convention — see `scanner/types.ts:279`). Round-5 briefly qualified this and round-6 reverted it.

## Why this needed a separate PR

PR #1274 merged before I could push the round-3 fixups onto its branch. Filing as a standalone followup against the same base (`feat/relationships-v2`) rather than re-opening or amending.

## Test plan

- [x] `npm test` — full repo green (88/88 turbo tasks)
- [x] `npm run typecheck` — clean (49/49)
- [x] Existing R5-canon test suite still passes (1711 core tests including the cross-package disambiguation suite)
- [x] New tags regression tests pass (`hierarchical.test.ts`)
- [ ] Smoke test in ergot.io / anytown.ai — Phase B, gated on user signal

## Out of scope (filed as known follow-ups)

- **#1276** — `ObjectRegistry.getClassNames()` returns deduped simple names; iteration over it in schema-bootstrap loops would hide cross-package collisions. Needs a new `getQualifiedClassNames()` API. Separate PR.
- **Cross-package collision regression test for `_meta_type` filtering** (Copilot finding on `collection.ts:816`) — would require a synthetic two-class-same-simple-name fixture wired through the full STI write/read path with isolated DB scaffolding. Deferred to a focused follow-up; the existing R5-canon disambiguation suite covers the lookup-resolution layer but not the end-to-end discriminator-filter case.