### PR TITLE
fix(core): honor api.exclude for custom methods when api.include is also set

### DIFF
--- a/packages/core/src/vite-plugin/sveltekit-generator.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.test.ts
@@ -864,6 +864,62 @@ describe('SvelteKit Route Generator', () => {
       expect(privateRoute).toBeUndefined();
     });
 
+    it('should honor api.exclude even when api.include is also set (#1304)', async () => {
+      // Regression: previously shouldIncludeInApi short-circuited on
+      // `apiConfig.include` and never consulted `apiConfig.exclude` for
+      // custom methods. CRUD path already honored both; custom path now
+      // matches.
+      const manifest: SmartObjectManifest = {
+        objects: {
+          Document: {
+            className: 'Document',
+            collection: 'documents',
+            fields: {},
+            methods: {
+              keepMe: {
+                name: 'keepMe',
+                parameters: [],
+                returnType: 'Promise<any>',
+                isPublic: true,
+              },
+              removeMe: {
+                name: 'removeMe',
+                parameters: [],
+                returnType: 'Promise<any>',
+                isPublic: true,
+              },
+            },
+            decoratorConfig: {
+              api: {
+                include: ['keepMe', 'removeMe'],
+                exclude: ['removeMe'],
+              },
+            },
+          },
+        },
+      };
+
+      await generateSvelteKitRoutes(projectRoot, manifest, {
+        enabled: true,
+        routesDir: 'src/routes/api',
+        objectsDir: 'src/lib/objects',
+      });
+
+      const keepRoute = vi
+        .mocked(writeFileSync)
+        .mock.calls.find((call) =>
+          call[0].toString().includes('keepMe/+server.ts'),
+        );
+      expect(keepRoute).toBeDefined();
+
+      const removeRoute = vi
+        .mocked(writeFileSync)
+        .mock.calls.find((call) =>
+          call[0].toString().includes('removeMe/+server.ts'),
+        );
+      expect(removeRoute).toBeUndefined();
+    });
+
     it('should import from package for external objects', async () => {
       const manifest: SmartObjectManifest = {
         objects: {

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -975,18 +975,25 @@ async function generateCollectionRoutesForObject(
 
 /**
  * Check if a custom action should be included in API
+ *
+ * When `include` is set, only listed actions pass. When `exclude` is set,
+ * listed actions are removed. When both are set, both apply: an action
+ * must be in `include` AND not in `exclude`. This mirrors the CRUD
+ * inclusion path in this same file so behavior is consistent between
+ * standard and custom actions (Issue #1304).
  */
 function shouldIncludeInApi(actionName: string, apiConfig: any): boolean {
   if (apiConfig === false) return false;
   if (apiConfig === true || apiConfig === undefined) return true;
 
   if (typeof apiConfig === 'object') {
-    if (apiConfig.include) {
-      return apiConfig.include.includes(actionName);
-    }
-    if (apiConfig.exclude) {
-      return !apiConfig.exclude.includes(actionName);
-    }
+    const included = apiConfig.include
+      ? apiConfig.include.includes(actionName)
+      : true;
+    const excluded = apiConfig.exclude
+      ? apiConfig.exclude.includes(actionName)
+      : false;
+    return included && !excluded;
   }
 
   return true;


### PR DESCRIPTION
## Summary

- `shouldIncludeInApi` in the sveltekit route generator returned early when `apiConfig.include` was set and never consulted `apiConfig.exclude` for custom methods. A method listed in both was silently exposed.
- The CRUD inclusion path in the same file already honored both — custom methods now follow the same intersect-then-subtract logic.

Fixes #1304.

## Why

Discovered while planning `@happyvertical/smrt-app-cli` decorator-driven resource discovery. Apps with decorators like `api: { include: ['discover', 'execute'], exclude: ['execute'] }` would unexpectedly expose `execute`. Low-frequency footgun, principle-of-least-surprise violation.

## Test plan

- [x] New regression test `should honor api.exclude even when api.include is also set (#1304)` covers the include+exclude case.
- [x] Existing `should skip actions not in api config` still passes (covers include-only case).
- [x] All 33 tests in `sveltekit-generator.test.ts` pass.
- [x] Pre-existing `inheritance.test.ts` failure on main is unrelated.