### PR TITLE
[codex] Fix test DB STI collection schemas

### DIFF
--- a/packages/core/src/__tests__/test-database-manifest-schema.test.ts
+++ b/packages/core/src/__tests__/test-database-manifest-schema.test.ts
@@ -310,4 +310,115 @@ describe('getTestDatabase manifest schemas', () => {
     expect(columnNames).toContain('_meta_data');
     expect(columnNames).toContain('name');
   });
+
+  it('maps collection subclasses to their inherited STI item schema before table creation', async () => {
+    ObjectRegistry.registerFromManifest(
+      '@test/messages:MessageCollection',
+      {
+        className: 'MessageCollection',
+        extends: 'SmrtCollection',
+        extendsTypeArg: 'Message',
+        fields: {},
+        methods: {},
+        decoratorConfig: {},
+        schema: {
+          tableName: 'message_collections',
+          ddl: '',
+          columns: {},
+          indexes: [],
+          version: 'test-version',
+        },
+      },
+      '@test/messages',
+    );
+
+    ObjectRegistry.registerFromManifest(
+      '@test/messages:EmailCollection',
+      {
+        className: 'EmailCollection',
+        extends: 'MessageCollection',
+        extendsTypeArg: null,
+        fields: {},
+        methods: {},
+        decoratorConfig: {
+          tableName: 'messages',
+        },
+        schema: {
+          tableName: 'messages',
+          ddl: `CREATE TABLE IF NOT EXISTS "messages" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "slug" TEXT NOT NULL,
+  "context" TEXT NOT NULL DEFAULT '',
+  "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp
+)`,
+          columns: {
+            id: { type: 'TEXT', notNull: true, primaryKey: true },
+            slug: { type: 'TEXT', notNull: true },
+            context: { type: 'TEXT', notNull: true, default: '' },
+            created_at: {
+              type: 'TIMESTAMP',
+              notNull: true,
+              default: 'current_timestamp',
+            },
+            updated_at: {
+              type: 'TIMESTAMP',
+              notNull: true,
+              default: 'current_timestamp',
+            },
+          },
+          indexes: [],
+          version: 'test-version',
+        },
+      },
+      '@test/messages',
+    );
+
+    ObjectRegistry.registerFromManifest(
+      '@test/messages:Message',
+      {
+        className: 'Message',
+        fields: {
+          subject: { type: 'text', required: false, default: '' },
+          messageId: { type: 'text', required: false, default: '' },
+        },
+        methods: {},
+        decoratorConfig: {
+          tableName: 'messages',
+          tableStrategy: 'sti',
+        },
+        schema: {
+          tableName: 'messages',
+          ddl: '',
+          columns: {},
+          indexes: [],
+          version: 'test-version',
+        },
+      },
+      '@test/messages',
+    );
+
+    const definitions = ObjectRegistry.getAllSchemasAsDefinitions();
+    expect(definitions.message_collections).toBeUndefined();
+    expect(definitions.messages.columns._meta_type).toBeDefined();
+    expect(definitions.messages.columns._meta_data).toBeDefined();
+    expect(definitions.messages.columns.subject).toBeDefined();
+    expect(definitions.messages.columns.message_id).toBeDefined();
+
+    const db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+    });
+
+    const columnsResult = await db.query(`PRAGMA table_info('messages')`);
+    const columns = Array.isArray(columnsResult)
+      ? columnsResult
+      : columnsResult.rows;
+    const columnNames = columns.map((row: { name: string }) => row.name);
+
+    expect(columnNames).toContain('_meta_type');
+    expect(columnNames).toContain('_meta_data');
+    expect(columnNames).toContain('subject');
+    expect(columnNames).toContain('message_id');
+  });
 });

--- a/packages/core/src/__tests__/test-database-manifest-schema.test.ts
+++ b/packages/core/src/__tests__/test-database-manifest-schema.test.ts
@@ -421,4 +421,112 @@ describe('getTestDatabase manifest schemas', () => {
     expect(columnNames).toContain('subject');
     expect(columnNames).toContain('message_id');
   });
+
+  it('prefers collection subclass item inference over inherited type args', async () => {
+    ObjectRegistry.registerFromManifest(
+      '@test/messages:AttachmentCollection',
+      {
+        className: 'AttachmentCollection',
+        extends: 'SmrtCollection',
+        extendsTypeArg: 'Attachment',
+        fields: {},
+        methods: {},
+        decoratorConfig: {},
+        schema: {
+          tableName: 'attachment_collections',
+          ddl: '',
+          columns: {},
+          indexes: [],
+          version: 'test-version',
+        },
+      },
+      '@test/messages',
+    );
+
+    ObjectRegistry.registerFromManifest(
+      '@test/messages:EmailAttachmentCollection',
+      {
+        className: 'EmailAttachmentCollection',
+        extends: 'AttachmentCollection',
+        fields: {},
+        methods: {},
+        decoratorConfig: {},
+        schema: {
+          tableName: 'email_attachment_collections',
+          ddl: '',
+          columns: {},
+          indexes: [],
+          version: 'test-version',
+        },
+      },
+      '@test/messages',
+    );
+
+    ObjectRegistry.registerFromManifest(
+      '@test/messages:Attachment',
+      {
+        className: 'Attachment',
+        fields: {
+          messageId: { type: 'text', required: false, default: '' },
+        },
+        methods: {},
+        decoratorConfig: {
+          tableName: 'attachments',
+        },
+        schema: {
+          tableName: 'attachments',
+          ddl: '',
+          columns: {},
+          indexes: [],
+          version: 'test-version',
+        },
+      },
+      '@test/messages',
+    );
+
+    ObjectRegistry.registerFromManifest(
+      '@test/messages:EmailAttachment',
+      {
+        className: 'EmailAttachment',
+        extends: 'Attachment',
+        fields: {},
+        methods: {},
+        decoratorConfig: {
+          tableName: 'email_attachments',
+        },
+        schema: {
+          tableName: 'email_attachments',
+          ddl: '',
+          columns: {},
+          indexes: [],
+          version: 'test-version',
+        },
+      },
+      '@test/messages',
+    );
+
+    const db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['EmailAttachmentCollection'],
+    });
+
+    const emailAttachmentColumnsResult = await db.query(
+      `PRAGMA table_info('email_attachments')`,
+    );
+    const emailAttachmentColumns = Array.isArray(emailAttachmentColumnsResult)
+      ? emailAttachmentColumnsResult
+      : emailAttachmentColumnsResult.rows;
+    const attachmentColumnsResult = await db.query(
+      `PRAGMA table_info('attachments')`,
+    );
+    const attachmentColumns = Array.isArray(attachmentColumnsResult)
+      ? attachmentColumnsResult
+      : attachmentColumnsResult.rows;
+
+    expect(
+      emailAttachmentColumns.map((row: { name: string }) => row.name),
+    ).toContain('id');
+    expect(attachmentColumns).toHaveLength(0);
+  });
 });

--- a/packages/core/src/registry/collection-resolution.ts
+++ b/packages/core/src/registry/collection-resolution.ts
@@ -1,0 +1,177 @@
+import type { RegisteredClass } from './types';
+
+export interface CollectionRegistrationLookup {
+  findClass: (name: string) => RegisteredClass | undefined;
+  findClassInPackage?: (
+    packageName: string,
+    className: string,
+  ) => RegisteredClass | undefined;
+  getInheritanceChain: (className: string) => string[];
+}
+
+export function isSmrtCollectionExtendsName(
+  extendsName: string | undefined,
+): boolean {
+  return (
+    extendsName === 'SmrtCollection' ||
+    extendsName?.endsWith(':SmrtCollection') === true
+  );
+}
+
+export function resolveRelatedRegistration(
+  className: string,
+  origin: RegisteredClass,
+  lookup: CollectionRegistrationLookup,
+): RegisteredClass | undefined {
+  if (className.includes(':')) {
+    return lookup.findClass(className);
+  }
+
+  if (origin.packageName && lookup.findClassInPackage) {
+    return (
+      lookup.findClassInPackage(origin.packageName, className) ||
+      lookup.findClass(className)
+    );
+  }
+
+  return lookup.findClass(className);
+}
+
+export function getCollectionChainRegistrations(
+  className: string,
+  registered: RegisteredClass,
+  lookup: CollectionRegistrationLookup,
+): RegisteredClass[] {
+  const lookupName = registered.qualifiedName || registered.name || className;
+  const chain = lookup.getInheritanceChain(lookupName);
+  const registrations: RegisteredClass[] = [];
+
+  for (const chainName of chain) {
+    const chainEntry = resolveRelatedRegistration(
+      chainName,
+      registered,
+      lookup,
+    );
+    if (chainEntry) {
+      registrations.push(chainEntry);
+    }
+  }
+
+  return registrations;
+}
+
+export function isCollectionRegistration(
+  className: string,
+  registered: RegisteredClass,
+  lookup: CollectionRegistrationLookup,
+): boolean {
+  if (isSmrtCollectionExtendsName(registered.extends)) {
+    return true;
+  }
+
+  return getCollectionChainRegistrations(className, registered, lookup).some(
+    (chainEntry) => isSmrtCollectionExtendsName(chainEntry.extends),
+  );
+}
+
+function getStaticItemClassName(
+  registered: RegisteredClass,
+): string | undefined {
+  const itemClass = (
+    registered.constructor as unknown as {
+      _itemClass?: { name?: string };
+    }
+  )._itemClass;
+  return itemClass?.name;
+}
+
+function getCollectionItemNameCandidates(className: string): string[] {
+  const candidates: string[] = [];
+  const simpleName = className.includes(':')
+    ? className.slice(className.lastIndexOf(':') + 1)
+    : className;
+
+  const addCandidate = (candidate: string): void => {
+    if (
+      candidate &&
+      candidate !== simpleName &&
+      !candidates.includes(candidate)
+    ) {
+      candidates.push(candidate);
+    }
+  };
+
+  if (simpleName.endsWith('Collection')) {
+    addCandidate(simpleName.slice(0, -'Collection'.length));
+  }
+
+  if (simpleName.endsWith('ies')) {
+    addCandidate(`${simpleName.slice(0, -3)}y`);
+  } else if (simpleName.endsWith('s')) {
+    addCandidate(simpleName.slice(0, -1));
+  }
+
+  return candidates;
+}
+
+function inferCollectionItemClassName(
+  className: string,
+  registered: RegisteredClass,
+  lookup: CollectionRegistrationLookup,
+): string | undefined {
+  const lookupName = registered.name || className;
+
+  for (const candidate of getCollectionItemNameCandidates(lookupName)) {
+    const candidateRegistration = resolveRelatedRegistration(
+      candidate,
+      registered,
+      lookup,
+    );
+    if (candidateRegistration) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+export function resolveCollectionItemClassName(
+  className: string,
+  registered: RegisteredClass,
+  lookup: CollectionRegistrationLookup,
+): string | undefined {
+  const staticItemClassName = getStaticItemClassName(registered);
+  if (staticItemClassName) {
+    return staticItemClassName;
+  }
+
+  if (registered.extendsTypeArg) {
+    return registered.extendsTypeArg;
+  }
+
+  const inferredItemClassName = inferCollectionItemClassName(
+    className,
+    registered,
+    lookup,
+  );
+  if (inferredItemClassName) {
+    return inferredItemClassName;
+  }
+
+  const chain = getCollectionChainRegistrations(
+    className,
+    registered,
+    lookup,
+  ).reverse();
+
+  for (const chainEntry of chain) {
+    if (chainEntry === registered) {
+      continue;
+    }
+    if (chainEntry.extendsTypeArg) {
+      return chainEntry.extendsTypeArg;
+    }
+  }
+
+  return undefined;
+}

--- a/packages/core/src/registry/schema-builder.ts
+++ b/packages/core/src/registry/schema-builder.ts
@@ -13,69 +13,24 @@ import type {
   SQLDataType,
 } from '../schema/types.js';
 import { classnameToTablename, toSnakeCase } from '../utils';
+import {
+  type CollectionRegistrationLookup,
+  isCollectionRegistration,
+} from './collection-resolution';
 import { findClass } from './name-resolver';
 import { getClasses, getCollectionTableNames } from './shared-state';
 
 type ForeignKeyAction = NonNullable<
   NonNullable<ColumnDefinition['foreignKey']>['onDelete']
 >;
-type RegisteredSchemaClass = NonNullable<ReturnType<typeof findClass>>;
 
-function isSmrtCollectionExtendsName(extendsName: string | undefined): boolean {
-  return (
-    extendsName === 'SmrtCollection' ||
-    extendsName?.endsWith(':SmrtCollection') === true
-  );
-}
-
-function resolveRelatedRegistration(
-  className: string,
-  origin: RegisteredSchemaClass,
-): RegisteredSchemaClass | undefined {
-  if (className.includes(':')) {
-    return findClass(className);
-  }
-
-  if (origin.packageName) {
-    return (
-      ObjectRegistry.getClassInPackage(origin.packageName, className) ||
-      findClass(className)
-    );
-  }
-
-  return findClass(className);
-}
-
-function getCollectionAncestorRegistrations(
-  className: string,
-  registered: RegisteredSchemaClass,
-): RegisteredSchemaClass[] {
-  const lookupName = registered.qualifiedName || registered.name || className;
-  const chain = ObjectRegistry.getInheritanceChain(lookupName);
-  const registrations: RegisteredSchemaClass[] = [];
-
-  for (const ancestorName of chain) {
-    const ancestor = resolveRelatedRegistration(ancestorName, registered);
-    if (ancestor) {
-      registrations.push(ancestor);
-    }
-  }
-
-  return registrations;
-}
-
-function isCollectionRegistration(
-  className: string,
-  registered: RegisteredSchemaClass,
-): boolean {
-  if (isSmrtCollectionExtendsName(registered.extends)) {
-    return true;
-  }
-
-  return getCollectionAncestorRegistrations(className, registered).some(
-    (ancestor) => isSmrtCollectionExtendsName(ancestor.extends),
-  );
-}
+const collectionRegistrationLookup: CollectionRegistrationLookup = {
+  findClass,
+  findClassInPackage: (packageName, className) =>
+    ObjectRegistry.getClassInPackage(packageName, className),
+  getInheritanceChain: (className) =>
+    ObjectRegistry.getInheritanceChain(className),
+};
 
 function applyDecoratorSqlTypeOverrides(
   className: string,
@@ -220,7 +175,13 @@ export function getAllSchemas(): Record<
   for (const [_className, registered] of getClasses()) {
     // Skip collection classes - they don't have their own tables
     // Their schemas incorrectly contain collection properties (loaded, options, etc.)
-    if (isCollectionRegistration(_className, registered)) {
+    if (
+      isCollectionRegistration(
+        _className,
+        registered,
+        collectionRegistrationLookup,
+      )
+    ) {
       continue;
     }
 
@@ -418,7 +379,13 @@ export function getAllSchemasAsDefinitions(): Record<string, SchemaDefinition> {
 
   for (const [_className, registered] of getClasses()) {
     // Skip collection classes - they don't have their own tables
-    if (isCollectionRegistration(_className, registered)) {
+    if (
+      isCollectionRegistration(
+        _className,
+        registered,
+        collectionRegistrationLookup,
+      )
+    ) {
       continue;
     }
 

--- a/packages/core/src/registry/schema-builder.ts
+++ b/packages/core/src/registry/schema-builder.ts
@@ -19,6 +19,63 @@ import { getClasses, getCollectionTableNames } from './shared-state';
 type ForeignKeyAction = NonNullable<
   NonNullable<ColumnDefinition['foreignKey']>['onDelete']
 >;
+type RegisteredSchemaClass = NonNullable<ReturnType<typeof findClass>>;
+
+function isSmrtCollectionExtendsName(extendsName: string | undefined): boolean {
+  return (
+    extendsName === 'SmrtCollection' ||
+    extendsName?.endsWith(':SmrtCollection') === true
+  );
+}
+
+function resolveRelatedRegistration(
+  className: string,
+  origin: RegisteredSchemaClass,
+): RegisteredSchemaClass | undefined {
+  if (className.includes(':')) {
+    return findClass(className);
+  }
+
+  if (origin.packageName) {
+    return (
+      ObjectRegistry.getClassInPackage(origin.packageName, className) ||
+      findClass(className)
+    );
+  }
+
+  return findClass(className);
+}
+
+function getCollectionAncestorRegistrations(
+  className: string,
+  registered: RegisteredSchemaClass,
+): RegisteredSchemaClass[] {
+  const lookupName = registered.qualifiedName || registered.name || className;
+  const chain = ObjectRegistry.getInheritanceChain(lookupName);
+  const registrations: RegisteredSchemaClass[] = [];
+
+  for (const ancestorName of chain) {
+    const ancestor = resolveRelatedRegistration(ancestorName, registered);
+    if (ancestor) {
+      registrations.push(ancestor);
+    }
+  }
+
+  return registrations;
+}
+
+function isCollectionRegistration(
+  className: string,
+  registered: RegisteredSchemaClass,
+): boolean {
+  if (isSmrtCollectionExtendsName(registered.extends)) {
+    return true;
+  }
+
+  return getCollectionAncestorRegistrations(className, registered).some(
+    (ancestor) => isSmrtCollectionExtendsName(ancestor.extends),
+  );
+}
 
 function applyDecoratorSqlTypeOverrides(
   className: string,
@@ -163,7 +220,7 @@ export function getAllSchemas(): Record<
   for (const [_className, registered] of getClasses()) {
     // Skip collection classes - they don't have their own tables
     // Their schemas incorrectly contain collection properties (loaded, options, etc.)
-    if (registered.extends === 'SmrtCollection') {
+    if (isCollectionRegistration(_className, registered)) {
       continue;
     }
 
@@ -361,7 +418,7 @@ export function getAllSchemasAsDefinitions(): Record<string, SchemaDefinition> {
 
   for (const [_className, registered] of getClasses()) {
     // Skip collection classes - they don't have their own tables
-    if (registered.extends === 'SmrtCollection') {
+    if (isCollectionRegistration(_className, registered)) {
       continue;
     }
 

--- a/packages/core/src/testing/database.ts
+++ b/packages/core/src/testing/database.ts
@@ -71,6 +71,153 @@ function isSTIChild(className: string): boolean {
   return stiBaseName !== className;
 }
 
+type RegisteredSchemaClass = NonNullable<
+  ReturnType<typeof ObjectRegistry.getClass>
+>;
+
+function isSmrtCollectionExtendsName(extendsName: string | undefined): boolean {
+  return (
+    extendsName === 'SmrtCollection' ||
+    extendsName?.endsWith(':SmrtCollection') === true
+  );
+}
+
+function resolveRelatedRegistration(
+  className: string,
+  origin: RegisteredSchemaClass,
+): RegisteredSchemaClass | undefined {
+  if (className.includes(':')) {
+    return ObjectRegistry.getClass(className);
+  }
+
+  if (origin.packageName) {
+    return (
+      ObjectRegistry.getClassInPackage(origin.packageName, className) ||
+      ObjectRegistry.getClass(className)
+    );
+  }
+
+  return ObjectRegistry.getClass(className);
+}
+
+function getCollectionAncestorRegistrations(
+  className: string,
+  registered: RegisteredSchemaClass,
+): RegisteredSchemaClass[] {
+  const lookupName = registered.qualifiedName || registered.name || className;
+  const chain = ObjectRegistry.getInheritanceChain(lookupName);
+  const registrations: RegisteredSchemaClass[] = [];
+
+  for (const ancestorName of chain) {
+    const ancestor = resolveRelatedRegistration(ancestorName, registered);
+    if (ancestor) {
+      registrations.push(ancestor);
+    }
+  }
+
+  return registrations;
+}
+
+function isCollectionRegistration(
+  className: string,
+  registered: RegisteredSchemaClass,
+): boolean {
+  if (isSmrtCollectionExtendsName(registered.extends)) {
+    return true;
+  }
+
+  return getCollectionAncestorRegistrations(className, registered).some(
+    (ancestor) => isSmrtCollectionExtendsName(ancestor.extends),
+  );
+}
+
+function resolveCollectionItemClassName(
+  className: string,
+  registered: RegisteredSchemaClass,
+): string | undefined {
+  if (registered.extendsTypeArg) {
+    return registered.extendsTypeArg;
+  }
+
+  const ancestors = getCollectionAncestorRegistrations(
+    className,
+    registered,
+  ).reverse();
+
+  for (const ancestor of ancestors) {
+    if (ancestor.extendsTypeArg) {
+      return ancestor.extendsTypeArg;
+    }
+  }
+
+  return undefined;
+}
+
+function resolveCollectionSchemaClassName(
+  className: string,
+  registered: RegisteredSchemaClass,
+): string {
+  const itemClassName = resolveCollectionItemClassName(className, registered);
+  if (itemClassName) {
+    const itemRegistration = resolveRelatedRegistration(
+      itemClassName,
+      registered,
+    );
+    const itemLookupName =
+      itemRegistration?.qualifiedName ||
+      itemRegistration?.name ||
+      itemClassName;
+    const stiBase = ObjectRegistry.getSTIBase(itemLookupName);
+    return stiBase
+      ? resolveSTIBaseLookupName(itemLookupName, stiBase)
+      : itemLookupName;
+  }
+
+  const tableName =
+    registered.schema?.tableName ||
+    registered.config.tableName ||
+    ObjectRegistry.getTableName(className);
+  if (!tableName) {
+    return className;
+  }
+
+  const collectionPackage = registered.packageName;
+
+  for (const candidate of ObjectRegistry.getAllClasses().values()) {
+    if (
+      candidate === registered ||
+      isCollectionRegistration(
+        candidate.qualifiedName || candidate.name,
+        candidate,
+      )
+    ) {
+      continue;
+    }
+
+    const candidateTableName =
+      candidate.schema?.tableName || candidate.config.tableName;
+    if (candidateTableName !== tableName) {
+      continue;
+    }
+
+    if (
+      collectionPackage &&
+      candidate.packageName &&
+      candidate.packageName !== collectionPackage
+    ) {
+      continue;
+    }
+
+    const candidateLookupName = candidate.qualifiedName || candidate.name;
+    const stiBase = ObjectRegistry.getSTIBase(candidateLookupName);
+    return stiBase
+      ? resolveSTIBaseLookupName(candidateLookupName, stiBase)
+      : candidateLookupName;
+  }
+
+  return className;
+}
+
 /**
  * Options for creating a test database
  */
@@ -114,48 +261,12 @@ function resolveRequestedSchemaClassName(className: string): string {
     return className;
   }
 
-  if (registered.extends !== 'SmrtCollection') {
+  if (!isCollectionRegistration(className, registered)) {
     const stiBase = ObjectRegistry.getSTIBase(className);
     return stiBase ? resolveSTIBaseLookupName(className, stiBase) : className;
   }
 
-  const tableName =
-    registered.schema?.tableName ||
-    registered.config.tableName ||
-    ObjectRegistry.getTableName(className);
-  if (!tableName) {
-    return className;
-  }
-
-  const collectionPackage = registered.packageName;
-
-  for (const candidate of ObjectRegistry.getAllClasses().values()) {
-    if (candidate === registered || candidate.extends === 'SmrtCollection') {
-      continue;
-    }
-
-    const candidateTableName =
-      candidate.schema?.tableName || candidate.config.tableName;
-    if (candidateTableName !== tableName) {
-      continue;
-    }
-
-    if (
-      collectionPackage &&
-      candidate.packageName &&
-      candidate.packageName !== collectionPackage
-    ) {
-      continue;
-    }
-
-    const candidateLookupName = candidate.qualifiedName || candidate.name;
-    const stiBase = ObjectRegistry.getSTIBase(candidateLookupName);
-    return stiBase
-      ? resolveSTIBaseLookupName(candidateLookupName, stiBase)
-      : candidateLookupName;
-  }
-
-  return className;
+  return resolveCollectionSchemaClassName(className, registered);
 }
 
 function resolveRequestedSchemaClassNames(classNames: string[]): string[] {

--- a/packages/core/src/testing/database.ts
+++ b/packages/core/src/testing/database.ts
@@ -18,6 +18,12 @@
 
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { getDatabase } from '@happyvertical/sql';
+import {
+  type CollectionRegistrationLookup,
+  isCollectionRegistration,
+  resolveCollectionItemClassName,
+  resolveRelatedRegistration,
+} from '../registry/collection-resolution.js';
 import { ObjectRegistry } from '../registry.js';
 import { SchemaGenerator } from '../schema/generator.js';
 import { ensureLegacySystemTableCompatibility } from '../system/compatibility.js';
@@ -75,93 +81,28 @@ type RegisteredSchemaClass = NonNullable<
   ReturnType<typeof ObjectRegistry.getClass>
 >;
 
-function isSmrtCollectionExtendsName(extendsName: string | undefined): boolean {
-  return (
-    extendsName === 'SmrtCollection' ||
-    extendsName?.endsWith(':SmrtCollection') === true
-  );
-}
-
-function resolveRelatedRegistration(
-  className: string,
-  origin: RegisteredSchemaClass,
-): RegisteredSchemaClass | undefined {
-  if (className.includes(':')) {
-    return ObjectRegistry.getClass(className);
-  }
-
-  if (origin.packageName) {
-    return (
-      ObjectRegistry.getClassInPackage(origin.packageName, className) ||
-      ObjectRegistry.getClass(className)
-    );
-  }
-
-  return ObjectRegistry.getClass(className);
-}
-
-function getCollectionAncestorRegistrations(
-  className: string,
-  registered: RegisteredSchemaClass,
-): RegisteredSchemaClass[] {
-  const lookupName = registered.qualifiedName || registered.name || className;
-  const chain = ObjectRegistry.getInheritanceChain(lookupName);
-  const registrations: RegisteredSchemaClass[] = [];
-
-  for (const ancestorName of chain) {
-    const ancestor = resolveRelatedRegistration(ancestorName, registered);
-    if (ancestor) {
-      registrations.push(ancestor);
-    }
-  }
-
-  return registrations;
-}
-
-function isCollectionRegistration(
-  className: string,
-  registered: RegisteredSchemaClass,
-): boolean {
-  if (isSmrtCollectionExtendsName(registered.extends)) {
-    return true;
-  }
-
-  return getCollectionAncestorRegistrations(className, registered).some(
-    (ancestor) => isSmrtCollectionExtendsName(ancestor.extends),
-  );
-}
-
-function resolveCollectionItemClassName(
-  className: string,
-  registered: RegisteredSchemaClass,
-): string | undefined {
-  if (registered.extendsTypeArg) {
-    return registered.extendsTypeArg;
-  }
-
-  const ancestors = getCollectionAncestorRegistrations(
-    className,
-    registered,
-  ).reverse();
-
-  for (const ancestor of ancestors) {
-    if (ancestor.extendsTypeArg) {
-      return ancestor.extendsTypeArg;
-    }
-  }
-
-  return undefined;
-}
+const collectionRegistrationLookup: CollectionRegistrationLookup = {
+  findClass: (className) => ObjectRegistry.getClass(className),
+  findClassInPackage: (packageName, className) =>
+    ObjectRegistry.getClassInPackage(packageName, className),
+  getInheritanceChain: (className) =>
+    ObjectRegistry.getInheritanceChain(className),
+};
 
 function resolveCollectionSchemaClassName(
   className: string,
   registered: RegisteredSchemaClass,
 ): string {
-  const itemClassName = resolveCollectionItemClassName(className, registered);
+  const itemClassName = resolveCollectionItemClassName(
+    className,
+    registered,
+    collectionRegistrationLookup,
+  );
   if (itemClassName) {
     const itemRegistration = resolveRelatedRegistration(
       itemClassName,
       registered,
+      collectionRegistrationLookup,
     );
     const itemLookupName =
       itemRegistration?.qualifiedName ||
@@ -189,6 +130,7 @@ function resolveCollectionSchemaClassName(
       isCollectionRegistration(
         candidate.qualifiedName || candidate.name,
         candidate,
+        collectionRegistrationLookup,
       )
     ) {
       continue;
@@ -261,7 +203,13 @@ function resolveRequestedSchemaClassName(className: string): string {
     return className;
   }
 
-  if (!isCollectionRegistration(className, registered)) {
+  if (
+    !isCollectionRegistration(
+      className,
+      registered,
+      collectionRegistrationLookup,
+    )
+  ) {
     const stiBase = ObjectRegistry.getSTIBase(className);
     return stiBase ? resolveSTIBaseLookupName(className, stiBase) : className;
   }

--- a/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
+++ b/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
@@ -320,6 +320,103 @@ describe('createIsolatedTestDbFromManifest', () => {
         await cleanup();
       }
     });
+
+    it('should keep qualified filters scoped when class names collide', async () => {
+      const manifestPath = join(testDir, 'namespaced-collision-filter.json');
+      const manifest = {
+        objects: {
+          '@test/one:Product': {
+            className: 'Product',
+            schema: {
+              tableName: 'pkg_one_products',
+              ddl: 'CREATE TABLE IF NOT EXISTS "pkg_one_products" ("id" TEXT PRIMARY KEY NOT NULL);',
+            },
+          },
+          '@test/two:Product': {
+            className: 'Product',
+            schema: {
+              tableName: 'pkg_two_products',
+              ddl: 'CREATE TABLE IF NOT EXISTS "pkg_two_products" ("id" TEXT PRIMARY KEY NOT NULL);',
+            },
+          },
+        },
+      };
+
+      writeFileSync(manifestPath, JSON.stringify(manifest));
+
+      const { db, cleanup } = await createIsolatedTestDbFromManifest({
+        manifestPath,
+        includeObjects: ['@test/one:Product'],
+      });
+
+      try {
+        await db.list('pkg_one_products', {});
+        await expect(db.list('pkg_two_products', {})).rejects.toThrow();
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it('should map collection subclass filters to their inherited STI item schema', async () => {
+      const manifestPath = join(testDir, 'collection-subclass-filter.json');
+      const manifest = {
+        packageName: '@test/messages',
+        objects: {
+          '@test/messages:MessageCollection': {
+            className: 'MessageCollection',
+            extends: 'SmrtCollection',
+            extendsTypeArg: 'Message',
+            schema: {
+              tableName: 'message_collections',
+              ddl: 'CREATE TABLE IF NOT EXISTS "message_collections" ("id" TEXT PRIMARY KEY NOT NULL);',
+            },
+          },
+          '@test/messages:EmailCollection': {
+            className: 'EmailCollection',
+            extends: 'MessageCollection',
+            schema: {
+              tableName: 'messages',
+              ddl: 'CREATE TABLE IF NOT EXISTS "messages" ("id" TEXT PRIMARY KEY NOT NULL, "slug" TEXT NOT NULL, "context" TEXT NOT NULL DEFAULT \'\', "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp, "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp);',
+            },
+          },
+          '@test/messages:Message': {
+            className: 'Message',
+            extends: 'SmrtObject',
+            decoratorConfig: {
+              tableStrategy: 'sti',
+            },
+            schema: {
+              tableName: 'messages',
+              ddl: 'CREATE TABLE IF NOT EXISTS "messages" ("id" TEXT PRIMARY KEY NOT NULL, "slug" TEXT NOT NULL, "context" TEXT NOT NULL DEFAULT \'\', "_meta_type" TEXT NOT NULL, "_meta_data" JSON, "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp, "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp, "subject" TEXT, "message_id" TEXT);',
+            },
+          },
+        },
+      };
+
+      writeFileSync(manifestPath, JSON.stringify(manifest));
+
+      const { baseDb, cleanup } = await createIsolatedTestDbFromManifest({
+        manifestPath,
+        includeObjects: ['EmailCollection'],
+      });
+
+      try {
+        const columnsResult = await baseDb.query(
+          `PRAGMA table_info('messages')`,
+        );
+        const columns = Array.isArray(columnsResult)
+          ? columnsResult
+          : columnsResult.rows;
+        const columnNames = columns.map((row: { name: string }) => row.name);
+
+        expect(columnNames).toContain('_meta_type');
+        expect(columnNames).toContain('_meta_data');
+        expect(columnNames).toContain('subject');
+        expect(columnNames).toContain('message_id');
+      } finally {
+        await cleanup();
+      }
+    });
   });
 
   describe('STI deduplication', () => {

--- a/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
+++ b/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
@@ -417,6 +417,64 @@ describe('createIsolatedTestDbFromManifest', () => {
         await cleanup();
       }
     });
+
+    it('should prefer collection subclass item inference over inherited type args', async () => {
+      const manifestPath = join(
+        testDir,
+        'collection-subclass-item-filter.json',
+      );
+      const manifest = {
+        packageName: '@test/messages',
+        objects: {
+          '@test/messages:AttachmentCollection': {
+            className: 'AttachmentCollection',
+            extends: 'SmrtCollection',
+            extendsTypeArg: 'Attachment',
+            schema: {
+              tableName: 'attachment_collections',
+              ddl: 'CREATE TABLE IF NOT EXISTS "attachment_collections" ("id" TEXT PRIMARY KEY NOT NULL);',
+            },
+          },
+          '@test/messages:EmailAttachmentCollection': {
+            className: 'EmailAttachmentCollection',
+            extends: 'AttachmentCollection',
+            schema: {
+              tableName: 'email_attachment_collections',
+              ddl: 'CREATE TABLE IF NOT EXISTS "email_attachment_collections" ("id" TEXT PRIMARY KEY NOT NULL);',
+            },
+          },
+          '@test/messages:Attachment': {
+            className: 'Attachment',
+            schema: {
+              tableName: 'attachments',
+              ddl: 'CREATE TABLE IF NOT EXISTS "attachments" ("id" TEXT PRIMARY KEY NOT NULL, "message_id" TEXT);',
+            },
+          },
+          '@test/messages:EmailAttachment': {
+            className: 'EmailAttachment',
+            extends: 'Attachment',
+            schema: {
+              tableName: 'email_attachments',
+              ddl: 'CREATE TABLE IF NOT EXISTS "email_attachments" ("id" TEXT PRIMARY KEY NOT NULL);',
+            },
+          },
+        },
+      };
+
+      writeFileSync(manifestPath, JSON.stringify(manifest));
+
+      const { db, cleanup } = await createIsolatedTestDbFromManifest({
+        manifestPath,
+        includeObjects: ['EmailAttachmentCollection'],
+      });
+
+      try {
+        await db.list('email_attachments', {});
+        await expect(db.list('attachments', {})).rejects.toThrow();
+      } finally {
+        await cleanup();
+      }
+    });
   });
 
   describe('STI deduplication', () => {

--- a/packages/vitest/src/test-db.ts
+++ b/packages/vitest/src/test-db.ts
@@ -63,6 +63,9 @@ interface ManifestSchema {
  */
 interface ManifestObjectDef {
   className: string;
+  extends?: string;
+  extendsTypeArg?: string | null;
+  packageName?: string;
   schema?: ManifestSchema;
 }
 
@@ -70,6 +73,7 @@ interface ManifestObjectDef {
  * Manifest file structure (minimal subset)
  */
 interface ManifestFile {
+  packageName?: string;
   objects: Record<string, ManifestObjectDef>;
 }
 
@@ -745,6 +749,213 @@ function mergeIndexes(
   return merged;
 }
 
+function isSmrtCollectionExtendsName(extendsName: string | undefined): boolean {
+  return (
+    extendsName === 'SmrtCollection' ||
+    extendsName?.endsWith(':SmrtCollection') === true
+  );
+}
+
+function getPackageNameFromKey(key: string): string | undefined {
+  const separatorIndex = key.lastIndexOf(':');
+  if (separatorIndex <= 0) {
+    return undefined;
+  }
+
+  return key.slice(0, separatorIndex);
+}
+
+function getObjectPackageName(
+  manifest: ManifestFile,
+  key: string,
+  objectDef: ManifestObjectDef,
+): string | undefined {
+  return (
+    objectDef.packageName || manifest.packageName || getPackageNameFromKey(key)
+  );
+}
+
+function addManifestObjectIdentifiers(
+  target: Set<string>,
+  manifest: ManifestFile,
+  key: string,
+  objectDef: ManifestObjectDef,
+  options: { includeSimpleName: boolean },
+): void {
+  target.add(key);
+  if (options.includeSimpleName && objectDef.className) {
+    target.add(objectDef.className);
+  }
+
+  const packageName = getObjectPackageName(manifest, key, objectDef);
+  if (packageName && objectDef.className) {
+    target.add(`${packageName}:${objectDef.className}`);
+  }
+}
+
+function findManifestObject(
+  manifest: ManifestFile,
+  lookupName: string,
+  packageName?: string,
+): { key: string; objectDef: ManifestObjectDef } | undefined {
+  const direct = manifest.objects[lookupName];
+  if (direct) {
+    return { key: lookupName, objectDef: direct };
+  }
+
+  const separatorIndex = lookupName.lastIndexOf(':');
+  const lookupPackage =
+    separatorIndex > 0 ? lookupName.slice(0, separatorIndex) : packageName;
+  const simpleName =
+    separatorIndex > 0 ? lookupName.slice(separatorIndex + 1) : lookupName;
+  const lowerSimpleName = simpleName.toLowerCase();
+
+  for (const [key, objectDef] of Object.entries(manifest.objects)) {
+    const objectPackageName = getObjectPackageName(manifest, key, objectDef);
+    if (
+      lookupPackage &&
+      objectPackageName &&
+      objectPackageName !== lookupPackage
+    ) {
+      continue;
+    }
+
+    if (
+      key === lookupName ||
+      objectDef.className === simpleName ||
+      objectDef.className?.toLowerCase() === lowerSimpleName
+    ) {
+      return { key, objectDef };
+    }
+  }
+
+  return undefined;
+}
+
+function getManifestCollectionAncestors(
+  manifest: ManifestFile,
+  key: string,
+  objectDef: ManifestObjectDef,
+): Array<{ key: string; objectDef: ManifestObjectDef }> {
+  const ancestors: Array<{ key: string; objectDef: ManifestObjectDef }> = [];
+  const visited = new Set<string>();
+  let currentKey = key;
+  let currentDef: ManifestObjectDef | undefined = objectDef;
+
+  while (currentDef?.extends) {
+    if (isSmrtCollectionExtendsName(currentDef.extends)) {
+      break;
+    }
+
+    const currentPackage = getObjectPackageName(
+      manifest,
+      currentKey,
+      currentDef,
+    );
+    const parent = findManifestObject(
+      manifest,
+      currentDef.extends,
+      currentPackage,
+    );
+    if (!parent || visited.has(parent.key)) {
+      break;
+    }
+
+    visited.add(parent.key);
+    ancestors.push(parent);
+    currentKey = parent.key;
+    currentDef = parent.objectDef;
+  }
+
+  return ancestors;
+}
+
+function isManifestCollectionObject(
+  manifest: ManifestFile,
+  key: string,
+  objectDef: ManifestObjectDef,
+): boolean {
+  if (isSmrtCollectionExtendsName(objectDef.extends)) {
+    return true;
+  }
+
+  return getManifestCollectionAncestors(manifest, key, objectDef).some(
+    (ancestor) => isSmrtCollectionExtendsName(ancestor.objectDef.extends),
+  );
+}
+
+function resolveManifestCollectionItemClassName(
+  manifest: ManifestFile,
+  key: string,
+  objectDef: ManifestObjectDef,
+): string | undefined {
+  if (objectDef.extendsTypeArg) {
+    return objectDef.extendsTypeArg;
+  }
+
+  for (const ancestor of getManifestCollectionAncestors(
+    manifest,
+    key,
+    objectDef,
+  )) {
+    if (ancestor.objectDef.extendsTypeArg) {
+      return ancestor.objectDef.extendsTypeArg;
+    }
+  }
+
+  return undefined;
+}
+
+function buildEffectiveIncludeObjects(
+  manifest: ManifestFile,
+  includeObjects?: string[],
+): Set<string> | undefined {
+  if (!includeObjects) {
+    return undefined;
+  }
+
+  const effectiveIncludes = new Set<string>();
+
+  for (const includeObject of includeObjects) {
+    const includeSimpleName = !includeObject.includes(':');
+    const entry = findManifestObject(manifest, includeObject);
+    if (!entry) {
+      effectiveIncludes.add(includeObject);
+      continue;
+    }
+
+    const objectPackageName = getObjectPackageName(
+      manifest,
+      entry.key,
+      entry.objectDef,
+    );
+    const itemClassName = isManifestCollectionObject(
+      manifest,
+      entry.key,
+      entry.objectDef,
+    )
+      ? resolveManifestCollectionItemClassName(
+          manifest,
+          entry.key,
+          entry.objectDef,
+        )
+      : undefined;
+    const itemEntry = itemClassName
+      ? findManifestObject(manifest, itemClassName, objectPackageName)
+      : undefined;
+
+    addManifestObjectIdentifiers(
+      effectiveIncludes,
+      manifest,
+      itemEntry?.key || entry.key,
+      itemEntry?.objectDef || entry.objectDef,
+      { includeSimpleName },
+    );
+  }
+
+  return effectiveIncludes;
+}
+
 /**
  * Extract DDL from manifest objects with STI deduplication
  *
@@ -757,15 +968,19 @@ function extractDDLFromManifest(
   includeObjects?: string[],
 ): TableInfo[] {
   const tableMap = new Map<string, TableInfo>();
+  const effectiveIncludes = buildEffectiveIncludeObjects(
+    manifest,
+    includeObjects,
+  );
 
   for (const [key, objectDef] of Object.entries(manifest.objects)) {
     // Skip if filter is specified and class not included
     // Compare against both the key (e.g., '@dumm/models:Product') and className (e.g., 'Product')
     // to support both namespaced and simple class names (Issue #860)
-    if (includeObjects) {
+    if (effectiveIncludes) {
       const className = objectDef.className || key;
-      const matchesKey = includeObjects.includes(key);
-      const matchesClassName = includeObjects.includes(className);
+      const matchesKey = effectiveIncludes.has(key);
+      const matchesClassName = effectiveIncludes.has(className);
       if (!matchesKey && !matchesClassName) {
         continue;
       }

--- a/packages/vitest/src/test-db.ts
+++ b/packages/vitest/src/test-db.ts
@@ -771,7 +771,7 @@ function getObjectPackageName(
   objectDef: ManifestObjectDef,
 ): string | undefined {
   return (
-    objectDef.packageName || manifest.packageName || getPackageNameFromKey(key)
+    objectDef.packageName || getPackageNameFromKey(key) || manifest.packageName
   );
 }
 
@@ -893,6 +893,15 @@ function resolveManifestCollectionItemClassName(
     return objectDef.extendsTypeArg;
   }
 
+  const inferredItemClassName = inferManifestCollectionItemClassName(
+    manifest,
+    key,
+    objectDef,
+  );
+  if (inferredItemClassName) {
+    return inferredItemClassName;
+  }
+
   for (const ancestor of getManifestCollectionAncestors(
     manifest,
     key,
@@ -900,6 +909,55 @@ function resolveManifestCollectionItemClassName(
   )) {
     if (ancestor.objectDef.extendsTypeArg) {
       return ancestor.objectDef.extendsTypeArg;
+    }
+  }
+
+  return undefined;
+}
+
+function getCollectionItemNameCandidates(className: string): string[] {
+  const candidates: string[] = [];
+
+  const addCandidate = (candidate: string): void => {
+    if (
+      candidate &&
+      candidate !== className &&
+      !candidates.includes(candidate)
+    ) {
+      candidates.push(candidate);
+    }
+  };
+
+  if (className.endsWith('Collection')) {
+    addCandidate(className.slice(0, -'Collection'.length));
+  }
+
+  if (className.endsWith('ies')) {
+    addCandidate(`${className.slice(0, -3)}y`);
+  } else if (className.endsWith('s')) {
+    addCandidate(className.slice(0, -1));
+  }
+
+  return candidates;
+}
+
+function inferManifestCollectionItemClassName(
+  manifest: ManifestFile,
+  key: string,
+  objectDef: ManifestObjectDef,
+): string | undefined {
+  const objectPackageName = getObjectPackageName(manifest, key, objectDef);
+
+  for (const candidate of getCollectionItemNameCandidates(
+    objectDef.className,
+  )) {
+    const candidateEntry = findManifestObject(
+      manifest,
+      candidate,
+      objectPackageName,
+    );
+    if (candidateEntry) {
+      return candidate;
     }
   }
 


### PR DESCRIPTION
## Summary
- Resolve inherited `SmrtCollection` registrations to their item/STI base schema before test DB table creation.
- Skip inherited collection classes in registry schema aggregation so collection stubs cannot create shared STI tables.
- Make manifest `includeObjects` filters map collection subclasses to inherited item schemas while preserving package-scoped qualified filters.

## Root Cause
Manifest collection subclasses such as `EmailCollection` extend a package collection base rather than `SmrtCollection` directly. Test schema prep treated those subclasses as model schemas, so a collection stub sharing an STI table could create the table before the STI base and omit `_meta_type` / `_meta_data`.

During local review, I also found the first include-filter fix widened qualified includes to same-named classes from other packages; this PR keeps qualified filters package-specific and covers that with a regression test.

## Validation
- `pnpm build`
- `pnpm --filter @happyvertical/smrt-core run build`
- `pnpm --filter @happyvertical/smrt-core run typecheck`
- `pnpm --filter @happyvertical/smrt-vitest run typecheck`
- `pnpm exec biome check packages/core/src/testing/database.ts packages/core/src/registry/schema-builder.ts packages/core/src/__tests__/test-database-manifest-schema.test.ts packages/vitest/src/test-db.ts packages/vitest/src/__tests__/test-db-from-manifest.test.ts`
- `(cd packages/core && pnpm exec vitest run src/__tests__/test-database-manifest-schema.test.ts)`
- `(cd packages/vitest && pnpm exec vitest run src/__tests__/test-db-from-manifest.test.ts)`
- `git diff --check`