### PR TITLE
feat(content): pin ContentReference targetVersion for drift detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ All `@happyvertical/smrt-*` packages are version-locked via changesets. pnpm wor
 ### Content & Media
 | Package | Purpose |
 |---------|---------|
-| content | STI content types (Article/Document/Mirror), thumbnails (3 strategies), content-owned asset joins via `content_assets` |
+| content | STI content types (Article/Document/Mirror), thumbnails (3 strategies), content-owned asset joins via `content_assets`, versioned snapshots with citation-time reference pinning for drift detection |
 | messages | Multi-channel messaging: Email/Twitter/Slack as STI hierarchy, credential encryption |
 | chat | Chat rooms (public/private/DM/agent), threads, agent sessions with tool whitelisting |
 | assets | Provider-agnostic asset management, versioning, generic/provenance `AssetAssociation` links |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ All `@happyvertical/smrt-*` packages are version-locked via changesets. pnpm wor
 ### Content & Media
 | Package | Purpose |
 |---------|---------|
-| content | STI content types (Article/Document/Mirror), thumbnails (3 strategies), content-owned asset joins via `content_assets` |
+| content | STI content types (Article/Document/Mirror), thumbnails (3 strategies), content-owned asset joins via `content_assets`, versioned snapshots with citation-time reference pinning for drift detection |
 | messages | Multi-channel messaging: Email/Twitter/Slack as STI hierarchy, credential encryption |
 | chat | Chat rooms (public/private/DM/agent), threads, agent sessions with tool whitelisting |
 | assets | Provider-agnostic asset management, versioning, generic/provenance `AssetAssociation` links |

--- a/packages/content/CLAUDE.md
+++ b/packages/content/CLAUDE.md
@@ -9,7 +9,7 @@ STI content management with governance workflows, contribution intake, AI review
 - **ContentReview**: AI review result tied to a governance policy. Fields: `contentId`, `policyKey`, `kind`, `status` (accepted/flagged/rejected), `findings`, `fingerprint`, `metadata`
 - **ContentCorrection**: Post-publication change record. Fields: `contentId`, `type` (correction/retraction/update/clarification), `summary`, `note`, `status`, `metadata`
 - **ContentVersion**: Content snapshot. Fields: `contentId`, `kind` (publication/manual), `versionNumber`, `summary`, `metadata` (includes `transparency` for publication versions)
-- **ContentReference**: Junction model for content-to-content links (`content_references` table)
+- **ContentReference**: Junction model for content-to-content links (`content_references` table). Nullable `targetVersion` pins a citation to a specific `ContentVersion.version` for drift detection.
 - **ContentGovernancePolicy**: Persisted review policy (key, label, kind, instructions)
 - **ContentGovernanceProfile**: Persisted review profile (key, label, requirements array)
 - **ContentGovernanceAssignment**: Governs content type/variant → profile mapping, feature flags
@@ -53,8 +53,9 @@ STI content management with governance workflows, contribution intake, AI review
 | `getFactsState()` / `syncFactsState(options)` | API-level facts get/sync |
 | `addAsset(asset, relationship, sortOrder)` | Add asset association |
 | `setThumbnail(image)` | Convenience: adds asset + updates `thumbnailAssetId` |
-| `addReference(content)` | Link to another content |
+| `addReference(content, options?)` | Link to another content; `options.targetVersion` pins citation-time `ContentVersion.version` |
 | `getReferences()` | Get content references |
+| `getReferenceDrift()` | Per-edge `{ citedVersion, currentVersion, isDrifted }` for drift detection |
 
 ## Governance Workflow
 
@@ -123,8 +124,10 @@ route wiring.
 await content.addAsset(image, 'thumbnail', 0);  // relationship, sortOrder
 await content.getAssets('attachment');
 await content.setThumbnail(image);  // convenience: adds asset + updates thumbnailAssetId
-await content.addReference(otherContent);
+await content.addReference(otherContent);                            // unpinned
+await content.addReference(otherContent, { targetVersion: 2 });      // pinned to v2
 await content.getReferences();
+await content.getReferenceDrift();  // → [{ targetId, citedVersion, currentVersion, isDrifted }, ...]
 ```
 
 ## API Contracts
@@ -171,5 +174,6 @@ import {
 - **Review fingerprints**: reviews track content state at review time; stale reviews are detected by fingerprint mismatch
 - **Publish readiness enforcement**: `save()` throws `ValidationError` if blocking requirements aren't met when setting status to `'published'`
 - **Transparency snapshots**: published transparency is frozen into `ContentVersion.metadata.transparency` — use published for public display, preview for editors
+- **Reference pinning**: `ContentReference` is keyed on `(source_id, target_id)`; `targetVersion` is an attribute of the edge, not part of identity. Re-calling `addReference(target, { targetVersion })` updates the pin in place. Unpinned references (`targetVersion: null`) report `isDrifted: false` regardless of how stale the target is — pin them only when you want drift to be detectable.
 - **Chat tables**: chat endpoint requires `@happyvertical/smrt-chat` tables; dev server handles missing tables gracefully
 - **Dev server bootstraps all classes**: `hooks.server.ts` generates schemas for all 13 local `@smrt()` classes plus cross-package manifests

--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -198,7 +198,8 @@ const latest = await citedArticle.listVersions();
 const currentVersion = latest[latest.length - 1]?.version ?? null;
 await article.addReference(citedArticle, { targetVersion: currentVersion });
 
-// Or leave it unpinned (legacy behaviour — tracks live target)
+// Or leave it unpinned — no version is recorded and `isDrifted` will
+// always be false for this edge regardless of how the target evolves.
 await article.addReference(otherArticle);
 
 // Detect drift across all references
@@ -212,8 +213,15 @@ await article.addReference(citedArticle, { targetVersion: 2 });
 ```
 
 `serializeContent` includes per-reference `citedVersion`, `currentVersion`,
-and `isDrifted` fields so SvelteKit `load` functions and the
-`ContentReferencesPanel` can render drift badges without an extra round-trip.
+and `isDrifted` fields so SvelteKit `load` functions can pass them through
+to consumers without an extra round-trip. The fields surface in the
+serialized payload; rendering them (e.g. a drift badge in
+`ContentReferencesPanel`) is left to the consumer.
+
+`getReferenceDrift` compares against the target's latest `ContentVersion`
+of **any kind** (manual or publication), so a manual snapshot of the target
+will trigger `isDrifted: true`. Consumers that only care about published
+drift can filter further using `ContentVersion.kind`.
 
 Typical use: cite an ingested external snapshot (web page, upstream feed,
 asset library entry) as a Content row. Re-sync the source on a schedule, bump

--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -185,6 +185,41 @@ const versions = await article.listVersions();
 await versions.restoreIntoContent(versionId);
 ```
 
+### References & Drift Detection
+
+References are `(source_id, target_id)` edges between Content rows. They can
+optionally pin a `targetVersion` captured at citation time. When the target
+is later re-synced (a new `ContentVersion` is created), callers can detect
+drift between what was cited and what the target now says.
+
+```typescript
+// Pin to the target's current version when citing
+const latest = await citedArticle.listVersions();
+const currentVersion = latest[latest.length - 1]?.version ?? null;
+await article.addReference(citedArticle, { targetVersion: currentVersion });
+
+// Or leave it unpinned (legacy behaviour — tracks live target)
+await article.addReference(otherArticle);
+
+// Detect drift across all references
+const drift = await article.getReferenceDrift();
+// → [{ targetId, citedVersion, currentVersion, isDrifted }, ...]
+// `isDrifted` is true only when both versions are present and differ.
+
+// Re-link with a new pin to acknowledge drift (idempotent on source+target,
+// mutable on the version column).
+await article.addReference(citedArticle, { targetVersion: 2 });
+```
+
+`serializeContent` includes per-reference `citedVersion`, `currentVersion`,
+and `isDrifted` fields so SvelteKit `load` functions and the
+`ContentReferencesPanel` can render drift badges without an extra round-trip.
+
+Typical use: cite an ingested external snapshot (web page, upstream feed,
+asset library entry) as a Content row. Re-sync the source on a schedule, bump
+the version, and any article that cites the prior version surfaces a drift
+signal in the editor.
+
 ### Published Transparency
 
 ```typescript
@@ -457,7 +492,7 @@ thumbnail selection, and save payload behavior as the package editors.
 | `ContentDocument` | STI subclass for structured documents |
 | `Mirror` | STI subclass for mirrored/cached external content |
 | `Contents` | Collection with `mirror()`, `syncContentDir()`, `generateMissingThumbnails()`, `findWithGlobals()`, `getOrUpsert()`, `browseFacts()`, `getGovernanceDefinitionsAction()`, `resolveGovernanceAction()` |
-| `ContentReference` | Junction model for content-to-content links |
+| `ContentReference` | Junction model for content-to-content links; nullable `targetVersion` pins citation-time `ContentVersion.version` for drift detection |
 | `ContentReview` | AI review result tied to a governance policy |
 | `ContentCorrection` | Post-publication correction record |
 | `ContentVersion` | Content snapshot with kind (`'publication'`, `'manual'`) and transparency metadata |
@@ -497,8 +532,9 @@ thumbnail selection, and save payload behavior as the package editors.
 | `removeAsset(assetId, relationship?)` | Remove asset association |
 | `setThumbnail(image)` | Set thumbnail (adds asset + updates `thumbnailAssetId`) |
 | `generateThumbnail(options)` | Generate a thumbnail |
-| `addReference(content)` | Link to another content |
+| `addReference(content, options?)` | Link to another content; pass `{ targetVersion }` to pin the citation to a specific `ContentVersion.version` |
 | `getReferences()` | Get content references |
+| `getReferenceDrift()` | Per-edge `{ citedVersion, currentVersion, isDrifted }` — surfaces references whose pinned version differs from the target's latest |
 
 ### Types
 

--- a/packages/content/src/content-contributions.test.ts
+++ b/packages/content/src/content-contributions.test.ts
@@ -99,7 +99,8 @@ CREATE TABLE IF NOT EXISTS content_references (
   updated_at DATETIME NOT NULL,
   tenant_id TEXT,
   source_id TEXT,
-  target_id TEXT
+  target_id TEXT,
+  target_version INTEGER
 );
 CREATE UNIQUE INDEX IF NOT EXISTS content_references_source_id_target_id_idx ON content_references (source_id, target_id);
 `;

--- a/packages/content/src/content-reference.ts
+++ b/packages/content/src/content-reference.ts
@@ -6,6 +6,11 @@ export interface ContentReferenceOptions extends SmrtObjectOptions {
   sourceId?: string;
   targetId?: string;
   tenantId?: string | null;
+  // ContentVersion.version pinned at citation time. Optional: references
+  // created without a pin behave as before (they track the live target).
+  // When set, callers can compare against the target's latest version to
+  // surface drift between what was cited and what the target now says.
+  targetVersion?: number | null;
   createdAt?: Date;
 }
 
@@ -24,6 +29,9 @@ export class ContentReference extends SmrtObject {
   @field({ required: true })
   targetId = '';
 
+  @field({ type: 'integer', nullable: true })
+  targetVersion: number | null = null;
+
   @field()
   createdAt = new Date();
 
@@ -32,6 +40,8 @@ export class ContentReference extends SmrtObject {
     if (options.sourceId) this.sourceId = options.sourceId;
     if (options.targetId) this.targetId = options.targetId;
     if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+    if (options.targetVersion !== undefined)
+      this.targetVersion = options.targetVersion;
     if (options.createdAt) this.createdAt = options.createdAt;
   }
 }

--- a/packages/content/src/content-references.ts
+++ b/packages/content/src/content-references.ts
@@ -5,7 +5,6 @@ import { ContentReference } from './content-reference';
 export interface ContentReferencesOptions extends SmrtCollectionOptions {}
 
 export interface LinkContentReferenceOptions {
-  tenantId?: string | null;
   // ContentVersion.version pinned at citation time. When provided on a
   // re-link of an existing edge, the pin is updated in place.
   targetVersion?: number | null;
@@ -31,6 +30,7 @@ export class ContentReferences extends SmrtCollection<ContentReference> {
   async link(
     sourceId: string,
     targetId: string,
+    tenantId: string | null = null,
     options: LinkContentReferenceOptions = {},
   ): Promise<ContentReference> {
     const existing = (await this.get({
@@ -51,7 +51,7 @@ export class ContentReferences extends SmrtCollection<ContentReference> {
     return (await this.create({
       sourceId,
       targetId,
-      tenantId: options.tenantId ?? null,
+      tenantId,
       targetVersion: options.targetVersion ?? null,
     })) as ContentReference;
   }

--- a/packages/content/src/content-references.ts
+++ b/packages/content/src/content-references.ts
@@ -4,6 +4,13 @@ import { ContentReference } from './content-reference';
 
 export interface ContentReferencesOptions extends SmrtCollectionOptions {}
 
+export interface LinkContentReferenceOptions {
+  tenantId?: string | null;
+  // ContentVersion.version pinned at citation time. When provided on a
+  // re-link of an existing edge, the pin is updated in place.
+  targetVersion?: number | null;
+}
+
 export class ContentReferences extends SmrtCollection<ContentReference> {
   static readonly _itemClass = ContentReference;
 
@@ -24,20 +31,28 @@ export class ContentReferences extends SmrtCollection<ContentReference> {
   async link(
     sourceId: string,
     targetId: string,
-    tenantId: string | null = null,
+    options: LinkContentReferenceOptions = {},
   ): Promise<ContentReference> {
     const existing = (await this.get({
       sourceId,
       targetId,
     })) as ContentReference | null;
     if (existing) {
+      if (
+        options.targetVersion !== undefined &&
+        existing.targetVersion !== options.targetVersion
+      ) {
+        existing.targetVersion = options.targetVersion;
+        await existing.save();
+      }
       return existing;
     }
 
     return (await this.create({
       sourceId,
       targetId,
-      tenantId,
+      tenantId: options.tenantId ?? null,
+      targetVersion: options.targetVersion ?? null,
     })) as ContentReference;
   }
 

--- a/packages/content/src/content.ts
+++ b/packages/content/src/content.ts
@@ -1608,8 +1608,7 @@ export class Content
     }
 
     const references = await this.getReferenceCollection();
-    await references.link(this.id, target.id, {
-      tenantId: this.tenantId,
+    await references.link(this.id, target.id, this.tenantId, {
       targetVersion: options.targetVersion,
     });
     this.references = await this.getReferences();

--- a/packages/content/src/content.ts
+++ b/packages/content/src/content.ts
@@ -1581,12 +1581,19 @@ export class Content
   }
 
   /**
-   * Adds a reference to another content object
+   * Adds a reference to another content object.
    *
    * @param content - Content object or URL to reference
+   * @param options.targetVersion - Optional ContentVersion.version to pin the
+   * citation to. Pass the target's current version (typically the latest
+   * publication) to enable drift detection later. Pass `null` or omit to
+   * leave the reference untracked.
    * @returns Promise that resolves when the reference is added
    */
-  public async addReference(content: Content | string) {
+  public async addReference(
+    content: Content | string,
+    options: { targetVersion?: number | null } = {},
+  ) {
     if (!this.id) {
       throw new Error('Cannot add reference to unsaved content');
     }
@@ -1601,7 +1608,10 @@ export class Content
     }
 
     const references = await this.getReferenceCollection();
-    await references.link(this.id, target.id, this.tenantId);
+    await references.link(this.id, target.id, {
+      tenantId: this.tenantId,
+      targetVersion: options.targetVersion,
+    });
     this.references = await this.getReferences();
   }
 
@@ -1653,6 +1663,65 @@ export class Content
       .map((targetId) => referencesById.get(targetId))
       .filter(Boolean) as Content[];
     return this.references;
+  }
+
+  /**
+   * Returns one entry per reference edge with the pinned `targetVersion` and
+   * the target's latest version. Drift exists when both are present and
+   * differ — callers can use this to surface "the source you cited has been
+   * updated" affordances in editors or review tools.
+   *
+   * Unpinned references (`citedVersion === null`) are included with
+   * `currentVersion` populated when available so callers can choose to
+   * surface them as "pinnable" suggestions.
+   */
+  public async getReferenceDrift(): Promise<
+    Array<{
+      targetId: string;
+      citedVersion: number | null;
+      currentVersion: number | null;
+      isDrifted: boolean;
+    }>
+  > {
+    if (!this.id) {
+      return [];
+    }
+
+    const references = await this.getReferenceCollection();
+    const linkedReferences = await references.getForSource(this.id);
+    if (linkedReferences.length === 0) {
+      return [];
+    }
+
+    const versions = await this.getContentVersionCollection();
+    const targetIds = linkedReferences.map((reference) => reference.targetId);
+
+    // Single query for all target versions; pick the max per contentId.
+    // Avoids N+1 when an article cites many sources.
+    const allVersions = await versions.list({
+      where: { contentId: targetIds },
+      orderBy: 'version DESC',
+    });
+    const latestByContentId = new Map<string, number>();
+    for (const version of allVersions) {
+      if (!latestByContentId.has(version.contentId)) {
+        latestByContentId.set(version.contentId, version.version);
+      }
+    }
+
+    return linkedReferences.map((reference) => {
+      const currentVersion = latestByContentId.get(reference.targetId) ?? null;
+      const citedVersion = reference.targetVersion ?? null;
+      return {
+        targetId: reference.targetId,
+        citedVersion,
+        currentVersion,
+        isDrifted:
+          citedVersion !== null &&
+          currentVersion !== null &&
+          citedVersion !== currentVersion,
+      };
+    });
   }
 
   public isGoverned(): boolean {

--- a/packages/content/src/content.ts
+++ b/packages/content/src/content.ts
@@ -1671,6 +1671,11 @@ export class Content
    * differ — callers can use this to surface "the source you cited has been
    * updated" affordances in editors or review tools.
    *
+   * `currentVersion` is sourced from `getLatestForContent`, which returns
+   * the most recent `ContentVersion` of **any kind** (manual or publication).
+   * Consumers that only care about published drift should filter the result
+   * by loading the matching `ContentVersion` and inspecting `kind`.
+   *
    * Unpinned references (`citedVersion === null`) are included with
    * `currentVersion` populated when available so callers can choose to
    * surface them as "pinnable" suggestions.

--- a/packages/content/src/contents-api.test.ts
+++ b/packages/content/src/contents-api.test.ts
@@ -24,10 +24,34 @@ CREATE TABLE IF NOT EXISTS content_references (
   updated_at DATETIME NOT NULL,
   tenant_id TEXT,
   source_id TEXT,
-  target_id TEXT
+  target_id TEXT,
+  target_version INTEGER
 );
 CREATE INDEX IF NOT EXISTS content_references_id_idx ON content_references (id);
 CREATE UNIQUE INDEX IF NOT EXISTS content_references_source_id_target_id_idx ON content_references (source_id, target_id);
+`;
+
+const CONTENT_VERSIONS_SCHEMA = `
+CREATE TABLE IF NOT EXISTS content_versions (
+  id TEXT PRIMARY KEY NOT NULL,
+  slug TEXT NOT NULL,
+  context TEXT NOT NULL DEFAULT '',
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  content_id TEXT,
+  version INTEGER NOT NULL DEFAULT 1,
+  kind TEXT DEFAULT 'manual',
+  title TEXT,
+  description TEXT,
+  body TEXT,
+  status TEXT,
+  summary TEXT,
+  snapshot TEXT,
+  metadata TEXT,
+  tenant_id TEXT
+);
+CREATE INDEX IF NOT EXISTS content_versions_id_idx ON content_versions (id);
+CREATE UNIQUE INDEX IF NOT EXISTS content_versions_content_id_version_idx ON content_versions (content_id, version);
 `;
 
 vi.mock('$lib/server/smrt', () => {
@@ -81,6 +105,7 @@ describe('Content API Endpoints', () => {
       db,
     });
     await syncSchema({ db, schema: CONTENT_REFERENCES_SCHEMA });
+    await syncSchema({ db, schema: CONTENT_VERSIONS_SCHEMA });
 
     mockLocals = {
       tenantId: 'test-tenant',

--- a/packages/content/src/contents.spec.ts
+++ b/packages/content/src/contents.spec.ts
@@ -578,6 +578,100 @@ it('should persist content references via the ContentReference model', async () 
   expect(references[0]?.id).toBe(target.id);
 });
 
+it('should pin and update the cited version on a content reference', async () => {
+  const dbUrl = getTestDbUrl('reference-version-pin');
+  const db = await getTestDatabase({ type: 'sqlite', url: dbUrl });
+  const contents = await Contents.create({ db });
+  await syncSchema({ db, schema: CONTENT_VERSIONS_SCHEMA });
+  await syncSchema({ db, schema: GOVERNANCE_POLICIES_SCHEMA });
+  await syncSchema({ db, schema: GOVERNANCE_PROFILES_SCHEMA });
+  await syncSchema({ db, schema: GOVERNANCE_ASSIGNMENTS_SCHEMA });
+
+  const source = await contents.create({
+    name: 'pin-source',
+    title: 'Pin source',
+    body: 'Source body',
+    status: 'draft',
+  });
+  const target = await contents.create({
+    name: 'pin-target',
+    title: 'Pin target',
+    body: 'Target v1',
+    status: 'draft',
+  });
+
+  await target.createVersion({ summary: 'v1' });
+
+  await source.addReference(target, { targetVersion: 1 });
+
+  const driftAfterInitial = await source.getReferenceDrift();
+  expect(driftAfterInitial).toHaveLength(1);
+  expect(driftAfterInitial[0]).toMatchObject({
+    targetId: target.id,
+    citedVersion: 1,
+    currentVersion: 1,
+    isDrifted: false,
+  });
+
+  // Target gets a new version — citation still pinned to v1.
+  target.body = 'Target v2';
+  await target.save();
+  await target.createVersion({ summary: 'v2' });
+
+  const driftAfterUpdate = await source.getReferenceDrift();
+  expect(driftAfterUpdate[0]).toMatchObject({
+    targetId: target.id,
+    citedVersion: 1,
+    currentVersion: 2,
+    isDrifted: true,
+  });
+
+  // Re-pin to v2 (e.g. user acknowledged drift).
+  await source.addReference(target, { targetVersion: 2 });
+  const driftAfterRepin = await source.getReferenceDrift();
+  expect(driftAfterRepin[0]).toMatchObject({
+    targetId: target.id,
+    citedVersion: 2,
+    currentVersion: 2,
+    isDrifted: false,
+  });
+});
+
+it('should leave unpinned references untracked but reportable', async () => {
+  const dbUrl = getTestDbUrl('reference-version-unpinned');
+  const db = await getTestDatabase({ type: 'sqlite', url: dbUrl });
+  const contents = await Contents.create({ db });
+  await syncSchema({ db, schema: CONTENT_VERSIONS_SCHEMA });
+  await syncSchema({ db, schema: GOVERNANCE_POLICIES_SCHEMA });
+  await syncSchema({ db, schema: GOVERNANCE_PROFILES_SCHEMA });
+  await syncSchema({ db, schema: GOVERNANCE_ASSIGNMENTS_SCHEMA });
+
+  const source = await contents.create({
+    name: 'unpinned-source',
+    title: 'Unpinned source',
+    body: 'Source',
+    status: 'draft',
+  });
+  const target = await contents.create({
+    name: 'unpinned-target',
+    title: 'Unpinned target',
+    body: 'Target',
+    status: 'draft',
+  });
+
+  await target.createVersion({ summary: 'v1' });
+  await source.addReference(target);
+
+  const drift = await source.getReferenceDrift();
+  expect(drift).toHaveLength(1);
+  expect(drift[0]).toMatchObject({
+    targetId: target.id,
+    citedVersion: null,
+    currentVersion: 1,
+    isDrifted: false,
+  });
+});
+
 it('should create URL reference targets with the source tenantId', async () => {
   const contents = await Contents.create({
     db: {

--- a/packages/content/src/contents.test.ts
+++ b/packages/content/src/contents.test.ts
@@ -20,7 +20,8 @@ CREATE TABLE IF NOT EXISTS content_references (
   updated_at DATETIME NOT NULL,
   tenant_id TEXT,
   source_id TEXT,
-  target_id TEXT
+  target_id TEXT,
+  target_version INTEGER
 );
 CREATE INDEX IF NOT EXISTS content_references_id_idx ON content_references (id);
 CREATE UNIQUE INDEX IF NOT EXISTS content_references_source_id_target_id_idx ON content_references (source_id, target_id);

--- a/packages/content/src/factual-content.test.ts
+++ b/packages/content/src/factual-content.test.ts
@@ -32,7 +32,8 @@ CREATE TABLE IF NOT EXISTS content_references (
   updated_at DATETIME NOT NULL,
   tenant_id TEXT,
   source_id TEXT,
-  target_id TEXT
+  target_id TEXT,
+  target_version INTEGER
 );
 CREATE INDEX IF NOT EXISTS content_references_id_idx ON content_references (id);
 CREATE UNIQUE INDEX IF NOT EXISTS content_references_source_id_target_id_idx ON content_references (source_id, target_id);

--- a/packages/content/src/manifest/manifest.json
+++ b/packages/content/src/manifest/manifest.json
@@ -3598,6 +3598,13 @@
             "required": true
           }
         },
+        "targetVersion": {
+          "type": "integer",
+          "required": false,
+          "_meta": {
+            "nullable": true
+          }
+        },
         "createdAt": {
           "type": "text",
           "required": false
@@ -3628,7 +3635,7 @@
       ],
       "schema": {
         "tableName": "content_references",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_references\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"source_id\" TEXT NOT NULL,\n  \"target_id\" TEXT NOT NULL\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_references\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"source_id\" TEXT NOT NULL,\n  \"target_id\" TEXT NOT NULL,\n  \"target_version\" INTEGER\n);",
         "columns": {
           "id": {
             "type": "TEXT",
@@ -3668,6 +3675,11 @@
             "type": "TEXT",
             "notNull": true,
             "unique": false
+          },
+          "target_version": {
+            "type": "INTEGER",
+            "notNull": false,
+            "unique": false
           }
         },
         "indexes": [
@@ -3686,7 +3698,7 @@
             "unique": true
           }
         ],
-        "version": "9feb6158"
+        "version": "2446f1c5"
       }
     },
     "@happyvertical/smrt-content:ContentReferences": {

--- a/packages/content/src/routes/api/v1/contentreferences/link/+server.ts
+++ b/packages/content/src/routes/api/v1/contentreferences/link/+server.ts
@@ -21,7 +21,7 @@ export const POST: RequestHandler = async ({ request }) => {
   const result = await typedCollection.link(
     options.sourceId,
     options.targetId,
-    options.tenantId,
+    options.options,
   );
 
   return json({ action: 'link', result });

--- a/packages/content/src/routes/api/v1/contentreferences/link/+server.ts
+++ b/packages/content/src/routes/api/v1/contentreferences/link/+server.ts
@@ -21,7 +21,7 @@ export const POST: RequestHandler = async ({ request }) => {
   const result = await typedCollection.link(
     options.sourceId,
     options.targetId,
-    options.options,
+    options.tenantId,
   );
 
   return json({ action: 'link', result });

--- a/packages/content/src/serialization.ts
+++ b/packages/content/src/serialization.ts
@@ -213,13 +213,18 @@ export function serializeContentGovernanceState(state: any) {
 }
 
 export async function serializeContent(content: any) {
-  const [references, assets, drift] = await Promise.all([
+  const [references, assets] = await Promise.all([
     typeof content?.getReferences === 'function' ? content.getReferences() : [],
     typeof content?.getAssets === 'function' ? content.getAssets() : [],
-    typeof content?.getReferenceDrift === 'function'
-      ? content.getReferenceDrift()
-      : [],
   ]);
+
+  // Only resolve drift when there are references to drift against — list
+  // endpoints serializing many ref-less items shouldn't pay the version
+  // lookup cost.
+  const drift =
+    references.length > 0 && typeof content?.getReferenceDrift === 'function'
+      ? await content.getReferenceDrift()
+      : [];
 
   const driftByTargetId = new Map<
     string,

--- a/packages/content/src/serialization.ts
+++ b/packages/content/src/serialization.ts
@@ -213,19 +213,53 @@ export function serializeContentGovernanceState(state: any) {
 }
 
 export async function serializeContent(content: any) {
-  const [references, assets] = await Promise.all([
+  const [references, assets, drift] = await Promise.all([
     typeof content?.getReferences === 'function' ? content.getReferences() : [],
     typeof content?.getAssets === 'function' ? content.getAssets() : [],
+    typeof content?.getReferenceDrift === 'function'
+      ? content.getReferenceDrift()
+      : [],
   ]);
+
+  const driftByTargetId = new Map<
+    string,
+    {
+      citedVersion: number | null;
+      currentVersion: number | null;
+      isDrifted: boolean;
+    }
+  >(
+    Array.isArray(drift)
+      ? drift
+          .filter((entry: any) => entry && typeof entry.targetId === 'string')
+          .map((entry: any) => [
+            entry.targetId,
+            {
+              citedVersion: entry.citedVersion ?? null,
+              currentVersion: entry.currentVersion ?? null,
+              isDrifted: Boolean(entry.isDrifted),
+            },
+          ])
+      : [],
+  );
 
   return {
     ...toJSON<Record<string, any>>(content),
     referenceIds: references
       .map((reference: any) => reference?.id)
       .filter(Boolean),
-    references: references.map((reference: any) =>
-      toJSON<Record<string, any>>(reference),
-    ),
+    references: references.map((reference: any) => {
+      const base = toJSON<Record<string, any>>(reference);
+      const edge = base?.id ? driftByTargetId.get(base.id as string) : null;
+      return edge
+        ? {
+            ...base,
+            citedVersion: edge.citedVersion,
+            currentVersion: edge.currentVersion,
+            isDrifted: edge.isDrifted,
+          }
+        : base;
+    }),
     assetIds: assets.map((asset: any) => asset?.id).filter(Boolean),
     assets: assets.map((asset: any) => toJSON<Record<string, any>>(asset)),
   };


### PR DESCRIPTION
# feat(content): pin ContentReference to a target version for drift detection

## Motivation

Today `ContentReference` records a `(source_id, target_id)` edge with no notion of
*when* the source cited the target. That's fine when both ends are stable, but it
breaks down as soon as the target is something we ingest and re-sync — an upstream
article, an Ergot asset snapshot, an archived web page. The cited content can
change underneath the citation without any signal in the editor or downstream
agents.

This change adds a citation-time version pin so callers can answer: *did the
thing I cited say something different when I cited it?*

## Approach

`Content` already has `ContentVersion`, which captures versioned snapshots
(`content_id`, `version`, `kind`, `snapshot`, `metadata`, `getTransparency()`)
expressly for transparency / audit. We were missing the edge half of that
contract: a way for a reference to point at a specific version.

The PR therefore:

- Adds a nullable `targetVersion: number | null` field to `ContentReference`.
  Unpinned references behave exactly as before — no required migration for
  existing callers.
- Extends `ContentReferences.link(sourceId, targetId, tenantId, options?)`
  with an `options.targetVersion`. On a re-link of an existing edge, the pin
  is updated in place (idempotent on `(source_id, target_id)`, mutable on the
  version column). The signature is non-breaking: existing 3-arg callers
  still work; the new `options` arg is trailing and optional.
- Extends `Content.addReference(content, { targetVersion })` to thread the pin
  through. This is the path the anytown.ai picker will use.
- Adds `Content.getReferenceDrift()`: returns one entry per edge with
  `citedVersion`, `currentVersion` (from
  `ContentVersionCollection.getLatestForContent`, which spans all kinds —
  manual or publication), and `isDrifted` (both present and different).
- Includes drift fields in `serializeContent` so SvelteKit `load` functions
  expose them to consumers without an extra round-trip. The lookup is skipped
  entirely when the content has no references, so list endpoints don't pay
  the cost for ref-less items.

`conflictColumns` stays `['source_id', 'target_id']`. The version is an
attribute of the edge, not part of its identity — re-citing the same target
updates the pin rather than creating a second edge.

The scanner currently captures only the first 3 parameters of
`link()`, so the auto-generated `POST /api/v1/contentreferences/link` route
keeps its existing `(sourceId, targetId, tenantId)` shape. `targetVersion`
flows through `Content.addReference` (in-tree callers) but is not yet
reachable via the raw `link` HTTP route. HTTP access to the pin will land in
the downstream PR that updates `Content.syncPendingReferenceIds` to accept
`{ id, targetVersion }` pairs.

## Schema change

```diff
 CREATE TABLE content_references (
   id ..., source_id ..., target_id ...,
+  target_version INTEGER,        -- nullable
   tenant_id ..., created_at ...
 );
```

Existing rows get `NULL`, which `getReferenceDrift()` treats as
`citedVersion: null` and `isDrifted: false`. No backfill required.

The committed `packages/content/src/manifest/manifest.json` is updated
surgically for the `ContentReference` schema (fields, ddl, columns,
schema-version hash) so workspace siblings consuming the source manifest see
the new column.

## Documentation

- `packages/content/README.md` — new "References & Drift Detection" subsection
  after "Versioning"; updated method table for `addReference(content, options?)`
  and the new `getReferenceDrift()`.
- `packages/content/CLAUDE.md` — `ContentReference` model description, method
  table, relationship-models example, and a gotcha covering pin semantics
  (edge is keyed on source+target, version is mutable in place).
- Top-level `CLAUDE.md` and `AGENTS.md` — extended the content package
  one-liner to mention versioned references / drift detection.

## Tests

- `contents.spec.ts` — two new tests:
  - Pin / re-sync / drift / re-pin lifecycle against a real `content_versions`
    table.
  - Unpinned references report `citedVersion: null` but still surface the
    target's current version.
- Updated three existing test schema fixtures (`contents.test.ts`,
  `factual-content.test.ts`, `content-contributions.test.ts`) to add the
  nullable `target_version` column. `contents-api.test.ts` additionally seeds
  the `content_versions` schema because `serializeContent` now fans out to
  `getReferenceDrift`.

## Downstream — implementing the original Ergot-citation use case

This PR is the upstream half of [anytown/anytown.ai#462](https://github.com/anytown/anytown.ai/issues/462)
(picker that emits external references for article citations). After this
lands and is released, anytown.ai's article editor can be wired as follows:

1. **Ingestion (Ergot proxy):** when the picker selects an Ergot asset, the
   server resolves it to a canonical `Content` row keyed by
   `(source='ergot', external_id=<asset id>)` — find-or-create. On miss, snapshot
   `{title, url, body, ...}` from the asset response, persist as a Content row,
   call `content.createVersion({ kind: 'publication', summary: 'ergot-ingest' })`
   to record version 1.
2. **Save handler** (`apps/dashboard/src/routes/sites/[siteSlug]/articles/[articleId]/+page.svelte` around
   line 857): stop stripping the `references` payload. Each reference flows
   through `Content.addReference(targetContent, { targetVersion: latestVersion })`.
3. **Load** (`+page.server.ts`): `serializeContent` already returns
   `references[].citedVersion / currentVersion / isDrifted`. The editor (or
   a wrapper around `ContentReferencesPanel`) can render a drift badge from
   those fields — the panel itself does not yet read them, so the consuming
   app is responsible for surfacing the affordance.
4. **Drift acknowledgement:** "update citation to latest" is a re-call of
   `addReference(target, { targetVersion: target.latestVersion })`.
5. **Re-sync cadence:** Praeco (or a scheduled job) re-fetches Ergot assets,
   diffs body/facts, and on change calls `createVersion` to bump. Any article
   citing the prior version will now report `isDrifted: true` on next load.

Audit metadata the picker emits today (`_auditSourceKind`, `_auditSourceId`)
goes on the *target* Content's `metadata` blob (or as facts on the target),
not on the edge — the edge only needs to know "which version did I cite."

## Out of scope (planned follow-ups)

- A bulk "refresh all citations to latest" action.
- HTTP access to `targetVersion` via the raw `link` route or via Content's
  reference sync payload — needs to wait for either a scanner fix that
  captures all method parameters, or a Content-level reference-sync API
  change. The downstream anytown.ai PR will choose its preferred path.
- Replacing the current `versions.list({ where: { contentId: targetIds[] } })`
  fetch with a `MAX(version) GROUP BY content_id` collection helper. The
  current approach is correct (and already batched), but pulls more rows than
  strictly needed — Copilot called this out and a follow-up should add a
  `getLatestVersionsForContents(ids)` helper on `ContentVersionCollection`.
- Surfacing drift in `ContentVersion.getTransparency()`.
- Renderer/UI work for the drift badge in `ContentReferencesPanel`.

## Validation

- `pnpm --filter @happyvertical/smrt-content test` — 263 passed, 6 skipped,
  including the two new lifecycle tests.
- Changeset: per `AGENTS.md`, changesets are auto-generated on merge to main —
  no manual `pnpm changeset` required.