### PR TITLE
[codex] Emit uuid ids and relationship columns

### DIFF
--- a/packages/ads/src/manifest/manifest.json
+++ b/packages/ads/src/manifest/manifest.json
@@ -1,941 +1,9 @@
 {
   "version": "1.0.0",
-  "timestamp": 1780375818917,
+  "timestamp": 1780379230704,
   "packageName": "@happyvertical/smrt-ads",
   "packageVersion": "0.25.8",
   "objects": {
-    "@happyvertical/smrt-ads:AdDeliveryTierCollection": {
-      "name": "addeliverytiercollection",
-      "className": "AdDeliveryTierCollection",
-      "qualifiedName": "@happyvertical/smrt-ads:AdDeliveryTierCollection",
-      "collection": "addeliverytiers",
-      "filePath": "packages/ads/src/collections/AdDeliveryTierCollection.ts",
-      "packageName": "@happyvertical/smrt-ads",
-      "fields": {},
-      "methods": {
-        "findByPriority": {
-          "name": "findByPriority",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdDeliveryTier[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByPricingModel": {
-          "name": "findByPricingModel",
-          "async": true,
-          "parameters": [
-            {
-              "name": "pricingModel",
-              "type": "PricingModel",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdDeliveryTier[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getHighestPriority": {
-          "name": "getHighestPriority",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdDeliveryTier | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findFixedPricing": {
-          "name": "findFixedPricing",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdDeliveryTier[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findCPM": {
-          "name": "findCPM",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdDeliveryTier[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findPerformanceBased": {
-          "name": "findPerformanceBased",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdDeliveryTier[]>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {},
-      "extends": "SmrtCollection",
-      "extendsTypeArg": "AdDeliveryTier",
-      "exportName": "AdDeliveryTierCollection",
-      "collectionExportName": "AdDeliveryTierCollectionCollection",
-      "schema": {
-        "tableName": "ad_delivery_tier_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_delivery_tier_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
-        "columns": {
-          "id": {
-            "type": "UUID",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          }
-        },
-        "indexes": [
-          {
-            "name": "ad_delivery_tier_collections_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "ad_delivery_tier_collections_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "8229e958"
-      }
-    },
-    "@happyvertical/smrt-ads:AdEventCollection": {
-      "name": "adeventcollection",
-      "className": "AdEventCollection",
-      "qualifiedName": "@happyvertical/smrt-ads:AdEventCollection",
-      "collection": "adevents",
-      "filePath": "packages/ads/src/collections/AdEventCollection.ts",
-      "packageName": "@happyvertical/smrt-ads",
-      "fields": {},
-      "methods": {
-        "findByVariation": {
-          "name": "findByVariation",
-          "async": true,
-          "parameters": [
-            {
-              "name": "variationId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdEvent[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByZone": {
-          "name": "findByZone",
-          "async": true,
-          "parameters": [
-            {
-              "name": "zoneId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdEvent[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findBySite": {
-          "name": "findBySite",
-          "async": true,
-          "parameters": [
-            {
-              "name": "siteId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdEvent[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByDateRange": {
-          "name": "findByDateRange",
-          "async": true,
-          "parameters": [
-            {
-              "name": "start",
-              "type": "Date",
-              "optional": false
-            },
-            {
-              "name": "end",
-              "type": "Date",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdEvent[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByType": {
-          "name": "findByType",
-          "async": true,
-          "parameters": [
-            {
-              "name": "eventType",
-              "type": "AdEventType",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdEvent[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "countByType": {
-          "name": "countByType",
-          "async": true,
-          "parameters": [
-            {
-              "name": "variationId",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "eventType",
-              "type": "AdEventType",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<number>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "countImpressions": {
-          "name": "countImpressions",
-          "async": true,
-          "parameters": [
-            {
-              "name": "variationId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<number>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "countClicks": {
-          "name": "countClicks",
-          "async": true,
-          "parameters": [
-            {
-              "name": "variationId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<number>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "countConversions": {
-          "name": "countConversions",
-          "async": true,
-          "parameters": [
-            {
-              "name": "variationId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<number>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findImpressions": {
-          "name": "findImpressions",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdEvent[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findClicks": {
-          "name": "findClicks",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdEvent[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findConversions": {
-          "name": "findConversions",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdEvent[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getVariationStats": {
-          "name": "getVariationStats",
-          "async": true,
-          "parameters": [
-            {
-              "name": "variationId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<object>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByTenant": {
-          "name": "findByTenant",
-          "async": true,
-          "parameters": [
-            {
-              "name": "tenantId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdEvent[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findGlobal": {
-          "name": "findGlobal",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdEvent[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findWithGlobals": {
-          "name": "findWithGlobals",
-          "async": true,
-          "parameters": [
-            {
-              "name": "tenantId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdEvent[]>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {},
-      "extends": "SmrtCollection",
-      "extendsTypeArg": "AdEvent",
-      "exportName": "AdEventCollection",
-      "collectionExportName": "AdEventCollectionCollection",
-      "schema": {
-        "tableName": "ad_event_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_event_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
-        "columns": {
-          "id": {
-            "type": "UUID",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          }
-        },
-        "indexes": [
-          {
-            "name": "ad_event_collections_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "ad_event_collections_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "1e5ee847"
-      }
-    },
-    "@happyvertical/smrt-ads:AdFormatCollection": {
-      "name": "adformatcollection",
-      "className": "AdFormatCollection",
-      "qualifiedName": "@happyvertical/smrt-ads:AdFormatCollection",
-      "collection": "adformats",
-      "filePath": "packages/ads/src/collections/AdFormatCollection.ts",
-      "packageName": "@happyvertical/smrt-ads",
-      "fields": {},
-      "methods": {
-        "findByDimensions": {
-          "name": "findByDimensions",
-          "async": true,
-          "parameters": [
-            {
-              "name": "width",
-              "type": "number",
-              "optional": false
-            },
-            {
-              "name": "height",
-              "type": "number",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdFormat | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByType": {
-          "name": "findByType",
-          "async": true,
-          "parameters": [
-            {
-              "name": "formatType",
-              "type": "AdFormatType",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdFormat[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findBanners": {
-          "name": "findBanners",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdFormat[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findNative": {
-          "name": "findNative",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdFormat[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findVideo": {
-          "name": "findVideo",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdFormat[]>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {},
-      "extends": "SmrtCollection",
-      "extendsTypeArg": "AdFormat",
-      "exportName": "AdFormatCollection",
-      "collectionExportName": "AdFormatCollectionCollection",
-      "schema": {
-        "tableName": "ad_format_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_format_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
-        "columns": {
-          "id": {
-            "type": "UUID",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          }
-        },
-        "indexes": [
-          {
-            "name": "ad_format_collections_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "ad_format_collections_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "5f32a70c"
-      }
-    },
-    "@happyvertical/smrt-ads:AdGroupCollection": {
-      "name": "adgroupcollection",
-      "className": "AdGroupCollection",
-      "qualifiedName": "@happyvertical/smrt-ads:AdGroupCollection",
-      "collection": "adgroups",
-      "filePath": "packages/ads/src/collections/AdGroupCollection.ts",
-      "packageName": "@happyvertical/smrt-ads",
-      "fields": {},
-      "methods": {
-        "findByContract": {
-          "name": "findByContract",
-          "async": true,
-          "parameters": [
-            {
-              "name": "contractId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdGroup[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByTier": {
-          "name": "findByTier",
-          "async": true,
-          "parameters": [
-            {
-              "name": "tierId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdGroup[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByStatus": {
-          "name": "findByStatus",
-          "async": true,
-          "parameters": [
-            {
-              "name": "status",
-              "type": "AdGroupStatus",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdGroup[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findActive": {
-          "name": "findActive",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdGroup[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByVertical": {
-          "name": "findByVertical",
-          "async": true,
-          "parameters": [
-            {
-              "name": "verticalSlug",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdGroup[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByZone": {
-          "name": "findByZone",
-          "async": true,
-          "parameters": [
-            {
-              "name": "zoneId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdGroup[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findEligibleForZone": {
-          "name": "findEligibleForZone",
-          "async": true,
-          "parameters": [
-            {
-              "name": "zoneId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdGroup[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findDrafts": {
-          "name": "findDrafts",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdGroup[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findPaused": {
-          "name": "findPaused",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdGroup[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findCompleted": {
-          "name": "findCompleted",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdGroup[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByTenant": {
-          "name": "findByTenant",
-          "async": true,
-          "parameters": [
-            {
-              "name": "tenantId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdGroup[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findGlobal": {
-          "name": "findGlobal",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdGroup[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findWithGlobals": {
-          "name": "findWithGlobals",
-          "async": true,
-          "parameters": [
-            {
-              "name": "tenantId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdGroup[]>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {},
-      "extends": "SmrtCollection",
-      "extendsTypeArg": "AdGroup",
-      "exportName": "AdGroupCollection",
-      "collectionExportName": "AdGroupCollectionCollection",
-      "schema": {
-        "tableName": "ad_group_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_group_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
-        "columns": {
-          "id": {
-            "type": "UUID",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          }
-        },
-        "indexes": [
-          {
-            "name": "ad_group_collections_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "ad_group_collections_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "e7850ea1"
-      }
-    },
-    "@happyvertical/smrt-ads:AdVariationCollection": {
-      "name": "advariationcollection",
-      "className": "AdVariationCollection",
-      "qualifiedName": "@happyvertical/smrt-ads:AdVariationCollection",
-      "collection": "advariations",
-      "filePath": "packages/ads/src/collections/AdVariationCollection.ts",
-      "packageName": "@happyvertical/smrt-ads",
-      "fields": {},
-      "methods": {
-        "findByGroup": {
-          "name": "findByGroup",
-          "async": true,
-          "parameters": [
-            {
-              "name": "groupId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdVariation[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByFormat": {
-          "name": "findByFormat",
-          "async": true,
-          "parameters": [
-            {
-              "name": "formatId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdVariation[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findActiveByGroup": {
-          "name": "findActiveByGroup",
-          "async": true,
-          "parameters": [
-            {
-              "name": "groupId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdVariation[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "selectByWeight": {
-          "name": "selectByWeight",
-          "async": true,
-          "parameters": [
-            {
-              "name": "groupId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdVariation | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByStatus": {
-          "name": "findByStatus",
-          "async": true,
-          "parameters": [
-            {
-              "name": "status",
-              "type": "AdVariationStatus",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdVariation[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findActive": {
-          "name": "findActive",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdVariation[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findDrafts": {
-          "name": "findDrafts",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdVariation[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findPaused": {
-          "name": "findPaused",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdVariation[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findTopPerformers": {
-          "name": "findTopPerformers",
-          "async": true,
-          "parameters": [
-            {
-              "name": "limit",
-              "type": "number",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<AdVariation[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByTenant": {
-          "name": "findByTenant",
-          "async": true,
-          "parameters": [
-            {
-              "name": "tenantId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdVariation[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findGlobal": {
-          "name": "findGlobal",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<AdVariation[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findWithGlobals": {
-          "name": "findWithGlobals",
-          "async": true,
-          "parameters": [
-            {
-              "name": "tenantId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<AdVariation[]>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {},
-      "extends": "SmrtCollection",
-      "extendsTypeArg": "AdVariation",
-      "exportName": "AdVariationCollection",
-      "collectionExportName": "AdVariationCollectionCollection",
-      "schema": {
-        "tableName": "ad_variation_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_variation_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
-        "columns": {
-          "id": {
-            "type": "UUID",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          }
-        },
-        "indexes": [
-          {
-            "name": "ad_variation_collections_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "ad_variation_collections_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "d8ef9671"
-      }
-    },
     "@happyvertical/smrt-ads:AdDeliveryTier": {
       "name": "addeliverytier",
       "className": "AdDeliveryTier",
@@ -1018,7 +86,7 @@
       "collectionExportName": "AdDeliveryTierCollection",
       "schema": {
         "tableName": "ad_delivery_tiers",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_delivery_tiers\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"priority\" INTEGER DEFAULT 0,\n  \"pricing_model\" TEXT,\n  \"description\" TEXT DEFAULT ''\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_delivery_tiers\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"priority\" INTEGER DEFAULT 0,\n  \"pricing_model\" TEXT,\n  \"description\" TEXT DEFAULT ''\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1615,7 +683,7 @@
       "collectionExportName": "AdEventCollection",
       "schema": {
         "tableName": "ad_events",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_events\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"variation_id\" uuid,\n  \"zone_id\" uuid,\n  \"site_id\" TEXT DEFAULT '',\n  \"event_type\" TEXT,\n  \"timestamp\" TIMESTAMP,\n  \"metadata\" TEXT DEFAULT ''\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_events\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"variation_id\" UUID,\n  \"zone_id\" UUID,\n  \"site_id\" TEXT DEFAULT '',\n  \"event_type\" TEXT,\n  \"timestamp\" TIMESTAMP,\n  \"metadata\" TEXT DEFAULT ''\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1790,7 +858,7 @@
       "collectionExportName": "AdFormatCollection",
       "schema": {
         "tableName": "ad_formats",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_formats\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"width\" INTEGER DEFAULT 0,\n  \"height\" INTEGER DEFAULT 0,\n  \"format_type\" TEXT,\n  \"description\" TEXT DEFAULT ''\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_formats\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"width\" INTEGER DEFAULT 0,\n  \"height\" INTEGER DEFAULT 0,\n  \"format_type\" TEXT,\n  \"description\" TEXT DEFAULT ''\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2509,7 +1577,7 @@
       "collectionExportName": "AdGroupCollection",
       "schema": {
         "tableName": "ad_groups",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_groups\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"contract_id\" uuid,\n  \"tier_id\" uuid,\n  \"name\" TEXT DEFAULT '',\n  \"vertical_slug\" TEXT DEFAULT '',\n  \"targeting\" TEXT DEFAULT '',\n  \"zone_ids\" TEXT DEFAULT '',\n  \"start_date\" TIMESTAMP,\n  \"end_date\" TIMESTAMP,\n  \"daily_budget\" DOUBLE PRECISION DEFAULT 0,\n  \"total_budget\" DOUBLE PRECISION DEFAULT 0,\n  \"status\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_groups\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"contract_id\" UUID,\n  \"tier_id\" UUID,\n  \"name\" TEXT DEFAULT '',\n  \"vertical_slug\" TEXT DEFAULT '',\n  \"targeting\" TEXT DEFAULT '',\n  \"zone_ids\" TEXT DEFAULT '',\n  \"start_date\" TIMESTAMP,\n  \"end_date\" TIMESTAMP,\n  \"daily_budget\" REAL DEFAULT 0,\n  \"total_budget\" REAL DEFAULT 0,\n  \"status\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3179,7 +2247,7 @@
       "collectionExportName": "AdVariationCollection",
       "schema": {
         "tableName": "ad_variations",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_variations\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"group_id\" uuid,\n  \"format_id\" uuid,\n  \"asset_id\" uuid,\n  \"name\" TEXT DEFAULT '',\n  \"click_url\" TEXT DEFAULT '',\n  \"alt_text\" TEXT DEFAULT '',\n  \"weight\" INTEGER DEFAULT 1,\n  \"status\" TEXT,\n  \"impressions\" INTEGER DEFAULT 0,\n  \"clicks\" INTEGER DEFAULT 0\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_variations\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"group_id\" UUID,\n  \"format_id\" UUID,\n  \"asset_id\" UUID,\n  \"name\" TEXT DEFAULT '',\n  \"click_url\" TEXT DEFAULT '',\n  \"alt_text\" TEXT DEFAULT '',\n  \"weight\" INTEGER DEFAULT 1,\n  \"status\" TEXT,\n  \"impressions\" INTEGER DEFAULT 0,\n  \"clicks\" INTEGER DEFAULT 0\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3289,13 +2357,947 @@
         ],
         "version": "e56c1b67"
       }
+    },
+    "@happyvertical/smrt-ads:AdDeliveryTierCollection": {
+      "name": "addeliverytiercollection",
+      "className": "AdDeliveryTierCollection",
+      "qualifiedName": "@happyvertical/smrt-ads:AdDeliveryTierCollection",
+      "collection": "addeliverytiers",
+      "filePath": "packages/ads/src/collections/AdDeliveryTierCollection.ts",
+      "packageName": "@happyvertical/smrt-ads",
+      "fields": {},
+      "methods": {
+        "findByPriority": {
+          "name": "findByPriority",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdDeliveryTier[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByPricingModel": {
+          "name": "findByPricingModel",
+          "async": true,
+          "parameters": [
+            {
+              "name": "pricingModel",
+              "type": "PricingModel",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdDeliveryTier[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getHighestPriority": {
+          "name": "getHighestPriority",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdDeliveryTier | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findFixedPricing": {
+          "name": "findFixedPricing",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdDeliveryTier[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findCPM": {
+          "name": "findCPM",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdDeliveryTier[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findPerformanceBased": {
+          "name": "findPerformanceBased",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdDeliveryTier[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "AdDeliveryTier",
+      "exportName": "AdDeliveryTierCollection",
+      "collectionExportName": "AdDeliveryTierCollectionCollection",
+      "schema": {
+        "tableName": "ad_delivery_tier_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_delivery_tier_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "ad_delivery_tier_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "ad_delivery_tier_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "8229e958"
+      }
+    },
+    "@happyvertical/smrt-ads:AdEventCollection": {
+      "name": "adeventcollection",
+      "className": "AdEventCollection",
+      "qualifiedName": "@happyvertical/smrt-ads:AdEventCollection",
+      "collection": "adevents",
+      "filePath": "packages/ads/src/collections/AdEventCollection.ts",
+      "packageName": "@happyvertical/smrt-ads",
+      "fields": {},
+      "methods": {
+        "findByVariation": {
+          "name": "findByVariation",
+          "async": true,
+          "parameters": [
+            {
+              "name": "variationId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByZone": {
+          "name": "findByZone",
+          "async": true,
+          "parameters": [
+            {
+              "name": "zoneId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findBySite": {
+          "name": "findBySite",
+          "async": true,
+          "parameters": [
+            {
+              "name": "siteId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByDateRange": {
+          "name": "findByDateRange",
+          "async": true,
+          "parameters": [
+            {
+              "name": "start",
+              "type": "Date",
+              "optional": false
+            },
+            {
+              "name": "end",
+              "type": "Date",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByType": {
+          "name": "findByType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "eventType",
+              "type": "AdEventType",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "countByType": {
+          "name": "countByType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "variationId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "eventType",
+              "type": "AdEventType",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "countImpressions": {
+          "name": "countImpressions",
+          "async": true,
+          "parameters": [
+            {
+              "name": "variationId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "countClicks": {
+          "name": "countClicks",
+          "async": true,
+          "parameters": [
+            {
+              "name": "variationId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "countConversions": {
+          "name": "countConversions",
+          "async": true,
+          "parameters": [
+            {
+              "name": "variationId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findImpressions": {
+          "name": "findImpressions",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findClicks": {
+          "name": "findClicks",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findConversions": {
+          "name": "findConversions",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getVariationStats": {
+          "name": "getVariationStats",
+          "async": true,
+          "parameters": [
+            {
+              "name": "variationId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<object>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "AdEvent",
+      "exportName": "AdEventCollection",
+      "collectionExportName": "AdEventCollectionCollection",
+      "schema": {
+        "tableName": "ad_event_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_event_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "ad_event_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "ad_event_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "1e5ee847"
+      }
+    },
+    "@happyvertical/smrt-ads:AdFormatCollection": {
+      "name": "adformatcollection",
+      "className": "AdFormatCollection",
+      "qualifiedName": "@happyvertical/smrt-ads:AdFormatCollection",
+      "collection": "adformats",
+      "filePath": "packages/ads/src/collections/AdFormatCollection.ts",
+      "packageName": "@happyvertical/smrt-ads",
+      "fields": {},
+      "methods": {
+        "findByDimensions": {
+          "name": "findByDimensions",
+          "async": true,
+          "parameters": [
+            {
+              "name": "width",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "height",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdFormat | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByType": {
+          "name": "findByType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "formatType",
+              "type": "AdFormatType",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdFormat[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findBanners": {
+          "name": "findBanners",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdFormat[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findNative": {
+          "name": "findNative",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdFormat[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findVideo": {
+          "name": "findVideo",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdFormat[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "AdFormat",
+      "exportName": "AdFormatCollection",
+      "collectionExportName": "AdFormatCollectionCollection",
+      "schema": {
+        "tableName": "ad_format_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_format_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "ad_format_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "ad_format_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "5f32a70c"
+      }
+    },
+    "@happyvertical/smrt-ads:AdGroupCollection": {
+      "name": "adgroupcollection",
+      "className": "AdGroupCollection",
+      "qualifiedName": "@happyvertical/smrt-ads:AdGroupCollection",
+      "collection": "adgroups",
+      "filePath": "packages/ads/src/collections/AdGroupCollection.ts",
+      "packageName": "@happyvertical/smrt-ads",
+      "fields": {},
+      "methods": {
+        "findByContract": {
+          "name": "findByContract",
+          "async": true,
+          "parameters": [
+            {
+              "name": "contractId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByTier": {
+          "name": "findByTier",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tierId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByStatus": {
+          "name": "findByStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "status",
+              "type": "AdGroupStatus",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findActive": {
+          "name": "findActive",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByVertical": {
+          "name": "findByVertical",
+          "async": true,
+          "parameters": [
+            {
+              "name": "verticalSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByZone": {
+          "name": "findByZone",
+          "async": true,
+          "parameters": [
+            {
+              "name": "zoneId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findEligibleForZone": {
+          "name": "findEligibleForZone",
+          "async": true,
+          "parameters": [
+            {
+              "name": "zoneId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findDrafts": {
+          "name": "findDrafts",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findPaused": {
+          "name": "findPaused",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findCompleted": {
+          "name": "findCompleted",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "AdGroup",
+      "exportName": "AdGroupCollection",
+      "collectionExportName": "AdGroupCollectionCollection",
+      "schema": {
+        "tableName": "ad_group_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_group_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "ad_group_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "ad_group_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "e7850ea1"
+      }
+    },
+    "@happyvertical/smrt-ads:AdVariationCollection": {
+      "name": "advariationcollection",
+      "className": "AdVariationCollection",
+      "qualifiedName": "@happyvertical/smrt-ads:AdVariationCollection",
+      "collection": "advariations",
+      "filePath": "packages/ads/src/collections/AdVariationCollection.ts",
+      "packageName": "@happyvertical/smrt-ads",
+      "fields": {},
+      "methods": {
+        "findByGroup": {
+          "name": "findByGroup",
+          "async": true,
+          "parameters": [
+            {
+              "name": "groupId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByFormat": {
+          "name": "findByFormat",
+          "async": true,
+          "parameters": [
+            {
+              "name": "formatId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findActiveByGroup": {
+          "name": "findActiveByGroup",
+          "async": true,
+          "parameters": [
+            {
+              "name": "groupId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "selectByWeight": {
+          "name": "selectByWeight",
+          "async": true,
+          "parameters": [
+            {
+              "name": "groupId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdVariation | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByStatus": {
+          "name": "findByStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "status",
+              "type": "AdVariationStatus",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findActive": {
+          "name": "findActive",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findDrafts": {
+          "name": "findDrafts",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findPaused": {
+          "name": "findPaused",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findTopPerformers": {
+          "name": "findTopPerformers",
+          "async": true,
+          "parameters": [
+            {
+              "name": "limit",
+              "type": "number",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "AdVariation",
+      "exportName": "AdVariationCollection",
+      "collectionExportName": "AdVariationCollectionCollection",
+      "schema": {
+        "tableName": "ad_variation_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_variation_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "ad_variation_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "ad_variation_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "d8ef9671"
+      }
     }
   },
   "moduleType": "smrt",
   "smrtDependencies": [
     "@happyvertical/smrt-assets",
+    "@happyvertical/smrt-commerce",
     "@happyvertical/smrt-core",
     "@happyvertical/smrt-properties",
-    "@happyvertical/smrt-tags"
+    "@happyvertical/smrt-tags",
+    "@happyvertical/smrt-tenancy"
   ]
 }

--- a/packages/ads/src/manifest/manifest.json
+++ b/packages/ads/src/manifest/manifest.json
@@ -1,157 +1,16 @@
 {
   "version": "1.0.0",
-  "timestamp": 1767322692093,
+  "timestamp": 1780375818917,
+  "packageName": "@happyvertical/smrt-ads",
+  "packageVersion": "0.25.8",
   "objects": {
-    "addeliverytier": {
-      "name": "addeliverytier",
-      "className": "AdDeliveryTier",
-      "collection": "addeliverytiers",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/ads/src/models/AdDeliveryTier.ts",
-      "fields": {
-        "name": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "priority": {
-          "type": "integer",
-          "required": false,
-          "default": 0
-        },
-        "pricingModel": {
-          "type": "text",
-          "required": false
-        },
-        "description": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        }
-      },
-      "methods": {
-        "isHigherPriorityThan": {
-          "name": "isHigherPriorityThan",
-          "async": false,
-          "parameters": [
-            {
-              "name": "other",
-              "type": "AdDeliveryTier",
-              "optional": false
-            }
-          ],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isFixedPricing": {
-          "name": "isFixedPricing",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isPerformanceBased": {
-          "name": "isPerformanceBased",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "api": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update"
-          ]
-        },
-        "mcp": {
-          "include": [
-            "list",
-            "get"
-          ]
-        },
-        "cli": true
-      },
-      "extends": "SmrtObject",
-      "exportName": "AdDeliveryTier",
-      "collectionExportName": "AdDeliveryTierCollection",
-      "schema": {
-        "tableName": "ad_delivery_tiers",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_delivery_tiers\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"priority\" INTEGER DEFAULT 0,\n  \"pricing_model\" TEXT,\n  \"description\" TEXT DEFAULT ''\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "name": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "priority": {
-            "type": "INTEGER",
-            "notNull": false,
-            "default": 0
-          },
-          "pricing_model": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "description": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          }
-        },
-        "indexes": [
-          {
-            "name": "ad_delivery_tiers_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "ad_delivery_tiers_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "b4e18e96"
-      }
-    },
-    "addeliverytiercollection": {
+    "@happyvertical/smrt-ads:AdDeliveryTierCollection": {
       "name": "addeliverytiercollection",
       "className": "AdDeliveryTierCollection",
+      "qualifiedName": "@happyvertical/smrt-ads:AdDeliveryTierCollection",
       "collection": "addeliverytiers",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/ads/src/collections/AdDeliveryTierCollection.ts",
+      "filePath": "packages/ads/src/collections/AdDeliveryTierCollection.ts",
+      "packageName": "@happyvertical/smrt-ads",
       "fields": {},
       "methods": {
         "findByPriority": {
@@ -216,10 +75,10 @@
       "collectionExportName": "AdDeliveryTierCollectionCollection",
       "schema": {
         "tableName": "ad_delivery_tier_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_delivery_tier_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_delivery_tier_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -259,878 +118,16 @@
             "unique": true
           }
         ],
-        "version": "9efdebfd"
+        "version": "8229e958"
       }
     },
-    "adformat": {
-      "name": "adformat",
-      "className": "AdFormat",
-      "collection": "adformats",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/ads/src/models/AdFormat.ts",
-      "fields": {
-        "name": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "width": {
-          "type": "integer",
-          "required": false,
-          "default": 0
-        },
-        "height": {
-          "type": "integer",
-          "required": false,
-          "default": 0
-        },
-        "formatType": {
-          "type": "text",
-          "required": false
-        },
-        "description": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        }
-      },
-      "methods": {
-        "getDimensions": {
-          "name": "getDimensions",
-          "async": false,
-          "parameters": [],
-          "returnType": "string",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "matchesDimensions": {
-          "name": "matchesDimensions",
-          "async": false,
-          "parameters": [
-            {
-              "name": "width",
-              "type": "number",
-              "optional": false
-            },
-            {
-              "name": "height",
-              "type": "number",
-              "optional": false
-            }
-          ],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "api": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update"
-          ]
-        },
-        "mcp": {
-          "include": [
-            "list",
-            "get"
-          ]
-        },
-        "cli": true
-      },
-      "extends": "SmrtObject",
-      "exportName": "AdFormat",
-      "collectionExportName": "AdFormatCollection",
-      "schema": {
-        "tableName": "ad_formats",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_formats\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"width\" INTEGER DEFAULT 0,\n  \"height\" INTEGER DEFAULT 0,\n  \"format_type\" TEXT,\n  \"description\" TEXT DEFAULT ''\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "name": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "width": {
-            "type": "INTEGER",
-            "notNull": false,
-            "default": 0
-          },
-          "height": {
-            "type": "INTEGER",
-            "notNull": false,
-            "default": 0
-          },
-          "format_type": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "description": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          }
-        },
-        "indexes": [
-          {
-            "name": "ad_formats_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "ad_formats_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "ee6160ff"
-      }
-    },
-    "adgroup": {
-      "name": "adgroup",
-      "className": "AdGroup",
-      "collection": "adgroups",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/ads/src/models/AdGroup.ts",
-      "fields": {
-        "contractId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "tierId": {
-          "type": "foreignKey",
-          "required": false
-        },
-        "name": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "verticalSlug": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "targeting": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "zoneIds": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "startDate": {
-          "type": "datetime",
-          "required": false,
-          "default": null
-        },
-        "endDate": {
-          "type": "datetime",
-          "required": false,
-          "default": null
-        },
-        "dailyBudget": {
-          "type": "decimal",
-          "required": false,
-          "default": 0
-        },
-        "totalBudget": {
-          "type": "decimal",
-          "required": false,
-          "default": 0
-        },
-        "status": {
-          "type": "text",
-          "required": false
-        }
-      },
-      "methods": {
-        "getZoneIds": {
-          "name": "getZoneIds",
-          "async": false,
-          "parameters": [],
-          "returnType": "string[]",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "setZoneIds": {
-          "name": "setZoneIds",
-          "async": false,
-          "parameters": [
-            {
-              "name": "ids",
-              "type": "string[]",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "addZoneId": {
-          "name": "addZoneId",
-          "async": false,
-          "parameters": [
-            {
-              "name": "zoneId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "removeZoneId": {
-          "name": "removeZoneId",
-          "async": false,
-          "parameters": [
-            {
-              "name": "zoneId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "hasZoneId": {
-          "name": "hasZoneId",
-          "async": false,
-          "parameters": [
-            {
-              "name": "zoneId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getTargeting": {
-          "name": "getTargeting",
-          "async": false,
-          "parameters": [],
-          "returnType": "Record<string, any>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "setTargeting": {
-          "name": "setTargeting",
-          "async": false,
-          "parameters": [
-            {
-              "name": "rules",
-              "type": "Record<string, any>",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isActive": {
-          "name": "isActive",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isDraft": {
-          "name": "isDraft",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isPaused": {
-          "name": "isPaused",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isCompleted": {
-          "name": "isCompleted",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "hasEnded": {
-          "name": "hasEnded",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "hasStarted": {
-          "name": "hasStarted",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "api": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update"
-          ]
-        },
-        "mcp": {
-          "include": [
-            "list",
-            "get",
-            "create"
-          ]
-        },
-        "cli": true
-      },
-      "extends": "SmrtObject",
-      "exportName": "AdGroup",
-      "collectionExportName": "AdGroupCollection",
-      "schema": {
-        "tableName": "ad_groups",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_groups\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"contract_id\" TEXT DEFAULT '',\n  \"tier_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"vertical_slug\" TEXT DEFAULT '',\n  \"targeting\" TEXT DEFAULT '',\n  \"zone_ids\" TEXT DEFAULT '',\n  \"start_date\" TIMESTAMP DEFAULT current_timestamp,\n  \"end_date\" TIMESTAMP DEFAULT current_timestamp,\n  \"daily_budget\" REAL DEFAULT 0,\n  \"total_budget\" REAL DEFAULT 0,\n  \"status\" TEXT\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "contract_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "tier_id": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "name": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "vertical_slug": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "targeting": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "zone_ids": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "start_date": {
-            "type": "TIMESTAMP",
-            "notNull": false,
-            "default": null
-          },
-          "end_date": {
-            "type": "TIMESTAMP",
-            "notNull": false,
-            "default": null
-          },
-          "daily_budget": {
-            "type": "REAL",
-            "notNull": false,
-            "default": 0
-          },
-          "total_budget": {
-            "type": "REAL",
-            "notNull": false,
-            "default": 0
-          },
-          "status": {
-            "type": "TEXT",
-            "notNull": false
-          }
-        },
-        "indexes": [
-          {
-            "name": "ad_groups_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "ad_groups_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "4f417b94"
-      }
-    },
-    "advariation": {
-      "name": "advariation",
-      "className": "AdVariation",
-      "collection": "advariations",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/ads/src/models/AdVariation.ts",
-      "fields": {
-        "groupId": {
-          "type": "foreignKey",
-          "required": false
-        },
-        "formatId": {
-          "type": "foreignKey",
-          "required": false
-        },
-        "assetId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "name": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "clickUrl": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "altText": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "weight": {
-          "type": "integer",
-          "required": false,
-          "default": 1
-        },
-        "status": {
-          "type": "text",
-          "required": false
-        },
-        "impressions": {
-          "type": "integer",
-          "required": false,
-          "default": 0
-        },
-        "clicks": {
-          "type": "integer",
-          "required": false,
-          "default": 0
-        }
-      },
-      "methods": {
-        "isActive": {
-          "name": "isActive",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isDraft": {
-          "name": "isDraft",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isPaused": {
-          "name": "isPaused",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getCTR": {
-          "name": "getCTR",
-          "async": false,
-          "parameters": [],
-          "returnType": "number",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "recordImpression": {
-          "name": "recordImpression",
-          "async": false,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "recordClick": {
-          "name": "recordClick",
-          "async": false,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "api": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update"
-          ]
-        },
-        "mcp": {
-          "include": [
-            "list",
-            "get",
-            "create"
-          ]
-        },
-        "cli": true
-      },
-      "extends": "SmrtObject",
-      "exportName": "AdVariation",
-      "collectionExportName": "AdVariationCollection",
-      "schema": {
-        "tableName": "ad_variations",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_variations\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"group_id\" TEXT,\n  \"format_id\" TEXT,\n  \"asset_id\" TEXT DEFAULT '',\n  \"name\" TEXT DEFAULT '',\n  \"click_url\" TEXT DEFAULT '',\n  \"alt_text\" TEXT DEFAULT '',\n  \"weight\" INTEGER DEFAULT 1,\n  \"status\" TEXT,\n  \"impressions\" INTEGER DEFAULT 0,\n  \"clicks\" INTEGER DEFAULT 0\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "group_id": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "format_id": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "asset_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "name": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "click_url": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "alt_text": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "weight": {
-            "type": "INTEGER",
-            "notNull": false,
-            "default": 1
-          },
-          "status": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "impressions": {
-            "type": "INTEGER",
-            "notNull": false,
-            "default": 0
-          },
-          "clicks": {
-            "type": "INTEGER",
-            "notNull": false,
-            "default": 0
-          }
-        },
-        "indexes": [
-          {
-            "name": "ad_variations_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "ad_variations_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "7f60948f"
-      }
-    },
-    "adevent": {
-      "name": "adevent",
-      "className": "AdEvent",
-      "collection": "adevents",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/ads/src/models/AdEvent.ts",
-      "fields": {
-        "variationId": {
-          "type": "foreignKey",
-          "required": false
-        },
-        "zoneId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "siteId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "eventType": {
-          "type": "text",
-          "required": false
-        },
-        "timestamp": {
-          "type": "datetime",
-          "required": false
-        },
-        "metadata": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        }
-      },
-      "methods": {
-        "getMetadata": {
-          "name": "getMetadata",
-          "async": false,
-          "parameters": [],
-          "returnType": "Record<string, any>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "setMetadata": {
-          "name": "setMetadata",
-          "async": false,
-          "parameters": [
-            {
-              "name": "data",
-              "type": "Record<string, any>",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isImpression": {
-          "name": "isImpression",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isClick": {
-          "name": "isClick",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isConversion": {
-          "name": "isConversion",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "api": {
-          "include": [
-            "create",
-            "list"
-          ]
-        },
-        "mcp": {
-          "include": [
-            "create"
-          ]
-        },
-        "cli": false
-      },
-      "extends": "SmrtObject",
-      "exportName": "AdEvent",
-      "collectionExportName": "AdEventCollection",
-      "schema": {
-        "tableName": "ad_events",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_events\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"variation_id\" TEXT,\n  \"zone_id\" TEXT DEFAULT '',\n  \"site_id\" TEXT DEFAULT '',\n  \"event_type\" TEXT,\n  \"timestamp\" TIMESTAMP,\n  \"metadata\" TEXT DEFAULT ''\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "variation_id": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "zone_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "site_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "event_type": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "timestamp": {
-            "type": "TIMESTAMP",
-            "notNull": false
-          },
-          "metadata": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          }
-        },
-        "indexes": [
-          {
-            "name": "ad_events_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "ad_events_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "04ca2f13"
-      }
-    },
-    "adeventcollection": {
+    "@happyvertical/smrt-ads:AdEventCollection": {
       "name": "adeventcollection",
       "className": "AdEventCollection",
+      "qualifiedName": "@happyvertical/smrt-ads:AdEventCollection",
       "collection": "adevents",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/ads/src/collections/AdEventCollection.ts",
+      "filePath": "packages/ads/src/collections/AdEventCollection.ts",
+      "packageName": "@happyvertical/smrt-ads",
       "fields": {},
       "methods": {
         "findByVariation": {
@@ -1303,7 +300,43 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<{\n    impressions: number;\n    clicks: number;\n    conversions: number;\n    ctr: number;\n    conversionRate: number;\n  }>",
+          "returnType": "Promise<object>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdEvent[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdEvent[]>",
           "isStatic": false,
           "isPublic": true
         }
@@ -1315,10 +348,10 @@
       "collectionExportName": "AdEventCollectionCollection",
       "schema": {
         "tableName": "ad_event_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_event_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_event_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1358,14 +391,16 @@
             "unique": true
           }
         ],
-        "version": "ee9d6da6"
+        "version": "1e5ee847"
       }
     },
-    "adformatcollection": {
+    "@happyvertical/smrt-ads:AdFormatCollection": {
       "name": "adformatcollection",
       "className": "AdFormatCollection",
+      "qualifiedName": "@happyvertical/smrt-ads:AdFormatCollection",
       "collection": "adformats",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/ads/src/collections/AdFormatCollection.ts",
+      "filePath": "packages/ads/src/collections/AdFormatCollection.ts",
+      "packageName": "@happyvertical/smrt-ads",
       "fields": {},
       "methods": {
         "findByDimensions": {
@@ -1433,10 +468,10 @@
       "collectionExportName": "AdFormatCollectionCollection",
       "schema": {
         "tableName": "ad_format_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_format_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_format_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1476,14 +511,16 @@
             "unique": true
           }
         ],
-        "version": "70d685a1"
+        "version": "5f32a70c"
       }
     },
-    "adgroupcollection": {
+    "@happyvertical/smrt-ads:AdGroupCollection": {
       "name": "adgroupcollection",
       "className": "AdGroupCollection",
+      "qualifiedName": "@happyvertical/smrt-ads:AdGroupCollection",
       "collection": "adgroups",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/ads/src/collections/AdGroupCollection.ts",
+      "filePath": "packages/ads/src/collections/AdGroupCollection.ts",
+      "packageName": "@happyvertical/smrt-ads",
       "fields": {},
       "methods": {
         "findByContract": {
@@ -1601,6 +638,42 @@
           "returnType": "Promise<AdGroup[]>",
           "isStatic": false,
           "isPublic": true
+        },
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdGroup[]>",
+          "isStatic": false,
+          "isPublic": true
         }
       },
       "decoratorConfig": {},
@@ -1610,10 +683,10 @@
       "collectionExportName": "AdGroupCollectionCollection",
       "schema": {
         "tableName": "ad_group_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_group_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_group_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1653,14 +726,16 @@
             "unique": true
           }
         ],
-        "version": "6d84a15a"
+        "version": "e7850ea1"
       }
     },
-    "advariationcollection": {
+    "@happyvertical/smrt-ads:AdVariationCollection": {
       "name": "advariationcollection",
       "className": "AdVariationCollection",
+      "qualifiedName": "@happyvertical/smrt-ads:AdVariationCollection",
       "collection": "advariations",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/ads/src/collections/AdVariationCollection.ts",
+      "filePath": "packages/ads/src/collections/AdVariationCollection.ts",
+      "packageName": "@happyvertical/smrt-ads",
       "fields": {},
       "methods": {
         "findByGroup": {
@@ -1764,8 +839,43 @@
             {
               "name": "limit",
               "type": "number",
-              "optional": false,
-              "default": 10
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AdVariation[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
             }
           ],
           "returnType": "Promise<AdVariation[]>",
@@ -1780,10 +890,10 @@
       "collectionExportName": "AdVariationCollectionCollection",
       "schema": {
         "tableName": "ad_variation_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_variation_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_variation_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1823,10 +933,2369 @@
             "unique": true
           }
         ],
-        "version": "4af1ef95"
+        "version": "d8ef9671"
+      }
+    },
+    "@happyvertical/smrt-ads:AdDeliveryTier": {
+      "name": "addeliverytier",
+      "className": "AdDeliveryTier",
+      "qualifiedName": "@happyvertical/smrt-ads:AdDeliveryTier",
+      "collection": "addeliverytiers",
+      "filePath": "packages/ads/src/models/AdDeliveryTier.ts",
+      "packageName": "@happyvertical/smrt-ads",
+      "fields": {
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "priority": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "pricingModel": {
+          "type": "text",
+          "required": false
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        }
+      },
+      "methods": {
+        "isHigherPriorityThan": {
+          "name": "isHigherPriorityThan",
+          "async": false,
+          "parameters": [
+            {
+              "name": "other",
+              "type": "AdDeliveryTier",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isFixedPricing": {
+          "name": "isFixedPricing",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isPerformanceBased": {
+          "name": "isPerformanceBased",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "AdDeliveryTier",
+      "collectionExportName": "AdDeliveryTierCollection",
+      "schema": {
+        "tableName": "ad_delivery_tiers",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_delivery_tiers\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"priority\" INTEGER DEFAULT 0,\n  \"pricing_model\" TEXT,\n  \"description\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": ""
+          },
+          "priority": {
+            "type": "INTEGER",
+            "notNull": false,
+            "unique": false,
+            "default": 0
+          },
+          "pricing_model": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "ad_delivery_tiers_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "ad_delivery_tiers_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "ad28e83a"
+      }
+    },
+    "@happyvertical/smrt-ads:AdEvent": {
+      "name": "adevent",
+      "className": "AdEvent",
+      "qualifiedName": "@happyvertical/smrt-ads:AdEvent",
+      "collection": "adevents",
+      "filePath": "packages/ads/src/models/AdEvent.ts",
+      "packageName": "@happyvertical/smrt-ads",
+      "fields": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "variationId": {
+          "type": "foreignKey",
+          "required": false,
+          "related": "AdVariation"
+        },
+        "zoneId": {
+          "type": "crossPackageRef",
+          "required": false,
+          "related": "@happyvertical/smrt-properties:Zone"
+        },
+        "siteId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "eventType": {
+          "type": "text",
+          "required": false
+        },
+        "timestamp": {
+          "type": "datetime",
+          "required": false
+        },
+        "metadata": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        }
+      },
+      "methods": {
+        "getAiUsageSnapshot": {
+          "name": "getAiUsageSnapshot",
+          "async": false,
+          "parameters": [],
+          "returnType": "AiUsageSnapshot | undefined",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetAiUsage": {
+          "name": "resetAiUsage",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listAiUsage": {
+          "name": "listAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageListOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<SmrtAiUsageRecord[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeAiUsage": {
+          "name": "summarizeAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageSummaryOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Record<string, AiUsageStats>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "destroy": {
+          "name": "destroy",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadDataFromDb": {
+          "name": "loadDataFromDb",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toJSON": {
+          "name": "toJSON",
+          "async": false,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPlainObject": {
+          "name": "toPlainObject",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getId": {
+          "name": "getId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSlug": {
+          "name": "getSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSavedId": {
+          "name": "getSavedId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSaved": {
+          "name": "isSaved",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromId": {
+          "name": "loadFromId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromSlug": {
+          "name": "loadFromSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "is": {
+          "name": "is",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "do": {
+          "name": "do",
+          "async": true,
+          "parameters": [
+            {
+              "name": "instructions",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "describe": {
+          "name": "describe",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "delete": {
+          "name": "delete",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRelatedLoaded": {
+          "name": "isRelatedLoaded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelated": {
+          "name": "loadRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelatedMany": {
+          "name": "loadRelatedMany",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelated": {
+          "name": "getRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAvailableTools": {
+          "name": "getAvailableTools",
+          "async": false,
+          "parameters": [],
+          "returnType": "AITool[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "executeToolCall": {
+          "name": "executeToolCall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toolCall",
+              "type": "ToolCall",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ToolCallResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "remember": {
+          "name": "remember",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recall": {
+          "name": "recall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recallAll": {
+          "name": "recallAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forget": {
+          "name": "forget",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forgetScope": {
+          "name": "forgetScope",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateEmbeddings": {
+          "name": "generateEmbeddings",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "GenerateEmbeddingsOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmbedding": {
+          "name": "getEmbedding",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "model",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number[] | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStaleEmbeddings": {
+          "name": "hasStaleEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearEmbeddings": {
+          "name": "clearEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setMetadata": {
+          "name": "setMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isImpression": {
+          "name": "isImpression",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isClick": {
+          "name": "isClick",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isConversion": {
+          "name": "isConversion",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "create",
+            "list"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "create"
+          ]
+        },
+        "cli": false
+      },
+      "extends": "SmrtObject",
+      "exportName": "AdEvent",
+      "collectionExportName": "AdEventCollection",
+      "schema": {
+        "tableName": "ad_events",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_events\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"variation_id\" uuid,\n  \"zone_id\" uuid,\n  \"site_id\" TEXT DEFAULT '',\n  \"event_type\" TEXT,\n  \"timestamp\" TIMESTAMP,\n  \"metadata\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "variation_id": {
+            "type": "UUID",
+            "notNull": false
+          },
+          "zone_id": {
+            "type": "UUID",
+            "notNull": false
+          },
+          "site_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "event_type": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "timestamp": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          },
+          "metadata": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "ad_events_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "ad_events_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "ad_events_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "9059954f"
+      }
+    },
+    "@happyvertical/smrt-ads:AdFormat": {
+      "name": "adformat",
+      "className": "AdFormat",
+      "qualifiedName": "@happyvertical/smrt-ads:AdFormat",
+      "collection": "adformats",
+      "filePath": "packages/ads/src/models/AdFormat.ts",
+      "packageName": "@happyvertical/smrt-ads",
+      "fields": {
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "width": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "height": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "formatType": {
+          "type": "text",
+          "required": false
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        }
+      },
+      "methods": {
+        "getDimensions": {
+          "name": "getDimensions",
+          "async": false,
+          "parameters": [],
+          "returnType": "string",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "matchesDimensions": {
+          "name": "matchesDimensions",
+          "async": false,
+          "parameters": [
+            {
+              "name": "width",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "height",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "AdFormat",
+      "collectionExportName": "AdFormatCollection",
+      "schema": {
+        "tableName": "ad_formats",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_formats\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"width\" INTEGER DEFAULT 0,\n  \"height\" INTEGER DEFAULT 0,\n  \"format_type\" TEXT,\n  \"description\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": ""
+          },
+          "width": {
+            "type": "INTEGER",
+            "notNull": false,
+            "unique": false,
+            "default": 0
+          },
+          "height": {
+            "type": "INTEGER",
+            "notNull": false,
+            "unique": false,
+            "default": 0
+          },
+          "format_type": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "ad_formats_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "ad_formats_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "307f1905"
+      }
+    },
+    "@happyvertical/smrt-ads:AdGroup": {
+      "name": "adgroup",
+      "className": "AdGroup",
+      "qualifiedName": "@happyvertical/smrt-ads:AdGroup",
+      "collection": "adgroups",
+      "filePath": "packages/ads/src/models/AdGroup.ts",
+      "packageName": "@happyvertical/smrt-ads",
+      "fields": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "contractId": {
+          "type": "crossPackageRef",
+          "required": false,
+          "related": "@happyvertical/smrt-commerce:Contract"
+        },
+        "tierId": {
+          "type": "foreignKey",
+          "required": false,
+          "related": "AdDeliveryTier"
+        },
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "verticalSlug": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "targeting": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "zoneIds": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "startDate": {
+          "type": "datetime",
+          "required": false
+        },
+        "endDate": {
+          "type": "datetime",
+          "required": false
+        },
+        "dailyBudget": {
+          "type": "decimal",
+          "required": false,
+          "default": 0
+        },
+        "totalBudget": {
+          "type": "decimal",
+          "required": false,
+          "default": 0
+        },
+        "status": {
+          "type": "text",
+          "required": false
+        }
+      },
+      "methods": {
+        "getAiUsageSnapshot": {
+          "name": "getAiUsageSnapshot",
+          "async": false,
+          "parameters": [],
+          "returnType": "AiUsageSnapshot | undefined",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetAiUsage": {
+          "name": "resetAiUsage",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listAiUsage": {
+          "name": "listAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageListOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<SmrtAiUsageRecord[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeAiUsage": {
+          "name": "summarizeAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageSummaryOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Record<string, AiUsageStats>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "destroy": {
+          "name": "destroy",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadDataFromDb": {
+          "name": "loadDataFromDb",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toJSON": {
+          "name": "toJSON",
+          "async": false,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPlainObject": {
+          "name": "toPlainObject",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getId": {
+          "name": "getId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSlug": {
+          "name": "getSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSavedId": {
+          "name": "getSavedId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSaved": {
+          "name": "isSaved",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromId": {
+          "name": "loadFromId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromSlug": {
+          "name": "loadFromSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "is": {
+          "name": "is",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "do": {
+          "name": "do",
+          "async": true,
+          "parameters": [
+            {
+              "name": "instructions",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "describe": {
+          "name": "describe",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "delete": {
+          "name": "delete",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRelatedLoaded": {
+          "name": "isRelatedLoaded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelated": {
+          "name": "loadRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelatedMany": {
+          "name": "loadRelatedMany",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelated": {
+          "name": "getRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAvailableTools": {
+          "name": "getAvailableTools",
+          "async": false,
+          "parameters": [],
+          "returnType": "AITool[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "executeToolCall": {
+          "name": "executeToolCall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toolCall",
+              "type": "ToolCall",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ToolCallResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "remember": {
+          "name": "remember",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recall": {
+          "name": "recall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recallAll": {
+          "name": "recallAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forget": {
+          "name": "forget",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forgetScope": {
+          "name": "forgetScope",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateEmbeddings": {
+          "name": "generateEmbeddings",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "GenerateEmbeddingsOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmbedding": {
+          "name": "getEmbedding",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "model",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number[] | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStaleEmbeddings": {
+          "name": "hasStaleEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearEmbeddings": {
+          "name": "clearEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getZoneIds": {
+          "name": "getZoneIds",
+          "async": false,
+          "parameters": [],
+          "returnType": "string[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setZoneIds": {
+          "name": "setZoneIds",
+          "async": false,
+          "parameters": [
+            {
+              "name": "ids",
+              "type": "string[]",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addZoneId": {
+          "name": "addZoneId",
+          "async": false,
+          "parameters": [
+            {
+              "name": "zoneId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeZoneId": {
+          "name": "removeZoneId",
+          "async": false,
+          "parameters": [
+            {
+              "name": "zoneId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasZoneId": {
+          "name": "hasZoneId",
+          "async": false,
+          "parameters": [
+            {
+              "name": "zoneId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getTargeting": {
+          "name": "getTargeting",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setTargeting": {
+          "name": "setTargeting",
+          "async": false,
+          "parameters": [
+            {
+              "name": "rules",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isDraft": {
+          "name": "isDraft",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isPaused": {
+          "name": "isPaused",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isCompleted": {
+          "name": "isCompleted",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasEnded": {
+          "name": "hasEnded",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStarted": {
+          "name": "hasStarted",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "AdGroup",
+      "collectionExportName": "AdGroupCollection",
+      "schema": {
+        "tableName": "ad_groups",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_groups\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"contract_id\" uuid,\n  \"tier_id\" uuid,\n  \"name\" TEXT DEFAULT '',\n  \"vertical_slug\" TEXT DEFAULT '',\n  \"targeting\" TEXT DEFAULT '',\n  \"zone_ids\" TEXT DEFAULT '',\n  \"start_date\" TIMESTAMP,\n  \"end_date\" TIMESTAMP,\n  \"daily_budget\" DOUBLE PRECISION DEFAULT 0,\n  \"total_budget\" DOUBLE PRECISION DEFAULT 0,\n  \"status\" TEXT\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "contract_id": {
+            "type": "UUID",
+            "notNull": false
+          },
+          "tier_id": {
+            "type": "UUID",
+            "notNull": false
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "vertical_slug": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "targeting": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "zone_ids": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "start_date": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          },
+          "end_date": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          },
+          "daily_budget": {
+            "type": "REAL",
+            "notNull": false,
+            "default": 0
+          },
+          "total_budget": {
+            "type": "REAL",
+            "notNull": false,
+            "default": 0
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "ad_groups_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "ad_groups_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "ad_groups_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "7cc44420"
+      }
+    },
+    "@happyvertical/smrt-ads:AdVariation": {
+      "name": "advariation",
+      "className": "AdVariation",
+      "qualifiedName": "@happyvertical/smrt-ads:AdVariation",
+      "collection": "advariations",
+      "filePath": "packages/ads/src/models/AdVariation.ts",
+      "packageName": "@happyvertical/smrt-ads",
+      "fields": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "groupId": {
+          "type": "foreignKey",
+          "required": false,
+          "related": "AdGroup"
+        },
+        "formatId": {
+          "type": "foreignKey",
+          "required": false,
+          "related": "AdFormat"
+        },
+        "assetId": {
+          "type": "crossPackageRef",
+          "required": false,
+          "related": "@happyvertical/smrt-assets:Asset"
+        },
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "clickUrl": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "altText": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "weight": {
+          "type": "integer",
+          "required": false,
+          "default": 1
+        },
+        "status": {
+          "type": "text",
+          "required": false
+        },
+        "impressions": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "clicks": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        }
+      },
+      "methods": {
+        "getAiUsageSnapshot": {
+          "name": "getAiUsageSnapshot",
+          "async": false,
+          "parameters": [],
+          "returnType": "AiUsageSnapshot | undefined",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetAiUsage": {
+          "name": "resetAiUsage",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listAiUsage": {
+          "name": "listAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageListOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<SmrtAiUsageRecord[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeAiUsage": {
+          "name": "summarizeAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageSummaryOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Record<string, AiUsageStats>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "destroy": {
+          "name": "destroy",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadDataFromDb": {
+          "name": "loadDataFromDb",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toJSON": {
+          "name": "toJSON",
+          "async": false,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPlainObject": {
+          "name": "toPlainObject",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getId": {
+          "name": "getId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSlug": {
+          "name": "getSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSavedId": {
+          "name": "getSavedId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSaved": {
+          "name": "isSaved",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromId": {
+          "name": "loadFromId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromSlug": {
+          "name": "loadFromSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "is": {
+          "name": "is",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "do": {
+          "name": "do",
+          "async": true,
+          "parameters": [
+            {
+              "name": "instructions",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "describe": {
+          "name": "describe",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "delete": {
+          "name": "delete",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRelatedLoaded": {
+          "name": "isRelatedLoaded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelated": {
+          "name": "loadRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelatedMany": {
+          "name": "loadRelatedMany",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelated": {
+          "name": "getRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAvailableTools": {
+          "name": "getAvailableTools",
+          "async": false,
+          "parameters": [],
+          "returnType": "AITool[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "executeToolCall": {
+          "name": "executeToolCall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toolCall",
+              "type": "ToolCall",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ToolCallResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "remember": {
+          "name": "remember",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recall": {
+          "name": "recall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recallAll": {
+          "name": "recallAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forget": {
+          "name": "forget",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forgetScope": {
+          "name": "forgetScope",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateEmbeddings": {
+          "name": "generateEmbeddings",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "GenerateEmbeddingsOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmbedding": {
+          "name": "getEmbedding",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "model",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number[] | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStaleEmbeddings": {
+          "name": "hasStaleEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearEmbeddings": {
+          "name": "clearEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isDraft": {
+          "name": "isDraft",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isPaused": {
+          "name": "isPaused",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getCTR": {
+          "name": "getCTR",
+          "async": false,
+          "parameters": [],
+          "returnType": "number",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recordImpression": {
+          "name": "recordImpression",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recordClick": {
+          "name": "recordClick",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "AdVariation",
+      "collectionExportName": "AdVariationCollection",
+      "schema": {
+        "tableName": "ad_variations",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"ad_variations\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"group_id\" uuid,\n  \"format_id\" uuid,\n  \"asset_id\" uuid,\n  \"name\" TEXT DEFAULT '',\n  \"click_url\" TEXT DEFAULT '',\n  \"alt_text\" TEXT DEFAULT '',\n  \"weight\" INTEGER DEFAULT 1,\n  \"status\" TEXT,\n  \"impressions\" INTEGER DEFAULT 0,\n  \"clicks\" INTEGER DEFAULT 0\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "group_id": {
+            "type": "UUID",
+            "notNull": false
+          },
+          "format_id": {
+            "type": "UUID",
+            "notNull": false
+          },
+          "asset_id": {
+            "type": "UUID",
+            "notNull": false
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "click_url": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "alt_text": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "weight": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 1
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "impressions": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "clicks": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          }
+        },
+        "indexes": [
+          {
+            "name": "ad_variations_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "ad_variations_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "ad_variations_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "e56c1b67"
       }
     }
   },
   "moduleType": "smrt",
-  "packageName": "@happyvertical/smrt-ads"
+  "smrtDependencies": [
+    "@happyvertical/smrt-assets",
+    "@happyvertical/smrt-core",
+    "@happyvertical/smrt-properties",
+    "@happyvertical/smrt-tags"
+  ]
 }

--- a/packages/agents/src/manifest/manifest.json
+++ b/packages/agents/src/manifest/manifest.json
@@ -1,13 +1,29 @@
 {
   "version": "1.0.0",
-  "timestamp": 1767322692069,
+  "timestamp": 1780375817764,
+  "packageName": "@happyvertical/smrt-agents",
+  "packageVersion": "0.25.8",
   "objects": {
-    "agent": {
+    "@happyvertical/smrt-agents:Agent": {
       "name": "agent",
       "className": "Agent",
+      "qualifiedName": "@happyvertical/smrt-agents:Agent",
       "collection": "agents",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/agents/src/agent.ts",
+      "filePath": "packages/agents/src/agent.ts",
+      "packageName": "@happyvertical/smrt-agents",
       "fields": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
         "status": {
           "type": "text",
           "required": false,
@@ -15,6 +31,480 @@
         }
       },
       "methods": {
+        "getAiUsageSnapshot": {
+          "name": "getAiUsageSnapshot",
+          "async": false,
+          "parameters": [],
+          "returnType": "AiUsageSnapshot | undefined",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetAiUsage": {
+          "name": "resetAiUsage",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listAiUsage": {
+          "name": "listAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageListOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<SmrtAiUsageRecord[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeAiUsage": {
+          "name": "summarizeAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageSummaryOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Record<string, AiUsageStats>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "destroy": {
+          "name": "destroy",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadDataFromDb": {
+          "name": "loadDataFromDb",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toJSON": {
+          "name": "toJSON",
+          "async": false,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPlainObject": {
+          "name": "toPlainObject",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getId": {
+          "name": "getId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSlug": {
+          "name": "getSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSavedId": {
+          "name": "getSavedId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSaved": {
+          "name": "isSaved",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromId": {
+          "name": "loadFromId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromSlug": {
+          "name": "loadFromSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "is": {
+          "name": "is",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "do": {
+          "name": "do",
+          "async": true,
+          "parameters": [
+            {
+              "name": "instructions",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "describe": {
+          "name": "describe",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "delete": {
+          "name": "delete",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRelatedLoaded": {
+          "name": "isRelatedLoaded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelated": {
+          "name": "loadRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelatedMany": {
+          "name": "loadRelatedMany",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelated": {
+          "name": "getRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAvailableTools": {
+          "name": "getAvailableTools",
+          "async": false,
+          "parameters": [],
+          "returnType": "AITool[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "executeToolCall": {
+          "name": "executeToolCall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toolCall",
+              "type": "ToolCall",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ToolCallResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "remember": {
+          "name": "remember",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recall": {
+          "name": "recall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recallAll": {
+          "name": "recallAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forget": {
+          "name": "forget",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forgetScope": {
+          "name": "forgetScope",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateEmbeddings": {
+          "name": "generateEmbeddings",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "GenerateEmbeddingsOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmbedding": {
+          "name": "getEmbedding",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "model",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number[] | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStaleEmbeddings": {
+          "name": "hasStaleEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearEmbeddings": {
+          "name": "clearEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getUISlots": {
+          "name": "getUISlots",
+          "async": false,
+          "parameters": [],
+          "returnType": "AgentUISlots",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadConfigs": {
+          "name": "loadConfigs",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "saveSlotConfig": {
+          "name": "saveSlotConfig",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slotId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "data",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getMergedConfig": {
+          "name": "getMergedConfig",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slotId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "exportConfig": {
+          "name": "exportConfig",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
         "getDispatch": {
           "name": "getDispatch",
           "async": true,
@@ -29,7 +519,7 @@
           "parameters": [
             {
               "name": "_payload",
-              "type": "unknown",
+              "type": "any",
               "optional": false
             },
             {
@@ -50,25 +540,9 @@
           "isStatic": false,
           "isPublic": true
         },
-        "initialize": {
-          "name": "initialize",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<this>",
-          "isStatic": false,
-          "isPublic": true
-        },
         "validate": {
           "name": "validate",
           "async": true,
-          "parameters": [],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "run": {
-          "name": "run",
-          "async": false,
           "parameters": [],
           "returnType": "Promise<void>",
           "isStatic": false,
@@ -108,12 +582,17 @@
       "extends": "SmrtObject",
       "exportName": "Agent",
       "collectionExportName": "AgentCollection",
+      "staticProperties": {
+        "uiSlots": {},
+        "adminRoutes": [],
+        "signalSubscriptions": []
+      },
       "schema": {
         "tableName": "agents",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"agents\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"status\" TEXT DEFAULT 'idle'\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"agents\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"status\" TEXT DEFAULT 'idle'\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -144,6 +623,10 @@
             "notNull": true,
             "default": "current_timestamp"
           },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
           "status": {
             "type": "TEXT",
             "notNull": false,
@@ -173,10 +656,1218 @@
             ]
           }
         ],
-        "version": "0298c555"
+        "version": "9831fba1"
+      }
+    },
+    "@happyvertical/smrt-agents:AgentConfig": {
+      "name": "agentconfig",
+      "className": "AgentConfig",
+      "qualifiedName": "@happyvertical/smrt-agents:AgentConfig",
+      "collection": "agentconfigs",
+      "filePath": "packages/agents/src/config.ts",
+      "packageName": "@happyvertical/smrt-agents",
+      "fields": {
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "agentId": {
+          "type": "text",
+          "required": false,
+          "_meta": {}
+        },
+        "agentClass": {
+          "type": "text",
+          "required": false,
+          "_meta": {}
+        },
+        "slotId": {
+          "type": "text",
+          "required": false,
+          "_meta": {}
+        },
+        "configData": {
+          "type": "json",
+          "required": false,
+          "_meta": {}
+        },
+        "schemaVersion": {
+          "type": "integer",
+          "required": false,
+          "_meta": {}
+        }
+      },
+      "methods": {
+        "forAgent": {
+          "name": "forAgent",
+          "async": true,
+          "parameters": [
+            {
+              "name": "agentId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "SmrtClassOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "forAgents": {
+          "name": "forAgents",
+          "async": true,
+          "parameters": [
+            {
+              "name": "agentIds",
+              "type": "string[]",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "SmrtClassOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Map<string, Map<string, any>>>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "forSlot": {
+          "name": "forSlot",
+          "async": true,
+          "parameters": [
+            {
+              "name": "agentId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "slotId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "SmrtClassOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | undefined>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "saveSlot": {
+          "name": "saveSlot",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "object",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "SmrtClassOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AgentConfig>",
+          "isStatic": true,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableName": "agent_configs",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "AgentConfig",
+      "collectionExportName": "AgentConfigCollection",
+      "schema": {
+        "tableName": "agent_configs",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"agent_configs\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"agent_id\" TEXT,\n  \"agent_class\" TEXT,\n  \"slot_id\" TEXT,\n  \"config_data\" JSONB,\n  \"schema_version\" INTEGER\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "agent_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "agent_class": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "slot_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "config_data": {
+            "type": "JSON",
+            "notNull": false,
+            "unique": false
+          },
+          "schema_version": {
+            "type": "INTEGER",
+            "notNull": false,
+            "unique": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "agent_configs_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "agent_configs_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "1e0d4929"
+      }
+    },
+    "@happyvertical/smrt-agents:AgentConfigCollection": {
+      "name": "agentconfigcollection",
+      "className": "AgentConfigCollection",
+      "qualifiedName": "@happyvertical/smrt-agents:AgentConfigCollection",
+      "collection": "agentconfigs",
+      "filePath": "packages/agents/src/config.ts",
+      "packageName": "@happyvertical/smrt-agents",
+      "fields": {},
+      "methods": {
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AgentConfig[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AgentConfig[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AgentConfig[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableName": "agent_configs"
+      },
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "AgentConfig",
+      "exportName": "AgentConfigCollection",
+      "collectionExportName": "AgentConfigCollectionCollection",
+      "schema": {
+        "tableName": "agent_configs",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"agent_configs\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "agent_configs_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "agent_configs_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "5a4fb895"
+      }
+    },
+    "@happyvertical/smrt-agents:AgentSchedule": {
+      "name": "agentschedule",
+      "className": "AgentSchedule",
+      "qualifiedName": "@happyvertical/smrt-agents:AgentSchedule",
+      "collection": "agentschedules",
+      "filePath": "packages/agents/src/schedule.ts",
+      "packageName": "@happyvertical/smrt-agents",
+      "fields": {
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "agentType": {
+          "type": "text",
+          "required": false,
+          "_meta": {}
+        },
+        "agentId": {
+          "type": "text",
+          "required": false,
+          "_meta": {
+            "nullable": true
+          }
+        },
+        "agentConfig": {
+          "type": "json",
+          "required": false,
+          "_meta": {
+            "sqlType": "TEXT"
+          }
+        },
+        "cron": {
+          "type": "text",
+          "required": false,
+          "_meta": {}
+        },
+        "timezone": {
+          "type": "text",
+          "required": false,
+          "_meta": {}
+        },
+        "enabled": {
+          "type": "boolean",
+          "required": false,
+          "_meta": {}
+        },
+        "status": {
+          "type": "text",
+          "required": false,
+          "_meta": {}
+        },
+        "lastRun": {
+          "type": "datetime",
+          "required": false,
+          "_meta": {
+            "nullable": true
+          }
+        },
+        "nextRun": {
+          "type": "datetime",
+          "required": false,
+          "_meta": {
+            "nullable": true
+          }
+        },
+        "lastStatus": {
+          "type": "text",
+          "required": false,
+          "_meta": {
+            "nullable": true
+          }
+        },
+        "lastError": {
+          "type": "text",
+          "required": false,
+          "_meta": {
+            "nullable": true
+          }
+        },
+        "runCount": {
+          "type": "integer",
+          "required": false,
+          "_meta": {}
+        },
+        "successCount": {
+          "type": "integer",
+          "required": false,
+          "_meta": {}
+        },
+        "failureCount": {
+          "type": "integer",
+          "required": false,
+          "_meta": {}
+        },
+        "maxConcurrent": {
+          "type": "integer",
+          "required": false,
+          "_meta": {}
+        },
+        "runningCount": {
+          "type": "integer",
+          "required": false,
+          "_meta": {}
+        },
+        "timeout": {
+          "type": "integer",
+          "required": false,
+          "_meta": {}
+        },
+        "method": {
+          "type": "text",
+          "required": false,
+          "_meta": {}
+        },
+        "methodArgs": {
+          "type": "json",
+          "required": false,
+          "_meta": {
+            "sqlType": "TEXT"
+          }
+        }
+      },
+      "methods": {
+        "enable": {
+          "name": "enable",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "disable": {
+          "name": "disable",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "pause": {
+          "name": "pause",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resume": {
+          "name": "resume",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recordSuccess": {
+          "name": "recordSuccess",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recordFailure": {
+          "name": "recordFailure",
+          "async": true,
+          "parameters": [
+            {
+              "name": "error",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isDue": {
+          "name": "isDue",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "calculateNextRun": {
+          "name": "calculateNextRun",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getDescription": {
+          "name": "getDescription",
+          "async": false,
+          "parameters": [],
+          "returnType": "string",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "beforeSave": {
+          "name": "beforeSave",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableName": "_smrt_agent_schedules",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "cli": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete",
+            "enable",
+            "disable"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        }
+      },
+      "extends": "SmrtObject",
+      "exportName": "AgentSchedule",
+      "collectionExportName": "AgentScheduleCollection",
+      "schema": {
+        "tableName": "_smrt_agent_schedules",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"_smrt_agent_schedules\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"agent_type\" TEXT,\n  \"agent_id\" TEXT,\n  \"agent_config\" TEXT,\n  \"cron\" TEXT,\n  \"timezone\" TEXT,\n  \"enabled\" BOOLEAN,\n  \"status\" TEXT,\n  \"last_run\" TIMESTAMP,\n  \"next_run\" TIMESTAMP,\n  \"last_status\" TEXT,\n  \"last_error\" TEXT,\n  \"run_count\" INTEGER,\n  \"success_count\" INTEGER,\n  \"failure_count\" INTEGER,\n  \"max_concurrent\" INTEGER,\n  \"running_count\" INTEGER,\n  \"timeout\" INTEGER,\n  \"method\" TEXT,\n  \"method_args\" TEXT\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "agent_type": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "agent_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "agent_config": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "cron": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "timezone": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "enabled": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "unique": false
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "last_run": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "unique": false
+          },
+          "next_run": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "unique": false
+          },
+          "last_status": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "last_error": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "run_count": {
+            "type": "INTEGER",
+            "notNull": false,
+            "unique": false
+          },
+          "success_count": {
+            "type": "INTEGER",
+            "notNull": false,
+            "unique": false
+          },
+          "failure_count": {
+            "type": "INTEGER",
+            "notNull": false,
+            "unique": false
+          },
+          "max_concurrent": {
+            "type": "INTEGER",
+            "notNull": false,
+            "unique": false
+          },
+          "running_count": {
+            "type": "INTEGER",
+            "notNull": false,
+            "unique": false
+          },
+          "timeout": {
+            "type": "INTEGER",
+            "notNull": false,
+            "unique": false
+          },
+          "method": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "method_args": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "_smrt_agent_schedules_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "_smrt_agent_schedules_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "521aef40"
+      }
+    },
+    "@happyvertical/smrt-agents:AgentScheduleCollection": {
+      "name": "agentschedulecollection",
+      "className": "AgentScheduleCollection",
+      "qualifiedName": "@happyvertical/smrt-agents:AgentScheduleCollection",
+      "collection": "agentschedules",
+      "filePath": "packages/agents/src/schedule.ts",
+      "packageName": "@happyvertical/smrt-agents",
+      "fields": {},
+      "methods": {
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AgentSchedule[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<AgentSchedule[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<AgentSchedule[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listByStatus": {
+          "name": "listByStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "status",
+              "type": "ScheduleStatus | ScheduleStatus[]",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<AgentSchedule[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listDue": {
+          "name": "listDue",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<AgentSchedule[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listByAgentType": {
+          "name": "listByAgentType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "agentType",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<AgentSchedule[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "stats": {
+          "name": "stats",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<object>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableName": "_smrt_agent_schedules"
+      },
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "AgentSchedule",
+      "exportName": "AgentScheduleCollection",
+      "collectionExportName": "AgentScheduleCollectionCollection",
+      "schema": {
+        "tableName": "_smrt_agent_schedules",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"_smrt_agent_schedules\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "_smrt_agent_schedules_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "_smrt_agent_schedules_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "7ec14c29"
+      }
+    },
+    "@happyvertical/smrt-agents:TenantAgent": {
+      "name": "tenantagent",
+      "className": "TenantAgent",
+      "qualifiedName": "@happyvertical/smrt-agents:TenantAgent",
+      "collection": "tenantagents",
+      "filePath": "packages/agents/src/tenant-agent.ts",
+      "packageName": "@happyvertical/smrt-agents",
+      "fields": {
+        "tenantId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "agentClass": {
+          "type": "text",
+          "required": false,
+          "_meta": {}
+        },
+        "status": {
+          "type": "text",
+          "required": false,
+          "_meta": {}
+        },
+        "permissions": {
+          "type": "json",
+          "required": false,
+          "_meta": {
+            "nullable": true
+          }
+        },
+        "config": {
+          "type": "json",
+          "required": false,
+          "_meta": {
+            "nullable": true
+          }
+        }
+      },
+      "methods": {},
+      "decoratorConfig": {
+        "tableName": "tenant_agents",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "cli": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "conflictColumns": [
+          "tenant_id",
+          "agent_class"
+        ]
+      },
+      "extends": "SmrtObject",
+      "exportName": "TenantAgent",
+      "collectionExportName": "TenantAgentCollection",
+      "schema": {
+        "tableName": "tenant_agents",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"tenant_agents\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT DEFAULT '',\n  \"agent_class\" TEXT,\n  \"status\" TEXT,\n  \"permissions\" JSONB,\n  \"config\" JSONB\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": ""
+          },
+          "agent_class": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "permissions": {
+            "type": "JSON",
+            "notNull": false,
+            "unique": false
+          },
+          "config": {
+            "type": "JSON",
+            "notNull": false,
+            "unique": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "tenant_agents_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "tenant_agents_tenant_id_agent_class_idx",
+            "columns": [
+              "tenant_id",
+              "agent_class"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "6ef2fe23"
+      }
+    },
+    "@happyvertical/smrt-agents:TenantAgentCollection": {
+      "name": "tenantagentcollection",
+      "className": "TenantAgentCollection",
+      "qualifiedName": "@happyvertical/smrt-agents:TenantAgentCollection",
+      "collection": "tenantagents",
+      "filePath": "packages/agents/src/tenant-agent.ts",
+      "packageName": "@happyvertical/smrt-agents",
+      "fields": {},
+      "methods": {
+        "resolveForTenant": {
+          "name": "resolveForTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "getAncestorIds",
+              "type": "Function",
+              "optional": false
+            },
+            {
+              "name": "manifests",
+              "type": "Map<string, AgentManifestInfo>",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<ResolvedAgentAvailability[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "enableAgent": {
+          "name": "enableAgent",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "agentClass",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<TenantAgent>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "disableAgent": {
+          "name": "disableAgent",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "agentClass",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<TenantAgent>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearOverride": {
+          "name": "clearOverride",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "agentClass",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setPermissions": {
+          "name": "setPermissions",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "agentClass",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "permissions",
+              "type": "Record<string, boolean>",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<TenantAgent>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByTenantAndClass": {
+          "name": "findByTenantAndClass",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "agentClass",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<TenantAgent | null>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableName": "tenant_agents"
+      },
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "TenantAgent",
+      "exportName": "TenantAgentCollection",
+      "collectionExportName": "TenantAgentCollectionCollection",
+      "schema": {
+        "tableName": "tenant_agents",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"tenant_agents\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "tenant_agents_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "tenant_agents_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "8c429d39"
       }
     }
   },
   "moduleType": "smrt",
-  "packageName": "@happyvertical/smrt-agents"
+  "smrtDependencies": [
+    "@happyvertical/smrt-core"
+  ]
 }

--- a/packages/agents/src/manifest/manifest.json
+++ b/packages/agents/src/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "timestamp": 1780375817764,
+  "timestamp": 1780379246364,
   "packageName": "@happyvertical/smrt-agents",
   "packageVersion": "0.25.8",
   "objects": {
@@ -589,7 +589,7 @@
       },
       "schema": {
         "tableName": "agents",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"agents\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"status\" TEXT DEFAULT 'idle'\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"agents\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"status\" TEXT DEFAULT 'idle'\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -804,7 +804,7 @@
       "collectionExportName": "AgentConfigCollection",
       "schema": {
         "tableName": "agent_configs",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"agent_configs\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"agent_id\" TEXT,\n  \"agent_class\" TEXT,\n  \"slot_id\" TEXT,\n  \"config_data\" JSONB,\n  \"schema_version\" INTEGER\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"agent_configs\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"agent_id\" TEXT,\n  \"agent_class\" TEXT,\n  \"slot_id\" TEXT,\n  \"config_data\" JSON,\n  \"schema_version\" INTEGER\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -935,7 +935,7 @@
       "collectionExportName": "AgentConfigCollectionCollection",
       "schema": {
         "tableName": "agent_configs",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"agent_configs\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"agent_configs\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1225,7 +1225,7 @@
       "collectionExportName": "AgentScheduleCollection",
       "schema": {
         "tableName": "_smrt_agent_schedules",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"_smrt_agent_schedules\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"agent_type\" TEXT,\n  \"agent_id\" TEXT,\n  \"agent_config\" TEXT,\n  \"cron\" TEXT,\n  \"timezone\" TEXT,\n  \"enabled\" BOOLEAN,\n  \"status\" TEXT,\n  \"last_run\" TIMESTAMP,\n  \"next_run\" TIMESTAMP,\n  \"last_status\" TEXT,\n  \"last_error\" TEXT,\n  \"run_count\" INTEGER,\n  \"success_count\" INTEGER,\n  \"failure_count\" INTEGER,\n  \"max_concurrent\" INTEGER,\n  \"running_count\" INTEGER,\n  \"timeout\" INTEGER,\n  \"method\" TEXT,\n  \"method_args\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"_smrt_agent_schedules\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"agent_type\" TEXT,\n  \"agent_id\" TEXT,\n  \"agent_config\" TEXT,\n  \"cron\" TEXT,\n  \"timezone\" TEXT,\n  \"enabled\" BOOLEAN,\n  \"status\" TEXT,\n  \"last_run\" TIMESTAMP,\n  \"next_run\" TIMESTAMP,\n  \"last_status\" TEXT,\n  \"last_error\" TEXT,\n  \"run_count\" INTEGER,\n  \"success_count\" INTEGER,\n  \"failure_count\" INTEGER,\n  \"max_concurrent\" INTEGER,\n  \"running_count\" INTEGER,\n  \"timeout\" INTEGER,\n  \"method\" TEXT,\n  \"method_args\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1486,7 +1486,7 @@
       "collectionExportName": "AgentScheduleCollectionCollection",
       "schema": {
         "tableName": "_smrt_agent_schedules",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"_smrt_agent_schedules\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"_smrt_agent_schedules\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1604,7 +1604,7 @@
       "collectionExportName": "TenantAgentCollection",
       "schema": {
         "tableName": "tenant_agents",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"tenant_agents\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT DEFAULT '',\n  \"agent_class\" TEXT,\n  \"status\" TEXT,\n  \"permissions\" JSONB,\n  \"config\" JSONB\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"tenant_agents\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT DEFAULT '',\n  \"agent_class\" TEXT,\n  \"status\" TEXT,\n  \"permissions\" JSON,\n  \"config\" JSON\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1819,7 +1819,7 @@
       "collectionExportName": "TenantAgentCollectionCollection",
       "schema": {
         "tableName": "tenant_agents",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"tenant_agents\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"tenant_agents\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1868,6 +1868,9 @@
   },
   "moduleType": "smrt",
   "smrtDependencies": [
-    "@happyvertical/smrt-core"
+    "@happyvertical/smrt-core",
+    "@happyvertical/smrt-secrets",
+    "@happyvertical/smrt-tenancy",
+    "@happyvertical/smrt-users"
   ]
 }

--- a/packages/analytics/src/manifest/manifest.json
+++ b/packages/analytics/src/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "timestamp": 1780375816606,
+  "timestamp": 1780379235055,
   "packageName": "@happyvertical/smrt-analytics",
   "packageVersion": "0.25.8",
   "objects": {
@@ -145,7 +145,7 @@
       "collectionExportName": "AnalyticsDataStreamCollectionCollection",
       "schema": {
         "tableName": "analytics_data_stream_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_data_stream_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_data_stream_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -443,7 +443,7 @@
       "collectionExportName": "AnalyticsEventCollectionCollection",
       "schema": {
         "tableName": "analytics_event_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_event_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_event_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -627,7 +627,7 @@
       "collectionExportName": "AnalyticsPropertyCollectionCollection",
       "schema": {
         "tableName": "analytics_property_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_property_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_property_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -813,7 +813,7 @@
       "collectionExportName": "AnalyticsReportCollectionCollection",
       "schema": {
         "tableName": "analytics_report_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_report_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_report_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1405,7 +1405,7 @@
       "collectionExportName": "AnalyticsDataStreamCollection",
       "schema": {
         "tableName": "analytics_data_streams",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_data_streams\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"property_id\" uuid,\n  \"display_name\" TEXT DEFAULT '',\n  \"stream_type\" TEXT,\n  \"external_id\" TEXT DEFAULT '',\n  \"measurement_id\" TEXT DEFAULT '',\n  \"firebase_app_id\" TEXT DEFAULT '',\n  \"default_uri\" TEXT DEFAULT '',\n  \"bundle_id\" TEXT DEFAULT '',\n  \"package_name\" TEXT DEFAULT '',\n  \"status\" TEXT,\n  \"enhanced_measurement\" BOOLEAN DEFAULT TRUE\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_data_streams\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"property_id\" UUID,\n  \"display_name\" TEXT DEFAULT '',\n  \"stream_type\" TEXT,\n  \"external_id\" TEXT DEFAULT '',\n  \"measurement_id\" TEXT DEFAULT '',\n  \"firebase_app_id\" TEXT DEFAULT '',\n  \"default_uri\" TEXT DEFAULT '',\n  \"bundle_id\" TEXT DEFAULT '',\n  \"package_name\" TEXT DEFAULT '',\n  \"status\" TEXT,\n  \"enhanced_measurement\" BOOLEAN DEFAULT TRUE\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2157,7 +2157,7 @@
       "collectionExportName": "AnalyticsEventCollection",
       "schema": {
         "tableName": "analytics_events",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_events\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"property_id\" uuid,\n  \"event_name\" TEXT DEFAULT '',\n  \"client_id\" TEXT DEFAULT '',\n  \"user_id\" TEXT DEFAULT '',\n  \"params\" TEXT DEFAULT '{}',\n  \"event_timestamp\" TIMESTAMP,\n  \"status\" TEXT,\n  \"sent_at\" TIMESTAMP,\n  \"error_message\" TEXT DEFAULT '',\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"non_personalized_ads\" BOOLEAN DEFAULT FALSE,\n  \"session_id\" TEXT DEFAULT '',\n  \"page_path\" TEXT DEFAULT '',\n  \"page_title\" TEXT DEFAULT '',\n  \"user_agent\" TEXT DEFAULT '',\n  \"ip_address\" TEXT DEFAULT ''\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_events\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"property_id\" UUID,\n  \"event_name\" TEXT DEFAULT '',\n  \"client_id\" TEXT DEFAULT '',\n  \"user_id\" TEXT DEFAULT '',\n  \"params\" TEXT DEFAULT '{}',\n  \"event_timestamp\" TIMESTAMP,\n  \"status\" TEXT,\n  \"sent_at\" TIMESTAMP,\n  \"error_message\" TEXT DEFAULT '',\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"non_personalized_ads\" BOOLEAN DEFAULT FALSE,\n  \"session_id\" TEXT DEFAULT '',\n  \"page_path\" TEXT DEFAULT '',\n  \"page_title\" TEXT DEFAULT '',\n  \"user_agent\" TEXT DEFAULT '',\n  \"ip_address\" TEXT DEFAULT ''\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2892,7 +2892,7 @@
       "collectionExportName": "AnalyticsPropertyCollection",
       "schema": {
         "tableName": "analytics_properties",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_properties\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"display_name\" TEXT DEFAULT '',\n  \"provider\" TEXT,\n  \"external_id\" TEXT DEFAULT '',\n  \"measurement_id\" TEXT DEFAULT '',\n  \"api_secret\" TEXT DEFAULT '',\n  \"site_domain\" TEXT DEFAULT '',\n  \"time_zone\" TEXT DEFAULT 'America/Los_Angeles',\n  \"currency_code\" TEXT DEFAULT 'USD',\n  \"industry_category\" TEXT DEFAULT '',\n  \"service_level\" TEXT DEFAULT 'STANDARD',\n  \"status\" TEXT,\n  \"last_sync_at\" TIMESTAMP,\n  \"provider_metadata\" TEXT DEFAULT '{}'\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_properties\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"display_name\" TEXT DEFAULT '',\n  \"provider\" TEXT,\n  \"external_id\" TEXT DEFAULT '',\n  \"measurement_id\" TEXT DEFAULT '',\n  \"api_secret\" TEXT DEFAULT '',\n  \"site_domain\" TEXT DEFAULT '',\n  \"time_zone\" TEXT DEFAULT 'America/Los_Angeles',\n  \"currency_code\" TEXT DEFAULT 'USD',\n  \"industry_category\" TEXT DEFAULT '',\n  \"service_level\" TEXT DEFAULT 'STANDARD',\n  \"status\" TEXT,\n  \"last_sync_at\" TIMESTAMP,\n  \"provider_metadata\" TEXT DEFAULT '{}'\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3702,7 +3702,7 @@
       "collectionExportName": "AnalyticsReportCollection",
       "schema": {
         "tableName": "analytics_reports",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_reports\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"property_id\" uuid,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"dimensions\" TEXT DEFAULT '[]',\n  \"metrics\" TEXT DEFAULT '[]',\n  \"date_range_start\" TEXT DEFAULT '7daysAgo',\n  \"date_range_end\" TEXT DEFAULT 'today',\n  \"dimension_filter\" TEXT DEFAULT '',\n  \"metric_filter\" TEXT DEFAULT '',\n  \"order_by\" TEXT DEFAULT '[]',\n  \"max_results\" INTEGER DEFAULT 0,\n  \"status\" TEXT,\n  \"frequency\" TEXT,\n  \"last_run_at\" TIMESTAMP,\n  \"next_run_at\" TIMESTAMP,\n  \"result_data\" TEXT DEFAULT '',\n  \"row_count\" INTEGER DEFAULT 0,\n  \"last_error\" TEXT DEFAULT ''\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_reports\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"property_id\" UUID,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"dimensions\" TEXT DEFAULT '[]',\n  \"metrics\" TEXT DEFAULT '[]',\n  \"date_range_start\" TEXT DEFAULT '7daysAgo',\n  \"date_range_end\" TEXT DEFAULT 'today',\n  \"dimension_filter\" TEXT DEFAULT '',\n  \"metric_filter\" TEXT DEFAULT '',\n  \"order_by\" TEXT DEFAULT '[]',\n  \"max_results\" INTEGER DEFAULT 0,\n  \"status\" TEXT,\n  \"frequency\" TEXT,\n  \"last_run_at\" TIMESTAMP,\n  \"next_run_at\" TIMESTAMP,\n  \"result_data\" TEXT DEFAULT '',\n  \"row_count\" INTEGER DEFAULT 0,\n  \"last_error\" TEXT DEFAULT ''\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3851,6 +3851,8 @@
   },
   "moduleType": "smrt",
   "smrtDependencies": [
-    "@happyvertical/smrt-core"
+    "@happyvertical/smrt-core",
+    "@happyvertical/smrt-prompts",
+    "@happyvertical/smrt-tenancy"
   ]
 }

--- a/packages/analytics/src/manifest/manifest.json
+++ b/packages/analytics/src/manifest/manifest.json
@@ -1,235 +1,16 @@
 {
   "version": "1.0.0",
-  "timestamp": 1777475395703,
+  "timestamp": 1780375816606,
+  "packageName": "@happyvertical/smrt-analytics",
+  "packageVersion": "0.25.8",
   "objects": {
-    "analyticsdatastream": {
-      "name": "analyticsdatastream",
-      "className": "AnalyticsDataStream",
-      "collection": "analyticsdatastreams",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/analytics/src/models/AnalyticsDataStream.ts",
-      "fields": {
-        "propertyId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "displayName": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "streamType": {
-          "type": "text",
-          "required": false
-        },
-        "externalId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "measurementId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "firebaseAppId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "defaultUri": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "bundleId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "packageName": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "status": {
-          "type": "text",
-          "required": false
-        },
-        "enhancedMeasurement": {
-          "type": "boolean",
-          "required": false,
-          "default": true
-        }
-      },
-      "methods": {
-        "isWeb": {
-          "name": "isWeb",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isIOS": {
-          "name": "isIOS",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isAndroid": {
-          "name": "isAndroid",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isMobileApp": {
-          "name": "isMobileApp",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getPlatformId": {
-          "name": "getPlatformId",
-          "async": false,
-          "parameters": [],
-          "returnType": "string",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "api": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update"
-          ]
-        },
-        "mcp": {
-          "include": [
-            "list",
-            "get"
-          ]
-        },
-        "cli": true
-      },
-      "extends": "SmrtObject",
-      "exportName": "AnalyticsDataStream",
-      "collectionExportName": "AnalyticsDataStreamCollection",
-      "schema": {
-        "tableName": "analytics_data_streams",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_data_streams\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"property_id\" TEXT DEFAULT '',\n  \"display_name\" TEXT DEFAULT '',\n  \"stream_type\" TEXT,\n  \"external_id\" TEXT DEFAULT '',\n  \"measurement_id\" TEXT DEFAULT '',\n  \"firebase_app_id\" TEXT DEFAULT '',\n  \"default_uri\" TEXT DEFAULT '',\n  \"bundle_id\" TEXT DEFAULT '',\n  \"package_name\" TEXT DEFAULT '',\n  \"status\" TEXT,\n  \"enhanced_measurement\" BOOLEAN DEFAULT TRUE\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "property_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "display_name": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "stream_type": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "external_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "measurement_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "firebase_app_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "default_uri": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "bundle_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "package_name": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "status": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "enhanced_measurement": {
-            "type": "BOOLEAN",
-            "notNull": false,
-            "default": true
-          }
-        },
-        "indexes": [
-          {
-            "name": "analytics_data_streams_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "analytics_data_streams_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "3049f8aa"
-      }
-    },
-    "analyticsdatastreamcollection": {
+    "@happyvertical/smrt-analytics:AnalyticsDataStreamCollection": {
       "name": "analyticsdatastreamcollection",
       "className": "AnalyticsDataStreamCollection",
+      "qualifiedName": "@happyvertical/smrt-analytics:AnalyticsDataStreamCollection",
       "collection": "analyticsdatastreams",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/analytics/src/collections/AnalyticsDataStreamCollection.ts",
+      "filePath": "packages/analytics/src/collections/AnalyticsDataStreamCollection.ts",
+      "packageName": "@happyvertical/smrt-analytics",
       "fields": {},
       "methods": {
         "findByProperty": {
@@ -364,10 +145,10 @@
       "collectionExportName": "AnalyticsDataStreamCollectionCollection",
       "schema": {
         "tableName": "analytics_data_stream_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_data_stream_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_data_stream_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -407,357 +188,16 @@
             "unique": true
           }
         ],
-        "version": "6beb016f"
+        "version": "444aebe5"
       }
     },
-    "analyticsevent": {
-      "name": "analyticsevent",
-      "className": "AnalyticsEvent",
-      "collection": "analyticsevents",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/analytics/src/models/AnalyticsEvent.ts",
-      "fields": {
-        "propertyId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "eventName": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "clientId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "userId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "params": {
-          "type": "text",
-          "required": false,
-          "default": "{}"
-        },
-        "eventTimestamp": {
-          "type": "datetime",
-          "required": false
-        },
-        "status": {
-          "type": "text",
-          "required": false
-        },
-        "sentAt": {
-          "type": "datetime",
-          "required": false,
-          "default": null
-        },
-        "errorMessage": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "retryCount": {
-          "type": "integer",
-          "required": false,
-          "default": 0
-        },
-        "nonPersonalizedAds": {
-          "type": "boolean",
-          "required": false,
-          "default": false
-        },
-        "sessionId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "pagePath": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "pageTitle": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "userAgent": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "ipAddress": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        }
-      },
-      "methods": {
-        "getParams": {
-          "name": "getParams",
-          "async": false,
-          "parameters": [],
-          "returnType": "Record<string, string | number | boolean>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "setParams": {
-          "name": "setParams",
-          "async": false,
-          "parameters": [
-            {
-              "name": "params",
-              "type": "Record<string, string | number | boolean>",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "addParam": {
-          "name": "addParam",
-          "async": false,
-          "parameters": [
-            {
-              "name": "key",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "value",
-              "type": "string | number | boolean",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isPageview": {
-          "name": "isPageview",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isConversion": {
-          "name": "isConversion",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "markSent": {
-          "name": "markSent",
-          "async": false,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "markFailed": {
-          "name": "markFailed",
-          "async": false,
-          "parameters": [
-            {
-              "name": "error",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "resetForRetry": {
-          "name": "resetForRetry",
-          "async": false,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "shouldRetry": {
-          "name": "shouldRetry",
-          "async": false,
-          "parameters": [
-            {
-              "name": "maxRetries",
-              "type": "number",
-              "optional": false,
-              "default": 3
-            }
-          ],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "toTrackEvent": {
-          "name": "toTrackEvent",
-          "async": false,
-          "parameters": [],
-          "returnType": "{\n    name: string;\n    params?: Record<string, string | number | boolean>;\n    clientId?: string;\n    userId?: string;\n    timestamp?: number;\n    nonPersonalizedAds?: boolean;\n  }",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "api": {
-          "include": [
-            "list",
-            "get",
-            "create"
-          ]
-        },
-        "mcp": {
-          "include": [
-            "list",
-            "get",
-            "track"
-          ]
-        },
-        "cli": true
-      },
-      "extends": "SmrtObject",
-      "exportName": "AnalyticsEvent",
-      "collectionExportName": "AnalyticsEventCollection",
-      "schema": {
-        "tableName": "analytics_events",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_events\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"property_id\" TEXT DEFAULT '',\n  \"event_name\" TEXT DEFAULT '',\n  \"client_id\" TEXT DEFAULT '',\n  \"user_id\" TEXT DEFAULT '',\n  \"params\" TEXT DEFAULT '{}',\n  \"event_timestamp\" TIMESTAMP,\n  \"status\" TEXT,\n  \"sent_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"error_message\" TEXT DEFAULT '',\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"non_personalized_ads\" BOOLEAN DEFAULT FALSE,\n  \"session_id\" TEXT DEFAULT '',\n  \"page_path\" TEXT DEFAULT '',\n  \"page_title\" TEXT DEFAULT '',\n  \"user_agent\" TEXT DEFAULT '',\n  \"ip_address\" TEXT DEFAULT ''\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "property_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "event_name": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "client_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "user_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "params": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "{}"
-          },
-          "event_timestamp": {
-            "type": "TIMESTAMP",
-            "notNull": false
-          },
-          "status": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "sent_at": {
-            "type": "TIMESTAMP",
-            "notNull": false,
-            "default": null
-          },
-          "error_message": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "retry_count": {
-            "type": "INTEGER",
-            "notNull": false,
-            "default": 0
-          },
-          "non_personalized_ads": {
-            "type": "BOOLEAN",
-            "notNull": false,
-            "default": false
-          },
-          "session_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "page_path": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "page_title": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "user_agent": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "ip_address": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          }
-        },
-        "indexes": [
-          {
-            "name": "analytics_events_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "analytics_events_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "17eba562"
-      }
-    },
-    "analyticseventcollection": {
+    "@happyvertical/smrt-analytics:AnalyticsEventCollection": {
       "name": "analyticseventcollection",
       "className": "AnalyticsEventCollection",
+      "qualifiedName": "@happyvertical/smrt-analytics:AnalyticsEventCollection",
       "collection": "analyticsevents",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/analytics/src/collections/AnalyticsEventCollection.ts",
+      "filePath": "packages/analytics/src/collections/AnalyticsEventCollection.ts",
+      "packageName": "@happyvertical/smrt-analytics",
       "fields": {},
       "methods": {
         "findByProperty": {
@@ -861,8 +301,7 @@
             {
               "name": "maxRetries",
               "type": "number",
-              "optional": false,
-              "default": 3
+              "optional": true
             }
           ],
           "returnType": "Promise<AnalyticsEvent[]>",
@@ -954,7 +393,45 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<{\n    total: number;\n    pending: number;\n    sent: number;\n    failed: number;\n    conversions: number;\n    pageviews: number;\n  }>",
+          "returnType": "Promise<object>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getPropertyStatsWithTrend": {
+          "name": "getPropertyStatsWithTrend",
+          "async": true,
+          "parameters": [
+            {
+              "name": "propertyId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "now",
+              "type": "Date",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<PropertyStatsWithTrend>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getBatchPropertyStats": {
+          "name": "getBatchPropertyStats",
+          "async": true,
+          "parameters": [
+            {
+              "name": "propertyIds",
+              "type": "string[]",
+              "optional": false
+            },
+            {
+              "name": "now",
+              "type": "Date",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, PropertyStatsWithTrend>>",
           "isStatic": false,
           "isPublic": true
         }
@@ -966,10 +443,10 @@
       "collectionExportName": "AnalyticsEventCollectionCollection",
       "schema": {
         "tableName": "analytics_event_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_event_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_event_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1009,306 +486,16 @@
             "unique": true
           }
         ],
-        "version": "11b34b89"
+        "version": "be13478c"
       }
     },
-    "analyticsproperty": {
-      "name": "analyticsproperty",
-      "className": "AnalyticsProperty",
-      "collection": "analyticsproperties",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/analytics/src/models/AnalyticsProperty.ts",
-      "fields": {
-        "name": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "displayName": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "provider": {
-          "type": "text",
-          "required": false
-        },
-        "externalId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "measurementId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "apiSecret": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "siteDomain": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "timeZone": {
-          "type": "text",
-          "required": false,
-          "default": "America/Los_Angeles"
-        },
-        "currencyCode": {
-          "type": "text",
-          "required": false,
-          "default": "USD"
-        },
-        "industryCategory": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "serviceLevel": {
-          "type": "text",
-          "required": false,
-          "default": "STANDARD"
-        },
-        "status": {
-          "type": "text",
-          "required": false
-        },
-        "lastSyncAt": {
-          "type": "datetime",
-          "required": false,
-          "default": null
-        },
-        "providerMetadata": {
-          "type": "text",
-          "required": false,
-          "default": "{}"
-        }
-      },
-      "methods": {
-        "isGA4": {
-          "name": "isGA4",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isPlausible": {
-          "name": "isPlausible",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isMatomo": {
-          "name": "isMatomo",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getProviderMetadata": {
-          "name": "getProviderMetadata",
-          "async": false,
-          "parameters": [],
-          "returnType": "Record<string, unknown>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "setProviderMetadata": {
-          "name": "setProviderMetadata",
-          "async": false,
-          "parameters": [
-            {
-              "name": "metadata",
-              "type": "Record<string, unknown>",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "markSynced": {
-          "name": "markSynced",
-          "async": false,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "analyzePerformance": {
-          "name": "analyzePerformance",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "{ period?: string }",
-              "optional": false,
-              "default": {}
-            }
-          ],
-          "returnType": "Promise<{\n    action: string;\n    period: string;\n    analysis: string;\n  }>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isPerformingWell": {
-          "name": "isPerformingWell",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<boolean>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "api": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update"
-          ]
-        },
-        "mcp": {
-          "include": [
-            "list",
-            "get",
-            "sync",
-            "runReport"
-          ]
-        },
-        "cli": true
-      },
-      "extends": "SmrtObject",
-      "exportName": "AnalyticsProperty",
-      "collectionExportName": "AnalyticsPropertyCollection",
-      "schema": {
-        "tableName": "analytics_propertys",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_propertys\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"display_name\" TEXT DEFAULT '',\n  \"provider\" TEXT,\n  \"external_id\" TEXT DEFAULT '',\n  \"measurement_id\" TEXT DEFAULT '',\n  \"api_secret\" TEXT DEFAULT '',\n  \"site_domain\" TEXT DEFAULT '',\n  \"time_zone\" TEXT DEFAULT 'America/Los_Angeles',\n  \"currency_code\" TEXT DEFAULT 'USD',\n  \"industry_category\" TEXT DEFAULT '',\n  \"service_level\" TEXT DEFAULT 'STANDARD',\n  \"status\" TEXT,\n  \"last_sync_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"provider_metadata\" TEXT DEFAULT '{}'\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "name": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "display_name": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "provider": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "external_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "measurement_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "api_secret": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "site_domain": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "time_zone": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "America/Los_Angeles"
-          },
-          "currency_code": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "USD"
-          },
-          "industry_category": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "service_level": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "STANDARD"
-          },
-          "status": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "last_sync_at": {
-            "type": "TIMESTAMP",
-            "notNull": false,
-            "default": null
-          },
-          "provider_metadata": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "{}"
-          }
-        },
-        "indexes": [
-          {
-            "name": "analytics_propertys_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "analytics_propertys_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "e3ea21e0"
-      }
-    },
-    "analyticspropertycollection": {
+    "@happyvertical/smrt-analytics:AnalyticsPropertyCollection": {
       "name": "analyticspropertycollection",
       "className": "AnalyticsPropertyCollection",
+      "qualifiedName": "@happyvertical/smrt-analytics:AnalyticsPropertyCollection",
       "collection": "analyticsproperties",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/analytics/src/collections/AnalyticsPropertyCollection.ts",
+      "filePath": "packages/analytics/src/collections/AnalyticsPropertyCollection.ts",
+      "packageName": "@happyvertical/smrt-analytics",
       "fields": {},
       "methods": {
         "findByExternalId": {
@@ -1425,8 +612,7 @@
             {
               "name": "hoursAgo",
               "type": "number",
-              "optional": false,
-              "default": 24
+              "optional": true
             }
           ],
           "returnType": "Promise<AnalyticsProperty[]>",
@@ -1441,10 +627,10 @@
       "collectionExportName": "AnalyticsPropertyCollectionCollection",
       "schema": {
         "tableName": "analytics_property_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_property_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_property_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1484,411 +670,16 @@
             "unique": true
           }
         ],
-        "version": "f4081c9a"
+        "version": "96c06cb6"
       }
     },
-    "analyticsreport": {
-      "name": "analyticsreport",
-      "className": "AnalyticsReport",
-      "collection": "analyticsreports",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/analytics/src/models/AnalyticsReport.ts",
-      "fields": {
-        "propertyId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "name": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "description": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "dimensions": {
-          "type": "text",
-          "required": false,
-          "default": "[]"
-        },
-        "metrics": {
-          "type": "text",
-          "required": false,
-          "default": "[]"
-        },
-        "dateRangeStart": {
-          "type": "text",
-          "required": false,
-          "default": "7daysAgo"
-        },
-        "dateRangeEnd": {
-          "type": "text",
-          "required": false,
-          "default": "today"
-        },
-        "dimensionFilter": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "metricFilter": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "orderBy": {
-          "type": "text",
-          "required": false,
-          "default": "[]"
-        },
-        "maxResults": {
-          "type": "integer",
-          "required": false,
-          "default": 0
-        },
-        "status": {
-          "type": "text",
-          "required": false
-        },
-        "frequency": {
-          "type": "text",
-          "required": false
-        },
-        "lastRunAt": {
-          "type": "datetime",
-          "required": false,
-          "default": null
-        },
-        "nextRunAt": {
-          "type": "datetime",
-          "required": false,
-          "default": null
-        },
-        "resultData": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "rowCount": {
-          "type": "integer",
-          "required": false,
-          "default": 0
-        },
-        "lastError": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        }
-      },
-      "methods": {
-        "getDimensions": {
-          "name": "getDimensions",
-          "async": false,
-          "parameters": [],
-          "returnType": "Array<{ name: string }>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "setDimensions": {
-          "name": "setDimensions",
-          "async": false,
-          "parameters": [
-            {
-              "name": "dimensions",
-              "type": "Array<{ name: string }>",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getMetrics": {
-          "name": "getMetrics",
-          "async": false,
-          "parameters": [],
-          "returnType": "Array<{ name: string }>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "setMetrics": {
-          "name": "setMetrics",
-          "async": false,
-          "parameters": [
-            {
-              "name": "metrics",
-              "type": "Array<{ name: string }>",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getResultData": {
-          "name": "getResultData",
-          "async": false,
-          "parameters": [],
-          "returnType": "Record<string, unknown> | null",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "setResultData": {
-          "name": "setResultData",
-          "async": false,
-          "parameters": [
-            {
-              "name": "data",
-              "type": "Record<string, unknown>",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "markRunning": {
-          "name": "markRunning",
-          "async": false,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "markCompleted": {
-          "name": "markCompleted",
-          "async": false,
-          "parameters": [
-            {
-              "name": "rowCount",
-              "type": "number",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "markFailed": {
-          "name": "markFailed",
-          "async": false,
-          "parameters": [
-            {
-              "name": "error",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "calculateNextRun": {
-          "name": "calculateNextRun",
-          "async": false,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isDue": {
-          "name": "isDue",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "analyzeResults": {
-          "name": "analyzeResults",
-          "async": true,
-          "parameters": [
-            {
-              "name": "_options",
-              "type": "any",
-              "optional": false,
-              "default": {}
-            }
-          ],
-          "returnType": "Promise<{\n    action: string;\n    analysis: string;\n    insights: string;\n  }>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "hasPositiveTrends": {
-          "name": "hasPositiveTrends",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<boolean>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "api": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update",
-            "run"
-          ]
-        },
-        "mcp": {
-          "include": [
-            "list",
-            "get",
-            "run",
-            "analyze"
-          ]
-        },
-        "cli": true
-      },
-      "extends": "SmrtObject",
-      "exportName": "AnalyticsReport",
-      "collectionExportName": "AnalyticsReportCollection",
-      "schema": {
-        "tableName": "analytics_reports",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_reports\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"property_id\" TEXT DEFAULT '',\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"dimensions\" TEXT DEFAULT '[]',\n  \"metrics\" TEXT DEFAULT '[]',\n  \"date_range_start\" TEXT DEFAULT '7daysAgo',\n  \"date_range_end\" TEXT DEFAULT 'today',\n  \"dimension_filter\" TEXT DEFAULT '',\n  \"metric_filter\" TEXT DEFAULT '',\n  \"order_by\" TEXT DEFAULT '[]',\n  \"max_results\" INTEGER DEFAULT 0,\n  \"status\" TEXT,\n  \"frequency\" TEXT,\n  \"last_run_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"next_run_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"result_data\" TEXT DEFAULT '',\n  \"row_count\" INTEGER DEFAULT 0,\n  \"last_error\" TEXT DEFAULT ''\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "property_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "name": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "description": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "dimensions": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "[]"
-          },
-          "metrics": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "[]"
-          },
-          "date_range_start": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "7daysAgo"
-          },
-          "date_range_end": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "today"
-          },
-          "dimension_filter": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "metric_filter": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "order_by": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "[]"
-          },
-          "max_results": {
-            "type": "INTEGER",
-            "notNull": false,
-            "default": 0
-          },
-          "status": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "frequency": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "last_run_at": {
-            "type": "TIMESTAMP",
-            "notNull": false,
-            "default": null
-          },
-          "next_run_at": {
-            "type": "TIMESTAMP",
-            "notNull": false,
-            "default": null
-          },
-          "result_data": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "row_count": {
-            "type": "INTEGER",
-            "notNull": false,
-            "default": 0
-          },
-          "last_error": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          }
-        },
-        "indexes": [
-          {
-            "name": "analytics_reports_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "analytics_reports_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "9452cffc"
-      }
-    },
-    "analyticsreportcollection": {
+    "@happyvertical/smrt-analytics:AnalyticsReportCollection": {
       "name": "analyticsreportcollection",
       "className": "AnalyticsReportCollection",
+      "qualifiedName": "@happyvertical/smrt-analytics:AnalyticsReportCollection",
       "collection": "analyticsreports",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/analytics/src/collections/AnalyticsReportCollection.ts",
+      "filePath": "packages/analytics/src/collections/AnalyticsReportCollection.ts",
+      "packageName": "@happyvertical/smrt-analytics",
       "fields": {},
       "methods": {
         "findByProperty": {
@@ -2007,8 +798,7 @@
             {
               "name": "hoursAgo",
               "type": "number",
-              "optional": false,
-              "default": 24
+              "optional": true
             }
           ],
           "returnType": "Promise<AnalyticsReport[]>",
@@ -2023,10 +813,10 @@
       "collectionExportName": "AnalyticsReportCollectionCollection",
       "schema": {
         "tableName": "analytics_report_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_report_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_report_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -2066,10 +856,3001 @@
             "unique": true
           }
         ],
-        "version": "e21049fe"
+        "version": "bb8bd9b6"
+      }
+    },
+    "@happyvertical/smrt-analytics:AnalyticsDataStream": {
+      "name": "analyticsdatastream",
+      "className": "AnalyticsDataStream",
+      "qualifiedName": "@happyvertical/smrt-analytics:AnalyticsDataStream",
+      "collection": "analyticsdatastreams",
+      "filePath": "packages/analytics/src/models/AnalyticsDataStream.ts",
+      "packageName": "@happyvertical/smrt-analytics",
+      "fields": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "propertyId": {
+          "type": "foreignKey",
+          "required": false,
+          "related": "AnalyticsProperty"
+        },
+        "displayName": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "streamType": {
+          "type": "text",
+          "required": false
+        },
+        "externalId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "measurementId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "firebaseAppId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "defaultUri": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "bundleId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "packageName": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "status": {
+          "type": "text",
+          "required": false
+        },
+        "enhancedMeasurement": {
+          "type": "boolean",
+          "required": false,
+          "default": true
+        }
+      },
+      "methods": {
+        "getAiUsageSnapshot": {
+          "name": "getAiUsageSnapshot",
+          "async": false,
+          "parameters": [],
+          "returnType": "AiUsageSnapshot | undefined",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetAiUsage": {
+          "name": "resetAiUsage",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listAiUsage": {
+          "name": "listAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageListOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<SmrtAiUsageRecord[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeAiUsage": {
+          "name": "summarizeAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageSummaryOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Record<string, AiUsageStats>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "destroy": {
+          "name": "destroy",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadDataFromDb": {
+          "name": "loadDataFromDb",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toJSON": {
+          "name": "toJSON",
+          "async": false,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPlainObject": {
+          "name": "toPlainObject",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getId": {
+          "name": "getId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSlug": {
+          "name": "getSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSavedId": {
+          "name": "getSavedId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSaved": {
+          "name": "isSaved",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromId": {
+          "name": "loadFromId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromSlug": {
+          "name": "loadFromSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "is": {
+          "name": "is",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "do": {
+          "name": "do",
+          "async": true,
+          "parameters": [
+            {
+              "name": "instructions",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "describe": {
+          "name": "describe",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "delete": {
+          "name": "delete",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRelatedLoaded": {
+          "name": "isRelatedLoaded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelated": {
+          "name": "loadRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelatedMany": {
+          "name": "loadRelatedMany",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelated": {
+          "name": "getRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAvailableTools": {
+          "name": "getAvailableTools",
+          "async": false,
+          "parameters": [],
+          "returnType": "AITool[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "executeToolCall": {
+          "name": "executeToolCall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toolCall",
+              "type": "ToolCall",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ToolCallResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "remember": {
+          "name": "remember",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recall": {
+          "name": "recall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recallAll": {
+          "name": "recallAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forget": {
+          "name": "forget",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forgetScope": {
+          "name": "forgetScope",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateEmbeddings": {
+          "name": "generateEmbeddings",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "GenerateEmbeddingsOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmbedding": {
+          "name": "getEmbedding",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "model",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number[] | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStaleEmbeddings": {
+          "name": "hasStaleEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearEmbeddings": {
+          "name": "clearEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isWeb": {
+          "name": "isWeb",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isIOS": {
+          "name": "isIOS",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isAndroid": {
+          "name": "isAndroid",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isMobileApp": {
+          "name": "isMobileApp",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getPlatformId": {
+          "name": "getPlatformId",
+          "async": false,
+          "parameters": [],
+          "returnType": "string",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "AnalyticsDataStream",
+      "collectionExportName": "AnalyticsDataStreamCollection",
+      "schema": {
+        "tableName": "analytics_data_streams",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_data_streams\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"property_id\" uuid,\n  \"display_name\" TEXT DEFAULT '',\n  \"stream_type\" TEXT,\n  \"external_id\" TEXT DEFAULT '',\n  \"measurement_id\" TEXT DEFAULT '',\n  \"firebase_app_id\" TEXT DEFAULT '',\n  \"default_uri\" TEXT DEFAULT '',\n  \"bundle_id\" TEXT DEFAULT '',\n  \"package_name\" TEXT DEFAULT '',\n  \"status\" TEXT,\n  \"enhanced_measurement\" BOOLEAN DEFAULT TRUE\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "property_id": {
+            "type": "UUID",
+            "notNull": false
+          },
+          "display_name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "stream_type": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "external_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "measurement_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "firebase_app_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "default_uri": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "bundle_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "package_name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "enhanced_measurement": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": true
+          }
+        },
+        "indexes": [
+          {
+            "name": "analytics_data_streams_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "analytics_data_streams_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "analytics_data_streams_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "1a96a399"
+      }
+    },
+    "@happyvertical/smrt-analytics:AnalyticsEvent": {
+      "name": "analyticsevent",
+      "className": "AnalyticsEvent",
+      "qualifiedName": "@happyvertical/smrt-analytics:AnalyticsEvent",
+      "collection": "analyticsevents",
+      "filePath": "packages/analytics/src/models/AnalyticsEvent.ts",
+      "packageName": "@happyvertical/smrt-analytics",
+      "fields": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "propertyId": {
+          "type": "foreignKey",
+          "required": false,
+          "related": "AnalyticsProperty"
+        },
+        "eventName": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "clientId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "userId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "params": {
+          "type": "text",
+          "required": false,
+          "default": "{}"
+        },
+        "eventTimestamp": {
+          "type": "datetime",
+          "required": false
+        },
+        "status": {
+          "type": "text",
+          "required": false
+        },
+        "sentAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "errorMessage": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "retryCount": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "nonPersonalizedAds": {
+          "type": "boolean",
+          "required": false,
+          "default": false
+        },
+        "sessionId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "pagePath": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "pageTitle": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "userAgent": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "ipAddress": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        }
+      },
+      "methods": {
+        "getAiUsageSnapshot": {
+          "name": "getAiUsageSnapshot",
+          "async": false,
+          "parameters": [],
+          "returnType": "AiUsageSnapshot | undefined",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetAiUsage": {
+          "name": "resetAiUsage",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listAiUsage": {
+          "name": "listAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageListOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<SmrtAiUsageRecord[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeAiUsage": {
+          "name": "summarizeAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageSummaryOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Record<string, AiUsageStats>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "destroy": {
+          "name": "destroy",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadDataFromDb": {
+          "name": "loadDataFromDb",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toJSON": {
+          "name": "toJSON",
+          "async": false,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPlainObject": {
+          "name": "toPlainObject",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getId": {
+          "name": "getId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSlug": {
+          "name": "getSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSavedId": {
+          "name": "getSavedId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSaved": {
+          "name": "isSaved",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromId": {
+          "name": "loadFromId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromSlug": {
+          "name": "loadFromSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "is": {
+          "name": "is",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "do": {
+          "name": "do",
+          "async": true,
+          "parameters": [
+            {
+              "name": "instructions",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "describe": {
+          "name": "describe",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "delete": {
+          "name": "delete",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRelatedLoaded": {
+          "name": "isRelatedLoaded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelated": {
+          "name": "loadRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelatedMany": {
+          "name": "loadRelatedMany",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelated": {
+          "name": "getRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAvailableTools": {
+          "name": "getAvailableTools",
+          "async": false,
+          "parameters": [],
+          "returnType": "AITool[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "executeToolCall": {
+          "name": "executeToolCall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toolCall",
+              "type": "ToolCall",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ToolCallResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "remember": {
+          "name": "remember",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recall": {
+          "name": "recall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recallAll": {
+          "name": "recallAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forget": {
+          "name": "forget",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forgetScope": {
+          "name": "forgetScope",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateEmbeddings": {
+          "name": "generateEmbeddings",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "GenerateEmbeddingsOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmbedding": {
+          "name": "getEmbedding",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "model",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number[] | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStaleEmbeddings": {
+          "name": "hasStaleEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearEmbeddings": {
+          "name": "clearEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParams": {
+          "name": "getParams",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, string | number | boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setParams": {
+          "name": "setParams",
+          "async": false,
+          "parameters": [
+            {
+              "name": "params",
+              "type": "Record<string, string | number | boolean>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addParam": {
+          "name": "addParam",
+          "async": false,
+          "parameters": [
+            {
+              "name": "key",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "value",
+              "type": "string | number | boolean",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isPageview": {
+          "name": "isPageview",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isConversion": {
+          "name": "isConversion",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markSent": {
+          "name": "markSent",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markFailed": {
+          "name": "markFailed",
+          "async": false,
+          "parameters": [
+            {
+              "name": "error",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetForRetry": {
+          "name": "resetForRetry",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "shouldRetry": {
+          "name": "shouldRetry",
+          "async": false,
+          "parameters": [
+            {
+              "name": "maxRetries",
+              "type": "number",
+              "optional": true
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toTrackEvent": {
+          "name": "toTrackEvent",
+          "async": false,
+          "parameters": [],
+          "returnType": "object",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "track"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "AnalyticsEvent",
+      "collectionExportName": "AnalyticsEventCollection",
+      "schema": {
+        "tableName": "analytics_events",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_events\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"property_id\" uuid,\n  \"event_name\" TEXT DEFAULT '',\n  \"client_id\" TEXT DEFAULT '',\n  \"user_id\" TEXT DEFAULT '',\n  \"params\" TEXT DEFAULT '{}',\n  \"event_timestamp\" TIMESTAMP,\n  \"status\" TEXT,\n  \"sent_at\" TIMESTAMP,\n  \"error_message\" TEXT DEFAULT '',\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"non_personalized_ads\" BOOLEAN DEFAULT FALSE,\n  \"session_id\" TEXT DEFAULT '',\n  \"page_path\" TEXT DEFAULT '',\n  \"page_title\" TEXT DEFAULT '',\n  \"user_agent\" TEXT DEFAULT '',\n  \"ip_address\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "property_id": {
+            "type": "UUID",
+            "notNull": false
+          },
+          "event_name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "client_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "user_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "params": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "{}"
+          },
+          "event_timestamp": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "sent_at": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          },
+          "error_message": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "retry_count": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "non_personalized_ads": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": false
+          },
+          "session_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "page_path": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "page_title": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "user_agent": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "ip_address": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "analytics_events_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "analytics_events_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "analytics_events_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "f628b4b8"
+      }
+    },
+    "@happyvertical/smrt-analytics:AnalyticsProperty": {
+      "name": "analyticsproperty",
+      "className": "AnalyticsProperty",
+      "qualifiedName": "@happyvertical/smrt-analytics:AnalyticsProperty",
+      "collection": "analyticsproperties",
+      "filePath": "packages/analytics/src/models/AnalyticsProperty.ts",
+      "packageName": "@happyvertical/smrt-analytics",
+      "fields": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "displayName": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "provider": {
+          "type": "text",
+          "required": false
+        },
+        "externalId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "measurementId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "apiSecret": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "siteDomain": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "timeZone": {
+          "type": "text",
+          "required": false,
+          "default": "America/Los_Angeles"
+        },
+        "currencyCode": {
+          "type": "text",
+          "required": false,
+          "default": "USD"
+        },
+        "industryCategory": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "serviceLevel": {
+          "type": "text",
+          "required": false,
+          "default": "STANDARD"
+        },
+        "status": {
+          "type": "text",
+          "required": false
+        },
+        "lastSyncAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "providerMetadata": {
+          "type": "text",
+          "required": false,
+          "default": "{}"
+        }
+      },
+      "methods": {
+        "getAiUsageSnapshot": {
+          "name": "getAiUsageSnapshot",
+          "async": false,
+          "parameters": [],
+          "returnType": "AiUsageSnapshot | undefined",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetAiUsage": {
+          "name": "resetAiUsage",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listAiUsage": {
+          "name": "listAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageListOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<SmrtAiUsageRecord[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeAiUsage": {
+          "name": "summarizeAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageSummaryOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Record<string, AiUsageStats>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "destroy": {
+          "name": "destroy",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadDataFromDb": {
+          "name": "loadDataFromDb",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toJSON": {
+          "name": "toJSON",
+          "async": false,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPlainObject": {
+          "name": "toPlainObject",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getId": {
+          "name": "getId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSlug": {
+          "name": "getSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSavedId": {
+          "name": "getSavedId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSaved": {
+          "name": "isSaved",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromId": {
+          "name": "loadFromId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromSlug": {
+          "name": "loadFromSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "is": {
+          "name": "is",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "do": {
+          "name": "do",
+          "async": true,
+          "parameters": [
+            {
+              "name": "instructions",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "describe": {
+          "name": "describe",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "delete": {
+          "name": "delete",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRelatedLoaded": {
+          "name": "isRelatedLoaded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelated": {
+          "name": "loadRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelatedMany": {
+          "name": "loadRelatedMany",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelated": {
+          "name": "getRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAvailableTools": {
+          "name": "getAvailableTools",
+          "async": false,
+          "parameters": [],
+          "returnType": "AITool[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "executeToolCall": {
+          "name": "executeToolCall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toolCall",
+              "type": "ToolCall",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ToolCallResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "remember": {
+          "name": "remember",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recall": {
+          "name": "recall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recallAll": {
+          "name": "recallAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forget": {
+          "name": "forget",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forgetScope": {
+          "name": "forgetScope",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateEmbeddings": {
+          "name": "generateEmbeddings",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "GenerateEmbeddingsOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmbedding": {
+          "name": "getEmbedding",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "model",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number[] | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStaleEmbeddings": {
+          "name": "hasStaleEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearEmbeddings": {
+          "name": "clearEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isGA4": {
+          "name": "isGA4",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isPlausible": {
+          "name": "isPlausible",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isMatomo": {
+          "name": "isMatomo",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getProviderMetadata": {
+          "name": "getProviderMetadata",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setProviderMetadata": {
+          "name": "setProviderMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "metadata",
+              "type": "Record<string>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markSynced": {
+          "name": "markSynced",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "analyzePerformance": {
+          "name": "analyzePerformance",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<object>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isPerformingWell": {
+          "name": "isPerformingWell",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "sync",
+            "runReport"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "AnalyticsProperty",
+      "collectionExportName": "AnalyticsPropertyCollection",
+      "schema": {
+        "tableName": "analytics_properties",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_properties\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"display_name\" TEXT DEFAULT '',\n  \"provider\" TEXT,\n  \"external_id\" TEXT DEFAULT '',\n  \"measurement_id\" TEXT DEFAULT '',\n  \"api_secret\" TEXT DEFAULT '',\n  \"site_domain\" TEXT DEFAULT '',\n  \"time_zone\" TEXT DEFAULT 'America/Los_Angeles',\n  \"currency_code\" TEXT DEFAULT 'USD',\n  \"industry_category\" TEXT DEFAULT '',\n  \"service_level\" TEXT DEFAULT 'STANDARD',\n  \"status\" TEXT,\n  \"last_sync_at\" TIMESTAMP,\n  \"provider_metadata\" TEXT DEFAULT '{}'\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "display_name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "provider": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "external_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "measurement_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "api_secret": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "site_domain": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "time_zone": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "America/Los_Angeles"
+          },
+          "currency_code": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "USD"
+          },
+          "industry_category": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "service_level": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "STANDARD"
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "last_sync_at": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          },
+          "provider_metadata": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "{}"
+          }
+        },
+        "indexes": [
+          {
+            "name": "analytics_properties_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "analytics_properties_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "analytics_properties_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "b38ffd95"
+      }
+    },
+    "@happyvertical/smrt-analytics:AnalyticsReport": {
+      "name": "analyticsreport",
+      "className": "AnalyticsReport",
+      "qualifiedName": "@happyvertical/smrt-analytics:AnalyticsReport",
+      "collection": "analyticsreports",
+      "filePath": "packages/analytics/src/models/AnalyticsReport.ts",
+      "packageName": "@happyvertical/smrt-analytics",
+      "fields": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "propertyId": {
+          "type": "foreignKey",
+          "required": false,
+          "related": "AnalyticsProperty"
+        },
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "dimensions": {
+          "type": "text",
+          "required": false,
+          "default": "[]"
+        },
+        "metrics": {
+          "type": "text",
+          "required": false,
+          "default": "[]"
+        },
+        "dateRangeStart": {
+          "type": "text",
+          "required": false,
+          "default": "7daysAgo"
+        },
+        "dateRangeEnd": {
+          "type": "text",
+          "required": false,
+          "default": "today"
+        },
+        "dimensionFilter": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "metricFilter": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "orderBy": {
+          "type": "text",
+          "required": false,
+          "default": "[]"
+        },
+        "maxResults": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "status": {
+          "type": "text",
+          "required": false
+        },
+        "frequency": {
+          "type": "text",
+          "required": false
+        },
+        "lastRunAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "nextRunAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "resultData": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "rowCount": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "lastError": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        }
+      },
+      "methods": {
+        "getAiUsageSnapshot": {
+          "name": "getAiUsageSnapshot",
+          "async": false,
+          "parameters": [],
+          "returnType": "AiUsageSnapshot | undefined",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetAiUsage": {
+          "name": "resetAiUsage",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listAiUsage": {
+          "name": "listAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageListOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<SmrtAiUsageRecord[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeAiUsage": {
+          "name": "summarizeAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageSummaryOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Record<string, AiUsageStats>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "destroy": {
+          "name": "destroy",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadDataFromDb": {
+          "name": "loadDataFromDb",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toJSON": {
+          "name": "toJSON",
+          "async": false,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPlainObject": {
+          "name": "toPlainObject",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getId": {
+          "name": "getId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSlug": {
+          "name": "getSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSavedId": {
+          "name": "getSavedId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSaved": {
+          "name": "isSaved",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromId": {
+          "name": "loadFromId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromSlug": {
+          "name": "loadFromSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "is": {
+          "name": "is",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "do": {
+          "name": "do",
+          "async": true,
+          "parameters": [
+            {
+              "name": "instructions",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "describe": {
+          "name": "describe",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "delete": {
+          "name": "delete",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRelatedLoaded": {
+          "name": "isRelatedLoaded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelated": {
+          "name": "loadRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelatedMany": {
+          "name": "loadRelatedMany",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelated": {
+          "name": "getRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAvailableTools": {
+          "name": "getAvailableTools",
+          "async": false,
+          "parameters": [],
+          "returnType": "AITool[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "executeToolCall": {
+          "name": "executeToolCall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toolCall",
+              "type": "ToolCall",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ToolCallResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "remember": {
+          "name": "remember",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recall": {
+          "name": "recall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recallAll": {
+          "name": "recallAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forget": {
+          "name": "forget",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forgetScope": {
+          "name": "forgetScope",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateEmbeddings": {
+          "name": "generateEmbeddings",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "GenerateEmbeddingsOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmbedding": {
+          "name": "getEmbedding",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "model",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number[] | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStaleEmbeddings": {
+          "name": "hasStaleEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearEmbeddings": {
+          "name": "clearEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getDimensions": {
+          "name": "getDimensions",
+          "async": false,
+          "parameters": [],
+          "returnType": "Array<object>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setDimensions": {
+          "name": "setDimensions",
+          "async": false,
+          "parameters": [
+            {
+              "name": "dimensions",
+              "type": "Array<object>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getMetrics": {
+          "name": "getMetrics",
+          "async": false,
+          "parameters": [],
+          "returnType": "Array<object>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setMetrics": {
+          "name": "setMetrics",
+          "async": false,
+          "parameters": [
+            {
+              "name": "metrics",
+              "type": "Array<object>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getResultData": {
+          "name": "getResultData",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string> | null",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setResultData": {
+          "name": "setResultData",
+          "async": false,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "Record<string>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markRunning": {
+          "name": "markRunning",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markCompleted": {
+          "name": "markCompleted",
+          "async": false,
+          "parameters": [
+            {
+              "name": "rowCount",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markFailed": {
+          "name": "markFailed",
+          "async": false,
+          "parameters": [
+            {
+              "name": "error",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "calculateNextRun": {
+          "name": "calculateNextRun",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isDue": {
+          "name": "isDue",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "analyzeResults": {
+          "name": "analyzeResults",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<object>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasPositiveTrends": {
+          "name": "hasPositiveTrends",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "run"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "run",
+            "analyze"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "AnalyticsReport",
+      "collectionExportName": "AnalyticsReportCollection",
+      "schema": {
+        "tableName": "analytics_reports",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"analytics_reports\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"property_id\" uuid,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"dimensions\" TEXT DEFAULT '[]',\n  \"metrics\" TEXT DEFAULT '[]',\n  \"date_range_start\" TEXT DEFAULT '7daysAgo',\n  \"date_range_end\" TEXT DEFAULT 'today',\n  \"dimension_filter\" TEXT DEFAULT '',\n  \"metric_filter\" TEXT DEFAULT '',\n  \"order_by\" TEXT DEFAULT '[]',\n  \"max_results\" INTEGER DEFAULT 0,\n  \"status\" TEXT,\n  \"frequency\" TEXT,\n  \"last_run_at\" TIMESTAMP,\n  \"next_run_at\" TIMESTAMP,\n  \"result_data\" TEXT DEFAULT '',\n  \"row_count\" INTEGER DEFAULT 0,\n  \"last_error\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "property_id": {
+            "type": "UUID",
+            "notNull": false
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "dimensions": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "[]"
+          },
+          "metrics": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "[]"
+          },
+          "date_range_start": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "7daysAgo"
+          },
+          "date_range_end": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "today"
+          },
+          "dimension_filter": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "metric_filter": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "order_by": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "[]"
+          },
+          "max_results": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "frequency": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "last_run_at": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          },
+          "next_run_at": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          },
+          "result_data": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "row_count": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "last_error": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "analytics_reports_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "analytics_reports_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "analytics_reports_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "411b88bb"
       }
     }
   },
   "moduleType": "smrt",
-  "packageName": "@happyvertical/smrt-analytics"
+  "smrtDependencies": [
+    "@happyvertical/smrt-core"
+  ]
 }

--- a/packages/assets/src/manifest/manifest.json
+++ b/packages/assets/src/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "timestamp": 1780375807201,
+  "timestamp": 1780379236418,
   "packageName": "@happyvertical/smrt-assets",
   "packageVersion": "0.25.8",
   "objects": {
@@ -14,8 +14,11 @@
       "fields": {
         "assetId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "Asset"
+          "required": true,
+          "related": "Asset",
+          "_meta": {
+            "required": true
+          }
         },
         "metaType": {
           "type": "text",
@@ -74,6 +77,11 @@
       "collectionExportName": "AssetAssociationCollection",
       "validationRules": [
         {
+          "field": "assetId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        },
+        {
           "field": "metaType",
           "rule": "required",
           "fieldType": "text"
@@ -91,7 +99,7 @@
       ],
       "schema": {
         "tableName": "asset_associations",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_associations\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"asset_id\" uuid,\n  \"meta_type\" TEXT NOT NULL,\n  \"meta_id\" TEXT NOT NULL,\n  \"role\" TEXT NOT NULL,\n  \"sort_order\" INTEGER DEFAULT 0\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_associations\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"asset_id\" UUID NOT NULL,\n  \"meta_type\" TEXT NOT NULL,\n  \"meta_id\" TEXT NOT NULL,\n  \"role\" TEXT NOT NULL,\n  \"sort_order\" INTEGER DEFAULT 0\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -119,7 +127,7 @@
           },
           "asset_id": {
             "type": "UUID",
-            "notNull": false,
+            "notNull": true,
             "unique": false
           },
           "meta_type": {
@@ -162,7 +170,7 @@
             "unique": true
           }
         ],
-        "version": "4f1d3516"
+        "version": "2baed304"
       }
     },
     "@happyvertical/smrt-assets:AssetAssociationCollection": {
@@ -312,7 +320,7 @@
       "collectionExportName": "AssetAssociationCollectionCollection",
       "schema": {
         "tableName": "asset_association_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_association_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_association_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -857,7 +865,7 @@
       "collectionExportName": "AssetMetafieldCollection",
       "schema": {
         "tableName": "asset_metafields",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_metafields\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT,\n  \"validation\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_metafields\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT,\n  \"validation\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -975,7 +983,7 @@
       "collectionExportName": "AssetMetafieldCollectionCollection",
       "schema": {
         "tableName": "asset_metafield_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_metafield_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_metafield_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1498,7 +1506,7 @@
       "collectionExportName": "AssetStatusCollection",
       "schema": {
         "tableName": "asset_statuses",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_statuses\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT,\n  \"description\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_statuses\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT,\n  \"description\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1616,7 +1624,7 @@
       "collectionExportName": "AssetStatusCollectionCollection",
       "schema": {
         "tableName": "asset_status_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_status_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_status_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2139,7 +2147,7 @@
       "collectionExportName": "AssetTypeCollection",
       "schema": {
         "tableName": "asset_types",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_types\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT,\n  \"description\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_types\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT,\n  \"description\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2257,7 +2265,7 @@
       "collectionExportName": "AssetTypeCollectionCollection",
       "schema": {
         "tableName": "asset_type_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_type_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_type_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3021,7 +3029,7 @@
       ],
       "schema": {
         "tableName": "assets",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"assets\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"source_uri\" TEXT,\n  \"mime_type\" TEXT,\n  \"description\" TEXT,\n  \"metadata\" TEXT,\n  \"version\" INTEGER DEFAULT 1,\n  \"primary_version_id\" uuid,\n  \"type_slug\" TEXT,\n  \"status_slug\" TEXT,\n  \"owner_profile_id\" uuid,\n  \"source_asset_id\" uuid,\n  \"folder_id\" uuid,\n  \"source_type\" TEXT,\n  \"external_id\" TEXT,\n  \"external_refs\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"assets\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"source_uri\" TEXT,\n  \"mime_type\" TEXT,\n  \"description\" TEXT,\n  \"metadata\" TEXT,\n  \"version\" INTEGER DEFAULT 1,\n  \"primary_version_id\" UUID,\n  \"type_slug\" TEXT,\n  \"status_slug\" TEXT,\n  \"owner_profile_id\" UUID,\n  \"source_asset_id\" UUID,\n  \"folder_id\" UUID,\n  \"source_type\" TEXT,\n  \"external_id\" TEXT,\n  \"external_refs\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3407,7 +3415,7 @@
       "collectionExportName": "AssetCollectionCollection",
       "schema": {
         "tableName": "asset_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3462,8 +3470,12 @@
       "packageName": "@happyvertical/smrt-assets",
       "fields": {
         "parentId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "Folder",
+          "_meta": {
+            "nullable": true
+          }
         },
         "tenantId": {
           "type": "text",
@@ -3586,7 +3598,7 @@
       "collectionExportName": "FolderCollection",
       "schema": {
         "tableName": "folders",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"folders\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"parent_id\" TEXT,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"description\" TEXT,\n  \"owner_profile_id\" uuid\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"folders\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"parent_id\" UUID,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"description\" TEXT,\n  \"owner_profile_id\" UUID\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3613,7 +3625,7 @@
             "default": "current_timestamp"
           },
           "parent_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           },
@@ -3654,7 +3666,7 @@
             "unique": true
           }
         ],
-        "version": "108eee55"
+        "version": "67babe0a"
       }
     },
     "@happyvertical/smrt-assets:FolderCollection": {
@@ -3740,7 +3752,7 @@
       "collectionExportName": "FolderCollectionCollection",
       "schema": {
         "tableName": "folder_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"folder_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"folder_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3790,6 +3802,7 @@
   "moduleType": "smrt",
   "smrtDependencies": [
     "@happyvertical/smrt-core",
-    "@happyvertical/smrt-tags"
+    "@happyvertical/smrt-tags",
+    "@happyvertical/smrt-tenancy"
   ]
 }

--- a/packages/assets/src/manifest/manifest.json
+++ b/packages/assets/src/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "timestamp": 1779220310906,
+  "timestamp": 1780375807201,
   "packageName": "@happyvertical/smrt-assets",
   "packageVersion": "0.25.8",
   "objects": {
@@ -13,11 +13,9 @@
       "packageName": "@happyvertical/smrt-assets",
       "fields": {
         "assetId": {
-          "type": "text",
-          "required": true,
-          "_meta": {
-            "required": true
-          }
+          "type": "foreignKey",
+          "required": false,
+          "related": "Asset"
         },
         "metaType": {
           "type": "text",
@@ -76,11 +74,6 @@
       "collectionExportName": "AssetAssociationCollection",
       "validationRules": [
         {
-          "field": "assetId",
-          "rule": "required",
-          "fieldType": "text"
-        },
-        {
           "field": "metaType",
           "rule": "required",
           "fieldType": "text"
@@ -98,10 +91,10 @@
       ],
       "schema": {
         "tableName": "asset_associations",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_associations\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"asset_id\" TEXT NOT NULL,\n  \"meta_type\" TEXT NOT NULL,\n  \"meta_id\" TEXT NOT NULL,\n  \"role\" TEXT NOT NULL,\n  \"sort_order\" INTEGER DEFAULT 0\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_associations\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"asset_id\" uuid,\n  \"meta_type\" TEXT NOT NULL,\n  \"meta_id\" TEXT NOT NULL,\n  \"role\" TEXT NOT NULL,\n  \"sort_order\" INTEGER DEFAULT 0\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -125,8 +118,8 @@
             "default": "current_timestamp"
           },
           "asset_id": {
-            "type": "TEXT",
-            "notNull": true,
+            "type": "UUID",
+            "notNull": false,
             "unique": false
           },
           "meta_type": {
@@ -169,7 +162,7 @@
             "unique": true
           }
         ],
-        "version": "ca8497f5"
+        "version": "4f1d3516"
       }
     },
     "@happyvertical/smrt-assets:AssetAssociationCollection": {
@@ -319,10 +312,10 @@
       "collectionExportName": "AssetAssociationCollectionCollection",
       "schema": {
         "tableName": "asset_association_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_association_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_association_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -362,7 +355,7 @@
             "unique": true
           }
         ],
-        "version": "4cd9ab63"
+        "version": "a1cd367f"
       }
     },
     "@happyvertical/smrt-assets:AssetMetafield": {
@@ -864,10 +857,10 @@
       "collectionExportName": "AssetMetafieldCollection",
       "schema": {
         "tableName": "asset_metafields",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_metafields\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT,\n  \"validation\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_metafields\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT,\n  \"validation\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -930,7 +923,7 @@
             ]
           }
         ],
-        "version": "6463e0dd"
+        "version": "721d05b7"
       }
     },
     "@happyvertical/smrt-assets:AssetMetafieldCollection": {
@@ -982,10 +975,10 @@
       "collectionExportName": "AssetMetafieldCollectionCollection",
       "schema": {
         "tableName": "asset_metafield_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_metafield_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_metafield_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1025,7 +1018,7 @@
             "unique": true
           }
         ],
-        "version": "edbf819d"
+        "version": "61c5c47e"
       }
     },
     "@happyvertical/smrt-assets:AssetStatus": {
@@ -1505,10 +1498,10 @@
       "collectionExportName": "AssetStatusCollection",
       "schema": {
         "tableName": "asset_statuses",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_statuses\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT,\n  \"description\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_statuses\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT,\n  \"description\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1571,7 +1564,7 @@
             ]
           }
         ],
-        "version": "0893c2a1"
+        "version": "0f8b7a09"
       }
     },
     "@happyvertical/smrt-assets:AssetStatusCollection": {
@@ -1623,10 +1616,10 @@
       "collectionExportName": "AssetStatusCollectionCollection",
       "schema": {
         "tableName": "asset_status_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_status_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_status_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1666,7 +1659,7 @@
             "unique": true
           }
         ],
-        "version": "331f0ad8"
+        "version": "051046ef"
       }
     },
     "@happyvertical/smrt-assets:AssetType": {
@@ -2146,10 +2139,10 @@
       "collectionExportName": "AssetTypeCollection",
       "schema": {
         "tableName": "asset_types",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_types\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT,\n  \"description\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_types\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT,\n  \"description\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -2212,7 +2205,7 @@
             ]
           }
         ],
-        "version": "d46f0f07"
+        "version": "a86988da"
       }
     },
     "@happyvertical/smrt-assets:AssetTypeCollection": {
@@ -2264,10 +2257,10 @@
       "collectionExportName": "AssetTypeCollectionCollection",
       "schema": {
         "tableName": "asset_type_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_type_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_type_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -2307,7 +2300,7 @@
             "unique": true
           }
         ],
-        "version": "57e0ddcd"
+        "version": "f40f1240"
       }
     },
     "@happyvertical/smrt-assets:Asset": {
@@ -2356,8 +2349,9 @@
           "default": 1
         },
         "primaryVersionId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "Asset"
         },
         "typeSlug": {
           "type": "text",
@@ -2368,16 +2362,19 @@
           "required": false
         },
         "ownerProfileId": {
-          "type": "text",
-          "required": false
+          "type": "crossPackageRef",
+          "required": false,
+          "related": "@happyvertical/smrt-profiles:Profile"
         },
         "sourceAssetId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "Asset"
         },
         "folderId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "Folder"
         },
         "sourceType": {
           "type": "text",
@@ -3024,10 +3021,10 @@
       ],
       "schema": {
         "tableName": "assets",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"assets\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"source_uri\" TEXT,\n  \"mime_type\" TEXT,\n  \"description\" TEXT,\n  \"metadata\" TEXT,\n  \"version\" INTEGER DEFAULT 1,\n  \"primary_version_id\" TEXT,\n  \"type_slug\" TEXT,\n  \"status_slug\" TEXT,\n  \"owner_profile_id\" TEXT,\n  \"source_asset_id\" TEXT,\n  \"folder_id\" TEXT,\n  \"source_type\" TEXT,\n  \"external_id\" TEXT,\n  \"external_refs\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"assets\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"source_uri\" TEXT,\n  \"mime_type\" TEXT,\n  \"description\" TEXT,\n  \"metadata\" TEXT,\n  \"version\" INTEGER DEFAULT 1,\n  \"primary_version_id\" uuid,\n  \"type_slug\" TEXT,\n  \"status_slug\" TEXT,\n  \"owner_profile_id\" uuid,\n  \"source_asset_id\" uuid,\n  \"folder_id\" uuid,\n  \"source_type\" TEXT,\n  \"external_id\" TEXT,\n  \"external_refs\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -3088,7 +3085,7 @@
             "default": 1
           },
           "primary_version_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "type_slug": {
@@ -3100,15 +3097,15 @@
             "notNull": false
           },
           "owner_profile_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "source_asset_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "folder_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "source_type": {
@@ -3147,7 +3144,7 @@
             ]
           }
         ],
-        "version": "302f9402"
+        "version": "90f07f0b"
       }
     },
     "@happyvertical/smrt-assets:AssetCollection": {
@@ -3410,10 +3407,10 @@
       "collectionExportName": "AssetCollectionCollection",
       "schema": {
         "tableName": "asset_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"asset_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -3453,7 +3450,7 @@
             "unique": true
           }
         ],
-        "version": "a0906bc4"
+        "version": "1a181bde"
       }
     },
     "@happyvertical/smrt-assets:Folder": {
@@ -3481,8 +3478,9 @@
           "required": false
         },
         "ownerProfileId": {
-          "type": "text",
-          "required": false
+          "type": "crossPackageRef",
+          "required": false,
+          "related": "@happyvertical/smrt-profiles:Profile"
         },
         "createdAt": {
           "type": "text",
@@ -3498,7 +3496,7 @@
           "name": "getParent",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<Folder | null>",
+          "returnType": "Promise<null>",
           "isStatic": false,
           "isPublic": true
         },
@@ -3506,7 +3504,7 @@
           "name": "getChildren",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<Folder[]>",
+          "returnType": "Promise",
           "isStatic": false,
           "isPublic": true
         },
@@ -3514,7 +3512,7 @@
           "name": "getAncestors",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<Folder[]>",
+          "returnType": "Promise",
           "isStatic": false,
           "isPublic": true
         },
@@ -3522,7 +3520,7 @@
           "name": "getDescendants",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<Folder[]>",
+          "returnType": "Promise",
           "isStatic": false,
           "isPublic": true
         },
@@ -3530,7 +3528,7 @@
           "name": "getHierarchy",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<HierarchyView<Folder>>",
+          "returnType": "Promise<HierarchyView>",
           "isStatic": false,
           "isPublic": true
         },
@@ -3540,7 +3538,7 @@
           "parameters": [
             {
               "name": "newParent",
-              "type": "Folder | string | null",
+              "type": "string | null",
               "optional": false
             }
           ],
@@ -3588,10 +3586,10 @@
       "collectionExportName": "FolderCollection",
       "schema": {
         "tableName": "folders",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"folders\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"parent_id\" TEXT,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"description\" TEXT,\n  \"owner_profile_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"folders\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"parent_id\" TEXT,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"description\" TEXT,\n  \"owner_profile_id\" uuid\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -3635,7 +3633,7 @@
             "unique": false
           },
           "owner_profile_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           }
@@ -3656,7 +3654,7 @@
             "unique": true
           }
         ],
-        "version": "a9783c63"
+        "version": "108eee55"
       }
     },
     "@happyvertical/smrt-assets:FolderCollection": {
@@ -3742,10 +3740,10 @@
       "collectionExportName": "FolderCollectionCollection",
       "schema": {
         "tableName": "folder_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"folder_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"folder_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -3785,14 +3783,13 @@
             "unique": true
           }
         ],
-        "version": "9df61270"
+        "version": "e515465c"
       }
     }
   },
   "moduleType": "smrt",
   "smrtDependencies": [
     "@happyvertical/smrt-core",
-    "@happyvertical/smrt-tags",
-    "@happyvertical/smrt-tenancy"
+    "@happyvertical/smrt-tags"
   ]
 }

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -65,10 +65,27 @@ interface IndexDef {
   unique?: boolean;
 }
 
+type DDLPreviewEngine = 'sqlite' | 'duckdb' | 'json' | 'postgres';
+
 export function resolveVitestEntrypoint(fromDir = process.cwd()): string {
   const requireFromDir = createRequire(resolve(fromDir, 'package.json'));
   const vitestPackageJson = requireFromDir.resolve('vitest/package.json');
   return join(dirname(vitestPackageJson), 'vitest.mjs');
+}
+
+function resolveDDLPreviewEngine(dbType: string): DDLPreviewEngine {
+  switch (dbType) {
+    case 'json':
+      return 'json';
+    case 'duckdb':
+      return 'duckdb';
+    case 'postgres':
+    case 'postgresql':
+    case 'pg':
+      return 'postgres';
+    default:
+      return 'sqlite';
+  }
 }
 
 /**
@@ -669,7 +686,11 @@ export default testManifest;
               continue;
             }
 
-            const schema = await generateSchema(registered.constructor);
+            const schema = await generateSchema(
+              registered.constructor,
+              undefined,
+              { engine: resolveDDLPreviewEngine(dbType) },
+            );
             if (schema && schema.trim() !== '') {
               const tableName = ObjectRegistry.getTableName(className);
               const strategy = tableStrategy === 'sti' ? 'STI' : 'CTI';

--- a/packages/content/src/manifest/manifest.json
+++ b/packages/content/src/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "timestamp": 1780375813147,
+  "timestamp": 1780379256044,
   "packageName": "@happyvertical/smrt-content",
   "packageVersion": "0.25.8",
   "objects": {
@@ -18,8 +18,11 @@
         },
         "contentId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "Content"
+          "required": true,
+          "related": "Content",
+          "_meta": {
+            "required": true
+          }
         },
         "assetId": {
           "type": "crossPackageRef",
@@ -56,6 +59,11 @@
       "collectionExportName": "ContentAssetCollection",
       "validationRules": [
         {
+          "field": "contentId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        },
+        {
           "field": "assetId",
           "rule": "required",
           "fieldType": "crossPackageRef"
@@ -73,7 +81,7 @@
       ],
       "schema": {
         "tableName": "content_assets",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_assets\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"content_id\" uuid,\n  \"asset_id\" uuid NOT NULL,\n  \"relationship\" TEXT NOT NULL,\n  \"sort_order\" INTEGER NOT NULL DEFAULT 0\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_assets\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"content_id\" UUID NOT NULL,\n  \"asset_id\" UUID NOT NULL,\n  \"relationship\" TEXT NOT NULL,\n  \"sort_order\" INTEGER NOT NULL DEFAULT 0\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -106,7 +114,7 @@
           },
           "content_id": {
             "type": "UUID",
-            "notNull": false,
+            "notNull": true,
             "unique": false
           },
           "asset_id": {
@@ -143,7 +151,7 @@
             "unique": true
           }
         ],
-        "version": "30176c74"
+        "version": "85d04e7f"
       }
     },
     "@happyvertical/smrt-content:ContentAssetCollection": {
@@ -278,7 +286,7 @@
       "collectionExportName": "ContentAssetCollectionCollection",
       "schema": {
         "tableName": "content_assets",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_assets\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_assets\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -334,8 +342,11 @@
       "fields": {
         "contributionId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "ContentContribution"
+          "required": true,
+          "related": "ContentContribution",
+          "_meta": {
+            "required": true
+          }
         },
         "revisionId": {
           "type": "foreignKey",
@@ -430,6 +441,11 @@
       "collectionExportName": "ContentContributionAttachmentCollection",
       "validationRules": [
         {
+          "field": "contributionId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        },
+        {
           "field": "size",
           "rule": "required",
           "fieldType": "integer"
@@ -437,7 +453,7 @@
       ],
       "schema": {
         "tableName": "content_contribution_attachments",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_attachments\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"contribution_id\" uuid,\n  \"revision_id\" uuid,\n  \"filename\" TEXT,\n  \"mime_type\" TEXT,\n  \"size\" INTEGER NOT NULL DEFAULT 0,\n  \"file_key\" TEXT,\n  \"source_uri\" TEXT,\n  \"channel\" TEXT DEFAULT 'web',\n  \"promoted_asset_id\" uuid,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_attachments\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"contribution_id\" UUID NOT NULL,\n  \"revision_id\" UUID,\n  \"filename\" TEXT,\n  \"mime_type\" TEXT,\n  \"size\" INTEGER NOT NULL DEFAULT 0,\n  \"file_key\" TEXT,\n  \"source_uri\" TEXT,\n  \"channel\" TEXT DEFAULT 'web',\n  \"promoted_asset_id\" UUID,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -465,7 +481,7 @@
           },
           "contribution_id": {
             "type": "UUID",
-            "notNull": false,
+            "notNull": true,
             "unique": false
           },
           "revision_id": {
@@ -536,7 +552,7 @@
             "unique": true
           }
         ],
-        "version": "26614056"
+        "version": "e7280ad1"
       }
     },
     "@happyvertical/smrt-content:ContentContributionAttachmentCollection": {
@@ -586,7 +602,7 @@
       "collectionExportName": "ContentContributionAttachmentCollectionCollection",
       "schema": {
         "tableName": "content_contribution_attachments",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_attachments\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_attachments\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -642,8 +658,11 @@
       "fields": {
         "contributionId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "ContentContribution"
+          "required": true,
+          "related": "ContentContribution",
+          "_meta": {
+            "required": true
+          }
         },
         "revisionNumber": {
           "type": "integer",
@@ -734,6 +753,11 @@
       "collectionExportName": "ContentContributionRevisionCollection",
       "validationRules": [
         {
+          "field": "contributionId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        },
+        {
           "field": "revisionNumber",
           "rule": "required",
           "fieldType": "integer"
@@ -741,7 +765,7 @@
       ],
       "schema": {
         "tableName": "content_contribution_revisions",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_revisions\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"contribution_id\" uuid,\n  \"revision_number\" INTEGER NOT NULL DEFAULT 1,\n  \"channel\" TEXT DEFAULT 'web',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"source_message_id\" uuid,\n  \"source_thread_key\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_revisions\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"contribution_id\" UUID NOT NULL,\n  \"revision_number\" INTEGER NOT NULL DEFAULT 1,\n  \"channel\" TEXT DEFAULT 'web',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"source_message_id\" UUID,\n  \"source_thread_key\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -769,7 +793,7 @@
           },
           "contribution_id": {
             "type": "UUID",
-            "notNull": false,
+            "notNull": true,
             "unique": false
           },
           "revision_number": {
@@ -836,7 +860,7 @@
             "unique": true
           }
         ],
-        "version": "5d72bd52"
+        "version": "6a88bf13"
       }
     },
     "@happyvertical/smrt-content:ContentContributionRevisionCollection": {
@@ -886,7 +910,7 @@
       "collectionExportName": "ContentContributionRevisionCollectionCollection",
       "schema": {
         "tableName": "content_contribution_revisions",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_revisions\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_revisions\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1163,7 +1187,7 @@
       ],
       "schema": {
         "tableName": "content_contribution_types",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_types\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"key\" TEXT NOT NULL,\n  \"label\" TEXT,\n  \"enabled\" BOOLEAN NOT NULL DEFAULT TRUE,\n  \"allowed_channels\" TEXT,\n  \"allow_text\" BOOLEAN NOT NULL DEFAULT TRUE,\n  \"allow_files\" BOOLEAN NOT NULL DEFAULT FALSE,\n  \"allow_empty_text\" BOOLEAN NOT NULL DEFAULT FALSE,\n  \"intake_rules\" TEXT,\n  \"promotion\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_types\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"key\" TEXT NOT NULL,\n  \"label\" TEXT,\n  \"enabled\" BOOLEAN NOT NULL DEFAULT TRUE,\n  \"allowed_channels\" TEXT,\n  \"allow_text\" BOOLEAN NOT NULL DEFAULT TRUE,\n  \"allow_files\" BOOLEAN NOT NULL DEFAULT FALSE,\n  \"allow_empty_text\" BOOLEAN NOT NULL DEFAULT FALSE,\n  \"intake_rules\" TEXT,\n  \"promotion\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1300,7 +1324,7 @@
       "collectionExportName": "ContentContributionTypeCollectionCollection",
       "schema": {
         "tableName": "content_contribution_types",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_types\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_types\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1356,8 +1380,11 @@
       "fields": {
         "contributorId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "ContentContributor"
+          "required": true,
+          "related": "ContentContributor",
+          "_meta": {
+            "required": true
+          }
         },
         "contributionTypeKey": {
           "type": "text",
@@ -1670,6 +1697,11 @@
       "collectionExportName": "ContentContributionCollection",
       "validationRules": [
         {
+          "field": "contributorId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        },
+        {
           "field": "contributionTypeKey",
           "rule": "required",
           "fieldType": "text"
@@ -1682,7 +1714,7 @@
       ],
       "schema": {
         "tableName": "content_contributions",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contributions\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"contributor_id\" uuid,\n  \"contribution_type_key\" TEXT NOT NULL,\n  \"status\" TEXT DEFAULT 'submitted',\n  \"intake_decision\" TEXT DEFAULT 'accepted',\n  \"channel\" TEXT DEFAULT 'web',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"contributor_email\" TEXT,\n  \"contributor_name\" TEXT,\n  \"thread_key\" TEXT,\n  \"source_message_id\" uuid,\n  \"editor_notes\" TEXT,\n  \"promoted_content_id\" uuid,\n  \"revision_count\" INTEGER NOT NULL DEFAULT 0,\n  \"approved_at\" TIMESTAMP,\n  \"promoted_at\" TIMESTAMP,\n  \"rejected_at\" TIMESTAMP,\n  \"withdrawn_at\" TIMESTAMP,\n  \"requested_changes_at\" TIMESTAMP,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contributions\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"contributor_id\" UUID NOT NULL,\n  \"contribution_type_key\" TEXT NOT NULL,\n  \"status\" TEXT DEFAULT 'submitted',\n  \"intake_decision\" TEXT DEFAULT 'accepted',\n  \"channel\" TEXT DEFAULT 'web',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"contributor_email\" TEXT,\n  \"contributor_name\" TEXT,\n  \"thread_key\" TEXT,\n  \"source_message_id\" UUID,\n  \"editor_notes\" TEXT,\n  \"promoted_content_id\" UUID,\n  \"revision_count\" INTEGER NOT NULL DEFAULT 0,\n  \"approved_at\" TIMESTAMP,\n  \"promoted_at\" TIMESTAMP,\n  \"rejected_at\" TIMESTAMP,\n  \"withdrawn_at\" TIMESTAMP,\n  \"requested_changes_at\" TIMESTAMP,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1710,7 +1742,7 @@
           },
           "contributor_id": {
             "type": "UUID",
-            "notNull": false,
+            "notNull": true,
             "unique": false
           },
           "contribution_type_key": {
@@ -1838,7 +1870,7 @@
             "unique": true
           }
         ],
-        "version": "f09bdda7"
+        "version": "c87be5bc"
       }
     },
     "@happyvertical/smrt-content:ContentContributions": {
@@ -1962,7 +1994,7 @@
       "collectionExportName": "ContentContributionsCollection",
       "schema": {
         "tableName": "content_contributions",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contributions\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contributions\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2115,7 +2147,7 @@
       ],
       "schema": {
         "tableName": "content_contributors",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contributors\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" uuid,\n  \"email\" TEXT NOT NULL,\n  \"name\" TEXT,\n  \"trust_level\" TEXT DEFAULT 'standard',\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contributors\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" UUID,\n  \"email\" TEXT NOT NULL,\n  \"name\" TEXT,\n  \"trust_level\" TEXT DEFAULT 'standard',\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2252,7 +2284,7 @@
       "collectionExportName": "ContentContributorCollectionCollection",
       "schema": {
         "tableName": "content_contributors",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contributors\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contributors\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2308,8 +2340,11 @@
       "fields": {
         "contentId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "Content"
+          "required": true,
+          "related": "Content",
+          "_meta": {
+            "required": true
+          }
         },
         "contentVersionId": {
           "type": "foreignKey",
@@ -2406,9 +2441,16 @@
       "extends": "SmrtObject",
       "exportName": "ContentCorrection",
       "collectionExportName": "ContentCorrectionCollection",
+      "validationRules": [
+        {
+          "field": "contentId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        }
+      ],
       "schema": {
         "tableName": "content_corrections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_corrections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"content_id\" uuid,\n  \"content_version_id\" uuid,\n  \"fact_id\" uuid,\n  \"replacement_fact_id\" uuid,\n  \"correction_type\" TEXT DEFAULT 'fact',\n  \"status\" TEXT DEFAULT 'draft',\n  \"summary\" TEXT,\n  \"incorrect_text\" TEXT,\n  \"corrected_text\" TEXT,\n  \"public_note\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT,\n  \"published_at\" TIMESTAMP\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_corrections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"content_id\" UUID NOT NULL,\n  \"content_version_id\" UUID,\n  \"fact_id\" UUID,\n  \"replacement_fact_id\" UUID,\n  \"correction_type\" TEXT DEFAULT 'fact',\n  \"status\" TEXT DEFAULT 'draft',\n  \"summary\" TEXT,\n  \"incorrect_text\" TEXT,\n  \"corrected_text\" TEXT,\n  \"public_note\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT,\n  \"published_at\" TIMESTAMP\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2436,7 +2478,7 @@
           },
           "content_id": {
             "type": "UUID",
-            "notNull": false,
+            "notNull": true,
             "unique": false
           },
           "content_version_id": {
@@ -2518,7 +2560,7 @@
             "unique": true
           }
         ],
-        "version": "b7060b2c"
+        "version": "5d060ebf"
       }
     },
     "@happyvertical/smrt-content:ContentCorrectionCollection": {
@@ -2582,7 +2624,7 @@
       "collectionExportName": "ContentCorrectionCollectionCollection",
       "schema": {
         "tableName": "content_corrections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_corrections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_corrections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2847,7 +2889,7 @@
       ],
       "schema": {
         "tableName": "content_feed_sources",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_feed_sources\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT NOT NULL,\n  \"feed_url\" TEXT NOT NULL,\n  \"homepage_url\" TEXT,\n  \"format\" TEXT,\n  \"status\" TEXT NOT NULL DEFAULT 'active',\n  \"default_category\" TEXT,\n  \"source_group\" TEXT,\n  \"poll_interval_minutes\" INTEGER NOT NULL DEFAULT 15,\n  \"etag\" TEXT,\n  \"last_modified\" TEXT,\n  \"last_fetched_at\" TIMESTAMP,\n  \"last_success_at\" TIMESTAMP,\n  \"last_error\" TEXT,\n  \"metadata\" JSONB DEFAULT '{}'\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_feed_sources\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT NOT NULL,\n  \"feed_url\" TEXT NOT NULL,\n  \"homepage_url\" TEXT,\n  \"format\" TEXT,\n  \"status\" TEXT NOT NULL DEFAULT 'active',\n  \"default_category\" TEXT,\n  \"source_group\" TEXT,\n  \"poll_interval_minutes\" INTEGER NOT NULL DEFAULT 15,\n  \"etag\" TEXT,\n  \"last_modified\" TEXT,\n  \"last_fetched_at\" TIMESTAMP,\n  \"last_success_at\" TIMESTAMP,\n  \"last_error\" TEXT,\n  \"metadata\" JSON DEFAULT '{}'\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3042,7 +3084,7 @@
       "collectionExportName": "ContentFeedSourceCollectionCollection",
       "schema": {
         "tableName": "content_feed_sources",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_feed_sources\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_feed_sources\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3248,7 +3290,7 @@
       ],
       "schema": {
         "tableName": "content_governance_assignments",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_assignments\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"key\" TEXT NOT NULL,\n  \"label\" TEXT,\n  \"content_type\" TEXT NOT NULL,\n  \"content_variant\" TEXT,\n  \"enabled\" BOOLEAN NOT NULL DEFAULT TRUE,\n  \"fact_linking_enabled\" BOOLEAN NOT NULL DEFAULT FALSE,\n  \"transparency_enabled\" BOOLEAN NOT NULL DEFAULT FALSE,\n  \"publication_profile_key\" TEXT,\n  \"correction_profile_key\" TEXT,\n  \"enforce_publish_readiness\" BOOLEAN NOT NULL DEFAULT FALSE,\n  \"default_fact_relationship\" TEXT DEFAULT 'supports',\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_assignments\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"key\" TEXT NOT NULL,\n  \"label\" TEXT,\n  \"content_type\" TEXT NOT NULL,\n  \"content_variant\" TEXT,\n  \"enabled\" BOOLEAN NOT NULL DEFAULT TRUE,\n  \"fact_linking_enabled\" BOOLEAN NOT NULL DEFAULT FALSE,\n  \"transparency_enabled\" BOOLEAN NOT NULL DEFAULT FALSE,\n  \"publication_profile_key\" TEXT,\n  \"correction_profile_key\" TEXT,\n  \"enforce_publish_readiness\" BOOLEAN NOT NULL DEFAULT FALSE,\n  \"default_fact_relationship\" TEXT DEFAULT 'supports',\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3410,7 +3452,7 @@
       "collectionExportName": "ContentGovernanceAssignmentCollectionCollection",
       "schema": {
         "tableName": "content_governance_assignments",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_assignments\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_assignments\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3489,7 +3531,7 @@
       "collectionExportName": "ContentGovernancePolicyCollectionCollection",
       "schema": {
         "tableName": "content_governance_policies",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_policies\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_policies\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3653,7 +3695,7 @@
       ],
       "schema": {
         "tableName": "content_governance_policies",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_policies\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"key\" TEXT NOT NULL,\n  \"label\" TEXT,\n  \"kind\" TEXT DEFAULT 'custom',\n  \"instructions\" TEXT,\n  \"enabled\" BOOLEAN NOT NULL DEFAULT TRUE,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_policies\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"key\" TEXT NOT NULL,\n  \"label\" TEXT,\n  \"kind\" TEXT DEFAULT 'custom',\n  \"instructions\" TEXT,\n  \"enabled\" BOOLEAN NOT NULL DEFAULT TRUE,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3860,7 +3902,7 @@
       ],
       "schema": {
         "tableName": "content_governance_profiles",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_profiles\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"key\" TEXT NOT NULL,\n  \"label\" TEXT,\n  \"description\" TEXT,\n  \"enabled\" BOOLEAN NOT NULL DEFAULT TRUE,\n  \"requirements\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_profiles\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"key\" TEXT NOT NULL,\n  \"label\" TEXT,\n  \"description\" TEXT,\n  \"enabled\" BOOLEAN NOT NULL DEFAULT TRUE,\n  \"requirements\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3974,7 +4016,7 @@
       "collectionExportName": "ContentGovernanceProfileCollectionCollection",
       "schema": {
         "tableName": "content_governance_profiles",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_profiles\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_profiles\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -4034,13 +4076,19 @@
         },
         "sourceId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "Content"
+          "required": true,
+          "related": "Content",
+          "_meta": {
+            "required": true
+          }
         },
         "targetId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "Content"
+          "required": true,
+          "related": "Content",
+          "_meta": {
+            "required": true
+          }
         },
         "createdAt": {
           "type": "text",
@@ -4058,9 +4106,21 @@
       "extends": "SmrtObject",
       "exportName": "ContentReference",
       "collectionExportName": "ContentReferenceCollection",
+      "validationRules": [
+        {
+          "field": "sourceId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        },
+        {
+          "field": "targetId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        }
+      ],
       "schema": {
         "tableName": "content_references",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_references\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"source_id\" uuid,\n  \"target_id\" uuid\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_references\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"source_id\" UUID NOT NULL,\n  \"target_id\" UUID NOT NULL\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -4093,12 +4153,12 @@
           },
           "source_id": {
             "type": "UUID",
-            "notNull": false,
+            "notNull": true,
             "unique": false
           },
           "target_id": {
             "type": "UUID",
-            "notNull": false,
+            "notNull": true,
             "unique": false
           }
         },
@@ -4118,7 +4178,7 @@
             "unique": true
           }
         ],
-        "version": "5b5bf4b4"
+        "version": "647d12c5"
       }
     },
     "@happyvertical/smrt-content:ContentReferences": {
@@ -4250,7 +4310,7 @@
       "collectionExportName": "ContentReferencesCollection",
       "schema": {
         "tableName": "content_references",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_references\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_references\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -4306,8 +4366,11 @@
       "fields": {
         "contentId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "Content"
+          "required": true,
+          "related": "Content",
+          "_meta": {
+            "required": true
+          }
         },
         "contentVersionId": {
           "type": "foreignKey",
@@ -4398,9 +4461,16 @@
       "extends": "SmrtObject",
       "exportName": "ContentReview",
       "collectionExportName": "ContentReviewCollection",
+      "validationRules": [
+        {
+          "field": "contentId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        }
+      ],
       "schema": {
         "tableName": "content_reviews",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_reviews\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"content_id\" uuid,\n  \"content_version_id\" uuid,\n  \"kind\" TEXT DEFAULT 'custom',\n  \"policy_key\" TEXT,\n  \"status\" TEXT DEFAULT 'pending',\n  \"summary\" TEXT,\n  \"findings\" TEXT,\n  \"reviewer\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_reviews\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"content_id\" UUID NOT NULL,\n  \"content_version_id\" UUID,\n  \"kind\" TEXT DEFAULT 'custom',\n  \"policy_key\" TEXT,\n  \"status\" TEXT DEFAULT 'pending',\n  \"summary\" TEXT,\n  \"findings\" TEXT,\n  \"reviewer\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -4428,7 +4498,7 @@
           },
           "content_id": {
             "type": "UUID",
-            "notNull": false,
+            "notNull": true,
             "unique": false
           },
           "content_version_id": {
@@ -4495,7 +4565,7 @@
             "unique": true
           }
         ],
-        "version": "78db7ddc"
+        "version": "d425c0ed"
       }
     },
     "@happyvertical/smrt-content:ContentReviewCollection": {
@@ -4607,7 +4677,7 @@
       "collectionExportName": "ContentReviewCollectionCollection",
       "schema": {
         "tableName": "content_reviews",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_reviews\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_reviews\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -6005,7 +6075,7 @@
       ],
       "schema": {
         "tableName": "contents",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type\" TEXT,\n  \"variant\" TEXT,\n  \"file_key\" TEXT,\n  \"author\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"body_format\" TEXT,\n  \"publish_date\" TIMESTAMP,\n  \"url\" TEXT,\n  \"source\" TEXT,\n  \"original_url\" TEXT,\n  \"language\" TEXT,\n  \"tags\" JSONB DEFAULT '[]',\n  \"category\" TEXT,\n  \"status\" TEXT DEFAULT 'draft',\n  \"state\" TEXT DEFAULT 'active',\n  \"metadata\" JSONB DEFAULT '{}',\n  \"thumbnail_asset_id\" uuid\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type\" TEXT,\n  \"variant\" TEXT,\n  \"file_key\" TEXT,\n  \"author\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"body_format\" TEXT,\n  \"publish_date\" TIMESTAMP,\n  \"url\" TEXT,\n  \"source\" TEXT,\n  \"original_url\" TEXT,\n  \"language\" TEXT,\n  \"tags\" JSON DEFAULT '[]',\n  \"category\" TEXT,\n  \"status\" TEXT DEFAULT 'draft',\n  \"state\" TEXT DEFAULT 'active',\n  \"metadata\" JSON DEFAULT '{}',\n  \"thumbnail_asset_id\" UUID\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -7507,7 +7577,7 @@
       ],
       "schema": {
         "tableName": "contents",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type\" TEXT,\n  \"variant\" TEXT,\n  \"file_key\" TEXT,\n  \"author\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"body_format\" TEXT,\n  \"publish_date\" TIMESTAMP,\n  \"url\" TEXT,\n  \"source\" TEXT,\n  \"original_url\" TEXT,\n  \"language\" TEXT,\n  \"tags\" JSONB DEFAULT '[]',\n  \"category\" TEXT,\n  \"status\" TEXT DEFAULT 'draft',\n  \"state\" TEXT DEFAULT 'active',\n  \"metadata\" JSONB DEFAULT '{}',\n  \"thumbnail_asset_id\" uuid\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type\" TEXT,\n  \"variant\" TEXT,\n  \"file_key\" TEXT,\n  \"author\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"body_format\" TEXT,\n  \"publish_date\" TIMESTAMP,\n  \"url\" TEXT,\n  \"source\" TEXT,\n  \"original_url\" TEXT,\n  \"language\" TEXT,\n  \"tags\" JSON DEFAULT '[]',\n  \"category\" TEXT,\n  \"status\" TEXT DEFAULT 'draft',\n  \"state\" TEXT DEFAULT 'active',\n  \"metadata\" JSON DEFAULT '{}',\n  \"thumbnail_asset_id\" UUID\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -9038,7 +9108,7 @@
       ],
       "schema": {
         "tableName": "contents",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type\" TEXT,\n  \"variant\" TEXT,\n  \"file_key\" TEXT,\n  \"author\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"body_format\" TEXT,\n  \"publish_date\" TIMESTAMP,\n  \"url\" TEXT,\n  \"source\" TEXT,\n  \"original_url\" TEXT,\n  \"language\" TEXT,\n  \"tags\" JSONB DEFAULT '[]',\n  \"category\" TEXT,\n  \"status\" TEXT DEFAULT 'draft',\n  \"state\" TEXT DEFAULT 'active',\n  \"metadata\" JSONB DEFAULT '{}',\n  \"thumbnail_asset_id\" uuid,\n  \"feed_source_id\" uuid,\n  \"source_guid\" TEXT,\n  \"source_name\" TEXT,\n  \"source_homepage_url\" TEXT,\n  \"external_url\" TEXT,\n  \"original_published_at\" TIMESTAMP,\n  \"dedupe_key\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type\" TEXT,\n  \"variant\" TEXT,\n  \"file_key\" TEXT,\n  \"author\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"body_format\" TEXT,\n  \"publish_date\" TIMESTAMP,\n  \"url\" TEXT,\n  \"source\" TEXT,\n  \"original_url\" TEXT,\n  \"language\" TEXT,\n  \"tags\" JSON DEFAULT '[]',\n  \"category\" TEXT,\n  \"status\" TEXT DEFAULT 'draft',\n  \"state\" TEXT DEFAULT 'active',\n  \"metadata\" JSON DEFAULT '{}',\n  \"thumbnail_asset_id\" UUID,\n  \"feed_source_id\" UUID,\n  \"source_guid\" TEXT,\n  \"source_name\" TEXT,\n  \"source_homepage_url\" TEXT,\n  \"external_url\" TEXT,\n  \"original_published_at\" TIMESTAMP,\n  \"dedupe_key\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -9226,8 +9296,11 @@
       "fields": {
         "contentId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "Content"
+          "required": true,
+          "related": "Content",
+          "_meta": {
+            "required": true
+          }
         },
         "version": {
           "type": "integer",
@@ -9348,6 +9421,11 @@
       "collectionExportName": "ContentVersionCollection",
       "validationRules": [
         {
+          "field": "contentId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        },
+        {
           "field": "version",
           "rule": "required",
           "fieldType": "integer"
@@ -9355,7 +9433,7 @@
       ],
       "schema": {
         "tableName": "content_versions",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_versions\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"content_id\" uuid,\n  \"version\" INTEGER NOT NULL DEFAULT 1,\n  \"kind\" TEXT DEFAULT 'manual',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"status\" TEXT,\n  \"summary\" TEXT,\n  \"snapshot\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_versions\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"content_id\" UUID NOT NULL,\n  \"version\" INTEGER NOT NULL DEFAULT 1,\n  \"kind\" TEXT DEFAULT 'manual',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"status\" TEXT,\n  \"summary\" TEXT,\n  \"snapshot\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -9383,7 +9461,7 @@
           },
           "content_id": {
             "type": "UUID",
-            "notNull": false,
+            "notNull": true,
             "unique": false
           },
           "version": {
@@ -9455,7 +9533,7 @@
             "unique": true
           }
         ],
-        "version": "af652f1d"
+        "version": "3c488e19"
       }
     },
     "@happyvertical/smrt-content:ContentVersionCollection": {
@@ -9590,7 +9668,7 @@
       "collectionExportName": "ContentVersionCollectionCollection",
       "schema": {
         "tableName": "content_versions",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_versions\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_versions\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -11100,7 +11178,7 @@
       ],
       "schema": {
         "tableName": "contents",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type\" TEXT,\n  \"variant\" TEXT,\n  \"file_key\" TEXT,\n  \"author\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"body_format\" TEXT,\n  \"publish_date\" TIMESTAMP,\n  \"url\" TEXT,\n  \"source\" TEXT,\n  \"original_url\" TEXT,\n  \"language\" TEXT,\n  \"tags\" JSONB DEFAULT '[]',\n  \"category\" TEXT,\n  \"status\" TEXT DEFAULT 'draft',\n  \"state\" TEXT DEFAULT 'active',\n  \"metadata\" JSONB DEFAULT '{}',\n  \"thumbnail_asset_id\" uuid,\n  \"feed_source_id\" uuid,\n  \"source_guid\" TEXT,\n  \"source_name\" TEXT,\n  \"source_homepage_url\" TEXT,\n  \"external_url\" TEXT,\n  \"original_published_at\" TIMESTAMP,\n  \"dedupe_key\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type\" TEXT,\n  \"variant\" TEXT,\n  \"file_key\" TEXT,\n  \"author\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"body_format\" TEXT,\n  \"publish_date\" TIMESTAMP,\n  \"url\" TEXT,\n  \"source\" TEXT,\n  \"original_url\" TEXT,\n  \"language\" TEXT,\n  \"tags\" JSON DEFAULT '[]',\n  \"category\" TEXT,\n  \"status\" TEXT DEFAULT 'draft',\n  \"state\" TEXT DEFAULT 'active',\n  \"metadata\" JSON DEFAULT '{}',\n  \"thumbnail_asset_id\" UUID,\n  \"feed_source_id\" UUID,\n  \"source_guid\" TEXT,\n  \"source_name\" TEXT,\n  \"source_homepage_url\" TEXT,\n  \"external_url\" TEXT,\n  \"original_published_at\" TIMESTAMP,\n  \"dedupe_key\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -11502,7 +11580,7 @@
       ],
       "schema": {
         "tableName": "contents",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"content_dir\" TEXT,\n  \"loaded\" JSONB NOT NULL\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"content_dir\" TEXT,\n  \"loaded\" JSON NOT NULL\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -11562,8 +11640,13 @@
   "moduleType": "smrt",
   "smrtDependencies": [
     "@happyvertical/smrt-assets",
+    "@happyvertical/smrt-chat",
     "@happyvertical/smrt-core",
+    "@happyvertical/smrt-facts",
+    "@happyvertical/smrt-images",
     "@happyvertical/smrt-messages",
-    "@happyvertical/smrt-profiles"
+    "@happyvertical/smrt-profiles",
+    "@happyvertical/smrt-prompts",
+    "@happyvertical/smrt-tenancy"
   ]
 }

--- a/packages/content/src/manifest/manifest.json
+++ b/packages/content/src/manifest/manifest.json
@@ -1,15 +1,15 @@
 {
   "version": "1.0.0",
-  "timestamp": 1774284585565,
+  "timestamp": 1780375813147,
   "packageName": "@happyvertical/smrt-content",
-  "packageVersion": "0.21.10",
+  "packageVersion": "0.25.8",
   "objects": {
     "@happyvertical/smrt-content:ContentAsset": {
       "name": "contentasset",
       "className": "ContentAsset",
       "qualifiedName": "@happyvertical/smrt-content:ContentAsset",
       "collection": "contentassets",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-asset.ts",
+      "filePath": "packages/content/src/content-asset.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {
         "tenantId": {
@@ -17,18 +17,14 @@
           "required": false
         },
         "contentId": {
-          "type": "text",
-          "required": true,
-          "_meta": {
-            "required": true
-          }
+          "type": "foreignKey",
+          "required": false,
+          "related": "Content"
         },
         "assetId": {
-          "type": "text",
+          "type": "crossPackageRef",
           "required": true,
-          "_meta": {
-            "required": true
-          }
+          "related": "@happyvertical/smrt-assets:Asset"
         },
         "relationship": {
           "type": "text",
@@ -60,14 +56,9 @@
       "collectionExportName": "ContentAssetCollection",
       "validationRules": [
         {
-          "field": "contentId",
-          "rule": "required",
-          "fieldType": "text"
-        },
-        {
           "field": "assetId",
           "rule": "required",
-          "fieldType": "text"
+          "fieldType": "crossPackageRef"
         },
         {
           "field": "relationship",
@@ -82,10 +73,10 @@
       ],
       "schema": {
         "tableName": "content_assets",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_assets\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"content_id\" TEXT NOT NULL,\n  \"asset_id\" TEXT NOT NULL,\n  \"relationship\" TEXT NOT NULL,\n  \"sort_order\" INTEGER NOT NULL DEFAULT 0\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_assets\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"content_id\" uuid,\n  \"asset_id\" uuid NOT NULL,\n  \"relationship\" TEXT NOT NULL,\n  \"sort_order\" INTEGER NOT NULL DEFAULT 0\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -114,12 +105,12 @@
             "unique": false
           },
           "content_id": {
-            "type": "TEXT",
-            "notNull": true,
+            "type": "UUID",
+            "notNull": false,
             "unique": false
           },
           "asset_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": true,
             "unique": false
           },
@@ -152,7 +143,7 @@
             "unique": true
           }
         ],
-        "version": "8ecd0b7c"
+        "version": "30176c74"
       }
     },
     "@happyvertical/smrt-content:ContentAssetCollection": {
@@ -160,40 +151,45 @@
       "className": "ContentAssetCollection",
       "qualifiedName": "@happyvertical/smrt-content:ContentAssetCollection",
       "collection": "contentassets",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-assets.ts",
+      "filePath": "packages/content/src/content-assets.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {},
       "methods": {
-        "getForContent": {
-          "name": "getForContent",
+        "byLeft": {
+          "name": "byLeft",
           "async": true,
           "parameters": [
             {
-              "name": "contentId",
+              "name": "leftId",
               "type": "string",
               "optional": false
             },
             {
-              "name": "relationship",
-              "type": "string",
+              "name": "opts",
+              "type": "JunctionFilterOptions",
               "optional": true
             }
           ],
-          "returnType": "Promise<ContentAsset[]>",
+          "returnType": "Promise<TItem[]>",
           "isStatic": false,
           "isPublic": true
         },
-        "getForAsset": {
-          "name": "getForAsset",
+        "byRight": {
+          "name": "byRight",
           "async": true,
           "parameters": [
             {
-              "name": "assetId",
+              "name": "rightId",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionFilterOptions",
+              "optional": true
             }
           ],
-          "returnType": "Promise<ContentAsset[]>",
+          "returnType": "Promise<TItem[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -202,33 +198,22 @@
           "async": true,
           "parameters": [
             {
-              "name": "contentId",
+              "name": "leftId",
               "type": "string",
               "optional": false
             },
             {
-              "name": "assetId",
+              "name": "rightId",
               "type": "string",
               "optional": false
             },
             {
-              "name": "relationship",
-              "type": "any",
-              "optional": true,
-              "default": "attachment"
-            },
-            {
-              "name": "sortOrder",
-              "type": "any",
-              "optional": true
-            },
-            {
-              "name": "tenantId",
-              "type": "string | null",
+              "name": "opts",
+              "type": "JunctionAttachOptions",
               "optional": true
             }
           ],
-          "returnType": "Promise<ContentAsset>",
+          "returnType": "Promise<TItem>",
           "isStatic": false,
           "isPublic": true
         },
@@ -237,18 +222,42 @@
           "async": true,
           "parameters": [
             {
-              "name": "contentId",
+              "name": "leftId",
               "type": "string",
               "optional": false
             },
             {
-              "name": "assetId",
+              "name": "rightId",
               "type": "string",
               "optional": false
             },
             {
-              "name": "relationship",
+              "name": "opts",
+              "type": "JunctionFilterOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setLinks": {
+          "name": "setLinks",
+          "async": true,
+          "parameters": [
+            {
+              "name": "leftId",
               "type": "string",
+              "optional": false
+            },
+            {
+              "name": "rightIds",
+              "type": "string[]",
+              "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionAttachOptions",
               "optional": true
             }
           ],
@@ -263,16 +272,16 @@
         "cli": false,
         "tableName": "content_assets"
       },
-      "extends": "SmrtCollection",
+      "extends": "SmrtJunction",
       "extendsTypeArg": "ContentAsset",
       "exportName": "ContentAssetCollection",
       "collectionExportName": "ContentAssetCollectionCollection",
       "schema": {
         "tableName": "content_assets",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_assets\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_assets\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -312,7 +321,7 @@
             "unique": true
           }
         ],
-        "version": "89edb984"
+        "version": "42994d88"
       }
     },
     "@happyvertical/smrt-content:ContentContributionAttachment": {
@@ -320,19 +329,18 @@
       "className": "ContentContributionAttachment",
       "qualifiedName": "@happyvertical/smrt-content:ContentContributionAttachment",
       "collection": "contentcontributionattachments",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-contribution-attachment.ts",
+      "filePath": "packages/content/src/content-contribution-attachment.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {
         "contributionId": {
-          "type": "text",
-          "required": true,
-          "_meta": {
-            "required": true
-          }
+          "type": "foreignKey",
+          "required": false,
+          "related": "ContentContribution"
         },
         "revisionId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "ContentContributionRevision"
         },
         "filename": {
           "type": "text",
@@ -361,8 +369,9 @@
           "default": "web"
         },
         "promotedAssetId": {
-          "type": "text",
-          "required": false
+          "type": "crossPackageRef",
+          "required": false,
+          "related": "@happyvertical/smrt-assets:Asset"
         },
         "metadata": {
           "type": "text",
@@ -421,11 +430,6 @@
       "collectionExportName": "ContentContributionAttachmentCollection",
       "validationRules": [
         {
-          "field": "contributionId",
-          "rule": "required",
-          "fieldType": "text"
-        },
-        {
           "field": "size",
           "rule": "required",
           "fieldType": "integer"
@@ -433,10 +437,10 @@
       ],
       "schema": {
         "tableName": "content_contribution_attachments",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_attachments\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"contribution_id\" TEXT NOT NULL,\n  \"revision_id\" TEXT,\n  \"filename\" TEXT,\n  \"mime_type\" TEXT,\n  \"size\" INTEGER NOT NULL DEFAULT 0,\n  \"file_key\" TEXT,\n  \"source_uri\" TEXT,\n  \"channel\" TEXT DEFAULT 'web',\n  \"promoted_asset_id\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_attachments\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"contribution_id\" uuid,\n  \"revision_id\" uuid,\n  \"filename\" TEXT,\n  \"mime_type\" TEXT,\n  \"size\" INTEGER NOT NULL DEFAULT 0,\n  \"file_key\" TEXT,\n  \"source_uri\" TEXT,\n  \"channel\" TEXT DEFAULT 'web',\n  \"promoted_asset_id\" uuid,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -460,12 +464,12 @@
             "default": "current_timestamp"
           },
           "contribution_id": {
-            "type": "TEXT",
-            "notNull": true,
+            "type": "UUID",
+            "notNull": false,
             "unique": false
           },
           "revision_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           },
@@ -502,7 +506,7 @@
             "default": "web"
           },
           "promoted_asset_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           },
@@ -532,7 +536,7 @@
             "unique": true
           }
         ],
-        "version": "ca0d7541"
+        "version": "26614056"
       }
     },
     "@happyvertical/smrt-content:ContentContributionAttachmentCollection": {
@@ -540,7 +544,7 @@
       "className": "ContentContributionAttachmentCollection",
       "qualifiedName": "@happyvertical/smrt-content:ContentContributionAttachmentCollection",
       "collection": "contentcontributionattachments",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-contribution-attachments.ts",
+      "filePath": "packages/content/src/content-contribution-attachments.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {},
       "methods": {
@@ -582,10 +586,10 @@
       "collectionExportName": "ContentContributionAttachmentCollectionCollection",
       "schema": {
         "tableName": "content_contribution_attachments",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_attachments\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_attachments\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -625,7 +629,7 @@
             "unique": true
           }
         ],
-        "version": "5541b237"
+        "version": "5dd478ad"
       }
     },
     "@happyvertical/smrt-content:ContentContributionRevision": {
@@ -633,15 +637,13 @@
       "className": "ContentContributionRevision",
       "qualifiedName": "@happyvertical/smrt-content:ContentContributionRevision",
       "collection": "contentcontributionrevisions",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-contribution-revision.ts",
+      "filePath": "packages/content/src/content-contribution-revision.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {
         "contributionId": {
-          "type": "text",
-          "required": true,
-          "_meta": {
-            "required": true
-          }
+          "type": "foreignKey",
+          "required": false,
+          "related": "ContentContribution"
         },
         "revisionNumber": {
           "type": "integer",
@@ -666,8 +668,9 @@
           "required": false
         },
         "sourceMessageId": {
-          "type": "text",
-          "required": false
+          "type": "crossPackageRef",
+          "required": false,
+          "related": "@happyvertical/smrt-messages:Message"
         },
         "sourceThreadKey": {
           "type": "text",
@@ -731,11 +734,6 @@
       "collectionExportName": "ContentContributionRevisionCollection",
       "validationRules": [
         {
-          "field": "contributionId",
-          "rule": "required",
-          "fieldType": "text"
-        },
-        {
           "field": "revisionNumber",
           "rule": "required",
           "fieldType": "integer"
@@ -743,10 +741,10 @@
       ],
       "schema": {
         "tableName": "content_contribution_revisions",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_revisions\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"contribution_id\" TEXT NOT NULL,\n  \"revision_number\" INTEGER NOT NULL DEFAULT 1,\n  \"channel\" TEXT DEFAULT 'web',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"source_message_id\" TEXT,\n  \"source_thread_key\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_revisions\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"contribution_id\" uuid,\n  \"revision_number\" INTEGER NOT NULL DEFAULT 1,\n  \"channel\" TEXT DEFAULT 'web',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"source_message_id\" uuid,\n  \"source_thread_key\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -770,8 +768,8 @@
             "default": "current_timestamp"
           },
           "contribution_id": {
-            "type": "TEXT",
-            "notNull": true,
+            "type": "UUID",
+            "notNull": false,
             "unique": false
           },
           "revision_number": {
@@ -802,7 +800,7 @@
             "unique": false
           },
           "source_message_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           },
@@ -838,7 +836,7 @@
             "unique": true
           }
         ],
-        "version": "a8c00659"
+        "version": "5d72bd52"
       }
     },
     "@happyvertical/smrt-content:ContentContributionRevisionCollection": {
@@ -846,7 +844,7 @@
       "className": "ContentContributionRevisionCollection",
       "qualifiedName": "@happyvertical/smrt-content:ContentContributionRevisionCollection",
       "collection": "contentcontributionrevisions",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-contribution-revisions.ts",
+      "filePath": "packages/content/src/content-contribution-revisions.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {},
       "methods": {
@@ -888,10 +886,10 @@
       "collectionExportName": "ContentContributionRevisionCollectionCollection",
       "schema": {
         "tableName": "content_contribution_revisions",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_revisions\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_revisions\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -931,7 +929,7 @@
             "unique": true
           }
         ],
-        "version": "cad6f3b5"
+        "version": "399c4d91"
       }
     },
     "@happyvertical/smrt-content:ContentContributionType": {
@@ -939,7 +937,7 @@
       "className": "ContentContributionType",
       "qualifiedName": "@happyvertical/smrt-content:ContentContributionType",
       "collection": "contentcontributiontypes",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-contribution-type.ts",
+      "filePath": "packages/content/src/content-contribution-type.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {
         "key": {
@@ -1165,10 +1163,10 @@
       ],
       "schema": {
         "tableName": "content_contribution_types",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_types\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"key\" TEXT NOT NULL,\n  \"label\" TEXT,\n  \"enabled\" BOOLEAN NOT NULL DEFAULT TRUE,\n  \"allowed_channels\" TEXT,\n  \"allow_text\" BOOLEAN NOT NULL DEFAULT TRUE,\n  \"allow_files\" BOOLEAN NOT NULL DEFAULT FALSE,\n  \"allow_empty_text\" BOOLEAN NOT NULL DEFAULT FALSE,\n  \"intake_rules\" TEXT,\n  \"promotion\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_types\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"key\" TEXT NOT NULL,\n  \"label\" TEXT,\n  \"enabled\" BOOLEAN NOT NULL DEFAULT TRUE,\n  \"allowed_channels\" TEXT,\n  \"allow_text\" BOOLEAN NOT NULL DEFAULT TRUE,\n  \"allow_files\" BOOLEAN NOT NULL DEFAULT FALSE,\n  \"allow_empty_text\" BOOLEAN NOT NULL DEFAULT FALSE,\n  \"intake_rules\" TEXT,\n  \"promotion\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1266,7 +1264,7 @@
             "unique": true
           }
         ],
-        "version": "7d72d677"
+        "version": "ac1450c1"
       }
     },
     "@happyvertical/smrt-content:ContentContributionTypeCollection": {
@@ -1274,7 +1272,7 @@
       "className": "ContentContributionTypeCollection",
       "qualifiedName": "@happyvertical/smrt-content:ContentContributionTypeCollection",
       "collection": "contentcontributiontypes",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-contribution-types.ts",
+      "filePath": "packages/content/src/content-contribution-types.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {},
       "methods": {
@@ -1302,10 +1300,10 @@
       "collectionExportName": "ContentContributionTypeCollectionCollection",
       "schema": {
         "tableName": "content_contribution_types",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_types\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contribution_types\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1345,7 +1343,7 @@
             "unique": true
           }
         ],
-        "version": "c46cc6a4"
+        "version": "273025ab"
       }
     },
     "@happyvertical/smrt-content:ContentContribution": {
@@ -1353,15 +1351,13 @@
       "className": "ContentContribution",
       "qualifiedName": "@happyvertical/smrt-content:ContentContribution",
       "collection": "contentcontributions",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-contribution.ts",
+      "filePath": "packages/content/src/content-contribution.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {
         "contributorId": {
-          "type": "text",
-          "required": true,
-          "_meta": {
-            "required": true
-          }
+          "type": "foreignKey",
+          "required": false,
+          "related": "ContentContributor"
         },
         "contributionTypeKey": {
           "type": "text",
@@ -1410,16 +1406,18 @@
           "required": false
         },
         "sourceMessageId": {
-          "type": "text",
-          "required": false
+          "type": "crossPackageRef",
+          "required": false,
+          "related": "@happyvertical/smrt-messages:Message"
         },
         "editorNotes": {
           "type": "text",
           "required": false
         },
         "promotedContentId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "Content"
         },
         "revisionCount": {
           "type": "integer",
@@ -1672,11 +1670,6 @@
       "collectionExportName": "ContentContributionCollection",
       "validationRules": [
         {
-          "field": "contributorId",
-          "rule": "required",
-          "fieldType": "text"
-        },
-        {
           "field": "contributionTypeKey",
           "rule": "required",
           "fieldType": "text"
@@ -1689,10 +1682,10 @@
       ],
       "schema": {
         "tableName": "content_contributions",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contributions\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"contributor_id\" TEXT NOT NULL,\n  \"contribution_type_key\" TEXT NOT NULL,\n  \"status\" TEXT DEFAULT 'submitted',\n  \"intake_decision\" TEXT DEFAULT 'accepted',\n  \"channel\" TEXT DEFAULT 'web',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"contributor_email\" TEXT,\n  \"contributor_name\" TEXT,\n  \"thread_key\" TEXT,\n  \"source_message_id\" TEXT,\n  \"editor_notes\" TEXT,\n  \"promoted_content_id\" TEXT,\n  \"revision_count\" INTEGER NOT NULL DEFAULT 0,\n  \"approved_at\" TIMESTAMP,\n  \"promoted_at\" TIMESTAMP,\n  \"rejected_at\" TIMESTAMP,\n  \"withdrawn_at\" TIMESTAMP,\n  \"requested_changes_at\" TIMESTAMP,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contributions\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"contributor_id\" uuid,\n  \"contribution_type_key\" TEXT NOT NULL,\n  \"status\" TEXT DEFAULT 'submitted',\n  \"intake_decision\" TEXT DEFAULT 'accepted',\n  \"channel\" TEXT DEFAULT 'web',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"contributor_email\" TEXT,\n  \"contributor_name\" TEXT,\n  \"thread_key\" TEXT,\n  \"source_message_id\" uuid,\n  \"editor_notes\" TEXT,\n  \"promoted_content_id\" uuid,\n  \"revision_count\" INTEGER NOT NULL DEFAULT 0,\n  \"approved_at\" TIMESTAMP,\n  \"promoted_at\" TIMESTAMP,\n  \"rejected_at\" TIMESTAMP,\n  \"withdrawn_at\" TIMESTAMP,\n  \"requested_changes_at\" TIMESTAMP,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1716,8 +1709,8 @@
             "default": "current_timestamp"
           },
           "contributor_id": {
-            "type": "TEXT",
-            "notNull": true,
+            "type": "UUID",
+            "notNull": false,
             "unique": false
           },
           "contribution_type_key": {
@@ -1774,7 +1767,7 @@
             "unique": false
           },
           "source_message_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           },
@@ -1784,7 +1777,7 @@
             "unique": false
           },
           "promoted_content_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           },
@@ -1845,7 +1838,7 @@
             "unique": true
           }
         ],
-        "version": "14efbed2"
+        "version": "f09bdda7"
       }
     },
     "@happyvertical/smrt-content:ContentContributions": {
@@ -1853,7 +1846,7 @@
       "className": "ContentContributions",
       "qualifiedName": "@happyvertical/smrt-content:ContentContributions",
       "collection": "contentcontributions",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-contributions.ts",
+      "filePath": "packages/content/src/content-contributions.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {},
       "methods": {
@@ -1969,10 +1962,10 @@
       "collectionExportName": "ContentContributionsCollection",
       "schema": {
         "tableName": "content_contributions",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contributions\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contributions\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -2012,7 +2005,7 @@
             "unique": true
           }
         ],
-        "version": "93613ba3"
+        "version": "10114762"
       }
     },
     "@happyvertical/smrt-content:ContentContributor": {
@@ -2020,12 +2013,13 @@
       "className": "ContentContributor",
       "qualifiedName": "@happyvertical/smrt-content:ContentContributor",
       "collection": "contentcontributors",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-contributor.ts",
+      "filePath": "packages/content/src/content-contributor.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {
         "profileId": {
-          "type": "text",
-          "required": false
+          "type": "crossPackageRef",
+          "required": false,
+          "related": "@happyvertical/smrt-profiles:Profile"
         },
         "email": {
           "type": "text",
@@ -2121,10 +2115,10 @@
       ],
       "schema": {
         "tableName": "content_contributors",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contributors\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" TEXT,\n  \"email\" TEXT NOT NULL,\n  \"name\" TEXT,\n  \"trust_level\" TEXT DEFAULT 'standard',\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contributors\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" uuid,\n  \"email\" TEXT NOT NULL,\n  \"name\" TEXT,\n  \"trust_level\" TEXT DEFAULT 'standard',\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -2148,7 +2142,7 @@
             "default": "current_timestamp"
           },
           "profile_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           },
@@ -2194,7 +2188,7 @@
             "unique": true
           }
         ],
-        "version": "f26d4d08"
+        "version": "99516741"
       }
     },
     "@happyvertical/smrt-content:ContentContributorCollection": {
@@ -2202,7 +2196,7 @@
       "className": "ContentContributorCollection",
       "qualifiedName": "@happyvertical/smrt-content:ContentContributorCollection",
       "collection": "contentcontributors",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-contributors.ts",
+      "filePath": "packages/content/src/content-contributors.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {},
       "methods": {
@@ -2258,10 +2252,10 @@
       "collectionExportName": "ContentContributorCollectionCollection",
       "schema": {
         "tableName": "content_contributors",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contributors\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_contributors\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -2301,7 +2295,7 @@
             "unique": true
           }
         ],
-        "version": "4a4c4145"
+        "version": "fae5dcf8"
       }
     },
     "@happyvertical/smrt-content:ContentCorrection": {
@@ -2309,27 +2303,28 @@
       "className": "ContentCorrection",
       "qualifiedName": "@happyvertical/smrt-content:ContentCorrection",
       "collection": "contentcorrections",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-correction.ts",
+      "filePath": "packages/content/src/content-correction.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {
         "contentId": {
-          "type": "text",
-          "required": true,
-          "_meta": {
-            "required": true
-          }
+          "type": "foreignKey",
+          "required": false,
+          "related": "Content"
         },
         "contentVersionId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "ContentVersion"
         },
         "factId": {
-          "type": "text",
-          "required": false
+          "type": "crossPackageRef",
+          "required": false,
+          "related": "@happyvertical/smrt-facts:Fact"
         },
         "replacementFactId": {
-          "type": "text",
-          "required": false
+          "type": "crossPackageRef",
+          "required": false,
+          "related": "@happyvertical/smrt-facts:Fact"
         },
         "correctionType": {
           "type": "text",
@@ -2411,19 +2406,12 @@
       "extends": "SmrtObject",
       "exportName": "ContentCorrection",
       "collectionExportName": "ContentCorrectionCollection",
-      "validationRules": [
-        {
-          "field": "contentId",
-          "rule": "required",
-          "fieldType": "text"
-        }
-      ],
       "schema": {
         "tableName": "content_corrections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_corrections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"content_id\" TEXT NOT NULL,\n  \"content_version_id\" TEXT,\n  \"fact_id\" TEXT,\n  \"replacement_fact_id\" TEXT,\n  \"correction_type\" TEXT DEFAULT 'fact',\n  \"status\" TEXT DEFAULT 'draft',\n  \"summary\" TEXT,\n  \"incorrect_text\" TEXT,\n  \"corrected_text\" TEXT,\n  \"public_note\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT,\n  \"published_at\" TIMESTAMP\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_corrections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"content_id\" uuid,\n  \"content_version_id\" uuid,\n  \"fact_id\" uuid,\n  \"replacement_fact_id\" uuid,\n  \"correction_type\" TEXT DEFAULT 'fact',\n  \"status\" TEXT DEFAULT 'draft',\n  \"summary\" TEXT,\n  \"incorrect_text\" TEXT,\n  \"corrected_text\" TEXT,\n  \"public_note\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT,\n  \"published_at\" TIMESTAMP\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -2447,22 +2435,22 @@
             "default": "current_timestamp"
           },
           "content_id": {
-            "type": "TEXT",
-            "notNull": true,
+            "type": "UUID",
+            "notNull": false,
             "unique": false
           },
           "content_version_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           },
           "fact_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           },
           "replacement_fact_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           },
@@ -2530,7 +2518,7 @@
             "unique": true
           }
         ],
-        "version": "39b81a60"
+        "version": "b7060b2c"
       }
     },
     "@happyvertical/smrt-content:ContentCorrectionCollection": {
@@ -2538,7 +2526,7 @@
       "className": "ContentCorrectionCollection",
       "qualifiedName": "@happyvertical/smrt-content:ContentCorrectionCollection",
       "collection": "contentcorrections",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-corrections.ts",
+      "filePath": "packages/content/src/content-corrections.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {},
       "methods": {
@@ -2594,10 +2582,10 @@
       "collectionExportName": "ContentCorrectionCollectionCollection",
       "schema": {
         "tableName": "content_corrections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_corrections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_corrections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -2637,7 +2625,467 @@
             "unique": true
           }
         ],
-        "version": "f4d8eacc"
+        "version": "14c7d5f5"
+      }
+    },
+    "@happyvertical/smrt-content:ContentFeedSource": {
+      "name": "contentfeedsource",
+      "className": "ContentFeedSource",
+      "qualifiedName": "@happyvertical/smrt-content:ContentFeedSource",
+      "collection": "contentfeedsources",
+      "filePath": "packages/content/src/content-feed-source.ts",
+      "packageName": "@happyvertical/smrt-content",
+      "fields": {
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "name": {
+          "type": "text",
+          "required": true,
+          "_meta": {
+            "required": true
+          }
+        },
+        "feedUrl": {
+          "type": "text",
+          "required": true,
+          "_meta": {
+            "required": true
+          }
+        },
+        "homepageUrl": {
+          "type": "text",
+          "required": false
+        },
+        "format": {
+          "type": "text",
+          "required": false
+        },
+        "status": {
+          "type": "text",
+          "required": true,
+          "default": "active",
+          "_meta": {
+            "required": true,
+            "default": "active"
+          }
+        },
+        "defaultCategory": {
+          "type": "text",
+          "required": false
+        },
+        "sourceGroup": {
+          "type": "text",
+          "required": false
+        },
+        "pollIntervalMinutes": {
+          "type": "integer",
+          "required": true,
+          "default": 15
+        },
+        "etag": {
+          "type": "text",
+          "required": false
+        },
+        "lastModified": {
+          "type": "text",
+          "required": false
+        },
+        "lastFetchedAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "lastSuccessAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "lastError": {
+          "type": "text",
+          "required": false
+        },
+        "metadata": {
+          "type": "json",
+          "required": false,
+          "default": {}
+        },
+        "createdAt": {
+          "type": "text",
+          "required": false
+        },
+        "updatedAt": {
+          "type": "text",
+          "required": false
+        }
+      },
+      "methods": {
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setMetadata": {
+          "name": "setMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "metadata",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markFetchStarted": {
+          "name": "markFetchStarted",
+          "async": false,
+          "parameters": [
+            {
+              "name": "at",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markFetchSucceeded": {
+          "name": "markFetchSucceeded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "at",
+              "type": "any",
+              "optional": true
+            },
+            {
+              "name": "headers",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markFetchFailed": {
+          "name": "markFetchFailed",
+          "async": false,
+          "parameters": [
+            {
+              "name": "error",
+              "type": "any",
+              "optional": false
+            },
+            {
+              "name": "at",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableName": "content_feed_sources",
+        "conflictColumns": [
+          "tenant_id",
+          "feed_url"
+        ],
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "ContentFeedSource",
+      "collectionExportName": "ContentFeedSourceCollection",
+      "validationRules": [
+        {
+          "field": "name",
+          "rule": "required",
+          "fieldType": "text"
+        },
+        {
+          "field": "feedUrl",
+          "rule": "required",
+          "fieldType": "text"
+        },
+        {
+          "field": "status",
+          "rule": "required",
+          "fieldType": "text"
+        },
+        {
+          "field": "pollIntervalMinutes",
+          "rule": "required",
+          "fieldType": "integer"
+        }
+      ],
+      "schema": {
+        "tableName": "content_feed_sources",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_feed_sources\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT NOT NULL,\n  \"feed_url\" TEXT NOT NULL,\n  \"homepage_url\" TEXT,\n  \"format\" TEXT,\n  \"status\" TEXT NOT NULL DEFAULT 'active',\n  \"default_category\" TEXT,\n  \"source_group\" TEXT,\n  \"poll_interval_minutes\" INTEGER NOT NULL DEFAULT 15,\n  \"etag\" TEXT,\n  \"last_modified\" TEXT,\n  \"last_fetched_at\" TIMESTAMP,\n  \"last_success_at\" TIMESTAMP,\n  \"last_error\" TEXT,\n  \"metadata\" JSONB DEFAULT '{}'\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": true,
+            "unique": false
+          },
+          "feed_url": {
+            "type": "TEXT",
+            "notNull": true,
+            "unique": false
+          },
+          "homepage_url": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "format": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": true,
+            "unique": false,
+            "default": "active"
+          },
+          "default_category": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "source_group": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "poll_interval_minutes": {
+            "type": "INTEGER",
+            "notNull": true,
+            "unique": false,
+            "default": 15
+          },
+          "etag": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "last_modified": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "last_fetched_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "unique": false
+          },
+          "last_success_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "unique": false
+          },
+          "last_error": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "metadata": {
+            "type": "JSON",
+            "notNull": false,
+            "unique": false,
+            "default": {}
+          }
+        },
+        "indexes": [
+          {
+            "name": "content_feed_sources_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "content_feed_sources_tenant_id_feed_url_idx",
+            "columns": [
+              "tenant_id",
+              "feed_url"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "1cb78b84"
+      }
+    },
+    "@happyvertical/smrt-content:ContentFeedSourceCollection": {
+      "name": "contentfeedsourcecollection",
+      "className": "ContentFeedSourceCollection",
+      "qualifiedName": "@happyvertical/smrt-content:ContentFeedSourceCollection",
+      "collection": "contentfeedsources",
+      "filePath": "packages/content/src/content-feed-sources.ts",
+      "packageName": "@happyvertical/smrt-content",
+      "fields": {},
+      "methods": {
+        "findActive": {
+          "name": "findActive",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string | null",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<ContentFeedSource[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByStatus": {
+          "name": "findByStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "status",
+              "type": "ContentFeedSourceStatus",
+              "optional": false
+            },
+            {
+              "name": "tenantId",
+              "type": "string | null",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<ContentFeedSource[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByFeedUrl": {
+          "name": "findByFeedUrl",
+          "async": true,
+          "parameters": [
+            {
+              "name": "feedUrl",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "tenantId",
+              "type": "string | null",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<ContentFeedSource | null>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableName": "content_feed_sources"
+      },
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "ContentFeedSource",
+      "exportName": "ContentFeedSourceCollection",
+      "collectionExportName": "ContentFeedSourceCollectionCollection",
+      "schema": {
+        "tableName": "content_feed_sources",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_feed_sources\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "content_feed_sources_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "content_feed_sources_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "daee797b"
       }
     },
     "@happyvertical/smrt-content:ContentGovernanceAssignment": {
@@ -2645,7 +3093,7 @@
       "className": "ContentGovernanceAssignment",
       "qualifiedName": "@happyvertical/smrt-content:ContentGovernanceAssignment",
       "collection": "contentgovernanceassignments",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-governance-assignment.ts",
+      "filePath": "packages/content/src/content-governance-assignment.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {
         "key": {
@@ -2800,10 +3248,10 @@
       ],
       "schema": {
         "tableName": "content_governance_assignments",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_assignments\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"key\" TEXT NOT NULL,\n  \"label\" TEXT,\n  \"content_type\" TEXT NOT NULL,\n  \"content_variant\" TEXT,\n  \"enabled\" BOOLEAN NOT NULL DEFAULT TRUE,\n  \"fact_linking_enabled\" BOOLEAN NOT NULL DEFAULT FALSE,\n  \"transparency_enabled\" BOOLEAN NOT NULL DEFAULT FALSE,\n  \"publication_profile_key\" TEXT,\n  \"correction_profile_key\" TEXT,\n  \"enforce_publish_readiness\" BOOLEAN NOT NULL DEFAULT FALSE,\n  \"default_fact_relationship\" TEXT DEFAULT 'supports',\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_assignments\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"key\" TEXT NOT NULL,\n  \"label\" TEXT,\n  \"content_type\" TEXT NOT NULL,\n  \"content_variant\" TEXT,\n  \"enabled\" BOOLEAN NOT NULL DEFAULT TRUE,\n  \"fact_linking_enabled\" BOOLEAN NOT NULL DEFAULT FALSE,\n  \"transparency_enabled\" BOOLEAN NOT NULL DEFAULT FALSE,\n  \"publication_profile_key\" TEXT,\n  \"correction_profile_key\" TEXT,\n  \"enforce_publish_readiness\" BOOLEAN NOT NULL DEFAULT FALSE,\n  \"default_fact_relationship\" TEXT DEFAULT 'supports',\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -2912,7 +3360,7 @@
             "unique": true
           }
         ],
-        "version": "1df43a06"
+        "version": "54ac80dd"
       }
     },
     "@happyvertical/smrt-content:ContentGovernanceAssignmentCollection": {
@@ -2920,7 +3368,7 @@
       "className": "ContentGovernanceAssignmentCollection",
       "qualifiedName": "@happyvertical/smrt-content:ContentGovernanceAssignmentCollection",
       "collection": "contentgovernanceassignments",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-governance-assignments.ts",
+      "filePath": "packages/content/src/content-governance-assignments.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {},
       "methods": {
@@ -2962,10 +3410,10 @@
       "collectionExportName": "ContentGovernanceAssignmentCollectionCollection",
       "schema": {
         "tableName": "content_governance_assignments",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_assignments\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_assignments\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -3005,7 +3453,7 @@
             "unique": true
           }
         ],
-        "version": "c14489e2"
+        "version": "314f6b01"
       }
     },
     "@happyvertical/smrt-content:ContentGovernancePolicyCollection": {
@@ -3013,7 +3461,7 @@
       "className": "ContentGovernancePolicyCollection",
       "qualifiedName": "@happyvertical/smrt-content:ContentGovernancePolicyCollection",
       "collection": "contentgovernancepolicies",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-governance-policies.ts",
+      "filePath": "packages/content/src/content-governance-policies.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {},
       "methods": {
@@ -3041,10 +3489,10 @@
       "collectionExportName": "ContentGovernancePolicyCollectionCollection",
       "schema": {
         "tableName": "content_governance_policies",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_policies\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_policies\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -3084,7 +3532,7 @@
             "unique": true
           }
         ],
-        "version": "364eee6b"
+        "version": "c50051e0"
       }
     },
     "@happyvertical/smrt-content:ContentGovernancePolicy": {
@@ -3092,7 +3540,7 @@
       "className": "ContentGovernancePolicy",
       "qualifiedName": "@happyvertical/smrt-content:ContentGovernancePolicy",
       "collection": "contentgovernancepolicies",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-governance-policy.ts",
+      "filePath": "packages/content/src/content-governance-policy.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {
         "key": {
@@ -3205,10 +3653,10 @@
       ],
       "schema": {
         "tableName": "content_governance_policies",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_policies\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"key\" TEXT NOT NULL,\n  \"label\" TEXT,\n  \"kind\" TEXT DEFAULT 'custom',\n  \"instructions\" TEXT,\n  \"enabled\" BOOLEAN NOT NULL DEFAULT TRUE,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_policies\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"key\" TEXT NOT NULL,\n  \"label\" TEXT,\n  \"kind\" TEXT DEFAULT 'custom',\n  \"instructions\" TEXT,\n  \"enabled\" BOOLEAN NOT NULL DEFAULT TRUE,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -3284,7 +3732,7 @@
             "unique": true
           }
         ],
-        "version": "c2e485a7"
+        "version": "fdd36975"
       }
     },
     "@happyvertical/smrt-content:ContentGovernanceProfile": {
@@ -3292,7 +3740,7 @@
       "className": "ContentGovernanceProfile",
       "qualifiedName": "@happyvertical/smrt-content:ContentGovernanceProfile",
       "collection": "contentgovernanceprofiles",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-governance-profile.ts",
+      "filePath": "packages/content/src/content-governance-profile.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {
         "key": {
@@ -3412,10 +3860,10 @@
       ],
       "schema": {
         "tableName": "content_governance_profiles",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_profiles\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"key\" TEXT NOT NULL,\n  \"label\" TEXT,\n  \"description\" TEXT,\n  \"enabled\" BOOLEAN NOT NULL DEFAULT TRUE,\n  \"requirements\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_profiles\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"key\" TEXT NOT NULL,\n  \"label\" TEXT,\n  \"description\" TEXT,\n  \"enabled\" BOOLEAN NOT NULL DEFAULT TRUE,\n  \"requirements\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -3490,7 +3938,7 @@
             "unique": true
           }
         ],
-        "version": "375cce06"
+        "version": "df478060"
       }
     },
     "@happyvertical/smrt-content:ContentGovernanceProfileCollection": {
@@ -3498,7 +3946,7 @@
       "className": "ContentGovernanceProfileCollection",
       "qualifiedName": "@happyvertical/smrt-content:ContentGovernanceProfileCollection",
       "collection": "contentgovernanceprofiles",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-governance-profiles.ts",
+      "filePath": "packages/content/src/content-governance-profiles.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {},
       "methods": {
@@ -3526,10 +3974,10 @@
       "collectionExportName": "ContentGovernanceProfileCollectionCollection",
       "schema": {
         "tableName": "content_governance_profiles",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_profiles\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_governance_profiles\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -3569,7 +4017,7 @@
             "unique": true
           }
         ],
-        "version": "d8e697d6"
+        "version": "56f8978c"
       }
     },
     "@happyvertical/smrt-content:ContentReference": {
@@ -3577,7 +4025,7 @@
       "className": "ContentReference",
       "qualifiedName": "@happyvertical/smrt-content:ContentReference",
       "collection": "contentreferences",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-reference.ts",
+      "filePath": "packages/content/src/content-reference.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {
         "tenantId": {
@@ -3585,18 +4033,14 @@
           "required": false
         },
         "sourceId": {
-          "type": "text",
-          "required": true,
-          "_meta": {
-            "required": true
-          }
+          "type": "foreignKey",
+          "required": false,
+          "related": "Content"
         },
         "targetId": {
-          "type": "text",
-          "required": true,
-          "_meta": {
-            "required": true
-          }
+          "type": "foreignKey",
+          "required": false,
+          "related": "Content"
         },
         "createdAt": {
           "type": "text",
@@ -3614,24 +4058,12 @@
       "extends": "SmrtObject",
       "exportName": "ContentReference",
       "collectionExportName": "ContentReferenceCollection",
-      "validationRules": [
-        {
-          "field": "sourceId",
-          "rule": "required",
-          "fieldType": "text"
-        },
-        {
-          "field": "targetId",
-          "rule": "required",
-          "fieldType": "text"
-        }
-      ],
       "schema": {
         "tableName": "content_references",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_references\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"source_id\" TEXT NOT NULL,\n  \"target_id\" TEXT NOT NULL\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_references\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"source_id\" uuid,\n  \"target_id\" uuid\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -3660,13 +4092,13 @@
             "unique": false
           },
           "source_id": {
-            "type": "TEXT",
-            "notNull": true,
+            "type": "UUID",
+            "notNull": false,
             "unique": false
           },
           "target_id": {
-            "type": "TEXT",
-            "notNull": true,
+            "type": "UUID",
+            "notNull": false,
             "unique": false
           }
         },
@@ -3686,7 +4118,7 @@
             "unique": true
           }
         ],
-        "version": "9feb6158"
+        "version": "5b5bf4b4"
       }
     },
     "@happyvertical/smrt-content:ContentReferences": {
@@ -3694,40 +4126,50 @@
       "className": "ContentReferences",
       "qualifiedName": "@happyvertical/smrt-content:ContentReferences",
       "collection": "contentreferences",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-references.ts",
+      "filePath": "packages/content/src/content-references.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {},
       "methods": {
-        "getForSource": {
-          "name": "getForSource",
+        "byLeft": {
+          "name": "byLeft",
           "async": true,
           "parameters": [
             {
-              "name": "sourceId",
+              "name": "leftId",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionFilterOptions",
+              "optional": true
             }
           ],
-          "returnType": "Promise<ContentReference[]>",
+          "returnType": "Promise<TItem[]>",
           "isStatic": false,
           "isPublic": true
         },
-        "getForTarget": {
-          "name": "getForTarget",
+        "byRight": {
+          "name": "byRight",
           "async": true,
           "parameters": [
             {
-              "name": "targetId",
+              "name": "rightId",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionFilterOptions",
+              "optional": true
             }
           ],
-          "returnType": "Promise<ContentReference[]>",
+          "returnType": "Promise<TItem[]>",
           "isStatic": false,
           "isPublic": true
         },
-        "link": {
-          "name": "link",
+        "attach": {
+          "name": "attach",
           "async": true,
           "parameters": [
             {
@@ -3741,8 +4183,8 @@
               "optional": false
             },
             {
-              "name": "tenantId",
-              "type": "string | null",
+              "name": "opts",
+              "type": "JunctionAttachOptions",
               "optional": true
             }
           ],
@@ -3750,19 +4192,48 @@
           "isStatic": false,
           "isPublic": true
         },
-        "unlink": {
-          "name": "unlink",
+        "detach": {
+          "name": "detach",
           "async": true,
           "parameters": [
             {
-              "name": "sourceId",
+              "name": "leftId",
               "type": "string",
               "optional": false
             },
             {
-              "name": "targetId",
+              "name": "rightId",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionFilterOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setLinks": {
+          "name": "setLinks",
+          "async": true,
+          "parameters": [
+            {
+              "name": "leftId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "rightIds",
+              "type": "string[]",
+              "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionAttachOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<void>",
@@ -3773,16 +4244,16 @@
       "decoratorConfig": {
         "tableName": "content_references"
       },
-      "extends": "SmrtCollection",
+      "extends": "SmrtJunction",
       "extendsTypeArg": "ContentReference",
       "exportName": "ContentReferences",
       "collectionExportName": "ContentReferencesCollection",
       "schema": {
         "tableName": "content_references",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_references\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_references\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -3822,7 +4293,7 @@
             "unique": true
           }
         ],
-        "version": "1a95153e"
+        "version": "2a91ce1c"
       }
     },
     "@happyvertical/smrt-content:ContentReview": {
@@ -3830,19 +4301,18 @@
       "className": "ContentReview",
       "qualifiedName": "@happyvertical/smrt-content:ContentReview",
       "collection": "contentreviews",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-review.ts",
+      "filePath": "packages/content/src/content-review.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {
         "contentId": {
-          "type": "text",
-          "required": true,
-          "_meta": {
-            "required": true
-          }
+          "type": "foreignKey",
+          "required": false,
+          "related": "Content"
         },
         "contentVersionId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "ContentVersion"
         },
         "kind": {
           "type": "text",
@@ -3928,19 +4398,12 @@
       "extends": "SmrtObject",
       "exportName": "ContentReview",
       "collectionExportName": "ContentReviewCollection",
-      "validationRules": [
-        {
-          "field": "contentId",
-          "rule": "required",
-          "fieldType": "text"
-        }
-      ],
       "schema": {
         "tableName": "content_reviews",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_reviews\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"content_id\" TEXT NOT NULL,\n  \"content_version_id\" TEXT,\n  \"kind\" TEXT DEFAULT 'custom',\n  \"policy_key\" TEXT,\n  \"status\" TEXT DEFAULT 'pending',\n  \"summary\" TEXT,\n  \"findings\" TEXT,\n  \"reviewer\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_reviews\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"content_id\" uuid,\n  \"content_version_id\" uuid,\n  \"kind\" TEXT DEFAULT 'custom',\n  \"policy_key\" TEXT,\n  \"status\" TEXT DEFAULT 'pending',\n  \"summary\" TEXT,\n  \"findings\" TEXT,\n  \"reviewer\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -3964,12 +4427,12 @@
             "default": "current_timestamp"
           },
           "content_id": {
-            "type": "TEXT",
-            "notNull": true,
+            "type": "UUID",
+            "notNull": false,
             "unique": false
           },
           "content_version_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           },
@@ -4032,7 +4495,7 @@
             "unique": true
           }
         ],
-        "version": "b0d76b98"
+        "version": "78db7ddc"
       }
     },
     "@happyvertical/smrt-content:ContentReviewCollection": {
@@ -4040,7 +4503,7 @@
       "className": "ContentReviewCollection",
       "qualifiedName": "@happyvertical/smrt-content:ContentReviewCollection",
       "collection": "contentreviews",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-reviews.ts",
+      "filePath": "packages/content/src/content-reviews.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {},
       "methods": {
@@ -4144,10 +4607,10 @@
       "collectionExportName": "ContentReviewCollectionCollection",
       "schema": {
         "tableName": "content_reviews",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_reviews\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_reviews\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -4187,7 +4650,7 @@
             "unique": true
           }
         ],
-        "version": "d1564c3a"
+        "version": "bf081e09"
       }
     },
     "@happyvertical/smrt-content:Article": {
@@ -4195,2667 +4658,17 @@
       "className": "Article",
       "qualifiedName": "@happyvertical/smrt-content:Article",
       "collection": "contents",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-types.ts",
+      "filePath": "packages/content/src/content-types.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {
         "created_at": {
-          "type": "json",
-          "required": false
-        },
-        "updated_at": {
-          "type": "json",
-          "required": false
-        },
-        "tenantId": {
-          "type": "text",
-          "required": false
-        },
-        "type": {
-          "type": "text",
-          "required": false
-        },
-        "variant": {
-          "type": "text",
-          "required": false
-        },
-        "fileKey": {
-          "type": "text",
-          "required": false
-        },
-        "author": {
-          "type": "text",
-          "required": false
-        },
-        "name": {
-          "type": "text",
-          "required": true,
-          "default": "",
-          "_meta": {
-            "required": true
-          }
-        },
-        "title": {
-          "type": "text",
-          "required": false
-        },
-        "description": {
-          "type": "text",
-          "required": false
-        },
-        "body": {
-          "type": "text",
-          "required": false
-        },
-        "publish_date": {
           "type": "datetime",
           "required": false
         },
-        "url": {
-          "type": "text",
-          "required": false
-        },
-        "source": {
-          "type": "text",
-          "required": false
-        },
-        "original_url": {
-          "type": "text",
-          "required": false
-        },
-        "language": {
-          "type": "text",
-          "required": false
-        },
-        "tags": {
-          "type": "json",
-          "required": false,
-          "default": []
-        },
-        "category": {
-          "type": "text",
-          "required": false
-        },
-        "status": {
-          "type": "text",
-          "required": false,
-          "default": "draft"
-        },
-        "state": {
-          "type": "text",
-          "required": false,
-          "default": "active"
-        },
-        "metadata": {
-          "type": "json",
-          "required": false,
-          "default": {}
-        },
-        "thumbnailAssetId": {
-          "type": "text",
-          "required": false
-        }
-      },
-      "methods": {
-        "getAiUsageSnapshot": {
-          "name": "getAiUsageSnapshot",
-          "async": false,
-          "parameters": [],
-          "returnType": "AiUsageSnapshot | undefined",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "resetAiUsage": {
-          "name": "resetAiUsage",
-          "async": false,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "listAiUsage": {
-          "name": "listAiUsage",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "AiUsageListOptions",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<SmrtAiUsageRecord[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "summarizeAiUsage": {
-          "name": "summarizeAiUsage",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "AiUsageSummaryOptions",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<Record<string, AiUsageStats>>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "destroy": {
-          "name": "destroy",
-          "async": false,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "initialize": {
-          "name": "initialize",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "loadDataFromDb": {
-          "name": "loadDataFromDb",
-          "async": true,
-          "parameters": [
-            {
-              "name": "data",
-              "type": "any",
-              "optional": false
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getFields": {
-          "name": "getFields",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "toJSON": {
-          "name": "toJSON",
-          "async": false,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "toPlainObject": {
-          "name": "toPlainObject",
-          "async": false,
-          "parameters": [],
-          "returnType": "Record<string>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getId": {
-          "name": "getId",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getSlug": {
-          "name": "getSlug",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getSavedId": {
-          "name": "getSavedId",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isSaved": {
-          "name": "isSaved",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "save": {
-          "name": "save",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "loadFromId": {
-          "name": "loadFromId",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "loadFromSlug": {
-          "name": "loadFromSlug",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "is": {
-          "name": "is",
-          "async": true,
-          "parameters": [
-            {
-              "name": "criteria",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "options",
-              "type": "any",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "do": {
-          "name": "do",
-          "async": true,
-          "parameters": [
-            {
-              "name": "instructions",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "options",
-              "type": "any",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "describe": {
-          "name": "describe",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "any",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "delete": {
-          "name": "delete",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isRelatedLoaded": {
-          "name": "isRelatedLoaded",
-          "async": false,
-          "parameters": [
-            {
-              "name": "fieldName",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "loadRelated": {
-          "name": "loadRelated",
-          "async": true,
-          "parameters": [
-            {
-              "name": "fieldName",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<any>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "loadRelatedMany": {
-          "name": "loadRelatedMany",
-          "async": true,
-          "parameters": [
-            {
-              "name": "fieldName",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<any[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getRelated": {
-          "name": "getRelated",
-          "async": true,
-          "parameters": [
-            {
-              "name": "fieldName",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<any>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getAvailableTools": {
-          "name": "getAvailableTools",
-          "async": false,
-          "parameters": [],
-          "returnType": "AITool[]",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "executeToolCall": {
-          "name": "executeToolCall",
-          "async": true,
-          "parameters": [
-            {
-              "name": "toolCall",
-              "type": "ToolCall",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<ToolCallResult>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "remember": {
-          "name": "remember",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "recall": {
-          "name": "recall",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<any | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "recallAll": {
-          "name": "recallAll",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<Map<string, any>>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "forget": {
-          "name": "forget",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "forgetScope": {
-          "name": "forgetScope",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<number>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "generateEmbeddings": {
-          "name": "generateEmbeddings",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "GenerateEmbeddingsOptions",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getEmbedding": {
-          "name": "getEmbedding",
-          "async": true,
-          "parameters": [
-            {
-              "name": "fieldName",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "model",
-              "type": "string",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<number[] | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "hasStaleEmbeddings": {
-          "name": "hasStaleEmbeddings",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<boolean>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "clearEmbeddings": {
-          "name": "clearEmbeddings",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "resolveGovernance": {
-          "name": "resolveGovernance",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<ResolvedContentGovernance>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "loadReferences": {
-          "name": "loadReferences",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "addReference": {
-          "name": "addReference",
-          "async": true,
-          "parameters": [
-            {
-              "name": "content",
-              "type": "Content | string",
-              "optional": false
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "removeReference": {
-          "name": "removeReference",
-          "async": true,
-          "parameters": [
-            {
-              "name": "targetId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getReferences": {
-          "name": "getReferences",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isGoverned": {
-          "name": "isGoverned",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getFactLinks": {
-          "name": "getFactLinks",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getFacts": {
-          "name": "getFacts",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<Fact[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "addFact": {
-          "name": "addFact",
-          "async": true,
-          "parameters": [
-            {
-              "name": "fact",
-              "type": "Fact | string",
-              "optional": false
-            },
-            {
-              "name": "relationship",
-              "type": "FactContentRelationship",
-              "optional": true
-            },
-            {
-              "name": "metadata",
-              "type": "Record<string, any>",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "removeFact": {
-          "name": "removeFact",
-          "async": true,
-          "parameters": [
-            {
-              "name": "factId",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "relationship",
-              "type": "FactContentRelationship",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "syncFacts": {
-          "name": "syncFacts",
-          "async": true,
-          "parameters": [
-            {
-              "name": "factIds",
-              "type": "string[]",
-              "optional": false
-            },
-            {
-              "name": "relationship",
-              "type": "FactContentRelationship",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<object>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "browseFacts": {
-          "name": "browseFacts",
-          "async": true,
-          "parameters": [
-            {
-              "name": "query",
-              "type": "any",
-              "optional": true,
-              "default": ""
-            },
-            {
-              "name": "options",
-              "type": "object",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<Fact[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getFactsState": {
-          "name": "getFactsState",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "syncFactsState": {
-          "name": "syncFactsState",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "createVersion": {
-          "name": "createVersion",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "CreateContentVersionOptions",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getVersions": {
-          "name": "getVersions",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "restoreFromVersion": {
-          "name": "restoreFromVersion",
-          "async": true,
-          "parameters": [
-            {
-              "name": "versionNumber",
-              "type": "number",
-              "optional": false
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getReviews": {
-          "name": "getReviews",
-          "async": true,
-          "parameters": [
-            {
-              "name": "kind",
-              "type": "any",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "listReviews": {
-          "name": "listReviews",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getReviewRequirements": {
-          "name": "getReviewRequirements",
-          "async": true,
-          "parameters": [
-            {
-              "name": "profileKey",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "governance",
-              "type": "ResolvedContentGovernance",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getGovernanceState": {
-          "name": "getGovernanceState",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<ContentGovernanceState>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getGovernanceStateAction": {
-          "name": "getGovernanceStateAction",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "listReviewProfilesAction": {
-          "name": "listReviewProfilesAction",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "evaluateReviewProfile": {
-          "name": "evaluateReviewProfile",
-          "async": true,
-          "parameters": [
-            {
-              "name": "profileKey",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<ContentReviewProfileEvaluation>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "evaluateReviewProfileAction": {
-          "name": "evaluateReviewProfileAction",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isReadyForReviewProfile": {
-          "name": "isReadyForReviewProfile",
-          "async": true,
-          "parameters": [
-            {
-              "name": "profileKey",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<boolean>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getPublishedTransparency": {
-          "name": "getPublishedTransparency",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getPublishedTransparencyAction": {
-          "name": "getPublishedTransparencyAction",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "previewTransparency": {
-          "name": "previewTransparency",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "previewTransparencyAction": {
-          "name": "previewTransparencyAction",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "runReview": {
-          "name": "runReview",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "RunContentReviewOptions",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "runReviewAction": {
-          "name": "runReviewAction",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "RunContentReviewOptions",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "reviewFacts": {
-          "name": "reviewFacts",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "Omit<RunContentReviewOptions, 'kind'>",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "reviewSafety": {
-          "name": "reviewSafety",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "Omit<RunContentReviewOptions, 'kind'>",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getCorrections": {
-          "name": "getCorrections",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "listCorrections": {
-          "name": "listCorrections",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "issueCorrection": {
-          "name": "issueCorrection",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "IssueContentCorrectionOptions",
-              "optional": false
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "issueCorrectionAction": {
-          "name": "issueCorrectionAction",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "IssueContentCorrectionOptions",
-              "optional": false
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "listVersions": {
-          "name": "listVersions",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "mutateVersionAction": {
-          "name": "mutateVersionAction",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "any",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getCategorySegments": {
-          "name": "getCategorySegments",
-          "async": false,
-          "parameters": [],
-          "returnType": "string[]",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getParentCategory": {
-          "name": "getParentCategory",
-          "async": false,
-          "parameters": [],
-          "returnType": "string | null",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getRootCategory": {
-          "name": "getRootCategory",
-          "async": false,
-          "parameters": [],
-          "returnType": "string | null",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getAncestorPaths": {
-          "name": "getAncestorPaths",
-          "async": false,
-          "parameters": [],
-          "returnType": "string[]",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isInCategory": {
-          "name": "isInCategory",
-          "async": false,
-          "parameters": [
-            {
-              "name": "categoryPath",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "includeChildren",
-              "type": "any",
-              "optional": true
-            }
-          ],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getAssets": {
-          "name": "getAssets",
-          "async": true,
-          "parameters": [
-            {
-              "name": "relationship",
-              "type": "string",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<Asset[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "addAsset": {
-          "name": "addAsset",
-          "async": true,
-          "parameters": [
-            {
-              "name": "asset",
-              "type": "Asset",
-              "optional": false
-            },
-            {
-              "name": "relationship",
-              "type": "any",
-              "optional": true,
-              "default": "attachment"
-            },
-            {
-              "name": "sortOrder",
-              "type": "any",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "removeAsset": {
-          "name": "removeAsset",
-          "async": true,
-          "parameters": [
-            {
-              "name": "assetId",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "relationship",
-              "type": "string",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getThumbnail": {
-          "name": "getThumbnail",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Image | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "setThumbnail": {
-          "name": "setThumbnail",
-          "async": true,
-          "parameters": [
-            {
-              "name": "image",
-              "type": "Image",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "generateThumbnail": {
-          "name": "generateThumbnail",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "ThumbnailOptions",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<Image>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "tableStrategy": "sti",
-        "api": false,
-        "mcp": false,
-        "cli": false,
-        "tableName": "contents"
-      },
-      "extends": "Content",
-      "exportName": "Article",
-      "collectionExportName": "ArticleCollection",
-      "validationRules": [
-        {
-          "field": "name",
-          "rule": "required",
-          "fieldType": "text"
-        }
-      ],
-      "schema": {
-        "tableName": "contents",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type\" TEXT,\n  \"variant\" TEXT,\n  \"file_key\" TEXT,\n  \"author\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"publish_date\" TIMESTAMP,\n  \"url\" TEXT,\n  \"source\" TEXT,\n  \"original_url\" TEXT,\n  \"language\" TEXT,\n  \"tags\" JSON DEFAULT '[]',\n  \"category\" TEXT,\n  \"status\" TEXT DEFAULT 'draft',\n  \"state\" TEXT DEFAULT 'active',\n  \"metadata\" JSON DEFAULT '{}',\n  \"thumbnail_asset_id\" TEXT\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "_meta_type": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "_meta_data": {
-            "type": "JSON",
-            "notNull": false
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "tenant_id": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "type": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "variant": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "file_key": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "author": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "name": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "title": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "description": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "body": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "publish_date": {
-            "type": "TIMESTAMP",
-            "notNull": false
-          },
-          "url": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "source": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "original_url": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "language": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "tags": {
-            "type": "JSON",
-            "notNull": false,
-            "default": []
-          },
-          "category": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "status": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "draft"
-          },
-          "state": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "active"
-          },
-          "metadata": {
-            "type": "JSON",
-            "notNull": false,
-            "default": {}
-          },
-          "thumbnail_asset_id": {
-            "type": "TEXT",
-            "notNull": false
-          }
-        },
-        "indexes": [
-          {
-            "name": "contents_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "contents_slug_context_meta_type_idx",
-            "columns": [
-              "slug",
-              "context",
-              "_meta_type"
-            ],
-            "unique": true
-          },
-          {
-            "name": "contents_meta_type_idx",
-            "columns": [
-              "_meta_type"
-            ]
-          }
-        ],
-        "version": "a8436abb"
-      }
-    },
-    "@happyvertical/smrt-content:ContentDocument": {
-      "name": "contentdocument",
-      "className": "ContentDocument",
-      "qualifiedName": "@happyvertical/smrt-content:ContentDocument",
-      "collection": "contents",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-types.ts",
-      "packageName": "@happyvertical/smrt-content",
-      "fields": {
-        "created_at": {
-          "type": "json",
-          "required": false
-        },
         "updated_at": {
-          "type": "json",
-          "required": false
-        },
-        "tenantId": {
-          "type": "text",
-          "required": false
-        },
-        "type": {
-          "type": "text",
-          "required": false
-        },
-        "variant": {
-          "type": "text",
-          "required": false
-        },
-        "fileKey": {
-          "type": "text",
-          "required": false
-        },
-        "author": {
-          "type": "text",
-          "required": false
-        },
-        "name": {
-          "type": "text",
-          "required": true,
-          "default": "",
-          "_meta": {
-            "required": true
-          }
-        },
-        "title": {
-          "type": "text",
-          "required": false
-        },
-        "description": {
-          "type": "text",
-          "required": false
-        },
-        "body": {
-          "type": "text",
-          "required": false
-        },
-        "publish_date": {
           "type": "datetime",
           "required": false
         },
-        "url": {
-          "type": "text",
-          "required": false
-        },
-        "source": {
-          "type": "text",
-          "required": false
-        },
-        "original_url": {
-          "type": "text",
-          "required": false
-        },
-        "language": {
-          "type": "text",
-          "required": false
-        },
-        "tags": {
-          "type": "json",
-          "required": false,
-          "default": []
-        },
-        "category": {
-          "type": "text",
-          "required": false
-        },
-        "status": {
-          "type": "text",
-          "required": false,
-          "default": "draft"
-        },
-        "state": {
-          "type": "text",
-          "required": false,
-          "default": "active"
-        },
-        "metadata": {
-          "type": "json",
-          "required": false,
-          "default": {}
-        },
-        "thumbnailAssetId": {
-          "type": "text",
-          "required": false
-        }
-      },
-      "methods": {
-        "getAiUsageSnapshot": {
-          "name": "getAiUsageSnapshot",
-          "async": false,
-          "parameters": [],
-          "returnType": "AiUsageSnapshot | undefined",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "resetAiUsage": {
-          "name": "resetAiUsage",
-          "async": false,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "listAiUsage": {
-          "name": "listAiUsage",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "AiUsageListOptions",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<SmrtAiUsageRecord[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "summarizeAiUsage": {
-          "name": "summarizeAiUsage",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "AiUsageSummaryOptions",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<Record<string, AiUsageStats>>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "destroy": {
-          "name": "destroy",
-          "async": false,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "initialize": {
-          "name": "initialize",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "loadDataFromDb": {
-          "name": "loadDataFromDb",
-          "async": true,
-          "parameters": [
-            {
-              "name": "data",
-              "type": "any",
-              "optional": false
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getFields": {
-          "name": "getFields",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "toJSON": {
-          "name": "toJSON",
-          "async": false,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "toPlainObject": {
-          "name": "toPlainObject",
-          "async": false,
-          "parameters": [],
-          "returnType": "Record<string>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getId": {
-          "name": "getId",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getSlug": {
-          "name": "getSlug",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getSavedId": {
-          "name": "getSavedId",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isSaved": {
-          "name": "isSaved",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "save": {
-          "name": "save",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "loadFromId": {
-          "name": "loadFromId",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "loadFromSlug": {
-          "name": "loadFromSlug",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "is": {
-          "name": "is",
-          "async": true,
-          "parameters": [
-            {
-              "name": "criteria",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "options",
-              "type": "any",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "do": {
-          "name": "do",
-          "async": true,
-          "parameters": [
-            {
-              "name": "instructions",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "options",
-              "type": "any",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "describe": {
-          "name": "describe",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "any",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "delete": {
-          "name": "delete",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isRelatedLoaded": {
-          "name": "isRelatedLoaded",
-          "async": false,
-          "parameters": [
-            {
-              "name": "fieldName",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "loadRelated": {
-          "name": "loadRelated",
-          "async": true,
-          "parameters": [
-            {
-              "name": "fieldName",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<any>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "loadRelatedMany": {
-          "name": "loadRelatedMany",
-          "async": true,
-          "parameters": [
-            {
-              "name": "fieldName",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<any[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getRelated": {
-          "name": "getRelated",
-          "async": true,
-          "parameters": [
-            {
-              "name": "fieldName",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<any>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getAvailableTools": {
-          "name": "getAvailableTools",
-          "async": false,
-          "parameters": [],
-          "returnType": "AITool[]",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "executeToolCall": {
-          "name": "executeToolCall",
-          "async": true,
-          "parameters": [
-            {
-              "name": "toolCall",
-              "type": "ToolCall",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<ToolCallResult>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "remember": {
-          "name": "remember",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "recall": {
-          "name": "recall",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<any | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "recallAll": {
-          "name": "recallAll",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<Map<string, any>>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "forget": {
-          "name": "forget",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "forgetScope": {
-          "name": "forgetScope",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<number>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "generateEmbeddings": {
-          "name": "generateEmbeddings",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "GenerateEmbeddingsOptions",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getEmbedding": {
-          "name": "getEmbedding",
-          "async": true,
-          "parameters": [
-            {
-              "name": "fieldName",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "model",
-              "type": "string",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<number[] | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "hasStaleEmbeddings": {
-          "name": "hasStaleEmbeddings",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<boolean>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "clearEmbeddings": {
-          "name": "clearEmbeddings",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "resolveGovernance": {
-          "name": "resolveGovernance",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<ResolvedContentGovernance>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "loadReferences": {
-          "name": "loadReferences",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "addReference": {
-          "name": "addReference",
-          "async": true,
-          "parameters": [
-            {
-              "name": "content",
-              "type": "Content | string",
-              "optional": false
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "removeReference": {
-          "name": "removeReference",
-          "async": true,
-          "parameters": [
-            {
-              "name": "targetId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getReferences": {
-          "name": "getReferences",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isGoverned": {
-          "name": "isGoverned",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getFactLinks": {
-          "name": "getFactLinks",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getFacts": {
-          "name": "getFacts",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<Fact[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "addFact": {
-          "name": "addFact",
-          "async": true,
-          "parameters": [
-            {
-              "name": "fact",
-              "type": "Fact | string",
-              "optional": false
-            },
-            {
-              "name": "relationship",
-              "type": "FactContentRelationship",
-              "optional": true
-            },
-            {
-              "name": "metadata",
-              "type": "Record<string, any>",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "removeFact": {
-          "name": "removeFact",
-          "async": true,
-          "parameters": [
-            {
-              "name": "factId",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "relationship",
-              "type": "FactContentRelationship",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "syncFacts": {
-          "name": "syncFacts",
-          "async": true,
-          "parameters": [
-            {
-              "name": "factIds",
-              "type": "string[]",
-              "optional": false
-            },
-            {
-              "name": "relationship",
-              "type": "FactContentRelationship",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<object>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "browseFacts": {
-          "name": "browseFacts",
-          "async": true,
-          "parameters": [
-            {
-              "name": "query",
-              "type": "any",
-              "optional": true,
-              "default": ""
-            },
-            {
-              "name": "options",
-              "type": "object",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<Fact[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getFactsState": {
-          "name": "getFactsState",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "syncFactsState": {
-          "name": "syncFactsState",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "createVersion": {
-          "name": "createVersion",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "CreateContentVersionOptions",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getVersions": {
-          "name": "getVersions",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "restoreFromVersion": {
-          "name": "restoreFromVersion",
-          "async": true,
-          "parameters": [
-            {
-              "name": "versionNumber",
-              "type": "number",
-              "optional": false
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getReviews": {
-          "name": "getReviews",
-          "async": true,
-          "parameters": [
-            {
-              "name": "kind",
-              "type": "any",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "listReviews": {
-          "name": "listReviews",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getReviewRequirements": {
-          "name": "getReviewRequirements",
-          "async": true,
-          "parameters": [
-            {
-              "name": "profileKey",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "governance",
-              "type": "ResolvedContentGovernance",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getGovernanceState": {
-          "name": "getGovernanceState",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<ContentGovernanceState>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getGovernanceStateAction": {
-          "name": "getGovernanceStateAction",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "listReviewProfilesAction": {
-          "name": "listReviewProfilesAction",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "evaluateReviewProfile": {
-          "name": "evaluateReviewProfile",
-          "async": true,
-          "parameters": [
-            {
-              "name": "profileKey",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<ContentReviewProfileEvaluation>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "evaluateReviewProfileAction": {
-          "name": "evaluateReviewProfileAction",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "object",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isReadyForReviewProfile": {
-          "name": "isReadyForReviewProfile",
-          "async": true,
-          "parameters": [
-            {
-              "name": "profileKey",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<boolean>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getPublishedTransparency": {
-          "name": "getPublishedTransparency",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getPublishedTransparencyAction": {
-          "name": "getPublishedTransparencyAction",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "previewTransparency": {
-          "name": "previewTransparency",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "previewTransparencyAction": {
-          "name": "previewTransparencyAction",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "runReview": {
-          "name": "runReview",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "RunContentReviewOptions",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "runReviewAction": {
-          "name": "runReviewAction",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "RunContentReviewOptions",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "reviewFacts": {
-          "name": "reviewFacts",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "Omit<RunContentReviewOptions, 'kind'>",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "reviewSafety": {
-          "name": "reviewSafety",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "Omit<RunContentReviewOptions, 'kind'>",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getCorrections": {
-          "name": "getCorrections",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "listCorrections": {
-          "name": "listCorrections",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "issueCorrection": {
-          "name": "issueCorrection",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "IssueContentCorrectionOptions",
-              "optional": false
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "issueCorrectionAction": {
-          "name": "issueCorrectionAction",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "IssueContentCorrectionOptions",
-              "optional": false
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "listVersions": {
-          "name": "listVersions",
-          "async": true,
-          "parameters": [],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "mutateVersionAction": {
-          "name": "mutateVersionAction",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "any",
-              "optional": true
-            }
-          ],
-          "returnType": "any",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getCategorySegments": {
-          "name": "getCategorySegments",
-          "async": false,
-          "parameters": [],
-          "returnType": "string[]",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getParentCategory": {
-          "name": "getParentCategory",
-          "async": false,
-          "parameters": [],
-          "returnType": "string | null",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getRootCategory": {
-          "name": "getRootCategory",
-          "async": false,
-          "parameters": [],
-          "returnType": "string | null",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getAncestorPaths": {
-          "name": "getAncestorPaths",
-          "async": false,
-          "parameters": [],
-          "returnType": "string[]",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isInCategory": {
-          "name": "isInCategory",
-          "async": false,
-          "parameters": [
-            {
-              "name": "categoryPath",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "includeChildren",
-              "type": "any",
-              "optional": true
-            }
-          ],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getAssets": {
-          "name": "getAssets",
-          "async": true,
-          "parameters": [
-            {
-              "name": "relationship",
-              "type": "string",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<Asset[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "addAsset": {
-          "name": "addAsset",
-          "async": true,
-          "parameters": [
-            {
-              "name": "asset",
-              "type": "Asset",
-              "optional": false
-            },
-            {
-              "name": "relationship",
-              "type": "any",
-              "optional": true,
-              "default": "attachment"
-            },
-            {
-              "name": "sortOrder",
-              "type": "any",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "removeAsset": {
-          "name": "removeAsset",
-          "async": true,
-          "parameters": [
-            {
-              "name": "assetId",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "relationship",
-              "type": "string",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getThumbnail": {
-          "name": "getThumbnail",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Image | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "setThumbnail": {
-          "name": "setThumbnail",
-          "async": true,
-          "parameters": [
-            {
-              "name": "image",
-              "type": "Image",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "generateThumbnail": {
-          "name": "generateThumbnail",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "ThumbnailOptions",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<Image>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "tableStrategy": "sti",
-        "api": false,
-        "mcp": false,
-        "cli": false,
-        "tableName": "contents"
-      },
-      "extends": "Content",
-      "exportName": "ContentDocument",
-      "collectionExportName": "ContentDocumentCollection",
-      "validationRules": [
-        {
-          "field": "name",
-          "rule": "required",
-          "fieldType": "text"
-        }
-      ],
-      "schema": {
-        "tableName": "contents",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type\" TEXT,\n  \"variant\" TEXT,\n  \"file_key\" TEXT,\n  \"author\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"publish_date\" TIMESTAMP,\n  \"url\" TEXT,\n  \"source\" TEXT,\n  \"original_url\" TEXT,\n  \"language\" TEXT,\n  \"tags\" JSON DEFAULT '[]',\n  \"category\" TEXT,\n  \"status\" TEXT DEFAULT 'draft',\n  \"state\" TEXT DEFAULT 'active',\n  \"metadata\" JSON DEFAULT '{}',\n  \"thumbnail_asset_id\" TEXT\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "_meta_type": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "_meta_data": {
-            "type": "JSON",
-            "notNull": false
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "tenant_id": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "type": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "variant": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "file_key": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "author": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "name": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "title": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "description": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "body": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "publish_date": {
-            "type": "TIMESTAMP",
-            "notNull": false
-          },
-          "url": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "source": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "original_url": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "language": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "tags": {
-            "type": "JSON",
-            "notNull": false,
-            "default": []
-          },
-          "category": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "status": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "draft"
-          },
-          "state": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "active"
-          },
-          "metadata": {
-            "type": "JSON",
-            "notNull": false,
-            "default": {}
-          },
-          "thumbnail_asset_id": {
-            "type": "TEXT",
-            "notNull": false
-          }
-        },
-        "indexes": [
-          {
-            "name": "contents_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "contents_slug_context_meta_type_idx",
-            "columns": [
-              "slug",
-              "context",
-              "_meta_type"
-            ],
-            "unique": true
-          },
-          {
-            "name": "contents_meta_type_idx",
-            "columns": [
-              "_meta_type"
-            ]
-          }
-        ],
-        "version": "312780d3"
-      }
-    },
-    "@happyvertical/smrt-content:Mirror": {
-      "name": "mirror",
-      "className": "Mirror",
-      "qualifiedName": "@happyvertical/smrt-content:Mirror",
-      "collection": "contents",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-types.ts",
-      "packageName": "@happyvertical/smrt-content",
-      "fields": {
         "tenantId": {
           "type": "text",
           "required": false
@@ -6945,12 +4758,3018 @@
           "default": {}
         },
         "thumbnailAssetId": {
+          "type": "crossPackageRef",
+          "required": false,
+          "related": "@happyvertical/smrt-assets:Asset"
+        }
+      },
+      "methods": {
+        "getAiUsageSnapshot": {
+          "name": "getAiUsageSnapshot",
+          "async": false,
+          "parameters": [],
+          "returnType": "AiUsageSnapshot | undefined",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetAiUsage": {
+          "name": "resetAiUsage",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listAiUsage": {
+          "name": "listAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageListOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<SmrtAiUsageRecord[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeAiUsage": {
+          "name": "summarizeAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageSummaryOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Record<string, AiUsageStats>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "destroy": {
+          "name": "destroy",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadDataFromDb": {
+          "name": "loadDataFromDb",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toJSON": {
+          "name": "toJSON",
+          "async": false,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPlainObject": {
+          "name": "toPlainObject",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getId": {
+          "name": "getId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSlug": {
+          "name": "getSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSavedId": {
+          "name": "getSavedId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSaved": {
+          "name": "isSaved",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromId": {
+          "name": "loadFromId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromSlug": {
+          "name": "loadFromSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "is": {
+          "name": "is",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "do": {
+          "name": "do",
+          "async": true,
+          "parameters": [
+            {
+              "name": "instructions",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "describe": {
+          "name": "describe",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "delete": {
+          "name": "delete",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRelatedLoaded": {
+          "name": "isRelatedLoaded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelated": {
+          "name": "loadRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelatedMany": {
+          "name": "loadRelatedMany",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelated": {
+          "name": "getRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAvailableTools": {
+          "name": "getAvailableTools",
+          "async": false,
+          "parameters": [],
+          "returnType": "AITool[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "executeToolCall": {
+          "name": "executeToolCall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toolCall",
+              "type": "ToolCall",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ToolCallResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "remember": {
+          "name": "remember",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recall": {
+          "name": "recall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recallAll": {
+          "name": "recallAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forget": {
+          "name": "forget",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forgetScope": {
+          "name": "forgetScope",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateEmbeddings": {
+          "name": "generateEmbeddings",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "GenerateEmbeddingsOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmbedding": {
+          "name": "getEmbedding",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "model",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number[] | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStaleEmbeddings": {
+          "name": "hasStaleEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearEmbeddings": {
+          "name": "clearEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resolveGovernance": {
+          "name": "resolveGovernance",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<ResolvedContentGovernance>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadReferences": {
+          "name": "loadReferences",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addReference": {
+          "name": "addReference",
+          "async": true,
+          "parameters": [
+            {
+              "name": "content",
+              "type": "Content | string",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeReference": {
+          "name": "removeReference",
+          "async": true,
+          "parameters": [
+            {
+              "name": "targetId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getReferences": {
+          "name": "getReferences",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isGoverned": {
+          "name": "isGoverned",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFactLinks": {
+          "name": "getFactLinks",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFacts": {
+          "name": "getFacts",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Fact[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addFact": {
+          "name": "addFact",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fact",
+              "type": "Fact | string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "FactContentRelationship",
+              "optional": true
+            },
+            {
+              "name": "metadata",
+              "type": "Record<string, any>",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeFact": {
+          "name": "removeFact",
+          "async": true,
+          "parameters": [
+            {
+              "name": "factId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "FactContentRelationship",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "syncFacts": {
+          "name": "syncFacts",
+          "async": true,
+          "parameters": [
+            {
+              "name": "factIds",
+              "type": "string[]",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "FactContentRelationship",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<object>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "browseFacts": {
+          "name": "browseFacts",
+          "async": true,
+          "parameters": [
+            {
+              "name": "query",
+              "type": "any",
+              "optional": true,
+              "default": ""
+            },
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Fact[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "repairFactAudit": {
+          "name": "repairFactAudit",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "repairFactAuditAction": {
+          "name": "repairFactAuditAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "repairFactEvidence": {
+          "name": "repairFactEvidence",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactAuditResourceRepairOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "repairFactEvidenceAction": {
+          "name": "repairFactEvidenceAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactAuditResourceRepairOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recheckFactClaims": {
+          "name": "recheckFactClaims",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactAuditClaimRecheckOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recheckFactClaimsAction": {
+          "name": "recheckFactClaimsAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactAuditClaimRecheckOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateFactEvidenceStatus": {
+          "name": "updateFactEvidenceStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactEvidenceStatusUpdateOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateFactEvidenceStatusAction": {
+          "name": "updateFactEvidenceStatusAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactEvidenceStatusUpdateOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFactAuditState": {
+          "name": "getFactAuditState",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<FactAuditState>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFactAuditStateAction": {
+          "name": "getFactAuditStateAction",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFactsState": {
+          "name": "getFactsState",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "syncFactsState": {
+          "name": "syncFactsState",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "createVersion": {
+          "name": "createVersion",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "CreateContentVersionOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getVersions": {
+          "name": "getVersions",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "restoreFromVersion": {
+          "name": "restoreFromVersion",
+          "async": true,
+          "parameters": [
+            {
+              "name": "versionNumber",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getReviews": {
+          "name": "getReviews",
+          "async": true,
+          "parameters": [
+            {
+              "name": "kind",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listReviews": {
+          "name": "listReviews",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getReviewRequirements": {
+          "name": "getReviewRequirements",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileKey",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "governance",
+              "type": "ResolvedContentGovernance",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getGovernanceState": {
+          "name": "getGovernanceState",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<ContentGovernanceState>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getGovernanceStateAction": {
+          "name": "getGovernanceStateAction",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listReviewProfilesAction": {
+          "name": "listReviewProfilesAction",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "evaluateReviewProfile": {
+          "name": "evaluateReviewProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileKey",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ContentReviewProfileEvaluation>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "evaluateReviewProfileAction": {
+          "name": "evaluateReviewProfileAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isReadyForReviewProfile": {
+          "name": "isReadyForReviewProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileKey",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getPublishedTransparency": {
+          "name": "getPublishedTransparency",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getPublishedTransparencyAction": {
+          "name": "getPublishedTransparencyAction",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "previewTransparency": {
+          "name": "previewTransparency",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "previewTransparencyAction": {
+          "name": "previewTransparencyAction",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "runReview": {
+          "name": "runReview",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "RunContentReviewOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "runReviewAction": {
+          "name": "runReviewAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "RunContentReviewOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "reviewFacts": {
+          "name": "reviewFacts",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "Omit<RunContentReviewOptions, 'kind'>",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "reviewSafety": {
+          "name": "reviewSafety",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "Omit<RunContentReviewOptions, 'kind'>",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getCorrections": {
+          "name": "getCorrections",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listCorrections": {
+          "name": "listCorrections",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "issueCorrection": {
+          "name": "issueCorrection",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "IssueContentCorrectionOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "issueCorrectionAction": {
+          "name": "issueCorrectionAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "IssueContentCorrectionOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listVersions": {
+          "name": "listVersions",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "mutateVersionAction": {
+          "name": "mutateVersionAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getCategorySegments": {
+          "name": "getCategorySegments",
+          "async": false,
+          "parameters": [],
+          "returnType": "string[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParentCategory": {
+          "name": "getParentCategory",
+          "async": false,
+          "parameters": [],
+          "returnType": "string | null",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRootCategory": {
+          "name": "getRootCategory",
+          "async": false,
+          "parameters": [],
+          "returnType": "string | null",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAncestorPaths": {
+          "name": "getAncestorPaths",
+          "async": false,
+          "parameters": [],
+          "returnType": "string[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isInCategory": {
+          "name": "isInCategory",
+          "async": false,
+          "parameters": [
+            {
+              "name": "categoryPath",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "includeChildren",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAssets": {
+          "name": "getAssets",
+          "async": true,
+          "parameters": [
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addAsset": {
+          "name": "addAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "asset",
+              "type": "Asset",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "any",
+              "optional": true,
+              "default": "attachment"
+            },
+            {
+              "name": "sortOrder",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeAsset": {
+          "name": "removeAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "assetId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setMetadata": {
+          "name": "setMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "metadata",
+              "type": "Record<string, any> | null | undefined",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateMetadata": {
+          "name": "updateMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "patch",
+              "type": "Partial<Record<string, any>>",
+              "optional": false
+            }
+          ],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getThumbnail": {
+          "name": "getThumbnail",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Image | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setThumbnail": {
+          "name": "setThumbnail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "image",
+              "type": "Image",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateThumbnail": {
+          "name": "generateThumbnail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "ThumbnailOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Image>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": false,
+        "mcp": false,
+        "cli": false,
+        "tableName": "contents"
+      },
+      "extends": "Content",
+      "exportName": "Article",
+      "collectionExportName": "ArticleCollection",
+      "validationRules": [
+        {
+          "field": "name",
+          "rule": "required",
+          "fieldType": "text"
+        }
+      ],
+      "schema": {
+        "tableName": "contents",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type\" TEXT,\n  \"variant\" TEXT,\n  \"file_key\" TEXT,\n  \"author\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"body_format\" TEXT,\n  \"publish_date\" TIMESTAMP,\n  \"url\" TEXT,\n  \"source\" TEXT,\n  \"original_url\" TEXT,\n  \"language\" TEXT,\n  \"tags\" JSONB DEFAULT '[]',\n  \"category\" TEXT,\n  \"status\" TEXT DEFAULT 'draft',\n  \"state\" TEXT DEFAULT 'active',\n  \"metadata\" JSONB DEFAULT '{}',\n  \"thumbnail_asset_id\" uuid\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "type": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "variant": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "file_key": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "author": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "title": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "body": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "body_format": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "publish_date": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          },
+          "url": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "source": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "original_url": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "language": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "tags": {
+            "type": "JSON",
+            "notNull": false,
+            "default": []
+          },
+          "category": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "draft"
+          },
+          "state": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "active"
+          },
+          "metadata": {
+            "type": "JSON",
+            "notNull": false,
+            "default": {}
+          },
+          "thumbnail_asset_id": {
+            "type": "UUID",
+            "notNull": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "contents_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "contents_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "contents_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "aade2a35"
+      }
+    },
+    "@happyvertical/smrt-content:ContentDocument": {
+      "name": "contentdocument",
+      "className": "ContentDocument",
+      "qualifiedName": "@happyvertical/smrt-content:ContentDocument",
+      "collection": "contents",
+      "filePath": "packages/content/src/content-types.ts",
+      "packageName": "@happyvertical/smrt-content",
+      "fields": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "tenantId": {
           "type": "text",
           "required": false
         },
-        "feedSourceId": {
+        "type": {
           "type": "text",
           "required": false
+        },
+        "variant": {
+          "type": "text",
+          "required": false
+        },
+        "fileKey": {
+          "type": "text",
+          "required": false
+        },
+        "author": {
+          "type": "text",
+          "required": false
+        },
+        "name": {
+          "type": "text",
+          "required": true,
+          "default": "",
+          "_meta": {
+            "required": true
+          }
+        },
+        "title": {
+          "type": "text",
+          "required": false
+        },
+        "description": {
+          "type": "text",
+          "required": false
+        },
+        "body": {
+          "type": "text",
+          "required": false
+        },
+        "bodyFormat": {
+          "type": "text",
+          "required": false
+        },
+        "publish_date": {
+          "type": "datetime",
+          "required": false
+        },
+        "url": {
+          "type": "text",
+          "required": false
+        },
+        "source": {
+          "type": "text",
+          "required": false
+        },
+        "original_url": {
+          "type": "text",
+          "required": false
+        },
+        "language": {
+          "type": "text",
+          "required": false
+        },
+        "tags": {
+          "type": "json",
+          "required": false,
+          "default": []
+        },
+        "category": {
+          "type": "text",
+          "required": false
+        },
+        "status": {
+          "type": "text",
+          "required": false,
+          "default": "draft"
+        },
+        "state": {
+          "type": "text",
+          "required": false,
+          "default": "active"
+        },
+        "metadata": {
+          "type": "json",
+          "required": false,
+          "default": {}
+        },
+        "thumbnailAssetId": {
+          "type": "crossPackageRef",
+          "required": false,
+          "related": "@happyvertical/smrt-assets:Asset"
+        }
+      },
+      "methods": {
+        "getAiUsageSnapshot": {
+          "name": "getAiUsageSnapshot",
+          "async": false,
+          "parameters": [],
+          "returnType": "AiUsageSnapshot | undefined",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetAiUsage": {
+          "name": "resetAiUsage",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listAiUsage": {
+          "name": "listAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageListOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<SmrtAiUsageRecord[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeAiUsage": {
+          "name": "summarizeAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageSummaryOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Record<string, AiUsageStats>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "destroy": {
+          "name": "destroy",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadDataFromDb": {
+          "name": "loadDataFromDb",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toJSON": {
+          "name": "toJSON",
+          "async": false,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPlainObject": {
+          "name": "toPlainObject",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getId": {
+          "name": "getId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSlug": {
+          "name": "getSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSavedId": {
+          "name": "getSavedId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSaved": {
+          "name": "isSaved",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromId": {
+          "name": "loadFromId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromSlug": {
+          "name": "loadFromSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "is": {
+          "name": "is",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "do": {
+          "name": "do",
+          "async": true,
+          "parameters": [
+            {
+              "name": "instructions",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "describe": {
+          "name": "describe",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "delete": {
+          "name": "delete",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRelatedLoaded": {
+          "name": "isRelatedLoaded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelated": {
+          "name": "loadRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelatedMany": {
+          "name": "loadRelatedMany",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelated": {
+          "name": "getRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAvailableTools": {
+          "name": "getAvailableTools",
+          "async": false,
+          "parameters": [],
+          "returnType": "AITool[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "executeToolCall": {
+          "name": "executeToolCall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toolCall",
+              "type": "ToolCall",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ToolCallResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "remember": {
+          "name": "remember",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recall": {
+          "name": "recall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recallAll": {
+          "name": "recallAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forget": {
+          "name": "forget",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forgetScope": {
+          "name": "forgetScope",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateEmbeddings": {
+          "name": "generateEmbeddings",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "GenerateEmbeddingsOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmbedding": {
+          "name": "getEmbedding",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "model",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number[] | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStaleEmbeddings": {
+          "name": "hasStaleEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearEmbeddings": {
+          "name": "clearEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resolveGovernance": {
+          "name": "resolveGovernance",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<ResolvedContentGovernance>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadReferences": {
+          "name": "loadReferences",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addReference": {
+          "name": "addReference",
+          "async": true,
+          "parameters": [
+            {
+              "name": "content",
+              "type": "Content | string",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeReference": {
+          "name": "removeReference",
+          "async": true,
+          "parameters": [
+            {
+              "name": "targetId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getReferences": {
+          "name": "getReferences",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isGoverned": {
+          "name": "isGoverned",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFactLinks": {
+          "name": "getFactLinks",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFacts": {
+          "name": "getFacts",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Fact[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addFact": {
+          "name": "addFact",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fact",
+              "type": "Fact | string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "FactContentRelationship",
+              "optional": true
+            },
+            {
+              "name": "metadata",
+              "type": "Record<string, any>",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeFact": {
+          "name": "removeFact",
+          "async": true,
+          "parameters": [
+            {
+              "name": "factId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "FactContentRelationship",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "syncFacts": {
+          "name": "syncFacts",
+          "async": true,
+          "parameters": [
+            {
+              "name": "factIds",
+              "type": "string[]",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "FactContentRelationship",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<object>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "browseFacts": {
+          "name": "browseFacts",
+          "async": true,
+          "parameters": [
+            {
+              "name": "query",
+              "type": "any",
+              "optional": true,
+              "default": ""
+            },
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Fact[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "repairFactAudit": {
+          "name": "repairFactAudit",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "repairFactAuditAction": {
+          "name": "repairFactAuditAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "repairFactEvidence": {
+          "name": "repairFactEvidence",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactAuditResourceRepairOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "repairFactEvidenceAction": {
+          "name": "repairFactEvidenceAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactAuditResourceRepairOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recheckFactClaims": {
+          "name": "recheckFactClaims",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactAuditClaimRecheckOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recheckFactClaimsAction": {
+          "name": "recheckFactClaimsAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactAuditClaimRecheckOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateFactEvidenceStatus": {
+          "name": "updateFactEvidenceStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactEvidenceStatusUpdateOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateFactEvidenceStatusAction": {
+          "name": "updateFactEvidenceStatusAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactEvidenceStatusUpdateOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFactAuditState": {
+          "name": "getFactAuditState",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<FactAuditState>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFactAuditStateAction": {
+          "name": "getFactAuditStateAction",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFactsState": {
+          "name": "getFactsState",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "syncFactsState": {
+          "name": "syncFactsState",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "createVersion": {
+          "name": "createVersion",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "CreateContentVersionOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getVersions": {
+          "name": "getVersions",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "restoreFromVersion": {
+          "name": "restoreFromVersion",
+          "async": true,
+          "parameters": [
+            {
+              "name": "versionNumber",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getReviews": {
+          "name": "getReviews",
+          "async": true,
+          "parameters": [
+            {
+              "name": "kind",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listReviews": {
+          "name": "listReviews",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getReviewRequirements": {
+          "name": "getReviewRequirements",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileKey",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "governance",
+              "type": "ResolvedContentGovernance",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getGovernanceState": {
+          "name": "getGovernanceState",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<ContentGovernanceState>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getGovernanceStateAction": {
+          "name": "getGovernanceStateAction",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listReviewProfilesAction": {
+          "name": "listReviewProfilesAction",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "evaluateReviewProfile": {
+          "name": "evaluateReviewProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileKey",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ContentReviewProfileEvaluation>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "evaluateReviewProfileAction": {
+          "name": "evaluateReviewProfileAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isReadyForReviewProfile": {
+          "name": "isReadyForReviewProfile",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileKey",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getPublishedTransparency": {
+          "name": "getPublishedTransparency",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getPublishedTransparencyAction": {
+          "name": "getPublishedTransparencyAction",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "previewTransparency": {
+          "name": "previewTransparency",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "previewTransparencyAction": {
+          "name": "previewTransparencyAction",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "runReview": {
+          "name": "runReview",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "RunContentReviewOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "runReviewAction": {
+          "name": "runReviewAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "RunContentReviewOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "reviewFacts": {
+          "name": "reviewFacts",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "Omit<RunContentReviewOptions, 'kind'>",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "reviewSafety": {
+          "name": "reviewSafety",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "Omit<RunContentReviewOptions, 'kind'>",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getCorrections": {
+          "name": "getCorrections",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listCorrections": {
+          "name": "listCorrections",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "issueCorrection": {
+          "name": "issueCorrection",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "IssueContentCorrectionOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "issueCorrectionAction": {
+          "name": "issueCorrectionAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "IssueContentCorrectionOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listVersions": {
+          "name": "listVersions",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "mutateVersionAction": {
+          "name": "mutateVersionAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getCategorySegments": {
+          "name": "getCategorySegments",
+          "async": false,
+          "parameters": [],
+          "returnType": "string[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParentCategory": {
+          "name": "getParentCategory",
+          "async": false,
+          "parameters": [],
+          "returnType": "string | null",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRootCategory": {
+          "name": "getRootCategory",
+          "async": false,
+          "parameters": [],
+          "returnType": "string | null",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAncestorPaths": {
+          "name": "getAncestorPaths",
+          "async": false,
+          "parameters": [],
+          "returnType": "string[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isInCategory": {
+          "name": "isInCategory",
+          "async": false,
+          "parameters": [
+            {
+              "name": "categoryPath",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "includeChildren",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAssets": {
+          "name": "getAssets",
+          "async": true,
+          "parameters": [
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addAsset": {
+          "name": "addAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "asset",
+              "type": "Asset",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "any",
+              "optional": true,
+              "default": "attachment"
+            },
+            {
+              "name": "sortOrder",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeAsset": {
+          "name": "removeAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "assetId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setMetadata": {
+          "name": "setMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "metadata",
+              "type": "Record<string, any> | null | undefined",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateMetadata": {
+          "name": "updateMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "patch",
+              "type": "Partial<Record<string, any>>",
+              "optional": false
+            }
+          ],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getThumbnail": {
+          "name": "getThumbnail",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Image | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setThumbnail": {
+          "name": "setThumbnail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "image",
+              "type": "Image",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateThumbnail": {
+          "name": "generateThumbnail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "ThumbnailOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Image>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": false,
+        "mcp": false,
+        "cli": false,
+        "tableName": "contents"
+      },
+      "extends": "Content",
+      "exportName": "ContentDocument",
+      "collectionExportName": "ContentDocumentCollection",
+      "validationRules": [
+        {
+          "field": "name",
+          "rule": "required",
+          "fieldType": "text"
+        }
+      ],
+      "schema": {
+        "tableName": "contents",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type\" TEXT,\n  \"variant\" TEXT,\n  \"file_key\" TEXT,\n  \"author\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"body_format\" TEXT,\n  \"publish_date\" TIMESTAMP,\n  \"url\" TEXT,\n  \"source\" TEXT,\n  \"original_url\" TEXT,\n  \"language\" TEXT,\n  \"tags\" JSONB DEFAULT '[]',\n  \"category\" TEXT,\n  \"status\" TEXT DEFAULT 'draft',\n  \"state\" TEXT DEFAULT 'active',\n  \"metadata\" JSONB DEFAULT '{}',\n  \"thumbnail_asset_id\" uuid\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "type": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "variant": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "file_key": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "author": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "title": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "body": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "body_format": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "publish_date": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          },
+          "url": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "source": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "original_url": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "language": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "tags": {
+            "type": "JSON",
+            "notNull": false,
+            "default": []
+          },
+          "category": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "draft"
+          },
+          "state": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "active"
+          },
+          "metadata": {
+            "type": "JSON",
+            "notNull": false,
+            "default": {}
+          },
+          "thumbnail_asset_id": {
+            "type": "UUID",
+            "notNull": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "contents_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "contents_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "contents_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "55c307f2"
+      }
+    },
+    "@happyvertical/smrt-content:Mirror": {
+      "name": "mirror",
+      "className": "Mirror",
+      "qualifiedName": "@happyvertical/smrt-content:Mirror",
+      "collection": "contents",
+      "filePath": "packages/content/src/content-types.ts",
+      "packageName": "@happyvertical/smrt-content",
+      "fields": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "type": {
+          "type": "text",
+          "required": false
+        },
+        "variant": {
+          "type": "text",
+          "required": false
+        },
+        "fileKey": {
+          "type": "text",
+          "required": false
+        },
+        "author": {
+          "type": "text",
+          "required": false
+        },
+        "name": {
+          "type": "text",
+          "required": true,
+          "default": "",
+          "_meta": {
+            "required": true
+          }
+        },
+        "title": {
+          "type": "text",
+          "required": false
+        },
+        "description": {
+          "type": "text",
+          "required": false
+        },
+        "body": {
+          "type": "text",
+          "required": false
+        },
+        "bodyFormat": {
+          "type": "text",
+          "required": false
+        },
+        "publish_date": {
+          "type": "datetime",
+          "required": false
+        },
+        "url": {
+          "type": "text",
+          "required": false
+        },
+        "source": {
+          "type": "text",
+          "required": false
+        },
+        "original_url": {
+          "type": "text",
+          "required": false
+        },
+        "language": {
+          "type": "text",
+          "required": false
+        },
+        "tags": {
+          "type": "json",
+          "required": false,
+          "default": []
+        },
+        "category": {
+          "type": "text",
+          "required": false
+        },
+        "status": {
+          "type": "text",
+          "required": false,
+          "default": "draft"
+        },
+        "state": {
+          "type": "text",
+          "required": false,
+          "default": "active"
+        },
+        "metadata": {
+          "type": "json",
+          "required": false,
+          "default": {}
+        },
+        "thumbnailAssetId": {
+          "type": "crossPackageRef",
+          "required": false,
+          "related": "@happyvertical/smrt-assets:Asset"
+        },
+        "feedSourceId": {
+          "type": "foreignKey",
+          "required": false,
+          "related": "ContentFeedSource"
         },
         "sourceGuid": {
           "type": "text",
@@ -7559,6 +8378,134 @@
           "isStatic": false,
           "isPublic": true
         },
+        "repairFactAudit": {
+          "name": "repairFactAudit",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "repairFactAuditAction": {
+          "name": "repairFactAuditAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "repairFactEvidence": {
+          "name": "repairFactEvidence",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactAuditResourceRepairOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "repairFactEvidenceAction": {
+          "name": "repairFactEvidenceAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactAuditResourceRepairOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recheckFactClaims": {
+          "name": "recheckFactClaims",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactAuditClaimRecheckOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recheckFactClaimsAction": {
+          "name": "recheckFactClaimsAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactAuditClaimRecheckOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateFactEvidenceStatus": {
+          "name": "updateFactEvidenceStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactEvidenceStatusUpdateOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateFactEvidenceStatusAction": {
+          "name": "updateFactEvidenceStatusAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactEvidenceStatusUpdateOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFactAuditState": {
+          "name": "getFactAuditState",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<FactAuditState>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFactAuditStateAction": {
+          "name": "getFactAuditStateAction",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
         "getFactsState": {
           "name": "getFactsState",
           "async": true,
@@ -7999,6 +8946,42 @@
           "isStatic": false,
           "isPublic": true
         },
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setMetadata": {
+          "name": "setMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "metadata",
+              "type": "Record<string, any> | null | undefined",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateMetadata": {
+          "name": "updateMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "patch",
+              "type": "Partial<Record<string, any>>",
+              "optional": false
+            }
+          ],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
         "getThumbnail": {
           "name": "getThumbnail",
           "async": true,
@@ -8055,10 +9038,10 @@
       ],
       "schema": {
         "tableName": "contents",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type\" TEXT,\n  \"variant\" TEXT,\n  \"file_key\" TEXT,\n  \"author\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"body_format\" TEXT,\n  \"publish_date\" TIMESTAMP,\n  \"url\" TEXT,\n  \"source\" TEXT,\n  \"original_url\" TEXT,\n  \"language\" TEXT,\n  \"tags\" JSON DEFAULT '[]',\n  \"category\" TEXT,\n  \"status\" TEXT DEFAULT 'draft',\n  \"state\" TEXT DEFAULT 'active',\n  \"metadata\" JSON DEFAULT '{}',\n  \"thumbnail_asset_id\" TEXT,\n  \"feed_source_id\" TEXT,\n  \"source_guid\" TEXT,\n  \"source_name\" TEXT,\n  \"source_homepage_url\" TEXT,\n  \"external_url\" TEXT,\n  \"original_published_at\" TIMESTAMP,\n  \"dedupe_key\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type\" TEXT,\n  \"variant\" TEXT,\n  \"file_key\" TEXT,\n  \"author\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"body_format\" TEXT,\n  \"publish_date\" TIMESTAMP,\n  \"url\" TEXT,\n  \"source\" TEXT,\n  \"original_url\" TEXT,\n  \"language\" TEXT,\n  \"tags\" JSONB DEFAULT '[]',\n  \"category\" TEXT,\n  \"status\" TEXT DEFAULT 'draft',\n  \"state\" TEXT DEFAULT 'active',\n  \"metadata\" JSONB DEFAULT '{}',\n  \"thumbnail_asset_id\" uuid,\n  \"feed_source_id\" uuid,\n  \"source_guid\" TEXT,\n  \"source_name\" TEXT,\n  \"source_homepage_url\" TEXT,\n  \"external_url\" TEXT,\n  \"original_published_at\" TIMESTAMP,\n  \"dedupe_key\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -8175,11 +9158,11 @@
             "default": {}
           },
           "thumbnail_asset_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "feed_source_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "source_guid": {
@@ -8230,7 +9213,7 @@
             ]
           }
         ],
-        "version": "d53c72d1"
+        "version": "f45d26f5"
       }
     },
     "@happyvertical/smrt-content:ContentVersion": {
@@ -8238,15 +9221,13 @@
       "className": "ContentVersion",
       "qualifiedName": "@happyvertical/smrt-content:ContentVersion",
       "collection": "contentversions",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-version.ts",
+      "filePath": "packages/content/src/content-version.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {
         "contentId": {
-          "type": "text",
-          "required": true,
-          "_meta": {
-            "required": true
-          }
+          "type": "foreignKey",
+          "required": false,
+          "related": "Content"
         },
         "version": {
           "type": "integer",
@@ -8367,11 +9348,6 @@
       "collectionExportName": "ContentVersionCollection",
       "validationRules": [
         {
-          "field": "contentId",
-          "rule": "required",
-          "fieldType": "text"
-        },
-        {
           "field": "version",
           "rule": "required",
           "fieldType": "integer"
@@ -8379,10 +9355,10 @@
       ],
       "schema": {
         "tableName": "content_versions",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_versions\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"content_id\" TEXT NOT NULL,\n  \"version\" INTEGER NOT NULL DEFAULT 1,\n  \"kind\" TEXT DEFAULT 'manual',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"status\" TEXT,\n  \"summary\" TEXT,\n  \"snapshot\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_versions\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"content_id\" uuid,\n  \"version\" INTEGER NOT NULL DEFAULT 1,\n  \"kind\" TEXT DEFAULT 'manual',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"status\" TEXT,\n  \"summary\" TEXT,\n  \"snapshot\" TEXT,\n  \"metadata\" TEXT,\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -8406,8 +9382,8 @@
             "default": "current_timestamp"
           },
           "content_id": {
-            "type": "TEXT",
-            "notNull": true,
+            "type": "UUID",
+            "notNull": false,
             "unique": false
           },
           "version": {
@@ -8479,7 +9455,7 @@
             "unique": true
           }
         ],
-        "version": "00c53e9b"
+        "version": "af652f1d"
       }
     },
     "@happyvertical/smrt-content:ContentVersionCollection": {
@@ -8487,7 +9463,7 @@
       "className": "ContentVersionCollection",
       "qualifiedName": "@happyvertical/smrt-content:ContentVersionCollection",
       "collection": "contentversions",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content-versions.ts",
+      "filePath": "packages/content/src/content-versions.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {},
       "methods": {
@@ -8614,10 +9590,10 @@
       "collectionExportName": "ContentVersionCollectionCollection",
       "schema": {
         "tableName": "content_versions",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_versions\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"content_versions\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -8657,7 +9633,7 @@
             "unique": true
           }
         ],
-        "version": "05b69246"
+        "version": "341957d7"
       }
     },
     "@happyvertical/smrt-content:Content": {
@@ -8665,9 +9641,17 @@
       "className": "Content",
       "qualifiedName": "@happyvertical/smrt-content:Content",
       "collection": "contents",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/content.ts",
+      "filePath": "packages/content/src/content.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
         "tenantId": {
           "type": "text",
           "required": false
@@ -8757,8 +9741,9 @@
           "default": {}
         },
         "thumbnailAssetId": {
-          "type": "text",
-          "required": false
+          "type": "crossPackageRef",
+          "required": false,
+          "related": "@happyvertical/smrt-assets:Asset"
         }
       },
       "methods": {
@@ -9343,6 +10328,134 @@
           "isStatic": false,
           "isPublic": true
         },
+        "repairFactAudit": {
+          "name": "repairFactAudit",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "repairFactAuditAction": {
+          "name": "repairFactAuditAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "repairFactEvidence": {
+          "name": "repairFactEvidence",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactAuditResourceRepairOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "repairFactEvidenceAction": {
+          "name": "repairFactEvidenceAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactAuditResourceRepairOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recheckFactClaims": {
+          "name": "recheckFactClaims",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactAuditClaimRecheckOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recheckFactClaimsAction": {
+          "name": "recheckFactClaimsAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactAuditClaimRecheckOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateFactEvidenceStatus": {
+          "name": "updateFactEvidenceStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactEvidenceStatusUpdateOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateFactEvidenceStatusAction": {
+          "name": "updateFactEvidenceStatusAction",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "FactEvidenceStatusUpdateOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFactAuditState": {
+          "name": "getFactAuditState",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<FactAuditState>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFactAuditStateAction": {
+          "name": "getFactAuditStateAction",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
         "getFactsState": {
           "name": "getFactsState",
           "async": true,
@@ -9783,6 +10896,42 @@
           "isStatic": false,
           "isPublic": true
         },
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setMetadata": {
+          "name": "setMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "metadata",
+              "type": "Record<string, any> | null | undefined",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateMetadata": {
+          "name": "updateMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "patch",
+              "type": "Partial<Record<string, any>>",
+              "optional": false
+            }
+          ],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
         "getThumbnail": {
           "name": "getThumbnail",
           "async": true,
@@ -9831,6 +10980,11 @@
             "delete",
             "getFactsState",
             "syncFactsState",
+            "getFactAuditStateAction",
+            "repairFactAuditAction",
+            "repairFactEvidenceAction",
+            "recheckFactClaimsAction",
+            "updateFactEvidenceStatusAction",
             "getGovernanceStateAction",
             "listReviews",
             "runReviewAction",
@@ -9851,6 +11005,26 @@
             "syncFactsState": {
               "method": "PUT",
               "path": "facts"
+            },
+            "getFactAuditStateAction": {
+              "method": "GET",
+              "path": "fact-audit"
+            },
+            "repairFactAuditAction": {
+              "method": "POST",
+              "path": "fact-audit/repair"
+            },
+            "repairFactEvidenceAction": {
+              "method": "POST",
+              "path": "fact-audit/evidence/repair"
+            },
+            "recheckFactClaimsAction": {
+              "method": "POST",
+              "path": "fact-audit/claims/recheck"
+            },
+            "updateFactEvidenceStatusAction": {
+              "method": "PUT",
+              "path": "fact-audit/evidence/status"
             },
             "getGovernanceStateAction": {
               "method": "GET",
@@ -9926,10 +11100,10 @@
       ],
       "schema": {
         "tableName": "contents",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type\" TEXT,\n  \"variant\" TEXT,\n  \"file_key\" TEXT,\n  \"author\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"body_format\" TEXT,\n  \"publish_date\" TIMESTAMP,\n  \"url\" TEXT,\n  \"source\" TEXT,\n  \"original_url\" TEXT,\n  \"language\" TEXT,\n  \"tags\" JSON DEFAULT '[]',\n  \"category\" TEXT,\n  \"status\" TEXT DEFAULT 'draft',\n  \"state\" TEXT DEFAULT 'active',\n  \"metadata\" JSON DEFAULT '{}',\n  \"thumbnail_asset_id\" TEXT,\n  \"feed_source_id\" TEXT,\n  \"source_guid\" TEXT,\n  \"source_name\" TEXT,\n  \"source_homepage_url\" TEXT,\n  \"external_url\" TEXT,\n  \"original_published_at\" TIMESTAMP,\n  \"dedupe_key\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type\" TEXT,\n  \"variant\" TEXT,\n  \"file_key\" TEXT,\n  \"author\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"title\" TEXT,\n  \"description\" TEXT,\n  \"body\" TEXT,\n  \"body_format\" TEXT,\n  \"publish_date\" TIMESTAMP,\n  \"url\" TEXT,\n  \"source\" TEXT,\n  \"original_url\" TEXT,\n  \"language\" TEXT,\n  \"tags\" JSONB DEFAULT '[]',\n  \"category\" TEXT,\n  \"status\" TEXT DEFAULT 'draft',\n  \"state\" TEXT DEFAULT 'active',\n  \"metadata\" JSONB DEFAULT '{}',\n  \"thumbnail_asset_id\" uuid,\n  \"feed_source_id\" uuid,\n  \"source_guid\" TEXT,\n  \"source_name\" TEXT,\n  \"source_homepage_url\" TEXT,\n  \"external_url\" TEXT,\n  \"original_published_at\" TIMESTAMP,\n  \"dedupe_key\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -10046,11 +11220,11 @@
             "default": {}
           },
           "thumbnail_asset_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "feed_source_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "source_guid": {
@@ -10101,7 +11275,7 @@
             ]
           }
         ],
-        "version": "1084d7e1"
+        "version": "af288b0a"
       }
     },
     "@happyvertical/smrt-content:Contents": {
@@ -10109,7 +11283,7 @@
       "className": "Contents",
       "qualifiedName": "@happyvertical/smrt-content:Contents",
       "collection": "contents",
-      "filePath": "/Users/will/.codex/worktrees/e81a/smrt/packages/content/src/contents.ts",
+      "filePath": "packages/content/src/contents.ts",
       "packageName": "@happyvertical/smrt-content",
       "fields": {
         "contentDir": {
@@ -10328,10 +11502,10 @@
       ],
       "schema": {
         "tableName": "contents",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"content_dir\" TEXT,\n  \"loaded\" JSON NOT NULL\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"contents\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"content_dir\" TEXT,\n  \"loaded\" JSONB NOT NULL\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -10381,479 +11555,15 @@
             "unique": true
           }
         ],
-        "version": "03fead76"
-      }
-    },
-    "@happyvertical/smrt-content:ContentFeedSource": {
-      "name": "contentfeedsource",
-      "className": "ContentFeedSource",
-      "qualifiedName": "@happyvertical/smrt-content:ContentFeedSource",
-      "collection": "contentfeedsources",
-      "filePath": "/Users/will/.codex/worktrees/8c80/smrt/packages/content/src/content-feed-source.ts",
-      "packageName": "@happyvertical/smrt-content",
-      "fields": {
-        "tenantId": {
-          "type": "text",
-          "required": false
-        },
-        "name": {
-          "type": "text",
-          "required": true,
-          "_meta": {
-            "required": true
-          }
-        },
-        "feedUrl": {
-          "type": "text",
-          "required": true,
-          "_meta": {
-            "required": true
-          }
-        },
-        "homepageUrl": {
-          "type": "text",
-          "required": false
-        },
-        "format": {
-          "type": "text",
-          "required": false
-        },
-        "status": {
-          "type": "text",
-          "required": true,
-          "default": "active",
-          "_meta": {
-            "required": true,
-            "default": "active"
-          }
-        },
-        "defaultCategory": {
-          "type": "text",
-          "required": false
-        },
-        "sourceGroup": {
-          "type": "text",
-          "required": false
-        },
-        "pollIntervalMinutes": {
-          "type": "integer",
-          "required": true,
-          "default": 15
-        },
-        "etag": {
-          "type": "text",
-          "required": false
-        },
-        "lastModified": {
-          "type": "text",
-          "required": false
-        },
-        "lastFetchedAt": {
-          "type": "datetime",
-          "required": false
-        },
-        "lastSuccessAt": {
-          "type": "datetime",
-          "required": false
-        },
-        "lastError": {
-          "type": "text",
-          "required": false
-        },
-        "metadata": {
-          "type": "json",
-          "required": false,
-          "default": {}
-        },
-        "createdAt": {
-          "type": "text",
-          "required": false
-        },
-        "updatedAt": {
-          "type": "text",
-          "required": false
-        }
-      },
-      "methods": {
-        "getMetadata": {
-          "name": "getMetadata",
-          "async": false,
-          "parameters": [],
-          "returnType": "Record<string, any>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "setMetadata": {
-          "name": "setMetadata",
-          "async": false,
-          "parameters": [
-            {
-              "name": "metadata",
-              "type": "Record<string, any>",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "markFetchStarted": {
-          "name": "markFetchStarted",
-          "async": false,
-          "parameters": [
-            {
-              "name": "at",
-              "type": "any",
-              "optional": true
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "markFetchSucceeded": {
-          "name": "markFetchSucceeded",
-          "async": false,
-          "parameters": [
-            {
-              "name": "at",
-              "type": "any",
-              "optional": true
-            },
-            {
-              "name": "headers",
-              "type": "object",
-              "optional": true
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "markFetchFailed": {
-          "name": "markFetchFailed",
-          "async": false,
-          "parameters": [
-            {
-              "name": "error",
-              "type": "any",
-              "optional": false
-            },
-            {
-              "name": "at",
-              "type": "any",
-              "optional": true
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "tableName": "content_feed_sources",
-        "conflictColumns": [
-          "tenant_id",
-          "feed_url"
-        ],
-        "api": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update",
-            "delete"
-          ]
-        },
-        "mcp": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update",
-            "delete"
-          ]
-        },
-        "cli": true
-      },
-      "extends": "SmrtObject",
-      "exportName": "ContentFeedSource",
-      "collectionExportName": "ContentFeedSourceCollection",
-      "validationRules": [
-        {
-          "field": "name",
-          "rule": "required",
-          "fieldType": "text"
-        },
-        {
-          "field": "feedUrl",
-          "rule": "required",
-          "fieldType": "text"
-        },
-        {
-          "field": "status",
-          "rule": "required",
-          "fieldType": "text"
-        },
-        {
-          "field": "pollIntervalMinutes",
-          "rule": "required",
-          "fieldType": "integer"
-        }
-      ],
-      "schema": {
-        "tableName": "content_feed_sources",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_feed_sources\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT NOT NULL,\n  \"feed_url\" TEXT NOT NULL,\n  \"homepage_url\" TEXT,\n  \"format\" TEXT,\n  \"status\" TEXT NOT NULL DEFAULT 'active',\n  \"default_category\" TEXT,\n  \"source_group\" TEXT,\n  \"poll_interval_minutes\" INTEGER NOT NULL DEFAULT 15,\n  \"etag\" TEXT,\n  \"last_modified\" TEXT,\n  \"last_fetched_at\" TIMESTAMP,\n  \"last_success_at\" TIMESTAMP,\n  \"last_error\" TEXT,\n  \"metadata\" JSON DEFAULT '{}'\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "tenant_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "unique": false
-          },
-          "name": {
-            "type": "TEXT",
-            "notNull": true,
-            "unique": false
-          },
-          "feed_url": {
-            "type": "TEXT",
-            "notNull": true,
-            "unique": false
-          },
-          "homepage_url": {
-            "type": "TEXT",
-            "notNull": false,
-            "unique": false
-          },
-          "format": {
-            "type": "TEXT",
-            "notNull": false,
-            "unique": false
-          },
-          "status": {
-            "type": "TEXT",
-            "notNull": true,
-            "unique": false,
-            "default": "active"
-          },
-          "default_category": {
-            "type": "TEXT",
-            "notNull": false,
-            "unique": false
-          },
-          "source_group": {
-            "type": "TEXT",
-            "notNull": false,
-            "unique": false
-          },
-          "poll_interval_minutes": {
-            "type": "INTEGER",
-            "notNull": true,
-            "unique": false,
-            "default": 15
-          },
-          "etag": {
-            "type": "TEXT",
-            "notNull": false,
-            "unique": false
-          },
-          "last_modified": {
-            "type": "TEXT",
-            "notNull": false,
-            "unique": false
-          },
-          "last_fetched_at": {
-            "type": "TIMESTAMP",
-            "notNull": false,
-            "unique": false
-          },
-          "last_success_at": {
-            "type": "TIMESTAMP",
-            "notNull": false,
-            "unique": false
-          },
-          "last_error": {
-            "type": "TEXT",
-            "notNull": false,
-            "unique": false
-          },
-          "metadata": {
-            "type": "JSON",
-            "notNull": false,
-            "unique": false,
-            "default": {}
-          }
-        },
-        "indexes": [
-          {
-            "name": "content_feed_sources_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "content_feed_sources_tenant_id_feed_url_idx",
-            "columns": [
-              "tenant_id",
-              "feed_url"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "de2bb298"
-      }
-    },
-    "@happyvertical/smrt-content:ContentFeedSourceCollection": {
-      "name": "contentfeedsourcecollection",
-      "className": "ContentFeedSourceCollection",
-      "qualifiedName": "@happyvertical/smrt-content:ContentFeedSourceCollection",
-      "collection": "contentfeedsources",
-      "filePath": "/Users/will/.codex/worktrees/8c80/smrt/packages/content/src/content-feed-sources.ts",
-      "packageName": "@happyvertical/smrt-content",
-      "fields": {},
-      "methods": {
-        "findActive": {
-          "name": "findActive",
-          "async": true,
-          "parameters": [
-            {
-              "name": "tenantId",
-              "type": "string | null",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<ContentFeedSource[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByStatus": {
-          "name": "findByStatus",
-          "async": true,
-          "parameters": [
-            {
-              "name": "status",
-              "type": "ContentFeedSourceStatus",
-              "optional": false
-            },
-            {
-              "name": "tenantId",
-              "type": "string | null",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<ContentFeedSource[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByFeedUrl": {
-          "name": "findByFeedUrl",
-          "async": true,
-          "parameters": [
-            {
-              "name": "feedUrl",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "tenantId",
-              "type": "string | null",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<ContentFeedSource | null>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "tableName": "content_feed_sources"
-      },
-      "extends": "SmrtCollection",
-      "extendsTypeArg": "ContentFeedSource",
-      "exportName": "ContentFeedSourceCollection",
-      "collectionExportName": "ContentFeedSourceCollectionCollection",
-      "schema": {
-        "tableName": "content_feed_sources",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"content_feed_sources\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          }
-        },
-        "indexes": [
-          {
-            "name": "content_feed_sources_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "content_feed_sources_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "ba9617ce"
+        "version": "33c2d9b6"
       }
     }
   },
   "moduleType": "smrt",
   "smrtDependencies": [
     "@happyvertical/smrt-assets",
-    "@happyvertical/smrt-chat",
     "@happyvertical/smrt-core",
-    "@happyvertical/smrt-facts",
-    "@happyvertical/smrt-images",
     "@happyvertical/smrt-messages",
-    "@happyvertical/smrt-profiles",
-    "@happyvertical/smrt-tenancy"
+    "@happyvertical/smrt-profiles"
   ]
 }

--- a/packages/core/src/__tests__/cross-package-ref.test.ts
+++ b/packages/core/src/__tests__/cross-package-ref.test.ts
@@ -1,10 +1,10 @@
 /**
  * Cross-package reference (`@crossPackageRef`) tests (R1).
  *
- * Cross-package refs are plain TEXT columns at the database level — no FK
- * constraint — but carry registry metadata so that `loadRelated()`, eager
- * loading via `include`, and optional save-time existence validation can work
- * across package boundaries without requiring a hard import of the target class.
+ * Cross-package refs are id columns with no FK constraint, but carry registry
+ * metadata so that `loadRelated()`, eager loading via `include`, and optional
+ * save-time existence validation can work across package boundaries without
+ * requiring a hard import of the target class.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -85,7 +85,7 @@ describe('@crossPackageRef (R1)', () => {
       expect(contactRel?.type).toBe('crossPackageRef');
     });
 
-    it('emits a plain TEXT column with no FK constraint', async () => {
+    it('emits a SQLite TEXT column with no FK constraint', async () => {
       // Initialize collection so the schema is materialized
       await ObjectRegistry.getCollection<typeof XPRefSourceCustomer.prototype>(
         'XPRefSourceCustomer',

--- a/packages/core/src/__tests__/issue-198-duckdb-datetime-compatibility.test.ts
+++ b/packages/core/src/__tests__/issue-198-duckdb-datetime-compatibility.test.ts
@@ -80,7 +80,7 @@ describe('Issue #198: DuckDB DATETIME Compatibility', () => {
 
     // Verify schema structure
     expect(schema).toContain('CREATE TABLE IF NOT EXISTS');
-    expect(schema).toContain('"id" TEXT PRIMARY KEY');
+    expect(schema).toContain('"id" UUID PRIMARY KEY');
     expect(schema).toContain(
       '"created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp',
     );

--- a/packages/core/src/__tests__/schema-generation.test.ts
+++ b/packages/core/src/__tests__/schema-generation.test.ts
@@ -130,7 +130,7 @@ describe('Issue #144: Schema Generation Duplicate Columns', () => {
     // - CREATE INDEX statements
 
     expect(schema).toContain(`CREATE TABLE IF NOT EXISTS "${tableName}"`);
-    expect(schema).toContain('"id" TEXT PRIMARY KEY');
+    expect(schema).toContain('"id" UUID PRIMARY KEY');
     expect(schema).toContain('"slug" TEXT NOT NULL');
     expect(schema).toContain('"context" TEXT NOT NULL');
     expect(schema).toContain('"title" TEXT NOT NULL'); // required: true
@@ -159,7 +159,7 @@ describe('Issue #144: Schema Generation Duplicate Columns', () => {
     const schema = await generateSchema(SchemaGenArticle);
 
     // Verify all base SmrtObject fields are included (with quoted column names)
-    expect(schema).toContain('"id" TEXT PRIMARY KEY');
+    expect(schema).toContain('"id" UUID PRIMARY KEY');
     expect(schema).toContain('"slug" TEXT NOT NULL');
     expect(schema).toContain('"context" TEXT NOT NULL');
     expect(schema).toContain('"created_at" TIMESTAMP');
@@ -210,7 +210,7 @@ describe('Issue #144: Schema Generation Duplicate Columns', () => {
     const schema = await generateSchema(CustomPrimaryKeyRecord);
 
     expect(schema).toContain('"external_id" TEXT PRIMARY KEY');
-    expect(schema).not.toContain('"id" TEXT PRIMARY KEY');
+    expect(schema).not.toContain('"id" UUID PRIMARY KEY');
     expect(schema).not.toContain('"slug" TEXT NOT NULL');
     expect(schema).not.toContain('"context" TEXT NOT NULL');
     expect(schema).toContain('"created_at" TIMESTAMP');

--- a/packages/core/src/__tests__/schema-generation.test.ts
+++ b/packages/core/src/__tests__/schema-generation.test.ts
@@ -144,6 +144,15 @@ describe('Issue #144: Schema Generation Duplicate Columns', () => {
     expect(schema).not.toContain('UNIQUE INDEX');
   });
 
+  it('should render engine-specific DDL when requested', async () => {
+    const schema = await generateSchema(SchemaGenTestEvent, undefined, {
+      engine: 'sqlite',
+    });
+
+    expect(schema).toContain('"id" TEXT PRIMARY KEY');
+    expect(schema).not.toContain('"id" UUID PRIMARY KEY');
+  });
+
   it('should handle classes with explicit timestamp field definitions', async () => {
     const schema = await generateSchema(CustomTimestamps);
 

--- a/packages/core/src/__tests__/sti-schema-generation-unit.test.ts
+++ b/packages/core/src/__tests__/sti-schema-generation-unit.test.ts
@@ -5,9 +5,8 @@
  * without relying on full class registration and manifest loading.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ObjectRegistry } from '../registry';
 import type { FieldDefinition } from '../scanner/types';
 import { SchemaGenerator } from '../schema/generator';
 
@@ -22,27 +21,26 @@ function createField(
   };
 }
 
-// Mock ObjectRegistry methods for unit tests
-vi.mock('../registry', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../registry')>();
-  return {
-    ...actual,
-    ObjectRegistry: {
-      ...actual.ObjectRegistry,
-      getDescendants: vi.fn(),
-      getAllFields: vi.fn(),
-    },
-  };
-});
+const registry = {
+  getDescendants: vi.fn(),
+  getAllFields: vi.fn(),
+};
+
+const registryConfig = { registry };
 
 describe('STI Schema Generation (Unit)', () => {
+  beforeEach(() => {
+    registry.getDescendants.mockReset();
+    registry.getAllFields.mockReset();
+  });
+
   describe('generateSTISchemaFromRegistry', () => {
     it('should include type discriminator column', async () => {
       const generator = new SchemaGenerator();
 
       // Mock: Event base class with no descendants
-      vi.mocked(ObjectRegistry.getDescendants).mockReturnValue([]);
-      vi.mocked(ObjectRegistry.getAllFields).mockResolvedValue(
+      vi.mocked(registry.getDescendants).mockReturnValue([]);
+      vi.mocked(registry.getAllFields).mockResolvedValue(
         new Map([
           ['title', createField('text', { description: 'Event title' })],
         ]),
@@ -52,6 +50,7 @@ describe('STI Schema Generation (Unit)', () => {
         'Event',
         'events',
         new Map([['title', createField('text')]]),
+        registryConfig,
       );
       const sql = generator.generateSQL(schema);
 
@@ -66,8 +65,8 @@ describe('STI Schema Generation (Unit)', () => {
     it('should include meta JSON column', async () => {
       const generator = new SchemaGenerator();
 
-      vi.mocked(ObjectRegistry.getDescendants).mockReturnValue([]);
-      vi.mocked(ObjectRegistry.getAllFields).mockResolvedValue(
+      vi.mocked(registry.getDescendants).mockReturnValue([]);
+      vi.mocked(registry.getAllFields).mockResolvedValue(
         new Map([['title', createField('text')]]),
       );
 
@@ -75,6 +74,7 @@ describe('STI Schema Generation (Unit)', () => {
         'Event',
         'events',
         new Map([['title', createField('text')]]),
+        registryConfig,
       );
       const sql = generator.generateSQL(schema);
 
@@ -89,8 +89,8 @@ describe('STI Schema Generation (Unit)', () => {
     it('should include base class fields', async () => {
       const generator = new SchemaGenerator();
 
-      vi.mocked(ObjectRegistry.getDescendants).mockReturnValue([]);
-      vi.mocked(ObjectRegistry.getAllFields).mockResolvedValue(
+      vi.mocked(registry.getDescendants).mockReturnValue([]);
+      vi.mocked(registry.getAllFields).mockResolvedValue(
         new Map([
           ['title', createField('text', { description: 'Event title' })],
           [
@@ -107,6 +107,7 @@ describe('STI Schema Generation (Unit)', () => {
           ['title', createField('text')],
           ['description', createField('text')],
         ]),
+        registryConfig,
       );
 
       expect(schema.columns.title).toBeDefined();
@@ -116,8 +117,8 @@ describe('STI Schema Generation (Unit)', () => {
     it('should create unique index on slug, context, and type', async () => {
       const generator = new SchemaGenerator();
 
-      vi.mocked(ObjectRegistry.getDescendants).mockReturnValue([]);
-      vi.mocked(ObjectRegistry.getAllFields).mockResolvedValue(
+      vi.mocked(registry.getDescendants).mockReturnValue([]);
+      vi.mocked(registry.getAllFields).mockResolvedValue(
         new Map([['title', createField('text')]]),
       );
 
@@ -125,6 +126,7 @@ describe('STI Schema Generation (Unit)', () => {
         'Event',
         'events',
         new Map([['title', createField('text')]]),
+        registryConfig,
       );
 
       const uniqueIndex = schema.indexes.find(
@@ -139,8 +141,8 @@ describe('STI Schema Generation (Unit)', () => {
     it('should create index on type column for polymorphic queries', async () => {
       const generator = new SchemaGenerator();
 
-      vi.mocked(ObjectRegistry.getDescendants).mockReturnValue([]);
-      vi.mocked(ObjectRegistry.getAllFields).mockResolvedValue(
+      vi.mocked(registry.getDescendants).mockReturnValue([]);
+      vi.mocked(registry.getAllFields).mockResolvedValue(
         new Map([['title', createField('text')]]),
       );
 
@@ -148,6 +150,7 @@ describe('STI Schema Generation (Unit)', () => {
         'Event',
         'events',
         new Map([['title', createField('text')]]),
+        registryConfig,
       );
 
       const typeIndex = schema.indexes.find(
@@ -163,37 +166,36 @@ describe('STI Schema Generation (Unit)', () => {
       const generator = new SchemaGenerator();
 
       // Mock: Event has Meeting and HockeyGame descendants
-      vi.mocked(ObjectRegistry.getDescendants).mockReturnValue([
+      vi.mocked(registry.getDescendants).mockReturnValue([
         'Meeting',
         'HockeyGame',
       ]);
 
       // Mock field retrieval for each class
-      vi.mocked(ObjectRegistry.getAllFields).mockImplementation(
-        async (className) => {
-          if (className === 'Event') {
-            return new Map([['title', createField('text')]]);
-          }
-          if (className === 'Meeting') {
-            return new Map([
-              ['title', createField('text')], // Inherited
-              ['roomNumber', createField('text')],
-            ]);
-          }
-          if (className === 'HockeyGame') {
-            return new Map([
-              ['title', createField('text')], // Inherited
-              ['homeTeam', createField('text')],
-            ]);
-          }
-          return new Map();
-        },
-      );
+      vi.mocked(registry.getAllFields).mockImplementation(async (className) => {
+        if (className === 'Event') {
+          return new Map([['title', createField('text')]]);
+        }
+        if (className === 'Meeting') {
+          return new Map([
+            ['title', createField('text')], // Inherited
+            ['roomNumber', createField('text')],
+          ]);
+        }
+        if (className === 'HockeyGame') {
+          return new Map([
+            ['title', createField('text')], // Inherited
+            ['homeTeam', createField('text')],
+          ]);
+        }
+        return new Map();
+      });
 
       const schema = await generator.generateSTISchemaFromRegistry(
         'Event',
         'events',
         new Map([['title', createField('text')]]),
+        registryConfig,
       );
 
       // Should have base field
@@ -209,28 +211,25 @@ describe('STI Schema Generation (Unit)', () => {
     it('should make all non-base fields nullable', async () => {
       const generator = new SchemaGenerator();
 
-      vi.mocked(ObjectRegistry.getDescendants).mockReturnValue(['Meeting']);
-      vi.mocked(ObjectRegistry.getAllFields).mockImplementation(
-        async (className) => {
-          if (className === 'Event') {
-            return new Map([
-              ['title', createField('text', { required: true })],
-            ]);
-          }
-          if (className === 'Meeting') {
-            return new Map([
-              ['title', createField('text', { required: true })],
-              ['roomNumber', createField('text', { required: true })],
-            ]);
-          }
-          return new Map();
-        },
-      );
+      vi.mocked(registry.getDescendants).mockReturnValue(['Meeting']);
+      vi.mocked(registry.getAllFields).mockImplementation(async (className) => {
+        if (className === 'Event') {
+          return new Map([['title', createField('text', { required: true })]]);
+        }
+        if (className === 'Meeting') {
+          return new Map([
+            ['title', createField('text', { required: true })],
+            ['roomNumber', createField('text', { required: true })],
+          ]);
+        }
+        return new Map();
+      });
 
       const schema = await generator.generateSTISchemaFromRegistry(
         'Event',
         'events',
         new Map([['title', createField('text', { required: true })]]),
+        registryConfig,
       );
 
       // All fields should be nullable in STI (even if required: true)
@@ -241,35 +240,34 @@ describe('STI Schema Generation (Unit)', () => {
     it('should generate partial indexes for FK columns', async () => {
       const generator = new SchemaGenerator();
 
-      vi.mocked(ObjectRegistry.getDescendants).mockReturnValue(['Meeting']);
+      vi.mocked(registry.getDescendants).mockReturnValue(['Meeting']);
 
       // Mock Meeting with FK
-      vi.mocked(ObjectRegistry.getAllFields).mockImplementation(
-        async (className) => {
-          if (className === 'Event') {
-            return new Map([['title', createField('text')]]);
-          }
-          if (className === 'Meeting') {
-            return new Map([
-              ['title', createField('text')],
-              [
-                'roomId',
-                {
-                  type: 'foreignKey',
-                  related: 'Room',
-                  getSqlType: () => 'TEXT',
-                } as any,
-              ],
-            ]);
-          }
-          return new Map();
-        },
-      );
+      vi.mocked(registry.getAllFields).mockImplementation(async (className) => {
+        if (className === 'Event') {
+          return new Map([['title', createField('text')]]);
+        }
+        if (className === 'Meeting') {
+          return new Map([
+            ['title', createField('text')],
+            [
+              'roomId',
+              {
+                type: 'foreignKey',
+                related: 'Room',
+                getSqlType: () => 'TEXT',
+              } as any,
+            ],
+          ]);
+        }
+        return new Map();
+      });
 
       const schema = await generator.generateSTISchemaFromRegistry(
         'Event',
         'events',
         new Map([['title', createField('text')]]),
+        registryConfig,
       );
 
       // Should have partial index for room_id filtered by Meeting type
@@ -285,8 +283,8 @@ describe('STI Schema Generation (Unit)', () => {
     it('should handle class with no descendants', async () => {
       const generator = new SchemaGenerator();
 
-      vi.mocked(ObjectRegistry.getDescendants).mockReturnValue([]);
-      vi.mocked(ObjectRegistry.getAllFields).mockResolvedValue(
+      vi.mocked(registry.getDescendants).mockReturnValue([]);
+      vi.mocked(registry.getAllFields).mockResolvedValue(
         new Map([['title', createField('text')]]),
       );
 
@@ -294,6 +292,7 @@ describe('STI Schema Generation (Unit)', () => {
         'Event',
         'events',
         new Map([['title', createField('text')]]),
+        registryConfig,
       );
 
       // Should still generate valid schema

--- a/packages/core/src/__tests__/test-database-manifest-schema.test.ts
+++ b/packages/core/src/__tests__/test-database-manifest-schema.test.ts
@@ -253,4 +253,50 @@ describe('getTestDatabase manifest schemas', () => {
     expect(columnNames).toContain('_meta_data');
     expect(columnNames).toContain('name');
   });
+
+  it('uses JSON adapter DDL for JSON-like test databases', async () => {
+    const statements: string[] = [];
+    const db = {
+      exportTable: () => undefined,
+      query: async (sql: string) => {
+        statements.push(sql);
+        return { rows: [] };
+      },
+    };
+
+    ObjectRegistry.registerFromManifest(
+      '@test/pkg:JsonIndexedThing',
+      {
+        className: 'JsonIndexedThing',
+        fields: {
+          label: { type: 'text', required: true },
+        },
+        methods: {},
+        decoratorConfig: {
+          tableName: 'json_indexed_things',
+        },
+      },
+      '@test/pkg',
+    );
+
+    await getTestDatabase({
+      db: db as any,
+      classes: ['JsonIndexedThing'],
+      includeSystemTables: false,
+    });
+
+    const createTable = statements.find((sql) =>
+      sql.startsWith('CREATE TABLE IF NOT EXISTS "json_indexed_things"'),
+    );
+
+    expect(createTable).toContain('"id" TEXT PRIMARY KEY');
+    expect(createTable).toContain('UNIQUE("slug", "context")');
+    expect(
+      statements.some(
+        (sql) =>
+          sql.includes('CREATE UNIQUE INDEX') &&
+          sql.includes('json_indexed_things_slug_context_idx'),
+      ),
+    ).toBe(false);
+  });
 });

--- a/packages/core/src/__tests__/uuid-schema-generator.test.ts
+++ b/packages/core/src/__tests__/uuid-schema-generator.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import { ManifestGenerator } from '../scanner/manifest-generator';
+import type {
+  FieldDefinition,
+  ManifestSchema,
+  SmartObjectDefinition,
+  SmartObjectManifest,
+} from '../scanner/types';
+import { SchemaGenerator } from '../schema/generator';
+import type { SchemaDefinition } from '../schema/types';
+
+function objectDef(
+  className: string,
+  fields: Record<string, FieldDefinition> = {},
+  decoratorConfig: Record<string, unknown> = {},
+): SmartObjectDefinition {
+  return {
+    name: className.toLowerCase(),
+    className,
+    collection: `${className.toLowerCase()}s`,
+    filePath: `packages/test/src/${className}.ts`,
+    packageName: '@happyvertical/smrt-test',
+    packageVersion: '0.0.0',
+    fields,
+    methods: {},
+    decoratorConfig,
+  } as SmartObjectDefinition;
+}
+
+function manifest(
+  objects: Record<string, SmartObjectDefinition>,
+): SmartObjectManifest {
+  return {
+    version: '1.0.0',
+    timestamp: 0,
+    packageName: '@happyvertical/smrt-test',
+    objects,
+  };
+}
+
+function schemaDefinitionFromManifest(
+  schema: ManifestSchema,
+): SchemaDefinition {
+  return {
+    tableName: schema.tableName,
+    columns: Object.fromEntries(
+      Object.entries(schema.columns).map(([name, column]) => [
+        name,
+        {
+          type: column.type as SchemaDefinition['columns'][string]['type'],
+          primaryKey: column.primaryKey,
+          notNull: column.notNull,
+          unique: column.unique,
+          defaultValue: column.default,
+        },
+      ]),
+    ),
+    indexes: [],
+    triggers: [],
+    foreignKeys: [],
+    dependencies: [],
+    version: schema.version,
+  };
+}
+
+describe('R11 UUID schema generation', () => {
+  it('emits UUID ids and relationship columns by default', () => {
+    const generator = new SchemaGenerator();
+    const schema = generator.generateCTISchemaFromManifest(
+      'UuidSource',
+      'uuid_sources',
+      {
+        parentId: { type: 'foreignKey', related: 'UuidTarget' },
+        externalId: {
+          type: 'crossPackageRef',
+          related: '@happyvertical/smrt-other:ExternalTarget',
+        },
+      },
+    );
+
+    expect(schema.columns.id.type).toBe('UUID');
+    expect(schema.columns.parent_id.type).toBe('UUID');
+    expect(schema.columns.external_id.type).toBe('UUID');
+    expect(schema.ddl).toContain('"id" uuid PRIMARY KEY');
+    expect(schema.ddl).toContain('"parent_id" uuid');
+    expect(schema.ddl).toContain('"external_id" uuid');
+
+    const sqliteDDL = generator.generateSQL(
+      schemaDefinitionFromManifest(schema),
+      'sqlite',
+    );
+    expect(sqliteDDL).toContain('"id" TEXT PRIMARY KEY');
+    expect(sqliteDDL).toContain('"parent_id" TEXT');
+  });
+
+  it('honors idType text opt-out', () => {
+    const generator = new SchemaGenerator();
+    const schema = generator.generateCTISchemaFromManifest(
+      'TextIdSource',
+      'text_id_sources',
+      {},
+      { idType: 'text' },
+    );
+
+    expect(schema.columns.id.type).toBe('TEXT');
+    expect(schema.ddl).toContain('"id" TEXT PRIMARY KEY');
+  });
+
+  it('matches same-package FK columns to the target id type', () => {
+    const textTarget = objectDef('TextTarget', {}, { idType: 'text' });
+    const uuidTarget = objectDef('UuidTarget');
+    const source = objectDef('SourceModel', {
+      textTargetId: { type: 'foreignKey', related: 'TextTarget' },
+      uuidTargetId: { type: 'foreignKey', related: 'UuidTarget' },
+      externalId: {
+        type: 'crossPackageRef',
+        related: '@happyvertical/smrt-other:ExternalTarget',
+      },
+    });
+    const smrtManifest = manifest({
+      TextTarget: textTarget,
+      UuidTarget: uuidTarget,
+      SourceModel: source,
+    });
+
+    new ManifestGenerator().generateSchemas(smrtManifest);
+
+    expect(textTarget.schema?.columns.id.type).toBe('TEXT');
+    expect(uuidTarget.schema?.columns.id.type).toBe('UUID');
+    expect(source.schema?.columns.id.type).toBe('UUID');
+    expect(source.schema?.columns.text_target_id.type).toBe('TEXT');
+    expect(source.schema?.columns.uuid_target_id.type).toBe('UUID');
+    expect(source.schema?.columns.external_id.type).toBe('UUID');
+    expect(source.schema?.ddl).toContain('"text_target_id" TEXT');
+    expect(source.schema?.ddl).toContain('"uuid_target_id" uuid');
+  });
+
+  it('uses canonical pluralization when resolving FK target tables', () => {
+    const property = objectDef('Property', {}, { idType: 'text' });
+    const listing = objectDef('Listing', {
+      propertyId: { type: 'foreignKey', related: 'Property' },
+    });
+    const smrtManifest = manifest({ Property: property, Listing: listing });
+
+    new ManifestGenerator().generateSchemas(smrtManifest);
+
+    expect(property.schema?.tableName).toBe('properties');
+    expect(listing.schema?.columns.property_id.type).toBe('TEXT');
+    expect(listing.schema?.ddl).toContain('"property_id" TEXT');
+  });
+});

--- a/packages/core/src/__tests__/uuid-schema-generator.test.ts
+++ b/packages/core/src/__tests__/uuid-schema-generator.test.ts
@@ -13,6 +13,7 @@ function objectDef(
   className: string,
   fields: Record<string, FieldDefinition> = {},
   decoratorConfig: Record<string, unknown> = {},
+  extendsName?: string,
 ): SmartObjectDefinition {
   return {
     name: className.toLowerCase(),
@@ -24,6 +25,7 @@ function objectDef(
     fields,
     methods: {},
     decoratorConfig,
+    extends: extendsName,
   } as SmartObjectDefinition;
 }
 
@@ -81,9 +83,17 @@ describe('R11 UUID schema generation', () => {
     expect(schema.columns.id.type).toBe('UUID');
     expect(schema.columns.parent_id.type).toBe('UUID');
     expect(schema.columns.external_id.type).toBe('UUID');
-    expect(schema.ddl).toContain('"id" uuid PRIMARY KEY');
-    expect(schema.ddl).toContain('"parent_id" uuid');
-    expect(schema.ddl).toContain('"external_id" uuid');
+    expect(schema.ddl).toContain('"id" UUID PRIMARY KEY');
+    expect(schema.ddl).toContain('"parent_id" UUID');
+    expect(schema.ddl).toContain('"external_id" UUID');
+
+    const postgresDDL = generator.generateSQL(
+      schemaDefinitionFromManifest(schema),
+      'postgres',
+    );
+    expect(postgresDDL).toContain('"id" uuid PRIMARY KEY');
+    expect(postgresDDL).toContain('"parent_id" uuid');
+    expect(postgresDDL).toContain('"external_id" uuid');
 
     const sqliteDDL = generator.generateSQL(
       schemaDefinitionFromManifest(schema),
@@ -132,7 +142,7 @@ describe('R11 UUID schema generation', () => {
     expect(source.schema?.columns.uuid_target_id.type).toBe('UUID');
     expect(source.schema?.columns.external_id.type).toBe('UUID');
     expect(source.schema?.ddl).toContain('"text_target_id" TEXT');
-    expect(source.schema?.ddl).toContain('"uuid_target_id" uuid');
+    expect(source.schema?.ddl).toContain('"uuid_target_id" UUID');
   });
 
   it('uses canonical pluralization when resolving FK target tables', () => {
@@ -147,5 +157,77 @@ describe('R11 UUID schema generation', () => {
     expect(property.schema?.tableName).toBe('properties');
     expect(listing.schema?.columns.property_id.type).toBe('TEXT');
     expect(listing.schema?.ddl).toContain('"property_id" TEXT');
+  });
+
+  it('normalizes inherited SmrtHierarchical parentId to a UUID self-FK', () => {
+    const hierarchicalBase = objectDef('SmrtHierarchical', {
+      parentId: { type: 'text', required: false },
+    });
+    const event = objectDef(
+      'Event',
+      { title: { type: 'text' } },
+      { tableStrategy: 'sti' },
+      'SmrtHierarchical',
+    );
+    const smrtManifest = manifest({
+      SmrtHierarchical: hierarchicalBase,
+      Event: event,
+    });
+    const generator = new ManifestGenerator();
+
+    (generator as any).mergeInheritedFields(smrtManifest);
+    generator.generateSchemas(smrtManifest);
+
+    expect(event.fields.parentId.type).toBe('foreignKey');
+    expect(event.fields.parentId.related).toBe('Event');
+    expect(event.schema?.columns.parent_id.type).toBe('UUID');
+    expect(event.schema?.ddl).toContain('"parent_id" UUID');
+  });
+
+  it('matches runtime FK columns to text id targets', () => {
+    const generator = new SchemaGenerator();
+    const schema = generator.generateSchemaFromRegistry(
+      'RuntimeSource',
+      'runtime_sources',
+      new Map([
+        [
+          'textTargetId',
+          { type: 'foreignKey', related: 'TextTarget', _meta: {} },
+        ],
+        [
+          'uuidTargetId',
+          { type: 'foreignKey', related: 'UuidTarget', _meta: {} },
+        ],
+      ]),
+      {
+        registry: {
+          getConfig: (className) =>
+            className === 'TextTarget' ? { idType: 'text' } : {},
+          getDescendants: () => [],
+          getAllFields: async () => new Map(),
+        },
+      },
+    );
+
+    expect(schema.columns.text_target_id.type).toBe('TEXT');
+    expect(schema.columns.uuid_target_id.type).toBe('UUID');
+  });
+
+  it('honors cross-package text id hints', () => {
+    const generator = new SchemaGenerator();
+    const schema = generator.generateCTISchemaFromManifest(
+      'SourceWithExternalTextId',
+      'source_with_external_text_ids',
+      {
+        externalId: {
+          type: 'crossPackageRef',
+          related: '@happyvertical/smrt-external:ExternalTextId',
+          _meta: { idType: 'text' },
+        },
+      },
+    );
+
+    expect(schema.columns.external_id.type).toBe('TEXT');
+    expect(schema.ddl).toContain('"external_id" TEXT');
   });
 });

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -135,6 +135,14 @@ export interface RelationshipFieldOptions extends FieldOptions {
 export interface CrossPackageRefOptions
   extends Omit<RelationshipFieldOptions, 'related' | 'type'> {
   /**
+   * Storage type for the referenced target id. Defaults to 'uuid'.
+   *
+   * Use 'text' only when the external target model declares
+   * `@smrt({ idType: 'text' })`.
+   */
+  idType?: 'uuid' | 'text';
+
+  /**
    * When `true`, the framework verifies the referenced object exists at save time.
    * Validation uses the target package's manifest (loaded on demand via
    * `ObjectRegistry.ensureManifestLoaded()`), so this requires the target manifest

--- a/packages/core/src/manifest/generator.ts
+++ b/packages/core/src/manifest/generator.ts
@@ -4,7 +4,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, isAbsolute, relative, resolve } from 'node:path';
 import fg from 'fast-glob';
 import { ManifestGenerator } from '../scanner/manifest-generator.js';
 import type { SmartObjectManifest } from '../scanner/types.js';
@@ -116,9 +116,42 @@ export class ManifestBuilder {
     );
 
     // 5. Write output files
+    this.normalizeFilePaths(manifest);
     await this.writeOutput(manifest, options);
 
     return manifest;
+  }
+
+  private normalizeFilePaths(manifest: SmartObjectManifest): void {
+    const workspaceRoot = this.findWorkspaceRoot(process.cwd());
+
+    for (const obj of Object.values(manifest.objects || {})) {
+      if (obj.filePath && isAbsolute(obj.filePath)) {
+        obj.filePath = relative(workspaceRoot, obj.filePath).replace(
+          /\\/g,
+          '/',
+        );
+      }
+    }
+  }
+
+  private findWorkspaceRoot(startDir: string): string {
+    let current = resolve(startDir);
+
+    while (true) {
+      if (
+        existsSync(resolve(current, 'pnpm-workspace.yaml')) ||
+        existsSync(resolve(current, '.git'))
+      ) {
+        return current;
+      }
+
+      const parent = dirname(current);
+      if (parent === current) {
+        return resolve(startDir);
+      }
+      current = parent;
+    }
   }
 
   /**

--- a/packages/core/src/migrations/__tests__/uuid-type.test.ts
+++ b/packages/core/src/migrations/__tests__/uuid-type.test.ts
@@ -143,4 +143,43 @@ describe('R11 differ tolerance: UUID <-> TEXT are equivalent', () => {
     );
     expect(idTypeChange).toBeUndefined();
   });
+
+  it('renders new UUID columns as TEXT for JSON adapter migrations', async () => {
+    const jsonDb = {
+      url: 'test.json',
+      exportTable: () => undefined,
+      query: async () => ({ rows: [{ name: 'things' }] }),
+      getTableSchema: async () => ({
+        tableName: 'things',
+        columns: {
+          id: { name: 'id', type: 'TEXT', primaryKey: true },
+        },
+        indexes: [],
+      }),
+    } as unknown as DatabaseProvider;
+    const jsonComparer = new SchemaComparer(jsonDb);
+
+    const diff = await jsonComparer.compare({
+      things: {
+        tableName: 'things',
+        ddl: '',
+        columns: {
+          id: { type: 'UUID', primaryKey: true },
+          related_id: { type: 'UUID' },
+        },
+        indexes: [],
+        triggers: [],
+        foreignKeys: [],
+        dependencies: [],
+        version: '1.0.0',
+      },
+    });
+
+    const addRelatedId = diff.changes.find(
+      (change) => change.type === 'add_column' && change.name === 'related_id',
+    );
+    expect(addRelatedId?.sql).toContain(
+      'ALTER TABLE "things" ADD COLUMN "related_id" TEXT',
+    );
+  });
 });

--- a/packages/core/src/migrations/__tests__/uuid-type.test.ts
+++ b/packages/core/src/migrations/__tests__/uuid-type.test.ts
@@ -23,6 +23,10 @@ describe('R11 UUID type mapping (per-dialect)', () => {
     expect(getDDLStrategy('duckdb').mapType('UUID')).toBe('UUID');
   });
 
+  it('maps UUID to TEXT on the JSON adapter to preserve JS round-tripping', () => {
+    expect(getDDLStrategy('json').mapType('UUID')).toBe('TEXT');
+  });
+
   it('maps UUID to TEXT on SQLite (no native uuid type)', () => {
     expect(getDDLStrategy('sqlite').mapType('UUID')).toBe('TEXT');
   });

--- a/packages/core/src/migrations/differ.ts
+++ b/packages/core/src/migrations/differ.ts
@@ -99,7 +99,10 @@ export class SchemaComparer {
     };
     // Use the shared detectEngine utility for consistent detection
     // Handles :memory:, .json, and other edge cases
-    this.engine = detectEngine(this.db.url || '');
+    this.engine =
+      typeof (this.db as any).exportTable === 'function'
+        ? 'json'
+        : detectEngine(this.db.url || '');
     this.ddlStrategy = getDDLStrategy(this.engine);
   }
 
@@ -798,23 +801,7 @@ export class SchemaComparer {
     colName: string,
     colDef: ColumnDefinition,
   ): string {
-    const parts: string[] = [this.quoteIdentifier(colName), colDef.type];
-
-    if (colDef.notNull) {
-      parts.push('NOT NULL');
-    }
-    if (colDef.unique) {
-      parts.push('UNIQUE');
-    }
-    if (colDef.defaultValue !== undefined) {
-      const defaultVal =
-        typeof colDef.defaultValue === 'string'
-          ? `'${colDef.defaultValue.replace(/'/g, "''")}'`
-          : String(colDef.defaultValue);
-      parts.push(`DEFAULT ${defaultVal}`);
-    }
-
-    return `ALTER TABLE ${this.quoteIdentifier(tableName)} ADD COLUMN ${parts.join(' ')}`;
+    return `ALTER TABLE ${this.quoteIdentifier(tableName)} ADD COLUMN ${this.ddlStrategy.generateColumnDefinition(colName, colDef)}`;
   }
 
   /**

--- a/packages/core/src/registry/inheritance-resolver.ts
+++ b/packages/core/src/registry/inheritance-resolver.ts
@@ -223,15 +223,21 @@ export async function getAllFields(
 
     // Merge fields from this ancestor
     for (const [fieldName, field] of ancestor.fields) {
+      const normalizedField = normalizeFrameworkInheritedField(
+        ancestorName,
+        fieldName,
+        field,
+        className,
+      );
       const existingField = allFields.get(fieldName);
       if (!existingField) {
         // New field from parent
-        allFields.set(fieldName, field);
+        allFields.set(fieldName, normalizedField);
       } else {
         // Field exists - merge configs
         allFields.set(
           fieldName,
-          mergeFieldConfigs(existingField, field, fieldName),
+          mergeFieldConfigs(existingField, normalizedField, fieldName),
         );
       }
     }
@@ -240,6 +246,32 @@ export async function getAllFields(
   registered.inheritedFields = new Map(allFields);
 
   return prependSmrtSystemFields(allFields);
+}
+
+function normalizeFrameworkInheritedField(
+  ancestorName: string,
+  fieldName: string,
+  field: any,
+  childClassName: string,
+): any {
+  const simpleAncestorName = ancestorName.includes(':')
+    ? ancestorName.split(':').pop()
+    : ancestorName;
+
+  if (simpleAncestorName === 'SmrtHierarchical' && fieldName === 'parentId') {
+    return {
+      ...field,
+      type: 'foreignKey',
+      related: childClassName,
+      required: false,
+      _meta: {
+        ...(field._meta || {}),
+        nullable: true,
+      },
+    };
+  }
+
+  return field;
 }
 
 export function mergeFieldConfigs(

--- a/packages/core/src/registry/schema-builder.ts
+++ b/packages/core/src/registry/schema-builder.ts
@@ -755,7 +755,9 @@ export function mapFieldTypeToSQL(
     case 'json':
       return 'JSON';
     case 'foreignKey':
-      return 'TEXT';
+      return 'UUID';
+    case 'crossPackageRef':
+      return 'UUID';
     default:
       return 'TEXT';
   }

--- a/packages/core/src/registry/schema-builder.ts
+++ b/packages/core/src/registry/schema-builder.ts
@@ -696,7 +696,12 @@ export function fieldsToColumns(
     }
 
     // Map field type to SQL type
-    const sqlType = fieldDef._meta?.sqlType || mapFieldTypeToSQL(fieldDef.type);
+    const sqlType =
+      fieldDef._meta?.sqlType ||
+      (fieldDef.type === 'crossPackageRef' &&
+      (fieldDef._meta?.idType === 'text' || (fieldDef as any).idType === 'text')
+        ? 'TEXT'
+        : mapFieldTypeToSQL(fieldDef.type));
 
     const column: ColumnDefinition = {
       type: sqlType,

--- a/packages/core/src/registry/types.ts
+++ b/packages/core/src/registry/types.ts
@@ -155,6 +155,15 @@ export interface SmartObjectConfig {
   tableName?: string;
 
   /**
+   * Storage type for the synthetic `id` primary key (defaults to 'uuid').
+   *
+   * Use 'text' only for models that intentionally generate non-UUID ids.
+   * On SQLite, UUID maps to TEXT at DDL render time because SQLite has no
+   * native UUID type.
+   */
+  idType?: 'uuid' | 'text';
+
+  /**
    * Table inheritance strategy (defaults to 'cti')
    * - 'cti': Class Table Inheritance - one table per class (current default)
    * - 'sti': Single Table Inheritance - shared table with discriminator column

--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -464,11 +464,16 @@ export class ManifestGenerator {
     generator: SchemaGeneratorLike,
   ): void {
     const schemaByTable = new Map<string, ManifestSchema>();
+    const ownerBySchema = new Map<
+      ManifestSchema,
+      { name: string; obj: SmartObjectDefinition }
+    >();
     const changedSchemas = new Set<ManifestSchema>();
 
-    for (const obj of Object.values(manifest.objects)) {
+    for (const [name, obj] of Object.entries(manifest.objects)) {
       if (obj.schema?.tableName) {
         schemaByTable.set(obj.schema.tableName, obj.schema);
+        ownerBySchema.set(obj.schema, { name, obj });
       }
     }
 
@@ -517,7 +522,12 @@ export class ManifestGenerator {
     }
 
     for (const schema of changedSchemas) {
-      this.refreshManifestSchemaDDL(schema, generator);
+      this.refreshManifestSchemaDDL(
+        schema,
+        generator,
+        ownerBySchema.get(schema),
+        manifest,
+      );
     }
   }
 
@@ -562,6 +572,8 @@ export class ManifestGenerator {
   private refreshManifestSchemaDDL(
     schema: ManifestSchema,
     generator: SchemaGeneratorLike,
+    owner: { name: string; obj: SmartObjectDefinition } | undefined,
+    manifest: SmartObjectManifest,
   ): void {
     const schemaDefinition = {
       tableName: schema.tableName,
@@ -591,16 +603,82 @@ export class ManifestGenerator {
       packageName: '',
     };
 
-    schema.ddl = generator.generateSQL(schemaDefinition, 'postgres');
-    schema.version = createHash('sha256')
+    schema.ddl = generator.generateSQL(schemaDefinition);
+    schema.version = this.computeManifestSchemaVersion(schema, owner, manifest);
+  }
+
+  private computeManifestSchemaVersion(
+    schema: ManifestSchema,
+    owner: { name: string; obj: SmartObjectDefinition } | undefined,
+    manifest: SmartObjectManifest,
+  ): string {
+    if (schema.columns._meta_type && owner) {
+      const baseClassName =
+        owner.obj.decoratorConfig?.tableStrategy === 'sti'
+          ? owner.name
+          : this.findSTIBaseInfo(owner.obj, manifest)?.className || owner.name;
+
+      return createHash('sha256')
+        .update(
+          JSON.stringify({
+            columns: schema.columns,
+            baseClassName,
+            descendants: this.findDescendantsInManifest(
+              baseClassName,
+              manifest,
+            ),
+          }),
+        )
+        .digest('hex')
+        .substring(0, 8);
+    }
+
+    return createHash('sha256')
       .update(
         JSON.stringify({
-          tableName: schema.tableName,
           columns: schema.columns,
+          className: owner?.name || schema.tableName,
         }),
       )
       .digest('hex')
       .substring(0, 8);
+  }
+
+  private findDescendantsInManifest(
+    baseClassName: string,
+    manifest: SmartObjectManifest,
+    visited: Set<string> = new Set(),
+  ): string[] {
+    const descendants: string[] = [];
+    if (visited.has(baseClassName)) {
+      return descendants;
+    }
+    visited.add(baseClassName);
+
+    const baseClassLower = this.simpleClassName(baseClassName).toLowerCase();
+
+    for (const [name, obj] of Object.entries(manifest.objects)) {
+      const classNameLower = this.simpleClassName(obj.className).toLowerCase();
+      const extendsLower = obj.extends
+        ? this.simpleClassName(obj.extends).toLowerCase()
+        : undefined;
+
+      if (
+        classNameLower === baseClassLower &&
+        extendsLower === baseClassLower
+      ) {
+        continue;
+      }
+
+      if (extendsLower === baseClassLower) {
+        descendants.push(name);
+        descendants.push(
+          ...this.findDescendantsInManifest(name, manifest, visited),
+        );
+      }
+    }
+
+    return descendants;
   }
 
   private applySqlTypeOverrides(obj: SmartObjectDefinition): void {
@@ -855,6 +933,37 @@ export class ManifestGenerator {
     return classnameToTablename(className);
   }
 
+  private normalizeFrameworkInheritedField(
+    ancestorName: string,
+    fieldName: string,
+    fieldDef: any,
+    childClassName: string,
+  ): any {
+    if (
+      this.simpleClassName(ancestorName) === 'SmrtHierarchical' &&
+      fieldName === 'parentId'
+    ) {
+      return {
+        ...fieldDef,
+        type: 'foreignKey',
+        related: childClassName,
+        required: false,
+        _meta: {
+          ...(fieldDef._meta || {}),
+          nullable: true,
+        },
+      };
+    }
+
+    return fieldDef;
+  }
+
+  private simpleClassName(className: string): string {
+    return className.includes(':')
+      ? className.split(':').pop() || className
+      : className;
+  }
+
   /**
    * Merge inherited fields into child classes (build-time inheritance resolution)
    *
@@ -983,7 +1092,12 @@ export class ManifestGenerator {
         // Merge fields (child fields override parent fields with same name)
         for (const [fieldName, fieldDef] of Object.entries(ancestor.fields)) {
           if (!mergedFields[fieldName]) {
-            mergedFields[fieldName] = fieldDef;
+            mergedFields[fieldName] = this.normalizeFrameworkInheritedField(
+              ancestorName,
+              fieldName,
+              fieldDef,
+              obj.className,
+            );
           }
         }
 

--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -2,14 +2,16 @@
  * Manifest generator for creating service manifests from AST scan results
  */
 
+import { createHash } from 'node:crypto';
 import { createRequire } from 'node:module';
 import {
   loadExternalManifestSync,
   lookupInManifest,
 } from '../manifest/manifest-loader.js';
+import { SchemaGenerator } from '../schema/generator.js';
 import { generateToolManifest } from '../tools/tool-generator.js';
+import { classnameToTablename, toSnakeCase } from '../utils/naming.js';
 import { createQualifiedName } from '../utils/qualified-names.js';
-import { classnameToTablename, toSnakeCase } from '../utils.js';
 import { isTestFile } from './test-file-patterns.js';
 import type {
   AgentAdminRouteManifest,
@@ -19,12 +21,17 @@ import type {
   AgentMenuItem,
   AgentPermission,
   AgentUISlotManifest,
+  ManifestSchema,
   ScanResult,
   SmartObjectDefinition,
   SmartObjectManifest,
   SmrtVisibility,
   ValidationRule,
 } from './types.js';
+
+type SchemaGeneratorLike = {
+  generateSQL: (schema: any, engine?: any) => string;
+};
 
 // Create require function for synchronous module loading in ESM context
 const require = createRequire(import.meta.url);
@@ -363,15 +370,6 @@ export class ManifestGenerator {
    * @param manifest - The manifest to process in-place
    */
   generateSchemas(manifest: SmartObjectManifest): void {
-    // Import SchemaGenerator synchronously (using createRequire for ESM compatibility)
-    // In Vitest/source runs, prefer the TypeScript source so tests exercise the
-    // current branch instead of stale built artifacts.
-    let SchemaGenerator: any;
-    try {
-      SchemaGenerator = require('../schema/generator.ts').SchemaGenerator;
-    } catch {
-      SchemaGenerator = require('../schema/generator.js').SchemaGenerator;
-    }
     const generator = new SchemaGenerator();
 
     // Create aggregated manifest that includes external package objects
@@ -409,6 +407,7 @@ export class ManifestGenerator {
           tableName,
           obj.fields,
           aggregatedManifest,
+          obj.decoratorConfig,
         );
         this.applySqlTypeOverrides(obj);
       } else if (this.isSTIChildClass(obj, manifest)) {
@@ -437,6 +436,7 @@ export class ManifestGenerator {
             baseTableName,
             obj.fields,
             aggregatedManifest,
+            obj.decoratorConfig,
           );
           this.applySqlTypeOverrides(obj);
         }
@@ -455,6 +455,152 @@ export class ManifestGenerator {
         this.applySqlTypeOverrides(obj);
       }
     }
+
+    this.resolveSamePackageForeignKeyColumnTypes(manifest, generator);
+  }
+
+  private resolveSamePackageForeignKeyColumnTypes(
+    manifest: SmartObjectManifest,
+    generator: SchemaGeneratorLike,
+  ): void {
+    const schemaByTable = new Map<string, ManifestSchema>();
+    const changedSchemas = new Set<ManifestSchema>();
+
+    for (const obj of Object.values(manifest.objects)) {
+      if (obj.schema?.tableName) {
+        schemaByTable.set(obj.schema.tableName, obj.schema);
+      }
+    }
+
+    for (const obj of Object.values(manifest.objects)) {
+      const sourceTable = this.getObjectTableName(obj);
+      if (!sourceTable) {
+        continue;
+      }
+
+      const sourceSchema = schemaByTable.get(sourceTable);
+      if (!sourceSchema) {
+        continue;
+      }
+
+      for (const [fieldName, field] of Object.entries(obj.fields || {})) {
+        if (
+          field.type !== 'foreignKey' ||
+          !field.related ||
+          field._meta?.sqlType
+        ) {
+          continue;
+        }
+
+        const columnName = toSnakeCase(fieldName);
+        const sourceColumn = sourceSchema.columns[columnName];
+        if (!sourceColumn) {
+          continue;
+        }
+
+        const targetSchema = this.findForeignKeyTargetSchema(
+          field.related,
+          manifest,
+          schemaByTable,
+        );
+        const targetIdType = targetSchema?.columns.id?.type;
+        if (!targetIdType || sourceColumn.type === targetIdType) {
+          continue;
+        }
+
+        sourceSchema.columns[columnName] = {
+          ...sourceColumn,
+          type: targetIdType,
+        };
+        changedSchemas.add(sourceSchema);
+      }
+    }
+
+    for (const schema of changedSchemas) {
+      this.refreshManifestSchemaDDL(schema, generator);
+    }
+  }
+
+  private findForeignKeyTargetSchema(
+    related: string,
+    manifest: SmartObjectManifest,
+    schemaByTable: Map<string, ManifestSchema>,
+  ): ManifestSchema | undefined {
+    const relatedTarget = related.split('.')[0];
+    if (schemaByTable.has(relatedTarget)) {
+      return schemaByTable.get(relatedTarget);
+    }
+
+    const targetObj = Object.values(manifest.objects).find(
+      (candidate) =>
+        candidate.className === relatedTarget ||
+        candidate.qualifiedName === relatedTarget ||
+        candidate.name === relatedTarget ||
+        candidate.decoratorConfig?.tableName === relatedTarget ||
+        candidate.schema?.tableName === relatedTarget,
+    );
+
+    if (!targetObj && relatedTarget.includes(':')) {
+      return undefined;
+    }
+
+    const targetTable = targetObj
+      ? this.getObjectTableName(targetObj)
+      : this.classNameToTableName(relatedTarget);
+
+    return targetTable ? schemaByTable.get(targetTable) : undefined;
+  }
+
+  private getObjectTableName(obj: SmartObjectDefinition): string | undefined {
+    return (
+      obj.schema?.tableName ||
+      obj.decoratorConfig?.tableName ||
+      this.classNameToTableName(obj.className)
+    );
+  }
+
+  private refreshManifestSchemaDDL(
+    schema: ManifestSchema,
+    generator: SchemaGeneratorLike,
+  ): void {
+    const schemaDefinition = {
+      tableName: schema.tableName,
+      columns: Object.fromEntries(
+        Object.entries(schema.columns).map(([name, column]) => [
+          name,
+          {
+            type: column.type,
+            primaryKey: column.primaryKey,
+            notNull: column.notNull,
+            unique: column.unique,
+            defaultValue: column.default,
+          },
+        ]),
+      ),
+      indexes: (schema.indexes || []).map((index) => ({
+        name: index.name,
+        columns: index.columns,
+        unique: index.unique,
+        where: index.where,
+        jsonPath: index.jsonPath,
+      })),
+      triggers: [],
+      foreignKeys: [],
+      dependencies: [],
+      version: schema.version,
+      packageName: '',
+    };
+
+    schema.ddl = generator.generateSQL(schemaDefinition, 'postgres');
+    schema.version = createHash('sha256')
+      .update(
+        JSON.stringify({
+          tableName: schema.tableName,
+          columns: schema.columns,
+        }),
+      )
+      .digest('hex')
+      .substring(0, 8);
   }
 
   private applySqlTypeOverrides(obj: SmartObjectDefinition): void {

--- a/packages/core/src/scanner/types.ts
+++ b/packages/core/src/scanner/types.ts
@@ -27,7 +27,7 @@ export interface FieldDefinition {
     | 'datetime'
     | 'json'
     | 'foreignKey'
-    | 'crossPackageRef' // Cross-package reference — plain TEXT, no DDL FK
+    | 'crossPackageRef' // Cross-package reference — UUID id column, no DDL FK
     | 'oneToMany'
     | 'manyToMany'
     | 'meta'; // STI meta fields (_meta_type, _meta_data)

--- a/packages/core/src/scanner/types.ts
+++ b/packages/core/src/scanner/types.ts
@@ -27,7 +27,7 @@ export interface FieldDefinition {
     | 'datetime'
     | 'json'
     | 'foreignKey'
-    | 'crossPackageRef' // Cross-package reference — UUID id column, no DDL FK
+    | 'crossPackageRef' // Cross-package reference — UUID id column by default, no DDL FK
     | 'oneToMany'
     | 'manyToMany'
     | 'meta'; // STI meta fields (_meta_type, _meta_data)

--- a/packages/core/src/schema/ddl/index.ts
+++ b/packages/core/src/schema/ddl/index.ts
@@ -7,12 +7,14 @@
 
 export { BaseDDLStrategy } from './base-strategy.js';
 export { DuckDBStrategy } from './duckdb-strategy.js';
+export { JsonDuckDBStrategy } from './json-duckdb-strategy.js';
 export { PostgresStrategy } from './postgres-strategy.js';
 export { SQLiteStrategy } from './sqlite-strategy.js';
 export * from './types.js';
 
 import type { SchemaDefinition } from '../types.js';
 import { DuckDBStrategy } from './duckdb-strategy.js';
+import { JsonDuckDBStrategy } from './json-duckdb-strategy.js';
 import { PostgresStrategy } from './postgres-strategy.js';
 import { SQLiteStrategy } from './sqlite-strategy.js';
 import type {
@@ -26,6 +28,7 @@ import type {
 const strategies: Record<DatabaseEngine, DDLStrategy> = {
   sqlite: new SQLiteStrategy(),
   duckdb: new DuckDBStrategy(),
+  json: new JsonDuckDBStrategy(),
   postgres: new PostgresStrategy(),
 };
 

--- a/packages/core/src/schema/ddl/index.ts
+++ b/packages/core/src/schema/ddl/index.ts
@@ -89,6 +89,7 @@ export function generateMultiEngineDDL(
   return {
     sqlite: generateDDLForEngine(schema, 'sqlite'),
     duckdb: generateDDLForEngine(schema, 'duckdb'),
+    json: generateDDLForEngine(schema, 'json'),
     postgres: generateDDLForEngine(schema, 'postgres'),
   };
 }
@@ -109,7 +110,10 @@ export function detectEngine(url: string, type?: string): DatabaseEngine {
         return 'sqlite';
       case 'duckdb':
       case 'json':
-        return 'duckdb'; // JSON adapter uses DuckDB internally
+        // Query-level compatibility treats JSON as DuckDB. DDL callers that
+        // need JSON's UUID-as-TEXT behavior should detect the adapter
+        // structurally (exportTable) or request the `json` strategy directly.
+        return 'duckdb';
       case 'postgres':
       case 'postgresql':
       case 'pg':
@@ -142,7 +146,10 @@ export function detectEngine(url: string, type?: string): DatabaseEngine {
     urlLower.includes('/json/') ||
     urlLower.includes('-json')
   ) {
-    return 'duckdb'; // JSON adapter uses DuckDB
+    // Query-level compatibility treats JSON as DuckDB. DDL callers that need
+    // JSON's UUID-as-TEXT behavior should detect the adapter structurally
+    // (exportTable) or request the `json` strategy directly.
+    return 'duckdb';
   }
 
   // Default to SQLite for file-based databases

--- a/packages/core/src/schema/ddl/json-duckdb-strategy.ts
+++ b/packages/core/src/schema/ddl/json-duckdb-strategy.ts
@@ -1,0 +1,24 @@
+/**
+ * JSON Adapter DDL Strategy
+ *
+ * The JSON adapter is backed by DuckDB, so it needs DuckDB's inline UNIQUE
+ * constraints for UPSERT. However, DuckDB's Node API currently round-trips
+ * native UUID values as their 128-bit numeric representation, so SMRT stores
+ * UUID columns as TEXT for JSON-backed databases.
+ */
+
+import type { SQLDataType } from '../types.js';
+import { DuckDBStrategy } from './duckdb-strategy.js';
+import type { DatabaseEngine } from './types.js';
+
+export class JsonDuckDBStrategy extends DuckDBStrategy {
+  readonly engine: DatabaseEngine = 'json';
+
+  mapType(type: SQLDataType): string {
+    if (type === 'UUID') {
+      return 'TEXT';
+    }
+
+    return super.mapType(type);
+  }
+}

--- a/packages/core/src/schema/ddl/types.ts
+++ b/packages/core/src/schema/ddl/types.ts
@@ -13,10 +13,12 @@ import type { SchemaDefinition, SQLDataType } from '../types.js';
 /**
  * Supported database engines
  * - sqlite: SQLite/LibSQL databases
- * - duckdb: DuckDB databases (including JSON adapter which uses DuckDB internally)
+ * - duckdb: DuckDB databases
+ * - json: JSON adapter backed by DuckDB, with UUID stored as TEXT for stable
+ *   JS round-tripping
  * - postgres: PostgreSQL databases
  */
-export type DatabaseEngine = 'sqlite' | 'duckdb' | 'postgres';
+export type DatabaseEngine = 'sqlite' | 'duckdb' | 'json' | 'postgres';
 
 /**
  * Engine-specific DDL output

--- a/packages/core/src/schema/ddl/types.ts
+++ b/packages/core/src/schema/ddl/types.ts
@@ -38,6 +38,7 @@ export interface EngineSpecificDDL {
 export interface MultiEngineDDL {
   sqlite: EngineSpecificDDL;
   duckdb: EngineSpecificDDL;
+  json: EngineSpecificDDL;
   postgres: EngineSpecificDDL;
 }
 

--- a/packages/core/src/schema/generator.ts
+++ b/packages/core/src/schema/generator.ts
@@ -28,8 +28,10 @@ type SchemaGeneratorConfig = {
   conflictColumns?: string[];
   idType?: 'uuid' | 'text';
   registry?: {
+    getConfig?(className: string): { idType?: 'uuid' | 'text' };
     getDescendants(baseClassName: string): string[];
     getAllFields(className: string): Promise<Map<string, any>>;
+    getSTIBase?(className: string): string | null;
   };
 };
 
@@ -90,6 +92,81 @@ export class SchemaGenerator {
 
   private getIdColumnType(config?: { idType?: 'uuid' | 'text' }): SQLDataType {
     return config?.idType === 'text' ? 'TEXT' : 'UUID';
+  }
+
+  private getRelationshipColumnType(field: any): SQLDataType {
+    if (field?._meta?.sqlType) {
+      return field._meta.sqlType;
+    }
+
+    if (
+      field?.type === 'crossPackageRef' &&
+      (field._meta?.idType === 'text' || field.idType === 'text')
+    ) {
+      return 'TEXT';
+    }
+
+    return this.mapFieldTypeToSQL(field?.type || 'text');
+  }
+
+  private getRegistryTargetIdColumnType(
+    relatedName: string | undefined,
+    registry: SchemaGeneratorConfig['registry'] | undefined,
+  ): SQLDataType | undefined {
+    if (!relatedName || !registry?.getConfig) {
+      return undefined;
+    }
+
+    const targetName = relatedName.split('.')[0];
+    const targetNames = [targetName];
+    const stiBase = registry.getSTIBase?.(targetName);
+    if (stiBase && !targetNames.includes(stiBase)) {
+      targetNames.push(stiBase);
+    }
+
+    for (const name of targetNames) {
+      const idType = registry.getConfig(name)?.idType;
+      if (idType === 'text') {
+        return 'TEXT';
+      }
+      if (idType === 'uuid') {
+        return 'UUID';
+      }
+    }
+
+    return undefined;
+  }
+
+  private reconcileRegistryForeignKeyColumnTypes(
+    columns: Record<string, ColumnDefinition>,
+    fields: Map<string, any>,
+    registry: SchemaGeneratorConfig['registry'] | undefined,
+  ): void {
+    if (!registry?.getConfig) {
+      return;
+    }
+
+    for (const [fieldName, field] of fields.entries()) {
+      if (field.type !== 'foreignKey' || field._meta?.sqlType) {
+        continue;
+      }
+
+      const targetIdType = this.getRegistryTargetIdColumnType(
+        field.related,
+        registry,
+      );
+      if (!targetIdType) {
+        continue;
+      }
+
+      const columnName = this.toSnakeCase(fieldName);
+      if (columns[columnName]) {
+        columns[columnName] = {
+          ...columns[columnName],
+          type: targetIdType,
+        };
+      }
+    }
   }
 
   /**
@@ -156,7 +233,7 @@ export class SchemaGenerator {
       }
 
       const column: ColumnDefinition = {
-        type: fieldDef._meta?.sqlType || this.mapFieldTypeToSQL(fieldDef.type),
+        type: this.getRelationshipColumnType(fieldDef),
         // If _meta.nullable is true, the field can be null regardless of required
         // This handles field helpers like text({ required: true, nullable: true })
         notNull: fieldDef._meta?.nullable ? false : fieldDef.required || false,
@@ -455,8 +532,7 @@ export class SchemaGenerator {
         continue;
       }
 
-      const sqlType =
-        field._meta?.sqlType || this.mapFieldTypeToSQL(field.type);
+      const sqlType = this.getRelationshipColumnType(field);
 
       const columnDef: ColumnDefinition = {
         type: sqlType,
@@ -526,6 +602,12 @@ export class SchemaGenerator {
         description: 'Last update timestamp',
       };
     }
+
+    this.reconcileRegistryForeignKeyColumnTypes(
+      columns,
+      fields,
+      config?.registry,
+    );
 
     // Generate indexes
     const indexes: IndexDefinition[] = [];
@@ -760,8 +842,7 @@ export class SchemaGenerator {
           continue;
         }
 
-        const sqlType =
-          field._meta?.sqlType || this.mapFieldTypeToSQL(field.type);
+        const sqlType = this.getRelationshipColumnType(field);
 
         const columnDef: ColumnDefinition = {
           type: sqlType,
@@ -822,6 +903,15 @@ export class SchemaGenerator {
         defaultValue: 'current_timestamp',
         description: 'Last update timestamp',
       };
+    }
+
+    for (const className of allClassNames) {
+      const classFields = await ObjectRegistry.getAllFields(className);
+      this.reconcileRegistryForeignKeyColumnTypes(
+        columns,
+        classFields,
+        ObjectRegistry,
+      );
     }
 
     // Generate indexes
@@ -1029,8 +1119,7 @@ export class SchemaGenerator {
           continue;
         }
 
-        const sqlType =
-          field._meta?.sqlType || this.mapFieldTypeToSQL(field.type);
+        const sqlType = this.getRelationshipColumnType(field);
 
         const columnDef: ManifestColumnDefinition = {
           type: sqlType,
@@ -1118,7 +1207,7 @@ export class SchemaGenerator {
       packageName: '',
     };
 
-    const ddl = this.generateSQL(schemaDefinition, 'postgres');
+    const ddl = this.generateSQL(schemaDefinition);
 
     // Generate version hash
     const version = createHash('sha256')
@@ -1213,8 +1302,7 @@ export class SchemaGenerator {
       }
 
       const columnName = this.toSnakeCase(fieldName);
-      const sqlType =
-        field._meta?.sqlType || this.mapFieldTypeToSQL(field.type);
+      const sqlType = this.getRelationshipColumnType(field);
 
       const columnDef: ManifestColumnDefinition = {
         type: sqlType,
@@ -1268,7 +1356,7 @@ export class SchemaGenerator {
       packageName: '',
     };
 
-    const ddl = this.generateSQL(schemaDefinition, 'postgres');
+    const ddl = this.generateSQL(schemaDefinition);
 
     // Generate version hash
     const version = createHash('sha256')

--- a/packages/core/src/schema/generator.ts
+++ b/packages/core/src/schema/generator.ts
@@ -12,6 +12,9 @@ import type {
   SmartObjectDefinition,
   SmartObjectManifest,
 } from '../scanner/types.js';
+import { classnameToTablename } from '../utils/naming.js';
+import { getDDLStrategy } from './ddl/index.js';
+import type { DatabaseEngine } from './ddl/types.js';
 import type {
   ColumnDefinition,
   ForeignKeyDefinition,
@@ -21,13 +24,25 @@ import type {
   TriggerDefinition,
 } from './types.js';
 
+type SchemaGeneratorConfig = {
+  conflictColumns?: string[];
+  idType?: 'uuid' | 'text';
+  registry?: {
+    getDescendants(baseClassName: string): string[];
+    getAllFields(className: string): Promise<Map<string, any>>;
+  };
+};
+
 export class SchemaGenerator {
   /**
    * Generate schema definition from SMRT object definition
    */
   generateSchema(objectDef: SmartObjectDefinition): SchemaDefinition {
     const tableName = this.getTableName(objectDef);
-    const columns = this.generateColumns(objectDef.fields);
+    const columns = this.generateColumns(
+      objectDef.fields,
+      objectDef.decoratorConfig,
+    );
     const indexes = this.generateIndexes(objectDef, columns);
     const triggers = this.generateTriggers(objectDef, tableName);
     const foreignKeys = this.extractForeignKeys(columns);
@@ -65,12 +80,16 @@ export class SchemaGenerator {
       case 'json':
         return 'JSON';
       case 'foreignKey':
-        return 'TEXT'; // Foreign keys are typically TEXT
+        return 'UUID'; // Foreign keys default to UUID, then same-package refs can be reconciled to target idType
       case 'crossPackageRef':
-        return 'TEXT'; // Cross-package refs are plain TEXT (no DDL FK constraint)
+        return 'UUID'; // Cross-package refs are UUID ids with no DDL FK constraint
       default:
         return 'TEXT'; // Default fallback
     }
+  }
+
+  private getIdColumnType(config?: { idType?: 'uuid' | 'text' }): SQLDataType {
+    return config?.idType === 'text' ? 'TEXT' : 'UUID';
   }
 
   /**
@@ -78,12 +97,13 @@ export class SchemaGenerator {
    */
   private generateColumns(
     fields: Record<string, FieldDefinition>,
+    config?: { idType?: 'uuid' | 'text' },
   ): Record<string, ColumnDefinition> {
     const columns: Record<string, ColumnDefinition> = {};
 
     // Always include base SMRT fields
     columns.id = {
-      type: 'TEXT',
+      type: this.getIdColumnType(config),
       primaryKey: true,
       notNull: true,
       description: 'Primary identifier',
@@ -308,11 +328,7 @@ export class SchemaGenerator {
    * Convert class name to table name (camelCase to snake_case, pluralized)
    */
   private classNameToTableName(className: string): string {
-    return `${className
-      .replace(/([A-Z])/g, '_$1')
-      .toLowerCase()
-      .replace(/^_/, '')
-      .replace(/s$/, '')}s`; // Simple pluralization
+    return classnameToTablename(className);
   }
 
   /**
@@ -338,7 +354,7 @@ export class SchemaGenerator {
     className: string,
     tableName: string,
     fields: Map<string, any>,
-    config?: { conflictColumns?: string[] },
+    config?: SchemaGeneratorConfig,
   ): SchemaDefinition {
     const columns: Record<string, ColumnDefinition> = {};
 
@@ -354,7 +370,7 @@ export class SchemaGenerator {
     // Add default SMRT fields if no custom primary key
     if (!hasCustomPK) {
       columns.id = {
-        type: 'TEXT',
+        type: this.getIdColumnType(config),
         primaryKey: true,
         notNull: true,
         description: 'Primary identifier',
@@ -619,13 +635,15 @@ export class SchemaGenerator {
     baseClassName: string,
     tableName: string,
     _fields: Map<string, any>,
+    config?: SchemaGeneratorConfig,
   ): Promise<SchemaDefinition> {
-    const { ObjectRegistry } = await import('../registry.js');
+    const ObjectRegistry =
+      config?.registry ?? (await import('../registry.js')).ObjectRegistry;
     const columns: Record<string, ColumnDefinition> = {};
 
     // Add default SMRT fields
     columns.id = {
-      type: 'TEXT',
+      type: this.getIdColumnType(config),
       primaryKey: true,
       notNull: true,
       description: 'Primary identifier',
@@ -901,12 +919,13 @@ export class SchemaGenerator {
     tableName: string,
     _baseFields: Record<string, FieldDefinition>,
     manifest: SmartObjectManifest,
+    config?: SchemaGeneratorConfig,
   ): ManifestSchema {
     const columns: Record<string, ManifestColumnDefinition> = {};
 
     // Add default SMRT fields
     columns.id = {
-      type: 'TEXT',
+      type: this.getIdColumnType(config),
       primaryKey: true,
       notNull: true,
     };
@@ -1099,7 +1118,7 @@ export class SchemaGenerator {
       packageName: '',
     };
 
-    const ddl = this.generateSQL(schemaDefinition);
+    const ddl = this.generateSQL(schemaDefinition, 'postgres');
 
     // Generate version hash
     const version = createHash('sha256')
@@ -1128,13 +1147,13 @@ export class SchemaGenerator {
     className: string,
     tableName: string,
     fields: Record<string, FieldDefinition>,
-    config?: { conflictColumns?: string[] },
+    config?: SchemaGeneratorConfig,
   ): ManifestSchema {
     const columns: Record<string, ManifestColumnDefinition> = {};
 
     // Add default SMRT fields
     columns.id = {
-      type: 'TEXT',
+      type: this.getIdColumnType(config),
       primaryKey: true,
       notNull: true,
     };
@@ -1249,7 +1268,7 @@ export class SchemaGenerator {
       packageName: '',
     };
 
-    const ddl = this.generateSQL(schemaDefinition);
+    const ddl = this.generateSQL(schemaDefinition, 'postgres');
 
     // Generate version hash
     const version = createHash('sha256')
@@ -1356,59 +1375,46 @@ export class SchemaGenerator {
    * @param schema - Schema definition object
    * @returns SQL CREATE TABLE statement with indexes
    */
-  generateSQL(schema: SchemaDefinition): string {
-    const { tableName, columns } = schema;
-
-    // Quote table name to handle SQL reserved keywords
-    let sql = `CREATE TABLE IF NOT EXISTS "${tableName}" (\n`;
-
-    // Track which columns we've added
-    const addedColumns: string[] = [];
-
-    // Add all columns
-    for (const [columnName, columnDef] of Object.entries(columns)) {
-      const parts: string[] = [];
-
-      // Column name and type - quote column name to handle SQL reserved keywords
-      parts.push(`  "${columnName}" ${columnDef.type}`);
-
-      // Primary key
-      if (columnDef.primaryKey) {
-        parts.push('PRIMARY KEY');
-      }
-
-      // Not null constraint
-      if (columnDef.notNull) {
-        parts.push('NOT NULL');
-      }
-
-      // Unique constraint
-      if (columnDef.unique && !columnDef.primaryKey) {
-        parts.push('UNIQUE');
-      }
-
-      // Default value with CAST for DuckDB compatibility
-      if (columnDef.defaultValue !== undefined) {
-        const defaultSQL = this.formatDefaultValue(
-          columnDef.defaultValue,
-          columnDef.type,
-        );
-        parts.push(`DEFAULT ${defaultSQL}`);
-      }
-
-      sql += `${parts.join(' ')},\n`;
-      addedColumns.push(columnName);
-    }
-
-    // Remove trailing comma and close table
-    sql = `${sql.slice(0, -2)}\n);`;
-
+  generateSQL(schema: SchemaDefinition, engine?: DatabaseEngine): string {
     // NOTE: We no longer append indexes to DDL string here.
     // The SDK expects ddl to contain ONLY the CREATE TABLE statement.
     // Indexes are stored separately in schema.indexes as SQL strings
     // and the SDK handles them via syncSchema() or dedicated index creation.
+    if (engine) {
+      return getDDLStrategy(engine).generateCreateTable(schema);
+    }
 
-    return sql;
+    const { tableName, columns } = schema;
+    let sql = `CREATE TABLE IF NOT EXISTS "${tableName}" (\n`;
+
+    for (const [columnName, columnDef] of Object.entries(columns)) {
+      const parts = [`  "${columnName}" ${columnDef.type}`];
+
+      if (columnDef.primaryKey) {
+        parts.push('PRIMARY KEY');
+      }
+
+      if (columnDef.notNull) {
+        parts.push('NOT NULL');
+      }
+
+      if (columnDef.unique && !columnDef.primaryKey) {
+        parts.push('UNIQUE');
+      }
+
+      if (columnDef.defaultValue !== undefined) {
+        parts.push(
+          `DEFAULT ${this.formatDefaultValue(
+            columnDef.defaultValue,
+            columnDef.type,
+          )}`,
+        );
+      }
+
+      sql += `${parts.join(' ')},\n`;
+    }
+
+    return `${sql.slice(0, -2)}\n);`;
   }
 
   /**

--- a/packages/core/src/schema/schema-manager.ts
+++ b/packages/core/src/schema/schema-manager.ts
@@ -49,9 +49,9 @@ export class SchemaManager {
       this.engine = options.engine;
     } else if ((db as any).exportTable) {
       // JSON adapter detected (has unique exportTable method)
-      // JSON adapter uses DuckDB internally, so use DuckDB DDL strategy
-      // This is critical for UPSERT to work (DuckDB requires inline UNIQUE constraints)
-      this.engine = 'duckdb';
+      // JSON adapter uses DuckDB internally, but native UUID values do not
+      // round-trip through the SDK row objects as canonical UUID strings.
+      this.engine = 'json';
     } else {
       this.engine = detectEngine(db.url);
     }

--- a/packages/core/src/schema/utils.ts
+++ b/packages/core/src/schema/utils.ts
@@ -11,6 +11,7 @@
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { ObjectRegistry } from '../registry.js';
 import { tableNameFromClass } from '../utils.js';
+import type { DatabaseEngine } from './ddl/types.js';
 import { SchemaManager } from './schema-manager.js';
 
 // Index-rendering helpers live in a separate file to avoid pulling the
@@ -34,6 +35,7 @@ export { isJsonPathIndex, renderIndexTarget } from './index-utils.js';
 export async function generateSchema(
   ClassType: new (...args: any[]) => any,
   providedFields?: Map<string, any>,
+  options: { engine?: DatabaseEngine } = {},
 ) {
   const className = ClassType.name;
   const tableName = tableNameFromClass(ClassType);
@@ -100,6 +102,7 @@ export async function generateSchema(
     ? {
         conflictColumns: registeredClass.config.conflictColumns,
         idType: registeredClass.config.idType,
+        registry: ObjectRegistry,
       }
     : undefined;
 
@@ -164,7 +167,7 @@ export async function generateSchema(
     );
   }
 
-  return generator.generateSQL(schemaDefinition);
+  return generator.generateSQL(schemaDefinition, options.engine);
 }
 
 /**

--- a/packages/core/src/schema/utils.ts
+++ b/packages/core/src/schema/utils.ts
@@ -99,6 +99,7 @@ export async function generateSchema(
   const runtimeSchemaConfig = registeredClass?.config
     ? {
         conflictColumns: registeredClass.config.conflictColumns,
+        idType: registeredClass.config.idType,
       }
     : undefined;
 
@@ -131,6 +132,7 @@ export async function generateSchema(
         className,
         tableName,
         cachedFields,
+        runtimeSchemaConfig,
       );
     } else {
       // This is a child class - return null or empty schema
@@ -156,7 +158,10 @@ export async function generateSchema(
     // Store the full SchemaDefinition for SchemaManager to use
     registeredClass.schema = schemaDefinition;
     // Also store generated DDL for backward compatibility
-    registeredClass.schema.ddl = generator.generateSQL(schemaDefinition);
+    registeredClass.schema.ddl = generator.generateSQL(
+      schemaDefinition,
+      'sqlite',
+    );
   }
 
   return generator.generateSQL(schemaDefinition);

--- a/packages/core/src/testing/database.ts
+++ b/packages/core/src/testing/database.ts
@@ -199,6 +199,10 @@ export async function getTestDatabase(
 
   // Use the same schema generation as production
   const schemaGenerator = new SchemaGenerator();
+  const ddlEngine =
+    type === 'json' || typeof (db as any).exportTable === 'function'
+      ? 'json'
+      : 'sqlite';
 
   // Track created tables to avoid duplicates (STI base classes)
   const createdTables = new Set<string>();
@@ -227,6 +231,7 @@ export async function getTestDatabase(
     const runtimeSchemaConfig = {
       conflictColumns: ObjectRegistry.getConflictColumns(className),
       idType: registered?.config.idType,
+      registry: ObjectRegistry,
     };
 
     // Generate schema using SchemaGenerator (same as migrations)
@@ -246,7 +251,7 @@ export async function getTestDatabase(
           );
 
     // Generate DDL using generateSQL() - the single source of truth
-    const ddl = schemaGenerator.generateSQL(schema, 'sqlite');
+    const ddl = schemaGenerator.generateSQL(schema, ddlEngine);
 
     try {
       await db.query(ddl);
@@ -255,12 +260,7 @@ export async function getTestDatabase(
       // Create indexes (use DDL strategy so jsonPath / where / etc. render)
       const ddlStrategy = (
         await import('../schema/ddl/index.js')
-      ).getDDLStrategy(
-        // Map test database type → DDL engine. We default to sqlite since
-        // getTestDatabase is sqlite-first; if extended for postgres, the
-        // outer schema generator already accounts for engine-specific shapes.
-        'sqlite',
-      );
+      ).getDDLStrategy(ddlEngine);
       const indexStatements = ddlStrategy.generateIndexes(schema);
       for (const indexSQL of indexStatements) {
         try {

--- a/packages/core/src/testing/database.ts
+++ b/packages/core/src/testing/database.ts
@@ -226,6 +226,7 @@ export async function getTestDatabase(
     const strategy = ObjectRegistry.getTableStrategy(className);
     const runtimeSchemaConfig = {
       conflictColumns: ObjectRegistry.getConflictColumns(className),
+      idType: registered?.config.idType,
     };
 
     // Generate schema using SchemaGenerator (same as migrations)
@@ -235,6 +236,7 @@ export async function getTestDatabase(
             className,
             tableName,
             fields,
+            runtimeSchemaConfig,
           )
         : schemaGenerator.generateSchemaFromRegistry(
             className,
@@ -244,7 +246,7 @@ export async function getTestDatabase(
           );
 
     // Generate DDL using generateSQL() - the single source of truth
-    const ddl = schemaGenerator.generateSQL(schema);
+    const ddl = schemaGenerator.generateSQL(schema, 'sqlite');
 
     try {
       await db.query(ddl);

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,24 +1,11 @@
-import pluralizeLib from 'pluralize';
 import { ObjectRegistry } from './registry';
+import {
+  classnameToTablename,
+  pluralize,
+  toSnakeCase,
+} from './utils/naming.js';
 
-/**
- * Converts a camelCase string to snake_case
- *
- * @param str - String in camelCase format
- * @returns String in snake_case format
- * @example
- * ```typescript
- * toSnakeCase('meetingsUrl'); // 'meetings_url'
- * toSnakeCase('createdAt'); // 'created_at'
- * toSnakeCase('id'); // 'id'
- * ```
- */
-export function toSnakeCase(str: string): string {
-  return str
-    .replace(/([A-Z])/g, '_$1')
-    .toLowerCase()
-    .replace(/^_/, '');
-}
+export { classnameToTablename, pluralize, toSnakeCase };
 
 /**
  * Converts a snake_case string to camelCase
@@ -176,41 +163,6 @@ export async function fieldsFromClass(
 // Import from './schema/utils' in Node.js code that needs schema generation.
 
 /**
- * Pluralizes an English word using the pluralize library.
- *
- * Uses the well-tested `pluralize` npm package which handles all English
- * pluralization rules including irregular plurals (person → people,
- * child → children), special cases (quiz → quizzes), and more.
- *
- * For snake_case table names with multiple words (e.g., 'journal_entry'),
- * only the last word is pluralized ('journal_entries').
- *
- * @param word - The word to pluralize (should be lowercase)
- * @returns The pluralized word
- * @example
- * ```typescript
- * pluralize('currency');        // 'currencies'
- * pluralize('journal_entry');   // 'journal_entries'
- * pluralize('statement_batch'); // 'statement_batches'
- * pluralize('product');         // 'products'
- * pluralize('person');          // 'people'
- * pluralize('child');           // 'children'
- * ```
- */
-export function pluralize(word: string): string {
-  // For snake_case words, only pluralize the last segment
-  // e.g., 'journal_entry' → 'journal_entries' (not 'journals_entries')
-  if (word.includes('_')) {
-    const parts = word.split('_');
-    const lastWord = parts.pop();
-    if (!lastWord) return word; // Safety check (shouldn't happen)
-    return [...parts, pluralizeLib(lastWord)].join('_');
-  }
-
-  return pluralizeLib(word);
-}
-
-/**
  * Returns the old (incorrect) pluralized table name for migration purposes.
  *
  * This function replicates the previous buggy behavior where 'y' → 'ies'
@@ -311,24 +263,6 @@ export function tableNameFromClass(
     // Convert to lowercase
     .toLowerCase();
 
-  return pluralize(snakeCase);
-}
-
-/**
- * Converts a class name to a table name with pluralization
- *
- * @param className - Name of the class
- * @returns Pluralized snake_case table name
- */
-export function classnameToTablename(className: string) {
-  // Convert camelCase/PascalCase to snake_case
-  const snakeCase = className
-    // Insert underscore between lower & upper case letters
-    .replace(/([a-z])([A-Z])/g, '$1_$2')
-    // Convert to lowercase
-    .toLowerCase();
-
-  // Pluralize using proper English rules
   return pluralize(snakeCase);
 }
 

--- a/packages/core/src/utils/naming.ts
+++ b/packages/core/src/utils/naming.ts
@@ -1,0 +1,37 @@
+import pluralizeLib from 'pluralize';
+
+/**
+ * Converts a camelCase string to snake_case.
+ */
+export function toSnakeCase(str: string): string {
+  return str
+    .replace(/([A-Z])/g, '_$1')
+    .toLowerCase()
+    .replace(/^_/, '');
+}
+
+/**
+ * Pluralizes an English word using the pluralize library.
+ *
+ * For snake_case table names with multiple words, only the last word is
+ * pluralized: `journal_entry` -> `journal_entries`.
+ */
+export function pluralize(word: string): string {
+  if (word.includes('_')) {
+    const parts = word.split('_');
+    const lastWord = parts.pop();
+    if (!lastWord) return word;
+    return [...parts, pluralizeLib(lastWord)].join('_');
+  }
+
+  return pluralizeLib(word);
+}
+
+/**
+ * Converts a class name to a pluralized snake_case table name.
+ */
+export function classnameToTablename(className: string): string {
+  const snakeCase = className.replace(/([a-z])([A-Z])/g, '$1_$2').toLowerCase();
+
+  return pluralize(snakeCase);
+}

--- a/packages/events/src/manifest/manifest.json
+++ b/packages/events/src/manifest/manifest.json
@@ -1,1455 +1,218 @@
 {
   "version": "1.0.0",
-  "timestamp": 1767322698151,
+  "timestamp": 1780375810662,
+  "packageName": "@happyvertical/smrt-events",
+  "packageVersion": "0.25.8",
   "objects": {
-    "eventtype": {
-      "name": "eventtype",
-      "className": "EventType",
-      "collection": "eventtypes",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/events/src/models/EventType.ts",
-      "fields": {
-        "name": {
-          "type": "text",
-          "required": true,
-          "_meta": {},
-          "default": ""
-        },
-        "description": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "schema": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "participantSchema": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "createdAt": {
-          "type": "datetime",
-          "required": false
-        },
-        "updatedAt": {
-          "type": "datetime",
-          "required": false
-        }
-      },
-      "methods": {
-        "getSchema": {
-          "name": "getSchema",
-          "async": false,
-          "parameters": [],
-          "returnType": "Record<string, any>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "setSchema": {
-          "name": "setSchema",
-          "async": false,
-          "parameters": [
-            {
-              "name": "data",
-              "type": "Record<string, any>",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getParticipantSchema": {
-          "name": "getParticipantSchema",
-          "async": false,
-          "parameters": [],
-          "returnType": "Record<string, any>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "setParticipantSchema": {
-          "name": "setParticipantSchema",
-          "async": false,
-          "parameters": [
-            {
-              "name": "data",
-              "type": "Record<string, any>",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getBySlug": {
-          "name": "getBySlug",
-          "async": true,
-          "parameters": [
-            {
-              "name": "_slug",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<EventType | null>",
-          "isStatic": true,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "tableStrategy": "sti",
-        "api": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update",
-            "delete"
-          ]
-        },
-        "mcp": {
-          "include": [
-            "list",
-            "get",
-            "create"
-          ]
-        },
-        "cli": true
-      },
-      "extends": "SmrtObject",
-      "exportName": "EventType",
-      "collectionExportName": "EventTypeCollection",
-      "schema": {
-        "tableName": "event_types",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"event_types\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"schema\" TEXT DEFAULT '',\n  \"participant_schema\" TEXT DEFAULT ''\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "_meta_type": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "_meta_data": {
-            "type": "JSON",
-            "notNull": false
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "name": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "description": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "schema": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "participant_schema": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          }
-        },
-        "indexes": [
-          {
-            "name": "event_types_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "event_types_slug_context_meta_type_idx",
-            "columns": [
-              "slug",
-              "context",
-              "_meta_type"
-            ],
-            "unique": true
-          },
-          {
-            "name": "event_types_meta_type_idx",
-            "columns": [
-              "_meta_type"
-            ]
-          }
-        ],
-        "version": "1208f39b"
-      }
-    },
-    "eventtypecollection": {
-      "name": "eventtypecollection",
-      "className": "EventTypeCollection",
-      "collection": "eventtypes",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/events/src/collections/EventTypeCollection.ts",
+    "@happyvertical/smrt-events:EventAssetCollection": {
+      "name": "eventassetcollection",
+      "className": "EventAssetCollection",
+      "qualifiedName": "@happyvertical/smrt-events:EventAssetCollection",
+      "collection": "eventassets",
+      "filePath": "packages/events/src/collections/EventAssetCollection.ts",
+      "packageName": "@happyvertical/smrt-events",
       "fields": {},
       "methods": {
-        "getOrCreate": {
-          "name": "getOrCreate",
+        "byLeft": {
+          "name": "byLeft",
           "async": true,
           "parameters": [
             {
-              "name": "slug",
+              "name": "leftId",
               "type": "string",
               "optional": false
             },
             {
-              "name": "name",
-              "type": "string",
+              "name": "opts",
+              "type": "JunctionFilterOptions",
               "optional": true
             }
           ],
-          "returnType": "Promise<EventType>",
+          "returnType": "Promise<TItem[]>",
           "isStatic": false,
           "isPublic": true
         },
-        "getBySlug": {
-          "name": "getBySlug",
+        "byRight": {
+          "name": "byRight",
           "async": true,
           "parameters": [
             {
-              "name": "slug",
+              "name": "rightId",
               "type": "string",
               "optional": false
-            }
-          ],
-          "returnType": "Promise<EventType | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "initializeDefaults": {
-          "name": "initializeDefaults",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<EventType[]>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {},
-      "extends": "SmrtCollection",
-      "extendsTypeArg": "EventType",
-      "exportName": "EventTypeCollection",
-      "collectionExportName": "EventTypeCollectionCollection",
-      "schema": {
-        "tableName": "event_type_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"event_type_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          }
-        },
-        "indexes": [
-          {
-            "name": "event_type_collections_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "event_type_collections_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "9d8686f6"
-      }
-    },
-    "eventseries": {
-      "name": "eventseries",
-      "className": "EventSeries",
-      "collection": "eventserieses",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/events/src/models/EventSeries.ts",
-      "fields": {
-        "name": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "typeId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "organizerId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "description": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "startDate": {
-          "type": "datetime",
-          "required": false,
-          "default": null
-        },
-        "endDate": {
-          "type": "datetime",
-          "required": false,
-          "default": null
-        },
-        "recurrence": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "metadata": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "externalId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "source": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "createdAt": {
-          "type": "datetime",
-          "required": false
-        },
-        "updatedAt": {
-          "type": "datetime",
-          "required": false
-        }
-      },
-      "methods": {
-        "getRecurrence": {
-          "name": "getRecurrence",
-          "async": false,
-          "parameters": [],
-          "returnType": "RecurrencePattern | null",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "setRecurrence": {
-          "name": "setRecurrence",
-          "async": false,
-          "parameters": [
+            },
             {
-              "name": "pattern",
-              "type": "RecurrencePattern",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getMetadata": {
-          "name": "getMetadata",
-          "async": false,
-          "parameters": [],
-          "returnType": "Record<string, any>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "setMetadata": {
-          "name": "setMetadata",
-          "async": false,
-          "parameters": [
-            {
-              "name": "data",
-              "type": "Record<string, any>",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "updateMetadata": {
-          "name": "updateMetadata",
-          "async": false,
-          "parameters": [
-            {
-              "name": "updates",
-              "type": "Record<string, any>",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getType": {
-          "name": "getType",
-          "async": true,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getOrganizer": {
-          "name": "getOrganizer",
-          "async": true,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getEvents": {
-          "name": "getEvents",
-          "async": true,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isActive": {
-          "name": "isActive",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "tableStrategy": "sti",
-        "api": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update",
-            "delete"
-          ]
-        },
-        "mcp": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update"
-          ]
-        },
-        "cli": true
-      },
-      "extends": "SmrtObject",
-      "exportName": "EventSeries",
-      "collectionExportName": "EventSeriesCollection",
-      "schema": {
-        "tableName": "event_series",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"event_series\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"type_id\" TEXT DEFAULT '',\n  \"organizer_id\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"start_date\" TIMESTAMP DEFAULT current_timestamp,\n  \"end_date\" TIMESTAMP DEFAULT current_timestamp,\n  \"recurrence\" TEXT DEFAULT '',\n  \"metadata\" TEXT DEFAULT '',\n  \"external_id\" TEXT DEFAULT '',\n  \"source\" TEXT DEFAULT ''\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "_meta_type": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "_meta_data": {
-            "type": "JSON",
-            "notNull": false
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "name": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "type_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "organizer_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "description": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "start_date": {
-            "type": "TIMESTAMP",
-            "notNull": false,
-            "default": null
-          },
-          "end_date": {
-            "type": "TIMESTAMP",
-            "notNull": false,
-            "default": null
-          },
-          "recurrence": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "metadata": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "external_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "source": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          }
-        },
-        "indexes": [
-          {
-            "name": "event_series_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "event_series_slug_context_meta_type_idx",
-            "columns": [
-              "slug",
-              "context",
-              "_meta_type"
-            ],
-            "unique": true
-          },
-          {
-            "name": "event_series_meta_type_idx",
-            "columns": [
-              "_meta_type"
-            ]
-          }
-        ],
-        "version": "04c5089d"
-      }
-    },
-    "eventseriescollection": {
-      "name": "eventseriescollection",
-      "className": "EventSeriesCollection",
-      "collection": "eventserieses",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/events/src/collections/EventSeriesCollection.ts",
-      "fields": {},
-      "methods": {
-        "getByOrganizer": {
-          "name": "getByOrganizer",
-          "async": true,
-          "parameters": [
-            {
-              "name": "organizerId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<EventSeries[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getActive": {
-          "name": "getActive",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<EventSeries[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getUpcoming": {
-          "name": "getUpcoming",
-          "async": true,
-          "parameters": [
-            {
-              "name": "limit",
-              "type": "number",
+              "name": "opts",
+              "type": "JunctionFilterOptions",
               "optional": true
             }
           ],
-          "returnType": "Promise<EventSeries[]>",
+          "returnType": "Promise<TItem[]>",
           "isStatic": false,
           "isPublic": true
         },
-        "getByType": {
-          "name": "getByType",
+        "attach": {
+          "name": "attach",
           "async": true,
           "parameters": [
             {
-              "name": "typeId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<EventSeries[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "search": {
-          "name": "search",
-          "async": true,
-          "parameters": [
-            {
-              "name": "query",
+              "name": "leftId",
               "type": "string",
               "optional": false
             },
             {
-              "name": "filters",
-              "type": "EventSeriesSearchFilters",
+              "name": "rightId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionAttachOptions",
               "optional": true
             }
           ],
-          "returnType": "Promise<EventSeries[]>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {},
-      "extends": "SmrtCollection",
-      "extendsTypeArg": "EventSeries",
-      "exportName": "EventSeriesCollection",
-      "collectionExportName": "EventSeriesCollectionCollection",
-      "schema": {
-        "tableName": "event_series_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"event_series_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          }
-        },
-        "indexes": [
-          {
-            "name": "event_series_collections_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "event_series_collections_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "a67c8f62"
-      }
-    },
-    "eventparticipant": {
-      "name": "eventparticipant",
-      "className": "EventParticipant",
-      "collection": "eventparticipants",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/events/src/models/EventParticipant.ts",
-      "fields": {
-        "eventId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "profileId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "role": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "placement": {
-          "type": "decimal",
-          "required": false,
-          "default": null
-        },
-        "groupId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "metadata": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "externalId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "source": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "createdAt": {
-          "type": "datetime",
-          "required": false
-        },
-        "updatedAt": {
-          "type": "datetime",
-          "required": false
-        }
-      },
-      "methods": {
-        "getMetadata": {
-          "name": "getMetadata",
-          "async": false,
-          "parameters": [],
-          "returnType": "Record<string, any>",
+          "returnType": "Promise<TItem>",
           "isStatic": false,
           "isPublic": true
         },
-        "setMetadata": {
-          "name": "setMetadata",
-          "async": false,
-          "parameters": [
-            {
-              "name": "data",
-              "type": "Record<string, any>",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "updateMetadata": {
-          "name": "updateMetadata",
-          "async": false,
-          "parameters": [
-            {
-              "name": "updates",
-              "type": "Record<string, any>",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getEvent": {
-          "name": "getEvent",
-          "async": true,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getProfile": {
-          "name": "getProfile",
-          "async": true,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getGroupParticipants": {
-          "name": "getGroupParticipants",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<EventParticipant[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isHome": {
-          "name": "isHome",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isAway": {
-          "name": "isAway",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "tableStrategy": "sti",
-        "api": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update",
-            "delete"
-          ]
-        },
-        "mcp": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update"
-          ]
-        },
-        "cli": true
-      },
-      "extends": "SmrtObject",
-      "exportName": "EventParticipant",
-      "collectionExportName": "EventParticipantCollection",
-      "schema": {
-        "tableName": "event_participants",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"event_participants\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"event_id\" TEXT DEFAULT '',\n  \"profile_id\" TEXT DEFAULT '',\n  \"role\" TEXT DEFAULT '',\n  \"placement\" REAL DEFAULT NULL,\n  \"group_id\" TEXT DEFAULT '',\n  \"metadata\" TEXT DEFAULT '',\n  \"external_id\" TEXT DEFAULT '',\n  \"source\" TEXT DEFAULT ''\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "_meta_type": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "_meta_data": {
-            "type": "JSON",
-            "notNull": false
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "event_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "profile_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "role": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "placement": {
-            "type": "REAL",
-            "notNull": false,
-            "default": null
-          },
-          "group_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "metadata": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "external_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "source": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          }
-        },
-        "indexes": [
-          {
-            "name": "event_participants_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "event_participants_slug_context_meta_type_idx",
-            "columns": [
-              "slug",
-              "context",
-              "_meta_type"
-            ],
-            "unique": true
-          },
-          {
-            "name": "event_participants_meta_type_idx",
-            "columns": [
-              "_meta_type"
-            ]
-          }
-        ],
-        "version": "e28cbb28"
-      }
-    },
-    "eventparticipantcollection": {
-      "name": "eventparticipantcollection",
-      "className": "EventParticipantCollection",
-      "collection": "eventparticipants",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/events/src/collections/EventParticipantCollection.ts",
-      "fields": {},
-      "methods": {
-        "getByEvent": {
-          "name": "getByEvent",
+        "detach": {
+          "name": "detach",
           "async": true,
           "parameters": [
             {
-              "name": "eventId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<EventParticipant[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getByProfile": {
-          "name": "getByProfile",
-          "async": true,
-          "parameters": [
-            {
-              "name": "profileId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<EventParticipant[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getByRole": {
-          "name": "getByRole",
-          "async": true,
-          "parameters": [
-            {
-              "name": "eventId",
+              "name": "leftId",
               "type": "string",
               "optional": false
             },
             {
-              "name": "role",
-              "type": "ParticipantRole | string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<EventParticipant[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getByPlacement": {
-          "name": "getByPlacement",
-          "async": true,
-          "parameters": [
-            {
-              "name": "eventId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<EventParticipant[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getByGroup": {
-          "name": "getByGroup",
-          "async": true,
-          "parameters": [
-            {
-              "name": "eventId",
+              "name": "rightId",
               "type": "string",
               "optional": false
             },
             {
-              "name": "groupId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<EventParticipant[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getHome": {
-          "name": "getHome",
-          "async": true,
-          "parameters": [
-            {
-              "name": "eventId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<EventParticipant[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getAway": {
-          "name": "getAway",
-          "async": true,
-          "parameters": [
-            {
-              "name": "eventId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<EventParticipant[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "search": {
-          "name": "search",
-          "async": true,
-          "parameters": [
-            {
-              "name": "filters",
-              "type": "ParticipantSearchFilters",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<EventParticipant[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getParticipantStats": {
-          "name": "getParticipantStats",
-          "async": true,
-          "parameters": [
-            {
-              "name": "profileId",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "eventTypeId",
-              "type": "string",
+              "name": "opts",
+              "type": "JunctionFilterOptions",
               "optional": true
-            }
-          ],
-          "returnType": "Promise<{\n    totalEvents: number;\n    byRole: Record<string, number>;\n    byPlacement: Record<number, number>;\n  }>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {},
-      "extends": "SmrtCollection",
-      "extendsTypeArg": "EventParticipant",
-      "exportName": "EventParticipantCollection",
-      "collectionExportName": "EventParticipantCollectionCollection",
-      "schema": {
-        "tableName": "event_participant_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"event_participant_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          }
-        },
-        "indexes": [
-          {
-            "name": "event_participant_collections_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "event_participant_collections_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "f6e133f3"
-      }
-    },
-    "event": {
-      "name": "event",
-      "className": "Event",
-      "collection": "events",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/events/src/models/Event.ts",
-      "fields": {
-        "name": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "seriesId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "parentId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "typeId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "placeId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "description": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "startDate": {
-          "type": "datetime",
-          "required": false,
-          "default": null
-        },
-        "endDate": {
-          "type": "datetime",
-          "required": false,
-          "default": null
-        },
-        "status": {
-          "type": "text",
-          "required": false,
-          "default": "scheduled"
-        },
-        "round": {
-          "type": "decimal",
-          "required": false,
-          "default": null
-        },
-        "metadata": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "externalId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "source": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "createdAt": {
-          "type": "datetime",
-          "required": false
-        },
-        "updatedAt": {
-          "type": "datetime",
-          "required": false
-        }
-      },
-      "methods": {
-        "getMetadata": {
-          "name": "getMetadata",
-          "async": false,
-          "parameters": [],
-          "returnType": "Record<string, any>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "setMetadata": {
-          "name": "setMetadata",
-          "async": false,
-          "parameters": [
-            {
-              "name": "data",
-              "type": "Record<string, any>",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "updateMetadata": {
-          "name": "updateMetadata",
-          "async": false,
-          "parameters": [
-            {
-              "name": "updates",
-              "type": "Record<string, any>",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "updateStatus": {
-          "name": "updateStatus",
-          "async": true,
-          "parameters": [
-            {
-              "name": "newStatus",
-              "type": "EventStatus",
-              "optional": false
             }
           ],
           "returnType": "Promise<void>",
           "isStatic": false,
           "isPublic": true
         },
-        "getSeries": {
-          "name": "getSeries",
+        "setLinks": {
+          "name": "setLinks",
           "async": true,
-          "parameters": [],
-          "returnType": "void",
+          "parameters": [
+            {
+              "name": "leftId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "rightIds",
+              "type": "string[]",
+              "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionAttachOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
           "isStatic": false,
           "isPublic": true
         },
-        "getType": {
-          "name": "getType",
+        "getAssets": {
+          "name": "getAssets",
           "async": true,
-          "parameters": [],
-          "returnType": "void",
+          "parameters": [
+            {
+              "name": "eventId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
           "isStatic": false,
           "isPublic": true
         },
-        "getPlace": {
-          "name": "getPlace",
+        "addAsset": {
+          "name": "addAsset",
           "async": true,
-          "parameters": [],
-          "returnType": "void",
+          "parameters": [
+            {
+              "name": "eventId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "asset",
+              "type": "Asset",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "any",
+              "optional": true,
+              "default": "attachment"
+            },
+            {
+              "name": "sortOrder",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
           "isStatic": false,
           "isPublic": true
         },
-        "getParent": {
-          "name": "getParent",
+        "removeAsset": {
+          "name": "removeAsset",
           "async": true,
-          "parameters": [],
-          "returnType": "Promise<Event | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getChildren": {
-          "name": "getChildren",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Event[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getAncestors": {
-          "name": "getAncestors",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Event[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getDescendants": {
-          "name": "getDescendants",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Event[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getRootEvent": {
-          "name": "getRootEvent",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Event>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getHierarchy": {
-          "name": "getHierarchy",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<{\n    ancestors: Event[];\n    current: Event;\n    descendants: Event[];\n  }>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getParticipants": {
-          "name": "getParticipants",
-          "async": true,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isInProgress": {
-          "name": "isInProgress",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isRoot": {
-          "name": "isRoot",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
+          "parameters": [
+            {
+              "name": "eventId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "assetId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
           "isStatic": false,
           "isPublic": true
         }
       },
       "decoratorConfig": {
-        "tableStrategy": "sti",
-        "api": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update",
-            "delete"
-          ]
-        },
-        "mcp": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update"
-          ]
-        },
-        "cli": true
+        "api": false,
+        "mcp": false,
+        "cli": false,
+        "tableName": "event_assets"
       },
-      "extends": "SmrtObject",
-      "exportName": "Event",
-      "collectionExportName": "EventCollection",
+      "extends": "SmrtJunction",
+      "extendsTypeArg": "EventAsset",
+      "exportName": "EventAssetCollection",
+      "collectionExportName": "EventAssetCollectionCollection",
       "schema": {
-        "tableName": "events",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"events\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"series_id\" TEXT DEFAULT '',\n  \"parent_id\" TEXT DEFAULT '',\n  \"type_id\" TEXT DEFAULT '',\n  \"place_id\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"start_date\" TIMESTAMP DEFAULT current_timestamp,\n  \"end_date\" TIMESTAMP DEFAULT current_timestamp,\n  \"status\" TEXT DEFAULT 'scheduled',\n  \"round\" REAL DEFAULT NULL,\n  \"metadata\" TEXT DEFAULT '',\n  \"external_id\" TEXT DEFAULT '',\n  \"source\" TEXT DEFAULT ''\n);",
+        "tableName": "event_assets",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_assets\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1462,14 +225,6 @@
             "notNull": true,
             "default": ""
           },
-          "_meta_type": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "_meta_data": {
-            "type": "JSON",
-            "notNull": false
-          },
           "created_at": {
             "type": "TIMESTAMP",
             "notNull": true,
@@ -1479,104 +234,34 @@
             "type": "TIMESTAMP",
             "notNull": true,
             "default": "current_timestamp"
-          },
-          "name": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "series_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "parent_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "type_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "place_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "description": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "start_date": {
-            "type": "TIMESTAMP",
-            "notNull": false,
-            "default": null
-          },
-          "end_date": {
-            "type": "TIMESTAMP",
-            "notNull": false,
-            "default": null
-          },
-          "status": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "scheduled"
-          },
-          "round": {
-            "type": "REAL",
-            "notNull": false,
-            "default": null
-          },
-          "metadata": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "external_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "source": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
           }
         },
         "indexes": [
           {
-            "name": "events_id_idx",
+            "name": "event_assets_id_idx",
             "columns": [
               "id"
             ]
           },
           {
-            "name": "events_slug_context_meta_type_idx",
+            "name": "event_assets_slug_context_idx",
             "columns": [
               "slug",
-              "context",
-              "_meta_type"
+              "context"
             ],
             "unique": true
-          },
-          {
-            "name": "events_meta_type_idx",
-            "columns": [
-              "_meta_type"
-            ]
           }
         ],
-        "version": "31a5eb8a"
+        "version": "e8626c67"
       }
     },
-    "eventcollection": {
+    "@happyvertical/smrt-events:EventCollection": {
       "name": "eventcollection",
       "className": "EventCollection",
+      "qualifiedName": "@happyvertical/smrt-events:EventCollection",
       "collection": "events",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/events/src/collections/EventCollection.ts",
+      "filePath": "packages/events/src/collections/EventCollection.ts",
+      "packageName": "@happyvertical/smrt-events",
       "fields": {},
       "methods": {
         "getBySeriesId": {
@@ -1704,6 +389,79 @@
           "isStatic": false,
           "isPublic": true
         },
+        "getAssets": {
+          "name": "getAssets",
+          "async": true,
+          "parameters": [
+            {
+              "name": "eventId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addAsset": {
+          "name": "addAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "eventId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "asset",
+              "type": "Asset",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "any",
+              "optional": true,
+              "default": "attachment"
+            },
+            {
+              "name": "sortOrder",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeAsset": {
+          "name": "removeAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "eventId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "assetId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
         "search": {
           "name": "search",
           "async": true,
@@ -1730,6 +488,42 @@
           "returnType": "Promise<Event[]>",
           "isStatic": false,
           "isPublic": true
+        },
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Event[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Event[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Event[]>",
+          "isStatic": false,
+          "isPublic": true
         }
       },
       "decoratorConfig": {},
@@ -1739,10 +533,10 @@
       "collectionExportName": "EventCollectionCollection",
       "schema": {
         "tableName": "event_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"event_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1782,10 +576,3234 @@
             "unique": true
           }
         ],
-        "version": "548d1610"
+        "version": "ab0de818"
+      }
+    },
+    "@happyvertical/smrt-events:EventParticipantCollection": {
+      "name": "eventparticipantcollection",
+      "className": "EventParticipantCollection",
+      "qualifiedName": "@happyvertical/smrt-events:EventParticipantCollection",
+      "collection": "eventparticipants",
+      "filePath": "packages/events/src/collections/EventParticipantCollection.ts",
+      "packageName": "@happyvertical/smrt-events",
+      "fields": {},
+      "methods": {
+        "byLeft": {
+          "name": "byLeft",
+          "async": true,
+          "parameters": [
+            {
+              "name": "leftId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionFilterOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<TItem[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "byRight": {
+          "name": "byRight",
+          "async": true,
+          "parameters": [
+            {
+              "name": "rightId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionFilterOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<TItem[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "attach": {
+          "name": "attach",
+          "async": true,
+          "parameters": [
+            {
+              "name": "leftId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "rightId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionAttachOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<TItem>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "detach": {
+          "name": "detach",
+          "async": true,
+          "parameters": [
+            {
+              "name": "leftId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "rightId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionFilterOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setLinks": {
+          "name": "setLinks",
+          "async": true,
+          "parameters": [
+            {
+              "name": "leftId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "rightIds",
+              "type": "string[]",
+              "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionAttachOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByPlacement": {
+          "name": "getByPlacement",
+          "async": true,
+          "parameters": [
+            {
+              "name": "eventId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventParticipant[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByGroup": {
+          "name": "getByGroup",
+          "async": true,
+          "parameters": [
+            {
+              "name": "eventId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "groupId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventParticipant[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getHome": {
+          "name": "getHome",
+          "async": true,
+          "parameters": [
+            {
+              "name": "eventId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventParticipant[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAway": {
+          "name": "getAway",
+          "async": true,
+          "parameters": [
+            {
+              "name": "eventId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventParticipant[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "search": {
+          "name": "search",
+          "async": true,
+          "parameters": [
+            {
+              "name": "filters",
+              "type": "ParticipantSearchFilters",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventParticipant[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParticipantStats": {
+          "name": "getParticipantStats",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "eventTypeId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<object>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventParticipant[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<EventParticipant[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventParticipant[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtJunction",
+      "extendsTypeArg": "EventParticipant",
+      "exportName": "EventParticipantCollection",
+      "collectionExportName": "EventParticipantCollectionCollection",
+      "schema": {
+        "tableName": "event_participant_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_participant_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "event_participant_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "event_participant_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "942c35fc"
+      }
+    },
+    "@happyvertical/smrt-events:EventSeriesCollection": {
+      "name": "eventseriescollection",
+      "className": "EventSeriesCollection",
+      "qualifiedName": "@happyvertical/smrt-events:EventSeriesCollection",
+      "collection": "eventserieses",
+      "filePath": "packages/events/src/collections/EventSeriesCollection.ts",
+      "packageName": "@happyvertical/smrt-events",
+      "fields": {},
+      "methods": {
+        "getByOrganizer": {
+          "name": "getByOrganizer",
+          "async": true,
+          "parameters": [
+            {
+              "name": "organizerId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventSeries[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getActive": {
+          "name": "getActive",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<EventSeries[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getUpcoming": {
+          "name": "getUpcoming",
+          "async": true,
+          "parameters": [
+            {
+              "name": "limit",
+              "type": "number",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<EventSeries[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByType": {
+          "name": "getByType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "typeId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventSeries[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "search": {
+          "name": "search",
+          "async": true,
+          "parameters": [
+            {
+              "name": "query",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "filters",
+              "type": "EventSeriesSearchFilters",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<EventSeries[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventSeries[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<EventSeries[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventSeries[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "EventSeries",
+      "exportName": "EventSeriesCollection",
+      "collectionExportName": "EventSeriesCollectionCollection",
+      "schema": {
+        "tableName": "event_series_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_series_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "event_series_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "event_series_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "6bdab34a"
+      }
+    },
+    "@happyvertical/smrt-events:EventTypeCollection": {
+      "name": "eventtypecollection",
+      "className": "EventTypeCollection",
+      "qualifiedName": "@happyvertical/smrt-events:EventTypeCollection",
+      "collection": "eventtypes",
+      "filePath": "packages/events/src/collections/EventTypeCollection.ts",
+      "packageName": "@happyvertical/smrt-events",
+      "fields": {},
+      "methods": {
+        "getOrCreate": {
+          "name": "getOrCreate",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<EventType>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getBySlug": {
+          "name": "getBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventType | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initializeDefaults": {
+          "name": "initializeDefaults",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<EventType[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventType[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<EventType[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventType[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "EventType",
+      "exportName": "EventTypeCollection",
+      "collectionExportName": "EventTypeCollectionCollection",
+      "schema": {
+        "tableName": "event_type_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_type_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "event_type_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "event_type_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "d8f92580"
+      }
+    },
+    "@happyvertical/smrt-events:Event": {
+      "name": "event",
+      "className": "Event",
+      "qualifiedName": "@happyvertical/smrt-events:Event",
+      "collection": "events",
+      "filePath": "packages/events/src/models/Event.ts",
+      "packageName": "@happyvertical/smrt-events",
+      "fields": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "parentId": {
+          "type": "text",
+          "required": false
+        },
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "seriesId": {
+          "type": "foreignKey",
+          "required": false,
+          "related": "EventSeries"
+        },
+        "typeId": {
+          "type": "foreignKey",
+          "required": false,
+          "related": "EventType"
+        },
+        "placeId": {
+          "type": "crossPackageRef",
+          "required": false,
+          "related": "@happyvertical/smrt-places:Place"
+        },
+        "description": {
+          "type": "text",
+          "required": false
+        },
+        "startDate": {
+          "type": "datetime",
+          "required": false
+        },
+        "endDate": {
+          "type": "datetime",
+          "required": false
+        },
+        "status": {
+          "type": "text",
+          "required": false,
+          "default": "scheduled"
+        },
+        "round": {
+          "type": "integer",
+          "required": false
+        },
+        "metadata": {
+          "type": "text",
+          "required": false
+        },
+        "externalId": {
+          "type": "text",
+          "required": false
+        },
+        "source": {
+          "type": "text",
+          "required": false
+        },
+        "createdAt": {
+          "type": "text",
+          "required": false
+        },
+        "updatedAt": {
+          "type": "text",
+          "required": false
+        }
+      },
+      "methods": {
+        "getAiUsageSnapshot": {
+          "name": "getAiUsageSnapshot",
+          "async": false,
+          "parameters": [],
+          "returnType": "AiUsageSnapshot | undefined",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetAiUsage": {
+          "name": "resetAiUsage",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listAiUsage": {
+          "name": "listAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageListOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<SmrtAiUsageRecord[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeAiUsage": {
+          "name": "summarizeAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageSummaryOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Record<string, AiUsageStats>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "destroy": {
+          "name": "destroy",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadDataFromDb": {
+          "name": "loadDataFromDb",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toJSON": {
+          "name": "toJSON",
+          "async": false,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPlainObject": {
+          "name": "toPlainObject",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getId": {
+          "name": "getId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSlug": {
+          "name": "getSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSavedId": {
+          "name": "getSavedId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSaved": {
+          "name": "isSaved",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromId": {
+          "name": "loadFromId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromSlug": {
+          "name": "loadFromSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "is": {
+          "name": "is",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "do": {
+          "name": "do",
+          "async": true,
+          "parameters": [
+            {
+              "name": "instructions",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "describe": {
+          "name": "describe",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "delete": {
+          "name": "delete",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRelatedLoaded": {
+          "name": "isRelatedLoaded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelated": {
+          "name": "loadRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelatedMany": {
+          "name": "loadRelatedMany",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelated": {
+          "name": "getRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAvailableTools": {
+          "name": "getAvailableTools",
+          "async": false,
+          "parameters": [],
+          "returnType": "AITool[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "executeToolCall": {
+          "name": "executeToolCall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toolCall",
+              "type": "ToolCall",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ToolCallResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "remember": {
+          "name": "remember",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recall": {
+          "name": "recall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recallAll": {
+          "name": "recallAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forget": {
+          "name": "forget",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forgetScope": {
+          "name": "forgetScope",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateEmbeddings": {
+          "name": "generateEmbeddings",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "GenerateEmbeddingsOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmbedding": {
+          "name": "getEmbedding",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "model",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number[] | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStaleEmbeddings": {
+          "name": "hasStaleEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearEmbeddings": {
+          "name": "clearEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParent": {
+          "name": "getParent",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getChildren": {
+          "name": "getChildren",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAncestors": {
+          "name": "getAncestors",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getDescendants": {
+          "name": "getDescendants",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getHierarchy": {
+          "name": "getHierarchy",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<HierarchyView>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "moveTo": {
+          "name": "moveTo",
+          "async": true,
+          "parameters": [
+            {
+              "name": "newParent",
+              "type": "string | null",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setMetadata": {
+          "name": "setMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateMetadata": {
+          "name": "updateMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "updates",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateStatus": {
+          "name": "updateStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "newStatus",
+              "type": "EventStatus",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSeries": {
+          "name": "getSeries",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getType": {
+          "name": "getType",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getPlace": {
+          "name": "getPlace",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRootEvent": {
+          "name": "getRootEvent",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Event>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParticipants": {
+          "name": "getParticipants",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAssets": {
+          "name": "getAssets",
+          "async": true,
+          "parameters": [
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addAsset": {
+          "name": "addAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "asset",
+              "type": "Asset",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "any",
+              "optional": true,
+              "default": "attachment"
+            },
+            {
+              "name": "sortOrder",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeAsset": {
+          "name": "removeAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "assetId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isInProgress": {
+          "name": "isInProgress",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRoot": {
+          "name": "isRoot",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtHierarchical",
+      "exportName": "Event",
+      "collectionExportName": "EventCollection",
+      "schema": {
+        "tableName": "events",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"events\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"parent_id\" TEXT,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"series_id\" uuid,\n  \"type_id\" uuid,\n  \"place_id\" uuid,\n  \"description\" TEXT,\n  \"start_date\" TIMESTAMP,\n  \"end_date\" TIMESTAMP,\n  \"status\" TEXT DEFAULT 'scheduled',\n  \"round\" INTEGER,\n  \"metadata\" TEXT,\n  \"external_id\" TEXT,\n  \"source\" TEXT\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "parent_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "series_id": {
+            "type": "UUID",
+            "notNull": false
+          },
+          "type_id": {
+            "type": "UUID",
+            "notNull": false
+          },
+          "place_id": {
+            "type": "UUID",
+            "notNull": false
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "start_date": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          },
+          "end_date": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "scheduled"
+          },
+          "round": {
+            "type": "INTEGER",
+            "notNull": false
+          },
+          "metadata": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "external_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "source": {
+            "type": "TEXT",
+            "notNull": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "events_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "events_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "events_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "6ed841fc"
+      }
+    },
+    "@happyvertical/smrt-events:EventAsset": {
+      "name": "eventasset",
+      "className": "EventAsset",
+      "qualifiedName": "@happyvertical/smrt-events:EventAsset",
+      "collection": "eventassets",
+      "filePath": "packages/events/src/models/EventAsset.ts",
+      "packageName": "@happyvertical/smrt-events",
+      "fields": {
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "eventId": {
+          "type": "foreignKey",
+          "required": false,
+          "related": "Event"
+        },
+        "assetId": {
+          "type": "crossPackageRef",
+          "required": true,
+          "related": "@happyvertical/smrt-assets:Asset"
+        },
+        "relationship": {
+          "type": "text",
+          "required": true,
+          "_meta": {
+            "required": true
+          }
+        },
+        "sortOrder": {
+          "type": "integer",
+          "required": true,
+          "default": 0
+        }
+      },
+      "methods": {},
+      "decoratorConfig": {
+        "tableName": "event_assets",
+        "conflictColumns": [
+          "event_id",
+          "asset_id",
+          "relationship"
+        ],
+        "api": false,
+        "mcp": false,
+        "cli": false
+      },
+      "extends": "SmrtObject",
+      "exportName": "EventAsset",
+      "collectionExportName": "EventAssetCollection",
+      "validationRules": [
+        {
+          "field": "assetId",
+          "rule": "required",
+          "fieldType": "crossPackageRef"
+        },
+        {
+          "field": "relationship",
+          "rule": "required",
+          "fieldType": "text"
+        },
+        {
+          "field": "sortOrder",
+          "rule": "required",
+          "fieldType": "integer"
+        }
+      ],
+      "schema": {
+        "tableName": "event_assets",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_assets\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"event_id\" uuid,\n  \"asset_id\" uuid NOT NULL,\n  \"relationship\" TEXT NOT NULL,\n  \"sort_order\" INTEGER NOT NULL DEFAULT 0\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "event_id": {
+            "type": "UUID",
+            "notNull": false,
+            "unique": false
+          },
+          "asset_id": {
+            "type": "UUID",
+            "notNull": true,
+            "unique": false
+          },
+          "relationship": {
+            "type": "TEXT",
+            "notNull": true,
+            "unique": false
+          },
+          "sort_order": {
+            "type": "INTEGER",
+            "notNull": true,
+            "unique": false,
+            "default": 0
+          }
+        },
+        "indexes": [
+          {
+            "name": "event_assets_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "event_assets_event_id_asset_id_idx",
+            "columns": [
+              "event_id",
+              "asset_id",
+              "relationship"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "c62ee267"
+      }
+    },
+    "@happyvertical/smrt-events:EventParticipant": {
+      "name": "eventparticipant",
+      "className": "EventParticipant",
+      "qualifiedName": "@happyvertical/smrt-events:EventParticipant",
+      "collection": "eventparticipants",
+      "filePath": "packages/events/src/models/EventParticipant.ts",
+      "packageName": "@happyvertical/smrt-events",
+      "fields": {
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "eventId": {
+          "type": "foreignKey",
+          "required": false,
+          "related": "Event"
+        },
+        "profileId": {
+          "type": "crossPackageRef",
+          "required": false,
+          "related": "@happyvertical/smrt-profiles:Profile"
+        },
+        "role": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "placement": {
+          "type": "integer",
+          "required": false
+        },
+        "groupId": {
+          "type": "text",
+          "required": false
+        },
+        "metadata": {
+          "type": "text",
+          "required": false
+        },
+        "externalId": {
+          "type": "text",
+          "required": false
+        },
+        "source": {
+          "type": "text",
+          "required": false
+        },
+        "createdAt": {
+          "type": "text",
+          "required": false
+        },
+        "updatedAt": {
+          "type": "text",
+          "required": false
+        }
+      },
+      "methods": {
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setMetadata": {
+          "name": "setMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateMetadata": {
+          "name": "updateMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "updates",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEvent": {
+          "name": "getEvent",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getProfile": {
+          "name": "getProfile",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getGroupParticipants": {
+          "name": "getGroupParticipants",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<EventParticipant[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isHome": {
+          "name": "isHome",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isAway": {
+          "name": "isAway",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "conflictColumns": [
+          "event_id",
+          "profile_id",
+          "role"
+        ],
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "EventParticipant",
+      "collectionExportName": "EventParticipantCollection",
+      "schema": {
+        "tableName": "event_participants",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_participants\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"event_id\" uuid,\n  \"profile_id\" uuid,\n  \"role\" TEXT DEFAULT '',\n  \"placement\" INTEGER,\n  \"group_id\" TEXT,\n  \"metadata\" TEXT,\n  \"external_id\" TEXT,\n  \"source\" TEXT\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "event_id": {
+            "type": "UUID",
+            "notNull": false,
+            "unique": false
+          },
+          "profile_id": {
+            "type": "UUID",
+            "notNull": false,
+            "unique": false
+          },
+          "role": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": ""
+          },
+          "placement": {
+            "type": "INTEGER",
+            "notNull": false,
+            "unique": false
+          },
+          "group_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "metadata": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "external_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "source": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "event_participants_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "event_participants_event_id_profile_id_idx",
+            "columns": [
+              "event_id",
+              "profile_id",
+              "role"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "822f86e6"
+      }
+    },
+    "@happyvertical/smrt-events:EventSeries": {
+      "name": "eventseries",
+      "className": "EventSeries",
+      "qualifiedName": "@happyvertical/smrt-events:EventSeries",
+      "collection": "eventserieses",
+      "filePath": "packages/events/src/models/EventSeries.ts",
+      "packageName": "@happyvertical/smrt-events",
+      "fields": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "typeId": {
+          "type": "foreignKey",
+          "required": false,
+          "related": "EventType"
+        },
+        "organizerId": {
+          "type": "crossPackageRef",
+          "required": false,
+          "related": "@happyvertical/smrt-profiles:Profile"
+        },
+        "description": {
+          "type": "text",
+          "required": false
+        },
+        "startDate": {
+          "type": "datetime",
+          "required": false
+        },
+        "endDate": {
+          "type": "datetime",
+          "required": false
+        },
+        "recurrence": {
+          "type": "text",
+          "required": false
+        },
+        "metadata": {
+          "type": "text",
+          "required": false
+        },
+        "externalId": {
+          "type": "text",
+          "required": false
+        },
+        "source": {
+          "type": "text",
+          "required": false
+        },
+        "createdAt": {
+          "type": "text",
+          "required": false
+        },
+        "updatedAt": {
+          "type": "text",
+          "required": false
+        }
+      },
+      "methods": {
+        "getAiUsageSnapshot": {
+          "name": "getAiUsageSnapshot",
+          "async": false,
+          "parameters": [],
+          "returnType": "AiUsageSnapshot | undefined",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetAiUsage": {
+          "name": "resetAiUsage",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listAiUsage": {
+          "name": "listAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageListOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<SmrtAiUsageRecord[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeAiUsage": {
+          "name": "summarizeAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageSummaryOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Record<string, AiUsageStats>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "destroy": {
+          "name": "destroy",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadDataFromDb": {
+          "name": "loadDataFromDb",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toJSON": {
+          "name": "toJSON",
+          "async": false,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPlainObject": {
+          "name": "toPlainObject",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getId": {
+          "name": "getId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSlug": {
+          "name": "getSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSavedId": {
+          "name": "getSavedId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSaved": {
+          "name": "isSaved",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromId": {
+          "name": "loadFromId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromSlug": {
+          "name": "loadFromSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "is": {
+          "name": "is",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "do": {
+          "name": "do",
+          "async": true,
+          "parameters": [
+            {
+              "name": "instructions",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "describe": {
+          "name": "describe",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "delete": {
+          "name": "delete",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRelatedLoaded": {
+          "name": "isRelatedLoaded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelated": {
+          "name": "loadRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelatedMany": {
+          "name": "loadRelatedMany",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelated": {
+          "name": "getRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAvailableTools": {
+          "name": "getAvailableTools",
+          "async": false,
+          "parameters": [],
+          "returnType": "AITool[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "executeToolCall": {
+          "name": "executeToolCall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toolCall",
+              "type": "ToolCall",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ToolCallResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "remember": {
+          "name": "remember",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recall": {
+          "name": "recall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recallAll": {
+          "name": "recallAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forget": {
+          "name": "forget",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forgetScope": {
+          "name": "forgetScope",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateEmbeddings": {
+          "name": "generateEmbeddings",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "GenerateEmbeddingsOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmbedding": {
+          "name": "getEmbedding",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "model",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number[] | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStaleEmbeddings": {
+          "name": "hasStaleEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearEmbeddings": {
+          "name": "clearEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRecurrence": {
+          "name": "getRecurrence",
+          "async": false,
+          "parameters": [],
+          "returnType": "RecurrencePattern | null",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setRecurrence": {
+          "name": "setRecurrence",
+          "async": false,
+          "parameters": [
+            {
+              "name": "pattern",
+              "type": "RecurrencePattern",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setMetadata": {
+          "name": "setMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateMetadata": {
+          "name": "updateMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "updates",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getType": {
+          "name": "getType",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getOrganizer": {
+          "name": "getOrganizer",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEvents": {
+          "name": "getEvents",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "EventSeries",
+      "collectionExportName": "EventSeriesCollection",
+      "schema": {
+        "tableName": "event_series",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_series\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"type_id\" uuid,\n  \"organizer_id\" uuid,\n  \"description\" TEXT,\n  \"start_date\" TIMESTAMP,\n  \"end_date\" TIMESTAMP,\n  \"recurrence\" TEXT,\n  \"metadata\" TEXT,\n  \"external_id\" TEXT,\n  \"source\" TEXT\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "type_id": {
+            "type": "UUID",
+            "notNull": false
+          },
+          "organizer_id": {
+            "type": "UUID",
+            "notNull": false
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "start_date": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          },
+          "end_date": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          },
+          "recurrence": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "metadata": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "external_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "source": {
+            "type": "TEXT",
+            "notNull": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "event_series_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "event_series_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "event_series_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "a6e42355"
+      }
+    },
+    "@happyvertical/smrt-events:EventType": {
+      "name": "eventtype",
+      "className": "EventType",
+      "qualifiedName": "@happyvertical/smrt-events:EventType",
+      "collection": "eventtypes",
+      "filePath": "packages/events/src/models/EventType.ts",
+      "packageName": "@happyvertical/smrt-events",
+      "fields": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "name": {
+          "type": "text",
+          "required": true,
+          "default": "",
+          "_meta": {
+            "required": true
+          }
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "schema": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "participantSchema": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "createdAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "updatedAt": {
+          "type": "datetime",
+          "required": false
+        }
+      },
+      "methods": {
+        "getAiUsageSnapshot": {
+          "name": "getAiUsageSnapshot",
+          "async": false,
+          "parameters": [],
+          "returnType": "AiUsageSnapshot | undefined",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetAiUsage": {
+          "name": "resetAiUsage",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listAiUsage": {
+          "name": "listAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageListOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<SmrtAiUsageRecord[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeAiUsage": {
+          "name": "summarizeAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageSummaryOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Record<string, AiUsageStats>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "destroy": {
+          "name": "destroy",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadDataFromDb": {
+          "name": "loadDataFromDb",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toJSON": {
+          "name": "toJSON",
+          "async": false,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPlainObject": {
+          "name": "toPlainObject",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getId": {
+          "name": "getId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSlug": {
+          "name": "getSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSavedId": {
+          "name": "getSavedId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSaved": {
+          "name": "isSaved",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromId": {
+          "name": "loadFromId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromSlug": {
+          "name": "loadFromSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "is": {
+          "name": "is",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "do": {
+          "name": "do",
+          "async": true,
+          "parameters": [
+            {
+              "name": "instructions",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "describe": {
+          "name": "describe",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "delete": {
+          "name": "delete",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRelatedLoaded": {
+          "name": "isRelatedLoaded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelated": {
+          "name": "loadRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelatedMany": {
+          "name": "loadRelatedMany",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelated": {
+          "name": "getRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAvailableTools": {
+          "name": "getAvailableTools",
+          "async": false,
+          "parameters": [],
+          "returnType": "AITool[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "executeToolCall": {
+          "name": "executeToolCall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toolCall",
+              "type": "ToolCall",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ToolCallResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "remember": {
+          "name": "remember",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recall": {
+          "name": "recall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recallAll": {
+          "name": "recallAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forget": {
+          "name": "forget",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forgetScope": {
+          "name": "forgetScope",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateEmbeddings": {
+          "name": "generateEmbeddings",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "GenerateEmbeddingsOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmbedding": {
+          "name": "getEmbedding",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "model",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number[] | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStaleEmbeddings": {
+          "name": "hasStaleEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearEmbeddings": {
+          "name": "clearEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSchema": {
+          "name": "getSchema",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setSchema": {
+          "name": "setSchema",
+          "async": false,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParticipantSchema": {
+          "name": "getParticipantSchema",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setParticipantSchema": {
+          "name": "setParticipantSchema",
+          "async": false,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getBySlug": {
+          "name": "getBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<EventType | null>",
+          "isStatic": true,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "EventType",
+      "collectionExportName": "EventTypeCollection",
+      "validationRules": [
+        {
+          "field": "name",
+          "rule": "required",
+          "fieldType": "text"
+        }
+      ],
+      "schema": {
+        "tableName": "event_types",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_types\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"schema\" TEXT DEFAULT '',\n  \"participant_schema\" TEXT DEFAULT ''\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "schema": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "participant_schema": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          }
+        },
+        "indexes": [
+          {
+            "name": "event_types_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "event_types_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "event_types_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "cb404685"
       }
     }
   },
   "moduleType": "smrt",
-  "packageName": "@happyvertical/smrt-events"
+  "smrtDependencies": [
+    "@happyvertical/smrt-assets",
+    "@happyvertical/smrt-core",
+    "@happyvertical/smrt-places",
+    "@happyvertical/smrt-profiles"
+  ]
 }

--- a/packages/events/src/manifest/manifest.json
+++ b/packages/events/src/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "timestamp": 1780375810662,
+  "timestamp": 1780379243051,
   "packageName": "@happyvertical/smrt-events",
   "packageVersion": "0.25.8",
   "objects": {
@@ -209,7 +209,7 @@
       "collectionExportName": "EventAssetCollectionCollection",
       "schema": {
         "tableName": "event_assets",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"event_assets\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_assets\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -533,7 +533,7 @@
       "collectionExportName": "EventCollectionCollection",
       "schema": {
         "tableName": "event_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"event_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -836,7 +836,7 @@
       "collectionExportName": "EventParticipantCollectionCollection",
       "schema": {
         "tableName": "event_participant_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"event_participant_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_participant_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1004,7 +1004,7 @@
       "collectionExportName": "EventSeriesCollectionCollection",
       "schema": {
         "tableName": "event_series_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"event_series_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_series_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1144,7 +1144,7 @@
       "collectionExportName": "EventTypeCollectionCollection",
       "schema": {
         "tableName": "event_type_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"event_type_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_type_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1207,8 +1207,12 @@
           "required": false
         },
         "parentId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "Event",
+          "_meta": {
+            "nullable": true
+          }
         },
         "tenantId": {
           "type": "text",
@@ -1933,7 +1937,7 @@
       "collectionExportName": "EventCollection",
       "schema": {
         "tableName": "events",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"events\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"parent_id\" TEXT,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"series_id\" uuid,\n  \"type_id\" uuid,\n  \"place_id\" uuid,\n  \"description\" TEXT,\n  \"start_date\" TIMESTAMP,\n  \"end_date\" TIMESTAMP,\n  \"status\" TEXT DEFAULT 'scheduled',\n  \"round\" INTEGER,\n  \"metadata\" TEXT,\n  \"external_id\" TEXT,\n  \"source\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"events\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"parent_id\" UUID,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"series_id\" UUID,\n  \"type_id\" UUID,\n  \"place_id\" UUID,\n  \"description\" TEXT,\n  \"start_date\" TIMESTAMP,\n  \"end_date\" TIMESTAMP,\n  \"status\" TEXT DEFAULT 'scheduled',\n  \"round\" INTEGER,\n  \"metadata\" TEXT,\n  \"external_id\" TEXT,\n  \"source\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1968,7 +1972,7 @@
             "default": "current_timestamp"
           },
           "parent_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "tenant_id": {
@@ -2049,7 +2053,7 @@
             ]
           }
         ],
-        "version": "6ed841fc"
+        "version": "e48a7ab2"
       }
     },
     "@happyvertical/smrt-events:EventAsset": {
@@ -2066,8 +2070,11 @@
         },
         "eventId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "Event"
+          "required": true,
+          "related": "Event",
+          "_meta": {
+            "required": true
+          }
         },
         "assetId": {
           "type": "crossPackageRef",
@@ -2104,6 +2111,11 @@
       "collectionExportName": "EventAssetCollection",
       "validationRules": [
         {
+          "field": "eventId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        },
+        {
           "field": "assetId",
           "rule": "required",
           "fieldType": "crossPackageRef"
@@ -2121,7 +2133,7 @@
       ],
       "schema": {
         "tableName": "event_assets",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"event_assets\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"event_id\" uuid,\n  \"asset_id\" uuid NOT NULL,\n  \"relationship\" TEXT NOT NULL,\n  \"sort_order\" INTEGER NOT NULL DEFAULT 0\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_assets\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"event_id\" UUID NOT NULL,\n  \"asset_id\" UUID NOT NULL,\n  \"relationship\" TEXT NOT NULL,\n  \"sort_order\" INTEGER NOT NULL DEFAULT 0\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2154,7 +2166,7 @@
           },
           "event_id": {
             "type": "UUID",
-            "notNull": false,
+            "notNull": true,
             "unique": false
           },
           "asset_id": {
@@ -2191,7 +2203,7 @@
             "unique": true
           }
         ],
-        "version": "c62ee267"
+        "version": "02ded4f6"
       }
     },
     "@happyvertical/smrt-events:EventParticipant": {
@@ -2358,7 +2370,7 @@
       "collectionExportName": "EventParticipantCollection",
       "schema": {
         "tableName": "event_participants",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"event_participants\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"event_id\" uuid,\n  \"profile_id\" uuid,\n  \"role\" TEXT DEFAULT '',\n  \"placement\" INTEGER,\n  \"group_id\" TEXT,\n  \"metadata\" TEXT,\n  \"external_id\" TEXT,\n  \"source\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_participants\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"event_id\" UUID,\n  \"profile_id\" UUID,\n  \"role\" TEXT DEFAULT '',\n  \"placement\" INTEGER,\n  \"group_id\" TEXT,\n  \"metadata\" TEXT,\n  \"external_id\" TEXT,\n  \"source\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3052,7 +3064,7 @@
       "collectionExportName": "EventSeriesCollection",
       "schema": {
         "tableName": "event_series",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"event_series\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"type_id\" uuid,\n  \"organizer_id\" uuid,\n  \"description\" TEXT,\n  \"start_date\" TIMESTAMP,\n  \"end_date\" TIMESTAMP,\n  \"recurrence\" TEXT,\n  \"metadata\" TEXT,\n  \"external_id\" TEXT,\n  \"source\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_series\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"type_id\" UUID,\n  \"organizer_id\" UUID,\n  \"description\" TEXT,\n  \"start_date\" TIMESTAMP,\n  \"end_date\" TIMESTAMP,\n  \"recurrence\" TEXT,\n  \"metadata\" TEXT,\n  \"external_id\" TEXT,\n  \"source\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3713,7 +3725,7 @@
       ],
       "schema": {
         "tableName": "event_types",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"event_types\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"schema\" TEXT DEFAULT '',\n  \"participant_schema\" TEXT DEFAULT ''\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"event_types\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"schema\" TEXT DEFAULT '',\n  \"participant_schema\" TEXT DEFAULT ''\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3804,6 +3816,7 @@
     "@happyvertical/smrt-assets",
     "@happyvertical/smrt-core",
     "@happyvertical/smrt-places",
-    "@happyvertical/smrt-profiles"
+    "@happyvertical/smrt-profiles",
+    "@happyvertical/smrt-tenancy"
   ]
 }

--- a/packages/gnode/src/manifest/manifest.json
+++ b/packages/gnode/src/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "timestamp": 1780375820065,
+  "timestamp": 1780379225707,
   "packageName": "@happyvertical/smrt-gnode",
   "packageVersion": "0.25.8",
   "objects": {},

--- a/packages/gnode/src/manifest/manifest.json
+++ b/packages/gnode/src/manifest/manifest.json
@@ -1,7 +1,11 @@
 {
   "version": "1.0.0",
-  "timestamp": 1767322690409,
+  "timestamp": 1780375820065,
+  "packageName": "@happyvertical/smrt-gnode",
+  "packageVersion": "0.25.8",
   "objects": {},
   "moduleType": "smrt",
-  "packageName": "@happyvertical/smrt-gnode"
+  "smrtDependencies": [
+    "@happyvertical/smrt-core"
+  ]
 }

--- a/packages/messages/src/manifest/manifest.json
+++ b/packages/messages/src/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "timestamp": 1780375811832,
+  "timestamp": 1780379232967,
   "packageName": "@happyvertical/smrt-messages",
   "packageVersion": "0.25.8",
   "objects": {
@@ -128,7 +128,7 @@
       "collectionExportName": "AccountCollectionCollection",
       "schema": {
         "tableName": "account_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"account_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"account_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -397,7 +397,7 @@
       "collectionExportName": "AttachmentCollectionCollection",
       "schema": {
         "tableName": "attachment_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"attachment_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"attachment_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -488,7 +488,7 @@
       "collectionExportName": "BlacklistCollectionCollection",
       "schema": {
         "tableName": "blacklist_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"blacklist_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"blacklist_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -736,7 +736,7 @@
       "collectionExportName": "EmailAccountCollectionCollection",
       "schema": {
         "tableName": "accounts",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"accounts\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"accounts\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -918,7 +918,7 @@
       "collectionExportName": "EmailAttachmentCollectionCollection",
       "schema": {
         "tableName": "email_attachment_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"email_attachment_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"email_attachment_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1262,7 +1262,7 @@
       "collectionExportName": "EmailCollectionCollection",
       "schema": {
         "tableName": "messages",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"messages\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"messages\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1581,7 +1581,7 @@
       "collectionExportName": "EmailFolderCollectionCollection",
       "schema": {
         "tableName": "email_folder_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"email_folder_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"email_folder_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1886,7 +1886,7 @@
       "collectionExportName": "MessageCollectionCollection",
       "schema": {
         "tableName": "message_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"message_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"message_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1996,7 +1996,7 @@
       "collectionExportName": "WhitelistCollectionCollection",
       "schema": {
         "tableName": "whitelist_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"whitelist_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"whitelist_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2613,7 +2613,7 @@
       ],
       "schema": {
         "tableName": "accounts",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"accounts\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"provider_type\" TEXT,\n  \"credential_secret_id\" TEXT,\n  \"is_active\" BOOLEAN DEFAULT TRUE,\n  \"last_sync_at\" TIMESTAMP,\n  \"settings\" TEXT,\n  \"email\" TEXT,\n  \"sync_interval_minutes\" INTEGER DEFAULT 60,\n  \"workspace_id\" TEXT,\n  \"workspace_name\" TEXT,\n  \"bot_user_id\" TEXT,\n  \"handle\" TEXT,\n  \"twitter_user_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"accounts\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"provider_type\" TEXT,\n  \"credential_secret_id\" TEXT,\n  \"is_active\" BOOLEAN DEFAULT TRUE,\n  \"last_sync_at\" TIMESTAMP,\n  \"settings\" TEXT,\n  \"email\" TEXT,\n  \"sync_interval_minutes\" INTEGER DEFAULT 60,\n  \"workspace_id\" TEXT,\n  \"workspace_name\" TEXT,\n  \"bot_user_id\" TEXT,\n  \"handle\" TEXT,\n  \"twitter_user_id\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2879,7 +2879,7 @@
       ],
       "schema": {
         "tableName": "attachments",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"attachments\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"message_id\" uuid,\n  \"filename\" TEXT,\n  \"content_type\" TEXT,\n  \"size\" INTEGER NOT NULL DEFAULT 0,\n  \"content_id\" TEXT,\n  \"content_disposition\" TEXT DEFAULT 'attachment',\n  \"file_path\" TEXT,\n  \"source_url\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"attachments\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"message_id\" UUID,\n  \"filename\" TEXT,\n  \"content_type\" TEXT,\n  \"size\" INTEGER NOT NULL DEFAULT 0,\n  \"content_id\" TEXT,\n  \"content_disposition\" TEXT DEFAULT 'attachment',\n  \"file_path\" TEXT,\n  \"source_url\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3035,7 +3035,7 @@
       "collectionExportName": "BlacklistCollection",
       "schema": {
         "tableName": "blacklists",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"blacklists\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"pattern\" TEXT DEFAULT '',\n  \"type\" TEXT DEFAULT 'email',\n  \"reason\" TEXT DEFAULT '',\n  \"auto_archive\" BOOLEAN DEFAULT TRUE\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"blacklists\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"pattern\" TEXT DEFAULT '',\n  \"type\" TEXT DEFAULT 'email',\n  \"reason\" TEXT DEFAULT '',\n  \"auto_archive\" BOOLEAN DEFAULT TRUE\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -4039,7 +4039,7 @@
       ],
       "schema": {
         "tableName": "messages",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"messages\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"account_id\" uuid,\n  \"thread_id\" TEXT,\n  \"subject\" TEXT,\n  \"body\" TEXT,\n  \"from_address\" TEXT,\n  \"from_name\" TEXT,\n  \"to_addresses\" TEXT,\n  \"date\" TIMESTAMP,\n  \"is_read\" BOOLEAN DEFAULT FALSE,\n  \"is_flagged\" BOOLEAN DEFAULT FALSE,\n  \"has_attachments\" BOOLEAN DEFAULT FALSE,\n  \"size\" INTEGER DEFAULT 0,\n  \"metadata\" TEXT,\n  \"send_status\" TEXT DEFAULT 'draft',\n  \"sent_at\" TIMESTAMP,\n  \"send_error\" TEXT,\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"max_retries\" INTEGER DEFAULT 3,\n  \"scheduled_send_at\" TIMESTAMP,\n  \"in_reply_to_message_id\" uuid,\n  \"message_id\" TEXT,\n  \"in_reply_to\" TEXT,\n  \"cc_addresses\" TEXT,\n  \"bcc_addresses\" TEXT,\n  \"reply_to_address\" TEXT,\n  \"reply_to_name\" TEXT,\n  \"text_body\" TEXT,\n  \"html_body\" TEXT,\n  \"folder_id\" TEXT,\n  \"folder_path\" TEXT,\n  \"labels\" TEXT,\n  \"flags\" TEXT,\n  \"is_answered\" BOOLEAN DEFAULT FALSE,\n  \"is_draft\" BOOLEAN DEFAULT FALSE,\n  \"raw_message\" TEXT,\n  \"headers\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"messages\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"account_id\" UUID,\n  \"thread_id\" TEXT,\n  \"subject\" TEXT,\n  \"body\" TEXT,\n  \"from_address\" TEXT,\n  \"from_name\" TEXT,\n  \"to_addresses\" TEXT,\n  \"date\" TIMESTAMP,\n  \"is_read\" BOOLEAN DEFAULT FALSE,\n  \"is_flagged\" BOOLEAN DEFAULT FALSE,\n  \"has_attachments\" BOOLEAN DEFAULT FALSE,\n  \"size\" INTEGER DEFAULT 0,\n  \"metadata\" TEXT,\n  \"send_status\" TEXT DEFAULT 'draft',\n  \"sent_at\" TIMESTAMP,\n  \"send_error\" TEXT,\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"max_retries\" INTEGER DEFAULT 3,\n  \"scheduled_send_at\" TIMESTAMP,\n  \"in_reply_to_message_id\" UUID,\n  \"message_id\" TEXT,\n  \"in_reply_to\" TEXT,\n  \"cc_addresses\" TEXT,\n  \"bcc_addresses\" TEXT,\n  \"reply_to_address\" TEXT,\n  \"reply_to_name\" TEXT,\n  \"text_body\" TEXT,\n  \"html_body\" TEXT,\n  \"folder_id\" TEXT,\n  \"folder_path\" TEXT,\n  \"labels\" TEXT,\n  \"flags\" TEXT,\n  \"is_answered\" BOOLEAN DEFAULT FALSE,\n  \"is_draft\" BOOLEAN DEFAULT FALSE,\n  \"raw_message\" TEXT,\n  \"headers\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -4917,7 +4917,7 @@
       ],
       "schema": {
         "tableName": "accounts",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"accounts\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"provider_type\" TEXT,\n  \"credential_secret_id\" TEXT,\n  \"is_active\" BOOLEAN DEFAULT TRUE,\n  \"last_sync_at\" TIMESTAMP,\n  \"settings\" TEXT,\n  \"email\" TEXT,\n  \"sync_interval_minutes\" INTEGER DEFAULT 60\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"accounts\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"provider_type\" TEXT,\n  \"credential_secret_id\" TEXT,\n  \"is_active\" BOOLEAN DEFAULT TRUE,\n  \"last_sync_at\" TIMESTAMP,\n  \"settings\" TEXT,\n  \"email\" TEXT,\n  \"sync_interval_minutes\" INTEGER DEFAULT 60\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -5040,7 +5040,7 @@
       "collectionExportName": "EmailAttachmentCollection",
       "schema": {
         "tableName": "email_attachments",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"email_attachments\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"email_attachments\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -5293,7 +5293,7 @@
       ],
       "schema": {
         "tableName": "email_folders",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"email_folders\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"account_id\" uuid,\n  \"name\" TEXT,\n  \"path\" TEXT,\n  \"delimiter\" TEXT,\n  \"special_use\" TEXT,\n  \"message_count\" INTEGER NOT NULL DEFAULT 0,\n  \"unread_count\" INTEGER NOT NULL DEFAULT 0,\n  \"subscribed\" BOOLEAN NOT NULL DEFAULT TRUE\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"email_folders\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"account_id\" UUID,\n  \"name\" TEXT,\n  \"path\" TEXT,\n  \"delimiter\" TEXT,\n  \"special_use\" TEXT,\n  \"message_count\" INTEGER NOT NULL DEFAULT 0,\n  \"unread_count\" INTEGER NOT NULL DEFAULT 0,\n  \"subscribed\" BOOLEAN NOT NULL DEFAULT TRUE\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -6135,7 +6135,7 @@
       ],
       "schema": {
         "tableName": "messages",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"messages\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"account_id\" uuid,\n  \"thread_id\" TEXT,\n  \"subject\" TEXT,\n  \"body\" TEXT,\n  \"from_address\" TEXT,\n  \"from_name\" TEXT,\n  \"to_addresses\" TEXT,\n  \"date\" TIMESTAMP,\n  \"is_read\" BOOLEAN DEFAULT FALSE,\n  \"is_flagged\" BOOLEAN DEFAULT FALSE,\n  \"has_attachments\" BOOLEAN DEFAULT FALSE,\n  \"size\" INTEGER DEFAULT 0,\n  \"metadata\" TEXT,\n  \"send_status\" TEXT DEFAULT 'draft',\n  \"sent_at\" TIMESTAMP,\n  \"send_error\" TEXT,\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"max_retries\" INTEGER DEFAULT 3,\n  \"scheduled_send_at\" TIMESTAMP,\n  \"in_reply_to_message_id\" uuid,\n  \"message_id\" TEXT,\n  \"in_reply_to\" TEXT,\n  \"cc_addresses\" TEXT,\n  \"bcc_addresses\" TEXT,\n  \"reply_to_address\" TEXT,\n  \"reply_to_name\" TEXT,\n  \"text_body\" TEXT,\n  \"html_body\" TEXT,\n  \"folder_id\" TEXT,\n  \"folder_path\" TEXT,\n  \"labels\" TEXT,\n  \"flags\" TEXT,\n  \"is_answered\" BOOLEAN DEFAULT FALSE,\n  \"is_draft\" BOOLEAN DEFAULT FALSE,\n  \"raw_message\" TEXT,\n  \"headers\" TEXT,\n  \"channel_id\" TEXT,\n  \"channel_name\" TEXT,\n  \"slack_ts\" TEXT,\n  \"slack_thread_ts\" TEXT,\n  \"reactions\" TEXT,\n  \"is_edited\" BOOLEAN DEFAULT FALSE,\n  \"message_type\" TEXT,\n  \"blocks\" TEXT,\n  \"tweet_id\" TEXT,\n  \"retweet_count\" INTEGER DEFAULT 0,\n  \"like_count\" INTEGER DEFAULT 0,\n  \"reply_count\" INTEGER DEFAULT 0,\n  \"is_retweet\" BOOLEAN DEFAULT FALSE,\n  \"is_reply\" BOOLEAN DEFAULT FALSE,\n  \"media_urls\" TEXT,\n  \"hashtags\" TEXT,\n  \"mentions\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"messages\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"account_id\" UUID,\n  \"thread_id\" TEXT,\n  \"subject\" TEXT,\n  \"body\" TEXT,\n  \"from_address\" TEXT,\n  \"from_name\" TEXT,\n  \"to_addresses\" TEXT,\n  \"date\" TIMESTAMP,\n  \"is_read\" BOOLEAN DEFAULT FALSE,\n  \"is_flagged\" BOOLEAN DEFAULT FALSE,\n  \"has_attachments\" BOOLEAN DEFAULT FALSE,\n  \"size\" INTEGER DEFAULT 0,\n  \"metadata\" TEXT,\n  \"send_status\" TEXT DEFAULT 'draft',\n  \"sent_at\" TIMESTAMP,\n  \"send_error\" TEXT,\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"max_retries\" INTEGER DEFAULT 3,\n  \"scheduled_send_at\" TIMESTAMP,\n  \"in_reply_to_message_id\" UUID,\n  \"message_id\" TEXT,\n  \"in_reply_to\" TEXT,\n  \"cc_addresses\" TEXT,\n  \"bcc_addresses\" TEXT,\n  \"reply_to_address\" TEXT,\n  \"reply_to_name\" TEXT,\n  \"text_body\" TEXT,\n  \"html_body\" TEXT,\n  \"folder_id\" TEXT,\n  \"folder_path\" TEXT,\n  \"labels\" TEXT,\n  \"flags\" TEXT,\n  \"is_answered\" BOOLEAN DEFAULT FALSE,\n  \"is_draft\" BOOLEAN DEFAULT FALSE,\n  \"raw_message\" TEXT,\n  \"headers\" TEXT,\n  \"channel_id\" TEXT,\n  \"channel_name\" TEXT,\n  \"slack_ts\" TEXT,\n  \"slack_thread_ts\" TEXT,\n  \"reactions\" TEXT,\n  \"is_edited\" BOOLEAN DEFAULT FALSE,\n  \"message_type\" TEXT,\n  \"blocks\" TEXT,\n  \"tweet_id\" TEXT,\n  \"retweet_count\" INTEGER DEFAULT 0,\n  \"like_count\" INTEGER DEFAULT 0,\n  \"reply_count\" INTEGER DEFAULT 0,\n  \"is_retweet\" BOOLEAN DEFAULT FALSE,\n  \"is_reply\" BOOLEAN DEFAULT FALSE,\n  \"media_urls\" TEXT,\n  \"hashtags\" TEXT,\n  \"mentions\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -7011,7 +7011,7 @@
       ],
       "schema": {
         "tableName": "accounts",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"accounts\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"provider_type\" TEXT,\n  \"credential_secret_id\" TEXT,\n  \"is_active\" BOOLEAN DEFAULT TRUE,\n  \"last_sync_at\" TIMESTAMP,\n  \"settings\" TEXT,\n  \"workspace_id\" TEXT,\n  \"workspace_name\" TEXT,\n  \"bot_user_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"accounts\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"provider_type\" TEXT,\n  \"credential_secret_id\" TEXT,\n  \"is_active\" BOOLEAN DEFAULT TRUE,\n  \"last_sync_at\" TIMESTAMP,\n  \"settings\" TEXT,\n  \"workspace_id\" TEXT,\n  \"workspace_name\" TEXT,\n  \"bot_user_id\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -7933,7 +7933,7 @@
       ],
       "schema": {
         "tableName": "messages",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"messages\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"account_id\" uuid,\n  \"thread_id\" TEXT,\n  \"subject\" TEXT,\n  \"body\" TEXT,\n  \"from_address\" TEXT,\n  \"from_name\" TEXT,\n  \"to_addresses\" TEXT,\n  \"date\" TIMESTAMP,\n  \"is_read\" BOOLEAN DEFAULT FALSE,\n  \"is_flagged\" BOOLEAN DEFAULT FALSE,\n  \"has_attachments\" BOOLEAN DEFAULT FALSE,\n  \"size\" INTEGER DEFAULT 0,\n  \"metadata\" TEXT,\n  \"send_status\" TEXT DEFAULT 'draft',\n  \"sent_at\" TIMESTAMP,\n  \"send_error\" TEXT,\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"max_retries\" INTEGER DEFAULT 3,\n  \"scheduled_send_at\" TIMESTAMP,\n  \"in_reply_to_message_id\" uuid,\n  \"channel_id\" TEXT,\n  \"channel_name\" TEXT,\n  \"slack_ts\" TEXT,\n  \"slack_thread_ts\" TEXT,\n  \"reactions\" TEXT,\n  \"is_edited\" BOOLEAN DEFAULT FALSE,\n  \"message_type\" TEXT,\n  \"blocks\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"messages\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"account_id\" UUID,\n  \"thread_id\" TEXT,\n  \"subject\" TEXT,\n  \"body\" TEXT,\n  \"from_address\" TEXT,\n  \"from_name\" TEXT,\n  \"to_addresses\" TEXT,\n  \"date\" TIMESTAMP,\n  \"is_read\" BOOLEAN DEFAULT FALSE,\n  \"is_flagged\" BOOLEAN DEFAULT FALSE,\n  \"has_attachments\" BOOLEAN DEFAULT FALSE,\n  \"size\" INTEGER DEFAULT 0,\n  \"metadata\" TEXT,\n  \"send_status\" TEXT DEFAULT 'draft',\n  \"sent_at\" TIMESTAMP,\n  \"send_error\" TEXT,\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"max_retries\" INTEGER DEFAULT 3,\n  \"scheduled_send_at\" TIMESTAMP,\n  \"in_reply_to_message_id\" UUID,\n  \"channel_id\" TEXT,\n  \"channel_name\" TEXT,\n  \"slack_ts\" TEXT,\n  \"slack_thread_ts\" TEXT,\n  \"reactions\" TEXT,\n  \"is_edited\" BOOLEAN DEFAULT FALSE,\n  \"message_type\" TEXT,\n  \"blocks\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -8966,7 +8966,7 @@
       ],
       "schema": {
         "tableName": "messages",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"messages\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"account_id\" uuid,\n  \"thread_id\" TEXT,\n  \"subject\" TEXT,\n  \"body\" TEXT,\n  \"from_address\" TEXT,\n  \"from_name\" TEXT,\n  \"to_addresses\" TEXT,\n  \"date\" TIMESTAMP,\n  \"is_read\" BOOLEAN DEFAULT FALSE,\n  \"is_flagged\" BOOLEAN DEFAULT FALSE,\n  \"has_attachments\" BOOLEAN DEFAULT FALSE,\n  \"size\" INTEGER DEFAULT 0,\n  \"metadata\" TEXT,\n  \"send_status\" TEXT DEFAULT 'draft',\n  \"sent_at\" TIMESTAMP,\n  \"send_error\" TEXT,\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"max_retries\" INTEGER DEFAULT 3,\n  \"scheduled_send_at\" TIMESTAMP,\n  \"in_reply_to_message_id\" uuid,\n  \"tweet_id\" TEXT,\n  \"retweet_count\" INTEGER DEFAULT 0,\n  \"like_count\" INTEGER DEFAULT 0,\n  \"reply_count\" INTEGER DEFAULT 0,\n  \"is_retweet\" BOOLEAN DEFAULT FALSE,\n  \"is_reply\" BOOLEAN DEFAULT FALSE,\n  \"media_urls\" TEXT,\n  \"hashtags\" TEXT,\n  \"mentions\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"messages\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"account_id\" UUID,\n  \"thread_id\" TEXT,\n  \"subject\" TEXT,\n  \"body\" TEXT,\n  \"from_address\" TEXT,\n  \"from_name\" TEXT,\n  \"to_addresses\" TEXT,\n  \"date\" TIMESTAMP,\n  \"is_read\" BOOLEAN DEFAULT FALSE,\n  \"is_flagged\" BOOLEAN DEFAULT FALSE,\n  \"has_attachments\" BOOLEAN DEFAULT FALSE,\n  \"size\" INTEGER DEFAULT 0,\n  \"metadata\" TEXT,\n  \"send_status\" TEXT DEFAULT 'draft',\n  \"sent_at\" TIMESTAMP,\n  \"send_error\" TEXT,\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"max_retries\" INTEGER DEFAULT 3,\n  \"scheduled_send_at\" TIMESTAMP,\n  \"in_reply_to_message_id\" UUID,\n  \"tweet_id\" TEXT,\n  \"retweet_count\" INTEGER DEFAULT 0,\n  \"like_count\" INTEGER DEFAULT 0,\n  \"reply_count\" INTEGER DEFAULT 0,\n  \"is_retweet\" BOOLEAN DEFAULT FALSE,\n  \"is_reply\" BOOLEAN DEFAULT FALSE,\n  \"media_urls\" TEXT,\n  \"hashtags\" TEXT,\n  \"mentions\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -9739,7 +9739,7 @@
       ],
       "schema": {
         "tableName": "accounts",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"accounts\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"provider_type\" TEXT,\n  \"credential_secret_id\" TEXT,\n  \"is_active\" BOOLEAN DEFAULT TRUE,\n  \"last_sync_at\" TIMESTAMP,\n  \"settings\" TEXT,\n  \"handle\" TEXT,\n  \"twitter_user_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"accounts\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"provider_type\" TEXT,\n  \"credential_secret_id\" TEXT,\n  \"is_active\" BOOLEAN DEFAULT TRUE,\n  \"last_sync_at\" TIMESTAMP,\n  \"settings\" TEXT,\n  \"handle\" TEXT,\n  \"twitter_user_id\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -9899,7 +9899,7 @@
       "collectionExportName": "WhitelistCollection",
       "schema": {
         "tableName": "whitelists",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"whitelists\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"pattern\" TEXT DEFAULT '',\n  \"type\" TEXT DEFAULT 'email',\n  \"category\" TEXT,\n  \"description\" TEXT DEFAULT ''\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"whitelists\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"pattern\" TEXT DEFAULT '',\n  \"type\" TEXT DEFAULT 'email',\n  \"category\" TEXT,\n  \"description\" TEXT DEFAULT ''\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -9971,6 +9971,8 @@
   },
   "moduleType": "smrt",
   "smrtDependencies": [
-    "@happyvertical/smrt-core"
+    "@happyvertical/smrt-core",
+    "@happyvertical/smrt-secrets",
+    "@happyvertical/smrt-tenancy"
   ]
 }

--- a/packages/messages/src/manifest/manifest.json
+++ b/packages/messages/src/manifest/manifest.json
@@ -1,15 +1,15 @@
 {
   "version": "1.0.0",
-  "timestamp": 1774147345640,
+  "timestamp": 1780375811832,
   "packageName": "@happyvertical/smrt-messages",
-  "packageVersion": "0.21.7",
+  "packageVersion": "0.25.8",
   "objects": {
     "@happyvertical/smrt-messages:AccountCollection": {
       "name": "accountcollection",
       "className": "AccountCollection",
       "qualifiedName": "@happyvertical/smrt-messages:AccountCollection",
       "collection": "accounts",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/collections/AccountCollection.ts",
+      "filePath": "packages/messages/src/collections/AccountCollection.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {},
       "methods": {
@@ -128,10 +128,10 @@
       "collectionExportName": "AccountCollectionCollection",
       "schema": {
         "tableName": "account_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"account_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"account_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -171,7 +171,7 @@
             "unique": true
           }
         ],
-        "version": "592cd629"
+        "version": "87560196"
       }
     },
     "@happyvertical/smrt-messages:AttachmentCollection": {
@@ -179,7 +179,7 @@
       "className": "AttachmentCollection",
       "qualifiedName": "@happyvertical/smrt-messages:AttachmentCollection",
       "collection": "attachments",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/collections/AttachmentCollection.ts",
+      "filePath": "packages/messages/src/collections/AttachmentCollection.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {},
       "methods": {
@@ -397,10 +397,10 @@
       "collectionExportName": "AttachmentCollectionCollection",
       "schema": {
         "tableName": "attachment_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"attachment_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"attachment_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -440,7 +440,7 @@
             "unique": true
           }
         ],
-        "version": "b641a19f"
+        "version": "bebd85b2"
       }
     },
     "@happyvertical/smrt-messages:BlacklistCollection": {
@@ -448,7 +448,7 @@
       "className": "BlacklistCollection",
       "qualifiedName": "@happyvertical/smrt-messages:BlacklistCollection",
       "collection": "blacklists",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/collections/BlacklistCollection.ts",
+      "filePath": "packages/messages/src/collections/BlacklistCollection.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {},
       "methods": {
@@ -488,10 +488,10 @@
       "collectionExportName": "BlacklistCollectionCollection",
       "schema": {
         "tableName": "blacklist_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"blacklist_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"blacklist_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -531,7 +531,7 @@
             "unique": true
           }
         ],
-        "version": "d12e3015"
+        "version": "980ba8d2"
       }
     },
     "@happyvertical/smrt-messages:EmailAccountCollection": {
@@ -539,7 +539,7 @@
       "className": "EmailAccountCollection",
       "qualifiedName": "@happyvertical/smrt-messages:EmailAccountCollection",
       "collection": "accounts",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/collections/EmailAccountCollection.ts",
+      "filePath": "packages/messages/src/collections/EmailAccountCollection.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {},
       "methods": {
@@ -736,10 +736,10 @@
       "collectionExportName": "EmailAccountCollectionCollection",
       "schema": {
         "tableName": "accounts",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"accounts\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"accounts\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -779,7 +779,7 @@
             "unique": true
           }
         ],
-        "version": "e4ebcf9f"
+        "version": "70e24d15"
       }
     },
     "@happyvertical/smrt-messages:EmailAttachmentCollection": {
@@ -787,7 +787,7 @@
       "className": "EmailAttachmentCollection",
       "qualifiedName": "@happyvertical/smrt-messages:EmailAttachmentCollection",
       "collection": "emailattachments",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/collections/EmailAttachmentCollection.ts",
+      "filePath": "packages/messages/src/collections/EmailAttachmentCollection.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {},
       "methods": {
@@ -918,10 +918,10 @@
       "collectionExportName": "EmailAttachmentCollectionCollection",
       "schema": {
         "tableName": "email_attachment_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"email_attachment_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"email_attachment_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -961,7 +961,7 @@
             "unique": true
           }
         ],
-        "version": "a0b6d2fd"
+        "version": "4f45d3a5"
       }
     },
     "@happyvertical/smrt-messages:EmailCollection": {
@@ -969,7 +969,7 @@
       "className": "EmailCollection",
       "qualifiedName": "@happyvertical/smrt-messages:EmailCollection",
       "collection": "messages",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/collections/EmailCollection.ts",
+      "filePath": "packages/messages/src/collections/EmailCollection.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {},
       "methods": {
@@ -1262,10 +1262,10 @@
       "collectionExportName": "EmailCollectionCollection",
       "schema": {
         "tableName": "messages",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"messages\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"messages\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1305,7 +1305,7 @@
             "unique": true
           }
         ],
-        "version": "17f5fa18"
+        "version": "60500205"
       }
     },
     "@happyvertical/smrt-messages:EmailFolderCollection": {
@@ -1313,7 +1313,7 @@
       "className": "EmailFolderCollection",
       "qualifiedName": "@happyvertical/smrt-messages:EmailFolderCollection",
       "collection": "emailfolders",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/collections/EmailFolderCollection.ts",
+      "filePath": "packages/messages/src/collections/EmailFolderCollection.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {},
       "methods": {
@@ -1581,10 +1581,10 @@
       "collectionExportName": "EmailFolderCollectionCollection",
       "schema": {
         "tableName": "email_folder_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"email_folder_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"email_folder_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1624,7 +1624,7 @@
             "unique": true
           }
         ],
-        "version": "54ac3713"
+        "version": "21262f44"
       }
     },
     "@happyvertical/smrt-messages:MessageCollection": {
@@ -1632,7 +1632,7 @@
       "className": "MessageCollection",
       "qualifiedName": "@happyvertical/smrt-messages:MessageCollection",
       "collection": "messages",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/collections/MessageCollection.ts",
+      "filePath": "packages/messages/src/collections/MessageCollection.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {},
       "methods": {
@@ -1886,10 +1886,10 @@
       "collectionExportName": "MessageCollectionCollection",
       "schema": {
         "tableName": "message_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"message_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"message_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1929,7 +1929,7 @@
             "unique": true
           }
         ],
-        "version": "5972a4e9"
+        "version": "1c0d7725"
       }
     },
     "@happyvertical/smrt-messages:WhitelistCollection": {
@@ -1937,7 +1937,7 @@
       "className": "WhitelistCollection",
       "qualifiedName": "@happyvertical/smrt-messages:WhitelistCollection",
       "collection": "whitelists",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/collections/WhitelistCollection.ts",
+      "filePath": "packages/messages/src/collections/WhitelistCollection.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {},
       "methods": {
@@ -1996,10 +1996,10 @@
       "collectionExportName": "WhitelistCollectionCollection",
       "schema": {
         "tableName": "whitelist_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"whitelist_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"whitelist_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -2039,7 +2039,7 @@
             "unique": true
           }
         ],
-        "version": "3d63374a"
+        "version": "92ba926c"
       }
     },
     "@happyvertical/smrt-messages:Account": {
@@ -2047,15 +2047,15 @@
       "className": "Account",
       "qualifiedName": "@happyvertical/smrt-messages:Account",
       "collection": "accounts",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/models/Account.ts",
+      "filePath": "packages/messages/src/models/Account.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {
         "created_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "updated_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "tenantId": {
@@ -2613,10 +2613,10 @@
       ],
       "schema": {
         "tableName": "accounts",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"accounts\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"provider_type\" TEXT,\n  \"credential_secret_id\" TEXT,\n  \"is_active\" BOOLEAN DEFAULT TRUE,\n  \"last_sync_at\" TIMESTAMP,\n  \"settings\" TEXT,\n  \"email\" TEXT,\n  \"sync_interval_minutes\" INTEGER DEFAULT 60,\n  \"workspace_id\" TEXT,\n  \"workspace_name\" TEXT,\n  \"bot_user_id\" TEXT,\n  \"handle\" TEXT,\n  \"twitter_user_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"accounts\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"provider_type\" TEXT,\n  \"credential_secret_id\" TEXT,\n  \"is_active\" BOOLEAN DEFAULT TRUE,\n  \"last_sync_at\" TIMESTAMP,\n  \"settings\" TEXT,\n  \"email\" TEXT,\n  \"sync_interval_minutes\" INTEGER DEFAULT 60,\n  \"workspace_id\" TEXT,\n  \"workspace_name\" TEXT,\n  \"bot_user_id\" TEXT,\n  \"handle\" TEXT,\n  \"twitter_user_id\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -2729,7 +2729,7 @@
             ]
           }
         ],
-        "version": "8893770e"
+        "version": "73a86fa3"
       }
     },
     "@happyvertical/smrt-messages:Attachment": {
@@ -2737,7 +2737,7 @@
       "className": "Attachment",
       "qualifiedName": "@happyvertical/smrt-messages:Attachment",
       "collection": "attachments",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/models/Attachment.ts",
+      "filePath": "packages/messages/src/models/Attachment.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {
         "tenantId": {
@@ -2745,8 +2745,9 @@
           "required": false
         },
         "messageId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "Message"
         },
         "filename": {
           "type": "text",
@@ -2878,10 +2879,10 @@
       ],
       "schema": {
         "tableName": "attachments",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"attachments\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"message_id\" TEXT,\n  \"filename\" TEXT,\n  \"content_type\" TEXT,\n  \"size\" INTEGER NOT NULL DEFAULT 0,\n  \"content_id\" TEXT,\n  \"content_disposition\" TEXT DEFAULT 'attachment',\n  \"file_path\" TEXT,\n  \"source_url\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"attachments\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"message_id\" uuid,\n  \"filename\" TEXT,\n  \"content_type\" TEXT,\n  \"size\" INTEGER NOT NULL DEFAULT 0,\n  \"content_id\" TEXT,\n  \"content_disposition\" TEXT DEFAULT 'attachment',\n  \"file_path\" TEXT,\n  \"source_url\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -2910,7 +2911,7 @@
             "unique": false
           },
           "message_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           },
@@ -2968,7 +2969,7 @@
             "unique": true
           }
         ],
-        "version": "f9ec7f42"
+        "version": "8c0c8d4e"
       }
     },
     "@happyvertical/smrt-messages:Blacklist": {
@@ -2976,7 +2977,7 @@
       "className": "Blacklist",
       "qualifiedName": "@happyvertical/smrt-messages:Blacklist",
       "collection": "blacklists",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/models/Blacklist.ts",
+      "filePath": "packages/messages/src/models/Blacklist.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {
         "pattern": {
@@ -3034,10 +3035,10 @@
       "collectionExportName": "BlacklistCollection",
       "schema": {
         "tableName": "blacklists",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"blacklists\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"pattern\" TEXT DEFAULT '',\n  \"type\" TEXT DEFAULT 'email',\n  \"reason\" TEXT DEFAULT '',\n  \"auto_archive\" BOOLEAN DEFAULT TRUE\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"blacklists\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"pattern\" TEXT DEFAULT '',\n  \"type\" TEXT DEFAULT 'email',\n  \"reason\" TEXT DEFAULT '',\n  \"auto_archive\" BOOLEAN DEFAULT TRUE\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -3101,7 +3102,7 @@
             "unique": true
           }
         ],
-        "version": "416ad1ad"
+        "version": "4cc4dc55"
       }
     },
     "@happyvertical/smrt-messages:Email": {
@@ -3109,15 +3110,15 @@
       "className": "Email",
       "qualifiedName": "@happyvertical/smrt-messages:Email",
       "collection": "messages",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/models/Email.ts",
+      "filePath": "packages/messages/src/models/Email.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {
         "created_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "updated_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "tenantId": {
@@ -3125,8 +3126,9 @@
           "required": false
         },
         "accountId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "Account"
         },
         "threadId": {
           "type": "text",
@@ -3208,8 +3210,9 @@
           "required": false
         },
         "inReplyToMessageId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "Message"
         },
         "createdAt": {
           "type": "text",
@@ -4036,10 +4039,10 @@
       ],
       "schema": {
         "tableName": "messages",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"messages\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"account_id\" TEXT,\n  \"thread_id\" TEXT,\n  \"subject\" TEXT,\n  \"body\" TEXT,\n  \"from_address\" TEXT,\n  \"from_name\" TEXT,\n  \"to_addresses\" TEXT,\n  \"date\" TIMESTAMP,\n  \"is_read\" BOOLEAN DEFAULT FALSE,\n  \"is_flagged\" BOOLEAN DEFAULT FALSE,\n  \"has_attachments\" BOOLEAN DEFAULT FALSE,\n  \"size\" INTEGER DEFAULT 0,\n  \"metadata\" TEXT,\n  \"send_status\" TEXT DEFAULT 'draft',\n  \"sent_at\" TIMESTAMP,\n  \"send_error\" TEXT,\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"max_retries\" INTEGER DEFAULT 3,\n  \"scheduled_send_at\" TIMESTAMP,\n  \"in_reply_to_message_id\" TEXT,\n  \"message_id\" TEXT,\n  \"in_reply_to\" TEXT,\n  \"cc_addresses\" TEXT,\n  \"bcc_addresses\" TEXT,\n  \"reply_to_address\" TEXT,\n  \"reply_to_name\" TEXT,\n  \"text_body\" TEXT,\n  \"html_body\" TEXT,\n  \"folder_id\" TEXT,\n  \"folder_path\" TEXT,\n  \"labels\" TEXT,\n  \"flags\" TEXT,\n  \"is_answered\" BOOLEAN DEFAULT FALSE,\n  \"is_draft\" BOOLEAN DEFAULT FALSE,\n  \"raw_message\" TEXT,\n  \"headers\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"messages\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"account_id\" uuid,\n  \"thread_id\" TEXT,\n  \"subject\" TEXT,\n  \"body\" TEXT,\n  \"from_address\" TEXT,\n  \"from_name\" TEXT,\n  \"to_addresses\" TEXT,\n  \"date\" TIMESTAMP,\n  \"is_read\" BOOLEAN DEFAULT FALSE,\n  \"is_flagged\" BOOLEAN DEFAULT FALSE,\n  \"has_attachments\" BOOLEAN DEFAULT FALSE,\n  \"size\" INTEGER DEFAULT 0,\n  \"metadata\" TEXT,\n  \"send_status\" TEXT DEFAULT 'draft',\n  \"sent_at\" TIMESTAMP,\n  \"send_error\" TEXT,\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"max_retries\" INTEGER DEFAULT 3,\n  \"scheduled_send_at\" TIMESTAMP,\n  \"in_reply_to_message_id\" uuid,\n  \"message_id\" TEXT,\n  \"in_reply_to\" TEXT,\n  \"cc_addresses\" TEXT,\n  \"bcc_addresses\" TEXT,\n  \"reply_to_address\" TEXT,\n  \"reply_to_name\" TEXT,\n  \"text_body\" TEXT,\n  \"html_body\" TEXT,\n  \"folder_id\" TEXT,\n  \"folder_path\" TEXT,\n  \"labels\" TEXT,\n  \"flags\" TEXT,\n  \"is_answered\" BOOLEAN DEFAULT FALSE,\n  \"is_draft\" BOOLEAN DEFAULT FALSE,\n  \"raw_message\" TEXT,\n  \"headers\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -4075,7 +4078,7 @@
             "notNull": false
           },
           "account_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "thread_id": {
@@ -4158,7 +4161,7 @@
             "notNull": false
           },
           "in_reply_to_message_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "message_id": {
@@ -4251,7 +4254,7 @@
             ]
           }
         ],
-        "version": "6a484284"
+        "version": "dd30941a"
       }
     },
     "@happyvertical/smrt-messages:EmailAccount": {
@@ -4259,15 +4262,15 @@
       "className": "EmailAccount",
       "qualifiedName": "@happyvertical/smrt-messages:EmailAccount",
       "collection": "accounts",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/models/EmailAccount.ts",
+      "filePath": "packages/messages/src/models/EmailAccount.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {
         "created_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "updated_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "tenantId": {
@@ -4914,10 +4917,10 @@
       ],
       "schema": {
         "tableName": "accounts",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"accounts\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"provider_type\" TEXT,\n  \"credential_secret_id\" TEXT,\n  \"is_active\" BOOLEAN DEFAULT TRUE,\n  \"last_sync_at\" TIMESTAMP,\n  \"settings\" TEXT,\n  \"email\" TEXT,\n  \"sync_interval_minutes\" INTEGER DEFAULT 60\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"accounts\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"provider_type\" TEXT,\n  \"credential_secret_id\" TEXT,\n  \"is_active\" BOOLEAN DEFAULT TRUE,\n  \"last_sync_at\" TIMESTAMP,\n  \"settings\" TEXT,\n  \"email\" TEXT,\n  \"sync_interval_minutes\" INTEGER DEFAULT 60\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -5010,7 +5013,7 @@
             ]
           }
         ],
-        "version": "08589575"
+        "version": "fec6fc44"
       }
     },
     "@happyvertical/smrt-messages:EmailAttachment": {
@@ -5018,7 +5021,7 @@
       "className": "EmailAttachment",
       "qualifiedName": "@happyvertical/smrt-messages:EmailAttachment",
       "collection": "emailattachments",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/models/EmailAttachment.ts",
+      "filePath": "packages/messages/src/models/EmailAttachment.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {},
       "methods": {
@@ -5037,10 +5040,10 @@
       "collectionExportName": "EmailAttachmentCollection",
       "schema": {
         "tableName": "email_attachments",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"email_attachments\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"email_attachments\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -5080,7 +5083,7 @@
             "unique": true
           }
         ],
-        "version": "a8e73595"
+        "version": "2b01abc2"
       }
     },
     "@happyvertical/smrt-messages:EmailFolder": {
@@ -5088,7 +5091,7 @@
       "className": "EmailFolder",
       "qualifiedName": "@happyvertical/smrt-messages:EmailFolder",
       "collection": "emailfolders",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/models/EmailFolder.ts",
+      "filePath": "packages/messages/src/models/EmailFolder.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {
         "tenantId": {
@@ -5096,8 +5099,9 @@
           "required": false
         },
         "accountId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "Account"
         },
         "name": {
           "type": "text",
@@ -5289,10 +5293,10 @@
       ],
       "schema": {
         "tableName": "email_folders",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"email_folders\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"account_id\" TEXT,\n  \"name\" TEXT,\n  \"path\" TEXT,\n  \"delimiter\" TEXT,\n  \"special_use\" TEXT,\n  \"message_count\" INTEGER NOT NULL DEFAULT 0,\n  \"unread_count\" INTEGER NOT NULL DEFAULT 0,\n  \"subscribed\" BOOLEAN NOT NULL DEFAULT TRUE\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"email_folders\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"account_id\" uuid,\n  \"name\" TEXT,\n  \"path\" TEXT,\n  \"delimiter\" TEXT,\n  \"special_use\" TEXT,\n  \"message_count\" INTEGER NOT NULL DEFAULT 0,\n  \"unread_count\" INTEGER NOT NULL DEFAULT 0,\n  \"subscribed\" BOOLEAN NOT NULL DEFAULT TRUE\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -5321,7 +5325,7 @@
             "unique": false
           },
           "account_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           },
@@ -5380,7 +5384,7 @@
             "unique": true
           }
         ],
-        "version": "32fcee39"
+        "version": "0911de8e"
       }
     },
     "@happyvertical/smrt-messages:Message": {
@@ -5388,15 +5392,15 @@
       "className": "Message",
       "qualifiedName": "@happyvertical/smrt-messages:Message",
       "collection": "messages",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/models/Message.ts",
+      "filePath": "packages/messages/src/models/Message.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {
         "created_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "updated_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "tenantId": {
@@ -5404,8 +5408,9 @@
           "required": false
         },
         "accountId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "Account"
         },
         "threadId": {
           "type": "text",
@@ -5487,8 +5492,9 @@
           "required": false
         },
         "inReplyToMessageId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "Message"
         },
         "createdAt": {
           "type": "text",
@@ -6129,10 +6135,10 @@
       ],
       "schema": {
         "tableName": "messages",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"messages\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"account_id\" TEXT,\n  \"thread_id\" TEXT,\n  \"subject\" TEXT,\n  \"body\" TEXT,\n  \"from_address\" TEXT,\n  \"from_name\" TEXT,\n  \"to_addresses\" TEXT,\n  \"date\" TIMESTAMP,\n  \"is_read\" BOOLEAN DEFAULT FALSE,\n  \"is_flagged\" BOOLEAN DEFAULT FALSE,\n  \"has_attachments\" BOOLEAN DEFAULT FALSE,\n  \"size\" INTEGER DEFAULT 0,\n  \"metadata\" TEXT,\n  \"send_status\" TEXT DEFAULT 'draft',\n  \"sent_at\" TIMESTAMP,\n  \"send_error\" TEXT,\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"max_retries\" INTEGER DEFAULT 3,\n  \"scheduled_send_at\" TIMESTAMP,\n  \"in_reply_to_message_id\" TEXT,\n  \"message_id\" TEXT,\n  \"in_reply_to\" TEXT,\n  \"cc_addresses\" TEXT,\n  \"bcc_addresses\" TEXT,\n  \"reply_to_address\" TEXT,\n  \"reply_to_name\" TEXT,\n  \"text_body\" TEXT,\n  \"html_body\" TEXT,\n  \"folder_id\" TEXT,\n  \"folder_path\" TEXT,\n  \"labels\" TEXT,\n  \"flags\" TEXT,\n  \"is_answered\" BOOLEAN DEFAULT FALSE,\n  \"is_draft\" BOOLEAN DEFAULT FALSE,\n  \"raw_message\" TEXT,\n  \"headers\" TEXT,\n  \"channel_id\" TEXT,\n  \"channel_name\" TEXT,\n  \"slack_ts\" TEXT,\n  \"slack_thread_ts\" TEXT,\n  \"reactions\" TEXT,\n  \"is_edited\" BOOLEAN DEFAULT FALSE,\n  \"message_type\" TEXT,\n  \"blocks\" TEXT,\n  \"tweet_id\" TEXT,\n  \"retweet_count\" INTEGER DEFAULT 0,\n  \"like_count\" INTEGER DEFAULT 0,\n  \"reply_count\" INTEGER DEFAULT 0,\n  \"is_retweet\" BOOLEAN DEFAULT FALSE,\n  \"is_reply\" BOOLEAN DEFAULT FALSE,\n  \"media_urls\" TEXT,\n  \"hashtags\" TEXT,\n  \"mentions\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"messages\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"account_id\" uuid,\n  \"thread_id\" TEXT,\n  \"subject\" TEXT,\n  \"body\" TEXT,\n  \"from_address\" TEXT,\n  \"from_name\" TEXT,\n  \"to_addresses\" TEXT,\n  \"date\" TIMESTAMP,\n  \"is_read\" BOOLEAN DEFAULT FALSE,\n  \"is_flagged\" BOOLEAN DEFAULT FALSE,\n  \"has_attachments\" BOOLEAN DEFAULT FALSE,\n  \"size\" INTEGER DEFAULT 0,\n  \"metadata\" TEXT,\n  \"send_status\" TEXT DEFAULT 'draft',\n  \"sent_at\" TIMESTAMP,\n  \"send_error\" TEXT,\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"max_retries\" INTEGER DEFAULT 3,\n  \"scheduled_send_at\" TIMESTAMP,\n  \"in_reply_to_message_id\" uuid,\n  \"message_id\" TEXT,\n  \"in_reply_to\" TEXT,\n  \"cc_addresses\" TEXT,\n  \"bcc_addresses\" TEXT,\n  \"reply_to_address\" TEXT,\n  \"reply_to_name\" TEXT,\n  \"text_body\" TEXT,\n  \"html_body\" TEXT,\n  \"folder_id\" TEXT,\n  \"folder_path\" TEXT,\n  \"labels\" TEXT,\n  \"flags\" TEXT,\n  \"is_answered\" BOOLEAN DEFAULT FALSE,\n  \"is_draft\" BOOLEAN DEFAULT FALSE,\n  \"raw_message\" TEXT,\n  \"headers\" TEXT,\n  \"channel_id\" TEXT,\n  \"channel_name\" TEXT,\n  \"slack_ts\" TEXT,\n  \"slack_thread_ts\" TEXT,\n  \"reactions\" TEXT,\n  \"is_edited\" BOOLEAN DEFAULT FALSE,\n  \"message_type\" TEXT,\n  \"blocks\" TEXT,\n  \"tweet_id\" TEXT,\n  \"retweet_count\" INTEGER DEFAULT 0,\n  \"like_count\" INTEGER DEFAULT 0,\n  \"reply_count\" INTEGER DEFAULT 0,\n  \"is_retweet\" BOOLEAN DEFAULT FALSE,\n  \"is_reply\" BOOLEAN DEFAULT FALSE,\n  \"media_urls\" TEXT,\n  \"hashtags\" TEXT,\n  \"mentions\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -6168,7 +6174,7 @@
             "notNull": false
           },
           "account_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "thread_id": {
@@ -6251,7 +6257,7 @@
             "notNull": false
           },
           "in_reply_to_message_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "message_id": {
@@ -6418,7 +6424,7 @@
             ]
           }
         ],
-        "version": "71b7a4b3"
+        "version": "38e8ba67"
       }
     },
     "@happyvertical/smrt-messages:SlackAccount": {
@@ -6426,15 +6432,15 @@
       "className": "SlackAccount",
       "qualifiedName": "@happyvertical/smrt-messages:SlackAccount",
       "collection": "accounts",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/models/SlackAccount.ts",
+      "filePath": "packages/messages/src/models/SlackAccount.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {
         "created_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "updated_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "tenantId": {
@@ -7005,10 +7011,10 @@
       ],
       "schema": {
         "tableName": "accounts",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"accounts\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"provider_type\" TEXT,\n  \"credential_secret_id\" TEXT,\n  \"is_active\" BOOLEAN DEFAULT TRUE,\n  \"last_sync_at\" TIMESTAMP,\n  \"settings\" TEXT,\n  \"workspace_id\" TEXT,\n  \"workspace_name\" TEXT,\n  \"bot_user_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"accounts\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"provider_type\" TEXT,\n  \"credential_secret_id\" TEXT,\n  \"is_active\" BOOLEAN DEFAULT TRUE,\n  \"last_sync_at\" TIMESTAMP,\n  \"settings\" TEXT,\n  \"workspace_id\" TEXT,\n  \"workspace_name\" TEXT,\n  \"bot_user_id\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -7104,7 +7110,7 @@
             ]
           }
         ],
-        "version": "d4d6b5ba"
+        "version": "21b50e2a"
       }
     },
     "@happyvertical/smrt-messages:SlackMessage": {
@@ -7112,15 +7118,15 @@
       "className": "SlackMessage",
       "qualifiedName": "@happyvertical/smrt-messages:SlackMessage",
       "collection": "messages",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/models/SlackMessage.ts",
+      "filePath": "packages/messages/src/models/SlackMessage.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {
         "created_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "updated_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "tenantId": {
@@ -7128,8 +7134,9 @@
           "required": false
         },
         "accountId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "Account"
         },
         "threadId": {
           "type": "text",
@@ -7211,8 +7218,9 @@
           "required": false
         },
         "inReplyToMessageId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "Message"
         },
         "createdAt": {
           "type": "text",
@@ -7925,10 +7933,10 @@
       ],
       "schema": {
         "tableName": "messages",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"messages\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"account_id\" TEXT,\n  \"thread_id\" TEXT,\n  \"subject\" TEXT,\n  \"body\" TEXT,\n  \"from_address\" TEXT,\n  \"from_name\" TEXT,\n  \"to_addresses\" TEXT,\n  \"date\" TIMESTAMP,\n  \"is_read\" BOOLEAN DEFAULT FALSE,\n  \"is_flagged\" BOOLEAN DEFAULT FALSE,\n  \"has_attachments\" BOOLEAN DEFAULT FALSE,\n  \"size\" INTEGER DEFAULT 0,\n  \"metadata\" TEXT,\n  \"send_status\" TEXT DEFAULT 'draft',\n  \"sent_at\" TIMESTAMP,\n  \"send_error\" TEXT,\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"max_retries\" INTEGER DEFAULT 3,\n  \"scheduled_send_at\" TIMESTAMP,\n  \"in_reply_to_message_id\" TEXT,\n  \"channel_id\" TEXT,\n  \"channel_name\" TEXT,\n  \"slack_ts\" TEXT,\n  \"slack_thread_ts\" TEXT,\n  \"reactions\" TEXT,\n  \"is_edited\" BOOLEAN DEFAULT FALSE,\n  \"message_type\" TEXT,\n  \"blocks\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"messages\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"account_id\" uuid,\n  \"thread_id\" TEXT,\n  \"subject\" TEXT,\n  \"body\" TEXT,\n  \"from_address\" TEXT,\n  \"from_name\" TEXT,\n  \"to_addresses\" TEXT,\n  \"date\" TIMESTAMP,\n  \"is_read\" BOOLEAN DEFAULT FALSE,\n  \"is_flagged\" BOOLEAN DEFAULT FALSE,\n  \"has_attachments\" BOOLEAN DEFAULT FALSE,\n  \"size\" INTEGER DEFAULT 0,\n  \"metadata\" TEXT,\n  \"send_status\" TEXT DEFAULT 'draft',\n  \"sent_at\" TIMESTAMP,\n  \"send_error\" TEXT,\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"max_retries\" INTEGER DEFAULT 3,\n  \"scheduled_send_at\" TIMESTAMP,\n  \"in_reply_to_message_id\" uuid,\n  \"channel_id\" TEXT,\n  \"channel_name\" TEXT,\n  \"slack_ts\" TEXT,\n  \"slack_thread_ts\" TEXT,\n  \"reactions\" TEXT,\n  \"is_edited\" BOOLEAN DEFAULT FALSE,\n  \"message_type\" TEXT,\n  \"blocks\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -7964,7 +7972,7 @@
             "notNull": false
           },
           "account_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "thread_id": {
@@ -8047,7 +8055,7 @@
             "notNull": false
           },
           "in_reply_to_message_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "channel_id": {
@@ -8107,7 +8115,7 @@
             ]
           }
         ],
-        "version": "211f41ef"
+        "version": "aa92111d"
       }
     },
     "@happyvertical/smrt-messages:Tweet": {
@@ -8115,15 +8123,15 @@
       "className": "Tweet",
       "qualifiedName": "@happyvertical/smrt-messages:Tweet",
       "collection": "messages",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/models/Tweet.ts",
+      "filePath": "packages/messages/src/models/Tweet.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {
         "created_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "updated_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "tenantId": {
@@ -8131,8 +8139,9 @@
           "required": false
         },
         "accountId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "Account"
         },
         "threadId": {
           "type": "text",
@@ -8214,8 +8223,9 @@
           "required": false
         },
         "inReplyToMessageId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "Message"
         },
         "createdAt": {
           "type": "text",
@@ -8956,10 +8966,10 @@
       ],
       "schema": {
         "tableName": "messages",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"messages\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"account_id\" TEXT,\n  \"thread_id\" TEXT,\n  \"subject\" TEXT,\n  \"body\" TEXT,\n  \"from_address\" TEXT,\n  \"from_name\" TEXT,\n  \"to_addresses\" TEXT,\n  \"date\" TIMESTAMP,\n  \"is_read\" BOOLEAN DEFAULT FALSE,\n  \"is_flagged\" BOOLEAN DEFAULT FALSE,\n  \"has_attachments\" BOOLEAN DEFAULT FALSE,\n  \"size\" INTEGER DEFAULT 0,\n  \"metadata\" TEXT,\n  \"send_status\" TEXT DEFAULT 'draft',\n  \"sent_at\" TIMESTAMP,\n  \"send_error\" TEXT,\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"max_retries\" INTEGER DEFAULT 3,\n  \"scheduled_send_at\" TIMESTAMP,\n  \"in_reply_to_message_id\" TEXT,\n  \"tweet_id\" TEXT,\n  \"retweet_count\" INTEGER DEFAULT 0,\n  \"like_count\" INTEGER DEFAULT 0,\n  \"reply_count\" INTEGER DEFAULT 0,\n  \"is_retweet\" BOOLEAN DEFAULT FALSE,\n  \"is_reply\" BOOLEAN DEFAULT FALSE,\n  \"media_urls\" TEXT,\n  \"hashtags\" TEXT,\n  \"mentions\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"messages\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"account_id\" uuid,\n  \"thread_id\" TEXT,\n  \"subject\" TEXT,\n  \"body\" TEXT,\n  \"from_address\" TEXT,\n  \"from_name\" TEXT,\n  \"to_addresses\" TEXT,\n  \"date\" TIMESTAMP,\n  \"is_read\" BOOLEAN DEFAULT FALSE,\n  \"is_flagged\" BOOLEAN DEFAULT FALSE,\n  \"has_attachments\" BOOLEAN DEFAULT FALSE,\n  \"size\" INTEGER DEFAULT 0,\n  \"metadata\" TEXT,\n  \"send_status\" TEXT DEFAULT 'draft',\n  \"sent_at\" TIMESTAMP,\n  \"send_error\" TEXT,\n  \"retry_count\" INTEGER DEFAULT 0,\n  \"max_retries\" INTEGER DEFAULT 3,\n  \"scheduled_send_at\" TIMESTAMP,\n  \"in_reply_to_message_id\" uuid,\n  \"tweet_id\" TEXT,\n  \"retweet_count\" INTEGER DEFAULT 0,\n  \"like_count\" INTEGER DEFAULT 0,\n  \"reply_count\" INTEGER DEFAULT 0,\n  \"is_retweet\" BOOLEAN DEFAULT FALSE,\n  \"is_reply\" BOOLEAN DEFAULT FALSE,\n  \"media_urls\" TEXT,\n  \"hashtags\" TEXT,\n  \"mentions\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -8995,7 +9005,7 @@
             "notNull": false
           },
           "account_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "thread_id": {
@@ -9078,7 +9088,7 @@
             "notNull": false
           },
           "in_reply_to_message_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "tweet_id": {
@@ -9146,7 +9156,7 @@
             ]
           }
         ],
-        "version": "add1ac68"
+        "version": "5122913d"
       }
     },
     "@happyvertical/smrt-messages:TwitterAccount": {
@@ -9154,15 +9164,15 @@
       "className": "TwitterAccount",
       "qualifiedName": "@happyvertical/smrt-messages:TwitterAccount",
       "collection": "accounts",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/models/TwitterAccount.ts",
+      "filePath": "packages/messages/src/models/TwitterAccount.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {
         "created_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "updated_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "tenantId": {
@@ -9729,10 +9739,10 @@
       ],
       "schema": {
         "tableName": "accounts",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"accounts\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"provider_type\" TEXT,\n  \"credential_secret_id\" TEXT,\n  \"is_active\" BOOLEAN DEFAULT TRUE,\n  \"last_sync_at\" TIMESTAMP,\n  \"settings\" TEXT,\n  \"handle\" TEXT,\n  \"twitter_user_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"accounts\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT,\n  \"provider_type\" TEXT,\n  \"credential_secret_id\" TEXT,\n  \"is_active\" BOOLEAN DEFAULT TRUE,\n  \"last_sync_at\" TIMESTAMP,\n  \"settings\" TEXT,\n  \"handle\" TEXT,\n  \"twitter_user_id\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -9824,7 +9834,7 @@
             ]
           }
         ],
-        "version": "83ce792f"
+        "version": "348ad94a"
       }
     },
     "@happyvertical/smrt-messages:Whitelist": {
@@ -9832,7 +9842,7 @@
       "className": "Whitelist",
       "qualifiedName": "@happyvertical/smrt-messages:Whitelist",
       "collection": "whitelists",
-      "filePath": "/Users/will/.codex/worktrees/b805/smrt/packages/messages/src/models/Whitelist.ts",
+      "filePath": "packages/messages/src/models/Whitelist.ts",
       "packageName": "@happyvertical/smrt-messages",
       "fields": {
         "pattern": {
@@ -9889,10 +9899,10 @@
       "collectionExportName": "WhitelistCollection",
       "schema": {
         "tableName": "whitelists",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"whitelists\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"pattern\" TEXT DEFAULT '',\n  \"type\" TEXT DEFAULT 'email',\n  \"category\" TEXT,\n  \"description\" TEXT DEFAULT ''\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"whitelists\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"pattern\" TEXT DEFAULT '',\n  \"type\" TEXT DEFAULT 'email',\n  \"category\" TEXT,\n  \"description\" TEXT DEFAULT ''\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -9955,7 +9965,7 @@
             "unique": true
           }
         ],
-        "version": "7f919088"
+        "version": "b5845567"
       }
     }
   },

--- a/packages/places/src/manifest/manifest.json
+++ b/packages/places/src/manifest/manifest.json
@@ -1,33 +1,2112 @@
 {
   "version": "1.0.0",
-  "timestamp": 1767322690568,
+  "timestamp": 1780375809500,
+  "packageName": "@happyvertical/smrt-places",
+  "packageVersion": "0.25.8",
   "objects": {
-    "placetype": {
+    "@happyvertical/smrt-places:PlaceAssetCollection": {
+      "name": "placeassetcollection",
+      "className": "PlaceAssetCollection",
+      "qualifiedName": "@happyvertical/smrt-places:PlaceAssetCollection",
+      "collection": "placeassets",
+      "filePath": "packages/places/src/collections/PlaceAssetCollection.ts",
+      "packageName": "@happyvertical/smrt-places",
+      "fields": {},
+      "methods": {
+        "byLeft": {
+          "name": "byLeft",
+          "async": true,
+          "parameters": [
+            {
+              "name": "leftId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionFilterOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<TItem[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "byRight": {
+          "name": "byRight",
+          "async": true,
+          "parameters": [
+            {
+              "name": "rightId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionFilterOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<TItem[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "attach": {
+          "name": "attach",
+          "async": true,
+          "parameters": [
+            {
+              "name": "leftId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "rightId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionAttachOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<TItem>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "detach": {
+          "name": "detach",
+          "async": true,
+          "parameters": [
+            {
+              "name": "leftId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "rightId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionFilterOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setLinks": {
+          "name": "setLinks",
+          "async": true,
+          "parameters": [
+            {
+              "name": "leftId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "rightIds",
+              "type": "string[]",
+              "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionAttachOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAssets": {
+          "name": "getAssets",
+          "async": true,
+          "parameters": [
+            {
+              "name": "placeId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addAsset": {
+          "name": "addAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "placeId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "asset",
+              "type": "Asset",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "any",
+              "optional": true,
+              "default": "attachment"
+            },
+            {
+              "name": "sortOrder",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeAsset": {
+          "name": "removeAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "placeId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "assetId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": false,
+        "mcp": false,
+        "cli": false,
+        "tableName": "place_assets"
+      },
+      "extends": "SmrtJunction",
+      "extendsTypeArg": "PlaceAsset",
+      "exportName": "PlaceAssetCollection",
+      "collectionExportName": "PlaceAssetCollectionCollection",
+      "schema": {
+        "tableName": "place_assets",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"place_assets\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "place_assets_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "place_assets_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "8aefcd10"
+      }
+    },
+    "@happyvertical/smrt-places:PlaceCollection": {
+      "name": "placecollection",
+      "className": "PlaceCollection",
+      "qualifiedName": "@happyvertical/smrt-places:PlaceCollection",
+      "collection": "places",
+      "filePath": "packages/places/src/collections/PlaceCollection.ts",
+      "packageName": "@happyvertical/smrt-places",
+      "fields": {},
+      "methods": {
+        "lookupOrCreate": {
+          "name": "lookupOrCreate",
+          "async": true,
+          "parameters": [
+            {
+              "name": "query",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "LookupOrCreateOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Place | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "discoverNearby": {
+          "name": "discoverNearby",
+          "async": true,
+          "parameters": [
+            {
+              "name": "latitude",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "longitude",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "radiusMeters",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "DiscoverNearbyOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Place[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resolveTrackPlaces": {
+          "name": "resolveTrackPlaces",
+          "async": true,
+          "parameters": [
+            {
+              "name": "points",
+              "type": "ReadonlyArray<TrackPoint>",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "ResolveTrackPlacesOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<TrackPlacesResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getChildren": {
+          "name": "getChildren",
+          "async": true,
+          "parameters": [
+            {
+              "name": "parentId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Place[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRootPlaces": {
+          "name": "getRootPlaces",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Place[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByType": {
+          "name": "getByType",
+          "async": true,
+          "parameters": [
+            {
+              "name": "typeSlug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Place[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getHierarchy": {
+          "name": "getHierarchy",
+          "async": true,
+          "parameters": [
+            {
+              "name": "placeId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAssets": {
+          "name": "getAssets",
+          "async": true,
+          "parameters": [
+            {
+              "name": "placeId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addAsset": {
+          "name": "addAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "placeId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "asset",
+              "type": "Asset",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "any",
+              "optional": true,
+              "default": "attachment"
+            },
+            {
+              "name": "sortOrder",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeAsset": {
+          "name": "removeAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "placeId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "assetId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "searchByProximity": {
+          "name": "searchByProximity",
+          "async": true,
+          "parameters": [
+            {
+              "name": "latitude",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "longitude",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "radiusKm",
+              "type": "number",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Place[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Place[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Place[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Place[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "Place",
+      "exportName": "PlaceCollection",
+      "collectionExportName": "PlaceCollectionCollection",
+      "schema": {
+        "tableName": "place_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"place_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "place_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "place_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "b8280cda"
+      }
+    },
+    "@happyvertical/smrt-places:PlaceTypeCollection": {
+      "name": "placetypecollection",
+      "className": "PlaceTypeCollection",
+      "qualifiedName": "@happyvertical/smrt-places:PlaceTypeCollection",
+      "collection": "placetypes",
+      "filePath": "packages/places/src/collections/PlaceTypeCollection.ts",
+      "packageName": "@happyvertical/smrt-places",
+      "fields": {},
+      "methods": {
+        "getOrCreate": {
+          "name": "getOrCreate",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<PlaceType>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getBySlug": {
+          "name": "getBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<PlaceType | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initializeDefaults": {
+          "name": "initializeDefaults",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<PlaceType[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "PlaceType",
+      "exportName": "PlaceTypeCollection",
+      "collectionExportName": "PlaceTypeCollectionCollection",
+      "schema": {
+        "tableName": "place_type_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"place_type_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "place_type_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "place_type_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "4de2e18a"
+      }
+    },
+    "@happyvertical/smrt-places:Place": {
+      "name": "place",
+      "className": "Place",
+      "qualifiedName": "@happyvertical/smrt-places:Place",
+      "collection": "places",
+      "filePath": "packages/places/src/models/Place.ts",
+      "packageName": "@happyvertical/smrt-places",
+      "fields": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "parentId": {
+          "type": "text",
+          "required": false
+        },
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "typeId": {
+          "type": "foreignKey",
+          "required": false,
+          "related": "PlaceType"
+        },
+        "name": {
+          "type": "text",
+          "required": false
+        },
+        "description": {
+          "type": "text",
+          "required": false
+        },
+        "latitude": {
+          "type": "decimal",
+          "required": false,
+          "_meta": {}
+        },
+        "longitude": {
+          "type": "decimal",
+          "required": false,
+          "_meta": {}
+        },
+        "streetNumber": {
+          "type": "text",
+          "required": false
+        },
+        "streetName": {
+          "type": "text",
+          "required": false
+        },
+        "city": {
+          "type": "text",
+          "required": false
+        },
+        "region": {
+          "type": "text",
+          "required": false
+        },
+        "country": {
+          "type": "text",
+          "required": false
+        },
+        "postalCode": {
+          "type": "text",
+          "required": false
+        },
+        "countryCode": {
+          "type": "text",
+          "required": false
+        },
+        "timezone": {
+          "type": "text",
+          "required": false
+        },
+        "externalId": {
+          "type": "text",
+          "required": false
+        },
+        "source": {
+          "type": "text",
+          "required": false
+        },
+        "metadata": {
+          "type": "text",
+          "required": false
+        },
+        "createdAt": {
+          "type": "text",
+          "required": false
+        },
+        "updatedAt": {
+          "type": "text",
+          "required": false
+        }
+      },
+      "methods": {
+        "getAiUsageSnapshot": {
+          "name": "getAiUsageSnapshot",
+          "async": false,
+          "parameters": [],
+          "returnType": "AiUsageSnapshot | undefined",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetAiUsage": {
+          "name": "resetAiUsage",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listAiUsage": {
+          "name": "listAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageListOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<SmrtAiUsageRecord[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeAiUsage": {
+          "name": "summarizeAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageSummaryOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Record<string, AiUsageStats>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "destroy": {
+          "name": "destroy",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadDataFromDb": {
+          "name": "loadDataFromDb",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toJSON": {
+          "name": "toJSON",
+          "async": false,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPlainObject": {
+          "name": "toPlainObject",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getId": {
+          "name": "getId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSlug": {
+          "name": "getSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSavedId": {
+          "name": "getSavedId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSaved": {
+          "name": "isSaved",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromId": {
+          "name": "loadFromId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromSlug": {
+          "name": "loadFromSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "is": {
+          "name": "is",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "do": {
+          "name": "do",
+          "async": true,
+          "parameters": [
+            {
+              "name": "instructions",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "describe": {
+          "name": "describe",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "delete": {
+          "name": "delete",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRelatedLoaded": {
+          "name": "isRelatedLoaded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelated": {
+          "name": "loadRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelatedMany": {
+          "name": "loadRelatedMany",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelated": {
+          "name": "getRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAvailableTools": {
+          "name": "getAvailableTools",
+          "async": false,
+          "parameters": [],
+          "returnType": "AITool[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "executeToolCall": {
+          "name": "executeToolCall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toolCall",
+              "type": "ToolCall",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ToolCallResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "remember": {
+          "name": "remember",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recall": {
+          "name": "recall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recallAll": {
+          "name": "recallAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forget": {
+          "name": "forget",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forgetScope": {
+          "name": "forgetScope",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateEmbeddings": {
+          "name": "generateEmbeddings",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "GenerateEmbeddingsOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmbedding": {
+          "name": "getEmbedding",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "model",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number[] | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStaleEmbeddings": {
+          "name": "hasStaleEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearEmbeddings": {
+          "name": "clearEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParent": {
+          "name": "getParent",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getChildren": {
+          "name": "getChildren",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAncestors": {
+          "name": "getAncestors",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getDescendants": {
+          "name": "getDescendants",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getHierarchy": {
+          "name": "getHierarchy",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<HierarchyView>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "moveTo": {
+          "name": "moveTo",
+          "async": true,
+          "parameters": [
+            {
+              "name": "newParent",
+              "type": "string | null",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getGeoData": {
+          "name": "getGeoData",
+          "async": false,
+          "parameters": [],
+          "returnType": "GeoData",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasCoordinates": {
+          "name": "hasCoordinates",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string, any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setMetadata": {
+          "name": "setMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateMetadata": {
+          "name": "updateMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "updates",
+              "type": "Record<string, any>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getType": {
+          "name": "getType",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAssets": {
+          "name": "getAssets",
+          "async": true,
+          "parameters": [
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addAsset": {
+          "name": "addAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "asset",
+              "type": "Asset",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "any",
+              "optional": true,
+              "default": "attachment"
+            },
+            {
+              "name": "sortOrder",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeAsset": {
+          "name": "removeAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "assetId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtHierarchical",
+      "exportName": "Place",
+      "collectionExportName": "PlaceCollection",
+      "schema": {
+        "tableName": "places",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"places\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"parent_id\" TEXT,\n  \"tenant_id\" TEXT,\n  \"type_id\" uuid,\n  \"name\" TEXT,\n  \"description\" TEXT,\n  \"latitude\" DOUBLE PRECISION,\n  \"longitude\" DOUBLE PRECISION,\n  \"street_number\" TEXT,\n  \"street_name\" TEXT,\n  \"city\" TEXT,\n  \"region\" TEXT,\n  \"country\" TEXT,\n  \"postal_code\" TEXT,\n  \"country_code\" TEXT,\n  \"timezone\" TEXT,\n  \"external_id\" TEXT,\n  \"source\" TEXT,\n  \"metadata\" TEXT\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "parent_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "type_id": {
+            "type": "UUID",
+            "notNull": false
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "latitude": {
+            "type": "REAL",
+            "notNull": false
+          },
+          "longitude": {
+            "type": "REAL",
+            "notNull": false
+          },
+          "street_number": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "street_name": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "city": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "region": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "country": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "postal_code": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "country_code": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "timezone": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "external_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "source": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "metadata": {
+            "type": "TEXT",
+            "notNull": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "places_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "places_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "places_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "c8b2b96d"
+      }
+    },
+    "@happyvertical/smrt-places:PlaceAsset": {
+      "name": "placeasset",
+      "className": "PlaceAsset",
+      "qualifiedName": "@happyvertical/smrt-places:PlaceAsset",
+      "collection": "placeassets",
+      "filePath": "packages/places/src/models/PlaceAsset.ts",
+      "packageName": "@happyvertical/smrt-places",
+      "fields": {
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "placeId": {
+          "type": "foreignKey",
+          "required": false,
+          "related": "Place"
+        },
+        "assetId": {
+          "type": "crossPackageRef",
+          "required": true,
+          "related": "@happyvertical/smrt-assets:Asset"
+        },
+        "relationship": {
+          "type": "text",
+          "required": true,
+          "_meta": {
+            "required": true
+          }
+        },
+        "sortOrder": {
+          "type": "integer",
+          "required": true,
+          "default": 0
+        }
+      },
+      "methods": {},
+      "decoratorConfig": {
+        "tableName": "place_assets",
+        "conflictColumns": [
+          "place_id",
+          "asset_id",
+          "relationship"
+        ],
+        "api": false,
+        "mcp": false,
+        "cli": false
+      },
+      "extends": "SmrtObject",
+      "exportName": "PlaceAsset",
+      "collectionExportName": "PlaceAssetCollection",
+      "validationRules": [
+        {
+          "field": "assetId",
+          "rule": "required",
+          "fieldType": "crossPackageRef"
+        },
+        {
+          "field": "relationship",
+          "rule": "required",
+          "fieldType": "text"
+        },
+        {
+          "field": "sortOrder",
+          "rule": "required",
+          "fieldType": "integer"
+        }
+      ],
+      "schema": {
+        "tableName": "place_assets",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"place_assets\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"place_id\" uuid,\n  \"asset_id\" uuid NOT NULL,\n  \"relationship\" TEXT NOT NULL,\n  \"sort_order\" INTEGER NOT NULL DEFAULT 0\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "place_id": {
+            "type": "UUID",
+            "notNull": false,
+            "unique": false
+          },
+          "asset_id": {
+            "type": "UUID",
+            "notNull": true,
+            "unique": false
+          },
+          "relationship": {
+            "type": "TEXT",
+            "notNull": true,
+            "unique": false
+          },
+          "sort_order": {
+            "type": "INTEGER",
+            "notNull": true,
+            "unique": false,
+            "default": 0
+          }
+        },
+        "indexes": [
+          {
+            "name": "place_assets_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "place_assets_place_id_asset_id_idx",
+            "columns": [
+              "place_id",
+              "asset_id",
+              "relationship"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "5562a3a6"
+      }
+    },
+    "@happyvertical/smrt-places:PlaceType": {
       "name": "placetype",
       "className": "PlaceType",
+      "qualifiedName": "@happyvertical/smrt-places:PlaceType",
       "collection": "placetypes",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/places/src/models/PlaceType.ts",
+      "filePath": "packages/places/src/models/PlaceType.ts",
+      "packageName": "@happyvertical/smrt-places",
       "fields": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
         "name": {
           "type": "text",
           "required": true,
-          "_meta": {},
-          "default": ""
+          "default": "",
+          "_meta": {
+            "required": true
+          }
         },
         "description": {
           "type": "text",
           "required": false
         },
         "createdAt": {
-          "type": "datetime",
+          "type": "text",
           "required": false
         },
         "updatedAt": {
-          "type": "datetime",
+          "type": "text",
           "required": false
         }
       },
       "methods": {
+        "getAiUsageSnapshot": {
+          "name": "getAiUsageSnapshot",
+          "async": false,
+          "parameters": [],
+          "returnType": "AiUsageSnapshot | undefined",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetAiUsage": {
+          "name": "resetAiUsage",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listAiUsage": {
+          "name": "listAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageListOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<SmrtAiUsageRecord[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeAiUsage": {
+          "name": "summarizeAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageSummaryOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Record<string, AiUsageStats>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "destroy": {
+          "name": "destroy",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadDataFromDb": {
+          "name": "loadDataFromDb",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toJSON": {
+          "name": "toJSON",
+          "async": false,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPlainObject": {
+          "name": "toPlainObject",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getId": {
+          "name": "getId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSlug": {
+          "name": "getSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSavedId": {
+          "name": "getSavedId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSaved": {
+          "name": "isSaved",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromId": {
+          "name": "loadFromId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromSlug": {
+          "name": "loadFromSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "is": {
+          "name": "is",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "do": {
+          "name": "do",
+          "async": true,
+          "parameters": [
+            {
+              "name": "instructions",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "describe": {
+          "name": "describe",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "delete": {
+          "name": "delete",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRelatedLoaded": {
+          "name": "isRelatedLoaded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelated": {
+          "name": "loadRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelatedMany": {
+          "name": "loadRelatedMany",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelated": {
+          "name": "getRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAvailableTools": {
+          "name": "getAvailableTools",
+          "async": false,
+          "parameters": [],
+          "returnType": "AITool[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "executeToolCall": {
+          "name": "executeToolCall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toolCall",
+              "type": "ToolCall",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ToolCallResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "remember": {
+          "name": "remember",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recall": {
+          "name": "recall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recallAll": {
+          "name": "recallAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forget": {
+          "name": "forget",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forgetScope": {
+          "name": "forgetScope",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateEmbeddings": {
+          "name": "generateEmbeddings",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "GenerateEmbeddingsOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmbedding": {
+          "name": "getEmbedding",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "model",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number[] | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStaleEmbeddings": {
+          "name": "hasStaleEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearEmbeddings": {
+          "name": "clearEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
         "getBySlug": {
           "name": "getBySlug",
           "async": true,
@@ -66,12 +2145,19 @@
       "extends": "SmrtObject",
       "exportName": "PlaceType",
       "collectionExportName": "PlaceTypeCollection",
+      "validationRules": [
+        {
+          "field": "name",
+          "rule": "required",
+          "fieldType": "text"
+        }
+      ],
       "schema": {
         "tableName": "place_types",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"place_types\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"place_types\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -135,642 +2221,13 @@
             ]
           }
         ],
-        "version": "2ef46db6"
-      }
-    },
-    "placetypecollection": {
-      "name": "placetypecollection",
-      "className": "PlaceTypeCollection",
-      "collection": "placetypes",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/places/src/collections/PlaceTypeCollection.ts",
-      "fields": {},
-      "methods": {
-        "getOrCreate": {
-          "name": "getOrCreate",
-          "async": true,
-          "parameters": [
-            {
-              "name": "slug",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "name",
-              "type": "string",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<PlaceType>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getBySlug": {
-          "name": "getBySlug",
-          "async": true,
-          "parameters": [
-            {
-              "name": "slug",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<PlaceType | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "initializeDefaults": {
-          "name": "initializeDefaults",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<PlaceType[]>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {},
-      "extends": "SmrtCollection",
-      "extendsTypeArg": "PlaceType",
-      "exportName": "PlaceTypeCollection",
-      "collectionExportName": "PlaceTypeCollectionCollection",
-      "schema": {
-        "tableName": "place_type_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"place_type_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          }
-        },
-        "indexes": [
-          {
-            "name": "place_type_collections_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "place_type_collections_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "8095a99e"
-      }
-    },
-    "place": {
-      "name": "place",
-      "className": "Place",
-      "collection": "places",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/places/src/models/Place.ts",
-      "fields": {
-        "typeId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "parentId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "name": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "description": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "latitude": {
-          "type": "decimal",
-          "required": false,
-          "_meta": {}
-        },
-        "longitude": {
-          "type": "decimal",
-          "required": false,
-          "_meta": {}
-        },
-        "streetNumber": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "streetName": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "city": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "region": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "country": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "postalCode": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "countryCode": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "timezone": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "externalId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "source": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "metadata": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "createdAt": {
-          "type": "datetime",
-          "required": false
-        },
-        "updatedAt": {
-          "type": "datetime",
-          "required": false
-        }
-      },
-      "methods": {
-        "getGeoData": {
-          "name": "getGeoData",
-          "async": false,
-          "parameters": [],
-          "returnType": "GeoData",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "hasCoordinates": {
-          "name": "hasCoordinates",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getMetadata": {
-          "name": "getMetadata",
-          "async": false,
-          "parameters": [],
-          "returnType": "Record<string, any>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "setMetadata": {
-          "name": "setMetadata",
-          "async": false,
-          "parameters": [
-            {
-              "name": "data",
-              "type": "Record<string, any>",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "updateMetadata": {
-          "name": "updateMetadata",
-          "async": false,
-          "parameters": [
-            {
-              "name": "updates",
-              "type": "Record<string, any>",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getType": {
-          "name": "getType",
-          "async": true,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getParent": {
-          "name": "getParent",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Place | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getChildren": {
-          "name": "getChildren",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Place[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getAncestors": {
-          "name": "getAncestors",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Place[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getDescendants": {
-          "name": "getDescendants",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Place[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getHierarchy": {
-          "name": "getHierarchy",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<{\n    ancestors: Place[];\n    current: Place;\n    descendants: Place[];\n  }>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "tableStrategy": "sti",
-        "api": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update",
-            "delete"
-          ]
-        },
-        "mcp": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update"
-          ]
-        },
-        "cli": true
-      },
-      "extends": "SmrtObject",
-      "exportName": "Place",
-      "collectionExportName": "PlaceCollection",
-      "schema": {
-        "tableName": "places",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"places\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"type_id\" TEXT DEFAULT '',\n  \"parent_id\" TEXT DEFAULT '',\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"latitude\" REAL DEFAULT NULL,\n  \"longitude\" REAL DEFAULT NULL,\n  \"street_number\" TEXT DEFAULT '',\n  \"street_name\" TEXT DEFAULT '',\n  \"city\" TEXT DEFAULT '',\n  \"region\" TEXT DEFAULT '',\n  \"country\" TEXT DEFAULT '',\n  \"postal_code\" TEXT DEFAULT '',\n  \"country_code\" TEXT DEFAULT '',\n  \"timezone\" TEXT DEFAULT '',\n  \"external_id\" TEXT DEFAULT '',\n  \"source\" TEXT DEFAULT '',\n  \"metadata\" TEXT DEFAULT ''\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "_meta_type": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "_meta_data": {
-            "type": "JSON",
-            "notNull": false
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "type_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "parent_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "name": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "description": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "latitude": {
-            "type": "REAL",
-            "notNull": false,
-            "default": null
-          },
-          "longitude": {
-            "type": "REAL",
-            "notNull": false,
-            "default": null
-          },
-          "street_number": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "street_name": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "city": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "region": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "country": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "postal_code": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "country_code": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "timezone": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "external_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "source": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "metadata": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          }
-        },
-        "indexes": [
-          {
-            "name": "places_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "places_slug_context_meta_type_idx",
-            "columns": [
-              "slug",
-              "context",
-              "_meta_type"
-            ],
-            "unique": true
-          },
-          {
-            "name": "places_meta_type_idx",
-            "columns": [
-              "_meta_type"
-            ]
-          }
-        ],
-        "version": "a00e5ff0"
-      }
-    },
-    "placecollection": {
-      "name": "placecollection",
-      "className": "PlaceCollection",
-      "collection": "places",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/places/src/collections/PlaceCollection.ts",
-      "fields": {},
-      "methods": {
-        "lookupOrCreate": {
-          "name": "lookupOrCreate",
-          "async": true,
-          "parameters": [
-            {
-              "name": "query",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "options",
-              "type": "LookupOrCreateOptions",
-              "optional": false,
-              "default": {}
-            }
-          ],
-          "returnType": "Promise<Place | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getChildren": {
-          "name": "getChildren",
-          "async": true,
-          "parameters": [
-            {
-              "name": "parentId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<Place[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getRootPlaces": {
-          "name": "getRootPlaces",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Place[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getByType": {
-          "name": "getByType",
-          "async": true,
-          "parameters": [
-            {
-              "name": "typeSlug",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<Place[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getHierarchy": {
-          "name": "getHierarchy",
-          "async": true,
-          "parameters": [
-            {
-              "name": "placeId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "searchByProximity": {
-          "name": "searchByProximity",
-          "async": true,
-          "parameters": [
-            {
-              "name": "latitude",
-              "type": "number",
-              "optional": false
-            },
-            {
-              "name": "longitude",
-              "type": "number",
-              "optional": false
-            },
-            {
-              "name": "radiusKm",
-              "type": "number",
-              "optional": false,
-              "default": 10
-            }
-          ],
-          "returnType": "Promise<Place[]>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {},
-      "extends": "SmrtCollection",
-      "extendsTypeArg": "Place",
-      "exportName": "PlaceCollection",
-      "collectionExportName": "PlaceCollectionCollection",
-      "schema": {
-        "tableName": "place_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"place_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          }
-        },
-        "indexes": [
-          {
-            "name": "place_collections_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "place_collections_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "9bc5d1e0"
+        "version": "c441b0e9"
       }
     }
   },
   "moduleType": "smrt",
-  "packageName": "@happyvertical/smrt-places"
+  "smrtDependencies": [
+    "@happyvertical/smrt-assets",
+    "@happyvertical/smrt-core"
+  ]
 }

--- a/packages/places/src/manifest/manifest.json
+++ b/packages/places/src/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "timestamp": 1780375809500,
+  "timestamp": 1780379238551,
   "packageName": "@happyvertical/smrt-places",
   "packageVersion": "0.25.8",
   "objects": {
@@ -209,7 +209,7 @@
       "collectionExportName": "PlaceAssetCollectionCollection",
       "schema": {
         "tableName": "place_assets",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"place_assets\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"place_assets\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -522,7 +522,7 @@
       "collectionExportName": "PlaceCollectionCollection",
       "schema": {
         "tableName": "place_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"place_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"place_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -626,7 +626,7 @@
       "collectionExportName": "PlaceTypeCollectionCollection",
       "schema": {
         "tableName": "place_type_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"place_type_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"place_type_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -689,8 +689,12 @@
           "required": false
         },
         "parentId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "Place",
+          "_meta": {
+            "nullable": true
+          }
         },
         "tenantId": {
           "type": "text",
@@ -1383,7 +1387,7 @@
       "collectionExportName": "PlaceCollection",
       "schema": {
         "tableName": "places",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"places\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"parent_id\" TEXT,\n  \"tenant_id\" TEXT,\n  \"type_id\" uuid,\n  \"name\" TEXT,\n  \"description\" TEXT,\n  \"latitude\" DOUBLE PRECISION,\n  \"longitude\" DOUBLE PRECISION,\n  \"street_number\" TEXT,\n  \"street_name\" TEXT,\n  \"city\" TEXT,\n  \"region\" TEXT,\n  \"country\" TEXT,\n  \"postal_code\" TEXT,\n  \"country_code\" TEXT,\n  \"timezone\" TEXT,\n  \"external_id\" TEXT,\n  \"source\" TEXT,\n  \"metadata\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"places\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"parent_id\" UUID,\n  \"tenant_id\" TEXT,\n  \"type_id\" UUID,\n  \"name\" TEXT,\n  \"description\" TEXT,\n  \"latitude\" REAL,\n  \"longitude\" REAL,\n  \"street_number\" TEXT,\n  \"street_name\" TEXT,\n  \"city\" TEXT,\n  \"region\" TEXT,\n  \"country\" TEXT,\n  \"postal_code\" TEXT,\n  \"country_code\" TEXT,\n  \"timezone\" TEXT,\n  \"external_id\" TEXT,\n  \"source\" TEXT,\n  \"metadata\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1418,7 +1422,7 @@
             "default": "current_timestamp"
           },
           "parent_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "tenant_id": {
@@ -1513,7 +1517,7 @@
             ]
           }
         ],
-        "version": "c8b2b96d"
+        "version": "2384435a"
       }
     },
     "@happyvertical/smrt-places:PlaceAsset": {
@@ -1530,8 +1534,11 @@
         },
         "placeId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "Place"
+          "required": true,
+          "related": "Place",
+          "_meta": {
+            "required": true
+          }
         },
         "assetId": {
           "type": "crossPackageRef",
@@ -1568,6 +1575,11 @@
       "collectionExportName": "PlaceAssetCollection",
       "validationRules": [
         {
+          "field": "placeId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        },
+        {
           "field": "assetId",
           "rule": "required",
           "fieldType": "crossPackageRef"
@@ -1585,7 +1597,7 @@
       ],
       "schema": {
         "tableName": "place_assets",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"place_assets\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"place_id\" uuid,\n  \"asset_id\" uuid NOT NULL,\n  \"relationship\" TEXT NOT NULL,\n  \"sort_order\" INTEGER NOT NULL DEFAULT 0\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"place_assets\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"place_id\" UUID NOT NULL,\n  \"asset_id\" UUID NOT NULL,\n  \"relationship\" TEXT NOT NULL,\n  \"sort_order\" INTEGER NOT NULL DEFAULT 0\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1618,7 +1630,7 @@
           },
           "place_id": {
             "type": "UUID",
-            "notNull": false,
+            "notNull": true,
             "unique": false
           },
           "asset_id": {
@@ -1655,7 +1667,7 @@
             "unique": true
           }
         ],
-        "version": "5562a3a6"
+        "version": "7a30a85b"
       }
     },
     "@happyvertical/smrt-places:PlaceType": {
@@ -2154,7 +2166,7 @@
       ],
       "schema": {
         "tableName": "place_types",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"place_types\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"place_types\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2228,6 +2240,7 @@
   "moduleType": "smrt",
   "smrtDependencies": [
     "@happyvertical/smrt-assets",
-    "@happyvertical/smrt-core"
+    "@happyvertical/smrt-core",
+    "@happyvertical/smrt-tenancy"
   ]
 }

--- a/packages/profiles/src/manifest/manifest.json
+++ b/packages/profiles/src/manifest/manifest.json
@@ -1,15 +1,15 @@
 {
   "version": "1.0.0",
-  "timestamp": 1774125630362,
+  "timestamp": 1780375808350,
   "packageName": "@happyvertical/smrt-profiles",
-  "packageVersion": "0.21.7",
+  "packageVersion": "0.25.8",
   "objects": {
     "@happyvertical/smrt-profiles:ApiKeyCollection": {
       "name": "apikeycollection",
       "className": "ApiKeyCollection",
       "qualifiedName": "@happyvertical/smrt-profiles:ApiKeyCollection",
       "collection": "apikeies",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/collections/ApiKeyCollection.ts",
+      "filePath": "packages/profiles/src/collections/ApiKeyCollection.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {},
       "methods": {
@@ -134,10 +134,10 @@
       "collectionExportName": "ApiKeyCollectionCollection",
       "schema": {
         "tableName": "api_keys",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"api_keys\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"api_keys\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -177,7 +177,7 @@
             "unique": true
           }
         ],
-        "version": "353c6b16"
+        "version": "cabc3d4f"
       }
     },
     "@happyvertical/smrt-profiles:AuditLogCollection": {
@@ -185,7 +185,7 @@
       "className": "AuditLogCollection",
       "qualifiedName": "@happyvertical/smrt-profiles:AuditLogCollection",
       "collection": "auditlogs",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/collections/AuditLogCollection.ts",
+      "filePath": "packages/profiles/src/collections/AuditLogCollection.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {},
       "methods": {
@@ -326,10 +326,10 @@
       "collectionExportName": "AuditLogCollectionCollection",
       "schema": {
         "tableName": "audit_logs",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"audit_logs\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"audit_logs\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -369,7 +369,7 @@
             "unique": true
           }
         ],
-        "version": "4f0c1562"
+        "version": "5087feea"
       }
     },
     "@happyvertical/smrt-profiles:MagicLinkTokenCollection": {
@@ -377,7 +377,7 @@
       "className": "MagicLinkTokenCollection",
       "qualifiedName": "@happyvertical/smrt-profiles:MagicLinkTokenCollection",
       "collection": "magiclinktokens",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/collections/MagicLinkTokenCollection.ts",
+      "filePath": "packages/profiles/src/collections/MagicLinkTokenCollection.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {},
       "methods": {
@@ -545,10 +545,10 @@
       "collectionExportName": "MagicLinkTokenCollectionCollection",
       "schema": {
         "tableName": "magic_link_tokens",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"magic_link_tokens\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"magic_link_tokens\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -588,7 +588,7 @@
             "unique": true
           }
         ],
-        "version": "7676bc7d"
+        "version": "adf7d499"
       }
     },
     "@happyvertical/smrt-profiles:NostrIdentityCollection": {
@@ -596,7 +596,7 @@
       "className": "NostrIdentityCollection",
       "qualifiedName": "@happyvertical/smrt-profiles:NostrIdentityCollection",
       "collection": "nostridentities",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/collections/NostrIdentityCollection.ts",
+      "filePath": "packages/profiles/src/collections/NostrIdentityCollection.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {},
       "methods": {
@@ -780,10 +780,10 @@
       "collectionExportName": "NostrIdentityCollectionCollection",
       "schema": {
         "tableName": "nostr_identities",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"nostr_identities\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"nostr_identities\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -823,7 +823,7 @@
             "unique": true
           }
         ],
-        "version": "e6381e2f"
+        "version": "48c0c7d7"
       }
     },
     "@happyvertical/smrt-profiles:OidcIdentityCollection": {
@@ -831,7 +831,7 @@
       "className": "OidcIdentityCollection",
       "qualifiedName": "@happyvertical/smrt-profiles:OidcIdentityCollection",
       "collection": "oidcidentities",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/collections/OidcIdentityCollection.ts",
+      "filePath": "packages/profiles/src/collections/OidcIdentityCollection.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {},
       "methods": {
@@ -935,10 +935,10 @@
       "collectionExportName": "OidcIdentityCollectionCollection",
       "schema": {
         "tableName": "oidc_identities",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"oidc_identities\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"oidc_identities\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -978,7 +978,258 @@
             "unique": true
           }
         ],
-        "version": "71175656"
+        "version": "860138b2"
+      }
+    },
+    "@happyvertical/smrt-profiles:ProfileAssetCollection": {
+      "name": "profileassetcollection",
+      "className": "ProfileAssetCollection",
+      "qualifiedName": "@happyvertical/smrt-profiles:ProfileAssetCollection",
+      "collection": "profileassets",
+      "filePath": "packages/profiles/src/collections/ProfileAssetCollection.ts",
+      "packageName": "@happyvertical/smrt-profiles",
+      "fields": {},
+      "methods": {
+        "byLeft": {
+          "name": "byLeft",
+          "async": true,
+          "parameters": [
+            {
+              "name": "leftId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionFilterOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<TItem[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "byRight": {
+          "name": "byRight",
+          "async": true,
+          "parameters": [
+            {
+              "name": "rightId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionFilterOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<TItem[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "attach": {
+          "name": "attach",
+          "async": true,
+          "parameters": [
+            {
+              "name": "leftId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "rightId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionAttachOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<TItem>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "detach": {
+          "name": "detach",
+          "async": true,
+          "parameters": [
+            {
+              "name": "leftId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "rightId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionFilterOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setLinks": {
+          "name": "setLinks",
+          "async": true,
+          "parameters": [
+            {
+              "name": "leftId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "rightIds",
+              "type": "string[]",
+              "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "JunctionAttachOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAssets": {
+          "name": "getAssets",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addAsset": {
+          "name": "addAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "asset",
+              "type": "Asset",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "any",
+              "optional": true,
+              "default": "attachment"
+            },
+            {
+              "name": "sortOrder",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeAsset": {
+          "name": "removeAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "assetId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": false,
+        "mcp": false,
+        "cli": false,
+        "tableName": "profile_assets"
+      },
+      "extends": "SmrtJunction",
+      "extendsTypeArg": "ProfileAsset",
+      "exportName": "ProfileAssetCollection",
+      "collectionExportName": "ProfileAssetCollectionCollection",
+      "schema": {
+        "tableName": "profile_assets",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_assets\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "profile_assets_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "profile_assets_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "f818ea6e"
       }
     },
     "@happyvertical/smrt-profiles:ProfileCollection": {
@@ -986,7 +1237,7 @@
       "className": "ProfileCollection",
       "qualifiedName": "@happyvertical/smrt-profiles:ProfileCollection",
       "collection": "profiles",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/collections/ProfileCollection.ts",
+      "filePath": "packages/profiles/src/collections/ProfileCollection.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {},
       "methods": {
@@ -1065,6 +1316,79 @@
           "isStatic": false,
           "isPublic": true
         },
+        "getAssets": {
+          "name": "getAssets",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addAsset": {
+          "name": "addAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "asset",
+              "type": "Asset",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "any",
+              "optional": true,
+              "default": "attachment"
+            },
+            {
+              "name": "sortOrder",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeAsset": {
+          "name": "removeAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "assetId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
         "getRelationshipNetwork": {
           "name": "getRelationshipNetwork",
           "async": true,
@@ -1128,10 +1452,10 @@
       "collectionExportName": "ProfileCollectionCollection",
       "schema": {
         "tableName": "profile_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1171,7 +1495,7 @@
             "unique": true
           }
         ],
-        "version": "c72136ee"
+        "version": "f4d04d88"
       }
     },
     "@happyvertical/smrt-profiles:ProfileMetadataCollection": {
@@ -1179,7 +1503,7 @@
       "className": "ProfileMetadataCollection",
       "qualifiedName": "@happyvertical/smrt-profiles:ProfileMetadataCollection",
       "collection": "profilemetadatas",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/collections/ProfileMetadataCollection.ts",
+      "filePath": "packages/profiles/src/collections/ProfileMetadataCollection.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {},
       "methods": {
@@ -1238,10 +1562,10 @@
       "collectionExportName": "ProfileMetadataCollectionCollection",
       "schema": {
         "tableName": "profile_metadata_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metadata_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metadata_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1281,7 +1605,7 @@
             "unique": true
           }
         ],
-        "version": "b3f26c59"
+        "version": "bf484840"
       }
     },
     "@happyvertical/smrt-profiles:ProfileMetafieldCollection": {
@@ -1289,7 +1613,7 @@
       "className": "ProfileMetafieldCollection",
       "qualifiedName": "@happyvertical/smrt-profiles:ProfileMetafieldCollection",
       "collection": "profilemetafields",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/collections/ProfileMetafieldCollection.ts",
+      "filePath": "packages/profiles/src/collections/ProfileMetafieldCollection.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {},
       "methods": {
@@ -1334,10 +1658,10 @@
       "collectionExportName": "ProfileMetafieldCollectionCollection",
       "schema": {
         "tableName": "profile_metafield_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metafield_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metafield_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1377,7 +1701,7 @@
             "unique": true
           }
         ],
-        "version": "78630e41"
+        "version": "7e7ca32f"
       }
     },
     "@happyvertical/smrt-profiles:ProfileRelationshipCollection": {
@@ -1385,7 +1709,7 @@
       "className": "ProfileRelationshipCollection",
       "qualifiedName": "@happyvertical/smrt-profiles:ProfileRelationshipCollection",
       "collection": "profilerelationships",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/collections/ProfileRelationshipCollection.ts",
+      "filePath": "packages/profiles/src/collections/ProfileRelationshipCollection.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {},
       "methods": {
@@ -1478,10 +1802,10 @@
       "collectionExportName": "ProfileRelationshipCollectionCollection",
       "schema": {
         "tableName": "profile_relationship_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1521,7 +1845,7 @@
             "unique": true
           }
         ],
-        "version": "c4c34a40"
+        "version": "a6f0256f"
       }
     },
     "@happyvertical/smrt-profiles:ProfileRelationshipTermCollection": {
@@ -1529,7 +1853,7 @@
       "className": "ProfileRelationshipTermCollection",
       "qualifiedName": "@happyvertical/smrt-profiles:ProfileRelationshipTermCollection",
       "collection": "profilerelationshipterms",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/collections/ProfileRelationshipTermCollection.ts",
+      "filePath": "packages/profiles/src/collections/ProfileRelationshipTermCollection.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {},
       "methods": {
@@ -1583,10 +1907,10 @@
       "collectionExportName": "ProfileRelationshipTermCollectionCollection",
       "schema": {
         "tableName": "profile_relationship_term_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_term_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_term_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1626,7 +1950,7 @@
             "unique": true
           }
         ],
-        "version": "eadce69f"
+        "version": "8511ee83"
       }
     },
     "@happyvertical/smrt-profiles:ProfileRelationshipTypeCollection": {
@@ -1634,7 +1958,7 @@
       "className": "ProfileRelationshipTypeCollection",
       "qualifiedName": "@happyvertical/smrt-profiles:ProfileRelationshipTypeCollection",
       "collection": "profilerelationshiptypes",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/collections/ProfileRelationshipTypeCollection.ts",
+      "filePath": "packages/profiles/src/collections/ProfileRelationshipTypeCollection.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {},
       "methods": {
@@ -1695,10 +2019,10 @@
       "collectionExportName": "ProfileRelationshipTypeCollectionCollection",
       "schema": {
         "tableName": "profile_relationship_type_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_type_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_type_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1738,7 +2062,7 @@
             "unique": true
           }
         ],
-        "version": "7aa7b380"
+        "version": "ef3c5ce5"
       }
     },
     "@happyvertical/smrt-profiles:ProfileTypeCollection": {
@@ -1746,7 +2070,7 @@
       "className": "ProfileTypeCollection",
       "qualifiedName": "@happyvertical/smrt-profiles:ProfileTypeCollection",
       "collection": "profiletypes",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/collections/ProfileTypeCollection.ts",
+      "filePath": "packages/profiles/src/collections/ProfileTypeCollection.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {},
       "methods": {
@@ -1791,10 +2115,10 @@
       "collectionExportName": "ProfileTypeCollectionCollection",
       "schema": {
         "tableName": "profile_type_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_type_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_type_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1834,7 +2158,7 @@
             "unique": true
           }
         ],
-        "version": "e6448822"
+        "version": "abf23a07"
       }
     },
     "@happyvertical/smrt-profiles:ApiKey": {
@@ -1842,7 +2166,7 @@
       "className": "ApiKey",
       "qualifiedName": "@happyvertical/smrt-profiles:ApiKey",
       "collection": "apikeies",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/models/ApiKey.ts",
+      "filePath": "packages/profiles/src/models/ApiKey.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {
         "profileId": {
@@ -2011,10 +2335,10 @@
       "collectionExportName": "ApiKeyCollection",
       "schema": {
         "tableName": "api_keys",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"api_keys\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" TEXT,\n  \"key_hash\" TEXT DEFAULT '',\n  \"key_prefix\" TEXT DEFAULT '',\n  \"name\" TEXT DEFAULT '',\n  \"scopes\" JSON DEFAULT '[]',\n  \"last_used_at\" TIMESTAMP,\n  \"expires_at\" TIMESTAMP,\n  \"revoked_at\" TIMESTAMP\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"api_keys\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" uuid,\n  \"key_hash\" TEXT DEFAULT '',\n  \"key_prefix\" TEXT DEFAULT '',\n  \"name\" TEXT DEFAULT '',\n  \"scopes\" JSONB DEFAULT '[]',\n  \"last_used_at\" TIMESTAMP,\n  \"expires_at\" TIMESTAMP,\n  \"revoked_at\" TIMESTAMP\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -2038,7 +2362,7 @@
             "default": "current_timestamp"
           },
           "profile_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           },
@@ -2098,7 +2422,7 @@
             "unique": true
           }
         ],
-        "version": "52136c0d"
+        "version": "36f60cc0"
       }
     },
     "@happyvertical/smrt-profiles:AuditLog": {
@@ -2106,7 +2430,7 @@
       "className": "AuditLog",
       "qualifiedName": "@happyvertical/smrt-profiles:AuditLog",
       "collection": "auditlogs",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/models/AuditLog.ts",
+      "filePath": "packages/profiles/src/models/AuditLog.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {
         "tenantId": {
@@ -2214,10 +2538,10 @@
       "collectionExportName": "AuditLogCollection",
       "schema": {
         "tableName": "audit_logs",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"audit_logs\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"profile_id\" TEXT,\n  \"action\" TEXT DEFAULT '',\n  \"resource_type\" TEXT DEFAULT '',\n  \"resource_id\" TEXT DEFAULT '',\n  \"source\" TEXT DEFAULT 'web',\n  \"metadata\" JSON DEFAULT '{}',\n  \"on_behalf_of_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"audit_logs\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"profile_id\" uuid,\n  \"action\" TEXT DEFAULT '',\n  \"resource_type\" TEXT DEFAULT '',\n  \"resource_id\" TEXT DEFAULT '',\n  \"source\" TEXT DEFAULT 'web',\n  \"metadata\" JSONB DEFAULT '{}',\n  \"on_behalf_of_id\" uuid\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -2246,7 +2570,7 @@
             "unique": false
           },
           "profile_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           },
@@ -2281,7 +2605,7 @@
             "default": {}
           },
           "on_behalf_of_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           }
@@ -2302,7 +2626,7 @@
             "unique": true
           }
         ],
-        "version": "945337eb"
+        "version": "a6e1fe51"
       }
     },
     "@happyvertical/smrt-profiles:MagicLinkToken": {
@@ -2310,7 +2634,7 @@
       "className": "MagicLinkToken",
       "qualifiedName": "@happyvertical/smrt-profiles:MagicLinkToken",
       "collection": "magiclinktokens",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/models/MagicLinkToken.ts",
+      "filePath": "packages/profiles/src/models/MagicLinkToken.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {
         "nostrIdentityId": {
@@ -2476,10 +2800,10 @@
       "collectionExportName": "MagicLinkTokenCollection",
       "schema": {
         "tableName": "magic_link_tokens",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"magic_link_tokens\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"nostr_identity_id\" TEXT,\n  \"token_hash\" TEXT DEFAULT '',\n  \"email\" TEXT DEFAULT '',\n  \"expires_at\" TIMESTAMP,\n  \"used_at\" TIMESTAMP,\n  \"requested_from_ip\" TEXT DEFAULT ''\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"magic_link_tokens\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"nostr_identity_id\" uuid,\n  \"token_hash\" TEXT DEFAULT '',\n  \"email\" TEXT DEFAULT '',\n  \"expires_at\" TIMESTAMP,\n  \"used_at\" TIMESTAMP,\n  \"requested_from_ip\" TEXT DEFAULT ''\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -2503,7 +2827,7 @@
             "default": "current_timestamp"
           },
           "nostr_identity_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           },
@@ -2552,7 +2876,7 @@
             "unique": true
           }
         ],
-        "version": "2fb73682"
+        "version": "7c1ffcb6"
       }
     },
     "@happyvertical/smrt-profiles:NostrIdentity": {
@@ -2560,7 +2884,7 @@
       "className": "NostrIdentity",
       "qualifiedName": "@happyvertical/smrt-profiles:NostrIdentity",
       "collection": "nostridentities",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/models/NostrIdentity.ts",
+      "filePath": "packages/profiles/src/models/NostrIdentity.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {
         "profileId": {
@@ -2766,10 +3090,10 @@
       "collectionExportName": "NostrIdentityCollection",
       "schema": {
         "tableName": "nostr_identities",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"nostr_identities\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" TEXT,\n  \"pubkey\" TEXT DEFAULT '',\n  \"encrypted_privkey\" TEXT DEFAULT '',\n  \"encryption_iv\" TEXT DEFAULT '',\n  \"encryption_tag\" TEXT DEFAULT '',\n  \"email\" TEXT DEFAULT '',\n  \"nip05_username\" TEXT DEFAULT '',\n  \"last_used_at\" TIMESTAMP,\n  \"verified_at\" TIMESTAMP\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"nostr_identities\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" uuid,\n  \"pubkey\" TEXT DEFAULT '',\n  \"encrypted_privkey\" TEXT DEFAULT '',\n  \"encryption_iv\" TEXT DEFAULT '',\n  \"encryption_tag\" TEXT DEFAULT '',\n  \"email\" TEXT DEFAULT '',\n  \"nip05_username\" TEXT DEFAULT '',\n  \"last_used_at\" TIMESTAMP,\n  \"verified_at\" TIMESTAMP\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -2793,7 +3117,7 @@
             "default": "current_timestamp"
           },
           "profile_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           },
@@ -2860,7 +3184,7 @@
             "unique": true
           }
         ],
-        "version": "0ab35f82"
+        "version": "3bfb83db"
       }
     },
     "@happyvertical/smrt-profiles:OidcIdentity": {
@@ -2868,7 +3192,7 @@
       "className": "OidcIdentity",
       "qualifiedName": "@happyvertical/smrt-profiles:OidcIdentity",
       "collection": "oidcidentities",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/models/OidcIdentity.ts",
+      "filePath": "packages/profiles/src/models/OidcIdentity.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {
         "profileId": {
@@ -2992,10 +3316,10 @@
       "collectionExportName": "OidcIdentityCollection",
       "schema": {
         "tableName": "oidc_identities",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"oidc_identities\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" TEXT,\n  \"provider\" TEXT DEFAULT '',\n  \"issuer\" TEXT DEFAULT '',\n  \"subject\" TEXT DEFAULT '',\n  \"email\" TEXT DEFAULT '',\n  \"last_used_at\" TIMESTAMP\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"oidc_identities\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" uuid,\n  \"provider\" TEXT DEFAULT '',\n  \"issuer\" TEXT DEFAULT '',\n  \"subject\" TEXT DEFAULT '',\n  \"email\" TEXT DEFAULT '',\n  \"last_used_at\" TIMESTAMP\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -3019,7 +3343,7 @@
             "default": "current_timestamp"
           },
           "profile_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           },
@@ -3069,7 +3393,7 @@
             "unique": true
           }
         ],
-        "version": "d9aca0ef"
+        "version": "4bff3825"
       }
     },
     "@happyvertical/smrt-profiles:Profile": {
@@ -3077,15 +3401,15 @@
       "className": "Profile",
       "qualifiedName": "@happyvertical/smrt-profiles:Profile",
       "collection": "profiles",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/models/Profile.ts",
+      "filePath": "packages/profiles/src/models/Profile.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {
         "created_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "updated_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "tenantId": {
@@ -3621,6 +3945,64 @@
           "isStatic": false,
           "isPublic": true
         },
+        "getAssets": {
+          "name": "getAssets",
+          "async": true,
+          "parameters": [
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addAsset": {
+          "name": "addAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "asset",
+              "type": "Asset",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "any",
+              "optional": true,
+              "default": "attachment"
+            },
+            {
+              "name": "sortOrder",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeAsset": {
+          "name": "removeAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "assetId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
         "addRelationship": {
           "name": "addRelationship",
           "async": true,
@@ -3916,10 +4298,10 @@
       ],
       "schema": {
         "tableName": "profiles",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type_id\" TEXT,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type_id\" uuid,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -3955,7 +4337,7 @@
             "notNull": false
           },
           "type_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "email": {
@@ -3995,7 +4377,149 @@
             ]
           }
         ],
-        "version": "e1d03203"
+        "version": "9156e298"
+      }
+    },
+    "@happyvertical/smrt-profiles:ProfileAsset": {
+      "name": "profileasset",
+      "className": "ProfileAsset",
+      "qualifiedName": "@happyvertical/smrt-profiles:ProfileAsset",
+      "collection": "profileassets",
+      "filePath": "packages/profiles/src/models/ProfileAsset.ts",
+      "packageName": "@happyvertical/smrt-profiles",
+      "fields": {
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "profileId": {
+          "type": "foreignKey",
+          "required": false,
+          "related": "Profile"
+        },
+        "assetId": {
+          "type": "crossPackageRef",
+          "required": true,
+          "related": "@happyvertical/smrt-assets:Asset"
+        },
+        "relationship": {
+          "type": "text",
+          "required": true,
+          "_meta": {
+            "required": true
+          }
+        },
+        "sortOrder": {
+          "type": "integer",
+          "required": true,
+          "default": 0
+        }
+      },
+      "methods": {},
+      "decoratorConfig": {
+        "tableName": "profile_assets",
+        "conflictColumns": [
+          "profile_id",
+          "asset_id",
+          "relationship"
+        ],
+        "api": false,
+        "mcp": false,
+        "cli": false
+      },
+      "extends": "SmrtObject",
+      "exportName": "ProfileAsset",
+      "collectionExportName": "ProfileAssetCollection",
+      "validationRules": [
+        {
+          "field": "assetId",
+          "rule": "required",
+          "fieldType": "crossPackageRef"
+        },
+        {
+          "field": "relationship",
+          "rule": "required",
+          "fieldType": "text"
+        },
+        {
+          "field": "sortOrder",
+          "rule": "required",
+          "fieldType": "integer"
+        }
+      ],
+      "schema": {
+        "tableName": "profile_assets",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_assets\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"profile_id\" uuid,\n  \"asset_id\" uuid NOT NULL,\n  \"relationship\" TEXT NOT NULL,\n  \"sort_order\" INTEGER NOT NULL DEFAULT 0\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "profile_id": {
+            "type": "UUID",
+            "notNull": false,
+            "unique": false
+          },
+          "asset_id": {
+            "type": "UUID",
+            "notNull": true,
+            "unique": false
+          },
+          "relationship": {
+            "type": "TEXT",
+            "notNull": true,
+            "unique": false
+          },
+          "sort_order": {
+            "type": "INTEGER",
+            "notNull": true,
+            "unique": false,
+            "default": 0
+          }
+        },
+        "indexes": [
+          {
+            "name": "profile_assets_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "profile_assets_profile_id_asset_id_idx",
+            "columns": [
+              "profile_id",
+              "asset_id",
+              "relationship"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "324da1bf"
       }
     },
     "@happyvertical/smrt-profiles:ProfileMetadata": {
@@ -4003,15 +4527,15 @@
       "className": "ProfileMetadata",
       "qualifiedName": "@happyvertical/smrt-profiles:ProfileMetadata",
       "collection": "profilemetadatas",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/models/ProfileMetadata.ts",
+      "filePath": "packages/profiles/src/models/ProfileMetadata.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {
         "created_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "updated_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "tenantId": {
@@ -4497,10 +5021,10 @@
       ],
       "schema": {
         "tableName": "profile_metadata",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metadata\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"profile_id\" TEXT,\n  \"metafield_id\" TEXT,\n  \"value\" TEXT DEFAULT ''\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metadata\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"profile_id\" uuid,\n  \"metafield_id\" uuid,\n  \"value\" TEXT DEFAULT ''\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -4536,11 +5060,11 @@
             "notNull": false
           },
           "profile_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "metafield_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "value": {
@@ -4572,7 +5096,7 @@
             ]
           }
         ],
-        "version": "b60119d6"
+        "version": "21223f0b"
       }
     },
     "@happyvertical/smrt-profiles:ProfileMetafield": {
@@ -4580,15 +5104,15 @@
       "className": "ProfileMetafield",
       "qualifiedName": "@happyvertical/smrt-profiles:ProfileMetafield",
       "collection": "profilemetafields",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/models/ProfileMetafield.ts",
+      "filePath": "packages/profiles/src/models/ProfileMetafield.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {
         "created_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "updated_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "tenantId": {
@@ -5117,10 +5641,10 @@
       ],
       "schema": {
         "tableName": "profile_metafields",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metafields\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT,\n  \"validation\" JSON DEFAULT '{}'\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metafields\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT,\n  \"validation\" JSONB DEFAULT '{}'\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -5193,7 +5717,7 @@
             ]
           }
         ],
-        "version": "d8f59f3e"
+        "version": "e4042aed"
       }
     },
     "@happyvertical/smrt-profiles:ProfileRelationship": {
@@ -5201,15 +5725,15 @@
       "className": "ProfileRelationship",
       "qualifiedName": "@happyvertical/smrt-profiles:ProfileRelationship",
       "collection": "profilerelationships",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/models/ProfileRelationship.ts",
+      "filePath": "packages/profiles/src/models/ProfileRelationship.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {
         "created_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "updated_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "tenantId": {
@@ -5735,10 +6259,10 @@
       "collectionExportName": "ProfileRelationshipCollection",
       "schema": {
         "tableName": "profile_relationships",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationships\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"from_profile_id\" TEXT,\n  \"to_profile_id\" TEXT,\n  \"type_id\" TEXT,\n  \"context_profile_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationships\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"from_profile_id\" uuid,\n  \"to_profile_id\" uuid,\n  \"type_id\" uuid,\n  \"context_profile_id\" uuid\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -5774,19 +6298,19 @@
             "notNull": false
           },
           "from_profile_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "to_profile_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "type_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "context_profile_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           }
         },
@@ -5813,7 +6337,7 @@
             ]
           }
         ],
-        "version": "d07c36d6"
+        "version": "b429e459"
       }
     },
     "@happyvertical/smrt-profiles:ProfileRelationshipTerm": {
@@ -5821,15 +6345,15 @@
       "className": "ProfileRelationshipTerm",
       "qualifiedName": "@happyvertical/smrt-profiles:ProfileRelationshipTerm",
       "collection": "profilerelationshipterms",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/models/ProfileRelationshipTerm.ts",
+      "filePath": "packages/profiles/src/models/ProfileRelationshipTerm.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {
         "created_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "updated_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "relationshipId": {
@@ -6323,10 +6847,10 @@
       ],
       "schema": {
         "tableName": "profile_relationship_terms",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_terms\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"relationship_id\" TEXT,\n  \"started_at\" TIMESTAMP,\n  \"ended_at\" TIMESTAMP\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_terms\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"relationship_id\" uuid,\n  \"started_at\" TIMESTAMP,\n  \"ended_at\" TIMESTAMP\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -6358,7 +6882,7 @@
             "default": "current_timestamp"
           },
           "relationship_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "started_at": {
@@ -6393,7 +6917,7 @@
             ]
           }
         ],
-        "version": "a1b7f803"
+        "version": "e8034c8e"
       }
     },
     "@happyvertical/smrt-profiles:ProfileRelationshipType": {
@@ -6401,15 +6925,15 @@
       "className": "ProfileRelationshipType",
       "qualifiedName": "@happyvertical/smrt-profiles:ProfileRelationshipType",
       "collection": "profilerelationshiptypes",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/models/ProfileRelationshipType.ts",
+      "filePath": "packages/profiles/src/models/ProfileRelationshipType.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {
         "created_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "updated_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "name": {
@@ -6930,10 +7454,10 @@
       ],
       "schema": {
         "tableName": "profile_relationship_types",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_types\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"reciprocal\" BOOLEAN DEFAULT TRUE\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_types\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"reciprocal\" BOOLEAN DEFAULT TRUE\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -6998,7 +7522,7 @@
             ]
           }
         ],
-        "version": "df0dc50e"
+        "version": "ce70af61"
       }
     },
     "@happyvertical/smrt-profiles:ProfileType": {
@@ -7006,15 +7530,15 @@
       "className": "ProfileType",
       "qualifiedName": "@happyvertical/smrt-profiles:ProfileType",
       "collection": "profiletypes",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/models/ProfileType.ts",
+      "filePath": "packages/profiles/src/models/ProfileType.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {
         "created_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "updated_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "tenantId": {
@@ -7491,10 +8015,10 @@
       ],
       "schema": {
         "tableName": "profile_types",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_types\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_types\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -7562,7 +8086,7 @@
             ]
           }
         ],
-        "version": "b60e60ef"
+        "version": "5ffff646"
       }
     },
     "@happyvertical/smrt-profiles:Person": {
@@ -7570,15 +8094,15 @@
       "className": "Person",
       "qualifiedName": "@happyvertical/smrt-profiles:Person",
       "collection": "profiles",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/models/ProfileTypes.ts",
+      "filePath": "packages/profiles/src/models/ProfileTypes.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {
         "created_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "updated_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "tenantId": {
@@ -8108,6 +8632,64 @@
               "name": "metafieldSlug",
               "type": "string",
               "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAssets": {
+          "name": "getAssets",
+          "async": true,
+          "parameters": [
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addAsset": {
+          "name": "addAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "asset",
+              "type": "Asset",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "any",
+              "optional": true,
+              "default": "attachment"
+            },
+            {
+              "name": "sortOrder",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeAsset": {
+          "name": "removeAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "assetId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
             }
           ],
           "returnType": "Promise<void>",
@@ -8392,10 +8974,10 @@
       ],
       "schema": {
         "tableName": "profiles",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type_id\" TEXT,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type_id\" uuid,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -8431,7 +9013,7 @@
             "notNull": false
           },
           "type_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "email": {
@@ -8471,7 +9053,7 @@
             ]
           }
         ],
-        "version": "fecba001"
+        "version": "1440208d"
       }
     },
     "@happyvertical/smrt-profiles:Organization": {
@@ -8479,15 +9061,15 @@
       "className": "Organization",
       "qualifiedName": "@happyvertical/smrt-profiles:Organization",
       "collection": "profiles",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/models/ProfileTypes.ts",
+      "filePath": "packages/profiles/src/models/ProfileTypes.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {
         "created_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "updated_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "tenantId": {
@@ -9017,6 +9599,64 @@
               "name": "metafieldSlug",
               "type": "string",
               "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAssets": {
+          "name": "getAssets",
+          "async": true,
+          "parameters": [
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addAsset": {
+          "name": "addAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "asset",
+              "type": "Asset",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "any",
+              "optional": true,
+              "default": "attachment"
+            },
+            {
+              "name": "sortOrder",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeAsset": {
+          "name": "removeAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "assetId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
             }
           ],
           "returnType": "Promise<void>",
@@ -9301,10 +9941,10 @@
       ],
       "schema": {
         "tableName": "profiles",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type_id\" TEXT,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type_id\" uuid,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -9340,7 +9980,7 @@
             "notNull": false
           },
           "type_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "email": {
@@ -9380,7 +10020,7 @@
             ]
           }
         ],
-        "version": "1c2893db"
+        "version": "72550014"
       }
     },
     "@happyvertical/smrt-profiles:Bot": {
@@ -9388,15 +10028,15 @@
       "className": "Bot",
       "qualifiedName": "@happyvertical/smrt-profiles:Bot",
       "collection": "profiles",
-      "filePath": "/Users/will/.codex/worktrees/9bd6/smrt/packages/profiles/src/models/ProfileTypes.ts",
+      "filePath": "packages/profiles/src/models/ProfileTypes.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {
         "created_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "updated_at": {
-          "type": "json",
+          "type": "datetime",
           "required": false
         },
         "tenantId": {
@@ -9932,6 +10572,64 @@
           "isStatic": false,
           "isPublic": true
         },
+        "getAssets": {
+          "name": "getAssets",
+          "async": true,
+          "parameters": [
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Asset[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addAsset": {
+          "name": "addAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "asset",
+              "type": "Asset",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "any",
+              "optional": true,
+              "default": "attachment"
+            },
+            {
+              "name": "sortOrder",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeAsset": {
+          "name": "removeAsset",
+          "async": true,
+          "parameters": [
+            {
+              "name": "assetId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "relationship",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
         "addRelationship": {
           "name": "addRelationship",
           "async": true,
@@ -10210,10 +10908,10 @@
       ],
       "schema": {
         "tableName": "profiles",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type_id\" TEXT,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type_id\" uuid,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -10249,7 +10947,7 @@
             "notNull": false
           },
           "type_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "email": {
@@ -10289,12 +10987,13 @@
             ]
           }
         ],
-        "version": "a9c9885b"
+        "version": "70948c50"
       }
     }
   },
   "moduleType": "smrt",
   "smrtDependencies": [
+    "@happyvertical/smrt-assets",
     "@happyvertical/smrt-core"
   ]
 }

--- a/packages/profiles/src/manifest/manifest.json
+++ b/packages/profiles/src/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "timestamp": 1780375808350,
+  "timestamp": 1780379238701,
   "packageName": "@happyvertical/smrt-profiles",
   "packageVersion": "0.25.8",
   "objects": {
@@ -134,7 +134,7 @@
       "collectionExportName": "ApiKeyCollectionCollection",
       "schema": {
         "tableName": "api_keys",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"api_keys\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"api_keys\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -326,7 +326,7 @@
       "collectionExportName": "AuditLogCollectionCollection",
       "schema": {
         "tableName": "audit_logs",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"audit_logs\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"audit_logs\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -545,7 +545,7 @@
       "collectionExportName": "MagicLinkTokenCollectionCollection",
       "schema": {
         "tableName": "magic_link_tokens",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"magic_link_tokens\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"magic_link_tokens\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -780,7 +780,7 @@
       "collectionExportName": "NostrIdentityCollectionCollection",
       "schema": {
         "tableName": "nostr_identities",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"nostr_identities\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"nostr_identities\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -935,7 +935,7 @@
       "collectionExportName": "OidcIdentityCollectionCollection",
       "schema": {
         "tableName": "oidc_identities",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"oidc_identities\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"oidc_identities\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1186,7 +1186,7 @@
       "collectionExportName": "ProfileAssetCollectionCollection",
       "schema": {
         "tableName": "profile_assets",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_assets\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_assets\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1452,7 +1452,7 @@
       "collectionExportName": "ProfileCollectionCollection",
       "schema": {
         "tableName": "profile_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1562,7 +1562,7 @@
       "collectionExportName": "ProfileMetadataCollectionCollection",
       "schema": {
         "tableName": "profile_metadata_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metadata_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metadata_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1658,7 +1658,7 @@
       "collectionExportName": "ProfileMetafieldCollectionCollection",
       "schema": {
         "tableName": "profile_metafield_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metafield_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metafield_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1802,7 +1802,7 @@
       "collectionExportName": "ProfileRelationshipCollectionCollection",
       "schema": {
         "tableName": "profile_relationship_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1907,7 +1907,7 @@
       "collectionExportName": "ProfileRelationshipTermCollectionCollection",
       "schema": {
         "tableName": "profile_relationship_term_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_term_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_term_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2019,7 +2019,7 @@
       "collectionExportName": "ProfileRelationshipTypeCollectionCollection",
       "schema": {
         "tableName": "profile_relationship_type_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_type_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_type_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2115,7 +2115,7 @@
       "collectionExportName": "ProfileTypeCollectionCollection",
       "schema": {
         "tableName": "profile_type_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_type_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_type_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2171,8 +2171,11 @@
       "fields": {
         "profileId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "Profile"
+          "required": true,
+          "related": "Profile",
+          "_meta": {
+            "required": true
+          }
         },
         "keyHash": {
           "type": "text",
@@ -2333,9 +2336,16 @@
       "extends": "SmrtObject",
       "exportName": "ApiKey",
       "collectionExportName": "ApiKeyCollection",
+      "validationRules": [
+        {
+          "field": "profileId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        }
+      ],
       "schema": {
         "tableName": "api_keys",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"api_keys\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" uuid,\n  \"key_hash\" TEXT DEFAULT '',\n  \"key_prefix\" TEXT DEFAULT '',\n  \"name\" TEXT DEFAULT '',\n  \"scopes\" JSONB DEFAULT '[]',\n  \"last_used_at\" TIMESTAMP,\n  \"expires_at\" TIMESTAMP,\n  \"revoked_at\" TIMESTAMP\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"api_keys\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" UUID NOT NULL,\n  \"key_hash\" TEXT DEFAULT '',\n  \"key_prefix\" TEXT DEFAULT '',\n  \"name\" TEXT DEFAULT '',\n  \"scopes\" JSON DEFAULT '[]',\n  \"last_used_at\" TIMESTAMP,\n  \"expires_at\" TIMESTAMP,\n  \"revoked_at\" TIMESTAMP\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2363,7 +2373,7 @@
           },
           "profile_id": {
             "type": "UUID",
-            "notNull": false,
+            "notNull": true,
             "unique": false
           },
           "key_hash": {
@@ -2422,7 +2432,7 @@
             "unique": true
           }
         ],
-        "version": "36f60cc0"
+        "version": "5115d1ab"
       }
     },
     "@happyvertical/smrt-profiles:AuditLog": {
@@ -2439,8 +2449,11 @@
         },
         "profileId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "Profile"
+          "required": true,
+          "related": "Profile",
+          "_meta": {
+            "required": true
+          }
         },
         "action": {
           "type": "text",
@@ -2470,7 +2483,10 @@
         "onBehalfOfId": {
           "type": "foreignKey",
           "required": false,
-          "related": "Profile"
+          "related": "Profile",
+          "_meta": {
+            "nullable": true
+          }
         }
       },
       "methods": {
@@ -2536,9 +2552,16 @@
       "extends": "SmrtObject",
       "exportName": "AuditLog",
       "collectionExportName": "AuditLogCollection",
+      "validationRules": [
+        {
+          "field": "profileId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        }
+      ],
       "schema": {
         "tableName": "audit_logs",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"audit_logs\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"profile_id\" uuid,\n  \"action\" TEXT DEFAULT '',\n  \"resource_type\" TEXT DEFAULT '',\n  \"resource_id\" TEXT DEFAULT '',\n  \"source\" TEXT DEFAULT 'web',\n  \"metadata\" JSONB DEFAULT '{}',\n  \"on_behalf_of_id\" uuid\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"audit_logs\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"profile_id\" UUID NOT NULL,\n  \"action\" TEXT DEFAULT '',\n  \"resource_type\" TEXT DEFAULT '',\n  \"resource_id\" TEXT DEFAULT '',\n  \"source\" TEXT DEFAULT 'web',\n  \"metadata\" JSON DEFAULT '{}',\n  \"on_behalf_of_id\" UUID\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2571,7 +2594,7 @@
           },
           "profile_id": {
             "type": "UUID",
-            "notNull": false,
+            "notNull": true,
             "unique": false
           },
           "action": {
@@ -2626,7 +2649,7 @@
             "unique": true
           }
         ],
-        "version": "a6e1fe51"
+        "version": "50825815"
       }
     },
     "@happyvertical/smrt-profiles:MagicLinkToken": {
@@ -2639,8 +2662,11 @@
       "fields": {
         "nostrIdentityId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "NostrIdentity"
+          "required": true,
+          "related": "NostrIdentity",
+          "_meta": {
+            "required": true
+          }
         },
         "tokenHash": {
           "type": "text",
@@ -2798,9 +2824,16 @@
       "extends": "SmrtObject",
       "exportName": "MagicLinkToken",
       "collectionExportName": "MagicLinkTokenCollection",
+      "validationRules": [
+        {
+          "field": "nostrIdentityId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        }
+      ],
       "schema": {
         "tableName": "magic_link_tokens",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"magic_link_tokens\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"nostr_identity_id\" uuid,\n  \"token_hash\" TEXT DEFAULT '',\n  \"email\" TEXT DEFAULT '',\n  \"expires_at\" TIMESTAMP,\n  \"used_at\" TIMESTAMP,\n  \"requested_from_ip\" TEXT DEFAULT ''\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"magic_link_tokens\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"nostr_identity_id\" UUID NOT NULL,\n  \"token_hash\" TEXT DEFAULT '',\n  \"email\" TEXT DEFAULT '',\n  \"expires_at\" TIMESTAMP,\n  \"used_at\" TIMESTAMP,\n  \"requested_from_ip\" TEXT DEFAULT ''\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2828,7 +2861,7 @@
           },
           "nostr_identity_id": {
             "type": "UUID",
-            "notNull": false,
+            "notNull": true,
             "unique": false
           },
           "token_hash": {
@@ -2876,7 +2909,7 @@
             "unique": true
           }
         ],
-        "version": "7c1ffcb6"
+        "version": "6f0efb13"
       }
     },
     "@happyvertical/smrt-profiles:NostrIdentity": {
@@ -2889,8 +2922,11 @@
       "fields": {
         "profileId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "Profile"
+          "required": true,
+          "related": "Profile",
+          "_meta": {
+            "required": true
+          }
         },
         "pubkey": {
           "type": "text",
@@ -3088,9 +3124,16 @@
       "extends": "SmrtObject",
       "exportName": "NostrIdentity",
       "collectionExportName": "NostrIdentityCollection",
+      "validationRules": [
+        {
+          "field": "profileId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        }
+      ],
       "schema": {
         "tableName": "nostr_identities",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"nostr_identities\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" uuid,\n  \"pubkey\" TEXT DEFAULT '',\n  \"encrypted_privkey\" TEXT DEFAULT '',\n  \"encryption_iv\" TEXT DEFAULT '',\n  \"encryption_tag\" TEXT DEFAULT '',\n  \"email\" TEXT DEFAULT '',\n  \"nip05_username\" TEXT DEFAULT '',\n  \"last_used_at\" TIMESTAMP,\n  \"verified_at\" TIMESTAMP\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"nostr_identities\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" UUID NOT NULL,\n  \"pubkey\" TEXT DEFAULT '',\n  \"encrypted_privkey\" TEXT DEFAULT '',\n  \"encryption_iv\" TEXT DEFAULT '',\n  \"encryption_tag\" TEXT DEFAULT '',\n  \"email\" TEXT DEFAULT '',\n  \"nip05_username\" TEXT DEFAULT '',\n  \"last_used_at\" TIMESTAMP,\n  \"verified_at\" TIMESTAMP\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3118,7 +3161,7 @@
           },
           "profile_id": {
             "type": "UUID",
-            "notNull": false,
+            "notNull": true,
             "unique": false
           },
           "pubkey": {
@@ -3184,7 +3227,7 @@
             "unique": true
           }
         ],
-        "version": "3bfb83db"
+        "version": "19f53fb6"
       }
     },
     "@happyvertical/smrt-profiles:OidcIdentity": {
@@ -3197,8 +3240,11 @@
       "fields": {
         "profileId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "Profile"
+          "required": true,
+          "related": "Profile",
+          "_meta": {
+            "required": true
+          }
         },
         "provider": {
           "type": "text",
@@ -3314,9 +3360,16 @@
       "extends": "SmrtObject",
       "exportName": "OidcIdentity",
       "collectionExportName": "OidcIdentityCollection",
+      "validationRules": [
+        {
+          "field": "profileId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        }
+      ],
       "schema": {
         "tableName": "oidc_identities",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"oidc_identities\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" uuid,\n  \"provider\" TEXT DEFAULT '',\n  \"issuer\" TEXT DEFAULT '',\n  \"subject\" TEXT DEFAULT '',\n  \"email\" TEXT DEFAULT '',\n  \"last_used_at\" TIMESTAMP\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"oidc_identities\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" UUID NOT NULL,\n  \"provider\" TEXT DEFAULT '',\n  \"issuer\" TEXT DEFAULT '',\n  \"subject\" TEXT DEFAULT '',\n  \"email\" TEXT DEFAULT '',\n  \"last_used_at\" TIMESTAMP\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3344,7 +3397,7 @@
           },
           "profile_id": {
             "type": "UUID",
-            "notNull": false,
+            "notNull": true,
             "unique": false
           },
           "provider": {
@@ -3393,7 +3446,7 @@
             "unique": true
           }
         ],
-        "version": "4bff3825"
+        "version": "e7e61106"
       }
     },
     "@happyvertical/smrt-profiles:Profile": {
@@ -3418,8 +3471,11 @@
         },
         "typeId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "ProfileType"
+          "required": true,
+          "related": "ProfileType",
+          "_meta": {
+            "required": true
+          }
         },
         "email": {
           "type": "text",
@@ -4291,6 +4347,11 @@
       "collectionExportName": "ProfileCollection",
       "validationRules": [
         {
+          "field": "typeId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        },
+        {
           "field": "name",
           "rule": "required",
           "fieldType": "text"
@@ -4298,7 +4359,7 @@
       ],
       "schema": {
         "tableName": "profiles",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type_id\" uuid,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type_id\" UUID,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -4394,8 +4455,11 @@
         },
         "profileId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "Profile"
+          "required": true,
+          "related": "Profile",
+          "_meta": {
+            "required": true
+          }
         },
         "assetId": {
           "type": "crossPackageRef",
@@ -4432,6 +4496,11 @@
       "collectionExportName": "ProfileAssetCollection",
       "validationRules": [
         {
+          "field": "profileId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        },
+        {
           "field": "assetId",
           "rule": "required",
           "fieldType": "crossPackageRef"
@@ -4449,7 +4518,7 @@
       ],
       "schema": {
         "tableName": "profile_assets",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_assets\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"profile_id\" uuid,\n  \"asset_id\" uuid NOT NULL,\n  \"relationship\" TEXT NOT NULL,\n  \"sort_order\" INTEGER NOT NULL DEFAULT 0\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_assets\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"profile_id\" UUID NOT NULL,\n  \"asset_id\" UUID NOT NULL,\n  \"relationship\" TEXT NOT NULL,\n  \"sort_order\" INTEGER NOT NULL DEFAULT 0\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -4482,7 +4551,7 @@
           },
           "profile_id": {
             "type": "UUID",
-            "notNull": false,
+            "notNull": true,
             "unique": false
           },
           "asset_id": {
@@ -4519,7 +4588,7 @@
             "unique": true
           }
         ],
-        "version": "324da1bf"
+        "version": "e113ab6b"
       }
     },
     "@happyvertical/smrt-profiles:ProfileMetadata": {
@@ -4544,13 +4613,19 @@
         },
         "profileId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "Profile"
+          "required": true,
+          "related": "Profile",
+          "_meta": {
+            "required": true
+          }
         },
         "metafieldId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "ProfileMetafield"
+          "required": true,
+          "related": "ProfileMetafield",
+          "_meta": {
+            "required": true
+          }
         },
         "value": {
           "type": "text",
@@ -5014,6 +5089,16 @@
       "collectionExportName": "ProfileMetadataCollection",
       "validationRules": [
         {
+          "field": "profileId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        },
+        {
+          "field": "metafieldId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        },
+        {
           "field": "value",
           "rule": "required",
           "fieldType": "text"
@@ -5021,7 +5106,7 @@
       ],
       "schema": {
         "tableName": "profile_metadata",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metadata\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"profile_id\" uuid,\n  \"metafield_id\" uuid,\n  \"value\" TEXT DEFAULT ''\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metadata\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"profile_id\" UUID,\n  \"metafield_id\" UUID,\n  \"value\" TEXT DEFAULT ''\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -5641,7 +5726,7 @@
       ],
       "schema": {
         "tableName": "profile_metafields",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metafields\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT,\n  \"validation\" JSONB DEFAULT '{}'\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metafields\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT,\n  \"validation\" JSON DEFAULT '{}'\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -5742,18 +5827,27 @@
         },
         "fromProfileId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "Profile"
+          "required": true,
+          "related": "Profile",
+          "_meta": {
+            "required": true
+          }
         },
         "toProfileId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "Profile"
+          "required": true,
+          "related": "Profile",
+          "_meta": {
+            "required": true
+          }
         },
         "typeId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "ProfileRelationshipType"
+          "required": true,
+          "related": "ProfileRelationshipType",
+          "_meta": {
+            "required": true
+          }
         },
         "contextProfileId": {
           "type": "foreignKey",
@@ -6257,9 +6351,26 @@
       "extends": "SmrtObject",
       "exportName": "ProfileRelationship",
       "collectionExportName": "ProfileRelationshipCollection",
+      "validationRules": [
+        {
+          "field": "fromProfileId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        },
+        {
+          "field": "toProfileId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        },
+        {
+          "field": "typeId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        }
+      ],
       "schema": {
         "tableName": "profile_relationships",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationships\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"from_profile_id\" uuid,\n  \"to_profile_id\" uuid,\n  \"type_id\" uuid,\n  \"context_profile_id\" uuid\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationships\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"from_profile_id\" UUID,\n  \"to_profile_id\" UUID,\n  \"type_id\" UUID,\n  \"context_profile_id\" UUID\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -6358,8 +6469,11 @@
         },
         "relationshipId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "ProfileRelationship"
+          "required": true,
+          "related": "ProfileRelationship",
+          "_meta": {
+            "required": true
+          }
         },
         "startedAt": {
           "type": "datetime",
@@ -6840,6 +6954,11 @@
       "collectionExportName": "ProfileRelationshipTermCollection",
       "validationRules": [
         {
+          "field": "relationshipId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        },
+        {
           "field": "startedAt",
           "rule": "required",
           "fieldType": "datetime"
@@ -6847,7 +6966,7 @@
       ],
       "schema": {
         "tableName": "profile_relationship_terms",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_terms\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"relationship_id\" uuid,\n  \"started_at\" TIMESTAMP,\n  \"ended_at\" TIMESTAMP\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_terms\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"relationship_id\" UUID,\n  \"started_at\" TIMESTAMP,\n  \"ended_at\" TIMESTAMP\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -7454,7 +7573,7 @@
       ],
       "schema": {
         "tableName": "profile_relationship_types",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_types\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"reciprocal\" BOOLEAN DEFAULT TRUE\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_relationship_types\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"reciprocal\" BOOLEAN DEFAULT TRUE\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -8015,7 +8134,7 @@
       ],
       "schema": {
         "tableName": "profile_types",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_types\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_types\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -8111,8 +8230,11 @@
         },
         "typeId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "ProfileType"
+          "required": true,
+          "related": "ProfileType",
+          "_meta": {
+            "required": true
+          }
         },
         "email": {
           "type": "text",
@@ -8967,6 +9089,11 @@
       "collectionExportName": "PersonCollection",
       "validationRules": [
         {
+          "field": "typeId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        },
+        {
           "field": "name",
           "rule": "required",
           "fieldType": "text"
@@ -8974,7 +9101,7 @@
       ],
       "schema": {
         "tableName": "profiles",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type_id\" uuid,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type_id\" UUID,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -9078,8 +9205,11 @@
         },
         "typeId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "ProfileType"
+          "required": true,
+          "related": "ProfileType",
+          "_meta": {
+            "required": true
+          }
         },
         "email": {
           "type": "text",
@@ -9934,6 +10064,11 @@
       "collectionExportName": "OrganizationCollection",
       "validationRules": [
         {
+          "field": "typeId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        },
+        {
           "field": "name",
           "rule": "required",
           "fieldType": "text"
@@ -9941,7 +10076,7 @@
       ],
       "schema": {
         "tableName": "profiles",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type_id\" uuid,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type_id\" UUID,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -10045,8 +10180,11 @@
         },
         "typeId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "ProfileType"
+          "required": true,
+          "related": "ProfileType",
+          "_meta": {
+            "required": true
+          }
         },
         "email": {
           "type": "text",
@@ -10901,6 +11039,11 @@
       "collectionExportName": "BotCollection",
       "validationRules": [
         {
+          "field": "typeId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        },
+        {
           "field": "name",
           "rule": "required",
           "fieldType": "text"
@@ -10908,7 +11051,7 @@
       ],
       "schema": {
         "tableName": "profiles",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type_id\" uuid,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"type_id\" UUID,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -10994,6 +11137,8 @@
   "moduleType": "smrt",
   "smrtDependencies": [
     "@happyvertical/smrt-assets",
-    "@happyvertical/smrt-core"
+    "@happyvertical/smrt-core",
+    "@happyvertical/smrt-prompts",
+    "@happyvertical/smrt-tenancy"
   ]
 }

--- a/packages/projects/src/manifest/manifest.json
+++ b/packages/projects/src/manifest/manifest.json
@@ -1,785 +1,16 @@
 {
   "version": "1.0.0",
-  "timestamp": 1767322693449,
+  "timestamp": 1780375815437,
+  "packageName": "@happyvertical/smrt-projects",
+  "packageVersion": "0.25.8",
   "objects": {
-    "comment": {
-      "name": "comment",
-      "className": "Comment",
-      "collection": "comments",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/projects/src/models/Comment.ts",
-      "fields": {
-        "issueId": {
-          "type": "foreignKey",
-          "required": false,
-          "_meta": {},
-          "related": "Issue"
-        },
-        "commentId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "body": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "author": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "createdAt": {
-          "type": "datetime",
-          "required": false,
-          "default": null
-        },
-        "updatedAt": {
-          "type": "datetime",
-          "required": false,
-          "default": null
-        },
-        "url": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        }
-      },
-      "methods": {
-        "isQuestion": {
-          "name": "isQuestion",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<boolean>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isApproval": {
-          "name": "isApproval",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<boolean>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "requestsChanges": {
-          "name": "requestsChanges",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<boolean>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "extractActionItems": {
-          "name": "extractActionItems",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<string[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "summarize": {
-          "name": "summarize",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<string>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getSentiment": {
-          "name": "getSentiment",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<'positive' | 'negative' | 'neutral'>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "api": {
-          "include": [
-            "list",
-            "get"
-          ]
-        },
-        "mcp": {
-          "include": [
-            "list",
-            "get"
-          ]
-        },
-        "cli": {
-          "include": [
-            "list",
-            "get"
-          ]
-        }
-      },
-      "extends": "SmrtObject",
-      "exportName": "Comment",
-      "collectionExportName": "CommentCollection",
-      "schema": {
-        "tableName": "comments",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"comments\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"issue_id\" TEXT,\n  \"comment_id\" TEXT DEFAULT '',\n  \"body\" TEXT DEFAULT '',\n  \"author\" TEXT DEFAULT '',\n  \"url\" TEXT DEFAULT ''\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "issue_id": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "comment_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "body": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "author": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "url": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          }
-        },
-        "indexes": [
-          {
-            "name": "comments_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "comments_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "94852faf"
-      }
-    },
-    "pullrequest": {
-      "name": "pullrequest",
-      "className": "PullRequest",
+    "@happyvertical/smrt-projects:IssueCollection": {
+      "name": "issuecollection",
+      "className": "IssueCollection",
+      "qualifiedName": "@happyvertical/smrt-projects:IssueCollection",
       "collection": "issues",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/projects/src/models/PullRequest.ts",
-      "fields": {
-        "repositoryId": {
-          "type": "foreignKey",
-          "required": true,
-          "_meta": {},
-          "related": "Repository"
-        },
-        "number": {
-          "type": "integer",
-          "required": false,
-          "default": 0
-        },
-        "nodeId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "title": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "body": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "state": {
-          "type": "text",
-          "required": false,
-          "default": "open"
-        },
-        "author": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "labels": {
-          "type": "json",
-          "required": false,
-          "default": []
-        },
-        "assignees": {
-          "type": "json",
-          "required": false,
-          "default": []
-        },
-        "commentsCount": {
-          "type": "integer",
-          "required": false,
-          "default": 0
-        },
-        "lastSyncedAt": {
-          "type": "datetime",
-          "required": false,
-          "default": null
-        },
-        "originalBody": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "synthesisCount": {
-          "type": "integer",
-          "required": false,
-          "default": 0
-        },
-        "headRef": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "baseRef": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "merged": {
-          "type": "boolean",
-          "required": false,
-          "default": false
-        },
-        "mergedAt": {
-          "type": "datetime",
-          "required": false,
-          "default": null
-        },
-        "mergeable": {
-          "type": "boolean",
-          "required": false,
-          "default": true
-        },
-        "draft": {
-          "type": "boolean",
-          "required": false,
-          "default": false
-        },
-        "additions": {
-          "type": "integer",
-          "required": false,
-          "default": 0
-        },
-        "deletions": {
-          "type": "integer",
-          "required": false,
-          "default": 0
-        },
-        "changedFiles": {
-          "type": "integer",
-          "required": false,
-          "default": 0
-        }
-      },
-      "methods": {
-        "getRepository": {
-          "name": "getRepository",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Repository>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getClient": {
-          "name": "getClient",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<IRepository>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "clearCache": {
-          "name": "clearCache",
-          "async": false,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "sync": {
-          "name": "sync",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "SyncOptions",
-              "optional": false,
-              "default": {}
-            }
-          ],
-          "returnType": "Promise<this>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getComments": {
-          "name": "getComments",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Comment[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "addComment": {
-          "name": "addComment",
-          "async": true,
-          "parameters": [
-            {
-              "name": "body",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<Comment>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "incorporateFeedback": {
-          "name": "incorporateFeedback",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "IncorporateFeedbackOptions",
-              "optional": false,
-              "default": {}
-            }
-          ],
-          "returnType": "Promise<IncorporateFeedbackResult>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "rollback": {
-          "name": "rollback",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<{ success: boolean; message: string }>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "needsReview": {
-          "name": "needsReview",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<boolean>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isBugReport": {
-          "name": "isBugReport",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<boolean>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isFeatureRequest": {
-          "name": "isFeatureRequest",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<boolean>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "suggestLabels": {
-          "name": "suggestLabels",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<string[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "close": {
-          "name": "close",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "addLabels": {
-          "name": "addLabels",
-          "async": true,
-          "parameters": [
-            {
-              "name": "labels",
-              "type": "string[]",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "removeLabel": {
-          "name": "removeLabel",
-          "async": true,
-          "parameters": [
-            {
-              "name": "label",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "assign": {
-          "name": "assign",
-          "async": true,
-          "parameters": [
-            {
-              "name": "assignees",
-              "type": "string[]",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getUrl": {
-          "name": "getUrl",
-          "async": false,
-          "parameters": [],
-          "returnType": "string",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "summarize": {
-          "name": "summarize",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<string>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "merge": {
-          "name": "merge",
-          "async": true,
-          "parameters": [
-            {
-              "name": "method",
-              "type": "MergeMethod",
-              "optional": false,
-              "default": "squash"
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "markReady": {
-          "name": "markReady",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "convertToDraft": {
-          "name": "convertToDraft",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "requestReviewers": {
-          "name": "requestReviewers",
-          "async": true,
-          "parameters": [
-            {
-              "name": "reviewers",
-              "type": "string[]",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findLinkedIssue": {
-          "name": "findLinkedIssue",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Issue | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isReadyToMerge": {
-          "name": "isReadyToMerge",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<boolean>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "suggestReviewers": {
-          "name": "suggestReviewers",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<string[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getChangeSize": {
-          "name": "getChangeSize",
-          "async": false,
-          "parameters": [],
-          "returnType": "'xs' | 's' | 'm' | 'l' | 'xl'",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "api": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update"
-          ]
-        },
-        "mcp": {
-          "include": [
-            "list",
-            "get",
-            "sync",
-            "summarize",
-            "merge"
-          ]
-        },
-        "cli": {
-          "include": [
-            "list",
-            "get",
-            "sync",
-            "summarize",
-            "merge",
-            "markReady"
-          ]
-        },
-        "tableName": "issues",
-        "tableStrategy": "sti"
-      },
-      "extends": "Issue",
-      "exportName": "PullRequest",
-      "collectionExportName": "PullRequestCollection",
-      "schema": {
-        "tableName": "issues",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"issues\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"repository_id\" TEXT,\n  \"number\" INTEGER DEFAULT 0,\n  \"node_id\" TEXT DEFAULT '',\n  \"title\" TEXT DEFAULT '',\n  \"body\" TEXT DEFAULT '',\n  \"state\" TEXT DEFAULT 'open',\n  \"author\" TEXT DEFAULT '',\n  \"labels\" JSON DEFAULT '',\n  \"assignees\" JSON DEFAULT '',\n  \"comments_count\" INTEGER DEFAULT 0,\n  \"last_synced_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"original_body\" TEXT DEFAULT '',\n  \"synthesis_count\" INTEGER DEFAULT 0,\n  \"head_ref\" TEXT DEFAULT '',\n  \"base_ref\" TEXT DEFAULT '',\n  \"merged\" BOOLEAN DEFAULT FALSE,\n  \"merged_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"mergeable\" BOOLEAN DEFAULT TRUE,\n  \"draft\" BOOLEAN DEFAULT FALSE,\n  \"additions\" INTEGER DEFAULT 0,\n  \"deletions\" INTEGER DEFAULT 0,\n  \"changed_files\" INTEGER DEFAULT 0\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "_meta_type": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "_meta_data": {
-            "type": "JSON",
-            "notNull": false
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "repository_id": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "number": {
-            "type": "INTEGER",
-            "notNull": false,
-            "default": 0
-          },
-          "node_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "title": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "body": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "state": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "open"
-          },
-          "author": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "labels": {
-            "type": "JSON",
-            "notNull": false,
-            "default": []
-          },
-          "assignees": {
-            "type": "JSON",
-            "notNull": false,
-            "default": []
-          },
-          "comments_count": {
-            "type": "INTEGER",
-            "notNull": false,
-            "default": 0
-          },
-          "last_synced_at": {
-            "type": "TIMESTAMP",
-            "notNull": false,
-            "default": null
-          },
-          "original_body": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "synthesis_count": {
-            "type": "INTEGER",
-            "notNull": false,
-            "default": 0
-          },
-          "head_ref": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "base_ref": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "merged": {
-            "type": "BOOLEAN",
-            "notNull": false,
-            "default": false
-          },
-          "merged_at": {
-            "type": "TIMESTAMP",
-            "notNull": false,
-            "default": null
-          },
-          "mergeable": {
-            "type": "BOOLEAN",
-            "notNull": false,
-            "default": true
-          },
-          "draft": {
-            "type": "BOOLEAN",
-            "notNull": false,
-            "default": false
-          },
-          "additions": {
-            "type": "INTEGER",
-            "notNull": false,
-            "default": 0
-          },
-          "deletions": {
-            "type": "INTEGER",
-            "notNull": false,
-            "default": 0
-          },
-          "changed_files": {
-            "type": "INTEGER",
-            "notNull": false,
-            "default": 0
-          }
-        },
-        "indexes": [
-          {
-            "name": "issues_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "issues_slug_context_meta_type_idx",
-            "columns": [
-              "slug",
-              "context",
-              "_meta_type"
-            ],
-            "unique": true
-          },
-          {
-            "name": "issues_meta_type_idx",
-            "columns": [
-              "_meta_type"
-            ]
-          }
-        ],
-        "version": "05e3ff9f"
-      }
-    },
-    "pullrequestcollection": {
-      "name": "pullrequestcollection",
-      "className": "PullRequestCollection",
-      "collection": "issues",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/projects/src/collections/PullRequests.ts",
+      "filePath": "packages/projects/src/collections/Issues.ts",
+      "packageName": "@happyvertical/smrt-projects",
       "fields": {},
       "methods": {
         "discover": {
@@ -788,7 +19,454 @@
           "parameters": [
             {
               "name": "options",
-              "type": "{\n    repository: Repository;\n    filters?: SearchFilters;\n  }",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByRepository": {
+          "name": "findByRepository",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findOpen": {
+          "name": "findOpen",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByLabel": {
+          "name": "findByLabel",
+          "async": true,
+          "parameters": [
+            {
+              "name": "label",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByAssignee": {
+          "name": "findByAssignee",
+          "async": true,
+          "parameters": [
+            {
+              "name": "assignee",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findNeedingReview": {
+          "name": "findNeedingReview",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByNumber": {
+          "name": "findByNumber",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "number",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Issue | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithUnincorporatedFeedback": {
+          "name": "findWithUnincorporatedFeedback",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "batchSync": {
+          "name": "batchSync",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repository",
+              "type": "Repository",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "Issue",
+      "exportName": "IssueCollection",
+      "collectionExportName": "IssueCollectionCollection",
+      "schema": {
+        "tableName": "issue_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"issue_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "issue_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "issue_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "9a30d763"
+      }
+    },
+    "@happyvertical/smrt-projects:ProjectCollection": {
+      "name": "projectcollection",
+      "className": "ProjectCollection",
+      "qualifiedName": "@happyvertical/smrt-projects:ProjectCollection",
+      "collection": "projects",
+      "filePath": "packages/projects/src/collections/Projects.ts",
+      "packageName": "@happyvertical/smrt-projects",
+      "fields": {},
+      "methods": {
+        "findByTitle": {
+          "name": "findByTitle",
+          "async": true,
+          "parameters": [
+            {
+              "name": "title",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Project | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByOwner": {
+          "name": "findByOwner",
+          "async": true,
+          "parameters": [
+            {
+              "name": "owner",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Project[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByProvider": {
+          "name": "findByProvider",
+          "async": true,
+          "parameters": [
+            {
+              "name": "providerType",
+              "type": "ProjectProviderType",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Project[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getOrCreate": {
+          "name": "getOrCreate",
+          "async": true,
+          "parameters": [
+            {
+              "name": "projectId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Project>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "syncAll": {
+          "name": "syncAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Project[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithItemsInStatus": {
+          "name": "findWithItemsInStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "status",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Project[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getStatistics": {
+          "name": "getStatistics",
+          "async": true,
+          "parameters": [
+            {
+              "name": "projectId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<object>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Project[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Project[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Project[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "Project",
+      "exportName": "ProjectCollection",
+      "collectionExportName": "ProjectCollectionCollection",
+      "schema": {
+        "tableName": "project_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"project_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "project_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "project_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "e9eabb1e"
+      }
+    },
+    "@happyvertical/smrt-projects:PullRequestCollection": {
+      "name": "pullrequestcollection",
+      "className": "PullRequestCollection",
+      "qualifiedName": "@happyvertical/smrt-projects:PullRequestCollection",
+      "collection": "issues",
+      "filePath": "packages/projects/src/collections/PullRequests.ts",
+      "packageName": "@happyvertical/smrt-projects",
+      "fields": {},
+      "methods": {
+        "discover": {
+          "name": "discover",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
               "optional": false
             }
           ],
@@ -934,9 +612,44 @@
             },
             {
               "name": "options",
-              "type": "{ force?: boolean }",
-              "optional": false,
-              "default": {}
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<PullRequest[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<PullRequest[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<PullRequest[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
             }
           ],
           "returnType": "Promise<PullRequest[]>",
@@ -953,10 +666,10 @@
       "collectionExportName": "PullRequestCollectionCollection",
       "schema": {
         "tableName": "issues",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"issues\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"issues\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -996,14 +709,16 @@
             "unique": true
           }
         ],
-        "version": "0b44eaa3"
+        "version": "6eb52552"
       }
     },
-    "repositorycollection": {
+    "@happyvertical/smrt-projects:RepositoryCollection": {
       "name": "repositorycollection",
       "className": "RepositoryCollection",
+      "qualifiedName": "@happyvertical/smrt-projects:RepositoryCollection",
       "collection": "repositories",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/projects/src/collections/Repositories.ts",
+      "filePath": "packages/projects/src/collections/Repositories.ts",
+      "packageName": "@happyvertical/smrt-projects",
       "fields": {},
       "methods": {
         "findByFullName": {
@@ -1069,9 +784,8 @@
             },
             {
               "name": "options",
-              "type": "{\n      providerType?: RepositoryProviderType;\n      tokenConfigKey?: string;\n      baseUrl?: string;\n    }",
-              "optional": false,
-              "default": {}
+              "type": "object",
+              "optional": true
             }
           ],
           "returnType": "Promise<Repository>",
@@ -1084,9 +798,8 @@
           "parameters": [
             {
               "name": "options",
-              "type": "{ force?: boolean }",
-              "optional": false,
-              "default": {}
+              "type": "object",
+              "optional": true
             }
           ],
           "returnType": "Promise<Repository[]>",
@@ -1100,6 +813,42 @@
           "returnType": "Promise<Repository[]>",
           "isStatic": false,
           "isPublic": true
+        },
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Repository[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Repository[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Repository[]>",
+          "isStatic": false,
+          "isPublic": true
         }
       },
       "decoratorConfig": {},
@@ -1109,10 +858,10 @@
       "collectionExportName": "RepositoryCollectionCollection",
       "schema": {
         "tableName": "repository_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"repository_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"repository_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1152,199 +901,102 @@
             "unique": true
           }
         ],
-        "version": "bcd2ed8e"
+        "version": "ede10607"
       }
     },
-    "repository": {
-      "name": "repository",
-      "className": "Repository",
-      "collection": "repositories",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/projects/src/models/Repository.ts",
+    "@happyvertical/smrt-projects:Comment": {
+      "name": "comment",
+      "className": "Comment",
+      "qualifiedName": "@happyvertical/smrt-projects:Comment",
+      "collection": "comments",
+      "filePath": "packages/projects/src/models/Comment.ts",
+      "packageName": "@happyvertical/smrt-projects",
       "fields": {
-        "owner": {
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "issueId": {
+          "type": "foreignKey",
+          "required": false,
+          "related": "Issue"
+        },
+        "commentId": {
           "type": "text",
           "required": false,
           "default": ""
         },
-        "name": {
+        "body": {
           "type": "text",
           "required": false,
           "default": ""
         },
-        "fullName": {
+        "author": {
           "type": "text",
           "required": false,
           "default": ""
         },
-        "description": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "defaultBranch": {
-          "type": "text",
-          "required": false,
-          "default": "main"
-        },
-        "isPrivate": {
-          "type": "boolean",
-          "required": false,
-          "default": false
-        },
-        "providerType": {
-          "type": "text",
-          "required": false,
-          "default": "github"
-        },
-        "baseUrl": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "tokenConfigKey": {
-          "type": "text",
-          "required": false,
-          "default": "GITHUB_TOKEN"
-        },
-        "lastSyncedAt": {
+        "createdAt": {
           "type": "datetime",
+          "required": false
+        },
+        "updatedAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "url": {
+          "type": "text",
           "required": false,
-          "default": null
+          "default": ""
         }
       },
       "methods": {
-        "getClient": {
-          "name": "getClient",
+        "isQuestion": {
+          "name": "isQuestion",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<IRepository>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "clearClient": {
-          "name": "clearClient",
-          "async": false,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "sync": {
-          "name": "sync",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "SyncOptions",
-              "optional": false,
-              "default": {}
-            }
-          ],
-          "returnType": "Promise<this>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getIssues": {
-          "name": "getIssues",
-          "async": true,
-          "parameters": [
-            {
-              "name": "filters",
-              "type": "SearchFilters",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<Issue[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getPullRequests": {
-          "name": "getPullRequests",
-          "async": true,
-          "parameters": [
-            {
-              "name": "filters",
-              "type": "SearchFilters",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<PullRequest[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "createIssue": {
-          "name": "createIssue",
-          "async": true,
-          "parameters": [
-            {
-              "name": "data",
-              "type": "CreateIssueInput",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<Issue>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "createPullRequest": {
-          "name": "createPullRequest",
-          "async": true,
-          "parameters": [
-            {
-              "name": "data",
-              "type": "CreatePRInput",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<PullRequest>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "hasOpenIssuesMatching": {
-          "name": "hasOpenIssuesMatching",
-          "async": true,
-          "parameters": [
-            {
-              "name": "criteria",
-              "type": "string",
-              "optional": false
-            }
-          ],
           "returnType": "Promise<boolean>",
           "isStatic": false,
           "isPublic": true
         },
-        "summarizeActivity": {
-          "name": "summarizeActivity",
+        "isApproval": {
+          "name": "isApproval",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "requestsChanges": {
+          "name": "requestsChanges",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "extractActionItems": {
+          "name": "extractActionItems",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarize": {
+          "name": "summarize",
           "async": true,
           "parameters": [],
           "returnType": "Promise<string>",
           "isStatic": false,
           "isPublic": true
         },
-        "getByFullName": {
-          "name": "getByFullName",
+        "getSentiment": {
+          "name": "getSentiment",
           "async": true,
-          "parameters": [
-            {
-              "name": "owner",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "name",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "options",
-              "type": "SmrtObjectOptions",
-              "optional": false,
-              "default": {}
-            }
-          ],
-          "returnType": "Promise<Repository | null>",
-          "isStatic": true,
+          "parameters": [],
+          "returnType": "Promise<'positive' | 'negative' | 'neutral'>",
+          "isStatic": false,
           "isPublic": true
         }
       },
@@ -1352,36 +1004,31 @@
         "api": {
           "include": [
             "list",
-            "get",
-            "create",
-            "update"
+            "get"
           ]
         },
         "mcp": {
           "include": [
             "list",
-            "get",
-            "sync"
+            "get"
           ]
         },
         "cli": {
           "include": [
             "list",
-            "get",
-            "sync",
-            "create"
+            "get"
           ]
         }
       },
       "extends": "SmrtObject",
-      "exportName": "Repository",
-      "collectionExportName": "RepositoryCollection",
+      "exportName": "Comment",
+      "collectionExportName": "CommentCollection",
       "schema": {
-        "tableName": "repositorys",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"repositorys\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"owner\" TEXT DEFAULT '',\n  \"name\" TEXT DEFAULT '',\n  \"full_name\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"default_branch\" TEXT DEFAULT 'main',\n  \"is_private\" BOOLEAN DEFAULT FALSE,\n  \"provider_type\" TEXT DEFAULT 'github',\n  \"base_url\" TEXT DEFAULT '',\n  \"token_config_key\" TEXT DEFAULT 'GITHUB_TOKEN',\n  \"last_synced_at\" TIMESTAMP DEFAULT current_timestamp\n);",
+        "tableName": "comments",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"comments\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"issue_id\" uuid,\n  \"comment_id\" TEXT DEFAULT '',\n  \"body\" TEXT DEFAULT '',\n  \"author\" TEXT DEFAULT '',\n  \"url\" TEXT DEFAULT ''\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1404,66 +1051,50 @@
             "notNull": true,
             "default": "current_timestamp"
           },
-          "owner": {
+          "tenant_id": {
             "type": "TEXT",
             "notNull": false,
+            "unique": false
+          },
+          "issue_id": {
+            "type": "UUID",
+            "notNull": false,
+            "unique": false
+          },
+          "comment_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
             "default": ""
           },
-          "name": {
+          "body": {
             "type": "TEXT",
             "notNull": false,
+            "unique": false,
             "default": ""
           },
-          "full_name": {
+          "author": {
             "type": "TEXT",
             "notNull": false,
+            "unique": false,
             "default": ""
           },
-          "description": {
+          "url": {
             "type": "TEXT",
             "notNull": false,
+            "unique": false,
             "default": ""
-          },
-          "default_branch": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "main"
-          },
-          "is_private": {
-            "type": "BOOLEAN",
-            "notNull": false,
-            "default": false
-          },
-          "provider_type": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "github"
-          },
-          "base_url": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "token_config_key": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "GITHUB_TOKEN"
-          },
-          "last_synced_at": {
-            "type": "TIMESTAMP",
-            "notNull": false,
-            "default": null
           }
         },
         "indexes": [
           {
-            "name": "repositorys_id_idx",
+            "name": "comments_id_idx",
             "columns": [
               "id"
             ]
           },
           {
-            "name": "repositorys_slug_context_idx",
+            "name": "comments_slug_context_idx",
             "columns": [
               "slug",
               "context"
@@ -1471,19 +1102,32 @@
             "unique": true
           }
         ],
-        "version": "bc666d05"
+        "version": "351ad194"
       }
     },
-    "issue": {
+    "@happyvertical/smrt-projects:Issue": {
       "name": "issue",
       "className": "Issue",
+      "qualifiedName": "@happyvertical/smrt-projects:Issue",
       "collection": "issues",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/projects/src/models/Issue.ts",
+      "filePath": "packages/projects/src/models/Issue.ts",
+      "packageName": "@happyvertical/smrt-projects",
       "fields": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
         "repositoryId": {
           "type": "foreignKey",
-          "required": true,
-          "_meta": {},
+          "required": false,
           "related": "Repository"
         },
         "number": {
@@ -1533,8 +1177,7 @@
         },
         "lastSyncedAt": {
           "type": "datetime",
-          "required": false,
-          "default": null
+          "required": false
         },
         "originalBody": {
           "type": "text",
@@ -1548,6 +1191,417 @@
         }
       },
       "methods": {
+        "getAiUsageSnapshot": {
+          "name": "getAiUsageSnapshot",
+          "async": false,
+          "parameters": [],
+          "returnType": "AiUsageSnapshot | undefined",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetAiUsage": {
+          "name": "resetAiUsage",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listAiUsage": {
+          "name": "listAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageListOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<SmrtAiUsageRecord[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeAiUsage": {
+          "name": "summarizeAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageSummaryOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Record<string, AiUsageStats>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "destroy": {
+          "name": "destroy",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadDataFromDb": {
+          "name": "loadDataFromDb",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toJSON": {
+          "name": "toJSON",
+          "async": false,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPlainObject": {
+          "name": "toPlainObject",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getId": {
+          "name": "getId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSlug": {
+          "name": "getSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSavedId": {
+          "name": "getSavedId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSaved": {
+          "name": "isSaved",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromId": {
+          "name": "loadFromId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromSlug": {
+          "name": "loadFromSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "is": {
+          "name": "is",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "do": {
+          "name": "do",
+          "async": true,
+          "parameters": [
+            {
+              "name": "instructions",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "describe": {
+          "name": "describe",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "delete": {
+          "name": "delete",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRelatedLoaded": {
+          "name": "isRelatedLoaded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelated": {
+          "name": "loadRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelatedMany": {
+          "name": "loadRelatedMany",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelated": {
+          "name": "getRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAvailableTools": {
+          "name": "getAvailableTools",
+          "async": false,
+          "parameters": [],
+          "returnType": "AITool[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "executeToolCall": {
+          "name": "executeToolCall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toolCall",
+              "type": "ToolCall",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ToolCallResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "remember": {
+          "name": "remember",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recall": {
+          "name": "recall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recallAll": {
+          "name": "recallAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forget": {
+          "name": "forget",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forgetScope": {
+          "name": "forgetScope",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateEmbeddings": {
+          "name": "generateEmbeddings",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "GenerateEmbeddingsOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmbedding": {
+          "name": "getEmbedding",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "model",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number[] | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStaleEmbeddings": {
+          "name": "hasStaleEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearEmbeddings": {
+          "name": "clearEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
         "getRepository": {
           "name": "getRepository",
           "async": true,
@@ -1579,11 +1633,10 @@
             {
               "name": "options",
               "type": "SyncOptions",
-              "optional": false,
-              "default": {}
+              "optional": true
             }
           ],
-          "returnType": "Promise<this>",
+          "returnType": "Promise",
           "isStatic": false,
           "isPublic": true
         },
@@ -1616,8 +1669,7 @@
             {
               "name": "options",
               "type": "IncorporateFeedbackOptions",
-              "optional": false,
-              "default": {}
+              "optional": true
             }
           ],
           "returnType": "Promise<IncorporateFeedbackResult>",
@@ -1628,7 +1680,7 @@
           "name": "rollback",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<{ success: boolean; message: string }>",
+          "returnType": "Promise<object>",
           "isStatic": false,
           "isPublic": true
         },
@@ -1756,10 +1808,10 @@
       "collectionExportName": "IssueCollection",
       "schema": {
         "tableName": "issues",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"issues\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"repository_id\" TEXT,\n  \"number\" INTEGER DEFAULT 0,\n  \"node_id\" TEXT DEFAULT '',\n  \"title\" TEXT DEFAULT '',\n  \"body\" TEXT DEFAULT '',\n  \"state\" TEXT DEFAULT 'open',\n  \"author\" TEXT DEFAULT '',\n  \"labels\" JSON DEFAULT '',\n  \"assignees\" JSON DEFAULT '',\n  \"comments_count\" INTEGER DEFAULT 0,\n  \"last_synced_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"original_body\" TEXT DEFAULT '',\n  \"synthesis_count\" INTEGER DEFAULT 0,\n  \"head_ref\" TEXT DEFAULT '',\n  \"base_ref\" TEXT DEFAULT '',\n  \"merged\" BOOLEAN DEFAULT FALSE,\n  \"merged_at\" TIMESTAMP DEFAULT current_timestamp,\n  \"mergeable\" BOOLEAN DEFAULT TRUE,\n  \"draft\" BOOLEAN DEFAULT FALSE,\n  \"additions\" INTEGER DEFAULT 0,\n  \"deletions\" INTEGER DEFAULT 0,\n  \"changed_files\" INTEGER DEFAULT 0\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"issues\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"repository_id\" uuid,\n  \"number\" INTEGER DEFAULT 0,\n  \"node_id\" TEXT DEFAULT '',\n  \"title\" TEXT DEFAULT '',\n  \"body\" TEXT DEFAULT '',\n  \"state\" TEXT DEFAULT 'open',\n  \"author\" TEXT DEFAULT '',\n  \"labels\" JSONB DEFAULT '[]',\n  \"assignees\" JSONB DEFAULT '[]',\n  \"comments_count\" INTEGER DEFAULT 0,\n  \"last_synced_at\" TIMESTAMP,\n  \"original_body\" TEXT DEFAULT '',\n  \"synthesis_count\" INTEGER DEFAULT 0,\n  \"head_ref\" TEXT DEFAULT '',\n  \"base_ref\" TEXT DEFAULT '',\n  \"merged\" BOOLEAN DEFAULT FALSE,\n  \"merged_at\" TIMESTAMP,\n  \"mergeable\" BOOLEAN DEFAULT TRUE,\n  \"draft\" BOOLEAN DEFAULT FALSE,\n  \"additions\" INTEGER DEFAULT 0,\n  \"deletions\" INTEGER DEFAULT 0,\n  \"changed_files\" INTEGER DEFAULT 0\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -1790,8 +1842,12 @@
             "notNull": true,
             "default": "current_timestamp"
           },
-          "repository_id": {
+          "tenant_id": {
             "type": "TEXT",
+            "notNull": false
+          },
+          "repository_id": {
+            "type": "UUID",
             "notNull": false
           },
           "number": {
@@ -1841,8 +1897,7 @@
           },
           "last_synced_at": {
             "type": "TIMESTAMP",
-            "notNull": false,
-            "default": null
+            "notNull": false
           },
           "original_body": {
             "type": "TEXT",
@@ -1871,8 +1926,7 @@
           },
           "merged_at": {
             "type": "TIMESTAMP",
-            "notNull": false,
-            "default": null
+            "notNull": false
           },
           "mergeable": {
             "type": "BOOLEAN",
@@ -1923,819 +1977,20 @@
             ]
           }
         ],
-        "version": "003dd4e2"
+        "version": "a622fea0"
       }
     },
-    "issuecollection": {
-      "name": "issuecollection",
-      "className": "IssueCollection",
-      "collection": "issues",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/projects/src/collections/Issues.ts",
-      "fields": {},
-      "methods": {
-        "discover": {
-          "name": "discover",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "{\n    repository: Repository;\n    filters?: SearchFilters;\n  }",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<Issue[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByRepository": {
-          "name": "findByRepository",
-          "async": true,
-          "parameters": [
-            {
-              "name": "repositoryId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<Issue[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findOpen": {
-          "name": "findOpen",
-          "async": true,
-          "parameters": [
-            {
-              "name": "repositoryId",
-              "type": "string",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<Issue[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByLabel": {
-          "name": "findByLabel",
-          "async": true,
-          "parameters": [
-            {
-              "name": "label",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "repositoryId",
-              "type": "string",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<Issue[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByAssignee": {
-          "name": "findByAssignee",
-          "async": true,
-          "parameters": [
-            {
-              "name": "assignee",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "repositoryId",
-              "type": "string",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<Issue[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findNeedingReview": {
-          "name": "findNeedingReview",
-          "async": true,
-          "parameters": [
-            {
-              "name": "repositoryId",
-              "type": "string",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<Issue[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByNumber": {
-          "name": "findByNumber",
-          "async": true,
-          "parameters": [
-            {
-              "name": "repositoryId",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "number",
-              "type": "number",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<Issue | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findWithUnincorporatedFeedback": {
-          "name": "findWithUnincorporatedFeedback",
-          "async": true,
-          "parameters": [
-            {
-              "name": "repositoryId",
-              "type": "string",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<Issue[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "batchSync": {
-          "name": "batchSync",
-          "async": true,
-          "parameters": [
-            {
-              "name": "repository",
-              "type": "Repository",
-              "optional": false
-            },
-            {
-              "name": "options",
-              "type": "{ force?: boolean }",
-              "optional": false,
-              "default": {}
-            }
-          ],
-          "returnType": "Promise<Issue[]>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {},
-      "extends": "SmrtCollection",
-      "extendsTypeArg": "Issue",
-      "exportName": "IssueCollection",
-      "collectionExportName": "IssueCollectionCollection",
-      "schema": {
-        "tableName": "issue_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"issue_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          }
-        },
-        "indexes": [
-          {
-            "name": "issue_collections_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "issue_collections_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "bbc4903d"
-      }
-    },
-    "project": {
-      "name": "project",
-      "className": "Project",
-      "collection": "projects",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/projects/src/models/Project.ts",
-      "fields": {
-        "projectId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "projectNumber": {
-          "type": "integer",
-          "required": false,
-          "default": 0
-        },
-        "title": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "description": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "owner": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "url": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "providerType": {
-          "type": "text",
-          "required": false,
-          "default": "github"
-        },
-        "tokenConfigKey": {
-          "type": "text",
-          "required": false,
-          "default": "GITHUB_TOKEN"
-        },
-        "statuses": {
-          "type": "json",
-          "required": false,
-          "default": []
-        },
-        "fields": {
-          "type": "json",
-          "required": false,
-          "default": []
-        },
-        "statusFieldId": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "statusOptions": {
-          "type": "json",
-          "required": false,
-          "default": {}
-        },
-        "lastSyncedAt": {
-          "type": "datetime",
-          "required": false,
-          "default": null
-        }
-      },
-      "methods": {
-        "getClient": {
-          "name": "getClient",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<IProject>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "clearClient": {
-          "name": "clearClient",
-          "async": false,
-          "parameters": [],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "sync": {
-          "name": "sync",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "SyncOptions",
-              "optional": false,
-              "default": {}
-            }
-          ],
-          "returnType": "Promise<this>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "addItem": {
-          "name": "addItem",
-          "async": true,
-          "parameters": [
-            {
-              "name": "item",
-              "type": "Issue | PullRequest",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<ProjectItem>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "removeItem": {
-          "name": "removeItem",
-          "async": true,
-          "parameters": [
-            {
-              "name": "itemId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getItem": {
-          "name": "getItem",
-          "async": true,
-          "parameters": [
-            {
-              "name": "itemId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<ProjectItem | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "listItems": {
-          "name": "listItems",
-          "async": true,
-          "parameters": [
-            {
-              "name": "filters",
-              "type": "ItemFilters",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<ProjectItem[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "updateItemStatus": {
-          "name": "updateItemStatus",
-          "async": true,
-          "parameters": [
-            {
-              "name": "itemId",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "status",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "updateItemField": {
-          "name": "updateItemField",
-          "async": true,
-          "parameters": [
-            {
-              "name": "itemId",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "fieldId",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "value",
-              "type": "unknown",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getStatuses": {
-          "name": "getStatuses",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<ProjectStatus[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getFields": {
-          "name": "getFields",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<ProjectField[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getItemsByStatus": {
-          "name": "getItemsByStatus",
-          "async": true,
-          "parameters": [
-            {
-              "name": "status",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<ProjectItem[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "moveItem": {
-          "name": "moveItem",
-          "async": true,
-          "parameters": [
-            {
-              "name": "item",
-              "type": "Issue | PullRequest",
-              "optional": false
-            },
-            {
-              "name": "status",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<void>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "analyzeHealth": {
-          "name": "analyzeHealth",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<string>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getByTitle": {
-          "name": "getByTitle",
-          "async": true,
-          "parameters": [
-            {
-              "name": "title",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "options",
-              "type": "SmrtObjectOptions",
-              "optional": false,
-              "default": {}
-            }
-          ],
-          "returnType": "Promise<Project | null>",
-          "isStatic": true,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "api": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update"
-          ]
-        },
-        "mcp": {
-          "include": [
-            "list",
-            "get",
-            "sync",
-            "addItem",
-            "updateItemStatus"
-          ]
-        },
-        "cli": {
-          "include": [
-            "list",
-            "get",
-            "sync",
-            "addItem",
-            "updateItemStatus",
-            "listItems"
-          ]
-        }
-      },
-      "extends": "SmrtObject",
-      "exportName": "Project",
-      "collectionExportName": "ProjectCollection",
-      "schema": {
-        "tableName": "projects",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"projects\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"project_id\" TEXT DEFAULT '',\n  \"project_number\" INTEGER DEFAULT 0,\n  \"title\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"owner\" TEXT DEFAULT '',\n  \"url\" TEXT DEFAULT '',\n  \"provider_type\" TEXT DEFAULT 'github',\n  \"token_config_key\" TEXT DEFAULT 'GITHUB_TOKEN',\n  \"statuses\" JSON DEFAULT '',\n  \"fields\" JSON DEFAULT '',\n  \"status_field_id\" TEXT DEFAULT '',\n  \"status_options\" JSON DEFAULT '[object Object]',\n  \"last_synced_at\" TIMESTAMP DEFAULT current_timestamp\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "project_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "project_number": {
-            "type": "INTEGER",
-            "notNull": false,
-            "default": 0
-          },
-          "title": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "description": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "owner": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "url": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "provider_type": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "github"
-          },
-          "token_config_key": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "GITHUB_TOKEN"
-          },
-          "statuses": {
-            "type": "JSON",
-            "notNull": false,
-            "default": []
-          },
-          "fields": {
-            "type": "JSON",
-            "notNull": false,
-            "default": []
-          },
-          "status_field_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "status_options": {
-            "type": "JSON",
-            "notNull": false,
-            "default": {}
-          },
-          "last_synced_at": {
-            "type": "TIMESTAMP",
-            "notNull": false,
-            "default": null
-          }
-        },
-        "indexes": [
-          {
-            "name": "projects_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "projects_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "54280864"
-      }
-    },
-    "projectcollection": {
-      "name": "projectcollection",
-      "className": "ProjectCollection",
-      "collection": "projects",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/projects/src/collections/Projects.ts",
-      "fields": {},
-      "methods": {
-        "findByTitle": {
-          "name": "findByTitle",
-          "async": true,
-          "parameters": [
-            {
-              "name": "title",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<Project | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByOwner": {
-          "name": "findByOwner",
-          "async": true,
-          "parameters": [
-            {
-              "name": "owner",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<Project[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByProvider": {
-          "name": "findByProvider",
-          "async": true,
-          "parameters": [
-            {
-              "name": "providerType",
-              "type": "ProjectProviderType",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<Project[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getOrCreate": {
-          "name": "getOrCreate",
-          "async": true,
-          "parameters": [
-            {
-              "name": "projectId",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "options",
-              "type": "{\n      title?: string;\n      owner?: string;\n      providerType?: ProjectProviderType;\n      tokenConfigKey?: string;\n      statusFieldId?: string;\n      statusOptions?: Record<string, string>;\n    }",
-              "optional": false,
-              "default": {}
-            }
-          ],
-          "returnType": "Promise<Project>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "syncAll": {
-          "name": "syncAll",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "{ force?: boolean }",
-              "optional": false,
-              "default": {}
-            }
-          ],
-          "returnType": "Promise<Project[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findWithItemsInStatus": {
-          "name": "findWithItemsInStatus",
-          "async": true,
-          "parameters": [
-            {
-              "name": "status",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<Project[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getStatistics": {
-          "name": "getStatistics",
-          "async": true,
-          "parameters": [
-            {
-              "name": "projectId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<{\n    totalItems: number;\n    itemsByStatus: Record<string, number>;\n    itemsByType: Record<string, number>;\n  }>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {},
-      "extends": "SmrtCollection",
-      "extendsTypeArg": "Project",
-      "exportName": "ProjectCollection",
-      "collectionExportName": "ProjectCollectionCollection",
-      "schema": {
-        "tableName": "project_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"project_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          }
-        },
-        "indexes": [
-          {
-            "name": "project_collections_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "project_collections_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "213b18c0"
-      }
-    },
-    "label": {
+    "@happyvertical/smrt-projects:Label": {
       "name": "label",
       "className": "Label",
+      "qualifiedName": "@happyvertical/smrt-projects:Label",
       "collection": "labels",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/projects/src/models/Label.ts",
+      "filePath": "packages/projects/src/models/Label.ts",
+      "packageName": "@happyvertical/smrt-projects",
       "fields": {
         "repositoryId": {
           "type": "foreignKey",
           "required": false,
-          "_meta": {},
           "related": "Repository"
         },
         "name": {
@@ -2852,10 +2107,10 @@
       "collectionExportName": "LabelCollection",
       "schema": {
         "tableName": "labels",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"labels\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"repository_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"color\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT ''\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"labels\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"repository_id\" uuid,\n  \"name\" TEXT DEFAULT '',\n  \"color\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT ''\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -2879,22 +2134,26 @@
             "default": "current_timestamp"
           },
           "repository_id": {
-            "type": "TEXT",
-            "notNull": false
+            "type": "UUID",
+            "notNull": false,
+            "unique": false
           },
           "name": {
             "type": "TEXT",
             "notNull": false,
+            "unique": false,
             "default": ""
           },
           "color": {
             "type": "TEXT",
             "notNull": false,
+            "unique": false,
             "default": ""
           },
           "description": {
             "type": "TEXT",
             "notNull": false,
+            "unique": false,
             "default": ""
           }
         },
@@ -2914,10 +2173,1801 @@
             "unique": true
           }
         ],
-        "version": "5f873a63"
+        "version": "15f82076"
+      }
+    },
+    "@happyvertical/smrt-projects:Project": {
+      "name": "project",
+      "className": "Project",
+      "qualifiedName": "@happyvertical/smrt-projects:Project",
+      "collection": "projects",
+      "filePath": "packages/projects/src/models/Project.ts",
+      "packageName": "@happyvertical/smrt-projects",
+      "fields": {
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "projectId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "projectNumber": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "title": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "owner": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "url": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "providerType": {
+          "type": "text",
+          "required": false,
+          "default": "github"
+        },
+        "tokenConfigKey": {
+          "type": "text",
+          "required": false,
+          "default": "GITHUB_TOKEN"
+        },
+        "statuses": {
+          "type": "json",
+          "required": false,
+          "default": []
+        },
+        "fields": {
+          "type": "json",
+          "required": false,
+          "default": []
+        },
+        "statusFieldId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "statusOptions": {
+          "type": "json",
+          "required": false,
+          "default": {}
+        },
+        "lastSyncedAt": {
+          "type": "datetime",
+          "required": false
+        }
+      },
+      "methods": {
+        "getClient": {
+          "name": "getClient",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<IProject>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearClient": {
+          "name": "clearClient",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "sync": {
+          "name": "sync",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "SyncOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addItem": {
+          "name": "addItem",
+          "async": true,
+          "parameters": [
+            {
+              "name": "item",
+              "type": "Issue | PullRequest",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ProjectItem>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeItem": {
+          "name": "removeItem",
+          "async": true,
+          "parameters": [
+            {
+              "name": "itemId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getItem": {
+          "name": "getItem",
+          "async": true,
+          "parameters": [
+            {
+              "name": "itemId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ProjectItem | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listItems": {
+          "name": "listItems",
+          "async": true,
+          "parameters": [
+            {
+              "name": "filters",
+              "type": "ItemFilters",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<ProjectItem[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateItemStatus": {
+          "name": "updateItemStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "itemId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "status",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateItemField": {
+          "name": "updateItemField",
+          "async": true,
+          "parameters": [
+            {
+              "name": "itemId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "fieldId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getStatuses": {
+          "name": "getStatuses",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<ProjectStatus[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<ProjectField[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getItemsByStatus": {
+          "name": "getItemsByStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "status",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ProjectItem[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "moveItem": {
+          "name": "moveItem",
+          "async": true,
+          "parameters": [
+            {
+              "name": "item",
+              "type": "Issue | PullRequest",
+              "optional": false
+            },
+            {
+              "name": "status",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "analyzeHealth": {
+          "name": "analyzeHealth",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByTitle": {
+          "name": "getByTitle",
+          "async": true,
+          "parameters": [
+            {
+              "name": "title",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "SmrtObjectOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Project | null>",
+          "isStatic": true,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "sync",
+            "addItem",
+            "updateItemStatus"
+          ]
+        },
+        "cli": {
+          "include": [
+            "list",
+            "get",
+            "sync",
+            "addItem",
+            "updateItemStatus",
+            "listItems"
+          ]
+        }
+      },
+      "extends": "SmrtObject",
+      "exportName": "Project",
+      "collectionExportName": "ProjectCollection",
+      "schema": {
+        "tableName": "projects",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"projects\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"project_id\" TEXT DEFAULT '',\n  \"project_number\" INTEGER DEFAULT 0,\n  \"title\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"owner\" TEXT DEFAULT '',\n  \"url\" TEXT DEFAULT '',\n  \"provider_type\" TEXT DEFAULT 'github',\n  \"token_config_key\" TEXT DEFAULT 'GITHUB_TOKEN',\n  \"statuses\" JSONB DEFAULT '[]',\n  \"fields\" JSONB DEFAULT '[]',\n  \"status_field_id\" TEXT DEFAULT '',\n  \"status_options\" JSONB DEFAULT '{}',\n  \"last_synced_at\" TIMESTAMP\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "project_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": ""
+          },
+          "project_number": {
+            "type": "INTEGER",
+            "notNull": false,
+            "unique": false,
+            "default": 0
+          },
+          "title": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": ""
+          },
+          "owner": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": ""
+          },
+          "url": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": ""
+          },
+          "provider_type": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": "github"
+          },
+          "token_config_key": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": "GITHUB_TOKEN"
+          },
+          "statuses": {
+            "type": "JSON",
+            "notNull": false,
+            "unique": false,
+            "default": []
+          },
+          "fields": {
+            "type": "JSON",
+            "notNull": false,
+            "unique": false,
+            "default": []
+          },
+          "status_field_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": ""
+          },
+          "status_options": {
+            "type": "JSON",
+            "notNull": false,
+            "unique": false,
+            "default": {}
+          },
+          "last_synced_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "unique": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "projects_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "projects_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "c8ef0a68"
+      }
+    },
+    "@happyvertical/smrt-projects:PullRequest": {
+      "name": "pullrequest",
+      "className": "PullRequest",
+      "qualifiedName": "@happyvertical/smrt-projects:PullRequest",
+      "collection": "issues",
+      "filePath": "packages/projects/src/models/PullRequest.ts",
+      "packageName": "@happyvertical/smrt-projects",
+      "fields": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "repositoryId": {
+          "type": "foreignKey",
+          "required": false,
+          "related": "Repository"
+        },
+        "number": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "nodeId": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "title": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "body": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "state": {
+          "type": "text",
+          "required": false,
+          "default": "open"
+        },
+        "author": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "labels": {
+          "type": "json",
+          "required": false,
+          "default": []
+        },
+        "assignees": {
+          "type": "json",
+          "required": false,
+          "default": []
+        },
+        "commentsCount": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "lastSyncedAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "originalBody": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "synthesisCount": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "headRef": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "baseRef": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "merged": {
+          "type": "boolean",
+          "required": false,
+          "default": false
+        },
+        "mergedAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "mergeable": {
+          "type": "boolean",
+          "required": false,
+          "default": true
+        },
+        "draft": {
+          "type": "boolean",
+          "required": false,
+          "default": false
+        },
+        "additions": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "deletions": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "changedFiles": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        }
+      },
+      "methods": {
+        "getAiUsageSnapshot": {
+          "name": "getAiUsageSnapshot",
+          "async": false,
+          "parameters": [],
+          "returnType": "AiUsageSnapshot | undefined",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetAiUsage": {
+          "name": "resetAiUsage",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listAiUsage": {
+          "name": "listAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageListOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<SmrtAiUsageRecord[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeAiUsage": {
+          "name": "summarizeAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageSummaryOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Record<string, AiUsageStats>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "destroy": {
+          "name": "destroy",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadDataFromDb": {
+          "name": "loadDataFromDb",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toJSON": {
+          "name": "toJSON",
+          "async": false,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPlainObject": {
+          "name": "toPlainObject",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getId": {
+          "name": "getId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSlug": {
+          "name": "getSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSavedId": {
+          "name": "getSavedId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSaved": {
+          "name": "isSaved",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromId": {
+          "name": "loadFromId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromSlug": {
+          "name": "loadFromSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "is": {
+          "name": "is",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "do": {
+          "name": "do",
+          "async": true,
+          "parameters": [
+            {
+              "name": "instructions",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "describe": {
+          "name": "describe",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "delete": {
+          "name": "delete",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRelatedLoaded": {
+          "name": "isRelatedLoaded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelated": {
+          "name": "loadRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelatedMany": {
+          "name": "loadRelatedMany",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelated": {
+          "name": "getRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAvailableTools": {
+          "name": "getAvailableTools",
+          "async": false,
+          "parameters": [],
+          "returnType": "AITool[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "executeToolCall": {
+          "name": "executeToolCall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toolCall",
+              "type": "ToolCall",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ToolCallResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "remember": {
+          "name": "remember",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recall": {
+          "name": "recall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recallAll": {
+          "name": "recallAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forget": {
+          "name": "forget",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forgetScope": {
+          "name": "forgetScope",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateEmbeddings": {
+          "name": "generateEmbeddings",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "GenerateEmbeddingsOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmbedding": {
+          "name": "getEmbedding",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "model",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number[] | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStaleEmbeddings": {
+          "name": "hasStaleEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearEmbeddings": {
+          "name": "clearEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRepository": {
+          "name": "getRepository",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Repository>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getClient": {
+          "name": "getClient",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<IRepository>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearCache": {
+          "name": "clearCache",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "sync": {
+          "name": "sync",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "SyncOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getComments": {
+          "name": "getComments",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Comment[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addComment": {
+          "name": "addComment",
+          "async": true,
+          "parameters": [
+            {
+              "name": "body",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Comment>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "incorporateFeedback": {
+          "name": "incorporateFeedback",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "IncorporateFeedbackOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<IncorporateFeedbackResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "rollback": {
+          "name": "rollback",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<object>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "needsReview": {
+          "name": "needsReview",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isBugReport": {
+          "name": "isBugReport",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isFeatureRequest": {
+          "name": "isFeatureRequest",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "suggestLabels": {
+          "name": "suggestLabels",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "close": {
+          "name": "close",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "addLabels": {
+          "name": "addLabels",
+          "async": true,
+          "parameters": [
+            {
+              "name": "labels",
+              "type": "string[]",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "removeLabel": {
+          "name": "removeLabel",
+          "async": true,
+          "parameters": [
+            {
+              "name": "label",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "assign": {
+          "name": "assign",
+          "async": true,
+          "parameters": [
+            {
+              "name": "assignees",
+              "type": "string[]",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getUrl": {
+          "name": "getUrl",
+          "async": false,
+          "parameters": [],
+          "returnType": "string",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarize": {
+          "name": "summarize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "merge": {
+          "name": "merge",
+          "async": true,
+          "parameters": [
+            {
+              "name": "method",
+              "type": "MergeMethod",
+              "optional": true,
+              "default": "squash"
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "markReady": {
+          "name": "markReady",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "convertToDraft": {
+          "name": "convertToDraft",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "requestReviewers": {
+          "name": "requestReviewers",
+          "async": true,
+          "parameters": [
+            {
+              "name": "reviewers",
+              "type": "string[]",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findLinkedIssue": {
+          "name": "findLinkedIssue",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Issue | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isReadyToMerge": {
+          "name": "isReadyToMerge",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "suggestReviewers": {
+          "name": "suggestReviewers",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getChangeSize": {
+          "name": "getChangeSize",
+          "async": false,
+          "parameters": [],
+          "returnType": "'xs' | 's' | 'm' | 'l' | 'xl'",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "sync",
+            "summarize",
+            "merge"
+          ]
+        },
+        "cli": {
+          "include": [
+            "list",
+            "get",
+            "sync",
+            "summarize",
+            "merge",
+            "markReady"
+          ]
+        },
+        "tableName": "issues",
+        "tableStrategy": "sti"
+      },
+      "extends": "Issue",
+      "exportName": "PullRequest",
+      "collectionExportName": "PullRequestCollection",
+      "schema": {
+        "tableName": "issues",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"issues\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"repository_id\" uuid,\n  \"number\" INTEGER DEFAULT 0,\n  \"node_id\" TEXT DEFAULT '',\n  \"title\" TEXT DEFAULT '',\n  \"body\" TEXT DEFAULT '',\n  \"state\" TEXT DEFAULT 'open',\n  \"author\" TEXT DEFAULT '',\n  \"labels\" JSONB DEFAULT '[]',\n  \"assignees\" JSONB DEFAULT '[]',\n  \"comments_count\" INTEGER DEFAULT 0,\n  \"last_synced_at\" TIMESTAMP,\n  \"original_body\" TEXT DEFAULT '',\n  \"synthesis_count\" INTEGER DEFAULT 0,\n  \"head_ref\" TEXT DEFAULT '',\n  \"base_ref\" TEXT DEFAULT '',\n  \"merged\" BOOLEAN DEFAULT FALSE,\n  \"merged_at\" TIMESTAMP,\n  \"mergeable\" BOOLEAN DEFAULT TRUE,\n  \"draft\" BOOLEAN DEFAULT FALSE,\n  \"additions\" INTEGER DEFAULT 0,\n  \"deletions\" INTEGER DEFAULT 0,\n  \"changed_files\" INTEGER DEFAULT 0\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "repository_id": {
+            "type": "UUID",
+            "notNull": false
+          },
+          "number": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "node_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "title": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "body": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "state": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "open"
+          },
+          "author": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "labels": {
+            "type": "JSON",
+            "notNull": false,
+            "default": []
+          },
+          "assignees": {
+            "type": "JSON",
+            "notNull": false,
+            "default": []
+          },
+          "comments_count": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "last_synced_at": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          },
+          "original_body": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "synthesis_count": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "head_ref": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "base_ref": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "merged": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": false
+          },
+          "merged_at": {
+            "type": "TIMESTAMP",
+            "notNull": false
+          },
+          "mergeable": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": true
+          },
+          "draft": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "default": false
+          },
+          "additions": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "deletions": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "changed_files": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          }
+        },
+        "indexes": [
+          {
+            "name": "issues_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "issues_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "issues_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "696351ce"
+      }
+    },
+    "@happyvertical/smrt-projects:Repository": {
+      "name": "repository",
+      "className": "Repository",
+      "qualifiedName": "@happyvertical/smrt-projects:Repository",
+      "collection": "repositories",
+      "filePath": "packages/projects/src/models/Repository.ts",
+      "packageName": "@happyvertical/smrt-projects",
+      "fields": {
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "owner": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "name": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "fullName": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "defaultBranch": {
+          "type": "text",
+          "required": false,
+          "default": "main"
+        },
+        "isPrivate": {
+          "type": "boolean",
+          "required": false,
+          "default": false
+        },
+        "providerType": {
+          "type": "text",
+          "required": false,
+          "default": "github"
+        },
+        "baseUrl": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "tokenConfigKey": {
+          "type": "text",
+          "required": false,
+          "default": "GITHUB_TOKEN"
+        },
+        "lastSyncedAt": {
+          "type": "datetime",
+          "required": false
+        }
+      },
+      "methods": {
+        "getClient": {
+          "name": "getClient",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<IRepository>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearClient": {
+          "name": "clearClient",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "sync": {
+          "name": "sync",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "SyncOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getIssues": {
+          "name": "getIssues",
+          "async": true,
+          "parameters": [
+            {
+              "name": "filters",
+              "type": "SearchFilters",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Issue[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getPullRequests": {
+          "name": "getPullRequests",
+          "async": true,
+          "parameters": [
+            {
+              "name": "filters",
+              "type": "SearchFilters",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<PullRequest[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "createIssue": {
+          "name": "createIssue",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "CreateIssueInput",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Issue>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "createPullRequest": {
+          "name": "createPullRequest",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "CreatePRInput",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<PullRequest>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasOpenIssuesMatching": {
+          "name": "hasOpenIssuesMatching",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeActivity": {
+          "name": "summarizeActivity",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getByFullName": {
+          "name": "getByFullName",
+          "async": true,
+          "parameters": [
+            {
+              "name": "owner",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "SmrtObjectOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Repository | null>",
+          "isStatic": true,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "sync"
+          ]
+        },
+        "cli": {
+          "include": [
+            "list",
+            "get",
+            "sync",
+            "create"
+          ]
+        }
+      },
+      "extends": "SmrtObject",
+      "exportName": "Repository",
+      "collectionExportName": "RepositoryCollection",
+      "schema": {
+        "tableName": "repositories",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"repositories\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"owner\" TEXT DEFAULT '',\n  \"name\" TEXT DEFAULT '',\n  \"full_name\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"default_branch\" TEXT DEFAULT 'main',\n  \"is_private\" BOOLEAN DEFAULT FALSE,\n  \"provider_type\" TEXT DEFAULT 'github',\n  \"base_url\" TEXT DEFAULT '',\n  \"token_config_key\" TEXT DEFAULT 'GITHUB_TOKEN',\n  \"last_synced_at\" TIMESTAMP\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "owner": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": ""
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": ""
+          },
+          "full_name": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": ""
+          },
+          "default_branch": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": "main"
+          },
+          "is_private": {
+            "type": "BOOLEAN",
+            "notNull": false,
+            "unique": false,
+            "default": false
+          },
+          "provider_type": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": "github"
+          },
+          "base_url": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": ""
+          },
+          "token_config_key": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false,
+            "default": "GITHUB_TOKEN"
+          },
+          "last_synced_at": {
+            "type": "TIMESTAMP",
+            "notNull": false,
+            "unique": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "repositories_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "repositories_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "426c7380"
       }
     }
   },
   "moduleType": "smrt",
-  "packageName": "@happyvertical/smrt-projects"
+  "smrtDependencies": [
+    "@happyvertical/smrt-core"
+  ]
 }

--- a/packages/projects/src/manifest/manifest.json
+++ b/packages/projects/src/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "timestamp": 1780375815437,
+  "timestamp": 1780379252178,
   "packageName": "@happyvertical/smrt-projects",
   "packageVersion": "0.25.8",
   "objects": {
@@ -203,7 +203,7 @@
       "collectionExportName": "IssueCollectionCollection",
       "schema": {
         "tableName": "issue_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"issue_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"issue_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -405,7 +405,7 @@
       "collectionExportName": "ProjectCollectionCollection",
       "schema": {
         "tableName": "project_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"project_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"project_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -666,7 +666,7 @@
       "collectionExportName": "PullRequestCollectionCollection",
       "schema": {
         "tableName": "issues",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"issues\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"issues\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -858,7 +858,7 @@
       "collectionExportName": "RepositoryCollectionCollection",
       "schema": {
         "tableName": "repository_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"repository_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"repository_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1025,7 +1025,7 @@
       "collectionExportName": "CommentCollection",
       "schema": {
         "tableName": "comments",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"comments\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"issue_id\" uuid,\n  \"comment_id\" TEXT DEFAULT '',\n  \"body\" TEXT DEFAULT '',\n  \"author\" TEXT DEFAULT '',\n  \"url\" TEXT DEFAULT ''\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"comments\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"issue_id\" UUID,\n  \"comment_id\" TEXT DEFAULT '',\n  \"body\" TEXT DEFAULT '',\n  \"author\" TEXT DEFAULT '',\n  \"url\" TEXT DEFAULT ''\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1127,8 +1127,11 @@
         },
         "repositoryId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "Repository"
+          "required": true,
+          "related": "Repository",
+          "_meta": {
+            "required": true
+          }
         },
         "number": {
           "type": "integer",
@@ -1806,9 +1809,16 @@
       "extends": "SmrtObject",
       "exportName": "Issue",
       "collectionExportName": "IssueCollection",
+      "validationRules": [
+        {
+          "field": "repositoryId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        }
+      ],
       "schema": {
         "tableName": "issues",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"issues\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"repository_id\" uuid,\n  \"number\" INTEGER DEFAULT 0,\n  \"node_id\" TEXT DEFAULT '',\n  \"title\" TEXT DEFAULT '',\n  \"body\" TEXT DEFAULT '',\n  \"state\" TEXT DEFAULT 'open',\n  \"author\" TEXT DEFAULT '',\n  \"labels\" JSONB DEFAULT '[]',\n  \"assignees\" JSONB DEFAULT '[]',\n  \"comments_count\" INTEGER DEFAULT 0,\n  \"last_synced_at\" TIMESTAMP,\n  \"original_body\" TEXT DEFAULT '',\n  \"synthesis_count\" INTEGER DEFAULT 0,\n  \"head_ref\" TEXT DEFAULT '',\n  \"base_ref\" TEXT DEFAULT '',\n  \"merged\" BOOLEAN DEFAULT FALSE,\n  \"merged_at\" TIMESTAMP,\n  \"mergeable\" BOOLEAN DEFAULT TRUE,\n  \"draft\" BOOLEAN DEFAULT FALSE,\n  \"additions\" INTEGER DEFAULT 0,\n  \"deletions\" INTEGER DEFAULT 0,\n  \"changed_files\" INTEGER DEFAULT 0\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"issues\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"repository_id\" UUID,\n  \"number\" INTEGER DEFAULT 0,\n  \"node_id\" TEXT DEFAULT '',\n  \"title\" TEXT DEFAULT '',\n  \"body\" TEXT DEFAULT '',\n  \"state\" TEXT DEFAULT 'open',\n  \"author\" TEXT DEFAULT '',\n  \"labels\" JSON DEFAULT '[]',\n  \"assignees\" JSON DEFAULT '[]',\n  \"comments_count\" INTEGER DEFAULT 0,\n  \"last_synced_at\" TIMESTAMP,\n  \"original_body\" TEXT DEFAULT '',\n  \"synthesis_count\" INTEGER DEFAULT 0,\n  \"head_ref\" TEXT DEFAULT '',\n  \"base_ref\" TEXT DEFAULT '',\n  \"merged\" BOOLEAN DEFAULT FALSE,\n  \"merged_at\" TIMESTAMP,\n  \"mergeable\" BOOLEAN DEFAULT TRUE,\n  \"draft\" BOOLEAN DEFAULT FALSE,\n  \"additions\" INTEGER DEFAULT 0,\n  \"deletions\" INTEGER DEFAULT 0,\n  \"changed_files\" INTEGER DEFAULT 0\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2107,7 +2117,7 @@
       "collectionExportName": "LabelCollection",
       "schema": {
         "tableName": "labels",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"labels\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"repository_id\" uuid,\n  \"name\" TEXT DEFAULT '',\n  \"color\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT ''\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"labels\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"repository_id\" UUID,\n  \"name\" TEXT DEFAULT '',\n  \"color\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT ''\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2494,7 +2504,7 @@
       "collectionExportName": "ProjectCollection",
       "schema": {
         "tableName": "projects",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"projects\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"project_id\" TEXT DEFAULT '',\n  \"project_number\" INTEGER DEFAULT 0,\n  \"title\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"owner\" TEXT DEFAULT '',\n  \"url\" TEXT DEFAULT '',\n  \"provider_type\" TEXT DEFAULT 'github',\n  \"token_config_key\" TEXT DEFAULT 'GITHUB_TOKEN',\n  \"statuses\" JSONB DEFAULT '[]',\n  \"fields\" JSONB DEFAULT '[]',\n  \"status_field_id\" TEXT DEFAULT '',\n  \"status_options\" JSONB DEFAULT '{}',\n  \"last_synced_at\" TIMESTAMP\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"projects\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"project_id\" TEXT DEFAULT '',\n  \"project_number\" INTEGER DEFAULT 0,\n  \"title\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"owner\" TEXT DEFAULT '',\n  \"url\" TEXT DEFAULT '',\n  \"provider_type\" TEXT DEFAULT 'github',\n  \"token_config_key\" TEXT DEFAULT 'GITHUB_TOKEN',\n  \"statuses\" JSON DEFAULT '[]',\n  \"fields\" JSON DEFAULT '[]',\n  \"status_field_id\" TEXT DEFAULT '',\n  \"status_options\" JSON DEFAULT '{}',\n  \"last_synced_at\" TIMESTAMP\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -2644,8 +2654,11 @@
         },
         "repositoryId": {
           "type": "foreignKey",
-          "required": false,
-          "related": "Repository"
+          "required": true,
+          "related": "Repository",
+          "_meta": {
+            "required": true
+          }
         },
         "number": {
           "type": "integer",
@@ -3455,9 +3468,16 @@
       "extends": "Issue",
       "exportName": "PullRequest",
       "collectionExportName": "PullRequestCollection",
+      "validationRules": [
+        {
+          "field": "repositoryId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        }
+      ],
       "schema": {
         "tableName": "issues",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"issues\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"repository_id\" uuid,\n  \"number\" INTEGER DEFAULT 0,\n  \"node_id\" TEXT DEFAULT '',\n  \"title\" TEXT DEFAULT '',\n  \"body\" TEXT DEFAULT '',\n  \"state\" TEXT DEFAULT 'open',\n  \"author\" TEXT DEFAULT '',\n  \"labels\" JSONB DEFAULT '[]',\n  \"assignees\" JSONB DEFAULT '[]',\n  \"comments_count\" INTEGER DEFAULT 0,\n  \"last_synced_at\" TIMESTAMP,\n  \"original_body\" TEXT DEFAULT '',\n  \"synthesis_count\" INTEGER DEFAULT 0,\n  \"head_ref\" TEXT DEFAULT '',\n  \"base_ref\" TEXT DEFAULT '',\n  \"merged\" BOOLEAN DEFAULT FALSE,\n  \"merged_at\" TIMESTAMP,\n  \"mergeable\" BOOLEAN DEFAULT TRUE,\n  \"draft\" BOOLEAN DEFAULT FALSE,\n  \"additions\" INTEGER DEFAULT 0,\n  \"deletions\" INTEGER DEFAULT 0,\n  \"changed_files\" INTEGER DEFAULT 0\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"issues\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"repository_id\" UUID,\n  \"number\" INTEGER DEFAULT 0,\n  \"node_id\" TEXT DEFAULT '',\n  \"title\" TEXT DEFAULT '',\n  \"body\" TEXT DEFAULT '',\n  \"state\" TEXT DEFAULT 'open',\n  \"author\" TEXT DEFAULT '',\n  \"labels\" JSON DEFAULT '[]',\n  \"assignees\" JSON DEFAULT '[]',\n  \"comments_count\" INTEGER DEFAULT 0,\n  \"last_synced_at\" TIMESTAMP,\n  \"original_body\" TEXT DEFAULT '',\n  \"synthesis_count\" INTEGER DEFAULT 0,\n  \"head_ref\" TEXT DEFAULT '',\n  \"base_ref\" TEXT DEFAULT '',\n  \"merged\" BOOLEAN DEFAULT FALSE,\n  \"merged_at\" TIMESTAMP,\n  \"mergeable\" BOOLEAN DEFAULT TRUE,\n  \"draft\" BOOLEAN DEFAULT FALSE,\n  \"additions\" INTEGER DEFAULT 0,\n  \"deletions\" INTEGER DEFAULT 0,\n  \"changed_files\" INTEGER DEFAULT 0\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3855,7 +3875,7 @@
       "collectionExportName": "RepositoryCollection",
       "schema": {
         "tableName": "repositories",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"repositories\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"owner\" TEXT DEFAULT '',\n  \"name\" TEXT DEFAULT '',\n  \"full_name\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"default_branch\" TEXT DEFAULT 'main',\n  \"is_private\" BOOLEAN DEFAULT FALSE,\n  \"provider_type\" TEXT DEFAULT 'github',\n  \"base_url\" TEXT DEFAULT '',\n  \"token_config_key\" TEXT DEFAULT 'GITHUB_TOKEN',\n  \"last_synced_at\" TIMESTAMP\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"repositories\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"owner\" TEXT DEFAULT '',\n  \"name\" TEXT DEFAULT '',\n  \"full_name\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"default_branch\" TEXT DEFAULT 'main',\n  \"is_private\" BOOLEAN DEFAULT FALSE,\n  \"provider_type\" TEXT DEFAULT 'github',\n  \"base_url\" TEXT DEFAULT '',\n  \"token_config_key\" TEXT DEFAULT 'GITHUB_TOKEN',\n  \"last_synced_at\" TIMESTAMP\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -3968,6 +3988,8 @@
   },
   "moduleType": "smrt",
   "smrtDependencies": [
-    "@happyvertical/smrt-core"
+    "@happyvertical/smrt-core",
+    "@happyvertical/smrt-prompts",
+    "@happyvertical/smrt-tenancy"
   ]
 }

--- a/packages/properties/src/manifest/manifest.json
+++ b/packages/properties/src/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "timestamp": 1780375814296,
+  "timestamp": 1780379250353,
   "packageName": "@happyvertical/smrt-properties",
   "packageVersion": "0.25.8",
   "objects": {
@@ -148,7 +148,7 @@
       "collectionExportName": "PropertyCollectionCollection",
       "schema": {
         "tableName": "property_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"property_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"property_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -464,7 +464,7 @@
       "collectionExportName": "ZoneCollectionCollection",
       "schema": {
         "tableName": "zone_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"zone_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"zone_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1055,7 +1055,7 @@
       "collectionExportName": "PropertyCollection",
       "schema": {
         "tableName": "properties",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"properties\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"domain\" TEXT DEFAULT '',\n  \"url\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"repository_id\" uuid,\n  \"owner_id\" uuid,\n  \"status\" TEXT DEFAULT 'active',\n  \"metadata\" JSONB DEFAULT '{}'\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"properties\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"domain\" TEXT DEFAULT '',\n  \"url\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"repository_id\" UUID,\n  \"owner_id\" UUID,\n  \"status\" TEXT DEFAULT 'active',\n  \"metadata\" JSON DEFAULT '{}'\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1167,8 +1167,12 @@
       "packageName": "@happyvertical/smrt-properties",
       "fields": {
         "parentId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "Zone",
+          "_meta": {
+            "nullable": true
+          }
         },
         "tenantId": {
           "type": "text",
@@ -1391,7 +1395,7 @@
       "collectionExportName": "ZoneCollection",
       "schema": {
         "tableName": "zones",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"zones\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"parent_id\" TEXT,\n  \"tenant_id\" TEXT,\n  \"property_id\" uuid,\n  \"name\" TEXT DEFAULT '',\n  \"type\" TEXT DEFAULT '',\n  \"path\" TEXT DEFAULT '',\n  \"selector\" TEXT DEFAULT '',\n  \"position\" TEXT DEFAULT '',\n  \"width\" INTEGER,\n  \"height\" INTEGER,\n  \"allowed_formats\" JSONB DEFAULT '[]',\n  \"default_content_id\" TEXT,\n  \"metadata\" JSONB DEFAULT '{}'\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"zones\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"parent_id\" UUID,\n  \"tenant_id\" TEXT,\n  \"property_id\" UUID,\n  \"name\" TEXT DEFAULT '',\n  \"type\" TEXT DEFAULT '',\n  \"path\" TEXT DEFAULT '',\n  \"selector\" TEXT DEFAULT '',\n  \"position\" TEXT DEFAULT '',\n  \"width\" INTEGER,\n  \"height\" INTEGER,\n  \"allowed_formats\" JSON DEFAULT '[]',\n  \"default_content_id\" TEXT,\n  \"metadata\" JSON DEFAULT '{}'\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1418,7 +1422,7 @@
             "default": "current_timestamp"
           },
           "parent_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false,
             "unique": false
           },
@@ -1506,7 +1510,7 @@
             "unique": true
           }
         ],
-        "version": "a34eb231"
+        "version": "55d6db2b"
       }
     }
   },
@@ -1514,6 +1518,8 @@
   "smrtDependencies": [
     "@happyvertical/smrt-core",
     "@happyvertical/smrt-profiles",
-    "@happyvertical/smrt-projects"
+    "@happyvertical/smrt-projects",
+    "@happyvertical/smrt-prompts",
+    "@happyvertical/smrt-tenancy"
   ]
 }

--- a/packages/properties/src/manifest/manifest.json
+++ b/packages/properties/src/manifest/manifest.json
@@ -1,12 +1,206 @@
 {
   "version": "1.0.0",
-  "timestamp": 1767322692523,
+  "timestamp": 1780375814296,
+  "packageName": "@happyvertical/smrt-properties",
+  "packageVersion": "0.25.8",
   "objects": {
-    "zonecollection": {
+    "@happyvertical/smrt-properties:PropertyCollection": {
+      "name": "propertycollection",
+      "className": "PropertyCollection",
+      "qualifiedName": "@happyvertical/smrt-properties:PropertyCollection",
+      "collection": "properties",
+      "filePath": "packages/properties/src/collections/Properties.ts",
+      "packageName": "@happyvertical/smrt-properties",
+      "fields": {},
+      "methods": {
+        "findByDomain": {
+          "name": "findByDomain",
+          "async": true,
+          "parameters": [
+            {
+              "name": "domain",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Property | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByRepository": {
+          "name": "findByRepository",
+          "async": true,
+          "parameters": [
+            {
+              "name": "repositoryId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Property[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByOwner": {
+          "name": "findByOwner",
+          "async": true,
+          "parameters": [
+            {
+              "name": "ownerId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Property[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findActive": {
+          "name": "findActive",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Property[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByStatus": {
+          "name": "findByStatus",
+          "async": true,
+          "parameters": [
+            {
+              "name": "status",
+              "type": "PropertyStatus",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Property[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getOrCreateByDomain": {
+          "name": "getOrCreateByDomain",
+          "async": true,
+          "parameters": [
+            {
+              "name": "domain",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "defaults",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Property>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "countByStatus": {
+          "name": "countByStatus",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Record<PropertyStatus, number>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Property[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Property[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Property[]>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {},
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "Property",
+      "exportName": "PropertyCollection",
+      "collectionExportName": "PropertyCollectionCollection",
+      "schema": {
+        "tableName": "property_collections",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"property_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "property_collections_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "property_collections_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "a18c7ad1"
+      }
+    },
+    "@happyvertical/smrt-properties:ZoneCollection": {
       "name": "zonecollection",
       "className": "ZoneCollection",
+      "qualifiedName": "@happyvertical/smrt-properties:ZoneCollection",
       "collection": "zones",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/properties/src/collections/Zones.ts",
+      "filePath": "packages/properties/src/collections/Zones.ts",
+      "packageName": "@happyvertical/smrt-properties",
       "fields": {},
       "methods": {
         "findByProperty": {
@@ -219,11 +413,46 @@
             {
               "name": "cascade",
               "type": "boolean",
-              "optional": false,
-              "default": false
+              "optional": true
             }
           ],
           "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Zone[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Zone[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Zone[]>",
           "isStatic": false,
           "isPublic": true
         }
@@ -235,10 +464,10 @@
       "collectionExportName": "ZoneCollectionCollection",
       "schema": {
         "tableName": "zone_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"zone_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"zone_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -278,24 +507,677 @@
             "unique": true
           }
         ],
-        "version": "5c78b453"
+        "version": "132b9f18"
       }
     },
-    "zone": {
-      "name": "zone",
-      "className": "Zone",
-      "collection": "zones",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/properties/src/models/Zone.ts",
+    "@happyvertical/smrt-properties:Property": {
+      "name": "property",
+      "className": "Property",
+      "qualifiedName": "@happyvertical/smrt-properties:Property",
+      "collection": "properties",
+      "filePath": "packages/properties/src/models/Property.ts",
+      "packageName": "@happyvertical/smrt-properties",
       "fields": {
-        "propertyId": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "name": {
           "type": "text",
           "required": false,
           "default": ""
         },
-        "parentId": {
+        "domain": {
           "type": "text",
           "required": false,
-          "default": null
+          "default": ""
+        },
+        "url": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "repositoryId": {
+          "type": "crossPackageRef",
+          "required": false,
+          "related": "@happyvertical/smrt-projects:Repository"
+        },
+        "ownerId": {
+          "type": "crossPackageRef",
+          "required": false,
+          "related": "@happyvertical/smrt-profiles:Profile"
+        },
+        "status": {
+          "type": "text",
+          "required": false,
+          "default": "active"
+        },
+        "metadata": {
+          "type": "json",
+          "required": false,
+          "default": {}
+        }
+      },
+      "methods": {
+        "getAiUsageSnapshot": {
+          "name": "getAiUsageSnapshot",
+          "async": false,
+          "parameters": [],
+          "returnType": "AiUsageSnapshot | undefined",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetAiUsage": {
+          "name": "resetAiUsage",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listAiUsage": {
+          "name": "listAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageListOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<SmrtAiUsageRecord[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeAiUsage": {
+          "name": "summarizeAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageSummaryOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Record<string, AiUsageStats>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "destroy": {
+          "name": "destroy",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadDataFromDb": {
+          "name": "loadDataFromDb",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toJSON": {
+          "name": "toJSON",
+          "async": false,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPlainObject": {
+          "name": "toPlainObject",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getId": {
+          "name": "getId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSlug": {
+          "name": "getSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSavedId": {
+          "name": "getSavedId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSaved": {
+          "name": "isSaved",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromId": {
+          "name": "loadFromId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromSlug": {
+          "name": "loadFromSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "is": {
+          "name": "is",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "do": {
+          "name": "do",
+          "async": true,
+          "parameters": [
+            {
+              "name": "instructions",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "describe": {
+          "name": "describe",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "delete": {
+          "name": "delete",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRelatedLoaded": {
+          "name": "isRelatedLoaded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelated": {
+          "name": "loadRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelatedMany": {
+          "name": "loadRelatedMany",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelated": {
+          "name": "getRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAvailableTools": {
+          "name": "getAvailableTools",
+          "async": false,
+          "parameters": [],
+          "returnType": "AITool[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "executeToolCall": {
+          "name": "executeToolCall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toolCall",
+              "type": "ToolCall",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ToolCallResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "remember": {
+          "name": "remember",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recall": {
+          "name": "recall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recallAll": {
+          "name": "recallAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forget": {
+          "name": "forget",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forgetScope": {
+          "name": "forgetScope",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateEmbeddings": {
+          "name": "generateEmbeddings",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "GenerateEmbeddingsOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmbedding": {
+          "name": "getEmbedding",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "model",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number[] | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStaleEmbeddings": {
+          "name": "hasStaleEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearEmbeddings": {
+          "name": "clearEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getZones": {
+          "name": "getZones",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getZoneTree": {
+          "name": "getZoneTree",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "createZone": {
+          "name": "createZone",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "Omit<'propertyId'>",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "async": false,
+          "parameters": [],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarize": {
+          "name": "summarize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<string>",
+          "isStatic": false,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtObject",
+      "exportName": "Property",
+      "collectionExportName": "PropertyCollection",
+      "schema": {
+        "tableName": "properties",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"properties\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"domain\" TEXT DEFAULT '',\n  \"url\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"repository_id\" uuid,\n  \"owner_id\" uuid,\n  \"status\" TEXT DEFAULT 'active',\n  \"metadata\" JSONB DEFAULT '{}'\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "domain": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "url": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "repository_id": {
+            "type": "UUID",
+            "notNull": false
+          },
+          "owner_id": {
+            "type": "UUID",
+            "notNull": false
+          },
+          "status": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": "active"
+          },
+          "metadata": {
+            "type": "JSON",
+            "notNull": false,
+            "default": {}
+          }
+        },
+        "indexes": [
+          {
+            "name": "properties_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "properties_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "properties_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "5994212b"
+      }
+    },
+    "@happyvertical/smrt-properties:Zone": {
+      "name": "zone",
+      "className": "Zone",
+      "qualifiedName": "@happyvertical/smrt-properties:Zone",
+      "collection": "zones",
+      "filePath": "packages/properties/src/models/Zone.ts",
+      "packageName": "@happyvertical/smrt-properties",
+      "fields": {
+        "parentId": {
+          "type": "text",
+          "required": false
+        },
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "propertyId": {
+          "type": "foreignKey",
+          "required": false,
+          "related": "Property"
         },
         "name": {
           "type": "text",
@@ -323,14 +1205,12 @@
           "default": ""
         },
         "width": {
-          "type": "decimal",
-          "required": false,
-          "default": null
+          "type": "integer",
+          "required": false
         },
         "height": {
-          "type": "decimal",
-          "required": false,
-          "default": null
+          "type": "integer",
+          "required": false
         },
         "allowedFormats": {
           "type": "json",
@@ -339,8 +1219,7 @@
         },
         "defaultContentId": {
           "type": "text",
-          "required": false,
-          "default": null
+          "required": false
         },
         "metadata": {
           "type": "json",
@@ -349,6 +1228,60 @@
         }
       },
       "methods": {
+        "getParent": {
+          "name": "getParent",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getChildren": {
+          "name": "getChildren",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAncestors": {
+          "name": "getAncestors",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getDescendants": {
+          "name": "getDescendants",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getHierarchy": {
+          "name": "getHierarchy",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<HierarchyView>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "moveTo": {
+          "name": "moveTo",
+          "async": true,
+          "parameters": [
+            {
+              "name": "newParent",
+              "type": "string | null",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
         "isTopLevel": {
           "name": "isTopLevel",
           "async": false,
@@ -377,39 +1310,7 @@
           "name": "getProperty",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<import('./Property').Property | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getParent": {
-          "name": "getParent",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Zone | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getChildren": {
-          "name": "getChildren",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Zone[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getAncestors": {
-          "name": "getAncestors",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Zone[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getDescendants": {
-          "name": "getDescendants",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Zone[]>",
+          "returnType": "Promise<null>",
           "isStatic": false,
           "isPublic": true
         },
@@ -485,15 +1386,15 @@
         },
         "cli": true
       },
-      "extends": "SmrtObject",
+      "extends": "SmrtHierarchical",
       "exportName": "Zone",
       "collectionExportName": "ZoneCollection",
       "schema": {
         "tableName": "zones",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"zones\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"property_id\" TEXT DEFAULT '',\n  \"parent_id\" TEXT DEFAULT 'null',\n  \"name\" TEXT DEFAULT '',\n  \"type\" TEXT DEFAULT '',\n  \"path\" TEXT DEFAULT '',\n  \"selector\" TEXT DEFAULT '',\n  \"position\" TEXT DEFAULT '',\n  \"width\" REAL DEFAULT NULL,\n  \"height\" REAL DEFAULT NULL,\n  \"allowed_formats\" JSON DEFAULT '',\n  \"default_content_id\" TEXT DEFAULT 'null',\n  \"metadata\" JSON DEFAULT '[object Object]'\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"zones\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"parent_id\" TEXT,\n  \"tenant_id\" TEXT,\n  \"property_id\" uuid,\n  \"name\" TEXT DEFAULT '',\n  \"type\" TEXT DEFAULT '',\n  \"path\" TEXT DEFAULT '',\n  \"selector\" TEXT DEFAULT '',\n  \"position\" TEXT DEFAULT '',\n  \"width\" INTEGER,\n  \"height\" INTEGER,\n  \"allowed_formats\" JSONB DEFAULT '[]',\n  \"default_content_id\" TEXT,\n  \"metadata\" JSONB DEFAULT '{}'\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -516,64 +1417,76 @@
             "notNull": true,
             "default": "current_timestamp"
           },
-          "property_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
           "parent_id": {
             "type": "TEXT",
             "notNull": false,
-            "default": null
+            "unique": false
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": false
+          },
+          "property_id": {
+            "type": "UUID",
+            "notNull": false,
+            "unique": false
           },
           "name": {
             "type": "TEXT",
             "notNull": false,
+            "unique": false,
             "default": ""
           },
           "type": {
             "type": "TEXT",
             "notNull": false,
+            "unique": false,
             "default": ""
           },
           "path": {
             "type": "TEXT",
             "notNull": false,
+            "unique": false,
             "default": ""
           },
           "selector": {
             "type": "TEXT",
             "notNull": false,
+            "unique": false,
             "default": ""
           },
           "position": {
             "type": "TEXT",
             "notNull": false,
+            "unique": false,
             "default": ""
           },
           "width": {
-            "type": "REAL",
+            "type": "INTEGER",
             "notNull": false,
-            "default": null
+            "unique": false
           },
           "height": {
-            "type": "REAL",
+            "type": "INTEGER",
             "notNull": false,
-            "default": null
+            "unique": false
           },
           "allowed_formats": {
             "type": "JSON",
             "notNull": false,
+            "unique": false,
             "default": []
           },
           "default_content_id": {
             "type": "TEXT",
             "notNull": false,
-            "default": null
+            "unique": false
           },
           "metadata": {
             "type": "JSON",
             "notNull": false,
+            "unique": false,
             "default": {}
           }
         },
@@ -593,368 +1506,14 @@
             "unique": true
           }
         ],
-        "version": "c22f2541"
-      }
-    },
-    "property": {
-      "name": "property",
-      "className": "Property",
-      "collection": "properties",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/properties/src/models/Property.ts",
-      "fields": {
-        "name": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "domain": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "url": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "description": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "repositoryId": {
-          "type": "text",
-          "required": false,
-          "default": null
-        },
-        "ownerId": {
-          "type": "text",
-          "required": false,
-          "default": null
-        },
-        "status": {
-          "type": "text",
-          "required": false,
-          "default": "active"
-        },
-        "metadata": {
-          "type": "json",
-          "required": false,
-          "default": {}
-        }
-      },
-      "methods": {
-        "getZones": {
-          "name": "getZones",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<import('./Zone').Zone[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getZoneTree": {
-          "name": "getZoneTree",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<\n    import('../types').ZoneTree<import('./Zone').Zone>\n  >",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "createZone": {
-          "name": "createZone",
-          "async": true,
-          "parameters": [
-            {
-              "name": "options",
-              "type": "Omit<import('../types').ZoneOptions, 'propertyId'>",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<import('./Zone').Zone>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "isActive": {
-          "name": "isActive",
-          "async": false,
-          "parameters": [],
-          "returnType": "boolean",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "summarize": {
-          "name": "summarize",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<string>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "api": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update",
-            "delete"
-          ]
-        },
-        "mcp": {
-          "include": [
-            "list",
-            "get",
-            "create"
-          ]
-        },
-        "cli": true
-      },
-      "extends": "SmrtObject",
-      "exportName": "Property",
-      "collectionExportName": "PropertyCollection",
-      "schema": {
-        "tableName": "propertys",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"propertys\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"domain\" TEXT DEFAULT '',\n  \"url\" TEXT DEFAULT '',\n  \"description\" TEXT DEFAULT '',\n  \"repository_id\" TEXT DEFAULT 'null',\n  \"owner_id\" TEXT DEFAULT 'null',\n  \"status\" TEXT DEFAULT 'active',\n  \"metadata\" JSON DEFAULT '[object Object]'\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "name": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "domain": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "url": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "description": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "repository_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": null
-          },
-          "owner_id": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": null
-          },
-          "status": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": "active"
-          },
-          "metadata": {
-            "type": "JSON",
-            "notNull": false,
-            "default": {}
-          }
-        },
-        "indexes": [
-          {
-            "name": "propertys_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "propertys_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "e2b370d2"
-      }
-    },
-    "propertycollection": {
-      "name": "propertycollection",
-      "className": "PropertyCollection",
-      "collection": "properties",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/properties/src/collections/Properties.ts",
-      "fields": {},
-      "methods": {
-        "findByDomain": {
-          "name": "findByDomain",
-          "async": true,
-          "parameters": [
-            {
-              "name": "domain",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<Property | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByRepository": {
-          "name": "findByRepository",
-          "async": true,
-          "parameters": [
-            {
-              "name": "repositoryId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<Property[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByOwner": {
-          "name": "findByOwner",
-          "async": true,
-          "parameters": [
-            {
-              "name": "ownerId",
-              "type": "string",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<Property[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findActive": {
-          "name": "findActive",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Property[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "findByStatus": {
-          "name": "findByStatus",
-          "async": true,
-          "parameters": [
-            {
-              "name": "status",
-              "type": "PropertyStatus",
-              "optional": false
-            }
-          ],
-          "returnType": "Promise<Property[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getOrCreateByDomain": {
-          "name": "getOrCreateByDomain",
-          "async": true,
-          "parameters": [
-            {
-              "name": "domain",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "defaults",
-              "type": "{\n      name?: string;\n      url?: string;\n      repositoryId?: string | null;\n      ownerId?: string | null;\n    }",
-              "optional": false,
-              "default": {}
-            }
-          ],
-          "returnType": "Promise<Property>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "countByStatus": {
-          "name": "countByStatus",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Record<PropertyStatus, number>>",
-          "isStatic": false,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {},
-      "extends": "SmrtCollection",
-      "extendsTypeArg": "Property",
-      "exportName": "PropertyCollection",
-      "collectionExportName": "PropertyCollectionCollection",
-      "schema": {
-        "tableName": "property_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"property_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          }
-        },
-        "indexes": [
-          {
-            "name": "property_collections_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "property_collections_slug_context_idx",
-            "columns": [
-              "slug",
-              "context"
-            ],
-            "unique": true
-          }
-        ],
-        "version": "9970f6bc"
+        "version": "a34eb231"
       }
     }
   },
   "moduleType": "smrt",
-  "packageName": "@happyvertical/smrt-properties"
+  "smrtDependencies": [
+    "@happyvertical/smrt-core",
+    "@happyvertical/smrt-profiles",
+    "@happyvertical/smrt-projects"
+  ]
 }

--- a/packages/scanner/src/__tests__/manifest-adapter.test.ts
+++ b/packages/scanner/src/__tests__/manifest-adapter.test.ts
@@ -138,6 +138,31 @@ describe('ManifestAdapter', () => {
         expect(result.type).toBe('foreignKey');
         expect(result.required).toBe(false); // Should be optional due to default value
       });
+
+      it('should let @foreignKey options override initializer-based requiredness', () => {
+        const field: RawFieldDefinition = {
+          name: 'assetId',
+          accessibility: 'public',
+          typeAnnotation: 'string',
+          initializer: "''",
+          optional: false,
+          hasDecimalPoint: false,
+          numericValue: null,
+          decorators: [
+            {
+              name: 'foreignKey',
+              arguments: ['Asset', '{ required: true }'],
+            },
+          ],
+        };
+
+        const result = adapter.inferFieldType(field);
+
+        expect(result.type).toBe('foreignKey');
+        expect(result.related).toBe('Asset');
+        expect(result.required).toBe(true);
+        expect(result._meta?.required).toBe(true);
+      });
     });
 
     describe('string literal union types', () => {

--- a/packages/scanner/src/manifest-adapter.ts
+++ b/packages/scanner/src/manifest-adapter.ts
@@ -734,12 +734,38 @@ export class ManifestAdapter {
       // Strip surrounding quotes — sliceSource() returns raw source text
       // which includes quotes for string literals (e.g., "'TestProfile'")
       const relatedClass = stripQuotes(decorator.arguments[0]?.trim());
+      const parsedOptions = this.parseFieldDecoratorOptions(
+        decorator.arguments[1],
+      );
+      const meta: Record<string, unknown> = {};
+      const META_KEYS = [
+        'required',
+        'nullable',
+        'unique',
+        'description',
+        'default',
+      ] as const;
+      if (parsedOptions) {
+        for (const key of META_KEYS) {
+          if (parsedOptions[key] !== undefined) {
+            meta[key] = parsedOptions[key];
+          }
+        }
+      }
       // Respect TypeScript optional marker (?) - fixes #846
       const hasDefaultValue = field.initializer !== null;
       return {
         type: 'foreignKey',
         related: relatedClass || undefined,
-        required: !field.optional && !hasDefaultValue,
+        required:
+          parsedOptions?.required !== undefined
+            ? Boolean(parsedOptions.required)
+            : !field.optional && !hasDefaultValue,
+        defaultValue:
+          parsedOptions?.default !== undefined
+            ? parsedOptions.default
+            : undefined,
+        ...(Object.keys(meta).length > 0 ? { _meta: meta } : {}),
         source: 'decorator',
       };
     }
@@ -762,6 +788,7 @@ export class ManifestAdapter {
         'description',
         'default',
         'indexed',
+        'idType',
       ] as const;
       if (parsedOptions) {
         for (const key of META_KEYS) {

--- a/packages/scanner/src/manifest-adapter.ts
+++ b/packages/scanner/src/manifest-adapter.ts
@@ -91,6 +91,7 @@ interface MethodDefinition {
 
 interface SmartObjectConfig {
   tableStrategy?: 'sti' | 'cti';
+  idType?: 'uuid' | 'text';
   features?: Record<
     string,
     {

--- a/packages/scanner/src/types.ts
+++ b/packages/scanner/src/types.ts
@@ -421,8 +421,8 @@ export interface FieldTypeInference {
   /**
    * Decorator-derived metadata that should be merged into the manifest
    * field's `_meta` object. Used by `@crossPackageRef`, `@manyToMany`,
-   * `@meta` to carry options (`validate`, `through`, `indexed`, etc.) that
-   * don't fit on the top-level FieldDefinition.
+   * `@meta` to carry options (`validate`, `through`, `indexed`, `idType`,
+   * etc.) that don't fit on the top-level FieldDefinition.
    */
   _meta?: Record<string, unknown>;
 }

--- a/packages/scanner/src/types.ts
+++ b/packages/scanner/src/types.ts
@@ -54,6 +54,9 @@ export interface RawDecoratorConfig {
   /** Table strategy: 'sti' | 'cti' */
   tableStrategy?: 'sti' | 'cti';
 
+  /** Storage type for the generated id primary key */
+  idType?: 'uuid' | 'text';
+
   /** Code-owned feature toggle declarations */
   features?: Record<
     string,
@@ -363,8 +366,8 @@ export interface ExternalManifest {
  * | `boolean` | `BOOLEAN` | `boolean` annotation or literal initialiser |
  * | `datetime` | `DATETIME` | `Date` annotation |
  * | `json` | `JSON` / `TEXT` | Arrays, `Record<>`, object types |
- * | `foreignKey` | `TEXT` (FK column) | `@foreignKey(Class)` decorator |
- * | `crossPackageRef` | `TEXT` (no FK constraint) | `@crossPackageRef('@pkg:Class')` decorator |
+ * | `foreignKey` | `UUID` by default (FK column) | `@foreignKey(Class)` decorator |
+ * | `crossPackageRef` | `UUID` by default (no FK constraint) | `@crossPackageRef('@pkg:Class')` decorator |
  * | `oneToMany` | — (virtual) | `@oneToMany(Class)` decorator |
  * | `manyToMany` | — (virtual) | `@manyToMany(Class)` decorator |
  * | `meta` | Stored in `_meta_data` | STI child field wrapped in `Meta<T>` |

--- a/packages/tags/src/manifest/manifest.json
+++ b/packages/tags/src/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "timestamp": 1780375805913,
+  "timestamp": 1780379230728,
   "packageName": "@happyvertical/smrt-tags",
   "packageVersion": "0.25.8",
   "objects": {
@@ -533,7 +533,7 @@
       ],
       "schema": {
         "tableName": "tag_aliases",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"tag_aliases\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tag_slug\" TEXT DEFAULT '',\n  \"alias\" TEXT DEFAULT '',\n  \"language\" TEXT DEFAULT '',\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"tag_aliases\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tag_slug\" TEXT DEFAULT '',\n  \"alias\" TEXT DEFAULT '',\n  \"language\" TEXT DEFAULT '',\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -799,7 +799,7 @@
       "collectionExportName": "TagAliasCollectionCollection",
       "schema": {
         "tableName": "tag_alias_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"tag_alias_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"tag_alias_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -862,8 +862,12 @@
           "required": false
         },
         "parentId": {
-          "type": "text",
-          "required": false
+          "type": "foreignKey",
+          "required": false,
+          "related": "Tag",
+          "_meta": {
+            "nullable": true
+          }
         },
         "name": {
           "type": "text",
@@ -1471,7 +1475,7 @@
       ],
       "schema": {
         "tableName": "tags",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"tags\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"parent_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"level\" INTEGER DEFAULT 0,\n  \"description\" TEXT DEFAULT '',\n  \"metadata\" TEXT DEFAULT '',\n  \"tenant_id\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"tags\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"parent_id\" UUID,\n  \"name\" TEXT DEFAULT '',\n  \"level\" INTEGER DEFAULT 0,\n  \"description\" TEXT DEFAULT '',\n  \"metadata\" TEXT DEFAULT '',\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1506,7 +1510,7 @@
             "default": "current_timestamp"
           },
           "parent_id": {
-            "type": "TEXT",
+            "type": "UUID",
             "notNull": false
           },
           "name": {
@@ -1557,7 +1561,7 @@
             ]
           }
         ],
-        "version": "abdc0af6"
+        "version": "9ca078d6"
       }
     },
     "@happyvertical/smrt-tags:TagCollection": {
@@ -1786,7 +1790,7 @@
       "collectionExportName": "TagCollectionCollection",
       "schema": {
         "tableName": "tag_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"tag_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"tag_collections\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
             "type": "UUID",
@@ -1835,6 +1839,7 @@
   },
   "moduleType": "smrt",
   "smrtDependencies": [
-    "@happyvertical/smrt-core"
+    "@happyvertical/smrt-core",
+    "@happyvertical/smrt-tenancy"
   ]
 }

--- a/packages/tags/src/manifest/manifest.json
+++ b/packages/tags/src/manifest/manifest.json
@@ -1,13 +1,25 @@
 {
   "version": "1.0.0",
-  "timestamp": 1767322690629,
+  "timestamp": 1780375805913,
+  "packageName": "@happyvertical/smrt-tags",
+  "packageVersion": "0.25.8",
   "objects": {
-    "tagalias": {
+    "@happyvertical/smrt-tags:TagAlias": {
       "name": "tagalias",
       "className": "TagAlias",
+      "qualifiedName": "@happyvertical/smrt-tags:TagAlias",
       "collection": "tagaliases",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/tags/src/tag-alias.ts",
+      "filePath": "packages/tags/src/tag-alias.ts",
+      "packageName": "@happyvertical/smrt-tags",
       "fields": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
         "tagSlug": {
           "type": "text",
           "required": false,
@@ -16,13 +28,19 @@
         "alias": {
           "type": "text",
           "required": true,
-          "_meta": {},
-          "default": ""
+          "default": "",
+          "_meta": {
+            "required": true
+          }
         },
         "language": {
           "type": "text",
           "required": false,
           "default": ""
+        },
+        "tenantId": {
+          "type": "text",
+          "required": false
         },
         "createdAt": {
           "type": "datetime",
@@ -30,6 +48,417 @@
         }
       },
       "methods": {
+        "getAiUsageSnapshot": {
+          "name": "getAiUsageSnapshot",
+          "async": false,
+          "parameters": [],
+          "returnType": "AiUsageSnapshot | undefined",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetAiUsage": {
+          "name": "resetAiUsage",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listAiUsage": {
+          "name": "listAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageListOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<SmrtAiUsageRecord[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeAiUsage": {
+          "name": "summarizeAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageSummaryOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Record<string, AiUsageStats>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "destroy": {
+          "name": "destroy",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadDataFromDb": {
+          "name": "loadDataFromDb",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toJSON": {
+          "name": "toJSON",
+          "async": false,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPlainObject": {
+          "name": "toPlainObject",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getId": {
+          "name": "getId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSlug": {
+          "name": "getSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSavedId": {
+          "name": "getSavedId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSaved": {
+          "name": "isSaved",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromId": {
+          "name": "loadFromId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromSlug": {
+          "name": "loadFromSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "is": {
+          "name": "is",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "do": {
+          "name": "do",
+          "async": true,
+          "parameters": [
+            {
+              "name": "instructions",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "describe": {
+          "name": "describe",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "delete": {
+          "name": "delete",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRelatedLoaded": {
+          "name": "isRelatedLoaded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelated": {
+          "name": "loadRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelatedMany": {
+          "name": "loadRelatedMany",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelated": {
+          "name": "getRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAvailableTools": {
+          "name": "getAvailableTools",
+          "async": false,
+          "parameters": [],
+          "returnType": "AITool[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "executeToolCall": {
+          "name": "executeToolCall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toolCall",
+              "type": "ToolCall",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ToolCallResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "remember": {
+          "name": "remember",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recall": {
+          "name": "recall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recallAll": {
+          "name": "recallAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forget": {
+          "name": "forget",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forgetScope": {
+          "name": "forgetScope",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateEmbeddings": {
+          "name": "generateEmbeddings",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "GenerateEmbeddingsOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmbedding": {
+          "name": "getEmbedding",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "model",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number[] | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStaleEmbeddings": {
+          "name": "hasStaleEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearEmbeddings": {
+          "name": "clearEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
         "getTag": {
           "name": "getTag",
           "async": true,
@@ -95,12 +524,19 @@
       "extends": "SmrtObject",
       "exportName": "TagAlias",
       "collectionExportName": "TagAliasCollection",
+      "validationRules": [
+        {
+          "field": "alias",
+          "rule": "required",
+          "fieldType": "text"
+        }
+      ],
       "schema": {
-        "tableName": "tag_alias",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"tag_alias\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tag_slug\" TEXT DEFAULT '',\n  \"alias\" TEXT DEFAULT '',\n  \"language\" TEXT DEFAULT ''\n);",
+        "tableName": "tag_aliases",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"tag_aliases\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tag_slug\" TEXT DEFAULT '',\n  \"alias\" TEXT DEFAULT '',\n  \"language\" TEXT DEFAULT '',\n  \"tenant_id\" TEXT\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -145,17 +581,21 @@
             "type": "TEXT",
             "notNull": false,
             "default": ""
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false
           }
         },
         "indexes": [
           {
-            "name": "tag_alias_id_idx",
+            "name": "tag_aliases_id_idx",
             "columns": [
               "id"
             ]
           },
           {
-            "name": "tag_alias_slug_context_meta_type_idx",
+            "name": "tag_aliases_slug_context_meta_type_idx",
             "columns": [
               "slug",
               "context",
@@ -164,20 +604,22 @@
             "unique": true
           },
           {
-            "name": "tag_alias_meta_type_idx",
+            "name": "tag_aliases_meta_type_idx",
             "columns": [
               "_meta_type"
             ]
           }
         ],
-        "version": "3bbbeee1"
+        "version": "34f24cc7"
       }
     },
-    "tagaliascollection": {
+    "@happyvertical/smrt-tags:TagAliasCollection": {
       "name": "tagaliascollection",
       "className": "TagAliasCollection",
+      "qualifiedName": "@happyvertical/smrt-tags:TagAliasCollection",
       "collection": "tagaliases",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/tags/src/tag-aliases.ts",
+      "filePath": "packages/tags/src/tag-aliases.ts",
+      "packageName": "@happyvertical/smrt-tags",
       "fields": {},
       "methods": {
         "addAlias": {
@@ -272,7 +714,7 @@
             },
             {
               "name": "aliases",
-              "type": "Array<{\n      alias: string;\n      language?: string;\n      context?: string;\n    }>",
+              "type": "Array<object>",
               "optional": false
             }
           ],
@@ -312,6 +754,42 @@
           "returnType": "Promise<TagAlias[]>",
           "isStatic": false,
           "isPublic": true
+        },
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<TagAlias[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<TagAlias[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<TagAlias[]>",
+          "isStatic": false,
+          "isPublic": true
         }
       },
       "decoratorConfig": {},
@@ -321,10 +799,10 @@
       "collectionExportName": "TagAliasCollectionCollection",
       "schema": {
         "tableName": "tag_alias_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"tag_alias_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"tag_alias_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -364,14 +842,731 @@
             "unique": true
           }
         ],
-        "version": "08747314"
+        "version": "b7be72e8"
       }
     },
-    "tagcollection": {
+    "@happyvertical/smrt-tags:Tag": {
+      "name": "tag",
+      "className": "Tag",
+      "qualifiedName": "@happyvertical/smrt-tags:Tag",
+      "collection": "tags",
+      "filePath": "packages/tags/src/tag.ts",
+      "packageName": "@happyvertical/smrt-tags",
+      "fields": {
+        "created_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "updated_at": {
+          "type": "datetime",
+          "required": false
+        },
+        "parentId": {
+          "type": "text",
+          "required": false
+        },
+        "name": {
+          "type": "text",
+          "required": true,
+          "default": "",
+          "_meta": {
+            "required": true
+          }
+        },
+        "level": {
+          "type": "integer",
+          "required": false,
+          "default": 0
+        },
+        "description": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "metadata": {
+          "type": "text",
+          "required": false,
+          "default": ""
+        },
+        "tenantId": {
+          "type": "text",
+          "required": false
+        },
+        "createdAt": {
+          "type": "datetime",
+          "required": false
+        },
+        "updatedAt": {
+          "type": "datetime",
+          "required": false
+        }
+      },
+      "methods": {
+        "getAiUsageSnapshot": {
+          "name": "getAiUsageSnapshot",
+          "async": false,
+          "parameters": [],
+          "returnType": "AiUsageSnapshot | undefined",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "resetAiUsage": {
+          "name": "resetAiUsage",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "listAiUsage": {
+          "name": "listAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageListOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<SmrtAiUsageRecord[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "summarizeAiUsage": {
+          "name": "summarizeAiUsage",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "AiUsageSummaryOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Record<string, AiUsageStats>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "destroy": {
+          "name": "destroy",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "initialize": {
+          "name": "initialize",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadDataFromDb": {
+          "name": "loadDataFromDb",
+          "async": true,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getFields": {
+          "name": "getFields",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toJSON": {
+          "name": "toJSON",
+          "async": false,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPlainObject": {
+          "name": "toPlainObject",
+          "async": false,
+          "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getId": {
+          "name": "getId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSlug": {
+          "name": "getSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getSavedId": {
+          "name": "getSavedId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isSaved": {
+          "name": "isSaved",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromId": {
+          "name": "loadFromId",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadFromSlug": {
+          "name": "loadFromSlug",
+          "async": true,
+          "parameters": [],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "is": {
+          "name": "is",
+          "async": true,
+          "parameters": [
+            {
+              "name": "criteria",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "do": {
+          "name": "do",
+          "async": true,
+          "parameters": [
+            {
+              "name": "instructions",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "describe": {
+          "name": "describe",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "any",
+              "optional": true
+            }
+          ],
+          "returnType": "any",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "delete": {
+          "name": "delete",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "isRelatedLoaded": {
+          "name": "isRelatedLoaded",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelated": {
+          "name": "loadRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "loadRelatedMany": {
+          "name": "loadRelatedMany",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getRelated": {
+          "name": "getRelated",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAvailableTools": {
+          "name": "getAvailableTools",
+          "async": false,
+          "parameters": [],
+          "returnType": "AITool[]",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "executeToolCall": {
+          "name": "executeToolCall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "toolCall",
+              "type": "ToolCall",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ToolCallResult>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "remember": {
+          "name": "remember",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recall": {
+          "name": "recall",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<any | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "recallAll": {
+          "name": "recallAll",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Map<string, any>>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forget": {
+          "name": "forget",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "forgetScope": {
+          "name": "forgetScope",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "generateEmbeddings": {
+          "name": "generateEmbeddings",
+          "async": true,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "GenerateEmbeddingsOptions",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getEmbedding": {
+          "name": "getEmbedding",
+          "async": true,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "model",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<number[] | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "hasStaleEmbeddings": {
+          "name": "hasStaleEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<boolean>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "clearEmbeddings": {
+          "name": "clearEmbeddings",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getParent": {
+          "name": "getParent",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getChildren": {
+          "name": "getChildren",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getAncestors": {
+          "name": "getAncestors",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getDescendants": {
+          "name": "getDescendants",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getHierarchy": {
+          "name": "getHierarchy",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<HierarchyView>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "moveTo": {
+          "name": "moveTo",
+          "async": true,
+          "parameters": [
+            {
+              "name": "newParent",
+              "type": "string | null",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<void>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getMetadata": {
+          "name": "getMetadata",
+          "async": false,
+          "parameters": [],
+          "returnType": "TagMetadata",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "setMetadata": {
+          "name": "setMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "data",
+              "type": "TagMetadata",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "updateMetadata": {
+          "name": "updateMetadata",
+          "async": false,
+          "parameters": [
+            {
+              "name": "updates",
+              "type": "Partial<TagMetadata>",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "getBySlug": {
+          "name": "getBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_slug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "_context",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Tag | null>",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "getRootTags": {
+          "name": "getRootTags",
+          "async": true,
+          "parameters": [
+            {
+              "name": "_context",
+              "type": "string",
+              "optional": true,
+              "default": "global"
+            }
+          ],
+          "returnType": "Promise<Tag[]>",
+          "isStatic": true,
+          "isPublic": true
+        }
+      },
+      "decoratorConfig": {
+        "tableStrategy": "sti",
+        "api": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "mcp": {
+          "include": [
+            "list",
+            "get",
+            "create",
+            "update"
+          ]
+        },
+        "cli": true
+      },
+      "extends": "SmrtHierarchical",
+      "exportName": "Tag",
+      "collectionExportName": "TagCollection",
+      "validationRules": [
+        {
+          "field": "name",
+          "rule": "required",
+          "fieldType": "text"
+        }
+      ],
+      "schema": {
+        "tableName": "tags",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"tags\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSONB,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"parent_id\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"level\" INTEGER DEFAULT 0,\n  \"description\" TEXT DEFAULT '',\n  \"metadata\" TEXT DEFAULT '',\n  \"tenant_id\" TEXT\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "_meta_type": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "_meta_data": {
+            "type": "JSON",
+            "notNull": false
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "parent_id": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "name": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "level": {
+            "type": "INTEGER",
+            "notNull": false,
+            "default": 0
+          },
+          "description": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "metadata": {
+            "type": "TEXT",
+            "notNull": false,
+            "default": ""
+          },
+          "tenant_id": {
+            "type": "TEXT",
+            "notNull": false
+          }
+        },
+        "indexes": [
+          {
+            "name": "tags_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "tags_slug_context_meta_type_idx",
+            "columns": [
+              "slug",
+              "context",
+              "_meta_type"
+            ],
+            "unique": true
+          },
+          {
+            "name": "tags_meta_type_idx",
+            "columns": [
+              "_meta_type"
+            ]
+          }
+        ],
+        "version": "abdc0af6"
+      }
+    },
+    "@happyvertical/smrt-tags:TagCollection": {
       "name": "tagcollection",
       "className": "TagCollection",
+      "qualifiedName": "@happyvertical/smrt-tags:TagCollection",
       "collection": "tags",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/tags/src/tags.ts",
+      "filePath": "packages/tags/src/tags.ts",
+      "packageName": "@happyvertical/smrt-tags",
       "fields": {},
       "methods": {
         "getOrCreate": {
@@ -386,7 +1581,7 @@
             {
               "name": "context",
               "type": "string",
-              "optional": false,
+              "optional": true,
               "default": "global"
             }
           ],
@@ -405,7 +1600,7 @@
             },
             {
               "name": "parentSlug",
-              "type": "string",
+              "type": "string | null",
               "optional": true
             }
           ],
@@ -420,7 +1615,7 @@
             {
               "name": "context",
               "type": "string",
-              "optional": false,
+              "optional": true,
               "default": "global"
             }
           ],
@@ -436,6 +1631,11 @@
               "name": "parentSlug",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "context",
+              "type": "string",
+              "optional": true
             }
           ],
           "returnType": "Promise<Tag[]>",
@@ -450,6 +1650,11 @@
               "name": "slug",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "context",
+              "type": "string",
+              "optional": true
             }
           ],
           "returnType": "Promise<TagHierarchy>",
@@ -469,6 +1674,11 @@
               "name": "newParentSlug",
               "type": "string | null",
               "optional": false
+            },
+            {
+              "name": "context",
+              "type": "string",
+              "optional": true
             }
           ],
           "returnType": "Promise<void>",
@@ -488,6 +1698,11 @@
               "name": "toSlug",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "context",
+              "type": "string",
+              "optional": true
             }
           ],
           "returnType": "Promise<void>",
@@ -516,9 +1731,50 @@
               "name": "parentSlug",
               "type": "string | null",
               "optional": false
+            },
+            {
+              "name": "context",
+              "type": "string",
+              "optional": true
             }
           ],
           "returnType": "Promise<number>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findByTenant": {
+          "name": "findByTenant",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Tag[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findGlobal": {
+          "name": "findGlobal",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise<Tag[]>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findWithGlobals": {
+          "name": "findWithGlobals",
+          "async": true,
+          "parameters": [
+            {
+              "name": "tenantId",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Tag[]>",
           "isStatic": false,
           "isPublic": true
         }
@@ -530,10 +1786,10 @@
       "collectionExportName": "TagCollectionCollection",
       "schema": {
         "tableName": "tag_collections",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"tag_collections\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"tag_collections\" (\n  \"id\" uuid PRIMARY KEY,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
         "columns": {
           "id": {
-            "type": "TEXT",
+            "type": "UUID",
             "primaryKey": true,
             "notNull": true
           },
@@ -573,265 +1829,12 @@
             "unique": true
           }
         ],
-        "version": "5e1695ba"
-      }
-    },
-    "tag": {
-      "name": "tag",
-      "className": "Tag",
-      "collection": "tags",
-      "filePath": "/Users/will/Work/happyvertical/repos/smrt/packages/tags/src/tag.ts",
-      "fields": {
-        "name": {
-          "type": "text",
-          "required": true,
-          "_meta": {},
-          "default": ""
-        },
-        "parentId": {
-          "type": "text",
-          "required": false
-        },
-        "level": {
-          "type": "integer",
-          "required": false,
-          "default": 0
-        },
-        "description": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "metadata": {
-          "type": "text",
-          "required": false,
-          "default": ""
-        },
-        "createdAt": {
-          "type": "datetime",
-          "required": false
-        },
-        "updatedAt": {
-          "type": "datetime",
-          "required": false
-        }
-      },
-      "methods": {
-        "getMetadata": {
-          "name": "getMetadata",
-          "async": false,
-          "parameters": [],
-          "returnType": "TagMetadata",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "setMetadata": {
-          "name": "setMetadata",
-          "async": false,
-          "parameters": [
-            {
-              "name": "data",
-              "type": "TagMetadata",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "updateMetadata": {
-          "name": "updateMetadata",
-          "async": false,
-          "parameters": [
-            {
-              "name": "updates",
-              "type": "Partial<TagMetadata>",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getParent": {
-          "name": "getParent",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Tag | null>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getChildren": {
-          "name": "getChildren",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Tag[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getAncestors": {
-          "name": "getAncestors",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Tag[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getDescendants": {
-          "name": "getDescendants",
-          "async": true,
-          "parameters": [],
-          "returnType": "Promise<Tag[]>",
-          "isStatic": false,
-          "isPublic": true
-        },
-        "getBySlug": {
-          "name": "getBySlug",
-          "async": true,
-          "parameters": [
-            {
-              "name": "_slug",
-              "type": "string",
-              "optional": false
-            },
-            {
-              "name": "_context",
-              "type": "string",
-              "optional": true
-            }
-          ],
-          "returnType": "Promise<Tag | null>",
-          "isStatic": true,
-          "isPublic": true
-        },
-        "getRootTags": {
-          "name": "getRootTags",
-          "async": true,
-          "parameters": [
-            {
-              "name": "_context",
-              "type": "string",
-              "optional": false,
-              "default": "global"
-            }
-          ],
-          "returnType": "Promise<Tag[]>",
-          "isStatic": true,
-          "isPublic": true
-        }
-      },
-      "decoratorConfig": {
-        "tableStrategy": "sti",
-        "api": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update",
-            "delete"
-          ]
-        },
-        "mcp": {
-          "include": [
-            "list",
-            "get",
-            "create",
-            "update"
-          ]
-        },
-        "cli": true
-      },
-      "extends": "SmrtHierarchical",
-      "exportName": "Tag",
-      "collectionExportName": "TagCollection",
-      "schema": {
-        "tableName": "tags",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"tags\" (\n  \"id\" TEXT PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"name\" TEXT DEFAULT '',\n  \"parent_id\" TEXT,\n  \"level\" INTEGER DEFAULT 0,\n  \"description\" TEXT DEFAULT '',\n  \"metadata\" TEXT DEFAULT ''\n);",
-        "columns": {
-          "id": {
-            "type": "TEXT",
-            "primaryKey": true,
-            "notNull": true
-          },
-          "slug": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "context": {
-            "type": "TEXT",
-            "notNull": true,
-            "default": ""
-          },
-          "_meta_type": {
-            "type": "TEXT",
-            "notNull": true
-          },
-          "_meta_data": {
-            "type": "JSON",
-            "notNull": false
-          },
-          "created_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "updated_at": {
-            "type": "TIMESTAMP",
-            "notNull": true,
-            "default": "current_timestamp"
-          },
-          "name": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "parent_id": {
-            "type": "TEXT",
-            "notNull": false
-          },
-          "level": {
-            "type": "INTEGER",
-            "notNull": false,
-            "default": 0
-          },
-          "description": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          },
-          "metadata": {
-            "type": "TEXT",
-            "notNull": false,
-            "default": ""
-          }
-        },
-        "indexes": [
-          {
-            "name": "tags_id_idx",
-            "columns": [
-              "id"
-            ]
-          },
-          {
-            "name": "tags_slug_context_meta_type_idx",
-            "columns": [
-              "slug",
-              "context",
-              "_meta_type"
-            ],
-            "unique": true
-          },
-          {
-            "name": "tags_meta_type_idx",
-            "columns": [
-              "_meta_type"
-            ]
-          }
-        ],
-        "version": "08b141ec"
+        "version": "51787577"
       }
     }
   },
   "moduleType": "smrt",
-  "packageName": "@happyvertical/smrt-tags"
+  "smrtDependencies": [
+    "@happyvertical/smrt-core"
+  ]
 }

--- a/packages/vitest/src/setup.ts
+++ b/packages/vitest/src/setup.ts
@@ -132,7 +132,7 @@ function buildSchemaSqlBatches(
     detectEngine(url: string, type?: string): string;
     generateDDLForEngine(
       schema: any,
-      engine: 'sqlite' | 'duckdb' | 'postgres',
+      engine: 'sqlite' | 'duckdb' | 'json' | 'postgres',
     ): {
       createTable: string;
       indexes: string[];
@@ -148,11 +148,11 @@ function buildSchemaSqlBatches(
       : {};
   const engine =
     typeof db.exportTable === 'function'
-      ? 'duckdb'
+      ? 'json'
       : (smrtCore.detectEngine(
           dbConfig.url || db.url || ':memory:',
           dbConfig.type,
-        ) as 'sqlite' | 'duckdb' | 'postgres');
+        ) as 'sqlite' | 'duckdb' | 'json' | 'postgres');
 
   return Object.values(
     smrtCore.ObjectRegistry.getAllSchemasAsDefinitions(),
@@ -161,7 +161,7 @@ function buildSchemaSqlBatches(
     return [
       ddl.createTable,
       ...ddl.indexes,
-      ...(engine === 'duckdb' ? [] : ddl.triggers),
+      ...(engine === 'duckdb' || engine === 'json' ? [] : ddl.triggers),
     ]
       .filter(Boolean)
       .map(normalizeSchemaStatement)


### PR DESCRIPTION
## Summary
- Default generated SMRT ids and relationship id columns to UUID, with an `idType` text opt-out for intentional non-UUID primary keys.
- Reconcile same-package foreign keys to the target model id type while keeping cross-package refs as UUID id columns without FK constraints.
- Add a JSON adapter DDL strategy that keeps DuckDB inline constraints but stores UUID columns as TEXT for stable JS round-tripping.
- Regenerate committed package manifests with UUID-aware DDL and normalized source paths.

## Validation
- `pnpm --filter @happyvertical/smrt-core build`
- focused Vitest UUID/schema/scanner suite
- targeted JSON UUID regression suite
- `pnpm --filter @happyvertical/smrt-core test`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm test`
- `git diff --check`
