### PR TITLE
feat(core): warn when cli.include lists methods not exposed by the API

### DIFF
--- a/packages/core/src/vite-plugin/sveltekit-generator.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.test.ts
@@ -810,6 +810,148 @@ describe('SvelteKit Route Generator', () => {
       consoleWarnSpy.mockRestore();
     });
 
+    it('should warn when cli.include lists methods not in resolved-api set (#1306)', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // Mirrors praeco's real-world decorator: cli.include is much wider
+      // than api.include, leaving most CLI commands without HTTP routes.
+      const manifest: SmartObjectManifest = {
+        objects: {
+          Praeco: {
+            className: 'Praeco',
+            collection: 'praecos',
+            fields: {},
+            methods: {
+              discoverFromUrl: {
+                name: 'discoverFromUrl',
+                parameters: [{ name: 'options', type: 'any' }],
+                returnType: 'Promise<any>',
+                isPublic: true,
+                isStatic: true,
+              },
+              discover: {
+                name: 'discover',
+                parameters: [],
+                returnType: 'Promise<any>',
+                isPublic: true,
+              },
+              analyze: {
+                name: 'analyze',
+                parameters: [],
+                returnType: 'Promise<any>',
+                isPublic: true,
+              },
+            },
+            decoratorConfig: {
+              api: { include: ['discoverFromUrl'] },
+              cli: {
+                include: ['discoverFromUrl', 'discover', 'analyze'],
+              },
+            },
+          },
+        },
+      };
+
+      await generateSvelteKitRoutes(projectRoot, manifest, {
+        enabled: true,
+        routesDir: 'src/routes/api',
+        objectsDir: 'src/lib/objects',
+      });
+
+      const warnedMethods = warnSpy.mock.calls
+        .map((args) => String(args[0] ?? ''))
+        .filter((msg) => msg.includes('cli.include'));
+
+      // Should warn about `discover` and `analyze` (cli-only).
+      expect(warnedMethods.some((m) => m.includes('Praeco.discover '))).toBe(
+        true,
+      );
+      expect(warnedMethods.some((m) => m.includes('Praeco.analyze'))).toBe(
+        true,
+      );
+      // Should NOT warn about `discoverFromUrl` (in both).
+      expect(
+        warnedMethods.some((m) => m.includes('Praeco.discoverFromUrl')),
+      ).toBe(false);
+
+      warnSpy.mockRestore();
+    });
+
+    it('should not warn when cli.include matches resolved-api set (#1306)', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const manifest: SmartObjectManifest = {
+        objects: {
+          Clean: {
+            className: 'Clean',
+            collection: 'cleans',
+            fields: {},
+            methods: {
+              analyze: {
+                name: 'analyze',
+                parameters: [],
+                returnType: 'Promise<any>',
+                isPublic: true,
+              },
+            },
+            decoratorConfig: {
+              api: { include: ['list', 'get', 'analyze'] },
+              cli: { include: ['list', 'get', 'analyze'] },
+            },
+          },
+        },
+      };
+
+      await generateSvelteKitRoutes(projectRoot, manifest, {
+        enabled: true,
+        routesDir: 'src/routes/api',
+        objectsDir: 'src/lib/objects',
+      });
+
+      const cliIncludeWarnings = warnSpy.mock.calls
+        .map((args) => String(args[0] ?? ''))
+        .filter((msg) => msg.includes('cli.include'));
+      expect(cliIncludeWarnings).toHaveLength(0);
+
+      warnSpy.mockRestore();
+    });
+
+    it('should skip cli.include validation when cli is undefined or boolean (#1306)', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const manifest: SmartObjectManifest = {
+        objects: {
+          A: {
+            className: 'A',
+            collection: 'as',
+            fields: {},
+            methods: {},
+            decoratorConfig: { api: true }, // cli unset
+          },
+          B: {
+            className: 'B',
+            collection: 'bs',
+            fields: {},
+            methods: {},
+            decoratorConfig: { api: true, cli: true }, // cli is boolean
+          },
+        },
+      };
+
+      await generateSvelteKitRoutes(projectRoot, manifest, {
+        enabled: true,
+        routesDir: 'src/routes/api',
+        objectsDir: 'src/lib/objects',
+      });
+
+      const cliIncludeWarnings = warnSpy.mock.calls
+        .map((args) => String(args[0] ?? ''))
+        .filter((msg) => msg.includes('cli.include'));
+      expect(cliIncludeWarnings).toHaveLength(0);
+
+      warnSpy.mockRestore();
+    });
+
     it('should skip actions not in api config', async () => {
       const manifest: SmartObjectManifest = {
         objects: {

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -363,6 +363,11 @@ export async function generateSvelteKitRoutes(
   let generatedCount = 0;
   let skippedCollections = 0;
   for (const [className, objectDef] of Object.entries(manifest.objects)) {
+    // Lint cli.include ⊂ resolved-api set (Issue #1306). Warns only; the
+    // route generator still runs so existing apps don't break before
+    // their decorators are migrated.
+    validateCliIncludeAgainstApi(className, objectDef);
+
     if (isCollectionClass(objectDef)) {
       const generatedCollectionRoutes = await generateCollectionRoutesForObject(
         projectRoot,
@@ -971,6 +976,81 @@ async function generateCollectionRoutesForObject(
   }
 
   return generatedAnyRoutes;
+}
+
+/**
+ * Compute the resolved set of action names exposed by the API decorator
+ * config: standard CRUD actions (filtered through include/exclude) plus
+ * any public custom methods that pass `shouldIncludeInApi`.
+ *
+ * Used by validateCliIncludeAgainstApi to detect cli.include entries
+ * that have no corresponding HTTP route (Issue #1306).
+ */
+function resolveApiActionSet(objectDef: SmartObjectDefinition): Set<string> {
+  const apiConfig = objectDef.decoratorConfig?.api;
+  if (apiConfig === false) return new Set();
+
+  const resolved = new Set<string>();
+
+  // Standard CRUD: same logic as generateRoutesForObject.
+  if (apiConfig === true || apiConfig === undefined) {
+    for (const a of STANDARD_API_ACTIONS) resolved.add(a);
+  } else if (typeof apiConfig === 'object') {
+    const apiObj = apiConfig as { include?: string[]; exclude?: string[] };
+    let crud: string[];
+    if (apiObj.include) {
+      crud = apiObj.include.filter((action) =>
+        STANDARD_API_ACTIONS.includes(action),
+      );
+    } else {
+      crud = [...STANDARD_API_ACTIONS];
+    }
+    if (apiObj.exclude && Array.isArray(apiObj.exclude)) {
+      crud = crud.filter((action) => !apiObj.exclude?.includes(action));
+    }
+    for (const a of crud) resolved.add(a);
+  }
+
+  // Custom methods: anything in objectDef.methods that's public and
+  // passes shouldIncludeInApi.
+  for (const [name, method] of Object.entries(objectDef.methods ?? {})) {
+    if (STANDARD_API_ACTIONS.includes(name)) continue;
+    if (!(method as { isPublic?: boolean }).isPublic) continue;
+    if (shouldIncludeInApi(name, apiConfig)) resolved.add(name);
+  }
+
+  return resolved;
+}
+
+/**
+ * Warn when a class's cli.include lists methods that have no
+ * corresponding API route. The CLI invokes methods over HTTP; methods
+ * not in the resolved-api set are unreachable from a CLI client.
+ *
+ * Currently emits warnings only. Will escalate to errors in a follow-up
+ * once existing apps have been migrated. Issue #1306.
+ */
+function validateCliIncludeAgainstApi(
+  className: string,
+  objectDef: SmartObjectDefinition,
+): void {
+  const cliConfig = objectDef.decoratorConfig?.cli;
+  if (!cliConfig || typeof cliConfig !== 'object') return;
+  const include = (cliConfig as { include?: string[] }).include;
+  if (!include || include.length === 0) return;
+
+  const apiSet = resolveApiActionSet(objectDef);
+  const unreachable = include.filter((name) => !apiSet.has(name));
+
+  if (unreachable.length === 0) return;
+
+  for (const name of unreachable) {
+    console.warn(
+      `[smrt] ${className}.${name} is declared in cli.include but is not exposed via the API. ` +
+        `CLI commands invoke methods over HTTP; without a corresponding entry in api.include, this command has no route. ` +
+        `Either add '${name}' to api.include, or remove '${name}' from cli.include. Issue #1306.`,
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a build-time lint that warns when `cli.include` lists methods not in the resolved-api set.
- Each unreachable command produces a clear warning naming the class, method, and remediation (add to `api.include` or remove from `cli.include`).
- Ships as a **warning**, not an error, so existing apps continue to build while their decorators are migrated. Easy to escalate to an error in a follow-up.

Refs #1306.

## Why

A SMRT CLI invokes methods over HTTP. Methods in `cli.include` without a corresponding `api.include` entry have no HTTP route and silently fail at runtime. Praeco's current decorator has 10/11 cli.include entries that are unreachable — discovered while planning `@happyvertical/smrt-app-cli`.

## Behavior

For each class with `cli: { include: [...] }`:
1. Build the resolved-api set (CRUD + custom methods that pass `shouldIncludeInApi`).
2. For each cli.include entry not in that set, emit:

```
[smrt] Praeco.discover is declared in cli.include but is not exposed via the API.
CLI commands invoke methods over HTTP; without a corresponding entry in api.include,
this command has no route. Either add 'discover' to api.include, or remove 'discover'
from cli.include. Issue #1306.
```

Skipped when:
- `cli` is undefined, `true`, or `false` (no include list to validate).
- The class has no methods at all.

## Test plan

- [x] Warns about praeco-style configs (cli.include ⊃ api.include): asserts warnings emitted for cli-only methods, NOT for shared methods.
- [x] Stays silent when cli.include == api.include set.
- [x] Stays silent when `cli` is undefined or boolean.
- [x] All 35 sveltekit-generator tests pass.

## Follow-up

When existing apps (ergot.io, anytown.ai) are migrated, this can be escalated to a build error. Tracked as a follow-up in the smrt-app-cli planning thread.