### PR TITLE
fix(core): surface real hydrate() failures in SmrtPolymorphicAssociation (R4 round-2)

### DIFF
--- a/packages/core/src/__tests__/polymorphic-association.test.ts
+++ b/packages/core/src/__tests__/polymorphic-association.test.ts
@@ -14,7 +14,7 @@
 import { existsSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SmrtCollection } from '../collection';
 import { SmrtObject } from '../object';
 import { SmrtPolymorphicAssociation } from '../polymorphic-association';
@@ -190,7 +190,7 @@ describe('SmrtPolymorphicAssociation', () => {
       expect(hydrated?.name).toBe('resolved-target');
     });
 
-    it('rehydrates an STI target as its concrete subclass', async () => {
+    it('rehydrates an STI target stored by its concrete subclass name', async () => {
       const article = new PolyArticle({
         ...dbOptions,
         title: 'STI Title',
@@ -213,6 +213,34 @@ describe('SmrtPolymorphicAssociation', () => {
       expect(hydrated?.byline).toBe('by line');
     });
 
+    it('dispatches to the concrete subclass when metaType is the STI base', async () => {
+      // metaType points at the STI BASE; the collection must dispatch via the
+      // _meta_type discriminator and return the concrete child instance.
+      const article = new PolyArticle({
+        ...dbOptions,
+        title: 'Dispatched',
+        byline: 'via discriminator',
+      });
+      await article.initialize();
+      await article.save();
+
+      const baseMetaType =
+        ObjectRegistry.getClass('PolyDoc')?.qualifiedName ?? 'PolyDoc';
+      const link = await links.create({
+        ownerId: 'owner-sti-base',
+        metaType: baseMetaType,
+        metaId: article.id,
+        role: 'hero',
+      });
+      await link.save();
+
+      const hydrated = await link.hydrate();
+      expect(hydrated).toBeInstanceOf(PolyArticle);
+      expect((hydrated as PolyArticle | null)?.byline).toBe(
+        'via discriminator',
+      );
+    });
+
     it('returns null when the target row no longer exists', async () => {
       const link = await links.create({
         ownerId: 'owner-5',
@@ -220,6 +248,28 @@ describe('SmrtPolymorphicAssociation', () => {
         metaId: 'missing-id',
       });
       expect(await link.hydrate()).toBeNull();
+    });
+
+    it('propagates real getCollection failures instead of masking them as null', async () => {
+      const target = await targets.create({ name: 'err-target' });
+      await target.save();
+      const link = await links.create({
+        ownerId: 'owner-err',
+        metaType: targetMetaType,
+        metaId: target.id,
+      });
+      await link.save();
+
+      // A genuine failure (e.g. DB/init error) during collection resolution
+      // must surface, not be swallowed and reported as a missing target.
+      const spy = vi
+        .spyOn(ObjectRegistry, 'getCollection')
+        .mockRejectedValueOnce(new Error('db connection failed'));
+      try {
+        await expect(link.hydrate()).rejects.toThrow('db connection failed');
+      } finally {
+        spy.mockRestore();
+      }
     });
 
     it('returns null when metaType is not registered', async () => {

--- a/packages/core/src/__tests__/polymorphic-association.test.ts
+++ b/packages/core/src/__tests__/polymorphic-association.test.ts
@@ -272,6 +272,25 @@ describe('SmrtPolymorphicAssociation', () => {
       }
     });
 
+    it('propagates lazy external-load failures (e.g. ambiguous type) instead of returning null', async () => {
+      const link = await links.create({
+        ownerId: 'owner-ambig',
+        metaType: '@unresolved/pkg:Unloaded',
+        metaId: 'x',
+      });
+
+      // tryLoadFromExternalPackage throws ConfigurationError for an ambiguous
+      // unqualified type; hydrate() must let that surface, not swallow it.
+      const spy = vi
+        .spyOn(ObjectRegistry, 'tryLoadFromExternalPackage')
+        .mockRejectedValueOnce(new Error('Ambiguous class name'));
+      try {
+        await expect(link.hydrate()).rejects.toThrow('Ambiguous class name');
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
     it('returns null when metaType is not registered', async () => {
       const link = await links.create({
         ownerId: 'owner-6',

--- a/packages/core/src/polymorphic-association.ts
+++ b/packages/core/src/polymorphic-association.ts
@@ -121,9 +121,10 @@ export class SmrtPolymorphicAssociation extends SmrtObject {
    * exists. The target shares this association's database connection via
    * `this.options`.
    *
-   * Prefer qualified `metaType` values (`@pkg:Class`): a bare simple name is
-   * resolved best-effort to the first registered match (with a warning) when
-   * two packages share a class name.
+   * Prefer qualified `metaType` values (`@pkg:Class`): a bare simple name
+   * resolves to the first registered match, and an ambiguous unqualified name
+   * that has to be lazily loaded surfaces a `ConfigurationError` rather than
+   * guessing.
    *
    * @typeParam T - Expected target type for the caller's convenience cast.
    */
@@ -137,14 +138,15 @@ export class SmrtPolymorphicAssociation extends SmrtObject {
       ObjectRegistry.getClass(this.metaType);
 
     // Not registered yet — try a lazy external-package load, then re-resolve.
-    // A failed load means the type is genuinely unavailable, so treat it as
-    // "no target" rather than letting the load error escape.
+    // Branch on the boolean: a `false` result means the type genuinely isn't
+    // installed (→ null), while real loader failures (e.g. an ambiguous
+    // unqualified name throwing ConfigurationError) propagate instead of being
+    // masked as "no target".
     if (!registered) {
-      try {
-        await ObjectRegistry.tryLoadFromExternalPackage(this.metaType);
-      } catch {
-        return null;
-      }
+      const loaded = await ObjectRegistry.tryLoadFromExternalPackage(
+        this.metaType,
+      );
+      if (!loaded) return null;
       registered =
         ObjectRegistry.getClassByQualifiedName(this.metaType) ??
         ObjectRegistry.getClass(this.metaType);

--- a/packages/core/src/polymorphic-association.ts
+++ b/packages/core/src/polymorphic-association.ts
@@ -42,7 +42,6 @@
  * ```
  */
 
-import type { SmrtCollection } from './collection';
 import { field } from './decorators/index';
 import { SmrtObject, type SmrtObjectOptions } from './object';
 import { ObjectRegistry } from './registry';
@@ -111,10 +110,11 @@ export class SmrtPolymorphicAssociation extends SmrtObject {
    * the target's collection. Going through the collection means STI targets
    * are rehydrated as their concrete subclass and a missing row yields `null`.
    *
-   * When the type isn't registered yet, the raw `metaType` is handed to
-   * `ObjectRegistry.getCollection`, which lazily loads an installed-but-
-   * unimported target package before resolving — so a qualified `metaType`
-   * still hydrates even if nothing has imported the target class.
+   * When the type isn't registered yet, a lazy external-package load is
+   * attempted so a qualified `metaType` still hydrates even if nothing has
+   * imported the target class. Once resolved, the load goes through the
+   * target's collection by its qualified name — genuine failures (DB/init
+   * errors) surface rather than being masked as "no target".
    *
    * Returns `null` when `metaType`/`metaId` are unset, the type can't be
    * resolved to a registered/loadable class, or the target row no longer
@@ -122,8 +122,8 @@ export class SmrtPolymorphicAssociation extends SmrtObject {
    * `this.options`.
    *
    * Prefer qualified `metaType` values (`@pkg:Class`): a bare simple name is
-   * resolved best-effort and is ambiguous when two packages share a class
-   * name.
+   * resolved best-effort to the first registered match (with a warning) when
+   * two packages share a class name.
    *
    * @typeParam T - Expected target type for the caller's convenience cast.
    */
@@ -131,24 +131,34 @@ export class SmrtPolymorphicAssociation extends SmrtObject {
     if (!this.metaType || !this.metaId) return null;
 
     // Prefer the qualified-name lookup; fall back to a simple-name lookup for
-    // legacy/unqualified values. When neither resolves, hand the raw metaType
-    // to getCollection so its lazy external-package load can still find it.
-    const registered =
+    // legacy/unqualified values.
+    let registered =
       ObjectRegistry.getClassByQualifiedName(this.metaType) ??
       ObjectRegistry.getClass(this.metaType);
-    const lookup =
-      registered?.qualifiedName ?? registered?.name ?? this.metaType;
 
-    let collection: SmrtCollection<SmrtObject>;
-    try {
-      collection = await ObjectRegistry.getCollection<SmrtObject>(
-        lookup,
-        this.options,
-      );
-    } catch {
-      // metaType doesn't resolve to a registered or loadable class.
-      return null;
+    // Not registered yet — try a lazy external-package load, then re-resolve.
+    // A failed load means the type is genuinely unavailable, so treat it as
+    // "no target" rather than letting the load error escape.
+    if (!registered) {
+      try {
+        await ObjectRegistry.tryLoadFromExternalPackage(this.metaType);
+      } catch {
+        return null;
+      }
+      registered =
+        ObjectRegistry.getClassByQualifiedName(this.metaType) ??
+        ObjectRegistry.getClass(this.metaType);
     }
+
+    if (!registered) return null;
+
+    // Resolve via the canonical (qualified) name so the lookup is
+    // unambiguous. getCollection is deliberately NOT wrapped in a catch:
+    // real DB/init failures must surface, not be reported as a missing row.
+    const collection = await ObjectRegistry.getCollection<SmrtObject>(
+      registered.qualifiedName ?? registered.name,
+      this.options,
+    );
 
     const target = await collection.get({ id: this.metaId });
     return target as T | null;


### PR DESCRIPTION
## Summary

Follow-up to #1328 (R4 `SmrtPolymorphicAssociation`, already merged). A **round-2** review cycle (codex gpt-5.5/xhigh + GitHub Copilot + Claude sub-agent) caught a real regression introduced by #1328's round-1 fixup: `hydrate()`'s bare `try { … } catch { return null }` around `ObjectRegistry.getCollection` swallowed **every** error — including ambiguous-class `ConfigurationError` and genuine DB/init failures — masking real misconfigurations as a silent "no target".

## Fix

`hydrate()` now:
1. Resolves the target class first via `getClassByQualifiedName` → `getClass`, with a lazy `tryLoadFromExternalPackage` + re-resolve on miss (preserves the round-1 "installed-but-unimported package still hydrates" behavior).
2. Returns `null` only when the type is genuinely unresolvable.
3. Calls `getCollection` with the **unambiguous qualified name, outside any catch**, so real DB/init failures propagate instead of being reported as a missing row.

No behavior change for the documented happy paths (resolve + load, null on missing row / unset keys / unknown type).

## Tests

- New regression test: a genuine `getCollection` failure (mocked) **propagates** rather than returning `null`.
- New STI test: `metaType` set to the STI **base** class name, asserting the collection's `_meta_type` discriminator dispatch returns the concrete subclass (the previous STI test only exercised direct instantiation via the child's own name — it passed for the wrong reason; both cases are now covered).

## Verification

`npm run build` (45/45), `npm run typecheck` (49/49), `npm test` (88/88, exit 0). Polymorphic-association suite now 10 tests.
