### PR TITLE
feat(core): @smrt() decorator coherence (#1304, #1305, #1306)

### DIFF
--- a/packages/agents/src/schedule.ts
+++ b/packages/agents/src/schedule.ts
@@ -40,6 +40,9 @@ export type ScheduleStatus = 'active' | 'paused' | 'disabled' | 'error';
   api: { include: ['list', 'get', 'create', 'update', 'delete'] },
   cli: {
     include: ['list', 'get', 'create', 'update', 'delete', 'enable', 'disable'],
+    // enable/disable are operator commands invoked in-process via the CLI;
+    // they intentionally aren't exposed over HTTP.
+    skipApiCheck: true,
   },
   mcp: { include: ['list', 'get'] },
 })

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -192,6 +192,12 @@ export const generateCommands: Record<string, CLICommand> = {
         default: false,
         short: 'f',
       },
+      'kebab-routes': {
+        type: 'boolean',
+        description:
+          'Use kebab-case for custom-method URL segments (e.g. /discover-from-url instead of /discoverFromUrl). Default off; will flip in the next major.',
+        default: false,
+      },
     },
     handler: async (_args: string[], options: any) => {
       console.log('\n🔍 Discovering SMRT objects...\n');
@@ -275,6 +281,7 @@ export const generateCommands: Record<string, CLICommand> = {
           objectsDir,
           configPath,
           configFileName: configFile,
+          kebabRoutes: !!options['kebab-routes'],
         });
 
         // Report results

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -141,7 +141,9 @@ const EXAMPLE_OBJECT_TEMPLATE = `/**
 import { SmrtObject, smrt } from '@happyvertical/smrt-core';
 
 @smrt({
-  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  api: {
+    include: ['list', 'get', 'create', 'update', 'delete', 'summarize'],
+  },
   cli: { include: ['list', 'get', 'summarize'] },
 })
 export class Example extends SmrtObject {

--- a/packages/core/src/registry/types.ts
+++ b/packages/core/src/registry/types.ts
@@ -256,6 +256,14 @@ export interface SmartObjectConfig {
          * Exclude specific commands (supports both standard CRUD actions and custom methods)
          */
         exclude?: string[];
+
+        /**
+         * Skip the build-time check that every `cli.include` method is also
+         * exposed via the API. Set this for classes whose CLI is invoked
+         * in-process (e.g. admin/security tools intentionally without HTTP
+         * routes) rather than over HTTP.
+         */
+        skipApiCheck?: boolean;
       };
 
   /**

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -1231,14 +1231,21 @@ ${fields}
       .join('\n\n');
 
     // Generate API client interface for each object
-    // Always use plural collection names (standard REST convention)
+    // Always use plural collection names (standard REST convention).
+    // Filter custom methods through resolveApiActionSet so the declared
+    // type surface matches what generateClientModule actually emits at
+    // runtime — otherwise consumers see methods in autocomplete that are
+    // undefined at runtime.
     const apiClientInterface = uniqueApiClientEntries(
       Object.entries(manifest.objects),
     )
       .map(({ obj, clientKey }) => {
         const { className, methods = {} } = obj;
         const interfaceName = `${className}Data`;
-        const customMethods = Object.entries(methods);
+        const exposedActions = resolveApiActionSet(obj);
+        const customMethods = Object.entries(methods).filter(
+          ([name, method]) => method.isPublic && exposedActions.has(name),
+        );
 
         // Generate custom method signatures
         // Custom methods are instance methods requiring id as first parameter

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -12,11 +12,26 @@ import type { SmartObjectManifest } from '../scanner/types';
 import { importWorkspaceModule } from '../utils/import-workspace-module.js';
 import type { ScannerModule } from '../utils/scanner-module.js';
 import { importBuildAwareModule } from './import-build-aware.js';
-import { generateSvelteKitRoutes } from './sveltekit-generator.js';
+import {
+  findCliApiCoherenceViolations,
+  generateSvelteKitRoutes,
+  methodNameToKebab,
+  resolveApiActionSet,
+  validateCliIncludeAgainstApi,
+} from './sveltekit-generator.js';
 
-export type { SvelteKitOptions } from './sveltekit-generator.js';
+export type {
+  CliApiCoherenceViolation,
+  SvelteKitOptions,
+} from './sveltekit-generator.js';
 // Re-export SvelteKit route generator for CLI usage
-export { generateSvelteKitRoutes } from './sveltekit-generator.js';
+export {
+  findCliApiCoherenceViolations,
+  generateSvelteKitRoutes,
+  methodNameToKebab,
+  resolveApiActionSet,
+  validateCliIncludeAgainstApi,
+} from './sveltekit-generator.js';
 
 export interface SmrtPluginOptions {
   /** Glob patterns for SMRT source files */
@@ -59,7 +74,19 @@ export interface SmrtPluginOptions {
     configPath?: string;
     /** Configuration file name (default: 'smrt.ts') */
     configFileName?: string;
+    /**
+     * Apply kebab-case to custom-method URL segments (e.g. `discoverFromUrl`
+     * becomes `/discover-from-url`). Opt-in for one minor; default flips in
+     * the next major. An explicit `api.routes[name].path` always wins.
+     */
+    kebabRoutes?: boolean;
   };
+  /**
+   * Validate that every method in `cli.include` is exposed via the API
+   * (so HTTP-based CLI consumers can actually reach them). Default: true.
+   * Per-class opt-out via `cli: { skipApiCheck: true }`.
+   */
+  validateCliApiCoherence?: boolean;
 }
 
 const VIRTUAL_MODULES = {
@@ -101,7 +128,34 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
       configPath: 'src/lib/server',
       configFileName: 'smrt.ts',
     },
+    validateCliApiCoherence = true,
   } = options;
+
+  /**
+   * Dev-watcher variant of the cli↔api coherence lint: warn instead of throw,
+   * so an in-flight decorator edit doesn't kill the dev server. Uses the same
+   * remediation text as the strict build-time gate (`validateCliIncludeAgainstApi`)
+   * so the dev-server message is as actionable as the build failure.
+   */
+  function warnCliApiCoherenceViolations(m: SmartObjectManifest): void {
+    if (!validateCliApiCoherence) return;
+    const violations = findCliApiCoherenceViolations(m);
+    if (violations.length === 0) return;
+    for (const { className, unreachable } of violations) {
+      for (const action of unreachable) {
+        console.warn(
+          `[smrt] ${className}.${action} is declared in cli.include but is not ` +
+            `exposed via the api. Build will fail until this is resolved.\n` +
+            `  Either:\n` +
+            `    - Add '${action}' to api.include, or\n` +
+            `    - Remove '${action}' from cli.include.\n` +
+            `  The CLI invokes methods over HTTP; methods without API routes are unreachable.\n` +
+            `  If this CLI is intentionally invoked in-process (no HTTP), set\n` +
+            `  \`cli: { skipApiCheck: true }\` on the @smrt() decorator to acknowledge.`,
+        );
+      }
+    }
+  }
 
   let server: ViteDevServer | undefined;
   let manifest: SmartObjectManifest | null = null;
@@ -244,6 +298,9 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
         await writeLocalManifest(manifest, projectRoot);
         validateLibraryMinifySetup(manifest, 'configResolved');
         validateConsumerPluginSetup(manifest, 'configResolved');
+        if (validateCliApiCoherence) {
+          validateCliIncludeAgainstApi(manifest);
+        }
       }
 
       // Generate SvelteKit routes if enabled
@@ -254,6 +311,7 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
           objectsDir: svelteKit.objectsDir || 'src/lib/objects',
           configPath: svelteKit.configPath || 'src/lib/server',
           configFileName: svelteKit.configFileName || 'smrt.ts',
+          kebabRoutes: svelteKit.kebabRoutes ?? false,
         });
       }
     },
@@ -267,6 +325,9 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
         await writeLocalManifest(manifest, projectRoot);
         validateLibraryMinifySetup(manifest, 'buildStart');
         validateConsumerPluginSetup(manifest, 'buildStart');
+        if (validateCliApiCoherence) {
+          validateCliIncludeAgainstApi(manifest);
+        }
       }
     },
 
@@ -325,6 +386,7 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
             // Write local manifest for CLI discovery (Issue #963)
             if (manifest) {
               await writeLocalManifest(manifest, projectRoot);
+              warnCliApiCoherenceViolations(manifest);
             }
 
             // Generate SvelteKit routes if enabled
@@ -335,6 +397,7 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
                 objectsDir: svelteKit.objectsDir || 'src/lib/objects',
                 configPath: svelteKit.configPath || 'src/lib/server',
                 configFileName: svelteKit.configFileName || 'smrt.ts',
+                kebabRoutes: svelteKit.kebabRoutes ?? false,
               });
             }
 
@@ -356,6 +419,7 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
             // Write local manifest for CLI discovery (Issue #963)
             if (manifest) {
               await writeLocalManifest(manifest, projectRoot);
+              warnCliApiCoherenceViolations(manifest);
             }
 
             // Generate SvelteKit routes if enabled
@@ -366,6 +430,7 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
                 objectsDir: svelteKit.objectsDir || 'src/lib/objects',
                 configPath: svelteKit.configPath || 'src/lib/server',
                 configFileName: svelteKit.configFileName || 'smrt.ts',
+                kebabRoutes: svelteKit.kebabRoutes ?? false,
               });
             }
           }
@@ -379,6 +444,7 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
             // Write local manifest for CLI discovery (Issue #963)
             if (manifest) {
               await writeLocalManifest(manifest, projectRoot);
+              warnCliApiCoherenceViolations(manifest);
             }
 
             // Generate SvelteKit routes if enabled
@@ -389,6 +455,7 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
                 objectsDir: svelteKit.objectsDir || 'src/lib/objects',
                 configPath: svelteKit.configPath || 'src/lib/server',
                 configFileName: svelteKit.configFileName || 'smrt.ts',
+                kebabRoutes: svelteKit.kebabRoutes ?? false,
               });
             }
           }
@@ -425,7 +492,9 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
 
         case 'smrt:client':
           // Client module available in both modes
-          return generateClientModule(manifest);
+          return generateClientModule(manifest, {
+            kebabRoutes: svelteKit.kebabRoutes ?? false,
+          });
 
         case 'smrt:mcp':
           // MCP module available in all modes
@@ -816,19 +885,54 @@ function uniqueApiClientEntries(
   });
 }
 
-function generateClientModule(manifest: SmartObjectManifest): string {
+function generateClientModule(
+  manifest: SmartObjectManifest,
+  options: { kebabRoutes?: boolean } = {},
+): string {
   const objects = uniqueApiClientEntries(Object.entries(manifest.objects));
 
   const clientMethods = objects
     .map(({ obj, clientKey }) => {
       const { collection, methods = {} } = obj;
-      const customMethods = Object.entries(methods);
 
-      // Generate custom method implementations
-      // Custom methods are instance methods: POST /{collection}/{id}/{methodName}
+      // Honor api include/exclude + scope/static skip rules for custom methods,
+      // so the client only emits proxies for methods that actually have routes
+      // emitted by the server. (Custom only — CRUD is left unconditional to
+      // preserve the existing client-type contract.)
+      const exposedActions = resolveApiActionSet(obj);
+      const apiConfig = obj.decoratorConfig?.api;
+      const apiRoutes: Record<string, { path?: string }> =
+        apiConfig && typeof apiConfig === 'object'
+          ? ((apiConfig as { routes?: Record<string, { path?: string }> })
+              .routes ?? {})
+          : {};
+
+      const customMethods = Object.entries(methods).filter(
+        ([name, method]) => method.isPublic && exposedActions.has(name),
+      );
+
+      // Resolve the URL segment for each custom method using the same priority
+      // the server does in normalizeCustomRoutePath: explicit api.routes[name].path
+      // override wins; else kebab-case when kebabRoutes is enabled; else source casing.
+      const segmentFor = (methodName: string): string => {
+        const overridePath = apiRoutes[methodName]?.path;
+        if (overridePath) {
+          const trimmed = overridePath
+            .split('/')
+            .map((s) => s.trim())
+            .filter(Boolean)
+            .join('/');
+          if (trimmed.length > 0) return trimmed;
+        }
+        return options.kebabRoutes ? methodNameToKebab(methodName) : methodName;
+      };
+
+      // Generate custom method implementations.
+      // Custom methods are instance methods: POST /{collection}/{id}/{urlSegment}.
       const customMethodImpls = customMethods
         .map(([methodName, _method]) => {
-          return `    ${methodName}: (id, options) => fetch(basePath + '/${collection}/' + id + '/${methodName}', {
+          const urlSegment = segmentFor(methodName);
+          return `    ${methodName}: (id, options) => fetch(basePath + '/${collection}/' + id + '/${urlSegment}', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(options || {})

--- a/packages/core/src/vite-plugin/sveltekit-generator.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.test.ts
@@ -25,7 +25,29 @@ vi.mock('node:fs', () => ({
 }));
 
 // Import after mocking
-import { generateSvelteKitRoutes } from './sveltekit-generator';
+import {
+  findCliApiCoherenceViolations,
+  generateSvelteKitRoutes,
+  methodNameToKebab,
+  resolveApiActionSet,
+  validateCliIncludeAgainstApi,
+} from './sveltekit-generator';
+
+describe('methodNameToKebab (#1305)', () => {
+  it.each([
+    ['discoverFromUrl', 'discover-from-url'],
+    ['XMLExport', 'xml-export'],
+    ['URL', 'url'],
+    ['getById', 'get-by-id'],
+    ['simple', 'simple'],
+    ['Already', 'already'],
+    ['aA', 'a-a'],
+    ['IOError', 'io-error'],
+    ['parseHTML5Data', 'parse-html5-data'],
+  ])('%s → %s', (input, expected) => {
+    expect(methodNameToKebab(input)).toBe(expected);
+  });
+});
 
 function expectGetCollectionCall(content: string, objectName: string): void {
   const escapedObjectName = objectName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -1675,6 +1697,369 @@ describe('SvelteKit Route Generator', () => {
       expect(collectionContent).toContain(
         'items.map((item) => serializeListItemResponse(item))',
       );
+    });
+  });
+
+  // Regression: api.exclude was silently ignored for custom methods when
+  // api.include was also set. See smrt#1304.
+  describe('Custom-method api.include + api.exclude (smrt#1304)', () => {
+    it('should drop methods listed in both api.include and api.exclude', async () => {
+      const manifest: SmartObjectManifest = {
+        objects: {
+          Thing: {
+            className: 'Thing',
+            collection: 'things',
+            fields: {},
+            methods: {
+              discover: {
+                name: 'discover',
+                parameters: [{ name: 'options', type: 'any' }],
+                returnType: 'Promise<any>',
+                isPublic: true,
+              },
+              execute: {
+                name: 'execute',
+                parameters: [{ name: 'options', type: 'any' }],
+                returnType: 'Promise<any>',
+                isPublic: true,
+              },
+            },
+            decoratorConfig: {
+              api: {
+                include: ['discover', 'execute'],
+                exclude: ['execute'],
+              },
+            },
+          },
+        },
+      };
+
+      await generateSvelteKitRoutes(projectRoot, manifest, {
+        enabled: true,
+        routesDir: 'src/routes/api',
+        objectsDir: 'src/lib/objects',
+      });
+
+      const discoverWrite = vi
+        .mocked(writeFileSync)
+        .mock.calls.find((call) =>
+          call[0].toString().includes('things/[id]/discover/+server.ts'),
+        );
+      const executeWrite = vi
+        .mocked(writeFileSync)
+        .mock.calls.find((call) =>
+          call[0].toString().includes('things/[id]/execute/+server.ts'),
+        );
+
+      expect(discoverWrite).toBeDefined();
+      expect(executeWrite).toBeUndefined();
+    });
+  });
+
+  // Regression: custom-method URL paths used method-name casing instead of
+  // kebab-case. See smrt#1305. Default off; opt-in via svelteKit.kebabRoutes.
+  describe('kebabRoutes option (smrt#1305)', () => {
+    function buildManifest(): SmartObjectManifest {
+      return {
+        objects: {
+          Praeco: {
+            className: 'Praeco',
+            collection: 'praecos',
+            fields: {},
+            methods: {
+              discoverFromUrl: {
+                name: 'discoverFromUrl',
+                parameters: [{ name: 'options', type: 'any' }],
+                returnType: 'Promise<any>',
+                isPublic: true,
+              },
+              XMLExport: {
+                name: 'XMLExport',
+                parameters: [{ name: 'options', type: 'any' }],
+                returnType: 'Promise<any>',
+                isPublic: true,
+              },
+            },
+            decoratorConfig: {
+              api: { include: ['discoverFromUrl', 'XMLExport'] },
+            },
+          },
+        },
+      };
+    }
+
+    it('should preserve source casing when kebabRoutes is off (default)', async () => {
+      await generateSvelteKitRoutes(projectRoot, buildManifest(), {
+        enabled: true,
+        routesDir: 'src/routes/api',
+        objectsDir: 'src/lib/objects',
+      });
+
+      const kebab = vi
+        .mocked(writeFileSync)
+        .mock.calls.find((call) =>
+          call[0].toString().includes('praecos/[id]/discover-from-url/'),
+        );
+      const camel = vi
+        .mocked(writeFileSync)
+        .mock.calls.find((call) =>
+          call[0].toString().includes('praecos/[id]/discoverFromUrl/'),
+        );
+      expect(kebab).toBeUndefined();
+      expect(camel).toBeDefined();
+    });
+
+    it('should kebab-case custom-method segments when kebabRoutes is true', async () => {
+      await generateSvelteKitRoutes(projectRoot, buildManifest(), {
+        enabled: true,
+        routesDir: 'src/routes/api',
+        objectsDir: 'src/lib/objects',
+        kebabRoutes: true,
+      });
+
+      const kebab = vi
+        .mocked(writeFileSync)
+        .mock.calls.find((call) =>
+          call[0]
+            .toString()
+            .includes('praecos/[id]/discover-from-url/+server.ts'),
+        );
+      const acronymKebab = vi
+        .mocked(writeFileSync)
+        .mock.calls.find((call) =>
+          call[0].toString().includes('praecos/[id]/xml-export/+server.ts'),
+        );
+      const camel = vi
+        .mocked(writeFileSync)
+        .mock.calls.find((call) =>
+          call[0].toString().includes('praecos/[id]/discoverFromUrl/'),
+        );
+      expect(kebab).toBeDefined();
+      expect(acronymKebab).toBeDefined();
+      expect(camel).toBeUndefined();
+    });
+
+    it('should honor an explicit api.routes[name].path over kebabRoutes', async () => {
+      const manifest: SmartObjectManifest = {
+        objects: {
+          Praeco: {
+            className: 'Praeco',
+            collection: 'praecos',
+            fields: {},
+            methods: {
+              discoverFromUrl: {
+                name: 'discoverFromUrl',
+                parameters: [{ name: 'options', type: 'any' }],
+                returnType: 'Promise<any>',
+                isPublic: true,
+              },
+            },
+            decoratorConfig: {
+              api: {
+                include: ['discoverFromUrl'],
+                routes: {
+                  discoverFromUrl: { path: 'discoverFromUrl' },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      await generateSvelteKitRoutes(projectRoot, manifest, {
+        enabled: true,
+        routesDir: 'src/routes/api',
+        objectsDir: 'src/lib/objects',
+        kebabRoutes: true,
+      });
+
+      const camel = vi
+        .mocked(writeFileSync)
+        .mock.calls.find((call) =>
+          call[0]
+            .toString()
+            .includes('praecos/[id]/discoverFromUrl/+server.ts'),
+        );
+      expect(camel).toBeDefined();
+    });
+  });
+
+  // Feature: build-time lint that catches cli.include methods missing from
+  // the resolved API set. See smrt#1306.
+  describe('cli.include vs api.include coherence lint (smrt#1306)', () => {
+    function buildManifest(decoratorConfig: any): SmartObjectManifest {
+      return {
+        objects: {
+          Praeco: {
+            className: 'Praeco',
+            collection: 'praecos',
+            fields: {},
+            methods: {
+              discover: {
+                name: 'discover',
+                parameters: [],
+                returnType: 'Promise<any>',
+                isPublic: true,
+              },
+              audit: {
+                name: 'audit',
+                parameters: [],
+                returnType: 'Promise<any>',
+                isPublic: true,
+              },
+            },
+            decoratorConfig,
+          },
+        },
+      };
+    }
+
+    it('resolveApiActionSet returns CRUD + included custom methods', () => {
+      const manifest = buildManifest({
+        api: { include: ['list', 'get', 'discover'] },
+      });
+      const set = resolveApiActionSet(manifest.objects.Praeco);
+      expect(Array.from(set).sort()).toEqual(['discover', 'get', 'list']);
+    });
+
+    it('flags cli.include methods that are not in the resolved api set', () => {
+      const manifest = buildManifest({
+        api: { include: ['list', 'get', 'discover'] },
+        cli: { include: ['list', 'discover', 'audit'] },
+      });
+      const violations = findCliApiCoherenceViolations(manifest);
+      expect(violations).toEqual([
+        { className: 'Praeco', unreachable: ['audit'] },
+      ]);
+    });
+
+    it('throws with remediation guidance when invoked as a build-time gate', () => {
+      const manifest = buildManifest({
+        api: { include: ['list', 'get'] },
+        cli: { include: ['list', 'discover', 'audit'] },
+      });
+      expect(() => validateCliIncludeAgainstApi(manifest)).toThrow(
+        /Praeco\.discover is declared in cli\.include but is not exposed via the api/,
+      );
+      expect(() => validateCliIncludeAgainstApi(manifest)).toThrow(/audit/);
+      expect(() => validateCliIncludeAgainstApi(manifest)).toThrow(
+        /cli: \{ skipApiCheck: true \}/,
+      );
+    });
+
+    it('honors per-class cli.skipApiCheck opt-out', () => {
+      const manifest = buildManifest({
+        api: { include: [] },
+        cli: { include: ['list'], skipApiCheck: true },
+      });
+      expect(findCliApiCoherenceViolations(manifest)).toEqual([]);
+      expect(() => validateCliIncludeAgainstApi(manifest)).not.toThrow();
+    });
+
+    it('passes when cli.include is empty', () => {
+      const manifest = buildManifest({
+        api: { include: [] },
+        cli: { include: [] },
+      });
+      expect(findCliApiCoherenceViolations(manifest)).toEqual([]);
+    });
+
+    it('passes when api.exclude removes a method from cli.include too', () => {
+      // Combined with smrt#1304: api.include+exclude both apply, so excluded
+      // methods must be flagged in cli.include even when listed in api.include.
+      const manifest = buildManifest({
+        api: { include: ['discover', 'audit'], exclude: ['audit'] },
+        cli: { include: ['discover', 'audit'] },
+      });
+      const violations = findCliApiCoherenceViolations(manifest);
+      expect(violations).toEqual([
+        { className: 'Praeco', unreachable: ['audit'] },
+      ]);
+    });
+
+    // Regression: resolveApiActionSet must mirror the scope/static skip rules
+    // applied by route generation, otherwise the lint reports a false negative
+    // (passes a cli.include method that no route is actually emitted for).
+    it('excludes collection-scoped non-static methods on a non-collection class', () => {
+      // User wrote `routes[name].scope: 'collection'` for an instance method
+      // — the generator skips this with a warning. The lint must agree.
+      const manifest: SmartObjectManifest = {
+        objects: {
+          Doc: {
+            className: 'Doc',
+            collection: 'docs',
+            fields: {},
+            methods: {
+              broken: {
+                name: 'broken',
+                parameters: [],
+                returnType: 'Promise<any>',
+                isPublic: true,
+                isStatic: false,
+              },
+            },
+            decoratorConfig: {
+              api: {
+                include: ['broken'],
+                routes: { broken: { scope: 'collection' } },
+              },
+              cli: { include: ['broken'] },
+            },
+          },
+        },
+      };
+      expect(Array.from(resolveApiActionSet(manifest.objects.Doc))).toEqual([]);
+      expect(findCliApiCoherenceViolations(manifest)).toEqual([
+        { className: 'Doc', unreachable: ['broken'] },
+      ]);
+    });
+
+    it('excludes scope=item methods on a SmrtCollection class', () => {
+      // Collection classes only emit collection-scoped custom routes; an
+      // explicit `routes[name].scope = 'item'` override on a collection class
+      // method is a misconfig the generator skips. The lint must agree.
+      const manifest: SmartObjectManifest = {
+        objects: {
+          DocCollection: {
+            className: 'DocCollection',
+            collection: 'docs',
+            fields: {},
+            extends: 'SmrtCollection',
+            extendsTypeArg: 'Doc',
+            methods: {
+              misconfigured: {
+                name: 'misconfigured',
+                parameters: [],
+                returnType: 'Promise<any>',
+                isPublic: true,
+                isStatic: false,
+              },
+              listSpecial: {
+                name: 'listSpecial',
+                parameters: [],
+                returnType: 'Promise<any>',
+                isPublic: true,
+                isStatic: true,
+              },
+            },
+            decoratorConfig: {
+              api: {
+                include: ['misconfigured', 'listSpecial'],
+                routes: { misconfigured: { scope: 'item' } },
+              },
+              cli: { include: ['misconfigured', 'listSpecial'] },
+            },
+          },
+        },
+      };
+      // misconfigured has explicit scope: 'item' on a collection class -> skipped.
+      // listSpecial defaults to 'collection' on collection class -> exposed.
+      expect(
+        Array.from(resolveApiActionSet(manifest.objects.DocCollection)).sort(),
+      ).toEqual(['listSpecial']);
+      expect(findCliApiCoherenceViolations(manifest)).toEqual([
+        { className: 'DocCollection', unreachable: ['misconfigured'] },
+      ]);
     });
   });
 });

--- a/packages/core/src/vite-plugin/sveltekit-generator.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.test.ts
@@ -1977,6 +1977,20 @@ describe('SvelteKit Route Generator', () => {
       ]);
     });
 
+    it('honors cli.exclude when checking effective CLI commands', () => {
+      // Match generateCLIModule: a command in both cli.include AND cli.exclude
+      // is not actually registered as a CLI command, so the lint must not
+      // flag it as unreachable even if no API route exists.
+      const manifest = buildManifest({
+        api: { include: ['discover'] }, // no 'audit' in API
+        cli: { include: ['discover', 'audit'], exclude: ['audit'] },
+      });
+      // 'audit' is in cli.include but also in cli.exclude → not a real
+      // CLI command → must not be flagged as unreachable.
+      expect(findCliApiCoherenceViolations(manifest)).toEqual([]);
+      expect(() => validateCliIncludeAgainstApi(manifest)).not.toThrow();
+    });
+
     // Regression: resolveApiActionSet must mirror the scope/static skip rules
     // applied by route generation, otherwise the lint reports a false negative
     // (passes a cli.include method that no route is actually emitted for).

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -1124,8 +1124,19 @@ export function findCliApiCoherenceViolations(
     if (cliConfig.skipApiCheck) continue;
     if (!cliConfig.include || cliConfig.include.length === 0) continue;
 
+    // Match generateCLIModule's effective command set: include − exclude.
+    // A command in both lists is not actually registered, so the lint must
+    // not flag it as unreachable.
+    const cliExclude = Array.isArray(cliConfig.exclude)
+      ? cliConfig.exclude
+      : [];
+    const effectiveCliCommands = cliConfig.include.filter(
+      (cmd: string) => !cliExclude.includes(cmd),
+    );
+    if (effectiveCliCommands.length === 0) continue;
+
     const apiActionSet = resolveApiActionSet(objectDef);
-    const unreachable = cliConfig.include.filter(
+    const unreachable = effectiveCliCommands.filter(
       (action: string) => !apiActionSet.has(action),
     );
 

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -29,6 +29,12 @@ export interface SvelteKitOptions {
   objectsDir: string;
   configPath?: string; // default: 'src/lib/server'
   configFileName?: string; // default: 'smrt.ts'
+  /**
+   * Apply kebab-case to custom-method URL segments (e.g. `discoverFromUrl`
+   * becomes `/discover-from-url`). Opt-in for one minor; default flips in the
+   * next major. An explicit `api.routes[name].path` always wins over this.
+   */
+  kebabRoutes?: boolean;
 }
 
 // Keep this aligned with biome.json formatter.lineWidth.
@@ -173,13 +179,46 @@ function normalizeApiHttpMethod(method?: string): ApiHttpMethod {
   }
 }
 
-function normalizeCustomRoutePath(actionName: string, path?: string): string[] {
-  const normalizedPath = (path || actionName)
-    .split('/')
-    .map((segment) => segment.trim())
-    .filter(Boolean);
+/**
+ * Convert a camelCase / PascalCase method name to a kebab-case URL segment.
+ * Examples:
+ *   discoverFromUrl -> discover-from-url
+ *   XMLExport       -> xml-export
+ *   URL             -> url
+ *   a1B2c3          -> a1-b2c3
+ *
+ * Known limitation: consecutive uppercase acronyms aren't split apart, e.g.
+ * `HTMLAPIExport` becomes `htmlapi-export` rather than `html-api-export`.
+ * Override with an explicit `api.routes[name].path` if you need a specific
+ * segmentation.
+ */
+export function methodNameToKebab(name: string): string {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase();
+}
 
-  return normalizedPath.length > 0 ? normalizedPath : [actionName];
+function normalizeCustomRoutePath(
+  actionName: string,
+  path?: string,
+  options: { kebabRoutes?: boolean } = {},
+): string[] {
+  // Explicit path override always wins, and is used verbatim (split on /).
+  if (path) {
+    const segments = path
+      .split('/')
+      .map((segment) => segment.trim())
+      .filter(Boolean);
+    if (segments.length > 0) {
+      return segments;
+    }
+  }
+
+  const segment = options.kebabRoutes
+    ? methodNameToKebab(actionName)
+    : actionName;
+  return [segment];
 }
 
 function extractRoutePathParamNames(pathSegments: string[]): string[] {
@@ -193,6 +232,7 @@ function resolveApiActionRouteConfig(
   actionName: string,
   actionDef: { isStatic?: boolean },
   apiConfig: unknown,
+  routeOptions: { kebabRoutes?: boolean } = {},
   defaultScope: 'item' | 'collection' = actionDef.isStatic
     ? 'collection'
     : 'item',
@@ -201,13 +241,17 @@ function resolveApiActionRouteConfig(
   const routeConfig: ApiCustomRouteConfig | undefined =
     config?.routes?.[actionName];
 
+  const pathSegments = normalizeCustomRoutePath(
+    actionName,
+    routeConfig?.path,
+    routeOptions,
+  );
+
   return {
     scope: routeConfig?.scope || defaultScope,
     method: normalizeApiHttpMethod(routeConfig?.method),
-    pathSegments: normalizeCustomRoutePath(actionName, routeConfig?.path),
-    pathParamNames: extractRoutePathParamNames(
-      normalizeCustomRoutePath(actionName, routeConfig?.path),
-    ),
+    pathSegments,
+    pathParamNames: extractRoutePathParamNames(pathSegments),
   };
 }
 
@@ -789,27 +833,8 @@ async function generateRoutesForObject(
     return;
   }
 
-  // Determine which actions to include
-  let includedActions: string[] = [];
-
-  if (apiConfig === true || apiConfig === undefined) {
-    // Include all standard actions by default
-    includedActions = [...STANDARD_API_ACTIONS];
-  } else if (typeof apiConfig === 'object') {
-    if (apiConfig.include) {
-      includedActions = apiConfig.include.filter((action) =>
-        STANDARD_API_ACTIONS.includes(action),
-      );
-    } else {
-      includedActions = [...STANDARD_API_ACTIONS];
-    }
-
-    if (apiConfig.exclude && Array.isArray(apiConfig.exclude)) {
-      includedActions = includedActions.filter(
-        (action) => !apiConfig.exclude?.includes(action),
-      );
-    }
-  }
+  // Determine which CRUD actions to include via the shared resolver.
+  const includedActions = resolveStandardCrudActions(apiConfig);
 
   // Generate collection route (list, create)
   if (includedActions.includes('list') || includedActions.includes('create')) {
@@ -857,6 +882,7 @@ async function generateRoutesForObject(
       actionName,
       actionDef,
       apiConfig,
+      { kebabRoutes: options.kebabRoutes },
     );
 
     if (routeConfig.scope === 'collection' && !actionDef.isStatic) {
@@ -935,6 +961,7 @@ async function generateCollectionRoutesForObject(
       actionName,
       actionDef,
       apiConfig,
+      { kebabRoutes: options.kebabRoutes },
       'collection',
     );
 
@@ -974,22 +1001,168 @@ async function generateCollectionRoutesForObject(
 }
 
 /**
- * Check if a custom action should be included in API
+ * Resolve the list of standard CRUD actions exposed by the API for a given
+ * apiConfig. Single source of truth for both the route generator and the
+ * cli↔api coherence lint.
+ */
+function resolveStandardCrudActions(apiConfig: unknown): string[] {
+  if (apiConfig === false) return [];
+  if (apiConfig === true || apiConfig === undefined) {
+    return [...STANDARD_API_ACTIONS];
+  }
+  if (typeof apiConfig !== 'object') return [...STANDARD_API_ACTIONS];
+
+  const config = apiConfig as { include?: string[]; exclude?: string[] };
+  let crud: string[] = config.include
+    ? config.include.filter((a) => STANDARD_API_ACTIONS.includes(a))
+    : [...STANDARD_API_ACTIONS];
+  if (Array.isArray(config.exclude)) {
+    const exclude = config.exclude;
+    crud = crud.filter((a) => !exclude.includes(a));
+  }
+  return crud;
+}
+
+/**
+ * Check if a custom action should be included in API.
+ *
+ * Mirrors the CRUD inclusion path: intersect with `include` (when set), then
+ * subtract `exclude`. Both filters apply together, matching principle of least
+ * surprise for users supplying both lists.
  */
 function shouldIncludeInApi(actionName: string, apiConfig: any): boolean {
   if (apiConfig === false) return false;
   if (apiConfig === true || apiConfig === undefined) return true;
 
   if (typeof apiConfig === 'object') {
-    if (apiConfig.include) {
-      return apiConfig.include.includes(actionName);
-    }
-    if (apiConfig.exclude) {
-      return !apiConfig.exclude.includes(actionName);
-    }
+    const included = apiConfig.include
+      ? apiConfig.include.includes(actionName)
+      : true;
+    const excluded = apiConfig.exclude
+      ? apiConfig.exclude.includes(actionName)
+      : false;
+    return included && !excluded;
   }
 
   return true;
+}
+
+/**
+ * Compute the set of action names (standard CRUD + custom methods) that the
+ * API exposes for a given object definition. This is the same resolution used
+ * to drive route generation, exposed so coherence checks (e.g. CLI vs API)
+ * can ask "what does the API expose?" without re-implementing the logic.
+ */
+export function resolveApiActionSet(
+  objectDef: SmartObjectDefinition,
+): Set<string> {
+  const apiConfig = objectDef.decoratorConfig?.api;
+  if (apiConfig === false) return new Set();
+
+  const actions = new Set<string>(resolveStandardCrudActions(apiConfig));
+  const objectIsCollectionClass = isCollectionClass(objectDef);
+  const config = getApiConfigObject(apiConfig);
+
+  // Custom (non-CRUD, public) methods. We mirror BOTH the include/exclude
+  // filter AND the scope/static skip rules that the route generators apply
+  // (sveltekit-generator.ts generateRoutesForObject and
+  // generateCollectionRoutesForObject). Otherwise the cli↔api coherence lint
+  // would claim "reachable via API" for methods that produce no HTTP route.
+  for (const [name, method] of Object.entries(objectDef.methods || {})) {
+    if (STANDARD_API_ACTIONS.includes(name)) continue;
+    if (!method.isPublic) continue;
+    if (!shouldIncludeInApi(name, apiConfig)) continue;
+
+    const routeConfig: ApiCustomRouteConfig | undefined =
+      config?.routes?.[name];
+    const defaultScope: 'item' | 'collection' = objectIsCollectionClass
+      ? 'collection'
+      : method.isStatic
+        ? 'collection'
+        : 'item';
+    const scope = routeConfig?.scope || defaultScope;
+
+    if (objectIsCollectionClass) {
+      // Collection classes only emit collection-scoped custom routes.
+      if (scope !== 'collection') continue;
+    } else {
+      // Non-collection classes skip collection-scoped non-static methods
+      // (the generator emits a console warning in this case).
+      if (scope === 'collection' && !method.isStatic) continue;
+    }
+
+    actions.add(name);
+  }
+
+  return actions;
+}
+
+/**
+ * Detail for a single cli-vs-api coherence violation.
+ */
+export interface CliApiCoherenceViolation {
+  className: string;
+  unreachable: string[];
+}
+
+/**
+ * Inspect a manifest and return classes whose `cli.include` references
+ * methods not exposed via the API. Classes that opt out via
+ * `cli: { skipApiCheck: true }` are skipped.
+ *
+ * Throws nothing; returns the violation list so callers can choose to throw
+ * or warn.
+ */
+export function findCliApiCoherenceViolations(
+  manifest: SmartObjectManifest,
+): CliApiCoherenceViolation[] {
+  const violations: CliApiCoherenceViolation[] = [];
+
+  for (const [className, objectDef] of Object.entries(manifest.objects)) {
+    const cliConfig = objectDef.decoratorConfig?.cli;
+    if (!cliConfig || typeof cliConfig !== 'object') continue;
+    if (cliConfig.skipApiCheck) continue;
+    if (!cliConfig.include || cliConfig.include.length === 0) continue;
+
+    const apiActionSet = resolveApiActionSet(objectDef);
+    const unreachable = cliConfig.include.filter(
+      (action: string) => !apiActionSet.has(action),
+    );
+
+    if (unreachable.length > 0) {
+      violations.push({ className, unreachable });
+    }
+  }
+
+  return violations;
+}
+
+/**
+ * Throw if any class in the manifest has `cli.include` methods that aren't
+ * reachable via the API. Default build-time gate; opt-out per-class via
+ * `cli: { skipApiCheck: true }` (or globally via the vite plugin option
+ * `validateCliApiCoherence: false`).
+ */
+export function validateCliIncludeAgainstApi(
+  manifest: SmartObjectManifest,
+): void {
+  const violations = findCliApiCoherenceViolations(manifest);
+  if (violations.length === 0) return;
+
+  const messages = violations.flatMap(({ className, unreachable }) =>
+    unreachable.map(
+      (action) =>
+        `[smrt] ${className}.${action} is declared in cli.include but is not exposed via the api.\n` +
+        `  Either:\n` +
+        `    - Add '${action}' to api.include, or\n` +
+        `    - Remove '${action}' from cli.include.\n` +
+        `  The CLI invokes methods over HTTP; methods without API routes are unreachable.\n` +
+        `  If this CLI is intentionally invoked in-process (no HTTP), set\n` +
+        `  \`cli: { skipApiCheck: true }\` on the @smrt() decorator to acknowledge.`,
+    ),
+  );
+
+  throw new Error(messages.join('\n\n'));
 }
 
 /**

--- a/packages/jobs/src/smrt-job.ts
+++ b/packages/jobs/src/smrt-job.ts
@@ -36,7 +36,9 @@ export type TimeoutBehavior = 'fail' | 'kill' | 'warn';
 @smrt({
   tableName: '_smrt_jobs',
   api: { include: ['list', 'get'] },
-  cli: { include: ['list', 'get', 'retry', 'cancel'] },
+  // retry/cancel are operator commands invoked in-process via the CLI;
+  // they intentionally aren't exposed over HTTP.
+  cli: { include: ['list', 'get', 'retry', 'cancel'], skipApiCheck: true },
   mcp: { include: ['list', 'get'] },
 })
 export class SmrtJob extends SmrtObject {

--- a/packages/languages/src/models/LanguageOverride.ts
+++ b/packages/languages/src/models/LanguageOverride.ts
@@ -24,6 +24,9 @@ export interface LanguageOverrideCtorOptions
   api: { include: ['list', 'get', 'create', 'update', 'delete'] },
   cli: {
     include: ['list', 'get', 'create', 'update', 'delete', 'approve'],
+    // approve is an admin review action invoked in-process via the CLI;
+    // it intentionally isn't exposed over HTTP today.
+    skipApiCheck: true,
   },
   mcp: { include: [] },
 })

--- a/packages/profiles/src/models/ApiKey.ts
+++ b/packages/profiles/src/models/ApiKey.ts
@@ -30,7 +30,9 @@ export interface GenerateKeyResult {
   tableName: 'api_keys',
   api: { include: ['list', 'get'] },
   mcp: { include: ['list', 'get'] },
-  cli: { include: ['list', 'get', 'create', 'revoke'] },
+  // create/revoke are admin operations invoked in-process via the CLI; only
+  // read-only list/get are exposed over HTTP.
+  cli: { include: ['list', 'get', 'create', 'revoke'], skipApiCheck: true },
 })
 export class ApiKey extends SmrtObject {
   /**

--- a/packages/projects/src/models/Issue.ts
+++ b/packages/projects/src/models/Issue.ts
@@ -50,7 +50,12 @@ export interface IssueOptions extends SmrtObjectOptions {
   tableStrategy: 'sti',
   api: { include: ['list', 'get', 'create', 'update'] },
   mcp: { include: ['list', 'get', 'sync', 'incorporateFeedback'] },
-  cli: { include: ['list', 'get', 'sync', 'incorporateFeedback', 'rollback'] },
+  // sync/incorporateFeedback/rollback are operator commands invoked in-process
+  // via the CLI; they intentionally aren't exposed over HTTP today.
+  cli: {
+    include: ['list', 'get', 'sync', 'incorporateFeedback', 'rollback'],
+    skipApiCheck: true,
+  },
 })
 export class Issue extends SmrtObject {
   /**

--- a/packages/projects/src/models/Project.ts
+++ b/packages/projects/src/models/Project.ts
@@ -47,6 +47,8 @@ export interface ProjectOptions extends SmrtObjectOptions {
 @smrt({
   api: { include: ['list', 'get', 'create', 'update'] },
   mcp: { include: ['list', 'get', 'sync', 'addItem', 'updateItemStatus'] },
+  // sync/addItem/updateItemStatus/listItems are operator commands invoked
+  // in-process via the CLI; they intentionally aren't exposed over HTTP today.
   cli: {
     include: [
       'list',
@@ -56,6 +58,7 @@ export interface ProjectOptions extends SmrtObjectOptions {
       'updateItemStatus',
       'listItems',
     ],
+    skipApiCheck: true,
   },
 })
 export class Project extends SmrtObject {

--- a/packages/projects/src/models/PullRequest.ts
+++ b/packages/projects/src/models/PullRequest.ts
@@ -27,7 +27,12 @@ export interface PullRequestOptions extends IssueOptions {
 @smrt({
   api: { include: ['list', 'get', 'create', 'update'] },
   mcp: { include: ['list', 'get', 'sync', 'summarize', 'merge'] },
-  cli: { include: ['list', 'get', 'sync', 'summarize', 'merge', 'markReady'] },
+  // sync/summarize/merge/markReady are operator commands invoked in-process
+  // via the CLI; they intentionally aren't exposed over HTTP today.
+  cli: {
+    include: ['list', 'get', 'sync', 'summarize', 'merge', 'markReady'],
+    skipApiCheck: true,
+  },
 })
 export class PullRequest extends Issue {
   /**

--- a/packages/projects/src/models/Repository.ts
+++ b/packages/projects/src/models/Repository.ts
@@ -43,7 +43,9 @@ export interface RepositoryOptions extends SmrtObjectOptions {
 @smrt({
   api: { include: ['list', 'get', 'create', 'update'] },
   mcp: { include: ['list', 'get', 'sync'] },
-  cli: { include: ['list', 'get', 'sync', 'create'] },
+  // sync is an operator command invoked in-process via the CLI;
+  // it intentionally isn't exposed over HTTP today.
+  cli: { include: ['list', 'get', 'sync', 'create'], skipApiCheck: true },
 })
 export class Repository extends SmrtObject {
   /**

--- a/packages/secrets/src/models/Secret.ts
+++ b/packages/secrets/src/models/Secret.ts
@@ -52,7 +52,9 @@ export type SecretStatus = 'active' | 'disabled' | 'expired';
   // NO API or MCP exposure for security
   api: { include: [] },
   mcp: { include: [] },
-  cli: { include: ['list'] }, // Only list names, not values
+  // CLI runs in-process; secrets must never be reachable over HTTP, so
+  // skipApiCheck acknowledges the cli.include / api.include divergence.
+  cli: { include: ['list'], skipApiCheck: true }, // Only list names, not values
 })
 export class Secret extends SmrtObject {
   /**

--- a/packages/secrets/src/models/SecretAuditLog.ts
+++ b/packages/secrets/src/models/SecretAuditLog.ts
@@ -73,7 +73,9 @@ export type SecretAuditResult = 'success' | 'failure' | 'denied';
   tenantScoped: true,
   api: { include: [] }, // No API exposure
   mcp: { include: [] }, // No MCP exposure
-  cli: { include: ['list'] },
+  // CLI runs in-process for compliance review; HTTP exposure is intentionally
+  // excluded, so skipApiCheck acknowledges the cli.include / api.include divergence.
+  cli: { include: ['list'], skipApiCheck: true },
 })
 export class SecretAuditLog extends SmrtObject {
   /**

--- a/packages/secrets/src/models/TenantKey.ts
+++ b/packages/secrets/src/models/TenantKey.ts
@@ -52,7 +52,9 @@ export type TenantKeyStatus = 'active' | 'rotating' | 'retired' | 'compromised';
   // NOT tenant-scoped - this model tracks keys FOR tenants
   api: { include: [] }, // No API exposure
   mcp: { include: [] }, // No MCP exposure
-  cli: { include: ['list', 'get'] },
+  // CLI runs in-process for key-rotation tooling and audit; HTTP exposure is
+  // intentionally excluded, so skipApiCheck acknowledges the divergence.
+  cli: { include: ['list', 'get'], skipApiCheck: true },
 })
 export class TenantKey extends SmrtObject {
   /**

--- a/packages/template-sveltekit/template/src/lib/objects/Item.ts
+++ b/packages/template-sveltekit/template/src/lib/objects/Item.ts
@@ -8,7 +8,9 @@
 import { SmrtObject, smrt } from '@happyvertical/smrt-core';
 
 @smrt({
-  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  api: {
+    include: ['list', 'get', 'create', 'update', 'delete', 'summarize'],
+  },
   cli: { include: ['list', 'get', 'summarize'] },
 })
 export class Item extends SmrtObject {


### PR DESCRIPTION
## Summary

Three coordinated improvements to `@smrt()` decorator handling, discovered while planning HTTP-based CLI consumers.

- **#1304 fix** — `api.exclude` now applies alongside `api.include` for custom methods. The custom path was returning early on a matched include without ever checking exclude; aligns with the existing CRUD intersect-then-subtract logic.
- **#1305 feat** — opt-in `kebabRoutes` flag for kebab-case custom-method URL segments (`/discover-from-url` vs `/discoverFromUrl`). Threaded through `SvelteKitOptions`, `smrtPlugin` options, the `smrt:client` virtual module URL paths, and the `smrt generate-routes` CLI command. Default off; planned to flip in the next major. Explicit `api.routes[name].path` always wins. `methodNameToKebab` is exported so downstream consumers can stay in sync.
- **#1306 feat** — default-error build-time lint catching `cli.include` methods not exposed via the resolved API set. New helpers: `resolveApiActionSet`, `findCliApiCoherenceViolations`, `validateCliIncludeAgainstApi`. Per-class opt-out via `cli: { skipApiCheck: true }`; global opt-out via plugin option `validateCliApiCoherence: false`. Throws at `configResolved`/`buildStart`; dev-server watcher rescans warn non-fatally so in-flight edits don't kill HMR.

### Behavioral notes

- **Decorator sweep**: 12 in-repo decorators that intentionally invoke their CLI in-process (`Secret`, `SecretAuditLog`, `TenantKey`, `AgentSchedule`, `SmrtJob`, `LanguageOverride`, `ApiKey`, `Issue`, `Project`, `PullRequest`, `Repository`) acknowledge the divergence via `skipApiCheck: true` with a one-line rationale.
- **Templates aligned**: the two SvelteKit templates (`template-sveltekit/template/src/lib/objects/Item.ts` and the `smrt init` `Example` scaffold) add `summarize` to `api.include` to model the recommended HTTP-first pattern.
- **Shared resolver**: `resolveStandardCrudActions` is the single source of truth for CRUD action resolution, used by both the route generator and the lint.
- **Scope-guard parity**: `resolveApiActionSet` mirrors the generator's scope/static skip rules so the lint doesn't report a false negative for misconfigured methods.

### Latent issue surfaced (out of scope)

- `api: { exclude: ['*'] }` is a string match, not a glob, so it's a silent no-op. Affects at least `packages/profiles/src/models/MagicLinkToken.ts`. Worth a follow-up to either replace with `api: { include: [] }` or implement glob support.

### Review cycle

Two rounds of parallel review with `codex` (gpt-5.5/xhigh) and `grok`. Round 1 caught a missed scaffold template (`init.ts`) that would have broken `smrt init` on the new lint, plus a server↔client URL mismatch when `kebabRoutes` and `api.routes[name].path` are combined. Round 2 caught lint false-negatives for explicit `scope` overrides and refined the dev-server warning message to match the build-time error format. All applied.

## Test plan

- [x] `pnpm typecheck` in `packages/core` and `packages/cli` — clean
- [x] `pnpm build` in `packages/core` — clean
- [x] 53 tests pass in `packages/core/src/vite-plugin/sveltekit-generator.test.ts` (including a 9-case `it.each` for `methodNameToKebab` and 2 scope-guard regression tests)
- [x] Downstream tests pass: `secrets`, `jobs`, `agents`, `languages`, `profiles`, `projects`
- [x] Biome formatting check passes
- [x] Custom verification script confirms zero remaining `cli.include` / `api.include` violations across the repo

Closes #1304
Closes #1305
Closes #1306