### PR TITLE
fix(secrets): keep retrieval resilient to tracking failures

### DIFF
--- a/packages/ads/CHANGELOG.md
+++ b/packages/ads/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-ads
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-properties@0.25.19
+- @happyvertical/smrt-assets@0.25.19
+- @happyvertical/smrt-commerce@0.25.19
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-tags@0.25.19
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/ads/package.json
+++ b/packages/ads/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-ads",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Advertising delivery and tracking models for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/affiliates/CHANGELOG.md
+++ b/packages/affiliates/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-affiliates
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-properties@0.25.19
+- @happyvertical/smrt-commerce@0.25.19
+- @happyvertical/smrt-ads@0.25.19
+- @happyvertical/smrt-profiles@0.25.19
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/affiliates/package.json
+++ b/packages/affiliates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-affiliates",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Affiliate partner and commission tracking models for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/CHANGELOG.md
+++ b/packages/agents/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-agents
 
+## 0.25.19
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-secrets@0.25.19
+  - @happyvertical/smrt-tenancy@0.25.19
+  - @happyvertical/smrt-users@0.25.19
+  - @happyvertical/smrt-config@0.25.19
+  - @happyvertical/smrt-core@0.25.19
+  - @happyvertical/smrt-types@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-agents",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "type": "module",
   "description": "Agent framework for building autonomous actors in the SMRT ecosystem",
   "author": "HappyVertical",

--- a/packages/analytics/CHANGELOG.md
+++ b/packages/analytics/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-analytics
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-svelte@0.25.19
+- @happyvertical/smrt-prompts@0.25.19
+- @happyvertical/smrt-core@0.25.19
+- @happyvertical/smrt-types@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-analytics",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Analytics integration models for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/assets-ergot/CHANGELOG.md
+++ b/packages/assets-ergot/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-assets-ergot
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-assets@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/assets-ergot/package.json
+++ b/packages/assets-ergot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-assets-ergot",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Ergot-backed processing, search, and workflow adapter for SMRT assets",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/assets-local/CHANGELOG.md
+++ b/packages/assets-local/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-assets-local
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-assets@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/assets-local/package.json
+++ b/packages/assets-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-assets-local",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Local image metadata and variant processor for SMRT assets",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/assets/CHANGELOG.md
+++ b/packages/assets/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-assets
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-svelte@0.25.19
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-tags@0.25.19
+- @happyvertical/smrt-core@0.25.19
+- @happyvertical/smrt-types@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-assets",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Asset management system with versioning, metadata, and AI-powered operations for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/chat/CHANGELOG.md
+++ b/packages/chat/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-chat
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-agents@0.25.19
+- @happyvertical/smrt-svelte@0.25.19
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-profiles@0.25.19
+- @happyvertical/smrt-core@0.25.19
+- @happyvertical/smrt-types@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-chat",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Chat rooms, DMs, threads, and agent conversations for the SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-cli
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-agents@0.25.19
+- @happyvertical/smrt-playground@0.25.19
+- @happyvertical/smrt-config@0.25.19
+- @happyvertical/smrt-core@0.25.19
+- @happyvertical/smrt-types@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-cli",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Developer CLI for SMRT framework - introspection, testing, and project management",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/commerce/CHANGELOG.md
+++ b/packages/commerce/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-commerce
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-svelte@0.25.19
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-profiles@0.25.19
+- @happyvertical/smrt-ledgers@0.25.19
+- @happyvertical/smrt-core@0.25.19
+- @happyvertical/smrt-types@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/commerce/package.json
+++ b/packages/commerce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-commerce",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Commerce models for the SMRT framework - contracts, fulfillments, payments",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-config
 
+## 0.25.19
+
 ## 0.25.18
 
 ## 0.25.17

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-config",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "type": "module",
   "description": "Centralized configuration management for SMRT modules",
   "author": "HappyVertical",

--- a/packages/content/CHANGELOG.md
+++ b/packages/content/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @happyvertical/smrt-content
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-messages@0.25.19
+- @happyvertical/smrt-chat@0.25.19
+- @happyvertical/smrt-assets@0.25.19
+- @happyvertical/smrt-images@0.25.19
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-profiles@0.25.19
+- @happyvertical/smrt-facts@0.25.19
+- @happyvertical/smrt-prompts@0.25.19
+- @happyvertical/smrt-core@0.25.19
+- @happyvertical/smrt-types@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-content",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Content processing module for SMRT framework - handles documents, web content, and media",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-core
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-config@0.25.19
+- @happyvertical/smrt-types@0.25.19
+- @happyvertical/smrt-scanner@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-core",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Core AI agent framework with standardized collections, object-relational mapping, and code generators",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/events/CHANGELOG.md
+++ b/packages/events/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-events
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-assets@0.25.19
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-places@0.25.19
+- @happyvertical/smrt-profiles@0.25.19
+- @happyvertical/smrt-core@0.25.19
+- @happyvertical/smrt-types@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-events",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Hierarchical event management with participant tracking and SMRT framework support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/facts/CHANGELOG.md
+++ b/packages/facts/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-facts
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-prompts@0.25.19
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/facts/package.json
+++ b/packages/facts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-facts",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Distributed memory and knowledge management with provenance tracking for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/features/CHANGELOG.md
+++ b/packages/features/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-features
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-users@0.25.19
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-features",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Code-first feature flags and tenant-aware overrides for the SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gnode/CHANGELOG.md
+++ b/packages/gnode/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-gnode
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/gnode/package.json
+++ b/packages/gnode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-gnode",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "SMRT federation library for building federated local knowledge bases (gnodes)",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/images/CHANGELOG.md
+++ b/packages/images/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-images
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-svelte@0.25.19
+- @happyvertical/smrt-assets@0.25.19
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-prompts@0.25.19
+- @happyvertical/smrt-core@0.25.19
+- @happyvertical/smrt-types@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/images/package.json
+++ b/packages/images/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-images",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Image asset management with AI-powered categorization, search, editing, and metadata extraction for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/inventory/CHANGELOG.md
+++ b/packages/inventory/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-inventory
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/inventory/package.json
+++ b/packages/inventory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-inventory",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Multi-location stock tracking for the SMRT framework — Sku, InventoryLocation, StockLevel, StockMovement, and a stock-mutation service",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/jobs/CHANGELOG.md
+++ b/packages/jobs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-jobs
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-svelte@0.25.19
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-config@0.25.19
+- @happyvertical/smrt-core@0.25.19
+- @happyvertical/smrt-types@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-jobs",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Background job processing for SMRT objects with persistence and scheduling",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/languages/CHANGELOG.md
+++ b/packages/languages/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-languages
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-features@0.25.19
+- @happyvertical/smrt-jobs@0.25.19
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-prompts@0.25.19
+- @happyvertical/smrt-config@0.25.19
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-languages",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Code-first language strings with config + tenant overrides and AI auto-translation for SMRT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ledgers/CHANGELOG.md
+++ b/packages/ledgers/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-ledgers
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-prompts@0.25.19
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/ledgers/package.json
+++ b/packages/ledgers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-ledgers",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Double-entry accounting ledger for the SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/manufacturing/CHANGELOG.md
+++ b/packages/manufacturing/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-manufacturing
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-inventory@0.25.19
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/manufacturing/package.json
+++ b/packages/manufacturing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-manufacturing",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Bills of materials, cost rollup, and production-order operations for the SMRT framework — strictly industry-neutral",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/messages/CHANGELOG.md
+++ b/packages/messages/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-messages
 
+## 0.25.19
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-secrets@0.25.19
+  - @happyvertical/smrt-svelte@0.25.19
+  - @happyvertical/smrt-tenancy@0.25.19
+  - @happyvertical/smrt-core@0.25.19
+  - @happyvertical/smrt-types@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-messages",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Unified multi-channel messaging with STI-based hierarchies",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/places/CHANGELOG.md
+++ b/packages/places/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-places
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-assets@0.25.19
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/places/package.json
+++ b/packages/places/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-places",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Hierarchical place management with geo integration and SMRT framework support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/products/CHANGELOG.md
+++ b/packages/products/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-products
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-assets@0.25.19
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/products/package.json
+++ b/packages/products/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-products",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "SMRT products module: triple-purpose microservice template for standalone apps, federated modules, and NPM libraries",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/profiles/CHANGELOG.md
+++ b/packages/profiles/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-profiles
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-assets@0.25.19
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-prompts@0.25.19
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/profiles/package.json
+++ b/packages/profiles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-profiles",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Profile management system with relationships, metadata, and reciprocal associations for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/projects/CHANGELOG.md
+++ b/packages/projects/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-projects
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-svelte@0.25.19
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-prompts@0.25.19
+- @happyvertical/smrt-config@0.25.19
+- @happyvertical/smrt-core@0.25.19
+- @happyvertical/smrt-types@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/projects/package.json
+++ b/packages/projects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-projects",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Provider-agnostic project management models (Issues, PRs, Repositories, Projects) for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/prompts/CHANGELOG.md
+++ b/packages/prompts/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-prompts
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-config@0.25.19
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-prompts",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Typed prompt registry, override resolution, and tenant-aware prompt settings for SMRT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/properties/CHANGELOG.md
+++ b/packages/properties/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-properties
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-projects@0.25.19
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-profiles@0.25.19
+- @happyvertical/smrt-prompts@0.25.19
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/properties/package.json
+++ b/packages/properties/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-properties",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Digital property and zone management models for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/scanner/CHANGELOG.md
+++ b/packages/scanner/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-scanner
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-scanner",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "High-performance TypeScript scanner using OXC for SMRT manifest generation",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/secrets/CHANGELOG.md
+++ b/packages/secrets/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-secrets
 
+## 0.25.19
+
+### Patch Changes
+
+- Keep secret retrieval successful when access-count tracking cannot be persisted.
+  - @happyvertical/smrt-tenancy@0.25.19
+  - @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/secrets/package.json
+++ b/packages/secrets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-secrets",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Per-tenant secret management with envelope encryption for SMRT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/secrets/src/__tests__/secret-service.test.ts
+++ b/packages/secrets/src/__tests__/secret-service.test.ts
@@ -16,7 +16,7 @@ import {
   withTenant,
 } from '@happyvertical/smrt-tenancy';
 import type { DatabaseInterface } from '@happyvertical/sql';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SecretCollection } from '../collections/SecretCollection.js';
 import { SecretService } from '../services/SecretService.js';
 
@@ -66,6 +66,41 @@ describe('SecretService', () => {
         expect(retrieved.value).toBe('sk_test_123');
         expect(retrieved.name).toBe('api-key');
         expect(retrieved.accessCount).toBe(1);
+      });
+    });
+
+    it('returns decrypted secrets when access tracking cannot be persisted', async () => {
+      await withTenant({ tenantId: 'tenant-1' }, async () => {
+        await service.store('api-key', 'sk_test_123');
+
+        const originalFindByName = SecretCollection.prototype.findByName;
+        const findByName = vi
+          .spyOn(SecretCollection.prototype, 'findByName')
+          .mockImplementation(async function (name: string) {
+            const secret = await originalFindByName.call(this, name);
+            if (name === 'api-key' && secret) {
+              secret.save = vi.fn(async () => {
+                throw new Error('tracking write failed');
+              });
+            }
+            return secret;
+          });
+        const consoleError = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
+
+        try {
+          const retrieved = await service.retrieve('api-key');
+
+          expect(retrieved.value).toBe('sk_test_123');
+          expect(consoleError).toHaveBeenCalledWith(
+            'Failed to update secret access tracking:',
+            expect.any(Error),
+          );
+        } finally {
+          findByName.mockRestore();
+          consoleError.mockRestore();
+        }
       });
     });
 

--- a/packages/secrets/src/__tests__/secret-service.test.ts
+++ b/packages/secrets/src/__tests__/secret-service.test.ts
@@ -72,6 +72,7 @@ describe('SecretService', () => {
     it('returns decrypted secrets when access tracking cannot be persisted', async () => {
       await withTenant({ tenantId: 'tenant-1' }, async () => {
         await service.store('api-key', 'sk_test_123');
+        const firstAccess = await service.retrieve('api-key');
 
         const originalFindByName = SecretCollection.prototype.findByName;
         const findByName = vi
@@ -93,6 +94,10 @@ describe('SecretService', () => {
           const retrieved = await service.retrieve('api-key');
 
           expect(retrieved.value).toBe('sk_test_123');
+          expect(retrieved.accessCount).toBe(firstAccess.accessCount);
+          expect(retrieved.lastAccessedAt?.getTime()).toBe(
+            firstAccess.lastAccessedAt?.getTime(),
+          );
           expect(consoleError).toHaveBeenCalledWith(
             'Failed to update secret access tracking:',
             expect.any(Error),

--- a/packages/secrets/src/services/SecretService.ts
+++ b/packages/secrets/src/services/SecretService.ts
@@ -288,10 +288,14 @@ export class SecretService {
 
       // Access tracking is operational telemetry. Retrieval should still
       // succeed if the decrypted value is available but this write fails.
+      const previousLastAccessedAt = secret.lastAccessedAt;
+      const previousAccessCount = secret.accessCount;
       try {
         secret.recordAccess();
         await secret.save();
       } catch (trackingError) {
+        secret.lastAccessedAt = previousLastAccessedAt;
+        secret.accessCount = previousAccessCount;
         console.error(
           'Failed to update secret access tracking:',
           trackingError,

--- a/packages/secrets/src/services/SecretService.ts
+++ b/packages/secrets/src/services/SecretService.ts
@@ -286,9 +286,17 @@ export class SecretService {
       const envelope: EncryptedEnvelope = JSON.parse(secret.encryptedValue);
       const decrypted = await this.secretStore.decrypt(tenantId, envelope);
 
-      // Update access tracking
-      secret.recordAccess();
-      await secret.save();
+      // Access tracking is operational telemetry. Retrieval should still
+      // succeed if the decrypted value is available but this write fails.
+      try {
+        secret.recordAccess();
+        await secret.save();
+      } catch (trackingError) {
+        console.error(
+          'Failed to update secret access tracking:',
+          trackingError,
+        );
+      }
 
       await this.audit(secret.id ?? null, name, userId, 'read', 'success');
 

--- a/packages/sites/CHANGELOG.md
+++ b/packages/sites/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-sites
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-agents@0.25.19
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-sites",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Site lifecycle management for multi-tenant SMRT networks",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-dev-mcp/CHANGELOG.md
+++ b/packages/smrt-dev-mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-dev-mcp
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/smrt-dev-mcp/package.json
+++ b/packages/smrt-dev-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-dev-mcp",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Development MCP server for SMRT framework - Code generation and project introspection",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-playground/CHANGELOG.md
+++ b/packages/smrt-playground/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-playground
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-svelte@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/smrt-playground/package.json
+++ b/packages/smrt-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-playground",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Shared playground discovery, runtime, and host components for SMRT UI packages",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-svelte/CHANGELOG.md
+++ b/packages/smrt-svelte/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-svelte
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-agents@0.25.19
+- @happyvertical/smrt-jobs@0.25.19
+- @happyvertical/smrt-users@0.25.19
+- @happyvertical/smrt-profiles@0.25.19
+- @happyvertical/smrt-types@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-svelte",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Svelte 5 components for SMRT user management - auth, users, tenants, roles, permissions, groups",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/social/CHANGELOG.md
+++ b/packages/social/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-social
 
+## 0.25.19
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-secrets@0.25.19
+  - @happyvertical/smrt-content@0.25.19
+  - @happyvertical/smrt-tenancy@0.25.19
+  - @happyvertical/smrt-video@0.25.19
+  - @happyvertical/smrt-config@0.25.19
+  - @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-social",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "type": "module",
   "description": "Social media account management for multi-platform publishing in the SMRT ecosystem",
   "author": "HappyVertical",

--- a/packages/tags/CHANGELOG.md
+++ b/packages/tags/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-tags
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-tags",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Reusable tagging system with hierarchies, contexts, and multi-language support for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/template-site-static-json/CHANGELOG.md
+++ b/packages/template-site-static-json/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-template-site-static-json
 
+## 0.25.19
+
 ## 0.25.18
 
 ## 0.25.17

--- a/packages/template-site-static-json/package.json
+++ b/packages/template-site-static-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-template-site-static-json",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Static community site template with JSON data storage and SMRT framework",
   "type": "module",
   "main": "index.js",

--- a/packages/template-sveltekit/CHANGELOG.md
+++ b/packages/template-sveltekit/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-template-sveltekit
 
+## 0.25.19
+
 ## 0.25.18
 
 ## 0.25.17

--- a/packages/template-sveltekit/package.json
+++ b/packages/template-sveltekit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-template-sveltekit",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "SvelteKit project template with SMRT framework integration",
   "type": "module",
   "main": "index.js",

--- a/packages/tenancy/CHANGELOG.md
+++ b/packages/tenancy/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-tenancy
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-users@0.25.19
+- @happyvertical/smrt-core@0.25.19
+- @happyvertical/smrt-types@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/tenancy/package.json
+++ b/packages/tenancy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-tenancy",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Production-ready multi-tenancy framework for SMRT with automatic tenant isolation and enforcement",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-types
 
+## 0.25.19
+
 ## 0.25.18
 
 ## 0.25.17

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-types",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Shared type definitions for the HAVE SDK",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/users/CHANGELOG.md
+++ b/packages/users/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-users
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-profiles@0.25.19
+- @happyvertical/smrt-config@0.25.19
+- @happyvertical/smrt-core@0.25.19
+- @happyvertical/smrt-types@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-users",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Multi-tenant user management for the SMRT framework - users, tenants, roles, permissions, groups",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/video/CHANGELOG.md
+++ b/packages/video/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-video
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-content@0.25.19
+- @happyvertical/smrt-assets@0.25.19
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-voice@0.25.19
+- @happyvertical/smrt-profiles@0.25.19
+- @happyvertical/smrt-config@0.25.19
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/video/package.json
+++ b/packages/video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-video",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "type": "module",
   "description": "Video content management for AI-powered video production in the SMRT ecosystem",
   "author": "HappyVertical",

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-vitest
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-vitest",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "description": "Vitest plugin for automatic cross-package manifest loading in SMRT tests",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/voice/CHANGELOG.md
+++ b/packages/voice/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-voice
 
+## 0.25.19
+
+### Patch Changes
+
+- @happyvertical/smrt-content@0.25.19
+- @happyvertical/smrt-assets@0.25.19
+- @happyvertical/smrt-tenancy@0.25.19
+- @happyvertical/smrt-config@0.25.19
+- @happyvertical/smrt-core@0.25.19
+
 ## 0.25.18
 
 ### Patch Changes

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-voice",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "type": "module",
   "description": "Voice profile management for AI-powered voice synthesis and cloning in the SMRT ecosystem",
   "author": "HappyVertical",


### PR DESCRIPTION
## Summary
- keeps secret retrieval successful when noncritical access-tracking persistence fails
- preserves decrypted secret return semantics while logging access tracking failures

## Validation
- `pnpm --filter @happyvertical/smrt-secrets test`
- `git diff --check`
- `pnpm run release`
- SMRT pre-push hooks: format check and workflow validation

## Release
- Published SMRT packages at `0.25.19` to GitHub Packages.
- Pushed the `@happyvertical/smrt-*@0.25.19` release tags.
