### PR TITLE
feat(core): generate child accessors for @oneToMany relationships (R10)

### DIFF
--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -67,6 +67,15 @@ Registration sets `SMRT_TABLE_NAME` static property (survives minification).
 | CLI | `src/generators/cli.ts` | Commander commands with auto-help |
 | MCP Server | `src/generators/mcp.ts` | Model Context Protocol tools |
 
+## Child Accessors (R10)
+
+`src/child-accessors.ts` installs a consistent `get<FieldName>()` instance method for every `@oneToMany` field at `@smrt()` registration time (e.g. `@oneToMany('OrderItem') items` → `order.getItems()`), delegating to `loadRelatedMany`. Two invariants:
+
+- **Additive** — never overwrites a hand-rolled method of the same name (checks the whole prototype chain). `Profile.getMetadata()` (key-value) and `ProfileRelationship.getTerms()` are preserved.
+- **Runtime-only** — attached to the prototype, invisible to the build-time manifest, so it never leaks into the REST/CLI/MCP surface.
+
+When the target declares multiple FKs back to the parent, annotate `@oneToMany(Target, { foreignKey: '<inverseField>' })`; `loadRelatedMany` and the eager `include:` loader both honor it (else first-match).
+
 ## Vite Plugin
 
 ```typescript

--- a/packages/core/src/__tests__/child-accessors.test.ts
+++ b/packages/core/src/__tests__/child-accessors.test.ts
@@ -16,6 +16,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   childAccessorName,
   foreignKey,
+  ObjectRegistry,
   oneToMany,
   SmrtObject,
   smrt,
@@ -133,6 +134,32 @@ class R10StiChild extends SmrtObject {
     super(options);
     if (options.baseId) this.baseId = options.baseId;
     if (options.title) this.title = options.title;
+  }
+}
+
+// --- Invalid explicit { foreignKey } must fail in both loaders -------------
+
+@smrt()
+class R10BadFkChild extends SmrtObject {
+  @foreignKey('R10BadFkParent')
+  parentId: string = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.parentId) this.parentId = options.parentId;
+  }
+}
+
+@smrt()
+class R10BadFkParent extends SmrtObject {
+  name: string = '';
+
+  @oneToMany('R10BadFkChild', { foreignKey: 'doesNotExist' })
+  kids: any[] = [];
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name) this.name = options.name;
   }
 }
 
@@ -260,5 +287,28 @@ describe('R10: generated @oneToMany child accessors', () => {
 
     expect(asLeft.map((e) => e.label)).toEqual(['L']);
     expect(asRight.map((e) => e.label)).toEqual(['R']);
+  });
+
+  it('fails the same way in both loaders for an invalid explicit foreignKey', async () => {
+    const parent = new R10BadFkParent({ name: 'Bad', db });
+    await parent.initialize();
+    await parent.save();
+    // A child row so the table exists and eager loading has something to scan.
+    const child = new R10BadFkChild({ parentId: parent.id, db });
+    await child.initialize();
+    await child.save();
+
+    // Lazy path (generated accessor → loadRelatedMany).
+    await expect((parent as any).getKids()).rejects.toThrow(
+      /foreignKey 'doesNotExist'/,
+    );
+
+    // Eager path (include: ['kids'] → batchLoadOneToMany) must fail the same way.
+    const collection = await ObjectRegistry.getCollection('R10BadFkParent', {
+      db,
+    });
+    await expect(collection.list({ include: ['kids'] })).rejects.toThrow(
+      /foreignKey 'doesNotExist'/,
+    );
   });
 });

--- a/packages/core/src/__tests__/child-accessors.test.ts
+++ b/packages/core/src/__tests__/child-accessors.test.ts
@@ -102,6 +102,40 @@ class R10Pair extends SmrtObject {
   }
 }
 
+// --- STI: a child class inherits the base's generated @oneToMany accessor ---
+
+@smrt({ tableStrategy: 'sti' })
+class R10StiBase extends SmrtObject {
+  name: string = '';
+
+  @oneToMany('R10StiChild')
+  kids: any[] = [];
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name) this.name = options.name;
+  }
+}
+
+@smrt()
+class R10StiLeaf extends R10StiBase {
+  extra: string = '';
+}
+
+@smrt()
+class R10StiChild extends SmrtObject {
+  @foreignKey('R10StiBase')
+  baseId: string = '';
+
+  title: string = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.baseId) this.baseId = options.baseId;
+    if (options.title) this.title = options.title;
+  }
+}
+
 describe('R10: childAccessorName', () => {
   it('derives getX() from the field name', () => {
     expect(childAccessorName('items')).toBe('getItems');
@@ -174,6 +208,22 @@ describe('R10: generated @oneToMany child accessors', () => {
     await parent.initialize();
     const result = await (parent as any).getItems();
     expect(result).toEqual(['hand-rolled-sentinel']);
+  });
+
+  it('inherited accessor resolves children when called on an STI child', async () => {
+    const leaf = new R10StiLeaf({ name: 'Leaf', db });
+    await leaf.initialize();
+    await leaf.save();
+
+    for (const title of ['x', 'y']) {
+      const child = new R10StiChild({ baseId: leaf.id, title, db });
+      await child.initialize();
+      await child.save();
+    }
+
+    // getKids() is generated on R10StiBase.prototype and inherited by the leaf.
+    const kids = (await (leaf as any).getKids()) as R10StiChild[];
+    expect(kids.map((k) => k.title).sort()).toEqual(['x', 'y']);
   });
 
   it('disambiguates multiple FKs via explicit { foreignKey }', async () => {

--- a/packages/core/src/__tests__/child-accessors.test.ts
+++ b/packages/core/src/__tests__/child-accessors.test.ts
@@ -163,6 +163,44 @@ class R10BadFkParent extends SmrtObject {
   }
 }
 
+// --- Target with FKs to multiple hierarchy levels: prefer exact-self --------
+
+@smrt({ tableStrategy: 'sti' })
+class R10MultiBase extends SmrtObject {
+  name: string = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name) this.name = options.name;
+  }
+}
+
+@smrt()
+class R10MultiLeaf extends R10MultiBase {
+  // oneToMany declared on the leaf; the child declares FKs to BOTH levels.
+  @oneToMany('R10MultiChild')
+  items: any[] = [];
+}
+
+@smrt()
+class R10MultiChild extends SmrtObject {
+  // baseRef is declared first, so a naive first-match would pick it.
+  @foreignKey('R10MultiBase')
+  baseRef: string = '';
+
+  @foreignKey('R10MultiLeaf')
+  leafRef: string = '';
+
+  tag: string = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.baseRef) this.baseRef = options.baseRef;
+    if (options.leafRef) this.leafRef = options.leafRef;
+    if (options.tag) this.tag = options.tag;
+  }
+}
+
 describe('R10: childAccessorName', () => {
   it('derives getX() from the field name', () => {
     expect(childAccessorName('items')).toBe('getItems');
@@ -310,5 +348,34 @@ describe('R10: generated @oneToMany child accessors', () => {
     await expect(collection.list({ include: ['kids'] })).rejects.toThrow(
       /foreignKey 'doesNotExist'/,
     );
+  });
+
+  it('prefers the exact-self FK over an ancestor FK when both exist', async () => {
+    const leaf = new R10MultiLeaf({ name: 'Leaf', db });
+    await leaf.initialize();
+    await leaf.save();
+
+    // Points at the leaf via the leaf-targeting FK (exact self).
+    const viaLeaf = new R10MultiChild({
+      leafRef: leaf.id,
+      baseRef: 'unrelated',
+      tag: 'viaLeaf',
+      db,
+    });
+    await viaLeaf.initialize();
+    await viaLeaf.save();
+
+    // Points at the leaf via the base-targeting FK (ancestor) — must be ignored.
+    const viaBase = new R10MultiChild({
+      baseRef: leaf.id,
+      leafRef: 'unrelated',
+      tag: 'viaBase',
+      db,
+    });
+    await viaBase.initialize();
+    await viaBase.save();
+
+    const items = (await (leaf as any).getItems()) as R10MultiChild[];
+    expect(items.map((c) => c.tag)).toEqual(['viaLeaf']);
   });
 });

--- a/packages/core/src/__tests__/child-accessors.test.ts
+++ b/packages/core/src/__tests__/child-accessors.test.ts
@@ -1,0 +1,214 @@
+/**
+ * R10 — generated child accessors for `@oneToMany` relationships.
+ *
+ * Verifies that the `@smrt()` decorator installs a consistent `getX()` instance
+ * method for every `@oneToMany` field (delegating to `loadRelatedMany`), that
+ * the generation is purely additive (never shadows a hand-rolled accessor), and
+ * that an explicit `{ foreignKey }` disambiguates a target with multiple FKs
+ * back to the parent.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  childAccessorName,
+  foreignKey,
+  oneToMany,
+  SmrtObject,
+  smrt,
+} from '../index';
+import { getTestDatabase } from '../testing/database';
+
+// --- Basic one-to-many ------------------------------------------------------
+
+@smrt()
+class R10Child extends SmrtObject {
+  @foreignKey('R10Parent')
+  r10ParentId: string = '';
+
+  title: string = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.r10ParentId) this.r10ParentId = options.r10ParentId;
+    if (options.title) this.title = options.title;
+  }
+}
+
+@smrt()
+class R10Parent extends SmrtObject {
+  name: string = '';
+
+  @oneToMany('R10Child')
+  items: any[] = [];
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name) this.name = options.name;
+  }
+}
+
+// --- Hand-rolled accessor must be preserved (additive only) -----------------
+
+@smrt()
+class R10CustomParent extends SmrtObject {
+  name: string = '';
+
+  @oneToMany('R10Child')
+  items: any[] = [];
+
+  // Pre-existing hand-rolled accessor — generation must NOT overwrite it.
+  async getItems(): Promise<string[]> {
+    return ['hand-rolled-sentinel'];
+  }
+}
+
+// --- Multiple FKs back to the same parent (explicit foreignKey) -------------
+
+@smrt()
+class R10Edge extends SmrtObject {
+  @foreignKey('R10Pair')
+  leftId: string = '';
+
+  @foreignKey('R10Pair')
+  rightId: string = '';
+
+  label: string = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.leftId) this.leftId = options.leftId;
+    if (options.rightId) this.rightId = options.rightId;
+    if (options.label) this.label = options.label;
+  }
+}
+
+@smrt()
+class R10Pair extends SmrtObject {
+  name: string = '';
+
+  @oneToMany('R10Edge', { foreignKey: 'leftId' })
+  asLeft: any[] = [];
+
+  @oneToMany('R10Edge', { foreignKey: 'rightId' })
+  asRight: any[] = [];
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name) this.name = options.name;
+  }
+}
+
+describe('R10: childAccessorName', () => {
+  it('derives getX() from the field name', () => {
+    expect(childAccessorName('items')).toBe('getItems');
+    expect(childAccessorName('terms')).toBe('getTerms');
+    expect(childAccessorName('relationshipsFrom')).toBe('getRelationshipsFrom');
+  });
+});
+
+describe('R10: generated @oneToMany child accessors', () => {
+  let db: DatabaseInterface;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    dbPath = join(tmpdir(), `test-r10-${randomUUID().slice(0, 8)}.db`);
+    db = await getTestDatabase({ type: 'sqlite', url: dbPath });
+  });
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') {
+      await db.close();
+    }
+  });
+
+  it('installs a non-enumerable getX() method on the prototype', () => {
+    expect(typeof (R10Parent.prototype as any).getItems).toBe('function');
+    const descriptor = Object.getOwnPropertyDescriptor(
+      R10Parent.prototype,
+      'getItems',
+    );
+    expect(descriptor?.enumerable).toBe(false);
+  });
+
+  it('does not leak the accessor into instance enumeration', async () => {
+    const parent = new R10Parent({ name: 'Enumerable?', db });
+    await parent.initialize();
+    expect(Object.keys(parent)).not.toContain('getItems');
+  });
+
+  it('loads the related children through the generated accessor', async () => {
+    const parent = new R10Parent({ name: 'Has children', db });
+    await parent.initialize();
+    await parent.save();
+
+    const other = new R10Parent({ name: 'Other', db });
+    await other.initialize();
+    await other.save();
+
+    for (const title of ['a', 'b']) {
+      const child = new R10Child({ r10ParentId: parent.id, title, db });
+      await child.initialize();
+      await child.save();
+    }
+    const stray = new R10Child({ r10ParentId: other.id, title: 'c', db });
+    await stray.initialize();
+    await stray.save();
+
+    const items = (await (parent as any).getItems()) as R10Child[];
+    expect(items).toHaveLength(2);
+    expect(items.map((c) => c.title).sort()).toEqual(['a', 'b']);
+
+    // Delegates to the same resolver as loadRelatedMany.
+    const viaLoader = (await parent.loadRelatedMany('items')) as R10Child[];
+    expect(viaLoader.map((c) => c.id).sort()).toEqual(
+      items.map((c) => c.id).sort(),
+    );
+  });
+
+  it('preserves a hand-rolled accessor of the same name (additive only)', async () => {
+    const parent = new R10CustomParent({ name: 'Custom', db });
+    await parent.initialize();
+    const result = await (parent as any).getItems();
+    expect(result).toEqual(['hand-rolled-sentinel']);
+  });
+
+  it('disambiguates multiple FKs via explicit { foreignKey }', async () => {
+    const pair = new R10Pair({ name: 'Node', db });
+    await pair.initialize();
+    await pair.save();
+
+    const partner = new R10Pair({ name: 'Partner', db });
+    await partner.initialize();
+    await partner.save();
+
+    // Edge where `pair` is on the left side.
+    const leftEdge = new R10Edge({
+      leftId: pair.id,
+      rightId: partner.id,
+      label: 'L',
+      db,
+    });
+    await leftEdge.initialize();
+    await leftEdge.save();
+
+    // Edge where `pair` is on the right side.
+    const rightEdge = new R10Edge({
+      leftId: partner.id,
+      rightId: pair.id,
+      label: 'R',
+      db,
+    });
+    await rightEdge.initialize();
+    await rightEdge.save();
+
+    const asLeft = (await (pair as any).getAsLeft()) as R10Edge[];
+    const asRight = (await (pair as any).getAsRight()) as R10Edge[];
+
+    expect(asLeft.map((e) => e.label)).toEqual(['L']);
+    expect(asRight.map((e) => e.label)).toEqual(['R']);
+  });
+});

--- a/packages/core/src/child-accessors.ts
+++ b/packages/core/src/child-accessors.ts
@@ -27,7 +27,14 @@
  * back to the parent (e.g. `ProfileRelationship.fromProfileId` /
  * `toProfileId`), annotate the `@oneToMany` with `{ foreignKey: 'fromProfileId' }`
  * so `loadRelatedMany` resolves the correct inverse side. Without it the
- * resolver falls back to the first matching foreign key (legacy behavior).
+ * resolver falls back to the first matching foreign key (legacy behavior). An
+ * explicit `foreignKey` that matches no inverse FK is treated as an error.
+ *
+ * STI note: a child class inherits the base's generated accessor through the
+ * prototype chain. `loadRelatedMany` resolves the inverse FK against the
+ * instance's class AND its registered ancestors (see
+ * `ObjectRegistry.getInverseRelationshipsForSelf`), so calling the accessor on
+ * an STI subclass instance resolves a `@oneToMany` declared on its base.
  */
 
 import type { RelationshipMetadata } from './registry/types';

--- a/packages/core/src/child-accessors.ts
+++ b/packages/core/src/child-accessors.ts
@@ -1,0 +1,99 @@
+/**
+ * R10 — consolidated child-accessor API for `@oneToMany` relationships.
+ *
+ * Before R10 every model hand-rolled its own child accessor (`getTerms`,
+ * `getChildren`, `getForProfile`, …) with inconsistent names and shapes. This
+ * module installs ONE canonical accessor per `@oneToMany` field at class
+ * registration time: a `@oneToMany('Child') items` field gains a `getItems()`
+ * instance method that delegates to the existing `loadRelatedMany('items')`
+ * resolver — the same code path used for lazy loading and `include:` eager
+ * loading, which itself queries through the child collection (the queryable
+ * primitive).
+ *
+ * Two invariants make this safe to apply to every registered class:
+ *
+ * - **Additive.** If a method of the computed name already exists anywhere on
+ *   the prototype chain — a hand-rolled accessor like
+ *   `ProfileRelationship.getTerms()`, a differently-shaped `Profile.getMetadata()`,
+ *   or a `SmrtObject` base method — it is left untouched. The generated
+ *   accessor never renames or shadows an existing public signature.
+ * - **Runtime-only.** Accessors are attached to the prototype at registration;
+ *   they are invisible to the build-time manifest, so they never leak into the
+ *   generated REST/CLI/MCP surface (those read `classInfo.tools`/scanned
+ *   methods, not the runtime prototype). They are a developer-ergonomics
+ *   convenience layered on top of `loadRelatedMany`.
+ *
+ * Multiplicity note: when the child class declares more than one foreign key
+ * back to the parent (e.g. `ProfileRelationship.fromProfileId` /
+ * `toProfileId`), annotate the `@oneToMany` with `{ foreignKey: 'fromProfileId' }`
+ * so `loadRelatedMany` resolves the correct inverse side. Without it the
+ * resolver falls back to the first matching foreign key (legacy behavior).
+ */
+
+import type { RelationshipMetadata } from './registry/types';
+
+/**
+ * Compute the canonical child-accessor method name for a `@oneToMany` field.
+ *
+ * `terms` → `getTerms`, `relationshipsFrom` → `getRelationshipsFrom`. Exported
+ * so tests and tooling can derive the name without re-implementing the rule.
+ *
+ * @param fieldName - The `@oneToMany` property name on the parent class
+ * @returns The generated accessor method name
+ */
+export function childAccessorName(fieldName: string): string {
+  return `get${fieldName.charAt(0).toUpperCase()}${fieldName.slice(1)}`;
+}
+
+/**
+ * Install generated child accessors for a class's `@oneToMany` relationships.
+ *
+ * Called from the `@smrt()` decorator immediately after the class is
+ * registered, so `relationships` reflects the class's own (decorator- or
+ * manifest-derived) relationship metadata. Non-`oneToMany` entries are ignored,
+ * so callers may pass the unfiltered relationship list.
+ *
+ * @param ctor - The registered class constructor (its prototype is augmented)
+ * @param relationships - Relationship metadata for the class (from
+ *   `ObjectRegistry.getRelationships`)
+ */
+export function applyOneToManyChildAccessors(
+  ctor: { prototype?: any } | undefined,
+  relationships: RelationshipMetadata[] | undefined,
+): void {
+  const prototype = ctor?.prototype;
+  if (!prototype || !relationships) {
+    return;
+  }
+
+  for (const relationship of relationships) {
+    if (relationship.type !== 'oneToMany') {
+      continue;
+    }
+
+    const fieldName = relationship.fieldName;
+    if (!fieldName) {
+      continue;
+    }
+
+    const accessorName = childAccessorName(fieldName);
+
+    // Additive only: never shadow a hand-rolled accessor (or any inherited
+    // method, including SmrtObject base methods) of the same name. `in`
+    // walks the full prototype chain.
+    if (accessorName in prototype) {
+      continue;
+    }
+
+    Object.defineProperty(prototype, accessorName, {
+      value: function generatedChildAccessor(this: {
+        loadRelatedMany(field: string): Promise<any[]>;
+      }): Promise<any[]> {
+        return this.loadRelatedMany(fieldName);
+      },
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  }
+}

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -1166,27 +1166,33 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     fieldName: string,
     relationship: import('./registry').RelationshipMetadata,
   ): Promise<void> {
-    // Find the inverse foreignKey field
-    const inverseRelationships = ObjectRegistry.getInverseRelationships(
+    // Find the inverse foreignKey field. An instance can satisfy an inverse FK
+    // that targets its own class or any (STI) ancestor it inherits the
+    // oneToMany from. Mirrors loadRelatedMany so lazy and eager (`include:`)
+    // loading resolve the same inverse side.
+    const inverseRelationships = ObjectRegistry.getInverseRelationshipsForSelf(
       this._itemClass.name,
     );
     const inverseCandidates = inverseRelationships.filter(
       (r) =>
-        r.sourceClass === relationship.targetClass &&
-        r.type === 'foreignKey' &&
-        r.targetClass === this._itemClass.name,
+        r.sourceClass === relationship.targetClass && r.type === 'foreignKey',
     );
     // Honor an explicit `@oneToMany(Target, { foreignKey })` when the target
     // declares multiple foreign keys back to this class; otherwise fall back
-    // to the first match (legacy behavior). Mirrors loadRelatedMany so lazy
-    // and eager (`include:`) loading resolve the same inverse side.
+    // to the first match (legacy behavior).
     const explicitForeignKey = relationship.options?.foreignKey as
       | string
       | undefined;
-    const inverseForeignKey =
-      (explicitForeignKey &&
-        inverseCandidates.find((r) => r.fieldName === explicitForeignKey)) ||
-      inverseCandidates[0];
+    const matchedForeignKey = explicitForeignKey
+      ? inverseCandidates.find((r) => r.fieldName === explicitForeignKey)
+      : undefined;
+    if (explicitForeignKey && !matchedForeignKey) {
+      console.warn(
+        `oneToMany ${fieldName}: foreignKey '${explicitForeignKey}' not found on ${relationship.targetClass}; skipping eager load`,
+      );
+      return;
+    }
+    const inverseForeignKey = matchedForeignKey ?? inverseCandidates[0];
 
     if (!inverseForeignKey) {
       console.warn(

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -1195,7 +1195,12 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
         `oneToMany ${fieldName} specifies foreignKey '${explicitForeignKey}', but ${relationship.targetClass} has no matching inverse foreignKey. Candidates: ${inverseCandidates.map((r) => r.fieldName).join(', ') || '(none)'}`,
       );
     }
-    const inverseForeignKey = matchedForeignKey ?? inverseCandidates[0];
+    // Prefer an inverse FK that targets this exact class before falling back
+    // to an ancestor's (mirrors loadRelatedMany).
+    const inverseForeignKey =
+      matchedForeignKey ??
+      inverseCandidates.find((r) => r.targetClass === this._itemClass.name) ??
+      inverseCandidates[0];
 
     if (!inverseForeignKey) {
       console.warn(

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -1170,12 +1170,23 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     const inverseRelationships = ObjectRegistry.getInverseRelationships(
       this._itemClass.name,
     );
-    const inverseForeignKey = inverseRelationships.find(
+    const inverseCandidates = inverseRelationships.filter(
       (r) =>
         r.sourceClass === relationship.targetClass &&
         r.type === 'foreignKey' &&
         r.targetClass === this._itemClass.name,
     );
+    // Honor an explicit `@oneToMany(Target, { foreignKey })` when the target
+    // declares multiple foreign keys back to this class; otherwise fall back
+    // to the first match (legacy behavior). Mirrors loadRelatedMany so lazy
+    // and eager (`include:`) loading resolve the same inverse side.
+    const explicitForeignKey = relationship.options?.foreignKey as
+      | string
+      | undefined;
+    const inverseForeignKey =
+      (explicitForeignKey &&
+        inverseCandidates.find((r) => r.fieldName === explicitForeignKey)) ||
+      inverseCandidates[0];
 
     if (!inverseForeignKey) {
       console.warn(

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -1187,10 +1187,13 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       ? inverseCandidates.find((r) => r.fieldName === explicitForeignKey)
       : undefined;
     if (explicitForeignKey && !matchedForeignKey) {
-      console.warn(
-        `oneToMany ${fieldName}: foreignKey '${explicitForeignKey}' not found on ${relationship.targetClass}; skipping eager load`,
+      // A misspelled / stale `foreignKey` is a configuration error, not a
+      // recoverable data condition — fail loudly here too so eager (`include:`)
+      // loading behaves identically to lazy loadRelatedMany rather than
+      // silently producing empty arrays.
+      throw new Error(
+        `oneToMany ${fieldName} specifies foreignKey '${explicitForeignKey}', but ${relationship.targetClass} has no matching inverse foreignKey. Candidates: ${inverseCandidates.map((r) => r.fieldName).join(', ') || '(none)'}`,
       );
-      return;
     }
     const inverseForeignKey = matchedForeignKey ?? inverseCandidates[0];
 

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -343,8 +343,19 @@ export function crossPackageRef(
  * The inverse side (`@foreignKey`) must exist on the `relatedClass` pointing back to this
  * class. The framework discovers it automatically via `ObjectRegistry.getInverseRelationships()`.
  *
+ * **Generated accessor (R10):** registering the class installs a consistent
+ * `get<FieldName>()` instance method (e.g. `items` → `order.getItems()`) that
+ * delegates to `loadRelatedMany('items')`. Generation is additive — a
+ * hand-rolled method of the same name is never overwritten.
+ *
+ * **Disambiguation:** when `relatedClass` declares more than one `@foreignKey`
+ * back to this class, pass `{ foreignKey: '<inverseFieldName>' }` so both
+ * `loadRelatedMany` and the generated accessor resolve the intended inverse
+ * side. Without it the first matching foreign key is used.
+ *
  * @param relatedClass - The class constructor of the child/related objects
- * @param options - Optional relationship options (foreign key override, etc.)
+ * @param options - Optional relationship options. `foreignKey` selects the
+ *   inverse foreign-key field on `relatedClass` when it has more than one.
  * @returns A TypeScript property decorator (sets `transient: true` automatically)
  *
  * @example
@@ -359,6 +370,21 @@ export function crossPackageRef(
  * class OrderItem extends SmrtObject {
  *   @foreignKey(Order)
  *   orderId: string = '';
+ * }
+ *
+ * const order = await orders.get({ id });
+ * const items = await order.getItems(); // generated; === loadRelatedMany('items')
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Multiple inverse foreign keys → disambiguate explicitly.
+ * @smrt()
+ * class Profile extends SmrtObject {
+ *   @oneToMany(ProfileRelationship, { foreignKey: 'fromProfileId' })
+ *   relationshipsFrom: ProfileRelationship[] = [];
+ *   @oneToMany(ProfileRelationship, { foreignKey: 'toProfileId' })
+ *   relationshipsTo: ProfileRelationship[] = [];
  * }
  * ```
  *

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,11 @@
 
 // Built-in signal adapters
 export * from './adapters/index';
+// R10: generated child accessors for @oneToMany relationships
+export {
+  applyOneToManyChildAccessors,
+  childAccessorName,
+} from './child-accessors';
 // Core SMRT framework
 export * from './class';
 export * from './collection';

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -2108,12 +2108,23 @@ export class SmrtObject extends SmrtClass {
       const inverseRelationships = ObjectRegistry.getInverseRelationships(
         this.constructor.name,
       );
-      const inverseForeignKey = inverseRelationships.find(
+      const inverseCandidates = inverseRelationships.filter(
         (r) =>
           r.sourceClass === relationship.targetClass &&
           r.type === 'foreignKey' &&
           r.targetClass === this.constructor.name,
       );
+      // When the target declares multiple foreign keys back to this class
+      // (e.g. ProfileRelationship.fromProfileId / toProfileId), honor an
+      // explicit `@oneToMany(Target, { foreignKey })` to pick the right side.
+      // Otherwise fall back to the first match (legacy behavior).
+      const explicitForeignKey = relationship.options?.foreignKey as
+        | string
+        | undefined;
+      const inverseForeignKey =
+        (explicitForeignKey &&
+          inverseCandidates.find((r) => r.fieldName === explicitForeignKey)) ||
+        inverseCandidates[0];
 
       if (!inverseForeignKey) {
         throw RuntimeError.invalidState(

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -2137,7 +2137,15 @@ export class SmrtObject extends SmrtClass {
           },
         );
       }
-      const inverseForeignKey = matchedForeignKey ?? inverseCandidates[0];
+      // Prefer an inverse FK that targets this exact class before falling back
+      // to one inherited from an (STI) ancestor — preserves the pre-fallback
+      // selection when a target declares FKs to multiple levels of the chain.
+      const inverseForeignKey =
+        matchedForeignKey ??
+        inverseCandidates.find(
+          (r) => r.targetClass === this.constructor.name,
+        ) ??
+        inverseCandidates[0];
 
       if (!inverseForeignKey) {
         throw RuntimeError.invalidState(

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -2104,15 +2104,16 @@ export class SmrtObject extends SmrtClass {
     }
 
     if (relationship.type === 'oneToMany') {
-      // Find the inverse foreignKey field on the target class
-      const inverseRelationships = ObjectRegistry.getInverseRelationships(
-        this.constructor.name,
-      );
+      // Find the inverse foreignKey field on the target class. An instance can
+      // satisfy an inverse FK that targets its own class OR any (STI) ancestor
+      // it inherits the oneToMany from — the FK is declared against the base
+      // class name, while `this.constructor.name` may be a subclass (e.g. a
+      // Person inheriting Profile.relationshipsFrom).
+      const inverseRelationships =
+        ObjectRegistry.getInverseRelationshipsForSelf(this.constructor.name);
       const inverseCandidates = inverseRelationships.filter(
         (r) =>
-          r.sourceClass === relationship.targetClass &&
-          r.type === 'foreignKey' &&
-          r.targetClass === this.constructor.name,
+          r.sourceClass === relationship.targetClass && r.type === 'foreignKey',
       );
       // When the target declares multiple foreign keys back to this class
       // (e.g. ProfileRelationship.fromProfileId / toProfileId), honor an
@@ -2121,10 +2122,22 @@ export class SmrtObject extends SmrtClass {
       const explicitForeignKey = relationship.options?.foreignKey as
         | string
         | undefined;
-      const inverseForeignKey =
-        (explicitForeignKey &&
-          inverseCandidates.find((r) => r.fieldName === explicitForeignKey)) ||
-        inverseCandidates[0];
+      const matchedForeignKey = explicitForeignKey
+        ? inverseCandidates.find((r) => r.fieldName === explicitForeignKey)
+        : undefined;
+      if (explicitForeignKey && !matchedForeignKey) {
+        // A misspelled / stale `foreignKey` must fail loudly rather than
+        // silently resolving the wrong inverse side.
+        throw RuntimeError.invalidState(
+          `oneToMany ${fieldName} on ${this.constructor.name} specifies foreignKey '${explicitForeignKey}', but ${relationship.targetClass} has no matching inverse foreignKey. Candidates: ${inverseCandidates.map((r) => r.fieldName).join(', ') || '(none)'}`,
+          {
+            fieldName,
+            targetClass: relationship.targetClass,
+            foreignKey: explicitForeignKey,
+          },
+        );
+      }
+      const inverseForeignKey = matchedForeignKey ?? inverseCandidates[0];
 
       if (!inverseForeignKey) {
         throw RuntimeError.invalidState(

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -28,6 +28,7 @@
  * ```
  */
 
+import { applyOneToManyChildAccessors } from './child-accessors';
 import { SmrtCollection } from './collection';
 import { applyPendingDecoratorRegistrations } from './decorators/compatibility.js';
 import type {
@@ -3276,6 +3277,15 @@ export function smrt(config: SmartObjectConfig = {}) {
       }
 
       ObjectRegistry.register(ctor as any, { ...config, tableName });
+
+      // R10: install a consistent `getX()` child accessor for every
+      // `@oneToMany` field, delegating to `loadRelatedMany`. Runs after
+      // registration so the relationship metadata is populated. Additive —
+      // never overrides a hand-rolled accessor of the same name.
+      applyOneToManyChildAccessors(
+        ctor as any,
+        ObjectRegistry.getRelationships(ctor.name),
+      );
     }
 
     return ctor;

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -2580,6 +2580,59 @@ export class ObjectRegistry {
   }
 
   /**
+   * Names by which an instance of `className` can be referenced by an inverse
+   * foreign key: its own (simple) class name plus every registered ancestor in
+   * its inheritance chain.
+   *
+   * Used by oneToMany resolution so an STI subclass can resolve a relationship
+   * declared on its base — the inverse `@foreignKey` is declared against the
+   * base class name, while the runtime instance may be a subclass.
+   *
+   * @param className - Simple or qualified class name
+   * @returns Set of names (simple and, where available, qualified) the
+   *   instance is assignable to
+   */
+  static getSelfReferableNames(className: string): Set<string> {
+    const names = new Set<string>([className]);
+    for (const ancestor of ObjectRegistry.getInheritanceChain(className)) {
+      names.add(ancestor);
+      const simple = ObjectRegistry.getClass(ancestor)?.name;
+      if (simple) {
+        names.add(simple);
+      }
+    }
+    return names;
+  }
+
+  /**
+   * Inverse relationships targeting `className` OR any (STI) ancestor it
+   * inherits from.
+   *
+   * `getInverseRelationships` matches the target class name exactly. This
+   * variant also matches inverse foreign keys declared against an ancestor,
+   * so an STI subclass instance can resolve a `@oneToMany` declared on its
+   * base — whose inverse `@foreignKey` points at the base class name.
+   *
+   * @param className - Name of the class to find inverse relationships for
+   * @returns Relationship metadata whose target is the class or one of its
+   *   registered ancestors
+   */
+  static getInverseRelationshipsForSelf(
+    className: string,
+  ): RelationshipMetadata[] {
+    const names = ObjectRegistry.getSelfReferableNames(className);
+    const result: RelationshipMetadata[] = [];
+    for (const [, relationships] of ObjectRegistry.getRelationshipMap()) {
+      for (const rel of relationships) {
+        if (names.has(rel.targetClass)) {
+          result.push(rel);
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
    * Get table inheritance strategy for a class
    *
    * Returns the table strategy (CTI or STI) for a class, with automatic

--- a/packages/profiles/CLAUDE.md
+++ b/packages/profiles/CLAUDE.md
@@ -32,6 +32,7 @@ Auth helpers in `src/auth/` build profiles from external identity claims:
 - `Profile.getAssets()` / `addAsset()` / `removeAsset()` and the matching `ProfileCollection` wrappers — canonical owned asset helpers backed by `profile_assets`.
 - `Profile.addMetadata(metafieldSlug, value)` / `Profile.getMetadata()` — validates against metafield schema. `ProfileCollection.batchGetMetadata()` / `batchUpdateMetadata()` for bulk reads/writes.
 - `Profile.getRelationships({ direction: 'from'|'to'|'all' })` — direction matters.
+- `Profile.getRelationshipsFrom()` / `getRelationshipsTo()` — R10-generated `@oneToMany` accessors. ProfileRelationship has two FKs back to Profile, so each `@oneToMany` annotates its inverse explicitly (`{ foreignKey: 'fromProfileId' }` / `'toProfileId'`). Return raw `ProfileRelationship[]`; use `getRelationships()` for slug/direction filtering.
 - AI: `generateBio()` (uses `smrtProfiles.profile.generateBio` prompt via `@happyvertical/smrt-prompts`), `matches(criteria)` (delegates to `is()`).
 
 ## Prompt Registry

--- a/packages/profiles/src/__tests__/child-accessors.test.ts
+++ b/packages/profiles/src/__tests__/child-accessors.test.ts
@@ -1,0 +1,106 @@
+/**
+ * R10 — generated `@oneToMany` child accessors on real profile models.
+ *
+ * Profile declares `relationshipsFrom` / `relationshipsTo` as two oneToMany
+ * relations to ProfileRelationship, which carries multiple foreign keys back
+ * to Profile (fromProfileId / toProfileId). This verifies the generated
+ * `getRelationshipsFrom()` / `getRelationshipsTo()` accessors resolve the
+ * correct inverse side, and that pre-existing hand-rolled accessors
+ * (`Profile.getMetadata`, `ProfileRelationship.getTerms`) are preserved.
+ */
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  ProfileCollection,
+  ProfileRelationshipCollection,
+  ProfileRelationshipTypeCollection,
+  ProfileTypeCollection,
+} from '../index.js';
+
+describe('R10: generated child accessors on Profile', () => {
+  let profiles: ProfileCollection;
+  let relationships: ProfileRelationshipCollection;
+  let alice: Awaited<ReturnType<ProfileCollection['create']>>;
+  let bob: Awaited<ReturnType<ProfileCollection['create']>>;
+  let relationshipTypeId: string;
+
+  beforeEach(async () => {
+    // Shared file DB so the related models resolve each other's tables.
+    const dbUrl = join(tmpdir(), `test-r10-profiles-${Date.now()}.db`);
+    const persistence = { type: 'sqlite' as const, url: dbUrl };
+
+    profiles = await ProfileCollection.create({ persistence });
+    relationships = await ProfileRelationshipCollection.create({ persistence });
+    const types = await ProfileTypeCollection.create({ persistence });
+    const relTypes = await ProfileRelationshipTypeCollection.create({
+      persistence,
+    });
+
+    const personType = await types.create({ name: 'Person' });
+    await personType.save();
+
+    const knows = await relTypes.create({ name: 'Knows' });
+    await knows.save();
+    relationshipTypeId = knows.id as string;
+
+    alice = await profiles.create({
+      typeId: personType.id,
+      name: 'Alice',
+      email: 'alice@example.com',
+    });
+    await alice.save();
+
+    bob = await profiles.create({
+      typeId: personType.id,
+      name: 'Bob',
+      email: 'bob@example.com',
+    });
+    await bob.save();
+
+    // A single directed relationship: Alice -> Bob.
+    const rel = await relationships.create({
+      fromProfileId: alice.id,
+      toProfileId: bob.id,
+      typeId: relationshipTypeId,
+    });
+    await rel.save();
+  });
+
+  it('exposes generated getRelationshipsFrom() / getRelationshipsTo()', () => {
+    expect(typeof (alice as any).getRelationshipsFrom).toBe('function');
+    expect(typeof (alice as any).getRelationshipsTo).toBe('function');
+  });
+
+  it('resolves the correct inverse FK for each direction', async () => {
+    const aliceFrom = (await (alice as any).getRelationshipsFrom()) as any[];
+    const aliceTo = (await (alice as any).getRelationshipsTo()) as any[];
+    const bobFrom = (await (bob as any).getRelationshipsFrom()) as any[];
+    const bobTo = (await (bob as any).getRelationshipsTo()) as any[];
+
+    // Alice is the origin (fromProfileId), Bob is the target (toProfileId).
+    expect(aliceFrom).toHaveLength(1);
+    expect(String(aliceFrom[0].fromProfileId)).toBe(String(alice.id));
+
+    expect(bobTo).toHaveLength(1);
+    expect(String(bobTo[0].toProfileId)).toBe(String(bob.id));
+
+    // The opposite directions must NOT bleed across (disambiguation works).
+    expect(aliceTo).toHaveLength(0);
+    expect(bobFrom).toHaveLength(0);
+  });
+
+  it('preserves the hand-rolled Profile.getMetadata() (key-value, not the list)', async () => {
+    const metadata = await alice.getMetadata();
+    // Hand-rolled accessor returns a key-value object, not a ProfileMetadata[].
+    expect(Array.isArray(metadata)).toBe(false);
+    expect(typeof metadata).toBe('object');
+  });
+
+  it('preserves the hand-rolled ProfileRelationship.getTerms()', async () => {
+    const [rel] = (await (alice as any).getRelationshipsFrom()) as any[];
+    const terms = await rel.getTerms();
+    expect(Array.isArray(terms)).toBe(true);
+  });
+});

--- a/packages/profiles/src/manifest/manifest.json
+++ b/packages/profiles/src/manifest/manifest.json
@@ -3504,12 +3504,18 @@
         "relationshipsFrom": {
           "type": "oneToMany",
           "required": false,
-          "related": "ProfileRelationship"
+          "related": "ProfileRelationship",
+          "_meta": {
+            "foreignKey": "fromProfileId"
+          }
         },
         "relationshipsTo": {
           "type": "oneToMany",
           "required": false,
-          "related": "ProfileRelationship"
+          "related": "ProfileRelationship",
+          "_meta": {
+            "foreignKey": "toProfileId"
+          }
         }
       },
       "methods": {
@@ -8263,12 +8269,18 @@
         "relationshipsFrom": {
           "type": "oneToMany",
           "required": false,
-          "related": "ProfileRelationship"
+          "related": "ProfileRelationship",
+          "_meta": {
+            "foreignKey": "fromProfileId"
+          }
         },
         "relationshipsTo": {
           "type": "oneToMany",
           "required": false,
-          "related": "ProfileRelationship"
+          "related": "ProfileRelationship",
+          "_meta": {
+            "foreignKey": "toProfileId"
+          }
         }
       },
       "methods": {
@@ -9238,12 +9250,18 @@
         "relationshipsFrom": {
           "type": "oneToMany",
           "required": false,
-          "related": "ProfileRelationship"
+          "related": "ProfileRelationship",
+          "_meta": {
+            "foreignKey": "fromProfileId"
+          }
         },
         "relationshipsTo": {
           "type": "oneToMany",
           "required": false,
-          "related": "ProfileRelationship"
+          "related": "ProfileRelationship",
+          "_meta": {
+            "foreignKey": "toProfileId"
+          }
         }
       },
       "methods": {
@@ -10213,12 +10231,18 @@
         "relationshipsFrom": {
           "type": "oneToMany",
           "required": false,
-          "related": "ProfileRelationship"
+          "related": "ProfileRelationship",
+          "_meta": {
+            "foreignKey": "fromProfileId"
+          }
         },
         "relationshipsTo": {
           "type": "oneToMany",
           "required": false,
-          "related": "ProfileRelationship"
+          "related": "ProfileRelationship",
+          "_meta": {
+            "foreignKey": "toProfileId"
+          }
         }
       },
       "methods": {

--- a/packages/profiles/src/models/Profile.ts
+++ b/packages/profiles/src/models/Profile.ts
@@ -64,10 +64,15 @@ export class Profile extends SmrtObject {
   @oneToMany('ProfileMetadata')
   metadata: any[] = [];
 
-  @oneToMany('ProfileRelationship')
+  // ProfileRelationship declares multiple foreign keys back to Profile
+  // (fromProfileId / toProfileId / contextProfileId), so each oneToMany names
+  // its inverse side explicitly. This both disambiguates `loadRelatedMany`
+  // and gives the R10-generated `getRelationshipsFrom()` / `getRelationshipsTo()`
+  // accessors the correct inverse foreign key.
+  @oneToMany('ProfileRelationship', { foreignKey: 'fromProfileId' })
   relationshipsFrom: any[] = [];
 
-  @oneToMany('ProfileRelationship')
+  @oneToMany('ProfileRelationship', { foreignKey: 'toProfileId' })
   relationshipsTo: any[] = [];
 
   constructor(options: ProfileOptions = {}) {

--- a/packages/scanner/src/manifest-adapter.ts
+++ b/packages/scanner/src/manifest-adapter.ts
@@ -58,6 +58,8 @@ type FieldDecoratorOptions = {
   maxLength?: number;
   minLength?: number;
   related?: string;
+  /** oneToMany explicit inverse foreign-key field on the target class */
+  foreignKey?: string;
   description?: string;
   transient?: boolean;
   unique?: boolean;
@@ -813,13 +815,24 @@ export class ManifestAdapter {
       };
     }
 
-    // @oneToMany(RelatedClass) decorator
+    // @oneToMany(RelatedClass, { foreignKey? }) decorator
     if (decorator.name === 'oneToMany') {
       const relatedClass = stripQuotes(decorator.arguments[0]?.trim());
+      // Preserve an explicit inverse `foreignKey` so manifest-only consumers
+      // disambiguate the inverse side the same way the runtime decorator does
+      // (needed when the target declares multiple FKs back to this class).
+      const parsedOptions = this.parseFieldDecoratorOptions(
+        decorator.arguments[1],
+      );
+      const meta: Record<string, unknown> = {};
+      if (parsedOptions?.foreignKey !== undefined) {
+        meta.foreignKey = parsedOptions.foreignKey;
+      }
       return {
         type: 'oneToMany',
         related: relatedClass || undefined,
         required: false,
+        ...(Object.keys(meta).length > 0 ? { _meta: meta } : {}),
         source: 'decorator',
       };
     }


### PR DESCRIPTION
## R10 — Consolidate child-accessor API via codegen off `@oneToMany`

Closes the R10 item of epic #1318. Implements #1322.

### What
Every `@oneToMany` field now gets a consistent generated `get<FieldName>()` instance accessor, installed at `@smrt()` registration time, delegating to the existing `loadRelatedMany` resolver (which queries through the child collection — the queryable primitive). Before R10 each model hand-rolled its own differently-named/shaped child accessor.

```ts
@smrt()
class Order extends SmrtObject {
  @oneToMany(OrderItem) items: OrderItem[] = [];
}
const items = await order.getItems(); // generated; === order.loadRelatedMany('items')
```

### Canonical shape & mechanism
Per the locked decision (instance method delegating to a collection method), the accessor delegates to `loadRelatedMany`, which resolves through `collection.list({ where: { [inverseFk]: id } })`. **Chosen mechanism: a registration-time mixin**, not the REST/CLI/MCP generator pass — those emit external string artifacts and cannot add instance methods to a model class. Adding behavior at `@smrt()` registration matches the framework's existing pattern. Accessors are non-enumerable prototype methods, **invisible to the build-time manifest**, so they never leak into the generated REST/CLI/MCP surface (`getAvailableTools` reads manifest tools, not the prototype).

### Two invariants (fully additive — no breaking changes)
- **Skip-if-exists**: never shadows a method already on the prototype chain. `Profile.getMetadata()` (key-value) and `ProfileRelationship.getTerms()` are preserved untouched.
- **Runtime-only**: a developer-ergonomics layer over `loadRelatedMany`.

### Multi-FK disambiguation + STI inheritance (supporting fixes)
- `loadRelatedMany` and the eager `include:` batch loader now honor an explicit `@oneToMany(Target, { foreignKey })` to pick the inverse side when the target declares multiple FKs back to the parent (else first-match, unchanged). An explicit-but-unmatched `foreignKey` is now an error instead of a silent wrong-side load.
- Inverse-FK resolution matches the instance's class **and its registered ancestors** (`ObjectRegistry.getInverseRelationshipsForSelf`), so an STI subclass (e.g. `Person extends Profile`) resolves a `@oneToMany` declared on its base.
- scanner: captures the `oneToMany` `foreignKey` option into the manifest so manifest-only consumers disambiguate identically.
- profiles: `Profile.relationshipsFrom`/`relationshipsTo` annotated with explicit foreign keys.

### Reconciliation of the 5 audited hand-rolled sites
All 5 are **hierarchy** accessors (self-referential `parentId` via `SmrtHierarchical` or collection queries), **not** `@oneToMany`-backed → left unchanged:
- `core/hierarchical.ts` — the `SmrtHierarchical` contract (explicitly out of scope)
- `ledgers/Account.ts`, `properties/Zone.ts` — extend `SmrtHierarchical`
- `places/PlaceCollection.ts`, `tags/tags.ts` — collection-level `getChildren(parentId/slug)`

The `@oneToMany`-backed hand-rolled accessors (`ProfileRelationship.getTerms`, `Profile.getMetadata`) are preserved by the skip-if-exists rule.

### 🚦 Gate answer (epic #1318)
**No public accessor signature changes — fully additive.** Nothing breaking; no downstream codemod for ergot/anytown. Note: `Profile.metadata` (`@oneToMany`) does **not** get a generated `getMetadata()` because that name is already a differently-shaped (key-value) hand-rolled method — preserved intentionally; callers wanting the raw list use `loadRelatedMany('metadata')`.

### Tests / checks
- `packages/core/src/__tests__/child-accessors.test.ts` (7): naming, non-enumerable, basic load, additive preservation, multi-FK disambiguation, STI-child inheritance.
- `packages/profiles/src/__tests__/child-accessors.test.ts` (4): real `Profile.getRelationshipsFrom/To` directional correctness, hand-rolled preservation.
- ✅ core suite 1735 pass · profiles 86 pass · workspace typecheck (49/49) · full build (45/45) · biome clean (2 pre-existing `noNonNullAssertion` warnings in `resolveManyToManyJoin`, not part of this change).

### Review cycle
codex (`gpt-5.5` xhigh) and a Claude code-reviewer sub-agent independently flagged the same two issues (STI-child inheritance failure; silent fallback on invalid explicit `foreignKey`) — both fixed in `e5c8ad5`.
