### PR TITLE
fix(core): consumer registry drops plain fields from external package schemas (#1331)

### DIFF
--- a/packages/core/src/__tests__/consumer-plain-fields-from-manifest.test.ts
+++ b/packages/core/src/__tests__/consumer-plain-fields-from-manifest.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Consumer-integration regression for issue #1331.
+ *
+ * Reproduces the downstream-migration canary failure: in a consumer runtime
+ * (tsx db:migrate, SvelteKit SSR, plain `vite dev`) that imports several
+ * external `@happyvertical/smrt-*` packages and then calls
+ * `ObjectRegistry.getAllSchemasAsDefinitions()`, plain (undecorated) fields
+ * were silently dropped from external-package model schemas — e.g. the
+ * `roles` table lost `name`, `description`, `is_system`, so
+ * `CREATE TABLE roles` omitted `name` and migration crashed with
+ * `column "name" of relation "roles" does not exist`.
+ *
+ * Root cause: each package's `__smrt-register__` self-registration shim
+ * resolves its manifest via `new URL('./manifest.json', import.meta.url)`,
+ * assuming the compiled side-effect sits next to `dist/manifest.json`. Vite
+ * chunk-splitting is non-deterministic and sometimes hoists that side-effect
+ * into a `dist/chunks/<hash>.js` chunk, so the URL resolves to a non-existent
+ * `dist/chunks/manifest.json`. Self-registration then silently no-opped and
+ * the package's classes registered with decorator-only fields — plain fields
+ * were never seen because they only exist in the build-time manifest.
+ *
+ * This test simulates two external packages whose shims were relocated into a
+ * `chunks/` subdirectory and asserts the consumer still gets COMPLETE schemas
+ * (plain + decorated fields) from `getAllSchemasAsDefinitions()`, and that the
+ * schema is manifest-derived (no silent reflection fallback).
+ *
+ * @see https://github.com/happyvertical/smrt/issues/1331
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import { clearManifestCache } from '../manifest/manifest-loader.js';
+import { ObjectRegistry } from '../registry.js';
+import { snapshotObjectRegistryState } from '../test-utils.js';
+
+/**
+ * Write a package manifest to <dir>/manifest.json and return the path that the
+ * RELOCATED chunk shim would derive: <dir>/chunks/manifest.json (which does
+ * NOT exist on disk — exactly the broken case from the regression).
+ */
+function writeRelocatedPackage(
+  root: string,
+  packageName: string,
+  objects: Record<
+    string,
+    {
+      tableName: string;
+      fields: Record<string, Record<string, unknown>>;
+      extends?: string;
+      decoratorConfig?: Record<string, unknown>;
+    }
+  >,
+): URL {
+  const pkgDir = join(root, packageName.replace(/[@/]/g, '_'));
+  mkdirSync(pkgDir, { recursive: true });
+
+  const qualifiedObjects = Object.fromEntries(
+    Object.entries(objects).map(([className, def]) => [
+      `${packageName}:${className}`,
+      {
+        className,
+        extends: def.extends,
+        decoratorConfig: {
+          tableName: def.tableName,
+          api: false,
+          cli: false,
+          mcp: false,
+          ...def.decoratorConfig,
+        },
+        schema: { tableName: def.tableName, columns: {} },
+        fields: def.fields,
+      },
+    ]),
+  );
+
+  const manifest = {
+    version: '1.0.0',
+    timestamp: Date.now(),
+    moduleType: 'smrt',
+    packageName,
+    objects: qualifiedObjects,
+  };
+
+  // Real manifest sits at <pkgDir>/manifest.json (i.e. dist/manifest.json).
+  writeFileSync(
+    join(pkgDir, 'manifest.json'),
+    JSON.stringify(manifest, null, 2),
+  );
+
+  // Shim hoisted into <pkgDir>/chunks/<hash>.js derives this non-existent URL.
+  const chunksDir = join(pkgDir, 'chunks');
+  mkdirSync(chunksDir, { recursive: true });
+  return pathToFileURL(join(chunksDir, 'manifest.json'));
+}
+
+function columnsFor(table: string): Record<string, { type?: string }> {
+  const defs = ObjectRegistry.getAllSchemasAsDefinitions();
+  const entry = Object.entries(defs).find(
+    ([key, value]) => (value?.tableName || key) === table,
+  );
+  return (entry?.[1]?.columns ?? {}) as Record<string, { type?: string }>;
+}
+
+describe('Consumer integration: plain fields survive in external-package schemas (#1331)', () => {
+  let restoreRegistry: () => void;
+  let tempRoot = '';
+
+  beforeAll(() => {
+    restoreRegistry = snapshotObjectRegistryState();
+  });
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'smrt-consumer-1331-'));
+    ObjectRegistry.clear();
+    clearManifestCache();
+    ObjectRegistry.clearDiagnostics();
+  });
+
+  afterEach(() => {
+    ObjectRegistry.clear();
+    clearManifestCache();
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    restoreRegistry();
+    clearManifestCache();
+  });
+
+  it('yields complete tables for plain-property models from two packages even when both register shims were chunk-relocated', () => {
+    // Package 1: a Role-like model with plain text/boolean fields plus one
+    // decorated-style foreign key. This is the exact shape that regressed.
+    const usersShimUrl = writeRelocatedPackage(
+      tempRoot,
+      '@happyvertical/smrt-users-fixture',
+      {
+        Role: {
+          tableName: 'roles_fixture',
+          fields: {
+            tenantId: { type: 'foreignKey' },
+            name: { type: 'text' },
+            description: { type: 'text' },
+            isSystem: { type: 'boolean', default: false },
+          },
+        },
+      },
+    );
+
+    // Package 2: a Place-like model with plain numeric/text fields.
+    const placesShimUrl = writeRelocatedPackage(
+      tempRoot,
+      '@happyvertical/smrt-places-fixture',
+      {
+        Place: {
+          tableName: 'places_fixture',
+          fields: {
+            name: { type: 'text' },
+            latitude: { type: 'decimal', default: 0.0 },
+            longitude: { type: 'decimal', default: 0.0 },
+          },
+        },
+      },
+    );
+
+    // Simulate the two packages' import-time self-registration. Both shims
+    // derive a non-existent dist/chunks/manifest.json — the regression.
+    const usersResult = ObjectRegistry.registerPackageManifest(usersShimUrl);
+    const placesResult = ObjectRegistry.registerPackageManifest(placesShimUrl);
+
+    expect(usersResult.loaded).toBe(true);
+    expect(placesResult.loaded).toBe(true);
+
+    // No silent reflection fallback: self-registration must have recovered the
+    // real manifest, so there is no PACKAGE_MANIFEST_NOT_FOUND diagnostic.
+    const notFound = ObjectRegistry.getDiagnostics().filter(
+      (d) => d.code === 'PACKAGE_MANIFEST_NOT_FOUND',
+    );
+    expect(notFound).toHaveLength(0);
+
+    // The registered classes carry the manifest's schema and package identity
+    // (i.e. they were hydrated from the manifest, not bare decorator
+    // reflection). This is the concrete signal behind the canary's
+    // `hasManifestSchema === true` expectation.
+    const role = ObjectRegistry.findClass('Role');
+    const place = ObjectRegistry.findClass('Place');
+    expect(role?.packageName).toBe('@happyvertical/smrt-users-fixture');
+    expect(place?.packageName).toBe('@happyvertical/smrt-places-fixture');
+    expect(role?.fields.has('name')).toBe(true);
+    expect(role?.fields.has('description')).toBe(true);
+    expect(role?.fields.has('isSystem')).toBe(true);
+    expect(place?.fields.has('latitude')).toBe(true);
+    expect(place?.fields.has('longitude')).toBe(true);
+
+    // End-to-end: the consumer-facing schema definitions include the plain
+    // fields, so a generated CREATE TABLE would not drop `name` etc.
+    const roleCols = columnsFor('roles_fixture');
+    expect(Object.keys(roleCols)).toEqual(
+      expect.arrayContaining([
+        'id',
+        'tenant_id',
+        'name',
+        'description',
+        'is_system',
+      ]),
+    );
+
+    const placeCols = columnsFor('places_fixture');
+    expect(Object.keys(placeCols)).toEqual(
+      expect.arrayContaining(['id', 'name', 'latitude', 'longitude']),
+    );
+  });
+});

--- a/packages/core/src/__tests__/register-package-manifest.test.ts
+++ b/packages/core/src/__tests__/register-package-manifest.test.ts
@@ -290,6 +290,86 @@ describe('ObjectRegistry.registerPackageManifest', () => {
     }
   });
 
+  it('recovers manifest.json relocated up a directory when vite splits the register shim into a chunk (#1331)', () => {
+    // Regression for #1331. The `__smrt-register__` shim resolves the manifest
+    // via `new URL('./manifest.json', import.meta.url)`, assuming the compiled
+    // side-effect sits next to `dist/manifest.json`. Vite chunk-splitting is
+    // non-deterministic and sometimes hoists that side-effect into a
+    // `dist/chunks/<hash>.js` chunk, so the URL resolves to a non-existent
+    // `dist/chunks/manifest.json` and self-registration silently no-opped —
+    // dropping every plain (undecorated) field from the package's models in
+    // consumer runtimes. registerPackageManifest() must walk up to recover the
+    // real manifest.
+    const packageName = '@happyvertical/smrt-self-register-fixture-chunk';
+    // Real manifest lives at <tempRoot>/manifest.json (i.e. dist/manifest.json).
+    writeManifest(tempRoot, packageName, {
+      FixtureChunkWidget: {
+        decoratorConfig: {
+          tableName: 'fixture_chunk_widgets',
+          api: false,
+          cli: false,
+          mcp: false,
+        },
+        fields: {
+          // A plain (undecorated) field — exactly what was being dropped.
+          handle: { type: 'text' },
+        },
+      },
+    });
+
+    // The shim, hoisted into dist/chunks/, would derive this non-existent path.
+    const chunksDir = join(tempRoot, 'chunks');
+    mkdirSync(chunksDir, { recursive: true });
+    const relocatedManifestUrl = pathToFileURL(
+      join(chunksDir, 'manifest.json'),
+    );
+
+    ObjectRegistry.clearDiagnostics();
+    const result = ObjectRegistry.registerPackageManifest(relocatedManifestUrl);
+
+    expect(result.loaded).toBe(true);
+    expect(result.packageName).toBe(packageName);
+    expect(result.objectsRegistered).toBe(1);
+
+    // No PACKAGE_MANIFEST_NOT_FOUND diagnostic — recovery succeeded.
+    const notFound = ObjectRegistry.getDiagnostics().find(
+      (d) => d.code === 'PACKAGE_MANIFEST_NOT_FOUND',
+    );
+    expect(notFound).toBeUndefined();
+
+    // And the plain field is registered, so consumers see a complete schema.
+    @smrt({
+      tableName: 'fixture_chunk_widgets',
+      api: false,
+      cli: false,
+      mcp: false,
+    })
+    class FixtureChunkWidget extends SmrtObject {}
+
+    const registered = ObjectRegistry.findClass('FixtureChunkWidget');
+    expect(registered?.fields.has('handle')).toBe(true);
+    void FixtureChunkWidget;
+  });
+
+  it('still no-ops when no manifest.json exists in any parent directory', () => {
+    // The upward search is bounded and must not spuriously recover an
+    // unrelated manifest. With nothing to find, the not-found diagnostic
+    // still fires.
+    const chunksDir = join(tempRoot, 'chunks');
+    mkdirSync(chunksDir, { recursive: true });
+    const missingUrl = pathToFileURL(join(chunksDir, 'manifest.json'));
+
+    ObjectRegistry.clearDiagnostics();
+    const result = ObjectRegistry.registerPackageManifest(missingUrl);
+
+    expect(result.loaded).toBe(false);
+    expect(result.objectsRegistered).toBe(0);
+    const notFound = ObjectRegistry.getDiagnostics().find(
+      (d) => d.code === 'PACKAGE_MANIFEST_NOT_FOUND',
+    );
+    expect(notFound).toBeDefined();
+  });
+
   it('accepts a plain string path as well as a URL', () => {
     const packageName = '@happyvertical/smrt-self-register-fixture-strpath';
     const manifestPath = writeManifest(tempRoot, packageName, {

--- a/packages/core/src/__tests__/register-package-manifest.test.ts
+++ b/packages/core/src/__tests__/register-package-manifest.test.ts
@@ -370,6 +370,44 @@ describe('ObjectRegistry.registerPackageManifest', () => {
     expect(notFound).toBeDefined();
   });
 
+  it('does not escape the package root to load an unrelated manifest.json', () => {
+    // Hardening guard: when THIS package's dist/manifest.json is genuinely
+    // absent (broken build), the upward search must not climb past the package
+    // root and match a DIFFERENT package's manifest — that would silently
+    // register the wrong schema, worse than a clean no-op. Layout:
+    //   <tempRoot>/manifest.json         <- unrelated manifest, ABOVE the package
+    //   <tempRoot>/pkg/package.json      <- the package root (boundary)
+    //   <tempRoot>/pkg/dist/chunks/...   <- relocated shim path (dist manifest missing)
+    const wrongPkg = '@happyvertical/smrt-wrong-package';
+    writeManifest(tempRoot, wrongPkg, {
+      WrongWidget: {
+        decoratorConfig: { tableName: 'wrong_widgets' },
+        fields: { wrongField: { type: 'text' } },
+      },
+    });
+    const pkgRoot = join(tempRoot, 'pkg');
+    const distChunks = join(pkgRoot, 'dist', 'chunks');
+    mkdirSync(distChunks, { recursive: true });
+    writeFileSync(
+      join(pkgRoot, 'package.json'),
+      JSON.stringify({ name: '@happyvertical/smrt-real-package' }),
+    );
+    // <pkg>/dist/manifest.json is intentionally absent (simulating a broken build).
+    const missingUrl = pathToFileURL(join(distChunks, 'manifest.json'));
+
+    ObjectRegistry.clearDiagnostics();
+    const result = ObjectRegistry.registerPackageManifest(missingUrl);
+
+    // Must NOT recover the unrelated manifest above the package root.
+    expect(result.loaded).toBe(false);
+    expect(result.objectsRegistered).toBe(0);
+    expect(result.packageName).not.toBe(wrongPkg);
+    const notFound = ObjectRegistry.getDiagnostics().find(
+      (d) => d.code === 'PACKAGE_MANIFEST_NOT_FOUND',
+    );
+    expect(notFound).toBeDefined();
+  });
+
   it('accepts a plain string path as well as a URL', () => {
     const packageName = '@happyvertical/smrt-self-register-fixture-strpath';
     const manifestPath = writeManifest(tempRoot, packageName, {

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -199,8 +199,9 @@ function resolveManifestByUpwardSearch(
   const fileName = path.basename(missingPath);
   // Bound the walk so a stray, deeply-nested path can never trigger a slow or
   // unbounded filesystem crawl. Chunks are normally one directory deep
-  // (`dist/chunks/`), so a handful of levels is comfortably sufficient.
-  const MAX_LEVELS = 5;
+  // (`dist/chunks/`), so a handful of levels is comfortably sufficient. The
+  // package-root stop below is the authoritative guard; this is just a backstop.
+  const MAX_LEVELS = 4;
   let dir = path.dirname(missingPath);
   for (let level = 0; level < MAX_LEVELS; level++) {
     const parent = path.dirname(dir);
@@ -211,6 +212,16 @@ function resolveManifestByUpwardSearch(
     const candidate = path.join(parent, fileName);
     if (fs.existsSync(candidate)) {
       return candidate;
+    }
+    // Never search above the package root. The real manifest is always at
+    // `<pkg>/dist/manifest.json`; once we have checked the directory that holds
+    // `package.json` (the package root), stop. Otherwise a chunk whose
+    // `dist/manifest.json` is genuinely absent could match an unrelated
+    // `manifest.json` from a parent package, the monorepo root, or a
+    // `node_modules` ancestor — registering the WRONG package's schema, which
+    // is worse than a clean no-op.
+    if (fs.existsSync(path.join(parent, 'package.json'))) {
+      break;
     }
     dir = parent;
   }

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -175,6 +175,49 @@ async function discoverInstalledSmrtPackages(): Promise<string[]> {
 }
 
 /**
+ * Recover a package's `manifest.json` when the path derived from the
+ * `__smrt-register__` shim's `import.meta.url` does not exist.
+ *
+ * The shim resolves the manifest with `new URL('./manifest.json',
+ * import.meta.url)`, which assumes the compiled side-effect sits directly
+ * next to `dist/manifest.json`. Vite chunk-splitting is non-deterministic and
+ * occasionally hoists that side-effect into a `dist/chunks/<hash>.js` chunk,
+ * so the URL resolves to a non-existent `dist/chunks/manifest.json`. This
+ * walks up a bounded number of parent directories looking for a sibling
+ * `manifest.json`, keeping self-registration working regardless of where the
+ * bundler placed the shim (#1331).
+ *
+ * @param builtins - Node fs/path/url modules from `getNodeBuiltins()`.
+ * @param missingPath - The non-existent manifest path the shim derived.
+ * @returns The recovered manifest path, or `null` if none was found.
+ */
+function resolveManifestByUpwardSearch(
+  builtins: NonNullable<ReturnType<typeof getNodeBuiltins>>,
+  missingPath: string,
+): string | null {
+  const { fs, path } = builtins;
+  const fileName = path.basename(missingPath);
+  // Bound the walk so a stray, deeply-nested path can never trigger a slow or
+  // unbounded filesystem crawl. Chunks are normally one directory deep
+  // (`dist/chunks/`), so a handful of levels is comfortably sufficient.
+  const MAX_LEVELS = 5;
+  let dir = path.dirname(missingPath);
+  for (let level = 0; level < MAX_LEVELS; level++) {
+    const parent = path.dirname(dir);
+    // Reached the filesystem root — `dirname` is now idempotent.
+    if (parent === dir) {
+      break;
+    }
+    const candidate = path.join(parent, fileName);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+    dir = parent;
+  }
+  return null;
+}
+
+/**
  * Central registry for all SMRT objects
  *
  * Uses globalThis for cross-module state sharing, ensuring all module instances
@@ -1072,14 +1115,30 @@ export class ObjectRegistry {
         filePath = urlString;
       }
 
+      // The `__smrt-register__` shim resolves the manifest via
+      // `new URL('./manifest.json', import.meta.url)`, which assumes the
+      // compiled side-effect sits directly next to `dist/manifest.json`.
+      // Vite chunk-splitting is non-deterministic and sometimes hoists that
+      // side-effect into a `dist/chunks/<hash>.js` chunk (observed for
+      // smrt-users / smrt-profiles), so the shim's URL resolves to a
+      // non-existent `dist/chunks/manifest.json` and self-registration
+      // silently no-ops — dropping every plain (undecorated) field from the
+      // package's models in consumer runtimes (#1331). When the direct path
+      // is missing, walk up a bounded number of parent directories to locate
+      // the real `manifest.json`. This keeps resolution deterministic
+      // regardless of where the bundler places the shim.
       if (!builtins.fs.existsSync(filePath)) {
-        recordRegistryDiagnostic(
-          'warn',
-          'PACKAGE_MANIFEST_NOT_FOUND',
-          `Package manifest not found at ${filePath}. Self-registration is a no-op; the vitest plugin may still populate this manifest via its own path.`,
-          { manifestUrl: String(manifestUrl), filePath },
-        );
-        return { loaded: false, objectsRegistered: 0 };
+        const recovered = resolveManifestByUpwardSearch(builtins, filePath);
+        if (!recovered) {
+          recordRegistryDiagnostic(
+            'warn',
+            'PACKAGE_MANIFEST_NOT_FOUND',
+            `Package manifest not found at ${filePath}. Self-registration is a no-op; the vitest plugin may still populate this manifest via its own path.`,
+            { manifestUrl: String(manifestUrl), filePath },
+          );
+          return { loaded: false, objectsRegistered: 0 };
+        }
+        filePath = recovered;
       }
 
       const parsed = JSON.parse(


### PR DESCRIPTION
## Summary

Fixes a confirmed **runtime registry regression** found by the willgriffin.dev downstream-migration canary (#1331). In consumer runtimes that import external `@happyvertical/smrt-*` packages via the documented tsx-script path (e.g. `db:migrate`), `ObjectRegistry.getAllSchemasAsDefinitions()` silently dropped every **plain (undecorated)** field from external-package model schemas.

Concretely, the `roles` table lost `name`, `description`, `is_system`, so the generated `CREATE TABLE roles` omitted `name` and migration crashed with `column "name" of relation "roles" does not exist`. Decorated fields (e.g. `@foreignKey` `tenant_id`) survived; only plain properties were lost.

## Root cause

Each package's `__smrt-register__` self-registration shim resolves its manifest via `new URL('./manifest.json', import.meta.url)`, assuming the compiled side-effect sits directly next to `dist/manifest.json`.

Vite chunk-splitting is non-deterministic and sometimes hoists that side-effect into a `dist/chunks/<hash>.js` chunk (observed for `smrt-users` and `smrt-profiles` on this branch; `smrt-places`/`smrt-tags` kept it in `index.js`). The shim's URL then resolves to a **non-existent** `dist/chunks/manifest.json`, `registerPackageManifest()` records a `PACKAGE_MANIFEST_NOT_FOUND` diagnostic and silently no-ops, and the package's classes register with **decorator-only fields**. Plain fields only exist in the build-time manifest, so they are never seen — `getAllSchemasAsDefinitions()` falls back to decorator reflection.

This is the same class of non-deterministic `import.meta.url`/bundler fragility called out in the core `CLAUDE.md` gotcha (#1139).

### Regression window
Reproduced empirically against linked consumers:
- OLD ref `2c9c6aee3`: `roles` schema complete (`name/description/is_system` present), `Role.packageName = @happyvertical/smrt-users`.
- NEW ref `889140ea2`: plain fields dropped, `Role.packageName = undefined`, `PACKAGE_MANIFEST_NOT_FOUND "…/dist/chunks/manifest.json"`.

The `manifest-loader.ts` discovery code is byte-identical between the two refs — the regression is purely the bundler relocating the register shim into a `chunks/` subdir during the relationships-v2 build, breaking the shim's relative manifest path.

## Fix

When the shim-derived manifest path does not exist, `registerPackageManifest()` now walks up a bounded number (5) of parent directories to recover the real `manifest.json`. Resolution is deterministic regardless of where the bundler places the shim. The bounded search still no-ops (and records the diagnostic) when no manifest exists anywhere up the chain.

## Verification

Against a self-contained linked consumer importing core + users/places/profiles/tags:
- `roles`: `id=UUID  tenant_id=UUID  name=TEXT  description=TEXT  is_system=BOOLEAN`
- `places`: `latitude=REAL  longitude=REAL  name=TEXT`
- `tags`: `name=TEXT`
- `profiles` (STI): plain `email/name/description` + STI `_meta_type/_meta_data` + decorated FK `type_id=UUID`
- `manifest diagnostics: 0`

STI discriminator columns and decorated FKs are unregressed.

## Severity / scope

Affects **all consumers** using the documented tsx-script path against any package whose vite build relocates the register shim into a `chunks/` subdir. It is not link-only (the `manifest.json` path is wrong relative to the chunk regardless of how the package is installed), and is non-deterministic per package/build — a release blocker for the breaking release consumed by the downstream apps.

## Tests

- `register-package-manifest.test.ts`: unit test for chunk-relocation recovery + a guard that the bounded upward search still no-ops with nothing to find.
- `consumer-plain-fields-from-manifest.test.ts` (new): consumer-integration test importing two simulated external packages whose shims were chunk-relocated, asserting complete tables for plain-property models AND that schemas are manifest-derived (no silent reflection fallback) — closes the gap in #1331.

Both new tests fail without the fix and pass with it. Full `@happyvertical/smrt-core` suite: 1839 passed; the 5 remaining failures are pre-existing on the unmodified `889140ea2` baseline (`@vitest/runner:X` stack-trace package-resolution, environment-specific, unrelated). `@happyvertical/smrt-users`: 165 passed. Typecheck and biome clean.

Closes #1331