### PR TITLE
feat: complete monorepo FK-relationship declaration sweep (R1)

### DIFF
--- a/packages/ads/src/models/AdEvent.ts
+++ b/packages/ads/src/models/AdEvent.ts
@@ -3,7 +3,12 @@
  * @packageDocumentation
  */
 
-import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import { AdEventType } from '../types/index.js';
 
@@ -63,6 +68,7 @@ export class AdEvent extends SmrtObject {
   /**
    * Zone ID (FK to smrt-properties Zone, cross-package)
    */
+  @crossPackageRef('@happyvertical/smrt-properties:Zone')
   zoneId: string = '';
 
   /**

--- a/packages/ads/src/models/AdGroup.ts
+++ b/packages/ads/src/models/AdGroup.ts
@@ -3,7 +3,12 @@
  * @packageDocumentation
  */
 
-import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import { AdGroupStatus } from '../types/index.js';
 
@@ -49,6 +54,7 @@ export class AdGroup extends SmrtObject {
   /**
    * Contract ID (FK to smrt-commerce Contract, cross-package)
    */
+  @crossPackageRef('@happyvertical/smrt-commerce:Contract')
   contractId: string = '';
 
   /**

--- a/packages/ads/src/models/AdVariation.ts
+++ b/packages/ads/src/models/AdVariation.ts
@@ -3,7 +3,12 @@
  * @packageDocumentation
  */
 
-import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import { AdVariationStatus } from '../types/index.js';
 
@@ -58,6 +63,7 @@ export class AdVariation extends SmrtObject {
   /**
    * Asset ID (FK to smrt-assets Asset, cross-package)
    */
+  @crossPackageRef('@happyvertical/smrt-assets:Asset')
   assetId: string = '';
 
   /**

--- a/packages/affiliates/src/models/Commission.ts
+++ b/packages/affiliates/src/models/Commission.ts
@@ -3,7 +3,12 @@
  * @packageDocumentation
  */
 
-import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { CommissionStatus, CommissionType } from '../types/index.js';
 
 /**
@@ -65,6 +70,7 @@ export class Commission extends SmrtObject {
   /**
    * Ad Event ID (FK to smrt-ads AdEvent, cross-package)
    */
+  @crossPackageRef('@happyvertical/smrt-ads:AdEvent')
   eventId: string = '';
 
   /**

--- a/packages/affiliates/src/models/Partner.ts
+++ b/packages/affiliates/src/models/Partner.ts
@@ -3,7 +3,12 @@
  * @packageDocumentation
  */
 
-import { crossPackageRef, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { PartnerStatus, PartnerType, PayoutMethod } from '../types/index.js';
 
 /**
@@ -76,12 +81,14 @@ export class Partner extends SmrtObject {
    * Parent partner ID (self-reference)
    * For site-attached salespeople, this is the publisher they work under
    */
+  @foreignKey('Partner')
   parentPartnerId: string = '';
 
   /**
    * Referred by partner ID (self-reference)
    * Tracks who referred this partner for referral commission attribution
    */
+  @foreignKey('Partner')
   referredById: string = '';
 
   /**

--- a/packages/affiliates/src/models/Partner.ts
+++ b/packages/affiliates/src/models/Partner.ts
@@ -3,7 +3,7 @@
  * @packageDocumentation
  */
 
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { crossPackageRef, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { PartnerStatus, PartnerType, PayoutMethod } from '../types/index.js';
 
 /**
@@ -56,12 +56,14 @@ export class Partner extends SmrtObject {
   /**
    * Profile ID (FK to smrt-profiles Profile, cross-package)
    */
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile')
   profileId: string = '';
 
   /**
    * Property ID (FK to smrt-properties Property, cross-package)
    * Only set for publisher partners
    */
+  @crossPackageRef('@happyvertical/smrt-properties:Property')
   propertyId: string = '';
 
   /**

--- a/packages/affiliates/src/models/Payout.ts
+++ b/packages/affiliates/src/models/Payout.ts
@@ -3,7 +3,12 @@
  * @packageDocumentation
  */
 
-import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { PayoutStatus } from '../types/index.js';
 
 /**
@@ -101,6 +106,7 @@ export class Payout extends SmrtObject {
    * Invoice ID when payout is processed (FK to smrt-commerce Invoice)
    * Partner is treated as a Vendor for payout invoices
    */
+  @crossPackageRef('@happyvertical/smrt-commerce:Invoice')
   invoiceId: string = '';
 
   /**

--- a/packages/analytics/src/models/AnalyticsDataStream.ts
+++ b/packages/analytics/src/models/AnalyticsDataStream.ts
@@ -3,7 +3,7 @@
  * @packageDocumentation
  */
 
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { DataStreamStatus, DataStreamType } from '../types/index.js';
 
 /**
@@ -30,6 +30,7 @@ export class AnalyticsDataStream extends SmrtObject {
   /**
    * Parent property ID (references AnalyticsProperty)
    */
+  @foreignKey('AnalyticsProperty')
   propertyId: string = '';
 
   /**

--- a/packages/analytics/src/models/AnalyticsEvent.ts
+++ b/packages/analytics/src/models/AnalyticsEvent.ts
@@ -3,7 +3,7 @@
  * @packageDocumentation
  */
 
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TrackingEventStatus } from '../types/index.js';
 
 /**
@@ -30,6 +30,7 @@ export class AnalyticsEvent extends SmrtObject {
   /**
    * Parent property ID (references AnalyticsProperty)
    */
+  @foreignKey('AnalyticsProperty')
   propertyId: string = '';
 
   /**

--- a/packages/analytics/src/models/AnalyticsReport.ts
+++ b/packages/analytics/src/models/AnalyticsReport.ts
@@ -3,7 +3,7 @@
  * @packageDocumentation
  */
 
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { resolvePrompt } from '@happyvertical/smrt-prompts';
 import {
   promptMessageOptions,
@@ -36,6 +36,7 @@ export class AnalyticsReport extends SmrtObject {
   /**
    * Parent property ID (references AnalyticsProperty)
    */
+  @foreignKey('AnalyticsProperty')
   propertyId: string = '';
 
   /**

--- a/packages/assets/src/asset-association.ts
+++ b/packages/assets/src/asset-association.ts
@@ -5,7 +5,7 @@
  * (e.g., Article, Profile, Event) with role-based categorization.
  */
 
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { field, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import type { AssetAssociationOptions } from './types';
 
 @smrt({
@@ -16,7 +16,7 @@ import type { AssetAssociationOptions } from './types';
 })
 export class AssetAssociation extends SmrtObject {
   /** FK to Asset.id */
-  @field({ required: true })
+  @foreignKey('Asset', { required: true })
   assetId = '';
 
   /** Target class name or qualified name (e.g., 'Article' or '@pkg:Article') */

--- a/packages/assets/src/asset.ts
+++ b/packages/assets/src/asset.ts
@@ -84,6 +84,9 @@ export class Asset extends SmrtObject {
   version = 1; // Version number
 
   // Foreign key references (stored as IDs/slugs)
+  // Self-referential: the version chain points at the first version's
+  // Asset record (createNewVersion() chains via primaryVersionId).
+  @foreignKey('Asset')
   primaryVersionId: string | null = null; // Points to first version's ID
   typeSlug = ''; // FK to AssetType.slug
   statusSlug = ''; // FK to AssetStatus.slug

--- a/packages/assets/src/asset.ts
+++ b/packages/assets/src/asset.ts
@@ -13,6 +13,8 @@
  */
 
 import {
+  crossPackageRef,
+  foreignKey,
   ObjectRegistry,
   type SmrtCollection,
   SmrtObject,
@@ -85,6 +87,7 @@ export class Asset extends SmrtObject {
   primaryVersionId: string | null = null; // Points to first version's ID
   typeSlug = ''; // FK to AssetType.slug
   statusSlug = ''; // FK to AssetStatus.slug
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile')
   ownerProfileId: string | null = null; // FK to Profile.id (nullable)
   /**
    * FK to the source Asset this one was derived from (e.g. thumbnail
@@ -95,7 +98,9 @@ export class Asset extends SmrtObject {
    * (SmrtHierarchical) across the framework. The column on the assets
    * table is `source_asset_id`.
    */
+  @foreignKey('Asset')
   sourceAssetId: string | null = null;
+  @foreignKey('Folder')
   folderId: string | null = null; // FK to Folder.id
 
   // Provenance fields

--- a/packages/assets/src/folder.ts
+++ b/packages/assets/src/folder.ts
@@ -23,7 +23,11 @@
  * @see Asset.sourceAssetId for the renamed derivation pointer.
  */
 
-import { SmrtHierarchical, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  SmrtHierarchical,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { FolderOptions } from './types';
 
@@ -43,6 +47,7 @@ export class Folder extends SmrtHierarchical {
   name = '';
   // `slug` is inherited as an accessor from SmrtObject.
   description = '';
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile')
   ownerProfileId: string | null = null;
 
   // Timestamps

--- a/packages/chat/src/models/AgentSession.ts
+++ b/packages/chat/src/models/AgentSession.ts
@@ -1,4 +1,10 @@
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { AgentSessionOptions, AgentSessionStatus } from '../types.js';
 
@@ -16,10 +22,10 @@ export class AgentSession extends SmrtObject {
   @field({ required: true })
   agentId: string = '';
 
-  @field({ required: true })
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile', { required: true })
   participantProfileId: string = '';
 
-  @field()
+  @foreignKey('ChatRoom')
   chatRoomId: string | null = null;
 
   @field({ required: true })

--- a/packages/chat/src/models/ChatMessage.ts
+++ b/packages/chat/src/models/ChatMessage.ts
@@ -1,4 +1,10 @@
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type {
   ChatMessageOptions,
@@ -17,13 +23,13 @@ export class ChatMessage extends SmrtObject {
   @tenantId()
   tenantId: string = '';
 
-  @field({ required: true })
+  @foreignKey('ChatRoom', { required: true })
   roomId: string = '';
-  @field()
+  @foreignKey('ChatThread')
   threadId: string | null = null;
-  @field({ required: true })
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile', { required: true })
   senderProfileId: string = '';
-  @field()
+  @foreignKey('AgentSession')
   agentSessionId: string | null = null;
 
   @field()
@@ -39,7 +45,7 @@ export class ChatMessage extends SmrtObject {
   editedAt: Date | null = null;
   @field()
   isDeleted: boolean = false;
-  @field()
+  @foreignKey('ChatMessage')
   replyToMessageId: string | null = null;
 
   @field()

--- a/packages/chat/src/models/ChatParticipant.ts
+++ b/packages/chat/src/models/ChatParticipant.ts
@@ -1,4 +1,10 @@
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type {
   ChatParticipantOptions,
@@ -18,9 +24,9 @@ export class ChatParticipant extends SmrtObject {
   @tenantId()
   tenantId: string = '';
 
-  @field({ required: true })
+  @foreignKey('ChatRoom', { required: true })
   roomId: string = '';
-  @field({ required: true })
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile', { required: true })
   profileId: string = '';
   @field({ required: true })
   role: ChatParticipantRole = 'member';
@@ -28,7 +34,7 @@ export class ChatParticipant extends SmrtObject {
   status: ChatParticipantStatus = 'active';
   @field({ required: true })
   onlineStatus: OnlineStatus = 'offline';
-  @field()
+  @foreignKey('ChatMessage')
   lastReadMessageId: string | null = null;
   @field()
   lastSeenAt: Date | null = null;

--- a/packages/chat/src/models/ChatReaction.ts
+++ b/packages/chat/src/models/ChatReaction.ts
@@ -1,4 +1,10 @@
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { ChatReactionOptions } from '../types.js';
 
@@ -13,9 +19,9 @@ export class ChatReaction extends SmrtObject {
   @tenantId()
   tenantId: string = '';
 
-  @field({ required: true })
+  @foreignKey('ChatMessage', { required: true })
   messageId: string = '';
-  @field({ required: true })
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile', { required: true })
   profileId: string = '';
   @field({ required: true })
   emoji: string = '';

--- a/packages/chat/src/models/ChatRoom.ts
+++ b/packages/chat/src/models/ChatRoom.ts
@@ -1,4 +1,9 @@
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  field,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type {
   ChatRoomOptions,
@@ -46,7 +51,7 @@ export class ChatRoom extends SmrtObject {
   maxParticipants: number = 0;
   @field()
   metadata: string = '{}';
-  @field()
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile')
   createdByProfileId: string = '';
   @field()
   lastMessageAt: Date | null = null;

--- a/packages/chat/src/models/ChatThread.ts
+++ b/packages/chat/src/models/ChatThread.ts
@@ -1,4 +1,4 @@
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { field, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { ChatThreadOptions } from '../types.js';
 
@@ -13,9 +13,9 @@ export class ChatThread extends SmrtObject {
   @tenantId()
   tenantId: string = '';
 
-  @field({ required: true })
+  @foreignKey('ChatRoom', { required: true })
   roomId: string = '';
-  @field()
+  @foreignKey('ChatMessage')
   rootMessageId: string = '';
   @field()
   title: string = '';

--- a/packages/commerce/src/models/ContractLineItem.ts
+++ b/packages/commerce/src/models/ContractLineItem.ts
@@ -3,7 +3,12 @@
  * @packageDocumentation
  */
 
-import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 
 /**
@@ -77,6 +82,7 @@ export class ContractLineItem extends SmrtObject {
   /**
    * Optional product reference (cross-package, plain string)
    */
+  @crossPackageRef('@happyvertical/smrt-products:Product')
   productId: string = '';
 
   /**

--- a/packages/commerce/src/models/Customer.ts
+++ b/packages/commerce/src/models/Customer.ts
@@ -3,7 +3,7 @@
  * @packageDocumentation
  */
 
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { crossPackageRef, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import { type Address, CustomerStatus } from '../types/index.js';
 
@@ -40,6 +40,7 @@ export class Customer extends SmrtObject {
    * Reference to smrt-profiles Profile
    * Plain string for cross-package reference
    */
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile')
   profileId: string = '';
 
   /**

--- a/packages/commerce/src/models/Invoice.ts
+++ b/packages/commerce/src/models/Invoice.ts
@@ -3,7 +3,12 @@
  * @packageDocumentation
  */
 
-import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import { InvoiceStatus, type RecognizeRevenueOptions } from '../types/index.js';
 
@@ -62,6 +67,7 @@ export class Invoice extends SmrtObject {
   /**
    * Optional link to Contract (cross-package reference)
    */
+  @foreignKey('Contract')
   contractId: string = '';
 
   // ============================================================================
@@ -143,11 +149,13 @@ export class Invoice extends SmrtObject {
   /**
    * Journal ID for AR recognition (cross-package ref to smrt-ledgers)
    */
+  @crossPackageRef('@happyvertical/smrt-ledgers:Journal')
   arJournalId: string = '';
 
   /**
    * Journal ID for revenue recognition (cross-package ref to smrt-ledgers)
    */
+  @crossPackageRef('@happyvertical/smrt-ledgers:Journal')
   revenueJournalId: string = '';
 
   // ============================================================================

--- a/packages/commerce/src/models/InvoiceLineItem.ts
+++ b/packages/commerce/src/models/InvoiceLineItem.ts
@@ -3,7 +3,12 @@
  * @packageDocumentation
  */
 
-import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 
 /**
@@ -114,6 +119,7 @@ export class InvoiceLineItem extends SmrtObject {
    * Revenue account ID (cross-package ref to smrt-ledgers)
    * Used for revenue recognition to specific accounts
    */
+  @crossPackageRef('@happyvertical/smrt-ledgers:Account')
   revenueAccountId: string = '';
 
   /**

--- a/packages/commerce/src/models/Payment.ts
+++ b/packages/commerce/src/models/Payment.ts
@@ -3,7 +3,12 @@
  * @packageDocumentation
  */
 
-import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import {
   PaymentMethod,
@@ -95,6 +100,7 @@ export class Payment extends SmrtObject {
   /**
    * Link to smrt-ledgers Journal (created by recordPayment)
    */
+  @crossPackageRef('@happyvertical/smrt-ledgers:Journal')
   journalId: string = '';
 
   /**

--- a/packages/commerce/src/models/Vendor.ts
+++ b/packages/commerce/src/models/Vendor.ts
@@ -3,7 +3,7 @@
  * @packageDocumentation
  */
 
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { crossPackageRef, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import { VendorStatus } from '../types/index.js';
 
@@ -41,6 +41,7 @@ export class Vendor extends SmrtObject {
    * Reference to smrt-profiles Profile
    * Plain string for cross-package reference
    */
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile')
   profileId: string = '';
 
   /**

--- a/packages/content/src/content-asset.ts
+++ b/packages/content/src/content-asset.ts
@@ -1,5 +1,11 @@
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 
 export interface ContentAssetOptions extends SmrtObjectOptions {
@@ -22,10 +28,10 @@ export class ContentAsset extends SmrtObject {
   @tenantId({ nullable: true })
   tenantId: string | null = null;
 
-  @field({ required: true })
+  @foreignKey('Content', { required: true })
   contentId = '';
 
-  @field({ required: true })
+  @crossPackageRef('@happyvertical/smrt-assets:Asset', { required: true })
   assetId = '';
 
   @field({ required: true })

--- a/packages/content/src/content-contribution-attachment.ts
+++ b/packages/content/src/content-contribution-attachment.ts
@@ -1,5 +1,10 @@
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { ContentContributionChannel } from './content-contribution-config';
 
@@ -52,17 +57,22 @@ function parseMetadata(raw: unknown): Record<string, any> {
   cli: true,
 })
 export class ContentContributionAttachment extends SmrtObject {
-  @field({ required: true })
+  @foreignKey('ContentContribution', { required: true })
   contributionId = '';
 
+  @foreignKey('ContentContributionRevision')
   revisionId = '';
+
   filename = '';
   mimeType = '';
   size = 0;
   fileKey = '';
   sourceUri = '';
   channel: ContentContributionChannel = 'web';
+
+  @crossPackageRef('@happyvertical/smrt-assets:Asset')
   promotedAssetId = '';
+
   metadata = '';
 
   @tenantId({ nullable: true })

--- a/packages/content/src/content-contribution-revision.ts
+++ b/packages/content/src/content-contribution-revision.ts
@@ -1,5 +1,10 @@
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { ContentContributionChannel } from './content-contribution-config';
 
@@ -50,7 +55,7 @@ function parseMetadata(raw: unknown): Record<string, any> {
   cli: true,
 })
 export class ContentContributionRevision extends SmrtObject {
-  @field({ required: true })
+  @foreignKey('ContentContribution', { required: true })
   contributionId = '';
 
   revisionNumber = 1;
@@ -58,7 +63,10 @@ export class ContentContributionRevision extends SmrtObject {
   title = '';
   description = '';
   body = '';
+
+  @crossPackageRef('@happyvertical/smrt-messages:Message')
   sourceMessageId = '';
+
   sourceThreadKey = '';
   metadata = '';
 

--- a/packages/content/src/content-contribution.ts
+++ b/packages/content/src/content-contribution.ts
@@ -4,7 +4,13 @@ import {
   AssetTypeCollection,
 } from '@happyvertical/smrt-assets';
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { ContentContributionAttachment } from './content-contribution-attachment';
 import {
@@ -154,7 +160,7 @@ function inferAssetTypeSlug(mimeType: string): string {
   cli: true,
 })
 export class ContentContribution extends SmrtObject {
-  @field({ required: true })
+  @foreignKey('ContentContributor', { required: true })
   contributorId = '';
 
   @field({ required: true })
@@ -169,8 +175,13 @@ export class ContentContribution extends SmrtObject {
   contributorEmail = '';
   contributorName = '';
   threadKey = '';
+
+  @crossPackageRef('@happyvertical/smrt-messages:Message')
   sourceMessageId = '';
+
   editorNotes = '';
+
+  @foreignKey('Content')
   promotedContentId = '';
   revisionCount = 0;
   approvedAt: Date | null = null;

--- a/packages/content/src/content-contributor.ts
+++ b/packages/content/src/content-contributor.ts
@@ -1,5 +1,10 @@
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  field,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { ContentContributorTrustLevel } from './content-contribution-config';
 
@@ -46,6 +51,7 @@ function parseMetadata(raw: unknown): Record<string, any> {
   cli: true,
 })
 export class ContentContributor extends SmrtObject {
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile')
   profileId = '';
 
   @field({ required: true })

--- a/packages/content/src/content-correction.ts
+++ b/packages/content/src/content-correction.ts
@@ -1,5 +1,10 @@
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type {
   ContentCorrectionStatus,
@@ -32,11 +37,16 @@ export interface ContentCorrectionOptions extends SmrtObjectOptions {
   cli: true,
 })
 export class ContentCorrection extends SmrtObject {
-  @field({ required: true })
+  @foreignKey('Content', { required: true })
   contentId = '';
 
+  @foreignKey('ContentVersion')
   contentVersionId = '';
+
+  @crossPackageRef('@happyvertical/smrt-facts:Fact')
   factId = '';
+
+  @crossPackageRef('@happyvertical/smrt-facts:Fact')
   replacementFactId = '';
   correctionType: ContentCorrectionType = 'fact';
   status: ContentCorrectionStatus = 'draft';

--- a/packages/content/src/content-reference.ts
+++ b/packages/content/src/content-reference.ts
@@ -1,5 +1,5 @@
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { field, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 
 export interface ContentReferenceOptions extends SmrtObjectOptions {
@@ -18,10 +18,10 @@ export class ContentReference extends SmrtObject {
   @tenantId({ nullable: true })
   tenantId: string | null = null;
 
-  @field({ required: true })
+  @foreignKey('Content', { required: true })
   sourceId = '';
 
-  @field({ required: true })
+  @foreignKey('Content', { required: true })
   targetId = '';
 
   @field()

--- a/packages/content/src/content-review.ts
+++ b/packages/content/src/content-review.ts
@@ -1,5 +1,5 @@
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type {
   ContentReviewFinding,
@@ -30,9 +30,10 @@ export interface ContentReviewOptions extends SmrtObjectOptions {
   cli: true,
 })
 export class ContentReview extends SmrtObject {
-  @field({ required: true })
+  @foreignKey('Content', { required: true })
   contentId = '';
 
+  @foreignKey('ContentVersion')
   contentVersionId = '';
   kind: ContentReviewKind = 'custom';
   policyKey = '';

--- a/packages/content/src/content-types.ts
+++ b/packages/content/src/content-types.ts
@@ -5,7 +5,7 @@
  * contents table with _meta_type discriminator.
  */
 
-import { smrt } from '@happyvertical/smrt-core';
+import { foreignKey, smrt } from '@happyvertical/smrt-core';
 import { Content, type ContentOptions } from './content';
 
 /**
@@ -75,6 +75,7 @@ function parseOptionalDate(
   cli: false,
 })
 export class Mirror extends Content {
+  @foreignKey('ContentFeedSource')
   feedSourceId: string | null = null;
   sourceGuid: string | null = null;
   sourceName: string | null = null;

--- a/packages/content/src/content-version.ts
+++ b/packages/content/src/content-version.ts
@@ -1,5 +1,5 @@
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { ContentVersionKind } from './content-governance';
 import { normalizeContentTransparency } from './content-transparency';
@@ -34,7 +34,7 @@ export interface ContentVersionOptions extends SmrtObjectOptions {
   cli: true,
 })
 export class ContentVersion extends SmrtObject {
-  @field({ required: true })
+  @foreignKey('Content', { required: true })
   contentId = '';
 
   version = 1;

--- a/packages/content/src/content.ts
+++ b/packages/content/src/content.ts
@@ -1,6 +1,7 @@
 import { type Asset, AssetCollection } from '@happyvertical/smrt-assets';
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
 import {
+  crossPackageRef,
   field,
   SmrtObject,
   smrt,
@@ -639,6 +640,7 @@ export class Content
   /**
    * ID of the thumbnail asset for this content
    */
+  @crossPackageRef('@happyvertical/smrt-assets:Asset')
   public thumbnailAssetId: string | null = null;
 
   /**

--- a/packages/events/src/models/Event.ts
+++ b/packages/events/src/models/Event.ts
@@ -10,7 +10,12 @@ import {
   assertValidOwnedAssetSortOrder,
   resolveOwnedAssetsById,
 } from '@happyvertical/smrt-assets';
-import { SmrtHierarchical, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtHierarchical,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { EventOptions, EventStatus } from '../types';
 
@@ -26,9 +31,12 @@ export class Event extends SmrtHierarchical {
   tenantId: string | null = null;
 
   name: string = '';
+  @foreignKey('EventSeries')
   seriesId = ''; // FK to EventSeries (nullable for standalone events)
   // parentId inherited from SmrtHierarchical (self-reference to parent Event)
+  @foreignKey('EventType')
   typeId = ''; // FK to EventType
+  @crossPackageRef('@happyvertical/smrt-places:Place')
   placeId = ''; // FK to Place (from @happyvertical/smrt-places)
   description = '';
   startDate: Date | null = null;

--- a/packages/events/src/models/EventAsset.ts
+++ b/packages/events/src/models/EventAsset.ts
@@ -1,5 +1,11 @@
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 
 export interface EventAssetOptions extends SmrtObjectOptions {
@@ -22,10 +28,10 @@ export class EventAsset extends SmrtObject {
   @tenantId({ nullable: true })
   tenantId: string | null = null;
 
-  @field({ required: true })
+  @foreignKey('Event', { required: true })
   eventId = '';
 
-  @field({ required: true })
+  @crossPackageRef('@happyvertical/smrt-assets:Asset', { required: true })
   assetId = '';
 
   @field({ required: true })

--- a/packages/events/src/models/EventParticipant.ts
+++ b/packages/events/src/models/EventParticipant.ts
@@ -4,7 +4,12 @@
  * Tracks who participated in an event with role and placement
  */
 
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { EventParticipantOptions } from '../types';
 
@@ -23,7 +28,9 @@ export class EventParticipant extends SmrtObject {
 
   // id inherited from SmrtObject
 
+  @foreignKey('Event')
   eventId = ''; // FK to Event
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile')
   profileId = ''; // FK to Profile (from @happyvertical/smrt-profiles)
   role: string = ''; // Participant role (ParticipantRole or custom)
   placement: number | null = null; // Numeric position/placement

--- a/packages/events/src/models/EventSeries.ts
+++ b/packages/events/src/models/EventSeries.ts
@@ -4,7 +4,12 @@
  * Examples: '2024 NBA Finals', 'Summer Tour 2024', 'Town Council 2024'
  */
 
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { EventSeriesOptions, RecurrencePattern } from '../types';
 
@@ -20,7 +25,9 @@ export class EventSeries extends SmrtObject {
   tenantId: string | null = null;
 
   name: string = '';
+  @foreignKey('EventType')
   typeId = ''; // FK to EventType
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile')
   organizerId = ''; // FK to Profile (from @happyvertical/smrt-profiles)
   description = '';
   startDate: Date | null = null;

--- a/packages/facts/src/fact-content.ts
+++ b/packages/facts/src/fact-content.ts
@@ -5,7 +5,13 @@
  * with relationship classification and metadata.
  */
 
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { FactContentOptions, FactContentRelationship } from './types';
 
@@ -17,10 +23,10 @@ import type { FactContentOptions, FactContentRelationship } from './types';
   cli: true,
 })
 export class FactContent extends SmrtObject {
-  @field({ required: true })
+  @foreignKey('Fact', { required: true })
   factId: string = '';
 
-  @field({ required: true })
+  @crossPackageRef('@happyvertical/smrt-content:Content', { required: true })
   contentId: string = '';
 
   @field({ required: true })

--- a/packages/facts/src/fact-evidence.ts
+++ b/packages/facts/src/fact-evidence.ts
@@ -5,7 +5,7 @@
  * concrete excerpt/span/artifact that supports a fact.
  */
 
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { field, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { FactEvidenceOptions, FactEvidenceStatus } from './types';
 
@@ -34,7 +34,7 @@ function normalizeFactEvidenceStatus(
   cli: true,
 })
 export class FactEvidence extends SmrtObject {
-  @field({ required: true })
+  @foreignKey('Fact', { required: true })
   factId: string = '';
 
   @field({ required: true })

--- a/packages/facts/src/fact-source.ts
+++ b/packages/facts/src/fact-source.ts
@@ -5,7 +5,7 @@
  * credibility, and extraction timestamp.
  */
 
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { field, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { FactSourceOptions } from './types';
 
@@ -17,7 +17,7 @@ import type { FactSourceOptions } from './types';
   cli: true,
 })
 export class FactSource extends SmrtObject {
-  @field({ required: true })
+  @foreignKey('Fact', { required: true })
   factId: string = '';
 
   @field()

--- a/packages/facts/src/fact-subject.ts
+++ b/packages/facts/src/fact-subject.ts
@@ -5,7 +5,7 @@
  * using polymorphic entityType + entityId with role classification.
  */
 
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { field, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { FactSubjectOptions, SubjectRole } from './types';
 
@@ -17,7 +17,7 @@ import type { FactSubjectOptions, SubjectRole } from './types';
   cli: true,
 })
 export class FactSubject extends SmrtObject {
-  @field({ required: true })
+  @foreignKey('Fact', { required: true })
   factId: string = '';
 
   @field({ required: true })

--- a/packages/facts/src/fact-tag.ts
+++ b/packages/facts/src/fact-tag.ts
@@ -5,7 +5,7 @@
  * enabling categorization and discovery of facts.
  */
 
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { field, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { FactTagOptions } from './types';
 
@@ -17,7 +17,7 @@ import type { FactTagOptions } from './types';
   cli: true,
 })
 export class FactTag extends SmrtObject {
-  @field({ required: true })
+  @foreignKey('Fact', { required: true })
   factId: string = '';
 
   @field({ required: true })

--- a/packages/facts/src/fact.ts
+++ b/packages/facts/src/fact.ts
@@ -13,7 +13,7 @@
  * semantic distinction.
  */
 
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { field, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type {
   EvolutionType,
@@ -63,7 +63,7 @@ export class Fact extends SmrtObject {
    * fact, then corrections, refinements, contradictions, or extensions of
    * that fact. See `evolutionType` for the kind of step.
    */
-  @field()
+  @foreignKey('Fact')
   previousFactId: string = '';
 
   @field()

--- a/packages/jobs/src/smrt-job-event.ts
+++ b/packages/jobs/src/smrt-job-event.ts
@@ -5,6 +5,7 @@ import './__smrt-register__.js';
 import {
   ensureJobEventsSystemTableCompatibility,
   field,
+  foreignKey,
   SmrtCollection,
   SmrtObject,
   smrt,
@@ -66,7 +67,7 @@ export class SmrtJobEvent extends SmrtObject {
   @tenantId({ nullable: true })
   tenantId: string | null | undefined = undefined;
 
-  @field({ type: 'text', required: true })
+  @foreignKey('SmrtJob', { required: true })
   jobId: string = '';
 
   @field({ type: 'text', required: true, default: 'log' })

--- a/packages/ledgers/src/models/JournalEntry.ts
+++ b/packages/ledgers/src/models/JournalEntry.ts
@@ -5,7 +5,7 @@
  * Each entry belongs to a Journal and references an Account.
  */
 
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { JournalEntryOptions } from '../types';
 
@@ -25,11 +25,13 @@ export class JournalEntry extends SmrtObject {
   /**
    * Parent journal ID (required)
    */
+  @foreignKey('Journal', { required: true })
   journalId: string = '';
 
   /**
    * Account ID (required)
    */
+  @foreignKey('Account', { required: true })
   accountId: string = '';
 
   /**

--- a/packages/ledgers/src/models/JournalEntry.ts
+++ b/packages/ledgers/src/models/JournalEntry.ts
@@ -25,13 +25,13 @@ export class JournalEntry extends SmrtObject {
   /**
    * Parent journal ID (required)
    */
-  @foreignKey('Journal', { required: true })
+  @foreignKey('Journal')
   journalId: string = '';
 
   /**
    * Account ID (required)
    */
-  @foreignKey('Account', { required: true })
+  @foreignKey('Account')
   accountId: string = '';
 
   /**

--- a/packages/messages/src/models/Account.ts
+++ b/packages/messages/src/models/Account.ts
@@ -4,7 +4,7 @@
  * Common fields shared across email, Slack, Twitter accounts, etc.
  */
 
-import { crossPackageRef, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { AccountOptions, MessageSenderInterface } from '../types';
 
@@ -21,7 +21,10 @@ export class Account extends SmrtObject {
 
   name = '';
   providerType = '';
-  @crossPackageRef('@happyvertical/smrt-secrets:Secret')
+  // credentialSecretId stores the Secret's NAME (keyed by name + tenant
+  // context in smrt-secrets), NOT its primary-key id — see setCredentials()/
+  // getCredentials() which call secretService.store/retrieve by name. So it is
+  // deliberately NOT a @crossPackageRef id FK.
   credentialSecretId: string | null = null;
   isActive = true;
   lastSyncAt: Date | null = null;

--- a/packages/messages/src/models/Account.ts
+++ b/packages/messages/src/models/Account.ts
@@ -4,7 +4,7 @@
  * Common fields shared across email, Slack, Twitter accounts, etc.
  */
 
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { crossPackageRef, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { AccountOptions, MessageSenderInterface } from '../types';
 
@@ -21,6 +21,7 @@ export class Account extends SmrtObject {
 
   name = '';
   providerType = '';
+  @crossPackageRef('@happyvertical/smrt-secrets:Secret')
   credentialSecretId: string | null = null;
   isActive = true;
   lastSyncAt: Date | null = null;

--- a/packages/messages/src/models/Attachment.ts
+++ b/packages/messages/src/models/Attachment.ts
@@ -4,7 +4,7 @@
  * Uses messageId instead of emailId for cross-type support.
  */
 
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { AttachmentOptions } from '../types';
 
@@ -18,6 +18,7 @@ export class Attachment extends SmrtObject {
   @tenantId({ nullable: true })
   tenantId: string | null = null;
 
+  @foreignKey('Message')
   messageId = '';
   filename = '';
   contentType = '';

--- a/packages/messages/src/models/EmailFolder.ts
+++ b/packages/messages/src/models/EmailFolder.ts
@@ -2,7 +2,7 @@
  * EmailFolder model - Folder/label tracking
  */
 
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { EmailFolderOptions } from '../types';
 
@@ -16,6 +16,7 @@ export class EmailFolder extends SmrtObject {
   @tenantId({ nullable: true })
   tenantId: string | null = null;
 
+  @foreignKey('Account')
   accountId = '';
   name = '';
   path = '';

--- a/packages/messages/src/models/Message.ts
+++ b/packages/messages/src/models/Message.ts
@@ -4,7 +4,7 @@
  * Common fields shared across email, tweets, slack messages, etc.
  */
 
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type {
   MessageOptions,
@@ -24,6 +24,7 @@ export class Message extends SmrtObject {
   @tenantId({ nullable: true })
   tenantId: string | null = null;
 
+  @foreignKey('Account')
   accountId = '';
   threadId = '';
   subject = '';
@@ -45,6 +46,7 @@ export class Message extends SmrtObject {
   retryCount = 0;
   maxRetries = 3;
   scheduledSendAt: Date | null = null;
+  @foreignKey('Message')
   inReplyToMessageId = '';
 
   // Timestamps

--- a/packages/places/src/models/Place.ts
+++ b/packages/places/src/models/Place.ts
@@ -15,7 +15,12 @@ import {
   assertValidOwnedAssetSortOrder,
   resolveOwnedAssetsById,
 } from '@happyvertical/smrt-assets';
-import { field, SmrtHierarchical, smrt } from '@happyvertical/smrt-core';
+import {
+  field,
+  foreignKey,
+  SmrtHierarchical,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { GeoData, PlaceOptions } from '../types';
 
@@ -34,6 +39,7 @@ export class Place extends SmrtHierarchical {
   tenantId: string | null = null;
 
   // Core fields
+  @foreignKey('PlaceType')
   typeId = ''; // FK to PlaceType
   // parentId inherited from SmrtHierarchical (nullable, self-reference)
   name = ''; // Place name/title

--- a/packages/places/src/models/PlaceAsset.ts
+++ b/packages/places/src/models/PlaceAsset.ts
@@ -1,5 +1,11 @@
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 
 export interface PlaceAssetOptions extends SmrtObjectOptions {
@@ -22,10 +28,10 @@ export class PlaceAsset extends SmrtObject {
   @tenantId({ nullable: true })
   tenantId: string | null = null;
 
-  @field({ required: true })
+  @foreignKey('Place', { required: true })
   placeId = '';
 
-  @field({ required: true })
+  @crossPackageRef('@happyvertical/smrt-assets:Asset', { required: true })
   assetId = '';
 
   @field({ required: true })

--- a/packages/products/src/lib/models/Category.ts
+++ b/packages/products/src/lib/models/Category.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  foreignKey,
   SmrtObject,
   type SmrtObjectOptions,
   smrt,
@@ -38,6 +39,7 @@ export interface CategoryOptions extends SmrtObjectOptions {
 export class Category extends SmrtObject {
   name = '';
   description = '';
+  @foreignKey('Category')
   parentId?: string; // For hierarchical categories
   level = 0; // Category depth in hierarchy
   productCount = 0; // Number of products in this category

--- a/packages/products/src/lib/models/ProductAsset.ts
+++ b/packages/products/src/lib/models/ProductAsset.ts
@@ -1,5 +1,11 @@
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 
 export interface ProductAssetOptions extends SmrtObjectOptions {
   productId?: string;
@@ -16,10 +22,10 @@ export interface ProductAssetOptions extends SmrtObjectOptions {
   cli: false,
 })
 export class ProductAsset extends SmrtObject {
-  @field({ required: true })
+  @foreignKey('Product', { required: true })
   productId = '';
 
-  @field({ required: true })
+  @crossPackageRef('@happyvertical/smrt-assets:Asset', { required: true })
   assetId = '';
 
   @field({ required: true })

--- a/packages/profiles/src/models/ProfileAsset.ts
+++ b/packages/profiles/src/models/ProfileAsset.ts
@@ -1,5 +1,11 @@
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 
 export interface ProfileAssetOptions extends SmrtObjectOptions {
@@ -22,10 +28,10 @@ export class ProfileAsset extends SmrtObject {
   @tenantId({ nullable: true })
   tenantId: string | null = null;
 
-  @field({ required: true })
+  @foreignKey('Profile', { required: true })
   profileId = '';
 
-  @field({ required: true })
+  @crossPackageRef('@happyvertical/smrt-assets:Asset', { required: true })
   assetId = '';
 
   @field({ required: true })

--- a/packages/properties/src/models/Property.ts
+++ b/packages/properties/src/models/Property.ts
@@ -5,7 +5,7 @@
  * hierarchical zones for content/ad placement.
  */
 
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { crossPackageRef, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { resolvePrompt } from '@happyvertical/smrt-prompts';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import {
@@ -52,12 +52,14 @@ export class Property extends SmrtObject {
    * Link to Repository (from smrt-projects)
    * Optional - used when property is backed by a git repository
    */
+  @crossPackageRef('@happyvertical/smrt-projects:Repository')
   repositoryId: string | null = null;
 
   /**
    * Link to Profile (from smrt-profiles)
    * Optional - owner/publisher of the property
    */
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile')
   ownerId: string | null = null;
 
   /**

--- a/packages/properties/src/models/Zone.ts
+++ b/packages/properties/src/models/Zone.ts
@@ -5,7 +5,7 @@
  * They can be nested arbitrarily using the parentId self-reference.
  */
 
-import { SmrtHierarchical, smrt } from '@happyvertical/smrt-core';
+import { foreignKey, SmrtHierarchical, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { ZoneOptions, ZoneTreeNode } from '../types';
 
@@ -25,6 +25,7 @@ export class Zone extends SmrtHierarchical {
   /**
    * Parent property ID (required)
    */
+  @foreignKey('Property')
   propertyId: string = '';
 
   // parentId inherited from SmrtHierarchical (null = top-level zone)

--- a/packages/secrets/src/models/SecretAuditLog.ts
+++ b/packages/secrets/src/models/SecretAuditLog.ts
@@ -4,7 +4,12 @@
  */
 
 import type { SmrtCreateInput } from '@happyvertical/smrt-core';
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 
 /**
  * Secret audit action types
@@ -79,6 +84,7 @@ export class SecretAuditLog extends SmrtObject {
   /**
    * ID of the secret (may be null for deleted secrets)
    */
+  @foreignKey('Secret')
   secretId: string | null = null;
 
   /**
@@ -89,6 +95,7 @@ export class SecretAuditLog extends SmrtObject {
   /**
    * ID of the user who performed the action
    */
+  @crossPackageRef('@happyvertical/smrt-users:User')
   userId: string = '';
 
   /**

--- a/packages/sites/src/models/SiteAgentBinding.ts
+++ b/packages/sites/src/models/SiteAgentBinding.ts
@@ -8,7 +8,7 @@
  * means the agent is not enabled for that site.
  */
 
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { SiteAgentBindingOptions } from '../types';
 
@@ -25,6 +25,7 @@ export class SiteAgentBinding extends SmrtObject {
   tenantId: string = '';
 
   /** FK to sites table */
+  @foreignKey('Site')
   siteId: string = '';
 
   /** Agent class name, e.g. "Praeco" */

--- a/packages/social/src/social-post.ts
+++ b/packages/social/src/social-post.ts
@@ -6,7 +6,12 @@
  */
 
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import { VideoContent } from '@happyvertical/smrt-video';
 import { SocialAccount } from './social-account.js';
@@ -228,6 +233,7 @@ export class SocialPost extends SmrtObject {
   /**
    * Generic content ID (for non-video content)
    */
+  @crossPackageRef('@happyvertical/smrt-content:Content')
   contentId: string | null = null;
 
   /**

--- a/packages/users/src/models/Session.ts
+++ b/packages/users/src/models/Session.ts
@@ -3,7 +3,7 @@
  * @packageDocumentation
  */
 
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { field, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { SessionStatus } from '../types/index.js';
 
 /**
@@ -47,12 +47,14 @@ export class Session extends SmrtObject {
   /**
    * User who owns this session
    */
+  @foreignKey('User')
   userId: string = '';
 
   /**
    * Tenant context for this session (for multi-tenant apps)
    * Null means no tenant context selected
    */
+  @foreignKey('Tenant', { nullable: true })
   tenantId: string | null = null;
 
   /**

--- a/packages/users/src/models/User.ts
+++ b/packages/users/src/models/User.ts
@@ -3,7 +3,12 @@
  * @packageDocumentation
  */
 
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  field,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { UserStatus } from '../types/index.js';
 
 /**
@@ -55,9 +60,9 @@ export function normalizeEmail(email: string): string {
 })
 export class User extends SmrtObject {
   /**
-   * Foreign key to smrt-profiles Profile
-   * Cross-package reference stored as plain string
+   * Foreign key to smrt-profiles Profile (cross-package)
    */
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile')
   profileId: string = '';
 
   /**

--- a/packages/video/src/character-owned-asset.ts
+++ b/packages/video/src/character-owned-asset.ts
@@ -1,6 +1,13 @@
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import { Character } from './character.js';
 import type { CharacterAssetRole } from './character-asset.js';
 
 export interface CharacterOwnedAssetOptions extends SmrtObjectOptions {
@@ -24,10 +31,10 @@ export class CharacterOwnedAsset extends SmrtObject {
   @tenantId({ nullable: true })
   tenantId: string | null = null;
 
-  @field({ required: true })
+  @foreignKey(() => Character, { required: true })
   characterId = '';
 
-  @field({ required: true })
+  @crossPackageRef('@happyvertical/smrt-assets:Asset', { required: true })
   assetId = '';
 
   @field({ required: true })

--- a/packages/video/src/character.ts
+++ b/packages/video/src/character.ts
@@ -11,7 +11,12 @@
 
 import type { Asset } from '@happyvertical/smrt-assets';
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { Profile } from '@happyvertical/smrt-profiles';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import { VoiceProfile } from '@happyvertical/smrt-voice';
@@ -167,9 +172,11 @@ export class Character extends SmrtObject {
   description: string | null = null;
 
   /** Asset ID of the seed image for I2V generation */
+  @crossPackageRef('@happyvertical/smrt-assets:Asset')
   imageAssetId: string | null = null;
 
   /** Asset ID of pre-baked base motion video */
+  @crossPackageRef('@happyvertical/smrt-assets:Asset')
   baseMotionAssetId: string | null = null;
 
   /** Voice profile ID for speech synthesis */

--- a/packages/video/src/character.ts
+++ b/packages/video/src/character.ts
@@ -17,9 +17,7 @@ import {
   SmrtObject,
   smrt,
 } from '@happyvertical/smrt-core';
-import { Profile } from '@happyvertical/smrt-profiles';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
-import { VoiceProfile } from '@happyvertical/smrt-voice';
 import type { CharacterAssetRole } from './character-asset.js';
 import {
   assertValidVideoAssetRole,
@@ -180,7 +178,7 @@ export class Character extends SmrtObject {
   baseMotionAssetId: string | null = null;
 
   /** Voice profile ID for speech synthesis */
-  @foreignKey(() => VoiceProfile)
+  @crossPackageRef('@happyvertical/smrt-voice:VoiceProfile')
   voiceProfileId: string | null = null;
 
   /** Branding configuration for video overlays */
@@ -201,7 +199,7 @@ export class Character extends SmrtObject {
   sceneConfigs: CharacterSceneConfig[] = [];
 
   /** 1-1 profile record for this character */
-  @foreignKey(() => Profile)
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile')
   profileId: string | null = null;
 
   constructor(options: CharacterOptions = {}) {

--- a/packages/video/src/composite-job.ts
+++ b/packages/video/src/composite-job.ts
@@ -5,8 +5,14 @@
  */
 
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import { Scene } from './scene.js';
 
 /**
  * Composite job status
@@ -89,9 +95,11 @@ export class CompositeJob extends SmrtObject {
   tenantId: string | null = null;
 
   /** Character video asset ID (after lip-sync) */
+  @crossPackageRef('@happyvertical/smrt-assets:Asset')
   characterVideoAssetId: string | null = null;
 
   /** Scene ID to composite onto */
+  @foreignKey(() => Scene)
   sceneId: string | null = null;
 
   /** Viewpoint ID (for 360° scenes) */
@@ -113,6 +121,7 @@ export class CompositeJob extends SmrtObject {
   progress: number = 0;
 
   /** Output video asset ID */
+  @crossPackageRef('@happyvertical/smrt-assets:Asset')
   outputAssetId: string | null = null;
 
   /** Error message if failed */

--- a/packages/video/src/performer-owned-asset.ts
+++ b/packages/video/src/performer-owned-asset.ts
@@ -1,6 +1,13 @@
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import { Performer } from './performer.js';
 import type { PerformerAssetRole } from './performer-asset.js';
 
 export interface PerformerOwnedAssetOptions extends SmrtObjectOptions {
@@ -24,10 +31,10 @@ export class PerformerOwnedAsset extends SmrtObject {
   @tenantId({ nullable: true })
   tenantId: string | null = null;
 
-  @field({ required: true })
+  @foreignKey(() => Performer, { required: true })
   performerId = '';
 
-  @field({ required: true })
+  @crossPackageRef('@happyvertical/smrt-assets:Asset', { required: true })
   assetId = '';
 
   @field({ required: true })

--- a/packages/video/src/performer.ts
+++ b/packages/video/src/performer.ts
@@ -8,15 +8,8 @@
 
 import type { Asset } from '@happyvertical/smrt-assets';
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import {
-  crossPackageRef,
-  foreignKey,
-  SmrtObject,
-  smrt,
-} from '@happyvertical/smrt-core';
-import { Profile } from '@happyvertical/smrt-profiles';
+import { crossPackageRef, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
-import { VoiceProfile } from '@happyvertical/smrt-voice';
 import {
   assertValidVideoAssetRole,
   assertValidVideoAssetSortOrder,
@@ -157,14 +150,14 @@ export class Performer extends SmrtObject {
   seedImageAssetId: string | null = null;
 
   /** Default voice profile for this performer */
-  @foreignKey(() => VoiceProfile)
+  @crossPackageRef('@happyvertical/smrt-voice:VoiceProfile')
   voiceProfileId: string | null = null;
 
   /** Performer status */
   status: PerformerStatus = 'pending';
 
   /** 1-1 profile record for this performer */
-  @foreignKey(() => Profile)
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile')
   profileId: string | null = null;
 
   constructor(options: PerformerOptions = {}) {

--- a/packages/video/src/performer.ts
+++ b/packages/video/src/performer.ts
@@ -8,9 +8,15 @@
 
 import type { Asset } from '@happyvertical/smrt-assets';
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { Profile } from '@happyvertical/smrt-profiles';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import { VoiceProfile } from '@happyvertical/smrt-voice';
 import {
   assertValidVideoAssetRole,
   assertValidVideoAssetSortOrder,
@@ -147,9 +153,11 @@ export class Performer extends SmrtObject {
   referenceAssetIds: string[] = [];
 
   /** Generated seed image asset ID */
+  @crossPackageRef('@happyvertical/smrt-assets:Asset')
   seedImageAssetId: string | null = null;
 
   /** Default voice profile for this performer */
+  @foreignKey(() => VoiceProfile)
   voiceProfileId: string | null = null;
 
   /** Performer status */

--- a/packages/video/src/scene-owned-asset.ts
+++ b/packages/video/src/scene-owned-asset.ts
@@ -1,6 +1,13 @@
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import { Scene } from './scene.js';
 import type { SceneAssetRole } from './scene-asset.js';
 
 export interface SceneOwnedAssetOptions extends SmrtObjectOptions {
@@ -24,10 +31,10 @@ export class SceneOwnedAsset extends SmrtObject {
   @tenantId({ nullable: true })
   tenantId: string | null = null;
 
-  @field({ required: true })
+  @foreignKey(() => Scene, { required: true })
   sceneId = '';
 
-  @field({ required: true })
+  @crossPackageRef('@happyvertical/smrt-assets:Asset', { required: true })
   assetId = '';
 
   @field({ required: true })

--- a/packages/video/src/scene.ts
+++ b/packages/video/src/scene.ts
@@ -7,7 +7,7 @@
 
 import type { Asset } from '@happyvertical/smrt-assets';
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { crossPackageRef, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import {
   assertValidVideoAssetRole,
@@ -193,6 +193,7 @@ export class Scene extends SmrtObject {
   description: string | null = null;
 
   /** Source media asset ID */
+  @crossPackageRef('@happyvertical/smrt-assets:Asset')
   sourceAssetId: string | null = null;
 
   /** Type of source media */

--- a/packages/voice/src/voice-output.ts
+++ b/packages/voice/src/voice-output.ts
@@ -6,7 +6,7 @@
  */
 
 import { Content, type ContentOptions } from '@happyvertical/smrt-content';
-import { foreignKey, smrt } from '@happyvertical/smrt-core';
+import { crossPackageRef, foreignKey, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped } from '@happyvertical/smrt-tenancy';
 import { VoiceProfile } from './voice-profile.js';
 
@@ -174,6 +174,7 @@ export class VoiceOutput extends Content {
   /**
    * Asset ID of the generated audio file
    */
+  @crossPackageRef('@happyvertical/smrt-assets:Asset')
   audioAssetId: string | null = null;
 
   /**

--- a/packages/voice/src/voice-profile.ts
+++ b/packages/voice/src/voice-profile.ts
@@ -7,7 +7,7 @@
  */
 
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { crossPackageRef, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 
 /**
@@ -180,6 +180,7 @@ export class VoiceProfile extends SmrtObject {
    * Asset ID of the audio sample for voice cloning
    * Should be at least 3 seconds of clear speech
    */
+  @crossPackageRef('@happyvertical/smrt-assets:Asset')
   sampleAssetId: string | null = null;
 
   /**

--- a/packages/voice/src/voice-sample.ts
+++ b/packages/voice/src/voice-sample.ts
@@ -6,7 +6,12 @@
  */
 
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
-import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import { VoiceProfile } from './voice-profile.js';
 
@@ -130,6 +135,7 @@ export class VoiceSample extends SmrtObject {
    * Asset ID of the audio file
    * References an Asset in smrt-assets
    */
+  @crossPackageRef('@happyvertical/smrt-assets:Asset')
   assetId: string | null = null;
 
   /**


### PR DESCRIPTION
## Summary

Declares **every** foreign-key reference across all domain packages with `@foreignKey` (same-package) / `@crossPackageRef` (cross-package), replacing the plain-string + doc-comment convention. Prerequisite for **R11** (native Postgres `uuid` id columns): a uuid PK needs its referencing FK columns to also be uuid, and the generator can only know/resolve that when the FK is declared.

Behavior-preserving: every field keeps its exact prior `required`/`nullable`; the decorators add relationship metadata + enable `loadRelated()` with **no** save-time validation (`crossPackageRef` validate stays opt-in/off) and **no** DB-level FK constraints (SMRT convention).

## Commits

1. **ads / affiliates / commerce** — 10 cross-package FKs (initial audited set)
2. **chat** — 15 FKs across 6 models
3. **profiles / ledgers / places / sites / users / messages / properties / secrets** — 14 FKs
4. **complete sweep** — assets, events, content, facts, video, voice, products, social + finish-ups (Partner self-refs, Session, Place.typeId). ~40 more fields across 41 files.

## Process

Round-1 review (copilot + claude sub-agent) of commits 1–3 found the "complete" claim was false — entire packages were unswept. The full sweep (commit 4) was executed by 9 package-scoped agents, each resolving every target against real exported classes, then centrally typechecked + tested.

**Corrections caught in review:**
- `ledgers/JournalEntry.{journalId,accountId}`: dropped `{required:true}` the earlier commit wrongly added (bare in base → restores behavior).
- `messages/Account.credentialSecretId`: **reverted** the `@crossPackageRef` — it stores the Secret's *name* (name+tenant-context keyed via `setCredentials`/`getCredentials`), not its PK id. Added an explanatory comment. (Caught by an agent noticing the identical `SocialAccount.credentialSecretId` name-not-id pattern.)

## Deliberately left undeclared

Polymorphic pairs (`entityId`/`entityType`, `sourceId`/`sourceKind`, `AuditLog.resourceId`); slug/name/key refs (`tagSlug`, `typeSlug`, `credentialSecretId`, `*Key`); external/provider ids (`platformUserId`, `nodeId`, GA4 `measurementId`, `tweetId`); JSON-array `*Ids`; loose agent refs (`agentId`, `agentClass` — agent ids may be composite); inherited `SmrtHierarchical.parentId` (a base-class R11 concern); and no-target fields (`Asset.primaryVersionId` — no Version class).

## Test plan

- [x] `turbo typecheck` clean across all touched packages
- [x] `turbo test` green (44/44 tasks on the 13 commit-4 packages; commits 1–3 packages green earlier)
- [x] `biome ci` clean
- [ ] Round-2 verify cycle (copilot + claude sub-agent + orchestrator; grok slot skipped — codex over-limit + grok 0.2.8 streaming bug → status partial)

## Note

`SmrtHierarchical.parentId` uuid-typing is handled at the base-class level in R11, not per-subclass here. `users/CLAUDE.md` calls `User.profileId` "plain string (not FK)" — now `@crossPackageRef` (value still a string); doc line to refresh later.