### PR TITLE
fix: materialize tenant-scoped manifest columns

### DIFF
--- a/packages/cli/src/commands/__tests__/db-migrate-atomic.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-atomic.test.ts
@@ -260,7 +260,9 @@ describe('db:migrate atomic schema execution', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { utilityCommands } = await import('../utilities.js');
 
-    await utilityCommands['db:migrate'].handler([], { 'postgres-safe': true });
+    await utilityCommands['db:migrate'].handler([], {
+      'postgres-safe': true,
+    });
 
     expect(migrationAttempts).toEqual([
       'add_column_contents_first_column',
@@ -289,7 +291,7 @@ describe('db:migrate atomic schema execution', () => {
       'add_column_contents_second_column: synthetic failure',
     );
     expect(stderr).toContain('successful steps shown above');
-  });
+  }, 15_000);
 
   it('warns when postgres-safe index operations are folded into the atomic batch', async () => {
     compareMock.mockResolvedValue({
@@ -313,7 +315,9 @@ describe('db:migrate atomic schema execution', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { utilityCommands } = await import('../utilities.js');
 
-    await utilityCommands['db:migrate'].handler([], { 'postgres-safe': true });
+    await utilityCommands['db:migrate'].handler([], {
+      'postgres-safe': true,
+    });
 
     expect(warnSpy.mock.calls.flat().join('\n')).toContain(
       '--postgres-safe requested',
@@ -332,5 +336,5 @@ describe('db:migrate atomic schema execution', () => {
     expect(logSpy.mock.calls.flat().join('\n')).toContain(
       'Created index contents_first_column_idx on contents',
     );
-  });
+  }, 15_000);
 });

--- a/packages/core/src/manifest/__tests__/generator.test.ts
+++ b/packages/core/src/manifest/__tests__/generator.test.ts
@@ -261,6 +261,57 @@ class TestClass extends SmrtObject {
   });
 
   describe('Manifest Creation', () => {
+    it('materializes tenantScoped tenantId fields before schema generation', async () => {
+      writeFileSync(
+        resolve(testFixturesDir, 'src', 'secret.ts'),
+        `
+import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+
+@smrt({ tenantScoped: true })
+class SecretLike extends SmrtObject {
+  name: string = '';
+}
+      `,
+      );
+
+      const builder = new ManifestBuilder();
+      const originalCwd = process.cwd();
+
+      try {
+        process.chdir(testFixturesDir);
+
+        const manifest = await builder.generate({
+          include: ['src/**/*.ts'],
+          outputDir: testOutputDir,
+          generateTypeStub: false,
+        });
+
+        const secretLike = Object.values(manifest.objects).find(
+          (objectDef) => objectDef.className === 'SecretLike',
+        );
+
+        expect(secretLike?.fields.tenantId).toEqual(
+          expect.objectContaining({
+            type: 'text',
+            _meta: expect.objectContaining({
+              sqlType: 'TEXT',
+              __tenancy: expect.objectContaining({
+                isTenantIdField: true,
+                mode: 'required',
+                field: 'tenantId',
+              }),
+            }),
+          }),
+        );
+        expect(secretLike?.schema?.columns.tenant_id).toEqual(
+          expect.objectContaining({ type: 'TEXT' }),
+        );
+        expect(secretLike?.schema?.ddl).toContain('"tenant_id" TEXT');
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
     it('should inject package info when requested', async () => {
       // Create package.json
       writeFileSync(

--- a/packages/core/src/manifest/generator.ts
+++ b/packages/core/src/manifest/generator.ts
@@ -242,9 +242,11 @@ export class ManifestBuilder {
 
     // Run manifest generation passes (same as Vite plugin path)
     const manifestGen = new ManifestGenerator();
+    manifestGen.injectTenantScopedFields(manifest);
     manifestGen.mergeInheritedFields(manifest);
     manifestGen.generateValidationRules(manifest);
     manifestGen.generateSchemas(manifest);
+    manifestGen.assertTenantScopedSchemaContract(manifest);
     manifestGen.generateAgentManifests(manifest, packageName, packageJson);
 
     return manifest;

--- a/packages/core/src/scanner/__tests__/manifest-generator.test.ts
+++ b/packages/core/src/scanner/__tests__/manifest-generator.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { ManifestGenerator } from '../manifest-generator';
-import type { ScanResult, SmartObjectDefinition } from '../types';
+import type {
+  ScanResult,
+  SmartObjectDefinition,
+  SmartObjectManifest,
+} from '../types';
 
 describe('ManifestGenerator', () => {
   describe('class name collision detection', () => {
@@ -277,6 +281,284 @@ describe('ManifestGenerator', () => {
       );
 
       expect(endpoints).toBe('GET /documents/facts');
+    });
+  });
+
+  describe('tenant scoped schema contract', () => {
+    it('injects tenantId fields before generating schemas', () => {
+      const generator = new ManifestGenerator();
+
+      const manifest = generator.generateManifest([
+        {
+          filePath: '/path/to/secret.ts',
+          objects: [
+            {
+              name: 'secret',
+              className: 'Secret',
+              collection: 'secrets',
+              filePath: '/path/to/secret.ts',
+              fields: {},
+              methods: {},
+              decoratorConfig: { tenantScoped: true },
+              exportName: 'Secret',
+              collectionExportName: 'SecretCollection',
+            },
+          ],
+          imports: [],
+          exports: [],
+        },
+      ]);
+
+      const secret = manifest.objects.secret;
+      expect(secret.fields.tenantId).toEqual(
+        expect.objectContaining({
+          type: 'text',
+          _meta: expect.objectContaining({
+            sqlType: 'TEXT',
+            __tenancy: expect.objectContaining({
+              isTenantIdField: true,
+              mode: 'required',
+              field: 'tenantId',
+            }),
+          }),
+        }),
+      );
+      expect(secret.schema?.columns.tenant_id).toEqual(
+        expect.objectContaining({ type: 'TEXT' }),
+      );
+    });
+
+    it('preserves explicit tenantId fields while adding tenancy metadata', () => {
+      const generator = new ManifestGenerator();
+
+      const manifest = generator.generateManifest([
+        {
+          filePath: '/path/to/scoped-membership.ts',
+          objects: [
+            {
+              name: 'scopedMembership',
+              className: 'ScopedMembership',
+              collection: 'scoped_memberships',
+              filePath: '/path/to/scoped-membership.ts',
+              fields: {
+                tenantId: {
+                  type: 'foreignKey',
+                  related: 'Tenant',
+                  _meta: {
+                    sqlType: 'text',
+                    indexed: true,
+                  },
+                },
+              },
+              methods: {},
+              decoratorConfig: { tenantScoped: true },
+              exportName: 'ScopedMembership',
+              collectionExportName: 'ScopedMembershipCollection',
+            },
+          ],
+          imports: [],
+          exports: [],
+        },
+      ]);
+
+      const membership = manifest.objects.scopedMembership;
+      expect(membership.fields.tenantId).toEqual(
+        expect.objectContaining({
+          type: 'foreignKey',
+          related: 'Tenant',
+          _meta: expect.objectContaining({
+            sqlType: 'TEXT',
+            indexed: true,
+            __tenancy: expect.objectContaining({
+              isTenantIdField: true,
+              mode: 'required',
+              field: 'tenantId',
+            }),
+          }),
+        }),
+      );
+      expect(membership.schema?.columns.tenant_id).toEqual(
+        expect.objectContaining({ type: 'TEXT' }),
+      );
+    });
+
+    it('rejects tenant scoped objects with non-text tenant fields', () => {
+      const generator = new ManifestGenerator();
+
+      expect(() =>
+        generator.generateManifest([
+          {
+            filePath: '/path/to/secret.ts',
+            objects: [
+              {
+                name: 'secret',
+                className: 'Secret',
+                collection: 'secrets',
+                filePath: '/path/to/secret.ts',
+                fields: {
+                  tenantId: {
+                    type: 'integer',
+                  },
+                },
+                methods: {},
+                decoratorConfig: { tenantScoped: true },
+                exportName: 'Secret',
+                collectionExportName: 'SecretCollection',
+              },
+            ],
+            imports: [],
+            exports: [],
+          },
+        ]),
+      ).toThrow(
+        /Secret: tenant-scoped field "tenantId" must use type "text" or "foreignKey"; received "integer"/,
+      );
+    });
+
+    it('rejects tenant scoped objects with non-text tenant SQL columns', () => {
+      const generator = new ManifestGenerator();
+
+      expect(() =>
+        generator.generateManifest([
+          {
+            filePath: '/path/to/secret.ts',
+            objects: [
+              {
+                name: 'secret',
+                className: 'Secret',
+                collection: 'secrets',
+                filePath: '/path/to/secret.ts',
+                fields: {
+                  tenantId: {
+                    type: 'text',
+                    _meta: {
+                      sqlType: 'INTEGER',
+                    },
+                  },
+                },
+                methods: {},
+                decoratorConfig: { tenantScoped: true },
+                exportName: 'Secret',
+                collectionExportName: 'SecretCollection',
+              },
+            ],
+            imports: [],
+            exports: [],
+          },
+        ]),
+      ).toThrow(
+        /Secret: tenant-scoped field "tenantId" must use SQL type "TEXT"; received "INTEGER"/,
+      );
+    });
+
+    it('fails when a tenant scoped object is missing its tenant field', () => {
+      const generator = new ManifestGenerator();
+      const manifest: SmartObjectManifest = {
+        version: '1.0.0',
+        timestamp: 0,
+        objects: {
+          secret: {
+            name: 'secret',
+            className: 'Secret',
+            collection: 'secrets',
+            filePath: '/path/to/secret.ts',
+            fields: {},
+            methods: {},
+            decoratorConfig: { tenantScoped: true },
+            exportName: 'Secret',
+            collectionExportName: 'SecretCollection',
+          },
+        },
+      };
+
+      expect(() =>
+        generator.assertTenantScopedSchemaContract(manifest),
+      ).toThrow(/Secret: missing tenant-scoped field "tenantId"/);
+    });
+
+    it('fails when a tenant scoped schema has not been generated', () => {
+      const generator = new ManifestGenerator();
+      const manifest: SmartObjectManifest = {
+        version: '1.0.0',
+        timestamp: 0,
+        objects: {
+          secret: {
+            name: 'secret',
+            className: 'Secret',
+            collection: 'secrets',
+            filePath: '/path/to/secret.ts',
+            fields: {
+              tenantId: {
+                type: 'text',
+                _meta: {
+                  sqlType: 'TEXT',
+                  __tenancy: {
+                    isTenantIdField: true,
+                    mode: 'required',
+                    field: 'tenantId',
+                  },
+                },
+              },
+            },
+            methods: {},
+            decoratorConfig: { tenantScoped: true },
+            exportName: 'Secret',
+            collectionExportName: 'SecretCollection',
+          },
+        },
+      };
+
+      expect(() =>
+        generator.assertTenantScopedSchemaContract(manifest),
+      ).toThrow(
+        /Secret: schema has not been generated for tenant-scoped column "tenant_id"/,
+      );
+    });
+
+    it('fails when a tenant scoped schema is missing its SQL column', () => {
+      const generator = new ManifestGenerator();
+      const manifest: SmartObjectManifest = {
+        version: '1.0.0',
+        timestamp: 0,
+        objects: {
+          secret: {
+            name: 'secret',
+            className: 'Secret',
+            collection: 'secrets',
+            filePath: '/path/to/secret.ts',
+            fields: {
+              tenantId: {
+                type: 'text',
+                _meta: {
+                  sqlType: 'TEXT',
+                  __tenancy: {
+                    isTenantIdField: true,
+                    mode: 'required',
+                    field: 'tenantId',
+                  },
+                },
+              },
+            },
+            methods: {},
+            decoratorConfig: { tenantScoped: true },
+            exportName: 'Secret',
+            collectionExportName: 'SecretCollection',
+            schema: {
+              tableName: 'secrets',
+              ddl: 'CREATE TABLE "secrets" ("id" TEXT PRIMARY KEY)',
+              columns: {
+                id: { type: 'TEXT', primaryKey: true },
+              },
+              indexes: [],
+              version: 'test',
+            },
+          },
+        },
+      };
+
+      expect(() =>
+        generator.assertTenantScopedSchemaContract(manifest),
+      ).toThrow(/Secret: schema is missing tenant-scoped column "tenant_id"/);
     });
   });
 });

--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -137,32 +137,6 @@ export class ManifestGenerator {
         objectDef.collectionExportName =
           objectDef.collectionExportName || `${objectDef.className}Collection`;
 
-        // Inject tenantId field if tenantScoped is configured (Issue #812)
-        if (objectDef.decoratorConfig.tenantScoped) {
-          const tenantConfig =
-            typeof objectDef.decoratorConfig.tenantScoped === 'boolean'
-              ? {}
-              : objectDef.decoratorConfig.tenantScoped;
-
-          const fieldName = tenantConfig.field || 'tenantId';
-          const isRequired = tenantConfig.mode === 'required';
-
-          // Inject tenantId field definition into manifest
-          objectDef.fields[fieldName] = {
-            type: 'text',
-            required: isRequired,
-            _meta: {
-              generated: true,
-              source: 'tenantScoped_decorator',
-              ...tenantConfig,
-            },
-          };
-
-          console.log(
-            `[manifest-generator] Injected ${fieldName} field for ${objectDef.className} (tenantScoped: ${JSON.stringify(tenantConfig)})`,
-          );
-        }
-
         // Generate AI tools from methods if AI config exists
         if (objectDef.decoratorConfig.ai) {
           const methods = Object.values(objectDef.methods);
@@ -196,20 +170,24 @@ export class ManifestGenerator {
       }
     }
 
-    // Second pass: Merge inherited fields for STI classes
+    // Second pass: materialize implicit tenant fields before inheritance and schema generation.
+    this.injectTenantScopedFields(manifest);
+
+    // Third pass: Merge inherited fields for STI classes
     // This ensures STI subclasses have all parent fields inline in the manifest
     this.mergeInheritedFields(manifest);
 
-    // Third pass: Generate validation rules for all objects
+    // Fourth pass: Generate validation rules for all objects
     // This pre-computes validation rules from field definitions, eliminating
     // the need to compile validator closures at runtime (Issue #782)
     this.generateValidationRules(manifest);
 
-    // Fourth pass: Generate schemas for each object (build-time schema generation)
+    // Fifth pass: Generate schemas for each object (build-time schema generation)
     // This pre-computes DDL, indexes, and columns for efficient external package consumption
     this.generateSchemas(manifest);
+    this.assertTenantScopedSchemaContract(manifest);
 
-    // Fifth pass: Generate agent manifests for Agent subclasses
+    // Sixth pass: Generate agent manifests for Agent subclasses
     // Derives permissions, features, menuItems, and components from code
     this.generateAgentManifests(
       manifest,
@@ -218,6 +196,201 @@ export class ManifestGenerator {
     );
 
     return manifest;
+  }
+
+  /**
+   * Materialize tenantScoped schema fields.
+   *
+   * Runtime registration already injects tenant fields for
+   * `@smrt({ tenantScoped: true })`, but published manifests must contain the
+   * same field before schema generation so migrations create `tenant_id`.
+   */
+  injectTenantScopedFields(manifest: SmartObjectManifest): void {
+    for (const objectDef of Object.values(manifest.objects)) {
+      this.injectTenantScopedField(objectDef);
+    }
+  }
+
+  private injectTenantScopedField(objectDef: SmartObjectDefinition): void {
+    const tenantScoped = objectDef.decoratorConfig?.tenantScoped;
+    if (!tenantScoped) {
+      return;
+    }
+
+    const { tenantConfig, tenantOptions } =
+      this.normalizeTenantScopedConfig(tenantScoped);
+    const fieldName = tenantConfig.field;
+    const existingField = objectDef.fields[fieldName];
+    const tenancyMeta = {
+      isTenantIdField: true,
+      ...tenantConfig,
+    };
+
+    if (existingField) {
+      const fieldTypeFailure = this.getTenantScopedFieldTypeFailure(
+        objectDef,
+        fieldName,
+      );
+      if (fieldTypeFailure) {
+        throw new Error(
+          `Tenant-scoped field configuration invalid: ${fieldTypeFailure}`,
+        );
+      }
+
+      existingField._meta = {
+        ...existingField._meta,
+        sqlType: existingField._meta?.sqlType
+          ? String(existingField._meta.sqlType).toUpperCase()
+          : 'TEXT',
+        __tenancy: {
+          ...existingField._meta?.__tenancy,
+          ...tenancyMeta,
+        },
+      };
+      return;
+    }
+
+    objectDef.fields[fieldName] = {
+      type: 'text',
+      // Preserve legacy migration behavior: boolean `tenantScoped: true`
+      // enables required-mode runtime scoping, but does not add a NOT NULL
+      // column to existing tables unless mode is explicitly set.
+      required: tenantOptions.mode === 'required',
+      _meta: {
+        generated: true,
+        source: 'tenantScoped_decorator',
+        sqlType: 'TEXT',
+        __tenancy: tenancyMeta,
+      },
+    };
+
+    console.log(
+      `[manifest-generator] Injected ${fieldName} field for ${objectDef.className} (tenantScoped: ${JSON.stringify(tenantConfig)})`,
+    );
+  }
+
+  assertTenantScopedSchemaContract(manifest: SmartObjectManifest): void {
+    const failures: string[] = [];
+
+    for (const objectDef of Object.values(manifest.objects)) {
+      const tenantScoped = objectDef.decoratorConfig?.tenantScoped;
+      if (!tenantScoped) {
+        continue;
+      }
+
+      const { tenantConfig } = this.normalizeTenantScopedConfig(tenantScoped);
+      const fieldName = tenantConfig.field;
+      const columnName = toSnakeCase(fieldName);
+
+      if (!objectDef.fields[fieldName]) {
+        failures.push(
+          `${objectDef.className}: missing tenant-scoped field "${fieldName}"`,
+        );
+        continue;
+      }
+
+      const fieldTypeFailure = this.getTenantScopedFieldTypeFailure(
+        objectDef,
+        fieldName,
+      );
+      if (fieldTypeFailure) {
+        failures.push(fieldTypeFailure);
+        continue;
+      }
+
+      const schemaOwner = this.getTenantScopedSchemaOwner(objectDef, manifest);
+      const schemaOwnerContext =
+        schemaOwner === objectDef
+          ? ''
+          : ` on STI base "${schemaOwner.className}"`;
+
+      if (!schemaOwner.schema?.columns) {
+        failures.push(
+          `${objectDef.className}: schema has not been generated for tenant-scoped column "${columnName}"${schemaOwnerContext}`,
+        );
+        continue;
+      }
+
+      if (!schemaOwner.schema.columns[columnName]) {
+        failures.push(
+          `${objectDef.className}: schema is missing tenant-scoped column "${columnName}"${schemaOwnerContext}`,
+        );
+      }
+    }
+
+    if (failures.length > 0) {
+      throw new Error(
+        `Tenant-scoped schema contract failed:\n${failures
+          .map((failure) => `  - ${failure}`)
+          .join('\n')}`,
+      );
+    }
+  }
+
+  private getTenantScopedSchemaOwner(
+    objectDef: SmartObjectDefinition,
+    manifest: SmartObjectManifest,
+  ): SmartObjectDefinition {
+    if (!this.isSTIChildClass(objectDef, manifest)) {
+      return objectDef;
+    }
+
+    const stiBase = this.findSTIBaseInfo(objectDef, manifest);
+    if (!stiBase) {
+      return objectDef;
+    }
+
+    const localBase = Object.values(manifest.objects).find(
+      (candidate) => candidate.className === stiBase.className,
+    );
+
+    return localBase ?? objectDef;
+  }
+
+  private getTenantScopedFieldTypeFailure(
+    objectDef: SmartObjectDefinition,
+    fieldName: string,
+  ): string | undefined {
+    const field = objectDef.fields[fieldName];
+    if (!field) {
+      return undefined;
+    }
+
+    if (field.type !== 'text' && field.type !== 'foreignKey') {
+      return `${objectDef.className}: tenant-scoped field "${fieldName}" must use type "text" or "foreignKey"; received "${field.type}"`;
+    }
+
+    const sqlType = field._meta?.sqlType;
+    if (sqlType && String(sqlType).toUpperCase() !== 'TEXT') {
+      return `${objectDef.className}: tenant-scoped field "${fieldName}" must use SQL type "TEXT"; received "${sqlType}"`;
+    }
+
+    return undefined;
+  }
+
+  private normalizeTenantScopedConfig(tenantScoped: unknown): {
+    tenantOptions: Record<string, any>;
+    tenantConfig: {
+      mode: string;
+      field: string;
+      autoFilter: boolean;
+      autoPopulate: boolean;
+      allowSuperAdminBypass: boolean;
+    };
+  } {
+    const tenantOptions: Record<string, any> =
+      typeof tenantScoped === 'boolean' ? {} : (tenantScoped as any);
+
+    return {
+      tenantOptions,
+      tenantConfig: {
+        mode: tenantOptions.mode ?? 'required',
+        field: tenantOptions.field ?? 'tenantId',
+        autoFilter: tenantOptions.autoFilter ?? true,
+        autoPopulate: tenantOptions.autoPopulate ?? true,
+        allowSuperAdminBypass: tenantOptions.allowSuperAdminBypass ?? false,
+      },
+    };
   }
 
   /**

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -703,12 +703,14 @@ export default testManifest;
         dist: '../scanner.js',
       });
       const manifestGen = new ManifestGenerator();
-      // IMPORTANT: Must merge inherited fields BEFORE generating schemas
-      // This ensures STI subclasses inherit tableName from their base class
+      // IMPORTANT: Materialize tenantScoped fields and merge inherited fields
+      // BEFORE generating schemas so migration manifests contain every column.
+      manifestGen.injectTenantScopedFields(newManifest);
       manifestGen.mergeInheritedFields(newManifest);
       manifestGen.generateValidationRules(newManifest);
       manifestGen.generateSchemas(newManifest);
-      // Fifth pass: Generate agent manifests for Agent subclasses
+      manifestGen.assertTenantScopedSchemaContract(newManifest);
+      // Final pass: Generate agent manifests for Agent subclasses
       // Derives permissions, features, menuItems, and components from code
       manifestGen.generateAgentManifests(newManifest, packageName, packageJson);
 

--- a/packages/core/src/vite-plugin/local-manifest.test.ts
+++ b/packages/core/src/vite-plugin/local-manifest.test.ts
@@ -77,6 +77,21 @@ function createLocalSmrtObject(projectRoot: string): void {
   );
 }
 
+function createTenantScopedLocalSmrtObject(projectRoot: string): void {
+  writeFileSync(
+    join(projectRoot, 'src', 'TenantScopedThing.ts'),
+    [
+      "import { SmrtObject, smrt } from '@happyvertical/smrt-core';",
+      '',
+      '@smrt({ tenantScoped: true })',
+      'export class TenantScopedThing extends SmrtObject {',
+      "  name: string = '';",
+      '}',
+      '',
+    ].join('\n'),
+  );
+}
+
 describe('smrtPlugin local manifest writing (Issue #963)', () => {
   let tmpDir: string;
 
@@ -206,6 +221,43 @@ describe('smrtPlugin local manifest writing (Issue #963)', () => {
     // But .smrt/manifest.json should exist (written during configResolved)
     const localManifestPath = join(tmpDir, '.smrt', 'manifest.json');
     expect(existsSync(localManifestPath)).toBe(true);
+  });
+
+  it('materializes tenantScoped fields in the Vite plugin manifest path', async () => {
+    createTenantScopedLocalSmrtObject(tmpDir);
+
+    const plugin = smrtPlugin({
+      include: ['src/**/*.ts'],
+      generateTypes: false,
+    });
+
+    await (plugin as any).configResolved({
+      root: tmpDir,
+      build: {},
+      plugins: [],
+    });
+
+    const manifestPath = join(tmpDir, '.smrt', 'manifest.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+    const tenantScopedThing = Object.values<any>(manifest.objects).find(
+      (objectDef) => objectDef.className === 'TenantScopedThing',
+    );
+
+    expect(tenantScopedThing?.fields.tenantId).toEqual(
+      expect.objectContaining({
+        type: 'text',
+        _meta: expect.objectContaining({
+          sqlType: 'TEXT',
+          __tenancy: expect.objectContaining({
+            isTenantIdField: true,
+            field: 'tenantId',
+          }),
+        }),
+      }),
+    );
+    expect(tenantScopedThing?.schema?.columns.tenant_id).toEqual(
+      expect.objectContaining({ type: 'TEXT' }),
+    );
   });
 
   it('fails fast when a consumer app has external SMRT dependencies but no smrtConsumer plugin', async () => {

--- a/packages/secrets/src/models/Secret.ts
+++ b/packages/secrets/src/models/Secret.ts
@@ -56,6 +56,11 @@ export type SecretStatus = 'active' | 'disabled' | 'expired';
 })
 export class Secret extends SmrtObject {
   /**
+   * Tenant that owns this secret. Also stored in context for per-tenant name uniqueness.
+   */
+  tenantId: string = '';
+
+  /**
    * Unique name for the secret within the tenant
    */
   name: string = '';
@@ -107,6 +112,7 @@ export class Secret extends SmrtObject {
 
   constructor(options: any = {}) {
     super(options);
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
     if (options.name !== undefined) this.name = options.name;
     if (options.description !== undefined)
       this.description = options.description;

--- a/packages/secrets/src/models/SecretAuditLog.ts
+++ b/packages/secrets/src/models/SecretAuditLog.ts
@@ -77,6 +77,11 @@ export type SecretAuditResult = 'success' | 'failure' | 'denied';
 })
 export class SecretAuditLog extends SmrtObject {
   /**
+   * Tenant associated with the audited secret operation.
+   */
+  tenantId: string | null = null;
+
+  /**
    * ID of the secret (may be null for deleted secrets)
    */
   secretId: string | null = null;
@@ -119,8 +124,7 @@ export class SecretAuditLog extends SmrtObject {
   constructor(options: any = {}) {
     super(options);
     if (options.tenantId !== undefined) {
-      (this as SecretAuditLog & { tenantId?: string | null }).tenantId =
-        options.tenantId;
+      this.tenantId = options.tenantId;
     }
     if (options.secretId !== undefined) this.secretId = options.secretId;
     if (options.secretName !== undefined) this.secretName = options.secretName;

--- a/packages/secrets/src/services/SecretService.ts
+++ b/packages/secrets/src/services/SecretService.ts
@@ -218,8 +218,6 @@ export class SecretService {
         context: tenantId, // Per-tenant uniqueness
         tenantId,
       });
-      (secret as Secret & { tenantId?: string | null }).tenantId = tenantId;
-      await secret.save();
 
       await this.audit(secret.id ?? null, name, userId, 'create', 'success');
       return secret;


### PR DESCRIPTION
## Summary
- Materialize `tenantScoped` tenant fields before inheritance/schema generation in the scanner, ManifestBuilder, and Vite/OXC manifest path.
- Add a tenant-scoped schema contract check that fails when tenant fields are missing, have an incompatible type/SQL type, or are absent from generated schema columns.
- Add concrete `tenantId` fields to `Secret` and `SecretAuditLog`, and remove the redundant post-create secret save.

## Root Cause
Runtime code wrote tenant IDs, but published manifests could omit the `tenantId` field before schema generation. That meant migration manifests could miss `tenant_id` even though runtime code later wrote the column.

## Review Resolution
- Claude CLI review completed within the requested timeout.
- Removed the manual changeset so repo auto-changeset generation can use the conventional `fix:` commit.
- Added validation for explicit tenant fields instead of silently coercing incompatible definitions.
- Removed the redundant second save in `SecretService.store()`.
- Fixed the Vite manifest pass comment and added a stricter schema-missing assertion from self-review.

## Validation
- `pnpm --dir packages/core exec vitest run src/scanner/__tests__/manifest-generator.test.ts src/manifest/__tests__/generator.test.ts src/vite-plugin/local-manifest.test.ts src/__tests__/issue-688-tenant-scoped.test.ts`
- `pnpm --dir packages/secrets test -- src/__tests__/secret-service.test.ts`
- `pnpm --dir packages/core typecheck`
- `pnpm --dir packages/core build`
- `pnpm --filter @happyvertical/smrt-tenancy build`
- `pnpm --dir packages/secrets build`
- `git diff --check`
- Verified `packages/secrets/dist/manifest.json` contains `tenantId`, `tenant_id`, and `"tenant_id" TEXT` for both `Secret` and `SecretAuditLog`.
