### PR TITLE
fix(core): carry manifest collection on RegisteredClass for runtime consumers

### DIFF
--- a/packages/core/src/__tests__/issue-1311-registry-collection.test.ts
+++ b/packages/core/src/__tests__/issue-1311-registry-collection.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Regression for the smrt#1311 consumer-migration finding: the registered
+ * class must carry the manifest's pluralized `collection` (the endpoint
+ * segment the SvelteKit generator routes under), distinct from the
+ * snake_case `tableName`. Runtime consumers like `createResourceListHandler`
+ * read `RegisteredClass.collection` to build URLs that match generated
+ * routes; without it, multi-word resources 404.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { ObjectRegistry } from '../registry.js';
+import { snapshotObjectRegistryState } from '../test-utils.js';
+
+describe('registerFromManifest stores collection (smrt#1311)', () => {
+  let restore: () => void;
+  afterEach(() => {
+    restore?.();
+  });
+
+  it('stores the manifest collection verbatim, even when it diverges from tableName', () => {
+    restore = snapshotObjectRegistryState();
+    ObjectRegistry.registerFromManifest(
+      '@test/app:SourceCrawl',
+      {
+        className: 'SourceCrawl',
+        collection: 'sourcecrawls', // endpoint segment (generator routes here)
+        fields: {},
+        methods: {},
+        decoratorConfig: { tableName: 'source_crawls', api: true, cli: true },
+        schema: { tableName: 'source_crawls', columns: {} },
+      },
+      '@test/app',
+    );
+
+    const registered = ObjectRegistry.getClass('SourceCrawl');
+    expect(registered?.collection).toBe('sourcecrawls');
+    // tableName (storage) stays snake_case and must NOT be used as the
+    // endpoint segment.
+    expect(registered?.schema?.tableName).toBe('source_crawls');
+  });
+
+  it('falls back to simple pluralization when the manifest omits collection', () => {
+    restore = snapshotObjectRegistryState();
+    // Legacy/partial manifest entry without a `collection` field.
+    ObjectRegistry.registerFromManifest(
+      '@test/app:CompanyResearch',
+      {
+        className: 'CompanyResearch',
+        fields: {},
+        methods: {},
+        decoratorConfig: { api: true, cli: true },
+      },
+      '@test/app',
+    );
+
+    const registered = ObjectRegistry.getClass('CompanyResearch');
+    // ch -> ches per the scanner's simple inflection.
+    expect(registered?.collection).toBe('companyresearches');
+  });
+});

--- a/packages/core/src/registry/class-registration.ts
+++ b/packages/core/src/registry/class-registration.ts
@@ -58,6 +58,29 @@ import type {
 import { compileValidators } from './validator';
 
 /**
+ * Compute the pluralized endpoint/collection name from a class name, using
+ * the SAME simple inflection rules as the scanner's manifest adapter
+ * (`packages/scanner/src/manifest-adapter.ts`). Used only as a fallback when
+ * a registered class has no manifest-provided `collection` (e.g. inline test
+ * classes registered purely via the decorator path). Keep in sync with the
+ * scanner; the manifest value is always preferred when present. (smrt#1311.)
+ *
+ *   Currency      -> currencies   (y -> ies)
+ *   CompanyResearch -> companyresearches  (ch -> ches)
+ *   SourceCrawl   -> sourcecrawls  (+ s)
+ *   EmploymentPerson -> employmentpersons (naive + s, NOT "people")
+ */
+function pluralizeCollection(className: string): string {
+  const lower = className.toLowerCase();
+  if (lower.endsWith('y')) return `${lower.slice(0, -1)}ies`;
+  if (lower.endsWith('s') || lower.endsWith('x') || lower.endsWith('z')) {
+    return `${lower}es`;
+  }
+  if (lower.endsWith('ch') || lower.endsWith('sh')) return `${lower}es`;
+  return `${lower}s`;
+}
+
+/**
  * Shared bundled-context detector. Source files in these output
  * directories come from a bundler (Vite library mode, webpack, Next.js,
  * Nuxt, svelte-kit) that can duplicate module code across chunks.
@@ -962,9 +985,16 @@ export function register(
     schema,
     validators,
     validationRules, // Pre-computed rules from manifest (Issue #782)
+    tools: manifestEntry?.tools, // AI-callable tool schemas (CLI param schemas)
+    // Pluralized endpoint name. Prefer the manifest's computed value (handles
+    // STI inheritance + any future inflection changes); fall back to the same
+    // simple pluralization the scanner uses for inline/test classes that have
+    // no manifest entry. (smrt#1311.)
+    collection: manifestEntry?.collection ?? pluralizeCollection(name),
     packageName, // Store package name from manifest for getPackageName() lookup
     sourceFilePath, // Store source file for collision detection (Issue #555)
     extends: extendsClass, // Capture parent class name from manifest OR prototype chain
+    extendsTypeArg: manifestEntry?.extendsTypeArg, // SmrtCollection<T> generic arg
     tenantScopedConfig, // Multi-tenancy config (Issue #688)
     visibility, // Visibility control for manifest filtering
     // NOTE: Don't pre-compute inheritanceChain here - let getInheritanceChain() compute
@@ -1551,9 +1581,14 @@ export function registerFromManifest(
     schema,
     validators,
     validationRules, // Pre-computed rules from manifest (Issue #782)
+    tools: objectDef.tools, // AI-callable tool schemas (used for CLI param schemas)
+    // Pluralized endpoint name; fall back to simple pluralization if a
+    // (legacy) manifest lacks it. (smrt#1311.)
+    collection: objectDef.collection ?? pluralizeCollection(simpleClassName),
     packageName,
     sourceFilePath: objectDef.filePath, // Store source file for collision detection (Issue #555)
     extends: qualifiedExtends, // Issue #1004: Pre-computed qualified parent
+    extendsTypeArg: objectDef.extendsTypeArg, // SmrtCollection<T> generic arg
     visibility, // New: Visibility control for manifest filtering
   });
 

--- a/packages/core/src/registry/types.ts
+++ b/packages/core/src/registry/types.ts
@@ -624,8 +624,20 @@ export interface RegisteredClass {
   packageName?: string;
   /** Source file path where the class was defined (for collision detection) */
   sourceFilePath?: string;
+  /**
+   * Pluralized endpoint/collection name from the manifest (e.g. `sourcecrawls`
+   * for `SourceCrawl`). This is the segment the SvelteKit route generator
+   * uses for `/api/<collection>/...`, and it is NOT the same as `tableName`
+   * (which is snake_case and can be overridden/uncountable). Stored here so
+   * runtime consumers (e.g. `createResourceListHandler`) can build URLs that
+   * match the generated routes instead of re-deriving from `tableName`.
+   * See smrt#1311 consumer-migration finding.
+   */
+  collection?: string;
   /** Parent class name (for inheritance chain tracking) */
   extends?: string;
+  /** Generic type arg from `SmrtCollection<X>` — marks collection classes. */
+  extendsTypeArg?: string;
   /** Full inheritance chain from base to this class (cached for performance) */
   inheritanceChain?: string[];
   /** Merged fields from entire inheritance chain (cached, includes parent fields) */

--- a/packages/users/src/__tests__/resource-list-handler.test.ts
+++ b/packages/users/src/__tests__/resource-list-handler.test.ts
@@ -27,6 +27,10 @@ type RegisteredClassLike = {
   config: any;
   methods: Map<string, any>;
   tools?: any[];
+  collection?: string;
+  extends?: string;
+  extendsTypeArg?: string;
+  constructor?: unknown;
 };
 
 function makeRegistered(
@@ -589,6 +593,42 @@ describe('createResourceListHandler', () => {
     const r = res.body.resources[0] as CliResource;
     expect(r.slug).toBe('weather_forecasts');
     expect(r.apiPath).toBe('weather_forecasts');
+  });
+
+  it('uses registry collection when it diverges from tableName — #1311 consumer-migration finding', async () => {
+    // The real bug willgriffin surfaced: multi-word class names produce a
+    // `collection` (`sourcecrawls`, what the generator routes under) that
+    // differs from the snake_case `tableName` (`source_crawls`). The handler
+    // must use the registry's `collection` field verbatim, NOT derive from
+    // tableName — otherwise the CLI 404s on every multi-word resource.
+    mockRegistry({
+      SourceCrawl: makeRegistered('SourceCrawl', { api: true, cli: true }, {}, {
+        // Divergent: collection (endpoint) vs tableName (storage).
+        collection: 'sourcecrawls',
+        config: { tableName: 'source_crawls', api: true, cli: true },
+      } as any),
+      // Also exercise an uncountable/overridden tableName (Education ->
+      // educations collection, but tableName 'education').
+      Education: makeRegistered('Education', { api: true, cli: true }, {}, {
+        collection: 'educations',
+        config: { tableName: 'education', api: true, cli: true },
+      } as any),
+    });
+
+    const res = await call(
+      { ensureRegistry: noopRegistry },
+      { locals: authedLocals },
+    );
+
+    const sc = res.body.resources.find(
+      (r: CliResource) => r.className === 'SourceCrawl',
+    );
+    expect(sc?.apiPath).toBe('sourcecrawls');
+    expect(sc?.slug).toBe('sourcecrawls');
+    const ed = res.body.resources.find(
+      (r: CliResource) => r.className === 'Education',
+    );
+    expect(ed?.apiPath).toBe('educations');
   });
 
   it('skips SmrtCollection subclasses — #1311 codex P2 collection', async () => {

--- a/packages/users/src/sveltekit/resource-list-handler.ts
+++ b/packages/users/src/sveltekit/resource-list-handler.ts
@@ -51,6 +51,12 @@ interface RegisteredClassLike {
   config: SmartObjectConfig;
   methods: Map<string, unknown>;
   tools?: ToolLike[];
+  /**
+   * Pluralized endpoint name from the manifest (e.g. `sourcecrawls`). Carried
+   * on the registered class since smrt-core 0.26.4 (smrt#1311); used verbatim
+   * as the URL segment so the CLI hits the same path the generator wrote.
+   */
+  collection?: string;
   /** Parent class simple name — `'SmrtCollection'` marks a collection class. */
   extends?: string;
   /** Generic type argument from `SmrtCollection<X>` — also marks collection. */
@@ -464,7 +470,14 @@ function synthesizeDefinition(
   }
 
   const decoratorConfig = (registered.config ?? {}) as SmartObjectConfig;
+  // Prefer the manifest-derived `collection` the registry now carries
+  // (smrt#1311). This is the SAME pluralized endpoint segment the SvelteKit
+  // route generator writes to disk — e.g. `sourcecrawls` for `SourceCrawl`,
+  // NOT the snake_case `tableName` (`source_crawls`). The tableName-based
+  // derivation below is only a fallback for older smrt-core builds that
+  // didn't store `collection` on the registered class.
   const collection =
+    registered.collection ??
     deriveCollectionFromConfig(decoratorConfig) ??
     classnameToTablename(registered.name);
 


### PR DESCRIPTION
## Summary

`createResourceListHandler` (added in #1311) walks `ObjectRegistry.getAllClasses()` at runtime to build the CLI resource list. But `RegisteredClass` dropped the manifest's pluralized `collection` during registration, so the handler fell back to deriving the URL segment from `tableName`.

That's wrong whenever `collection` ≠ `tableName`:

| Class | collection (endpoint) | tableName (storage) |
|---|---|---|
| `SourceCrawl` | `sourcecrawls` | `source_crawls` |
| `SkillCategory` | `skillcategories` | `skill_categories` |
| `Education` | `educations` | `education` (uncountable) |
| `EmploymentPerson` | `employmentpersons` | `people` (overridden) |

The generated SvelteKit route lives at `/api/<collection>/`, so the CLI **404'd on every multi-word resource**. Single-word names (`Company` → `companies` == `companies`) coincide, which is why every mocked test passed and the round 1–4 reviews missed it.

**Surfaced by the willgriffin.dev consumer migration** — exactly the e2e gap reviewer D flagged in the #1311 review rounds (all handler tests mocked the registry; none exercised a real multi-word class through registration).

## Fix

- Store `collection` (plus `tools` and `extendsTypeArg`, both also read by the handler) on `RegisteredClass` in **both** registration paths: `registerFromManifest` and the decorator `register()` path.
- Prefer the manifest's computed `collection` (handles STI inheritance and any future inflection changes). Fall back to a `pluralizeCollection` helper that mirrors the scanner's simple inflection (`y→ies`, `s/x/z/ch/sh→es`, else `+s` — naive, no irregular plurals) for inline/test classes with no manifest entry.
- `createResourceListHandler` now reads `registered.collection` verbatim; the old `tableName`-based derivation is kept only as a fallback for pre-0.26.4 cores.

## Test plan

- [x] New `issue-1311-registry-collection.test.ts`: registry stores collection verbatim when it diverges from tableName; pluralize fallback when manifest omits it.
- [x] Handler test: builds correct `apiPath` for `SourceCrawl`→`sourcecrawls` and `Education`→`educations` (collection ≠ tableName).
- [x] Full smrt-core suite green (1734 passed, 2 skipped).
- [x] smrt-users handler suite green (28 passed).
- [x] biome clean on all touched files.

## Release / downstream

Needs a 0.26.4 release. willgriffin.dev (and ergot.io / anytown.ai) will bump to it to complete their smrt-app-cli CLI migrations — the migration is blocked on this fix.