### PR TITLE
feat(content): ContentReferencesPanel accepts a children snippet

### DIFF
--- a/.changeset/content-references-panel-children-snippet.md
+++ b/.changeset/content-references-panel-children-snippet.md
@@ -1,0 +1,12 @@
+---
+'@happyvertical/smrt-content': patch
+---
+
+ContentReferencesPanel: accept an optional `children` snippet so host
+applications can inject a richer picker (browsing a tenant asset pool,
+searching an external archive, etc.) inside the panel without forking
+the component. The snippet renders below the existing references list
+and add-reference input; the host is responsible for calling
+`onReferenceIdsChange` (or otherwise mutating parent state) when the
+user picks an entry. Unblocks `anytown/anytown.ai#462` (Ergot tenant
+asset pool integration in the article editor).

--- a/packages/content/src/svelte/components/ContentReferencesPanel.svelte
+++ b/packages/content/src/svelte/components/ContentReferencesPanel.svelte
@@ -1,16 +1,27 @@
 <script lang="ts">
+import type { Snippet } from 'svelte';
 import type { ContentEditorReference } from '../content-editor-form';
 
 export interface Props {
   referenceIds?: string[];
   references?: ContentEditorReference[];
   onReferenceIdsChange?: (referenceIds: string[]) => void;
+  /**
+   * Optional snippet rendered inside the panel beneath the references list
+   * and the "add reference by ID" input. Host applications use this to inject
+   * a richer picker (browsing a tenant asset pool, searching an external
+   * archive, etc.) without forking the component. The snippet is responsible
+   * for calling `onReferenceIdsChange` (or otherwise mutating the parent
+   * state) when the user selects an entry.
+   */
+  children?: Snippet;
 }
 
 let {
   referenceIds = [],
   references = [],
   onReferenceIdsChange = undefined,
+  children = undefined,
 }: Props = $props();
 
 let newReferenceId = $state('');
@@ -108,6 +119,12 @@ function removeReference(id: string) {
     />
     <button type="button" onclick={addReference}>Add</button>
   </div>
+
+  {#if children}
+    <div class="reference-extras">
+      {@render children()}
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -170,6 +187,11 @@ function removeReference(id: string) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
     gap: 0.5rem;
+  }
+
+  .reference-extras {
+    display: grid;
+    gap: 0.65rem;
   }
 
   input,


### PR DESCRIPTION
## Summary

Adds an optional `children?: Snippet` prop to `ContentReferencesPanel` so host applications can compose richer pickers inside the panel without forking it.

## Why

[anytown/anytown.ai#462](https://github.com/anytown/anytown.ai/issues/462) wires an Ergot tenant asset pool into Anytown's article editor. The picker needs filter controls (project / session / place / tag / date) and a selectable asset grid — all Ergot-specific UX that doesn't belong upstream in \`smrt-content\`. Adding a snippet slot lets Anytown render that picker *inside* the existing references panel (matching the user's "one unified panel, all assets browsable side-by-side" preference) while keeping Ergot-specific logic where it belongs.

## What

- New `children?: Snippet` prop, rendered below the existing references list and add-reference input
- Hosts call `onReferenceIdsChange` (or otherwise mutate parent state) when their picker emits a selection
- The picker UI is the host's responsibility; the panel just renders the slot

No changes to existing API: all current callers (passing only `referenceIds` / `references` / `onReferenceIdsChange`) render unchanged.

## Test plan

- [x] `pnpm --filter @happyvertical/smrt-content check` — 0 errors, 0 warnings across 1604 files
- [x] `pnpm --filter @happyvertical/smrt-content test` — 261/267 (6 pre-existing skips)
- [x] `pnpm --filter @happyvertical/smrt-content build` — clean
- [x] `pnpm exec biome ci --diagnostic-level=error .` — clean (no formatting issues)

Patch changeset attached; release will pick up the bump with the rest of the workspace.

Unblocks [anytown/anytown.ai#462](https://github.com/anytown/anytown.ai/issues/462).