### PR TITLE
fix(svelte): keep workspace sidebar footer pinned

### DIFF
--- a/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
@@ -466,8 +466,10 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
     background: var(--smrt-color-surface, #ffffff);
     border-right: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
     min-width: 0;
-    overflow-y: auto;
-    overscroll-behavior: contain;
+    min-height: 0;
+    height: 100vh;
+    height: 100dvh;
+    overflow: hidden;
     z-index: 20;
   }
 
@@ -476,6 +478,7 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
     justify-content: space-between;
     align-items: flex-start;
     gap: 0.75rem;
+    flex: 0 0 auto;
   }
 
   .brand {
@@ -543,13 +546,18 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
   .nav-region {
     display: flex;
     flex-direction: column;
+    flex: 1 1 auto;
     min-height: 0;
     gap: 0.5rem;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding-right: 0.25rem;
   }
 
   .sidebar-footer {
     margin-top: auto;
     display: grid;
+    flex: 0 0 auto;
     gap: 0.75rem;
     padding-top: 0.75rem;
     border-top: 1px solid var(--smrt-color-outline-variant, #e5e7eb);

--- a/packages/smrt-svelte/src/components/workspace/__tests__/WorkspaceShell.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/WorkspaceShell.test.ts
@@ -6,6 +6,7 @@
  * the package doesn't depend on).
  */
 
+import { readFileSync } from 'node:fs';
 import { createRawSnippet, mount, tick, unmount } from 'svelte';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import WorkspaceShell from '../WorkspaceShell.svelte';
@@ -121,6 +122,23 @@ describe('WorkspaceShell', () => {
     } finally {
       unmount(component);
     }
+  });
+
+  it('keeps sidebar scrolling scoped to the nav region', () => {
+    const source = readFileSync(
+      'src/components/workspace/WorkspaceShell.svelte',
+      'utf8',
+    );
+    const sidebarRule =
+      source.match(/\.smrt-workspace-sidebar\s*\{[^}]+\}/)?.[0] ?? '';
+    const navRule = source.match(/\.nav-region\s*\{[^}]+\}/)?.[0] ?? '';
+    const footerRule = source.match(/\.sidebar-footer\s*\{[^}]+\}/)?.[0] ?? '';
+
+    expect(sidebarRule).toContain('overflow: hidden;');
+    expect(navRule).toContain('flex: 1 1 auto;');
+    expect(navRule).toContain('overflow-y: auto;');
+    expect(navRule).toContain('overscroll-behavior: contain;');
+    expect(footerRule).toContain('flex: 0 0 auto;');
   });
 
   it('renders topbar actions on the right of the top bar', () => {


### PR DESCRIPTION
## Summary
- keep WorkspaceShell sidebar overflow hidden so the footer does not participate in sidebar scrolling
- move scroll behavior to the nav region and keep brand/footer as non-shrinking flex children
- add a regression test for the sidebar/nav/footer CSS contract

## Validation
- pnpm --filter @happyvertical/smrt-svelte exec vitest run src/components/workspace/__tests__/WorkspaceShell.test.ts
- pnpm --filter @happyvertical/smrt-svelte check
- pnpm --filter @happyvertical/smrt-svelte build

Note: a broader `pnpm --filter @happyvertical/smrt-svelte test -- WorkspaceShell` invocation also ran unrelated workspace tests and hit existing `window.localStorage.clear is not a function` failures in `define-tools-dock.test.ts`; the targeted WorkspaceShell test passed.