### PR TITLE
[codex] Fix WorkspaceShell mobile rail padding

### DIFF
--- a/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
@@ -905,12 +905,15 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
     }
 
     .smrt-workspace-shell.has-inspector .smrt-workspace-content,
-    .smrt-workspace-shell.has-inspector .smrt-workspace-topbar,
+    .smrt-workspace-shell.has-inspector .smrt-workspace-topbar {
+      padding-right: var(--smrt-ws-page-pad);
+    }
+
     .smrt-workspace-shell.has-inspector-rail:not(.has-inspector)
       .smrt-workspace-content,
     .smrt-workspace-shell.has-inspector-rail:not(.has-inspector)
       .smrt-workspace-topbar {
-      padding-right: var(--smrt-ws-page-pad);
+      padding-right: calc(var(--smrt-ws-rail-width) + 1rem);
     }
 
     .inspector-backdrop {


### PR DESCRIPTION
## Summary
- keep `WorkspaceShell` mobile content/topbar padding reserved for the inspector rail when the inspector panel is closed
- preserve the existing mobile drawer behavior when the inspector panel is open

## Why
At `max-width: 960px`, the rail remains fixed to the right edge, but the mobile rule reset content and topbar right padding to the normal page pad. That lets right-aligned page controls slide underneath the rail.

Fixes #1291.

## Validation
- `pnpm --filter @happyvertical/smrt-svelte check`
- `pnpm exec biome check packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte`
- `pnpm exec vitest run src/components/workspace/__tests__/WorkspaceShell.test.ts` from `packages/smrt-svelte`

Note: `pnpm --filter @happyvertical/smrt-svelte test -- WorkspaceShell` currently runs the broader package suite in this setup and fails in `define-tools-dock.test.ts` because `window.localStorage.clear` is unavailable; the targeted WorkspaceShell file passes.
