### PR TITLE
fix(core): render postgres json add-column defaults

### DIFF
--- a/.changeset/fix-postgres-json-add-column.md
+++ b/.changeset/fix-postgres-json-add-column.md
@@ -1,0 +1,5 @@
+---
+"@happyvertical/smrt-core": patch
+---
+
+Fix PostgreSQL ADD COLUMN migrations for JSON defaults so array defaults render valid JSONB SQL.

--- a/packages/core/src/migrations/__tests__/differ.test.ts
+++ b/packages/core/src/migrations/__tests__/differ.test.ts
@@ -455,6 +455,85 @@ describe('SchemaComparer engine-specific SQL generation', () => {
     ]);
   });
 
+  it('should preserve DuckDB UNIQUE constraints in ADD COLUMN SQL', async () => {
+    const mockDuckDb = {
+      url: '/path/to/test.duckdb',
+      query: async () => ({ rows: [{ name: 'users' }] }),
+      getTableSchema: async () => ({
+        columns: {
+          id: { type: 'TEXT', notnull: true },
+        },
+        indexes: [],
+      }),
+    };
+
+    const duckComparer = new SchemaComparer(mockDuckDb as any);
+
+    const manifest: Record<string, SchemaDefinition> = {
+      users: {
+        tableName: 'users',
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          email: { type: 'TEXT', unique: true },
+        },
+        indexes: [],
+        triggers: [],
+        foreignKeys: [],
+        dependencies: [],
+        version: '1.0.0',
+      },
+    };
+
+    const diff = await duckComparer.compare(manifest);
+
+    expect(diff.changes).toEqual([
+      expect.objectContaining({
+        type: 'add_column',
+        table: 'users',
+        name: 'email',
+        sql: `ALTER TABLE "users" ADD COLUMN "email" TEXT UNIQUE`,
+      }),
+    ]);
+  });
+
+  it('should not emit PRIMARY KEY constraints in ADD COLUMN SQL', async () => {
+    const mockPostgresDb = {
+      url: 'postgresql://localhost/test',
+      query: async () => ({ rows: [{ table_name: 'users' }] }),
+      getTableSchema: async () => ({
+        columns: {},
+        indexes: [],
+      }),
+    };
+
+    const pgComparer = new SchemaComparer(mockPostgresDb as any);
+
+    const manifest: Record<string, SchemaDefinition> = {
+      users: {
+        tableName: 'users',
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+        },
+        indexes: [],
+        triggers: [],
+        foreignKeys: [],
+        dependencies: [],
+        version: '1.0.0',
+      },
+    };
+
+    const diff = await pgComparer.compare(manifest);
+
+    expect(diff.changes).toEqual([
+      expect.objectContaining({
+        type: 'add_column',
+        table: 'users',
+        name: 'id',
+        sql: `ALTER TABLE "users" ADD COLUMN "id" TEXT`,
+      }),
+    ]);
+  });
+
   it('should generate PostgreSQL USING clause for legacy JSON→TIMESTAMP drift', async () => {
     const mockPostgresDb = {
       url: 'postgresql://localhost/test',

--- a/packages/core/src/migrations/__tests__/differ.test.ts
+++ b/packages/core/src/migrations/__tests__/differ.test.ts
@@ -414,6 +414,47 @@ describe('SchemaComparer engine-specific SQL generation', () => {
     expect(typeUpgrades[0].sql).toContain("SET DEFAULT '{}'::jsonb");
   });
 
+  it('should generate PostgreSQL ADD COLUMN SQL for JSON array defaults', async () => {
+    const mockPostgresDb = {
+      url: 'postgresql://localhost/test',
+      query: async () => ({ rows: [{ table_name: 'contents' }] }),
+      getTableSchema: async () => ({
+        columns: {
+          id: { type: 'TEXT', notnull: true },
+        },
+        indexes: [],
+      }),
+    };
+
+    const pgComparer = new SchemaComparer(mockPostgresDb as any);
+
+    const manifest: Record<string, SchemaDefinition> = {
+      contents: {
+        tableName: 'contents',
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          word_timings: { type: 'JSON', defaultValue: [] },
+        },
+        indexes: [],
+        triggers: [],
+        foreignKeys: [],
+        dependencies: [],
+        version: '1.0.0',
+      },
+    };
+
+    const diff = await pgComparer.compare(manifest);
+
+    expect(diff.changes).toEqual([
+      expect.objectContaining({
+        type: 'add_column',
+        table: 'contents',
+        name: 'word_timings',
+        sql: `ALTER TABLE "contents" ADD COLUMN "word_timings" JSONB DEFAULT '[]'`,
+      }),
+    ]);
+  });
+
   it('should generate PostgreSQL USING clause for legacy JSON→TIMESTAMP drift', async () => {
     const mockPostgresDb = {
       url: 'postgresql://localhost/test',

--- a/packages/core/src/migrations/differ.ts
+++ b/packages/core/src/migrations/differ.ts
@@ -763,13 +763,29 @@ export class SchemaComparer {
       );
     }
 
-    const columnDefinition = this.ddlStrategy.generateColumnDefinition(
-      colName,
-      {
-        ...colDef,
-        type: validatedType,
-      },
-    );
+    const parts: string[] = [
+      this.quoteIdentifier(colName),
+      this.ddlStrategy.mapType(validatedType),
+    ];
+
+    if (colDef.notNull) {
+      parts.push('NOT NULL');
+    }
+    if (colDef.unique) {
+      parts.push('UNIQUE');
+    }
+    if (colDef.defaultValue !== undefined) {
+      const defaultVal = this.ddlStrategy.formatDefaultValue(
+        colDef.defaultValue,
+        validatedType,
+      );
+      parts.push(`DEFAULT ${defaultVal}`);
+    }
+    if (colDef.check) {
+      parts.push(`CHECK (${colDef.check})`);
+    }
+
+    const columnDefinition = parts.join(' ');
 
     return `ALTER TABLE ${this.quoteIdentifier(tableName)} ADD COLUMN ${columnDefinition}`;
   }

--- a/packages/core/src/migrations/differ.ts
+++ b/packages/core/src/migrations/differ.ts
@@ -754,23 +754,24 @@ export class SchemaComparer {
     colName: string,
     colDef: ColumnDefinition,
   ): string {
-    const parts: string[] = [this.quoteIdentifier(colName), colDef.type];
-
-    if (colDef.notNull) {
-      parts.push('NOT NULL');
-    }
-    if (colDef.unique) {
-      parts.push('UNIQUE');
-    }
-    if (colDef.defaultValue !== undefined) {
-      const defaultVal =
-        typeof colDef.defaultValue === 'string'
-          ? `'${colDef.defaultValue.replace(/'/g, "''")}'`
-          : String(colDef.defaultValue);
-      parts.push(`DEFAULT ${defaultVal}`);
+    const validatedType: SQLDataType = isValidSQLDataType(colDef.type)
+      ? colDef.type
+      : 'TEXT';
+    if (!isValidSQLDataType(colDef.type)) {
+      console.warn(
+        `[SchemaComparer] Invalid manifest type "${colDef.type}" for ${tableName}.${colName}, treating as TEXT`,
+      );
     }
 
-    return `ALTER TABLE ${this.quoteIdentifier(tableName)} ADD COLUMN ${parts.join(' ')}`;
+    const columnDefinition = this.ddlStrategy.generateColumnDefinition(
+      colName,
+      {
+        ...colDef,
+        type: validatedType,
+      },
+    );
+
+    return `ALTER TABLE ${this.quoteIdentifier(tableName)} ADD COLUMN ${columnDefinition}`;
   }
 
   /**


### PR DESCRIPTION
## Summary
- reuse the engine-aware DDL strategy when generating ADD COLUMN migration SQL
- add a regression test for PostgreSQL JSON array defaults
- add a patch changeset for @happyvertical/smrt-core

## Root cause
PostgreSQL ADD COLUMN migrations were hand-formatting default values instead of using the DDL strategy. A JSON array default from smrt-voice rendered as an empty default clause: `JSON DEFAULT `, which failed dev migration jobs with `syntax error at end of input`.

## Validation
- `pnpm --dir packages/core exec vitest run src/migrations/__tests__/differ.test.ts`
- `pnpm exec turbo typecheck --filter=@happyvertical/smrt-core`
- pre-push `format-check` and workflow validation