### PR TITLE
fix(tags): include unscoped aliases when merging default-context tags (R5-canon round-8 followup)

### DIFF
--- a/packages/tags/src/__tests__/hierarchical.test.ts
+++ b/packages/tags/src/__tests__/hierarchical.test.ts
@@ -271,6 +271,48 @@ describe('Tag hierarchy (R3-B: slug API → UUID storage)', () => {
       const forumBarAliases = forumAliases.filter((a) => a.tagSlug === 'bar');
       expect(forumBarAliases).toHaveLength(0);
     });
+
+    it('migrates unscoped aliases (context="") on default-context merge', async () => {
+      // Codex round-8 finding: `Tag._context` defaults to `'global'`,
+      // but `TagAliasCollection.addAlias(slug, alias)` leaves the
+      // alias's `_context` at its `''` default when no context is
+      // passed. A strict `context: fromTag.context` filter would
+      // orphan those `''`-context aliases for default-context
+      // merges, leaving rows that point at a now-deleted tag.
+      const aliases = await TagAliasCollection.create({
+        db: { type: 'sqlite', url: dbUrl },
+      });
+
+      // Default-context (global) tags.
+      const globalFoo = await tags.getOrCreate('foo');
+      const globalBar = await tags.getOrCreate('bar');
+      expect(globalFoo.context).toBe('global');
+      expect(globalBar.context).toBe('global');
+
+      // Alias created via `addAlias` with no context — ends up with
+      // `_context = ''` (NOT 'global').
+      await aliases.addAlias('foo', 'GlobalUnscoped', 'en');
+
+      // Sanity-check the default-mismatch the bug hinges on.
+      const beforeUnscoped = await aliases.list({
+        where: { tagSlug: 'foo', context: '' },
+      });
+      expect(beforeUnscoped).toHaveLength(1);
+
+      await tags.mergeTag('foo', 'bar');
+
+      // After merge, the alias must have been rewritten to `bar`
+      // — not orphaned at `tagSlug: 'foo'` (now deleted).
+      const orphans = await aliases.list({
+        where: { tagSlug: 'foo' },
+      });
+      expect(orphans).toHaveLength(0);
+
+      const migrated = await aliases.list({
+        where: { tagSlug: 'bar', context: '' },
+      });
+      expect(migrated.map((a) => a.alias)).toContain('GlobalUnscoped');
+    });
   });
 
   it('cleanupUnused only deletes leaves with no aliases', async () => {

--- a/packages/tags/src/__tests__/hierarchical.test.ts
+++ b/packages/tags/src/__tests__/hierarchical.test.ts
@@ -272,6 +272,64 @@ describe('Tag hierarchy (R3-B: slug API → UUID storage)', () => {
       expect(forumBarAliases).toHaveLength(0);
     });
 
+    it("doesn't migrate unscoped aliases when merge is scoped to a non-default context", async () => {
+      // Inverse of the default-context unscoped-alias test below.
+      // Codex + copilot + sub-agent all flagged the round-8 fix's
+      // initial form (`aliasContexts = [fromTag.context, '']` for
+      // ALL merges) as re-introducing the cross-context corruption
+      // the round-7 fix was guarding against:
+      //
+      // - `addAlias('foo', 'GlobalAlias')` creates an alias with
+      //   `_context = ''` — semantically belonging to the
+      //   default-context (`global:foo`) tag, NOT to `blog:foo`.
+      // - `mergeTag('foo', 'bar', 'blog')` should ONLY touch
+      //   `blog`-context aliases for slug `foo` — it must leave the
+      //   `''`-context alias alone (it belongs to a different tag).
+      //
+      // The final round-8 fix gates the `''` widening to
+      // default-context merges only, so non-default merges keep
+      // the round-7 strict-equality behavior.
+      const aliases = await TagAliasCollection.create({
+        db: { type: 'sqlite', url: dbUrl },
+      });
+
+      // Same-slug tags in two contexts: global (default) + blog.
+      const globalFoo = await tags.getOrCreate('foo');
+      const blogFoo = await tags.getOrCreate('foo', 'blog');
+      const blogBar = await tags.getOrCreate('bar', 'blog');
+      expect(globalFoo.context).toBe('global');
+      expect(blogFoo.context).toBe('blog');
+      expect(blogBar.id).toBeTruthy();
+
+      // Unscoped alias for `foo` — created via `addAlias` without
+      // an explicit context, so `_context = ''`. Conceptually owned
+      // by the global/foo tag (which is NOT being merged).
+      await aliases.addAlias('foo', 'GlobalAlias', 'en');
+
+      // Confirm the alias was indeed created at `context = ''`.
+      const beforeUnscoped = await aliases.list({
+        where: { tagSlug: 'foo', context: '' },
+      });
+      expect(beforeUnscoped).toHaveLength(1);
+
+      // Merge blog/foo → blog/bar. The blog merge MUST NOT touch
+      // the unscoped alias.
+      await tags.mergeTag('foo', 'bar', 'blog');
+
+      // The unscoped alias must still point at `foo`, NOT `bar`.
+      const afterUnscoped = await aliases.list({
+        where: { tagSlug: 'foo', context: '' },
+      });
+      expect(afterUnscoped).toHaveLength(1);
+      expect(afterUnscoped[0].alias).toBe('GlobalAlias');
+
+      // And `bar` must have NOT received the unscoped alias.
+      const barUnscoped = await aliases.list({
+        where: { tagSlug: 'bar', context: '' },
+      });
+      expect(barUnscoped).toHaveLength(0);
+    });
+
     it('migrates unscoped aliases (context="") on default-context merge', async () => {
       // Codex round-8 finding: `Tag._context` defaults to `'global'`,
       // but `TagAliasCollection.addAlias(slug, alias)` leaves the

--- a/packages/tags/src/tags.ts
+++ b/packages/tags/src/tags.ts
@@ -295,13 +295,23 @@ export class TagCollection extends SmrtCollection<Tag> {
     // slug. Otherwise `mergeTag('foo', 'bar', 'blog')` rewrites
     // `foo`'s aliases in EVERY context (forum, etc.), corrupting tag
     // data outside the requested merge scope.
+    //
+    // Round-8 codex follow-up: `Tag._context` defaults to `'global'` but
+    // `TagAlias._context` defaults to `''` (and `addAlias()` doesn't
+    // backfill the default), so a strict equality filter would orphan
+    // aliases that were created without an explicit context whenever
+    // the merge happens at the default 'global' scope. Match BOTH the
+    // resolved context AND `''` so unscoped-default-context aliases
+    // migrate too, while still excluding aliases that were
+    // intentionally scoped to a DIFFERENT context.
     const { TagAliasCollection } = await import('./tag-aliases');
     const aliasCollection = await (TagAliasCollection as any).create(
       this.options,
     );
 
+    const aliasContexts = Array.from(new Set([fromTag.context, '']));
     const aliases = await aliasCollection.list({
-      where: { tagSlug: fromSlug, context: fromTag.context },
+      where: { tagSlug: fromSlug, context: aliasContexts },
     });
     for (const alias of aliases) {
       alias.tagSlug = toSlug;

--- a/packages/tags/src/tags.ts
+++ b/packages/tags/src/tags.ts
@@ -296,20 +296,34 @@ export class TagCollection extends SmrtCollection<Tag> {
     // `foo`'s aliases in EVERY context (forum, etc.), corrupting tag
     // data outside the requested merge scope.
     //
-    // Round-8 codex follow-up: `Tag._context` defaults to `'global'` but
-    // `TagAlias._context` defaults to `''` (and `addAlias()` doesn't
-    // backfill the default), so a strict equality filter would orphan
-    // aliases that were created without an explicit context whenever
-    // the merge happens at the default 'global' scope. Match BOTH the
-    // resolved context AND `''` so unscoped-default-context aliases
-    // migrate too, while still excluding aliases that were
-    // intentionally scoped to a DIFFERENT context.
+    // Round-8 codex follow-up: `Tag._context` defaults to `'global'`
+    // but `TagAlias._context` defaults to `''` (and `addAlias()`
+    // doesn't backfill the default), so a strict equality filter
+    // would orphan aliases that were created without an explicit
+    // context whenever the merge happens at the default 'global'
+    // scope.
+    //
+    // Round-8 fix (initial): widen to `[fromTag.context, '']` —
+    // BUT codex + copilot caught that this overcorrected. For a
+    // non-default merge like `mergeTag('foo','bar','blog')`, the
+    // unscoped (`''`) aliases for slug `foo` belong to a DIFFERENT
+    // tag entirely (the `global/foo` row that the blog merge isn't
+    // touching). Widening unconditionally re-introduced the
+    // cross-context corruption round-7 was guarding against.
+    //
+    // Round-8 fix (final): only include `''` when the merge is at
+    // the default context — that's the case where the
+    // addAlias/Tag default-mismatch would orphan rows. For any
+    // other context, the strict equality from round-7 is correct.
     const { TagAliasCollection } = await import('./tag-aliases');
     const aliasCollection = await (TagAliasCollection as any).create(
       this.options,
     );
 
-    const aliasContexts = Array.from(new Set([fromTag.context, '']));
+    const aliasContexts: string[] = [fromTag.context];
+    if (fromTag.context === 'global') {
+      aliasContexts.push('');
+    }
     const aliases = await aliasCollection.list({
       where: { tagSlug: fromSlug, context: aliasContexts },
     });


### PR DESCRIPTION
## Summary

Round-8 codex finding on now-merged PR [#1277](https://github.com/happyvertical/smrt/pull/1277). The round-7 fix that scoped `mergeTag`'s alias rewrite to `fromTag.context` (to prevent cross-context corruption) overcorrected for the common default-context case.

## The bug

Default-mismatch between Tag and TagAlias:
- `Tag._context` defaults to `'global'`
- `TagAlias._context` defaults to `''`
- `TagAliasCollection.addAlias(slug, alias)` without an explicit `context` arg leaves the alias's `_context` at its `''` default (the constructor only assigns when `options.context !== undefined`)

So after #1277, `mergeTag('foo', 'bar')` against default-context tags only matched aliases with `context === 'global'` — silently orphaning every alias created via the public `addAlias` API without an explicit context. After the source tag was deleted, those rows still pointed at `tagSlug: 'foo'` which no longer resolved to a tag.

## The fix

`packages/tags/src/tags.ts:312-315` — query for aliases where `context` is in `[fromTag.context, '']`:

```ts
const aliasContexts = Array.from(new Set([fromTag.context, '']));
const aliases = await aliasCollection.list({
  where: { tagSlug: fromSlug, context: aliasContexts },
});
```

This restores the unscoped-alias migration that the round-7 fix broke, while preserving the cross-context guarantee — aliases intentionally scoped to a DIFFERENT context still stay put because they don't appear in `[fromTag.context, '']`.

## Test plan

- [x] New regression test in `packages/tags/src/__tests__/hierarchical.test.ts`: covers the default-context tag + `addAlias`-without-context flow that round-7 broke. Asserts no orphan rows survive at `tagSlug: 'foo'` after merge.
- [x] Existing cross-context regression test (`doesn't rewrite aliases in OTHER contexts when merge is context-scoped`) still passes.
- [x] `npm test` against `packages/tags`: 29/29 green.
- [ ] Full repo `npm test` + `npm run typecheck` — to be run before merge.

## Why this isn't a revert

The round-7 fix solved a real cross-context corruption bug (`mergeTag('foo', 'bar', 'blog')` previously rewrote `foo` aliases in EVERY context). That fix's behavior in the cross-context case is preserved here — we only widen the match to ALSO include the `''`-context unscoped aliases that follow the source tag's default scope.

## Out of scope

- Normalizing `TagAlias._context` to default to `'global'` (matching `Tag._context`) would be the deeper fix but is a schema-touching change worth its own PR + migration analysis. The query-side fix here is sufficient correctness without that risk surface.