### PR TITLE
feat(core): opt-in kebab-case URL segments for custom action routes

### DIFF
--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -59,6 +59,16 @@ export interface SmrtPluginOptions {
     configPath?: string;
     /** Configuration file name (default: 'smrt.ts') */
     configFileName?: string;
+    /**
+     * Kebab-case custom action route URLs (default: false).
+     *
+     * When true, `discoverFromUrl` generates `/discover-from-url` instead
+     * of the legacy `/discoverFromUrl`. Explicit `api.routes[name].path`
+     * overrides always win.
+     *
+     * New apps should set this to true. Issue #1305.
+     */
+    kebabRoutes?: boolean;
   };
 }
 
@@ -254,6 +264,7 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
           objectsDir: svelteKit.objectsDir || 'src/lib/objects',
           configPath: svelteKit.configPath || 'src/lib/server',
           configFileName: svelteKit.configFileName || 'smrt.ts',
+          kebabRoutes: svelteKit.kebabRoutes ?? false,
         });
       }
     },

--- a/packages/core/src/vite-plugin/sveltekit-generator.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.test.ts
@@ -25,7 +25,10 @@ vi.mock('node:fs', () => ({
 }));
 
 // Import after mocking
-import { generateSvelteKitRoutes } from './sveltekit-generator';
+import {
+  generateSvelteKitRoutes,
+  methodNameToKebab,
+} from './sveltekit-generator';
 
 function expectGetCollectionCall(content: string, objectName: string): void {
   const escapedObjectName = objectName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -33,6 +36,22 @@ function expectGetCollectionCall(content: string, objectName: string): void {
     new RegExp(`getCollection(?:<any>)?\\(\\s*'${escapedObjectName}',?\\s*\\)`),
   );
 }
+
+describe('methodNameToKebab (#1305)', () => {
+  it.each([
+    ['discoverFromUrl', 'discover-from-url'],
+    ['XMLExport', 'xml-export'],
+    ['URL', 'url'],
+    ['getById', 'get-by-id'],
+    ['simple', 'simple'],
+    ['Already', 'already'],
+    ['aA', 'a-a'],
+    ['IOError', 'io-error'],
+    ['parseHTML5Data', 'parse-html5-data'],
+  ])('%s → %s', (input, expected) => {
+    expect(methodNameToKebab(input)).toBe(expected);
+  });
+});
 
 describe('SvelteKit Route Generator', () => {
   const projectRoot = '/test/project';
@@ -513,6 +532,166 @@ describe('SvelteKit Route Generator', () => {
         );
 
       expect(summarizeRoute).toBeDefined();
+    });
+
+    it('should preserve camelCase URL segments by default (#1305 opt-in)', async () => {
+      // Regression: default (kebabRoutes off) keeps the legacy camelCase
+      // URL shape so existing apps don't break.
+      const manifest: SmartObjectManifest = {
+        objects: {
+          Praeco: {
+            className: 'Praeco',
+            collection: 'praecos',
+            fields: {},
+            methods: {
+              discoverFromUrl: {
+                name: 'discoverFromUrl',
+                parameters: [{ name: 'options', type: 'any' }],
+                returnType: 'Promise<any>',
+                isPublic: true,
+                isStatic: true,
+              },
+            },
+            decoratorConfig: {
+              api: { include: ['discoverFromUrl'] },
+            },
+          },
+        },
+      };
+
+      await generateSvelteKitRoutes(projectRoot, manifest, {
+        enabled: true,
+        routesDir: 'src/routes/api',
+        objectsDir: 'src/lib/objects',
+      });
+
+      const camelRoute = vi
+        .mocked(writeFileSync)
+        .mock.calls.find((call) =>
+          call[0].toString().includes('praecos/discoverFromUrl/+server.ts'),
+        );
+      expect(camelRoute).toBeDefined();
+
+      const kebabRoute = vi
+        .mocked(writeFileSync)
+        .mock.calls.find((call) =>
+          call[0].toString().includes('praecos/discover-from-url/+server.ts'),
+        );
+      expect(kebabRoute).toBeUndefined();
+    });
+
+    it('should kebab-case custom route URLs when kebabRoutes is enabled (#1305)', async () => {
+      const manifest: SmartObjectManifest = {
+        objects: {
+          Praeco: {
+            className: 'Praeco',
+            collection: 'praecos',
+            fields: {},
+            methods: {
+              discoverFromUrl: {
+                name: 'discoverFromUrl',
+                parameters: [{ name: 'options', type: 'any' }],
+                returnType: 'Promise<any>',
+                isPublic: true,
+                isStatic: true,
+              },
+              XMLExport: {
+                name: 'XMLExport',
+                parameters: [{ name: 'options', type: 'any' }],
+                returnType: 'Promise<any>',
+                isPublic: true,
+                isStatic: true,
+              },
+            },
+            decoratorConfig: {
+              api: { include: ['discoverFromUrl', 'XMLExport'] },
+            },
+          },
+        },
+      };
+
+      await generateSvelteKitRoutes(projectRoot, manifest, {
+        enabled: true,
+        routesDir: 'src/routes/api',
+        objectsDir: 'src/lib/objects',
+        kebabRoutes: true,
+      });
+
+      expect(
+        vi
+          .mocked(writeFileSync)
+          .mock.calls.find((call) =>
+            call[0].toString().includes('praecos/discover-from-url/+server.ts'),
+          ),
+      ).toBeDefined();
+      expect(
+        vi
+          .mocked(writeFileSync)
+          .mock.calls.find((call) =>
+            call[0].toString().includes('praecos/discoverFromUrl/+server.ts'),
+          ),
+      ).toBeUndefined();
+
+      expect(
+        vi
+          .mocked(writeFileSync)
+          .mock.calls.find((call) =>
+            call[0].toString().includes('praecos/xml-export/+server.ts'),
+          ),
+      ).toBeDefined();
+    });
+
+    it('should let explicit api.routes path override win even with kebabRoutes enabled (#1305)', async () => {
+      const manifest: SmartObjectManifest = {
+        objects: {
+          Praeco: {
+            className: 'Praeco',
+            collection: 'praecos',
+            fields: {},
+            methods: {
+              discoverFromUrl: {
+                name: 'discoverFromUrl',
+                parameters: [{ name: 'options', type: 'any' }],
+                returnType: 'Promise<any>',
+                isPublic: true,
+                isStatic: true,
+              },
+            },
+            decoratorConfig: {
+              api: {
+                include: ['discoverFromUrl'],
+                routes: {
+                  discoverFromUrl: { path: 'legacyCamel' },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      await generateSvelteKitRoutes(projectRoot, manifest, {
+        enabled: true,
+        routesDir: 'src/routes/api',
+        objectsDir: 'src/lib/objects',
+        kebabRoutes: true,
+      });
+
+      // Explicit override wins; no kebab transform applied.
+      expect(
+        vi
+          .mocked(writeFileSync)
+          .mock.calls.find((call) =>
+            call[0].toString().includes('praecos/legacyCamel/+server.ts'),
+          ),
+      ).toBeDefined();
+      // The kebab-of-override (`legacy-camel`) must NOT be generated.
+      expect(
+        vi
+          .mocked(writeFileSync)
+          .mock.calls.find((call) =>
+            call[0].toString().includes('praecos/legacy-camel/+server.ts'),
+          ),
+      ).toBeUndefined();
     });
 
     it('should generate collection-scoped custom routes for static methods', async () => {

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -29,6 +29,19 @@ export interface SvelteKitOptions {
   objectsDir: string;
   configPath?: string; // default: 'src/lib/server'
   configFileName?: string; // default: 'smrt.ts'
+  /**
+   * When true, custom action route paths are kebab-cased from the method
+   * name (e.g. `discoverFromUrl` → `/discover-from-url`). When false
+   * (default), the method name is used verbatim (`/discoverFromUrl`).
+   *
+   * Explicit `api.routes[name].path` overrides always win; this flag only
+   * affects the implicit-default-path case.
+   *
+   * Default: false (preserves existing camelCase URL behavior). New apps
+   * are encouraged to enable this for REST-conventional kebab URLs;
+   * future major may flip the default. See Issue #1305.
+   */
+  kebabRoutes?: boolean;
 }
 
 // Keep this aligned with biome.json formatter.lineWidth.
@@ -173,13 +186,41 @@ function normalizeApiHttpMethod(method?: string): ApiHttpMethod {
   }
 }
 
-function normalizeCustomRoutePath(actionName: string, path?: string): string[] {
-  const normalizedPath = (path || actionName)
-    .split('/')
-    .map((segment) => segment.trim())
-    .filter(Boolean);
+/**
+ * Convert a method name in source casing to a kebab-case URL segment.
+ *
+ *   discoverFromUrl → discover-from-url
+ *   XMLExport       → xml-export
+ *   URL             → url
+ *   getById         → get-by-id
+ *   simple          → simple
+ *
+ * Exported for re-use by downstream tools (e.g. `@happyvertical/smrt-app-cli`
+ * uses the same transform for surface command names). Issue #1305.
+ */
+export function methodNameToKebab(name: string): string {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase();
+}
 
-  return normalizedPath.length > 0 ? normalizedPath : [actionName];
+function normalizeCustomRoutePath(
+  actionName: string,
+  path?: string,
+  kebabRoutes = false,
+): string[] {
+  // Explicit path override always wins; no kebab transform applied to
+  // overrides so authors retain full control over the URL shape.
+  if (path) {
+    const normalized = path
+      .split('/')
+      .map((segment) => segment.trim())
+      .filter(Boolean);
+    if (normalized.length > 0) return normalized;
+  }
+  const segment = kebabRoutes ? methodNameToKebab(actionName) : actionName;
+  return [segment];
 }
 
 function extractRoutePathParamNames(pathSegments: string[]): string[] {
@@ -196,18 +237,23 @@ function resolveApiActionRouteConfig(
   defaultScope: 'item' | 'collection' = actionDef.isStatic
     ? 'collection'
     : 'item',
+  kebabRoutes = false,
 ): ResolvedApiActionRouteConfig {
   const config = getApiConfigObject(apiConfig);
   const routeConfig: ApiCustomRouteConfig | undefined =
     config?.routes?.[actionName];
 
+  const pathSegments = normalizeCustomRoutePath(
+    actionName,
+    routeConfig?.path,
+    kebabRoutes,
+  );
+
   return {
     scope: routeConfig?.scope || defaultScope,
     method: normalizeApiHttpMethod(routeConfig?.method),
-    pathSegments: normalizeCustomRoutePath(actionName, routeConfig?.path),
-    pathParamNames: extractRoutePathParamNames(
-      normalizeCustomRoutePath(actionName, routeConfig?.path),
-    ),
+    pathSegments,
+    pathParamNames: extractRoutePathParamNames(pathSegments),
   };
 }
 
@@ -857,6 +903,8 @@ async function generateRoutesForObject(
       actionName,
       actionDef,
       apiConfig,
+      undefined,
+      options.kebabRoutes,
     );
 
     if (routeConfig.scope === 'collection' && !actionDef.isStatic) {
@@ -936,6 +984,7 @@ async function generateCollectionRoutesForObject(
       actionDef,
       apiConfig,
       'collection',
+      options.kebabRoutes,
     );
 
     if (routeConfig.scope !== 'collection') {


### PR DESCRIPTION
## Summary

- Adds `svelteKit.kebabRoutes` (default false) to the SMRT vite plugin.
- When enabled, custom action method names become kebab-cased URL segments: `discoverFromUrl` → `/discover-from-url` instead of the legacy `/discoverFromUrl`.
- Explicit `api.routes[name].path` overrides always win — kebab transform applies only to implicit defaults.
- Exports `methodNameToKebab` for re-use by downstream tools.

Refs #1305.

## Why

Custom action URLs currently use the method name verbatim, producing non-REST-conventional camelCase URLs. The upcoming `@happyvertical/smrt-app-cli` uses kebab command names (`discover-from-url`) for ergonomics and needs the URLs to match so the CLI surface and the HTTP surface align.

Default-off ships zero breaking change. Migration story:

1. **Now:** new apps set `kebabRoutes: true` from the start.
2. **Existing apps:** can opt in incrementally. Any URL that must stay camelCase can use an explicit `api.routes[name].path` override (which always wins).
3. **Future major:** flip the default to `true`.

## Test plan

- [x] Pure unit tests for `methodNameToKebab` across camelCase (`discoverFromUrl`), ALLCAPS (`URL`), prefix-allcaps (`XMLExport`), mixed-with-digits (`parseHTML5Data`), single-letter transitions (`aA`).
- [x] Regression: with default options (kebabRoutes off), `discoverFromUrl` generates `praecos/discoverFromUrl/+server.ts` — existing behavior preserved.
- [x] With `kebabRoutes: true`, `discoverFromUrl` → `praecos/discover-from-url/+server.ts`, `XMLExport` → `praecos/xml-export/+server.ts`.
- [x] With `kebabRoutes: true` AND an explicit `api.routes[name].path = 'legacyCamel'` override, the override wins; no kebab transform applied to the override.
- [x] All 44 sveltekit-generator tests pass (up from 33).

## Notes

The exported `methodNameToKebab` will be re-used by `@happyvertical/smrt-app-cli` so the CLI's kebab command surface matches the kebab URL surface when this flag is on.