### PR TITLE
feat(core)!: enforce tenant isolation on relationship loaders (#1321)

### DIFF
--- a/packages/core/src/__tests__/issue-1321-tenant-isolation-load-related.test.ts
+++ b/packages/core/src/__tests__/issue-1321-tenant-isolation-load-related.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Issue #1321 (R8): tenant-isolation guard on loadRelated / loadRelatedMany.
+ *
+ * `loadRelated()` fetches a relationship target by id with NO tenant filtering,
+ * which silently leaks another tenant's data across a foreign key. This guard
+ * throws a `TenantIsolationError` ONLY in the genuine-leak case — when the
+ * owning object and the loaded target both carry a non-null `tenantId` that
+ * differ — so global/null-tenant models and same-tenant loads are unaffected.
+ * Callers can opt out of deliberate cross-tenant flows with
+ * `{ allowCrossTenant: true }`.
+ *
+ * @see https://github.com/happyvertical/smrt/issues/1321
+ */
+
+import { randomUUID } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { TenantIsolationError } from '../errors';
+import {
+  field,
+  foreignKey,
+  manyToMany,
+  oneToMany,
+  SmrtObject,
+  smrt,
+} from '../index.js';
+import { ObjectRegistry } from '../registry';
+import { getTestDatabase } from '../testing/database';
+
+// Owning side — a tenant-scoped "Customer" with many orders.
+// `tenantId` needs an explicit type because the framework cannot infer a
+// column type from a `null` initializer.
+@smrt()
+class IsoCustomer extends SmrtObject {
+  @field({ type: 'text', nullable: true })
+  tenantId: string | null = null;
+  name: string = '';
+
+  @oneToMany('IsoOrder')
+  orders: IsoOrder[] = [];
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name) this.name = options.name;
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+  }
+}
+
+// Related side — a tenant-scoped "Order" with a foreignKey back to Customer.
+@smrt()
+class IsoOrder extends SmrtObject {
+  @field({ type: 'text', nullable: true })
+  tenantId: string | null = null;
+
+  @foreignKey('IsoCustomer')
+  customerId: string = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.customerId) this.customerId = options.customerId;
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+  }
+}
+
+// manyToMany fixtures — a tenant-scoped "Product" linked to "Tag"s through a
+// plain junction table (consumer-owned, no SmrtObject backing).
+@smrt()
+class IsoTag extends SmrtObject {
+  @field({ type: 'text', nullable: true })
+  tenantId: string | null = null;
+  label: string = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.label) this.label = options.label;
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+  }
+}
+
+@smrt()
+class IsoProduct extends SmrtObject {
+  @field({ type: 'text', nullable: true })
+  tenantId: string | null = null;
+
+  @manyToMany(IsoTag, { through: 'iso_product_tags' })
+  tags: IsoTag[] = [];
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+  }
+}
+
+describe('Issue #1321: tenant isolation on relationship loading', () => {
+  let db: DatabaseInterface;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    dbPath = join(tmpdir(), `test-tenant-iso-${randomUUID().slice(0, 8)}.db`);
+    db = await getTestDatabase({ type: 'sqlite', url: dbPath });
+  });
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') {
+      await db.close();
+    }
+  });
+
+  async function makeCustomer(tenantId: string | null): Promise<IsoCustomer> {
+    const customer = new IsoCustomer({ name: 'Acme', tenantId, db });
+    await customer.initialize();
+    await customer.save();
+    return customer;
+  }
+
+  async function makeOrder(
+    tenantId: string | null,
+    customerId: string,
+  ): Promise<IsoOrder> {
+    const order = new IsoOrder({ tenantId, customerId, db });
+    await order.initialize();
+    await order.save();
+    return order;
+  }
+
+  async function ensureJunctionTable(): Promise<void> {
+    await db.query(
+      `CREATE TABLE IF NOT EXISTS iso_product_tags (
+        iso_product_id TEXT NOT NULL,
+        iso_tag_id TEXT NOT NULL,
+        PRIMARY KEY (iso_product_id, iso_tag_id)
+      )`,
+    );
+  }
+
+  async function makeProduct(tenantId: string | null): Promise<IsoProduct> {
+    const product = new IsoProduct({ tenantId, db });
+    await product.initialize();
+    await product.save();
+    return product;
+  }
+
+  async function makeTag(
+    tenantId: string | null,
+    label: string,
+  ): Promise<IsoTag> {
+    const tag = new IsoTag({ tenantId, label, db });
+    await tag.initialize();
+    await tag.save();
+    return tag;
+  }
+
+  async function linkProductTag(
+    product: IsoProduct,
+    tag: IsoTag,
+  ): Promise<void> {
+    await db.query(
+      'INSERT INTO iso_product_tags (iso_product_id, iso_tag_id) VALUES (?, ?)',
+      [product.id, tag.id],
+    );
+  }
+
+  describe('loadRelated (foreignKey)', () => {
+    it('resolves a same-tenant relationship without throwing', async () => {
+      const customer = await makeCustomer('tenant-a');
+      const order = await makeOrder('tenant-a', customer.id);
+
+      const loaded = await order.loadRelated('customerId');
+
+      expect(loaded).not.toBeNull();
+      expect(loaded.id).toBe(customer.id);
+    });
+
+    it('is a no-op when the target has a null tenant (global model)', async () => {
+      const customer = await makeCustomer(null);
+      const order = await makeOrder('tenant-a', customer.id);
+
+      const loaded = await order.loadRelated('customerId');
+
+      expect(loaded.id).toBe(customer.id);
+    });
+
+    it('is a no-op when the owning object has a null tenant', async () => {
+      const customer = await makeCustomer('tenant-b');
+      const order = await makeOrder(null, customer.id);
+
+      const loaded = await order.loadRelated('customerId');
+
+      expect(loaded.id).toBe(customer.id);
+    });
+
+    it('throws TenantIsolationError on a genuine cross-tenant load', async () => {
+      const customer = await makeCustomer('tenant-b');
+      const order = await makeOrder('tenant-a', customer.id);
+
+      await expect(order.loadRelated('customerId')).rejects.toThrow(
+        TenantIsolationError,
+      );
+    });
+
+    it('surfaces the owning and attempted tenants on the error', async () => {
+      const customer = await makeCustomer('tenant-b');
+      const order = await makeOrder('tenant-a', customer.id);
+
+      await expect(order.loadRelated('customerId')).rejects.toMatchObject({
+        code: 'TENANT_ISOLATION_VIOLATION',
+        tenantId: 'tenant-a',
+        attemptedTenantId: 'tenant-b',
+      });
+    });
+
+    it('bypasses the guard with { allowCrossTenant: true }', async () => {
+      const customer = await makeCustomer('tenant-b');
+      const order = await makeOrder('tenant-a', customer.id);
+
+      const loaded = await order.loadRelated('customerId', {
+        allowCrossTenant: true,
+      });
+
+      expect(loaded.id).toBe(customer.id);
+    });
+
+    it('does not cache a blocked cross-tenant target (re-throws on retry)', async () => {
+      const customer = await makeCustomer('tenant-b');
+      const order = await makeOrder('tenant-a', customer.id);
+
+      await expect(order.loadRelated('customerId')).rejects.toThrow(
+        TenantIsolationError,
+      );
+      // A second attempt must still throw — the leak was never cached.
+      await expect(order.loadRelated('customerId')).rejects.toThrow(
+        TenantIsolationError,
+      );
+    });
+
+    it('re-validates a prior allowCrossTenant load on a later guarded call', async () => {
+      const customer = await makeCustomer('tenant-b');
+      const order = await makeOrder('tenant-a', customer.id);
+
+      // First load opts into the cross-tenant target (and caches it)...
+      const allowed = await order.loadRelated('customerId', {
+        allowCrossTenant: true,
+      });
+      expect(allowed.id).toBe(customer.id);
+
+      // ...but a later call WITHOUT the opt-in must still be blocked.
+      await expect(order.loadRelated('customerId')).rejects.toThrow(
+        TenantIsolationError,
+      );
+    });
+
+    it('blocks a cross-tenant target cached by an eager include load', async () => {
+      const customer = await makeCustomer('tenant-b');
+      await makeOrder('tenant-a', customer.id);
+
+      // Eager `include` populates _loadedRelationships directly, bypassing the
+      // lazy loader. A later guarded read must NOT leak that cross-tenant target.
+      const orders = await ObjectRegistry.getCollection<IsoOrder>('IsoOrder', {
+        db,
+      });
+      const [loadedOrder] = (await orders.list({
+        include: ['customerId'],
+      })) as IsoOrder[];
+
+      await expect(loadedOrder.loadRelated('customerId')).rejects.toThrow(
+        TenantIsolationError,
+      );
+      await expect(loadedOrder.getRelated('customerId')).rejects.toThrow(
+        TenantIsolationError,
+      );
+      // The deliberate opt-in still works against the eager-populated cache.
+      const allowed = await loadedOrder.loadRelated('customerId', {
+        allowCrossTenant: true,
+      });
+      expect(allowed.id).toBe(customer.id);
+    });
+  });
+
+  describe('loadRelatedMany (manyToMany)', () => {
+    beforeEach(async () => {
+      await ensureJunctionTable();
+    });
+
+    it('returns same-tenant linked targets without throwing', async () => {
+      const product = await makeProduct('tenant-a');
+      const tag = await makeTag('tenant-a', 'Featured');
+      await linkProductTag(product, tag);
+
+      const tags = (await product.loadRelatedMany('tags')) as IsoTag[];
+
+      expect(tags).toHaveLength(1);
+      expect(tags[0].id).toBe(tag.id);
+    });
+
+    it('is a no-op when a linked target has a null tenant (global)', async () => {
+      const product = await makeProduct('tenant-a');
+      const tag = await makeTag(null, 'Global');
+      await linkProductTag(product, tag);
+
+      const tags = (await product.loadRelatedMany('tags')) as IsoTag[];
+
+      expect(tags).toHaveLength(1);
+    });
+
+    it('throws TenantIsolationError on a cross-tenant linked target', async () => {
+      const product = await makeProduct('tenant-a');
+      const tag = await makeTag('tenant-b', 'Leaked');
+      await linkProductTag(product, tag);
+
+      await expect(product.loadRelatedMany('tags')).rejects.toThrow(
+        TenantIsolationError,
+      );
+    });
+
+    it('bypasses the per-item guard with { allowCrossTenant: true }', async () => {
+      const product = await makeProduct('tenant-a');
+      const tag = await makeTag('tenant-b', 'Leaked');
+      await linkProductTag(product, tag);
+
+      const tags = (await product.loadRelatedMany('tags', {
+        allowCrossTenant: true,
+      })) as IsoTag[];
+
+      expect(tags).toHaveLength(1);
+    });
+  });
+
+  describe('loadRelatedMany (oneToMany)', () => {
+    it('returns same-tenant children without throwing', async () => {
+      const customer = await makeCustomer('tenant-a');
+      await makeOrder('tenant-a', customer.id);
+      await makeOrder('tenant-a', customer.id);
+
+      const orders = (await customer.loadRelatedMany('orders')) as IsoOrder[];
+
+      expect(orders).toHaveLength(2);
+    });
+
+    it('throws TenantIsolationError when any child is cross-tenant', async () => {
+      const customer = await makeCustomer('tenant-a');
+      await makeOrder('tenant-a', customer.id);
+      await makeOrder('tenant-b', customer.id); // leaked child
+
+      await expect(customer.loadRelatedMany('orders')).rejects.toThrow(
+        TenantIsolationError,
+      );
+    });
+
+    it('bypasses per-item guard with { allowCrossTenant: true }', async () => {
+      const customer = await makeCustomer('tenant-a');
+      await makeOrder('tenant-a', customer.id);
+      await makeOrder('tenant-b', customer.id);
+
+      const orders = (await customer.loadRelatedMany('orders', {
+        allowCrossTenant: true,
+      })) as IsoOrder[];
+
+      expect(orders).toHaveLength(2);
+    });
+  });
+});

--- a/packages/core/src/errors.spec.ts
+++ b/packages/core/src/errors.spec.ts
@@ -8,6 +8,7 @@ import {
   DatabaseError,
   ErrorUtils,
   SmrtError,
+  TenantIsolationError,
   ValidationError,
 } from './errors';
 
@@ -123,6 +124,25 @@ describe('SMRT Error System', () => {
         ValidationError,
       );
       expect(attempts).toBe(1); // Should not retry
+    });
+
+    it('should not retry tenant isolation errors', async () => {
+      let attempts = 0;
+      const operation = async () => {
+        attempts++;
+        throw TenantIsolationError.crossTenantReference({
+          sourceClass: 'Order',
+          fieldName: 'customerId',
+          sourceTenantId: 'tenant-a',
+          targetClass: 'Customer',
+          targetTenantId: 'tenant-b',
+        });
+      };
+
+      await expect(ErrorUtils.withRetry(operation, 3, 10)).rejects.toThrow(
+        TenantIsolationError,
+      );
+      expect(attempts).toBe(1); // Security boundary: deterministic, never retried
     });
 
     it('should identify retryable errors', () => {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -690,15 +690,18 @@ export class RuntimeError extends SmrtError {
  * relationship.
  *
  * Raised by {@link SmrtObject.loadRelated} / {@link SmrtObject.loadRelatedMany}
- * when a tenant-scoped object resolves a relationship to an object belonging to
- * a *different*, non-null tenant — the genuine cross-tenant data leak. The guard
+ * (and {@link SmrtObject.getRelated}, which delegates to them) when a
+ * tenant-scoped object resolves a relationship to an object belonging to a
+ * *different*, non-null tenant — the genuine cross-tenant data leak. The guard
  * is a no-op when either side has a `null` tenant (global / non-tenant-scoped
  * models) and when both sides share the same tenant, so it only fires on real
  * leaks. Pass `{ allowCrossTenant: true }` to the loader to deliberately opt out.
  *
  * The `code` is always `'TENANT_ISOLATION_VIOLATION'` and the category is
- * `'validation'` (never retried). `tenantId` is the owning object's tenant and
- * `attemptedTenantId` is the tenant of the object that was reached.
+ * `'validation'`. It is never retried — `ErrorUtils.withRetry()` rethrows it
+ * immediately and `ErrorUtils.isRetryable()` returns `false` — because a tenant
+ * boundary violation is deterministic. `tenantId` is the owning object's tenant
+ * and `attemptedTenantId` is the tenant of the object that was reached.
  *
  * This shares its stable `code`, `name`, `tenantId`, and `attemptedTenantId`
  * shape with the interceptor-level `TenantIsolationError` in
@@ -759,7 +762,7 @@ export class TenantIsolationError extends SmrtError {
     return new TenantIsolationError(
       `Cross-tenant relationship access blocked on ${details.sourceClass}.${details.fieldName}: ` +
         `owning tenant '${details.sourceTenantId}' does not match ${target}. ` +
-        `Pass { allowCrossTenant: true } to loadRelated()/loadRelatedMany() to override.`,
+        `Pass { allowCrossTenant: true } to loadRelated()/loadRelatedMany()/getRelated() to override.`,
       {
         tenantId: details.sourceTenantId,
         attemptedTenantId: details.targetTenantId,
@@ -796,10 +799,13 @@ export class ErrorUtils {
           throw lastError;
         }
 
-        // Skip retry for certain error types
+        // Skip retry for certain error types. A tenant isolation violation is
+        // deterministic — retrying re-fetches the same cross-tenant target — and
+        // is a security boundary, so it must never be retried.
         if (
           error instanceof ValidationError ||
-          error instanceof ConfigurationError
+          error instanceof ConfigurationError ||
+          error instanceof TenantIsolationError
         ) {
           throw error;
         }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -686,6 +686,92 @@ export class RuntimeError extends SmrtError {
 }
 
 /**
+ * Error thrown when a tenant isolation boundary is crossed while resolving a
+ * relationship.
+ *
+ * Raised by {@link SmrtObject.loadRelated} / {@link SmrtObject.loadRelatedMany}
+ * when a tenant-scoped object resolves a relationship to an object belonging to
+ * a *different*, non-null tenant — the genuine cross-tenant data leak. The guard
+ * is a no-op when either side has a `null` tenant (global / non-tenant-scoped
+ * models) and when both sides share the same tenant, so it only fires on real
+ * leaks. Pass `{ allowCrossTenant: true }` to the loader to deliberately opt out.
+ *
+ * The `code` is always `'TENANT_ISOLATION_VIOLATION'` and the category is
+ * `'validation'` (never retried). `tenantId` is the owning object's tenant and
+ * `attemptedTenantId` is the tenant of the object that was reached.
+ *
+ * This shares its stable `code`, `name`, `tenantId`, and `attemptedTenantId`
+ * shape with the interceptor-level `TenantIsolationError` in
+ * `@happyvertical/smrt-tenancy`, so cross-cutting handlers can match either via
+ * `err.code === 'TENANT_ISOLATION_VIOLATION'`. They are intentionally distinct
+ * classes because `@happyvertical/smrt-core` cannot depend on the tenancy
+ * package (the dependency runs the other way).
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await order.loadRelated('customerId');
+ * } catch (err) {
+ *   if (err instanceof TenantIsolationError) {
+ *     // err.tenantId          — the order's tenant
+ *     // err.attemptedTenantId — the customer's tenant
+ *   }
+ * }
+ * ```
+ *
+ * @see SmrtObject.loadRelated
+ * @see SmrtObject.loadRelatedMany
+ */
+export class TenantIsolationError extends SmrtError {
+  /** The tenant ID of the object that owns the relationship. */
+  public readonly tenantId?: string;
+  /** The tenant ID of the related object that was reached (and rejected). */
+  public readonly attemptedTenantId?: string;
+
+  constructor(
+    message: string,
+    details?: {
+      tenantId?: string;
+      attemptedTenantId?: string;
+      [key: string]: any;
+    },
+    cause?: Error,
+  ) {
+    super(message, 'TENANT_ISOLATION_VIOLATION', 'validation', details, cause);
+    this.tenantId = details?.tenantId;
+    this.attemptedTenantId = details?.attemptedTenantId;
+  }
+
+  /**
+   * Builds a {@link TenantIsolationError} for a blocked cross-tenant
+   * relationship resolution, with a descriptive message and structured details.
+   */
+  static crossTenantReference(details: {
+    sourceClass: string;
+    fieldName: string;
+    sourceTenantId: string;
+    targetClass?: string;
+    targetTenantId: string;
+  }): TenantIsolationError {
+    const target = details.targetClass
+      ? `${details.targetClass} (tenant '${details.targetTenantId}')`
+      : `tenant '${details.targetTenantId}'`;
+    return new TenantIsolationError(
+      `Cross-tenant relationship access blocked on ${details.sourceClass}.${details.fieldName}: ` +
+        `owning tenant '${details.sourceTenantId}' does not match ${target}. ` +
+        `Pass { allowCrossTenant: true } to loadRelated()/loadRelatedMany() to override.`,
+      {
+        tenantId: details.sourceTenantId,
+        attemptedTenantId: details.targetTenantId,
+        sourceClass: details.sourceClass,
+        fieldName: details.fieldName,
+        targetClass: details.targetClass,
+      },
+    );
+  }
+}
+
+/**
  * Utility functions for error handling
  */
 export class ErrorUtils {

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -11,6 +11,7 @@ import {
   DatabaseError,
   ErrorUtils,
   RuntimeError,
+  TenantIsolationError,
   ValidationError,
 } from './errors';
 import { createInterceptorContext, GlobalInterceptors } from './interceptors';
@@ -166,6 +167,24 @@ export interface SmrtObjectOptions extends SmrtClassOptions {
    * Allow arbitrary field values to be passed
    */
   [key: string]: any;
+}
+
+/**
+ * Options for the relationship loaders {@link SmrtObject.loadRelated},
+ * {@link SmrtObject.loadRelatedMany}, and {@link SmrtObject.getRelated}.
+ */
+export interface LoadRelatedOptions {
+  /**
+   * Bypass the cross-tenant isolation guard.
+   *
+   * By default, resolving a relationship from a tenant-scoped object to an
+   * object in a *different*, non-null tenant throws a `TenantIsolationError`.
+   * Set this to `true` for deliberate cross-tenant flows (admin tooling,
+   * migrations, super-admin bypass paths) where the access is intentional.
+   *
+   * @default false
+   */
+  allowCrossTenant?: boolean;
 }
 
 /**
@@ -1952,10 +1971,19 @@ export class SmrtObject extends SmrtClass {
    * For STI relationships, the correct subclass is determined by reading
    * `_meta_type` from the database row before instantiation.
    *
+   * Enforces tenant isolation: if this object and the loaded target both carry
+   * a non-null `tenantId` that differ, a {@link TenantIsolationError} is thrown
+   * (unless `opts.allowCrossTenant` is set). The check is a no-op for
+   * global/null-tenant models and same-tenant loads, so it only catches genuine
+   * cross-tenant leaks (Issue #1321).
+   *
    * @param fieldName - Name of the `@foreignKey()` decorated property
+   * @param opts - Optional loader options; see {@link LoadRelatedOptions}
    * @returns The related object, or `null` if the foreign key is empty
    * @throws {RuntimeError} If `fieldName` is not a `foreignKey` relationship,
    *   or the target class is not found in the ObjectRegistry
+   * @throws {TenantIsolationError} If the target belongs to a different,
+   *   non-null tenant and `opts.allowCrossTenant` is not set
    *
    * @example
    * ```typescript
@@ -1966,10 +1994,18 @@ export class SmrtObject extends SmrtClass {
    *
    * @see {@link getRelated} for a convenience wrapper that auto-detects relationship type
    */
-  public async loadRelated(fieldName: string): Promise<any> {
+  public async loadRelated(
+    fieldName: string,
+    opts?: LoadRelatedOptions,
+  ): Promise<any> {
     // Check if already loaded
     if (this._loadedRelationships.has(fieldName)) {
-      return this._loadedRelationships.get(fieldName);
+      const cached = this._loadedRelationships.get(fieldName);
+      // Re-validate cached targets: a cache populated by an eager `include`
+      // load (or a prior allowCrossTenant load) must not leak cross-tenant data
+      // through a later guarded call (Issue #1321).
+      this.assertRelatedTenant(cached, fieldName, opts?.allowCrossTenant);
+      return cached;
     }
 
     // Ensure manifest is loaded for external packages before accessing relationships
@@ -2059,9 +2095,73 @@ export class SmrtObject extends SmrtClass {
     relatedInstance.id = foreignKeyValue as string;
     await relatedInstance.loadFromId();
 
+    // Enforce tenant isolation before caching/returning so a blocked
+    // cross-tenant target is never cached (Issue #1321).
+    this.assertRelatedTenant(
+      relatedInstance,
+      fieldName,
+      opts?.allowCrossTenant,
+    );
+
     // Cache the loaded object
     this._loadedRelationships.set(fieldName, relatedInstance);
     return relatedInstance;
+  }
+
+  /**
+   * Guards a loaded relationship target against cross-tenant access.
+   *
+   * Throws {@link TenantIsolationError} when this object and `loaded` both carry
+   * a non-null `tenantId` that differ — the genuine cross-tenant leak. It is a
+   * no-op when `allowCrossTenant === true`, when `loaded` is `null`, when either
+   * side has a `null`/`undefined` tenant (global / non-tenant-scoped models),
+   * and when both sides share the same tenant (Issue #1321).
+   *
+   * `loaded` may be a single related object or an array (oneToMany / manyToMany);
+   * arrays are validated per item. This runs on both fresh loads and cache hits,
+   * so a cache populated by an eager `include` load — or by a prior
+   * `allowCrossTenant` load — cannot leak cross-tenant data through a later
+   * guarded call.
+   *
+   * @param loaded - The loaded related object, or array of objects.
+   * @param fieldName - The relationship field name (for error context).
+   * @param allowCrossTenant - When exactly `true`, bypasses the guard entirely.
+   */
+  private assertRelatedTenant(
+    loaded: unknown,
+    fieldName: string,
+    allowCrossTenant?: boolean,
+  ): void {
+    // Strict `=== true`: only the documented opt-in bypasses the guard, never an
+    // incidental truthy value passed from untyped JS callers.
+    if (allowCrossTenant === true || loaded == null) {
+      return;
+    }
+
+    if (Array.isArray(loaded)) {
+      for (const item of loaded) {
+        this.assertRelatedTenant(item, fieldName, allowCrossTenant);
+      }
+      return;
+    }
+
+    const sourceTenantId = (this as { tenantId?: unknown }).tenantId;
+    const targetTenantId = (loaded as { tenantId?: unknown }).tenantId;
+
+    if (
+      sourceTenantId != null &&
+      targetTenantId != null &&
+      sourceTenantId !== targetTenantId
+    ) {
+      throw TenantIsolationError.crossTenantReference({
+        sourceClass: this.constructor.name,
+        fieldName,
+        sourceTenantId: String(sourceTenantId),
+        targetClass: (loaded as { constructor?: { name?: string } })
+          ?.constructor?.name,
+        targetTenantId: String(targetTenantId),
+      });
+    }
   }
 
   /**
@@ -2070,9 +2170,18 @@ export class SmrtObject extends SmrtClass {
    * Loads all related objects from the database. For oneToMany, queries by
    * the inverse foreign key. For manyToMany, queries through the join table.
    *
+   * Enforces tenant isolation per item: if this object and a loaded target both
+   * carry a non-null `tenantId` that differ, a {@link TenantIsolationError} is
+   * thrown (unless `opts.allowCrossTenant` is set). The check is a no-op for
+   * global/null-tenant models and same-tenant loads, so it only catches genuine
+   * cross-tenant leaks (Issue #1321).
+   *
    * @param fieldName - Name of the oneToMany or manyToMany field
+   * @param opts - Optional loader options; see {@link LoadRelatedOptions}
    * @returns Promise resolving to array of related objects
    * @throws {RuntimeError} If the field is not a relationship or not implemented
+   * @throws {TenantIsolationError} If any loaded item belongs to a different,
+   *   non-null tenant and `opts.allowCrossTenant` is not set
    * @example
    * ```typescript
    * // Given: class Customer with orders = oneToMany(Order)
@@ -2080,10 +2189,18 @@ export class SmrtObject extends SmrtClass {
    * console.log(`${orders.length} orders found`);
    * ```
    */
-  public async loadRelatedMany(fieldName: string): Promise<any[]> {
+  public async loadRelatedMany(
+    fieldName: string,
+    opts?: LoadRelatedOptions,
+  ): Promise<any[]> {
     // Check if already loaded
     if (this._loadedRelationships.has(fieldName)) {
-      return this._loadedRelationships.get(fieldName);
+      const cached = this._loadedRelationships.get(fieldName);
+      // Re-validate cached targets: a cache populated by an eager `include`
+      // load (or a prior allowCrossTenant load) must not leak cross-tenant data
+      // through a later guarded call (Issue #1321).
+      this.assertRelatedTenant(cached, fieldName, opts?.allowCrossTenant);
+      return cached;
     }
 
     // Ensure manifest is loaded for external packages before accessing relationships
@@ -2133,6 +2250,13 @@ export class SmrtObject extends SmrtClass {
         where: { [inverseForeignKey.fieldName]: this.id },
       });
 
+      // Enforce tenant isolation per item before caching (Issue #1321).
+      this.assertRelatedTenant(
+        relatedObjects,
+        fieldName,
+        opts?.allowCrossTenant,
+      );
+
       // Cache the loaded objects
       this._loadedRelationships.set(fieldName, relatedObjects);
       return relatedObjects;
@@ -2173,6 +2297,13 @@ export class SmrtObject extends SmrtClass {
       const targetObjects = await targetCollection.list({
         where: { 'id in': targetIds },
       });
+
+      // Enforce tenant isolation per item before caching (Issue #1321).
+      this.assertRelatedTenant(
+        targetObjects,
+        fieldName,
+        opts?.allowCrossTenant,
+      );
 
       this._loadedRelationships.set(fieldName, targetObjects);
       return targetObjects;
@@ -2251,8 +2382,14 @@ export class SmrtObject extends SmrtClass {
    * Convenience method that checks if the relationship is loaded and
    * loads it if necessary. Automatically detects foreignKey vs oneToMany/manyToMany.
    *
+   * Tenant isolation is enforced by the underlying loaders; see
+   * {@link loadRelated} and {@link loadRelatedMany}.
+   *
    * @param fieldName - Name of the relationship field
+   * @param opts - Optional loader options; see {@link LoadRelatedOptions}
    * @returns Promise resolving to the related object(s)
+   * @throws {TenantIsolationError} If a loaded target belongs to a different,
+   *   non-null tenant and `opts.allowCrossTenant` is not set
    * @example
    * ```typescript
    * // Loads customer if not already loaded
@@ -2262,9 +2399,16 @@ export class SmrtObject extends SmrtClass {
    * const orders = await customer.getRelated('orders');
    * ```
    */
-  public async getRelated(fieldName: string): Promise<any> {
+  public async getRelated(
+    fieldName: string,
+    opts?: LoadRelatedOptions,
+  ): Promise<any> {
     if (this._loadedRelationships.has(fieldName)) {
-      return this._loadedRelationships.get(fieldName);
+      const cached = this._loadedRelationships.get(fieldName);
+      // Re-validate cached targets so an eager `include` load cannot leak
+      // cross-tenant data through this convenience accessor (Issue #1321).
+      this.assertRelatedTenant(cached, fieldName, opts?.allowCrossTenant);
+      return cached;
     }
 
     // Ensure manifest is loaded for external packages before accessing relationships
@@ -2289,10 +2433,10 @@ export class SmrtObject extends SmrtClass {
       relationship.type === 'foreignKey' ||
       relationship.type === 'crossPackageRef'
     ) {
-      return this.loadRelated(fieldName);
+      return this.loadRelated(fieldName, opts);
     }
 
-    return this.loadRelatedMany(fieldName);
+    return this.loadRelatedMany(fieldName, opts);
   }
 
   /**

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -1961,7 +1961,8 @@ export class SmrtObject extends SmrtClass {
   }
 
   /**
-   * Lazy-loads a `foreignKey` relationship and caches the result.
+   * Lazy-loads a `foreignKey` or `crossPackageRef` relationship and caches the
+   * result.
    *
    * Looks up the relationship metadata in the ObjectRegistry, reads the
    * foreign key value on this object, and fetches the related object from
@@ -1977,11 +1978,13 @@ export class SmrtObject extends SmrtClass {
    * global/null-tenant models and same-tenant loads, so it only catches genuine
    * cross-tenant leaks (Issue #1321).
    *
-   * @param fieldName - Name of the `@foreignKey()` decorated property
+   * @param fieldName - Name of the `@foreignKey()` or `@crossPackageRef()`
+   *   decorated property
    * @param opts - Optional loader options; see {@link LoadRelatedOptions}
    * @returns The related object, or `null` if the foreign key is empty
-   * @throws {RuntimeError} If `fieldName` is not a `foreignKey` relationship,
-   *   or the target class is not found in the ObjectRegistry
+   * @throws {RuntimeError} If `fieldName` is not a `foreignKey` or
+   *   `crossPackageRef` relationship, or the target class is not found in the
+   *   ObjectRegistry
    * @throws {TenantIsolationError} If the target belongs to a different,
    *   non-null tenant and `opts.allowCrossTenant` is not set
    *


### PR DESCRIPTION
## What

Implements **#1321 (R8)** — a narrow tenant-isolation guard on the relationship loaders in `packages/core/src/object.ts`, per the locked "ENFORCE, narrowly" decision in the issue.

`loadRelated()` / `loadRelatedMany()` / `getRelated()` previously fetched relationship targets **by id with no tenant filtering**, silently leaking another tenant's data across `foreignKey`, `crossPackageRef`, `oneToMany`, and `manyToMany` relationships. This adds a guard that throws a new `TenantIsolationError` **only in the genuine-leak case**.

## The guard

Fires **only** when **all** of:
- `this.tenantId != null` **and**
- `loaded.tenantId != null` **and**
- `this.tenantId !== loaded.tenantId` **and**
- the caller did **not** pass `{ allowCrossTenant: true }`

So it is a **no-op** for global / non-tenant-scoped models (either side `null`/`undefined`) and for same-tenant loads — it catches only real cross-tenant leaks. `loadRelatedMany` validates **per item**.

```ts
// blocked (order tenant 'a' → customer tenant 'b')
await order.loadRelated('customerId');            // throws TenantIsolationError
// deliberate cross-tenant flow
await order.loadRelated('customerId', { allowCrossTenant: true });  // ok
```

## Changes

- **`errors.ts`** — new `TenantIsolationError extends SmrtError` (`code: 'TENANT_ISOLATION_VIOLATION'`, `category: 'validation'`, `tenantId` / `attemptedTenantId`), with a `crossTenantReference()` factory.
- **`object.ts`** — new exported `LoadRelatedOptions` (`{ allowCrossTenant?: boolean }`); optional `opts` arg threaded through `loadRelated` / `loadRelatedMany` / `getRelated`; a private `assertRelatedTenant()` helper (handles single + array targets) called on every load and cache-hit path.
- **Tests** — `issue-1321-tenant-isolation-load-related.test.ts` (16 tests, real in-memory SQLite): same-tenant ok, null-tenant ok (both sides), cross-tenant throws, `allowCrossTenant` bypasses, error shape, eager-`include` bypass closed, prior-`allowCrossTenant` re-validation, and the `manyToMany` path.

## Design notes

**Why a second `TenantIsolationError`** — `@happyvertical/smrt-core` cannot import `@happyvertical/smrt-tenancy` (the dependency runs tenancy → core), and tenancy already has an interceptor-level `TenantIsolationError`. The new core class is intentionally distinct but shares the same stable `code` / `name` / `tenantId` / `attemptedTenantId`, so cross-cutting handlers can match either via `err.code === 'TENANT_ISOLATION_VIOLATION'`. (Consolidating the two behind a single canonical class is a reasonable follow-up but was kept out of scope to avoid touching tenancy on this coordinated branch.)

**Cache-hit re-validation** (surfaced in review) — the guard runs on cache hits too, not just fresh loads. Eager `list({ include: [...] })` writes related objects straight into `_loadedRelationships`; without re-validation a later `loadRelated`/`getRelated` would return that cached cross-tenant object un-guarded. `_loadedRelationships` is **only** read inside these three (now-guarded) methods — never in serialization/`toJSON` — so re-validating on cache hit fully closes the public bypass without modifying `collection.ts` (which avoids breaking super-admin eager loads that have no opt-out today). A defense-in-depth guard at the eager-load *write* site, with an `include`-level opt-out, is noted as a possible follow-up for the epic.

**First-party caller audit** — all current callers (`profiles`: `ProfileMetadata`, `ProfileRelationship`, `Profile`, `ApiKey`, `OidcIdentity`, `NostrIdentity`, `AuditLog`, `MagicLinkToken`) resolve same-tenant or global (e.g. `ProfileRelationshipType` is global) relationships, so the guard is a no-op for them — **none needed `allowCrossTenant`**, matching the issue's prediction.

## Verification

- `packages/core`: **1744 tests pass** (0 fail), incl. the 16 new tests
- `smrt-tenancy` (54) and `smrt-profiles` (82) test suites pass
- Workspace `turbo typecheck`: **49/49 green**
- Biome clean on changed files

## Review

Multi-reviewer cycle (codex `gpt-5.5`/xhigh ×2 + Claude sub-agent + checklist): the eager-load cache bypass and `allowCrossTenant` strictness (`=== true`) were caught and fixed; second-round fixup review returned **no findings**.

## Breaking change

`loadRelated` / `loadRelatedMany` / `getRelated` now throw `TenantIsolationError` on genuine cross-tenant relationship resolution. Intentional cross-tenant access must pass `{ allowCrossTenant: true }`.

Closes #1321 · Part of #1318
