### PR TITLE
feat(core): extract SmrtPolymorphicAssociation base from AssetAssociation (R4, #1320)

### DIFF
--- a/packages/assets/src/asset-association.ts
+++ b/packages/assets/src/asset-association.ts
@@ -3,9 +3,18 @@
  *
  * Enables many-to-many relationships between assets and arbitrary objects
  * (e.g., Article, Profile, Event) with role-based categorization.
+ *
+ * The polymorphic right side (`metaType` + `metaId` + `role` + `sortOrder`)
+ * and the registry-aware `hydrate()` helper come from
+ * `SmrtPolymorphicAssociation` in core; this class only adds the `assetId`
+ * left/owner FK.
  */
 
-import { field, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  foreignKey,
+  SmrtPolymorphicAssociation,
+  smrt,
+} from '@happyvertical/smrt-core';
 import type { AssetAssociationOptions } from './types';
 
 @smrt({
@@ -14,33 +23,13 @@ import type { AssetAssociationOptions } from './types';
   mcp: { include: ['list', 'get', 'create'] },
   cli: true,
 })
-export class AssetAssociation extends SmrtObject {
+export class AssetAssociation extends SmrtPolymorphicAssociation {
   /** FK to Asset.id */
   @foreignKey('Asset', { required: true })
   assetId = '';
 
-  /** Target class name or qualified name (e.g., 'Article' or '@pkg:Article') */
-  @field({ required: true })
-  metaType = '';
-
-  /** Target object ID */
-  @field({ required: true })
-  metaId = '';
-
-  /** Role of this association (e.g., 'hero', 'thumbnail', 'attachment') */
-  @field({ required: true })
-  role = 'default';
-
-  /** Sort order for ordering assets within a role */
-  @field()
-  sortOrder: number = 0;
-
   constructor(options: AssetAssociationOptions = {}) {
     super(options);
     if (options.assetId) this.assetId = options.assetId;
-    if (options.metaType) this.metaType = options.metaType;
-    if (options.metaId) this.metaId = options.metaId;
-    if (options.role) this.role = options.role;
-    if (options.sortOrder !== undefined) this.sortOrder = options.sortOrder;
   }
 }

--- a/packages/assets/src/types.ts
+++ b/packages/assets/src/types.ts
@@ -2,7 +2,10 @@
  * Type definitions for @have/assets package
  */
 
-import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
+import type {
+  SmrtObjectOptions,
+  SmrtPolymorphicAssociationOptions,
+} from '@happyvertical/smrt-core';
 
 /**
  * Options for creating an AssetType instance
@@ -61,14 +64,14 @@ export interface AssetOptions extends SmrtObjectOptions {
 }
 
 /**
- * Options for creating an AssetAssociation instance
+ * Options for creating an AssetAssociation instance.
+ *
+ * The polymorphic `metaType` / `metaId` / `role` / `sortOrder` options come
+ * from `SmrtPolymorphicAssociationOptions`; this only adds the owner FK.
  */
-export interface AssetAssociationOptions extends SmrtObjectOptions {
+export interface AssetAssociationOptions
+  extends SmrtPolymorphicAssociationOptions {
   assetId?: string;
-  metaType?: string;
-  metaId?: string;
-  role?: string;
-  sortOrder?: number;
 }
 
 /**

--- a/packages/core/src/__tests__/polymorphic-association.test.ts
+++ b/packages/core/src/__tests__/polymorphic-association.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for SmrtPolymorphicAssociation base class.
+ *
+ * Covers:
+ * - Inherited polymorphic columns (metaType / metaId / role / sortOrder)
+ *   persist and reload on a concrete `@smrt()` subclass that adds its own
+ *   owner field.
+ * - `hydrate()` resolves `metaType` via the registry and loads `metaId`,
+ *   returning the concrete target row.
+ * - `hydrate()` returns `null` for a missing target row, an unregistered
+ *   `metaType`, and unset `metaType` / `metaId`.
+ */
+
+import { existsSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SmrtCollection } from '../collection';
+import { SmrtObject } from '../object';
+import { SmrtPolymorphicAssociation } from '../polymorphic-association';
+import { ObjectRegistry, smrt } from '../registry';
+
+@smrt({ tableName: 'poly_assoc_test_targets' })
+class PolyTarget extends SmrtObject {
+  name = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+  }
+}
+
+@smrt()
+class PolyTargetCollection extends SmrtCollection<PolyTarget> {
+  static readonly _itemClass = PolyTarget;
+}
+
+@smrt({
+  tableName: 'poly_assoc_test_links',
+  conflictColumns: ['owner_id', 'meta_type', 'meta_id', 'role'],
+})
+class PolyLink extends SmrtPolymorphicAssociation {
+  ownerId = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.ownerId !== undefined) this.ownerId = options.ownerId;
+  }
+}
+
+@smrt()
+class PolyLinkCollection extends SmrtCollection<PolyLink> {
+  static readonly _itemClass = PolyLink;
+}
+
+function tmpDbUrl(name: string): string {
+  return `file:${join(
+    tmpdir(),
+    `smrt-poly-assoc-test-${name}-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2)}.db`,
+  )}`;
+}
+
+describe('SmrtPolymorphicAssociation', () => {
+  let dbPath: string;
+  let dbUrl: string;
+  let targets: PolyTargetCollection;
+  let links: PolyLinkCollection;
+  /** Canonical metaType for PolyTarget (qualified name when available). */
+  let targetMetaType: string;
+
+  beforeEach(async () => {
+    dbUrl = tmpDbUrl('basic');
+    dbPath = dbUrl.replace('file:', '');
+    const dbOptions = { db: { type: 'sqlite' as const, url: dbUrl } };
+    targets = await PolyTargetCollection.create(dbOptions);
+    links = await PolyLinkCollection.create(dbOptions);
+    targetMetaType =
+      ObjectRegistry.getClass('PolyTarget')?.qualifiedName ?? 'PolyTarget';
+  });
+
+  afterEach(() => {
+    if (existsSync(dbPath)) unlinkSync(dbPath);
+  });
+
+  describe('inherited polymorphic columns', () => {
+    it('persists and reloads metaType / metaId / role / sortOrder', async () => {
+      const target = await targets.create({ name: 'hero-image' });
+      await target.save();
+
+      const link = await links.create({
+        ownerId: 'owner-1',
+        metaType: targetMetaType,
+        metaId: target.id,
+        role: 'hero',
+        sortOrder: 3,
+      });
+      await link.save();
+
+      const reloaded = await links.get({ id: link.id });
+      expect(reloaded).not.toBeNull();
+      expect(reloaded?.ownerId).toBe('owner-1');
+      expect(reloaded?.metaType).toBe(targetMetaType);
+      expect(reloaded?.metaId).toBe(target.id);
+      expect(reloaded?.role).toBe('hero');
+      expect(reloaded?.sortOrder).toBe(3);
+    });
+
+    it('defaults role to "default" and sortOrder to 0', async () => {
+      const link = await links.create({
+        ownerId: 'owner-2',
+        metaType: targetMetaType,
+        metaId: 'some-id',
+      });
+      expect(link.role).toBe('default');
+      expect(link.sortOrder).toBe(0);
+    });
+
+    it('supports WHERE queries against inherited columns', async () => {
+      const target = await targets.create({ name: 't' });
+      await target.save();
+      const link = await links.create({
+        ownerId: 'owner-3',
+        metaType: targetMetaType,
+        metaId: target.id,
+        role: 'thumbnail',
+      });
+      await link.save();
+
+      const found = (await links.list({
+        where: {
+          metaType: targetMetaType,
+          metaId: target.id,
+          role: 'thumbnail',
+        },
+      })) as PolyLink[];
+      expect(found.map((l) => l.id)).toContain(link.id);
+    });
+  });
+
+  describe('hydrate()', () => {
+    it('resolves metaType and loads the concrete target row', async () => {
+      const target = await targets.create({ name: 'resolved-target' });
+      await target.save();
+
+      const link = await links.create({
+        ownerId: 'owner-4',
+        metaType: targetMetaType,
+        metaId: target.id,
+        role: 'hero',
+      });
+      await link.save();
+
+      const hydrated = await link.hydrate<PolyTarget>();
+      expect(hydrated).not.toBeNull();
+      expect(hydrated).toBeInstanceOf(PolyTarget);
+      expect(hydrated?.id).toBe(target.id);
+      expect(hydrated?.name).toBe('resolved-target');
+    });
+
+    it('returns null when the target row no longer exists', async () => {
+      const link = await links.create({
+        ownerId: 'owner-5',
+        metaType: targetMetaType,
+        metaId: 'missing-id',
+      });
+      expect(await link.hydrate()).toBeNull();
+    });
+
+    it('returns null when metaType is not registered', async () => {
+      const link = await links.create({
+        ownerId: 'owner-6',
+        metaType: '@nonexistent/pkg:NotAClass',
+        metaId: 'whatever',
+      });
+      expect(await link.hydrate()).toBeNull();
+    });
+
+    it('returns null when metaType or metaId is unset', async () => {
+      // metaType / metaId are required columns, so build a valid row and
+      // blank the fields in memory to exercise hydrate()'s guard.
+      const target = await targets.create({ name: 'guard-target' });
+      await target.save();
+      const link = await links.create({
+        ownerId: 'owner-7',
+        metaType: targetMetaType,
+        metaId: target.id,
+      });
+      await link.save();
+
+      link.metaType = '';
+      expect(await link.hydrate()).toBeNull();
+
+      link.metaType = targetMetaType;
+      link.metaId = '';
+      expect(await link.hydrate()).toBeNull();
+    });
+  });
+});

--- a/packages/core/src/__tests__/polymorphic-association.test.ts
+++ b/packages/core/src/__tests__/polymorphic-association.test.ts
@@ -53,6 +53,32 @@ class PolyLinkCollection extends SmrtCollection<PolyLink> {
   static readonly _itemClass = PolyLink;
 }
 
+// STI hierarchy used to verify hydrate() rehydrates the concrete subclass.
+@smrt({ tableName: 'poly_assoc_test_docs', tableStrategy: 'sti' })
+class PolyDoc extends SmrtObject {
+  title = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.title !== undefined) this.title = options.title;
+  }
+}
+
+@smrt()
+class PolyArticle extends PolyDoc {
+  byline = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.byline !== undefined) this.byline = options.byline;
+  }
+}
+
+@smrt()
+class PolyDocCollection extends SmrtCollection<PolyDoc> {
+  static readonly _itemClass = PolyDoc;
+}
+
 function tmpDbUrl(name: string): string {
   return `file:${join(
     tmpdir(),
@@ -67,17 +93,22 @@ describe('SmrtPolymorphicAssociation', () => {
   let dbUrl: string;
   let targets: PolyTargetCollection;
   let links: PolyLinkCollection;
+  let dbOptions: { db: { type: 'sqlite'; url: string } };
   /** Canonical metaType for PolyTarget (qualified name when available). */
   let targetMetaType: string;
+  /** Canonical metaType for the STI child PolyArticle. */
+  let articleMetaType: string;
 
   beforeEach(async () => {
     dbUrl = tmpDbUrl('basic');
     dbPath = dbUrl.replace('file:', '');
-    const dbOptions = { db: { type: 'sqlite' as const, url: dbUrl } };
+    dbOptions = { db: { type: 'sqlite' as const, url: dbUrl } };
     targets = await PolyTargetCollection.create(dbOptions);
     links = await PolyLinkCollection.create(dbOptions);
     targetMetaType =
       ObjectRegistry.getClass('PolyTarget')?.qualifiedName ?? 'PolyTarget';
+    articleMetaType =
+      ObjectRegistry.getClass('PolyArticle')?.qualifiedName ?? 'PolyArticle';
   });
 
   afterEach(() => {
@@ -157,6 +188,29 @@ describe('SmrtPolymorphicAssociation', () => {
       expect(hydrated).toBeInstanceOf(PolyTarget);
       expect(hydrated?.id).toBe(target.id);
       expect(hydrated?.name).toBe('resolved-target');
+    });
+
+    it('rehydrates an STI target as its concrete subclass', async () => {
+      const article = new PolyArticle({
+        ...dbOptions,
+        title: 'STI Title',
+        byline: 'by line',
+      });
+      await article.initialize();
+      await article.save();
+
+      const link = await links.create({
+        ownerId: 'owner-sti',
+        metaType: articleMetaType,
+        metaId: article.id,
+        role: 'hero',
+      });
+      await link.save();
+
+      const hydrated = await link.hydrate<PolyArticle>();
+      expect(hydrated).toBeInstanceOf(PolyArticle);
+      expect(hydrated?.title).toBe('STI Title');
+      expect(hydrated?.byline).toBe('by line');
     });
 
     it('returns null when the target row no longer exists', async () => {

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -35,6 +35,10 @@ export {
   SmrtJunction,
 } from './junction';
 export * from './object';
+export {
+  SmrtPolymorphicAssociation,
+  type SmrtPolymorphicAssociationOptions,
+} from './polymorphic-association';
 export * from './registry';
 export { smrt as smrtRegistry } from './registry';
 // Universal signaling system

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -102,6 +102,10 @@ export {
   SchemaComparer,
 } from './migrations/differ';
 export * from './object';
+export {
+  SmrtPolymorphicAssociation,
+  type SmrtPolymorphicAssociationOptions,
+} from './polymorphic-association';
 export * from './registry';
 export { smrt as smrtRegistry } from './registry';
 // Runtime utilities

--- a/packages/core/src/polymorphic-association.ts
+++ b/packages/core/src/polymorphic-association.ts
@@ -42,6 +42,7 @@
  * ```
  */
 
+import type { SmrtCollection } from './collection';
 import { field } from './decorators/index';
 import { SmrtObject, type SmrtObjectOptions } from './object';
 import { ObjectRegistry } from './registry';
@@ -110,24 +111,44 @@ export class SmrtPolymorphicAssociation extends SmrtObject {
    * the target's collection. Going through the collection means STI targets
    * are rehydrated as their concrete subclass and a missing row yields `null`.
    *
-   * Returns `null` when `metaType`/`metaId` are unset, the type isn't
-   * registered, or the target row no longer exists. The target shares this
-   * association's database connection via `this.options`.
+   * When the type isn't registered yet, the raw `metaType` is handed to
+   * `ObjectRegistry.getCollection`, which lazily loads an installed-but-
+   * unimported target package before resolving — so a qualified `metaType`
+   * still hydrates even if nothing has imported the target class.
+   *
+   * Returns `null` when `metaType`/`metaId` are unset, the type can't be
+   * resolved to a registered/loadable class, or the target row no longer
+   * exists. The target shares this association's database connection via
+   * `this.options`.
+   *
+   * Prefer qualified `metaType` values (`@pkg:Class`): a bare simple name is
+   * resolved best-effort and is ambiguous when two packages share a class
+   * name.
    *
    * @typeParam T - Expected target type for the caller's convenience cast.
    */
   async hydrate<T extends SmrtObject = SmrtObject>(): Promise<T | null> {
     if (!this.metaType || !this.metaId) return null;
 
+    // Prefer the qualified-name lookup; fall back to a simple-name lookup for
+    // legacy/unqualified values. When neither resolves, hand the raw metaType
+    // to getCollection so its lazy external-package load can still find it.
     const registered =
       ObjectRegistry.getClassByQualifiedName(this.metaType) ??
       ObjectRegistry.getClass(this.metaType);
-    if (!registered) return null;
+    const lookup =
+      registered?.qualifiedName ?? registered?.name ?? this.metaType;
 
-    const collection = await ObjectRegistry.getCollection<SmrtObject>(
-      registered.qualifiedName ?? registered.name,
-      this.options,
-    );
+    let collection: SmrtCollection<SmrtObject>;
+    try {
+      collection = await ObjectRegistry.getCollection<SmrtObject>(
+        lookup,
+        this.options,
+      );
+    } catch {
+      // metaType doesn't resolve to a registered or loadable class.
+      return null;
+    }
 
     const target = await collection.get({ id: this.metaId });
     return target as T | null;

--- a/packages/core/src/polymorphic-association.ts
+++ b/packages/core/src/polymorphic-association.ts
@@ -1,0 +1,135 @@
+/**
+ * SmrtPolymorphicAssociation — base class for polymorphic association rows.
+ *
+ * A polymorphic association links an owner row to an arbitrary target
+ * SmrtObject identified by a `(metaType, metaId)` pair — `metaType` being the
+ * target's qualified class name (e.g. `@happyvertical/smrt-content:Article`)
+ * and `metaId` its row id. Pair that with a `role` discriminator and a
+ * `sortOrder`, and one join table can reference many different target types
+ * without a typed foreign key per type.
+ *
+ * Subclasses add their own "owner" side and decorate with `@smrt()`:
+ *
+ * ```typescript
+ * @smrt({ conflictColumns: ['asset_id', 'meta_type', 'meta_id', 'role'] })
+ * export class AssetAssociation extends SmrtPolymorphicAssociation {
+ *   @foreignKey('Asset', { required: true })
+ *   assetId = '';
+ * }
+ *
+ * const target = await association.hydrate(); // resolves metaType + loads metaId
+ * ```
+ *
+ * Convention: `metaId` is intentionally a bare string, NOT a typed
+ * `@foreignKey` / `@crossPackageRef` — it is polymorphic, so there is no
+ * single target table to point at. `metaType` carries the type information
+ * instead, resolved at runtime via `ObjectRegistry`.
+ *
+ * This is an abstract framework base in the same family as
+ * `SmrtHierarchical` and `SmrtJunction`: it has no `@smrt()` decorator and no
+ * table of its own. Its columns are merged into each concrete subclass's
+ * manifest by the scanner's `FRAMEWORK_BASE_CLASSES` /
+ * `FRAMEWORK_ABSTRACT_BASE_NAMES` wiring. Keep those two lists in sync when
+ * touching this class.
+ *
+ * @example
+ * ```typescript
+ * @smrt({ conflictColumns: ['owner_id', 'meta_type', 'meta_id', 'role'] })
+ * export class CommentAssociation extends SmrtPolymorphicAssociation {
+ *   @foreignKey('Comment', { required: true })
+ *   ownerId = '';
+ * }
+ * ```
+ */
+
+import { field } from './decorators/index';
+import { SmrtObject, type SmrtObjectOptions } from './object';
+import { ObjectRegistry } from './registry';
+
+/**
+ * Options accepted by `SmrtPolymorphicAssociation` (and its subclasses)
+ * covering the polymorphic right side of the join.
+ */
+export interface SmrtPolymorphicAssociationOptions extends SmrtObjectOptions {
+  /** Target class name or qualified name (e.g. `'Article'` or `'@pkg:Article'`). */
+  metaType?: string;
+  /** Target object id. */
+  metaId?: string;
+  /** Association role (e.g. `'hero'`, `'thumbnail'`, `'attachment'`). */
+  role?: string;
+  /** Sort order within a role. */
+  sortOrder?: number;
+}
+
+export class SmrtPolymorphicAssociation extends SmrtObject {
+  /**
+   * Internal marker so the scanner can recognize this framework abstract base
+   * even when consumers haven't built its package. Mirrors
+   * `SmrtHierarchical._isHierarchicalBase` and `SmrtJunction._isJunctionBase`.
+   * Don't rename without also updating the scanner's `FRAMEWORK_BASE_CLASSES`
+   * set in `packages/scanner/src/inheritance-resolver.ts` and
+   * `FRAMEWORK_ABSTRACT_BASE_NAMES` in
+   * `packages/core/src/scanner/manifest-generator.ts`.
+   */
+  static readonly _isPolymorphicAssociationBase = true as const;
+
+  /** Target class name or qualified name (e.g. `'Article'` or `'@pkg:Article'`). */
+  @field({ required: true })
+  metaType = '';
+
+  /**
+   * Target object id. Bare string by design — polymorphic, not a typed
+   * `@foreignKey` / `@crossPackageRef`, because there is no single target
+   * table to point at.
+   */
+  @field({ required: true })
+  metaId = '';
+
+  /** Role of this association (e.g. `'hero'`, `'thumbnail'`, `'attachment'`). */
+  @field({ required: true })
+  role = 'default';
+
+  /** Sort order for ordering targets within a role. */
+  @field()
+  sortOrder: number = 0;
+
+  constructor(options: SmrtPolymorphicAssociationOptions = {}) {
+    super(options);
+    if (options.metaType) this.metaType = options.metaType;
+    if (options.metaId) this.metaId = options.metaId;
+    if (options.role) this.role = options.role;
+    if (options.sortOrder !== undefined) this.sortOrder = options.sortOrder;
+  }
+
+  /**
+   * Resolve and load the target object this association points at.
+   *
+   * Resolves `metaType` to its registered class via
+   * `ObjectRegistry.getClassByQualifiedName` (falling back to a simple-name
+   * lookup for legacy/unqualified values), then loads the `metaId` row through
+   * the target's collection. Going through the collection means STI targets
+   * are rehydrated as their concrete subclass and a missing row yields `null`.
+   *
+   * Returns `null` when `metaType`/`metaId` are unset, the type isn't
+   * registered, or the target row no longer exists. The target shares this
+   * association's database connection via `this.options`.
+   *
+   * @typeParam T - Expected target type for the caller's convenience cast.
+   */
+  async hydrate<T extends SmrtObject = SmrtObject>(): Promise<T | null> {
+    if (!this.metaType || !this.metaId) return null;
+
+    const registered =
+      ObjectRegistry.getClassByQualifiedName(this.metaType) ??
+      ObjectRegistry.getClass(this.metaType);
+    if (!registered) return null;
+
+    const collection = await ObjectRegistry.getCollection<SmrtObject>(
+      registered.qualifiedName ?? registered.name,
+      this.options,
+    );
+
+    const target = await collection.get({ id: this.metaId });
+    return target as T | null;
+  }
+}

--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -61,6 +61,7 @@ const require = createRequire(import.meta.url);
 const FRAMEWORK_ABSTRACT_BASE_NAMES = new Set([
   'SmrtJunction',
   'SmrtHierarchical',
+  'SmrtPolymorphicAssociation',
 ]);
 
 /**

--- a/packages/scanner/src/inheritance-resolver.ts
+++ b/packages/scanner/src/inheritance-resolver.ts
@@ -19,16 +19,18 @@ import type {
  * packages can subclass without needing `@smrt()` must appear here, or
  * the scanner will silently drop undecorated subclasses from the manifest.
  *
- * `SmrtJunction` and `SmrtHierarchical` are stopgap entries pending a
- * manifest-driven base-class detection scheme — core would export its
- * abstract bases in its manifest and dependents would resolve through
- * them via the existing cross-package chain walker (see
+ * `SmrtJunction`, `SmrtHierarchical`, and `SmrtPolymorphicAssociation` are
+ * stopgap entries pending a manifest-driven base-class detection scheme —
+ * core would export its abstract bases in its manifest and dependents would
+ * resolve through them via the existing cross-package chain walker (see
  * `findClassDefinition`). After tracing the wiring at R3 kickoff
  * (2026-05-18), generalization was deferred: new `SmartObjectManifest →
  * ExternalManifest` adapter, new vite-plugin scan-path failure modes,
  * new sync-I/O surface — large cost for ~two saved lines per future
- * abstract base. Extend this list instead; revisit only if a third+
- * abstract base shows up with a concrete motivating case.
+ * abstract base. R4 added the third base and re-confirmed the call: a new
+ * abstract base is still two lines here + two in
+ * `FRAMEWORK_ABSTRACT_BASE_NAMES`, far cheaper than the generalization's
+ * new failure surface. Extend this list instead.
  */
 const FRAMEWORK_BASE_CLASSES = new Set([
   'SmrtObject',
@@ -36,6 +38,7 @@ const FRAMEWORK_BASE_CLASSES = new Set([
   'SmrtCollection',
   'SmrtJunction',
   'SmrtHierarchical',
+  'SmrtPolymorphicAssociation',
 ]);
 
 /**


### PR DESCRIPTION
## Summary

Promotes the `metaType`/`metaId`/`role`/`sortOrder` polymorphic-association pattern out of `AssetAssociation` and into a generic **`SmrtPolymorphicAssociation`** base class in core, with a registry-aware `hydrate()` helper. Other packages (TagAssociation, CommentAssociation, …) can now declare polymorphic joins by extending the base instead of copy-pasting the columns + resolution logic.

Closes #1320 · Part of the relationships-v2 epic #1318 (R4 / Phase-A gate item).

## What changed

- **New `SmrtPolymorphicAssociation` base** (`packages/core/src/polymorphic-association.ts`) — carries the four polymorphic columns and a `hydrate()` helper that resolves `metaType` (a qualified class name) via `ObjectRegistry.getClassByQualifiedName` (simple-name fallback) and loads `metaId` through the target's collection. Going through the collection gives STI-correct rehydration and `null` on a missing/unresolvable target. Exported from both the node (`index.ts`) and browser (`browser.ts`) entries.
- **`AssetAssociation extends SmrtPolymorphicAssociation`** — keeps its `assetId` left/owner FK, its `@smrt({ conflictColumns: [...] })`, and its public name. `AssetAssociationCollection` is untouched (already a `SmrtJunction` post-R2).
- **Framework-abstract-base wiring** — `SmrtPolymorphicAssociation` is added to the two in-sync sets that already power `SmrtHierarchical`/`SmrtJunction`: `FRAMEWORK_BASE_CLASSES` (scanner) and `FRAMEWORK_ABSTRACT_BASE_NAMES` (core manifest-generator), so the base's columns merge into the CTI subclass's manifest. Modeled exactly on the existing `SmrtHierarchical` precedent (incl. the `_isPolymorphicAssociationBase` marker).

## Additive / no schema drift

`metaId` stays a **bare string** (polymorphic — intentionally not a typed FK). The merged `asset_associations` schema is unchanged: columns `id, slug, context, created_at, updated_at, meta_type, meta_id, role, sort_order, asset_id` with identical types/nullability/defaults (`meta_type`/`meta_id`/`role` NOT NULL via the original `@field({ required: true })`, `sort_order` integer default 0). The schema differ compares columns by name, so the base-first column ordering is not drift. Public names preserved → **no downstream codemod**.

## Verification

- `npm run build` (45/45), `npm run typecheck` (49/49), `npm test` (88/88 task groups, exit 0).
- New `packages/core/src/__tests__/polymorphic-association.test.ts` (8 tests): inherited-column persistence + WHERE queries, defaults, `hydrate()` happy path, STI-subclass rehydration, and null on missing row / unregistered type / unset keys.

## Review cycle

Reviewed by codex (gpt-5.5 xhigh), GitHub Copilot, and a Claude sub-agent + orchestrator checklist (grok/gemini unavailable). Findings addressed in the follow-up commit:
- **Added the missing `browser.ts` export** (would have broken browser-condition builds importing `AssetAssociation`).
- **`hydrate()` now routes unresolved `metaType` through `getCollection`'s lazy external-package load and returns `null` instead of throwing** on resolution failure.
- Added the STI-target regression test.

Verified non-issues: the abstract base appearing in core's manifest with a `smrt_polymorphic_associations` schema is identical, shipped behavior for `SmrtHierarchical`/`SmrtJunction`; column-order is not drift (differ is name-based).
