### PR TITLE
fix(core): break FK cycles in migration ordering (#1333)

### DIFF
--- a/packages/core/src/__tests__/issue-1333-migration-circular-fk.test.ts
+++ b/packages/core/src/__tests__/issue-1333-migration-circular-fk.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Regression test for issue #1333: db:migrate aborts on a pre-existing FK cycle.
+ *
+ * A genuine same-package foreign-key cycle (e.g. smrt-chat's
+ * ChatMessage.threadId -> ChatThread and ChatThread.rootMessageId ->
+ * ChatMessage) must not abort schema ordering. SMRT does not emit real DB
+ * FOREIGN KEY constraints in its CREATE TABLE DDL, so a cycle has no valid
+ * strict topological order — the ordering must BREAK the back-edge (standard
+ * RDBMS approach: create tables first, wire cyclic references afterward)
+ * instead of throwing.
+ *
+ * Two facets are covered:
+ *   1. A fresh cyclic pair must produce a usable initialization order that
+ *      contains BOTH tables (cycle broken, not aborted).
+ *   2. An additive migration whose pending changes are unrelated to the cyclic
+ *      tables must not trip on the pre-existing cycle when the full registered
+ *      graph is ordered.
+ *
+ * @see https://github.com/happyvertical/smrt/issues/1333
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SmrtObject } from '../object.js';
+import { ObjectRegistry } from '../registry.js';
+import type { FieldDefinition } from '../scanner/types.js';
+
+// Minimal field stub mirroring registry.test.ts's helper: `related` is a
+// top-level property (not nested in _meta), matching how the scanner records
+// foreignKey targets.
+class StubField implements FieldDefinition {
+  type: FieldDefinition['type'];
+  _meta: Record<string, any>;
+  related?: string;
+
+  constructor(
+    type: FieldDefinition['type'],
+    options: Record<string, any> = {},
+  ) {
+    this.type = type;
+    if (options.related) {
+      this.related = options.related;
+      const { related, ...metaOptions } = options;
+      this._meta = metaOptions;
+    } else {
+      this._meta = options;
+    }
+  }
+}
+
+function registerWithFields(
+  ctor: typeof SmrtObject,
+  fields: Map<string, FieldDefinition>,
+): void {
+  ObjectRegistry.register(ctor, {
+    api: { include: ['list', 'get'] },
+  });
+  const registered = ObjectRegistry.getClass(ctor.name);
+  if (registered) {
+    registered.fields = fields;
+  }
+}
+
+describe('Issue #1333: FK cycles must not abort migration ordering', () => {
+  beforeEach(() => {
+    ObjectRegistry.clear();
+  });
+
+  afterEach(() => {
+    ObjectRegistry.clear();
+  });
+
+  it('breaks a two-class FK cycle instead of throwing (fresh create)', () => {
+    // class CycleNodeA { @foreignKey('CycleNodeB') bId }
+    // class CycleNodeB { @foreignKey('CycleNodeA') aId }
+    class CycleNodeA extends SmrtObject {}
+    class CycleNodeB extends SmrtObject {}
+
+    registerWithFields(
+      CycleNodeA,
+      new Map<string, FieldDefinition>([
+        ['bId', new StubField('foreignKey', { related: 'CycleNodeB' })],
+      ]),
+    );
+    registerWithFields(
+      CycleNodeB,
+      new Map<string, FieldDefinition>([
+        ['aId', new StubField('foreignKey', { related: 'CycleNodeA' })],
+      ]),
+    );
+
+    // The dependency graph reflects the genuine cycle.
+    const graph = ObjectRegistry.getDependencyGraph();
+    expect(graph.get('CycleNodeA')).toContain('CycleNodeB');
+    expect(graph.get('CycleNodeB')).toContain('CycleNodeA');
+
+    // Ordering must NOT throw — it breaks the back-edge instead.
+    let order: string[] = [];
+    expect(() => {
+      order = ObjectRegistry.getInitializationOrder();
+    }).not.toThrow();
+
+    // Both tables must still appear so both get created.
+    expect(order).toContain('CycleNodeA');
+    expect(order).toContain('CycleNodeB');
+  });
+
+  it('handles a self-referential class participating in a cycle', () => {
+    // Mirrors ChatMessage: a cyclic FK plus a self-ref.
+    class CycleSelfA extends SmrtObject {}
+    class CycleSelfB extends SmrtObject {}
+
+    registerWithFields(
+      CycleSelfA,
+      new Map<string, FieldDefinition>([
+        ['bId', new StubField('foreignKey', { related: 'CycleSelfB' })],
+        ['parentId', new StubField('foreignKey', { related: 'CycleSelfA' })],
+      ]),
+    );
+    registerWithFields(
+      CycleSelfB,
+      new Map<string, FieldDefinition>([
+        ['aId', new StubField('foreignKey', { related: 'CycleSelfA' })],
+      ]),
+    );
+
+    let order: string[] = [];
+    expect(() => {
+      order = ObjectRegistry.getInitializationOrder();
+    }).not.toThrow();
+    expect(order).toContain('CycleSelfA');
+    expect(order).toContain('CycleSelfB');
+  });
+
+  it('does not abort when an unrelated additive change coexists with a pre-existing cycle', () => {
+    // Pre-existing cyclic pair (e.g. ChatMessage <-> ChatThread already in DB).
+    class PreexistingCycleA extends SmrtObject {}
+    class PreexistingCycleB extends SmrtObject {}
+    registerWithFields(
+      PreexistingCycleA,
+      new Map<string, FieldDefinition>([
+        ['bId', new StubField('foreignKey', { related: 'PreexistingCycleB' })],
+      ]),
+    );
+    registerWithFields(
+      PreexistingCycleB,
+      new Map<string, FieldDefinition>([
+        ['aId', new StubField('foreignKey', { related: 'PreexistingCycleA' })],
+      ]),
+    );
+
+    // An unrelated NEW acyclic table (the actual pending change), plus one of
+    // its dependencies, both outside the cycle.
+    class NewParent extends SmrtObject {}
+    class NewChild extends SmrtObject {}
+    registerWithFields(NewParent, new Map<string, FieldDefinition>());
+    registerWithFields(
+      NewChild,
+      new Map<string, FieldDefinition>([
+        ['parentId', new StubField('foreignKey', { related: 'NewParent' })],
+      ]),
+    );
+
+    // db:migrate calls getInitializationOrder() over the WHOLE registered graph
+    // before diffing. It must not throw on the pre-existing cycle.
+    let order: string[] = [];
+    expect(() => {
+      order = ObjectRegistry.getInitializationOrder();
+    }).not.toThrow();
+
+    // Every registered class is present, and the acyclic dependency is ordered
+    // correctly (dependency before dependant).
+    expect(order).toContain('PreexistingCycleA');
+    expect(order).toContain('PreexistingCycleB');
+    expect(order).toContain('NewParent');
+    expect(order).toContain('NewChild');
+    expect(order.indexOf('NewParent')).toBeLessThan(order.indexOf('NewChild'));
+  });
+});

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1985,8 +1985,20 @@ export class ObjectRegistry {
    * Uses topological sort to ensure that classes are initialized in
    * an order that respects foreignKey dependencies (dependencies first).
    *
-   * @returns Array of class names in initialization order
-   * @throws {Error} If circular dependencies are detected
+   * Foreign-key cycles (e.g. smrt-chat's ChatMessage.threadId -> ChatThread
+   * and ChatThread.rootMessageId -> ChatMessage) are BROKEN rather than
+   * treated as a fatal error: when a back-edge is encountered the recursion
+   * stops there, so every class still appears in the returned order. SMRT does
+   * not emit real DB `FOREIGN KEY` constraints in its generated CREATE TABLE
+   * DDL, so a table can be created before its cyclic reference target exists —
+   * the reference is satisfied once both tables are present. This mirrors the
+   * standard RDBMS approach (create tables first, wire cyclic references
+   * afterward) and matches SchemaManager.sortByDependencies, which already
+   * tolerates cycles. See issue #1333.
+   *
+   * @returns Array of class names in initialization order. Every registered
+   *   class appears exactly once; cycle back-edges are dropped from the
+   *   ordering constraints.
    * @example
    * ```typescript
    * const order = ObjectRegistry.getInitializationOrder();
@@ -1999,13 +2011,16 @@ export class ObjectRegistry {
     const visited = new Set<string>();
     const visiting = new Set<string>();
     const order: string[] = [];
+    const cycleMembers = new Set<string>();
 
     function visit(className: string): void {
-      // Circular dependency check
+      // Back-edge: this class is already on the current DFS path, so following
+      // it would close a foreign-key cycle. Break the cycle by stopping here
+      // instead of throwing — the class is created earlier on the path and the
+      // cyclic reference resolves once both tables exist (#1333).
       if (visiting.has(className)) {
-        throw new Error(
-          `Circular dependency detected involving class: ${className}`,
-        );
+        cycleMembers.add(className);
+        return;
       }
 
       // Already processed
@@ -2031,6 +2046,18 @@ export class ObjectRegistry {
       if (!visited.has(className)) {
         visit(className);
       }
+    }
+
+    if (cycleMembers.size > 0) {
+      // Informational only — cycles are handled, not fatal. Surfacing the
+      // involved classes helps operators understand why strict FK ordering
+      // could not be honored for these tables.
+      console.warn(
+        `[ObjectRegistry] Foreign-key cycle(s) detected and broken for ordering: ${[
+          ...cycleMembers,
+        ].join(', ')}. Tables are created without strict cyclic ordering; ` +
+          'SMRT does not emit DB-level FOREIGN KEY constraints, so this is safe.',
+      );
     }
 
     return order;


### PR DESCRIPTION
## Release-blocker #1333

`smrt db:migrate` aborts with `Circular dependency detected involving class: ChatMessage` for **any** consumer of `smrt-chat`. Found by the anytown.ai downstream migration canary. Sibling of #1332.

### Root cause
`ObjectRegistry.getInitializationOrder()` (`packages/core/src/registry.ts:~2006`) throws on the first **back-edge** of its DFS topological sort instead of tolerating the cycle. `smrt-chat` has a genuine same-package FK cycle:

- `ChatMessage.threadId` → `ChatThread` (`packages/chat/src/models/ChatMessage.ts:28`)
- `ChatThread.rootMessageId` → `ChatMessage` (`packages/chat/src/models/ChatThread.ts:18`)
- plus a `ChatMessage.replyToMessageId` self-ref (already skipped by the graph builder)

`db:migrate` (`packages/cli/src/commands/utilities.ts:1306`) calls `getInitializationOrder()` over the **entire** registered class graph *before* any schema diffing, so the pre-existing chat cycle aborts the run even when the actual pending tables are unrelated (in the canary: `folders, payment_intents, smrt_hierarchicals, smrt_polymorphic_associations, users_cli_auth_requests` — no chat tables).

Key insight: SMRT's DDL generator (`packages/core/src/schema/ddl/base-strategy.ts`) emits **no** `FOREIGN KEY ... REFERENCES` constraints. FKs are tracked purely as logical ordering dependencies. So a cyclic pair has no valid strict order **and needs none** — a table can be created before its cyclic target exists.

### Fix
Break cycles the standard RDBMS way. When the sort hits a back-edge, stop the recursion (drop that one ordering constraint) instead of throwing, so every class still appears exactly once in the returned order. An informational `console.warn` lists the involved classes. This mirrors `SchemaManager.sortByDependencies`, which already tolerates cycles via warn-and-continue.

This resolves **both** facets from the issue:
1. **No cycle handling** → cycles are now broken, not fatal. A fresh cyclic pair yields a usable order containing both tables (both get created).
2. **Over-broad sort aborting unrelated migrations** → with the throw gone, the full-graph ordering no longer trips on a pre-existing cycle, so additive migrations with unrelated pending changes proceed. (No DB-level FK constraints exist, so table-creation order is not a correctness concern; scoping the sort was unnecessary once the abort is removed.)

### Regression test
`packages/core/src/__tests__/issue-1333-migration-circular-fk.test.ts` — self-contained cyclic fixtures (no anytown dependency). Asserts:
- a two-class FK cycle (`A → B`, `B → A`) orders without throwing and includes both classes;
- a self-ref-plus-cycle (mirrors `ChatMessage`) orders without throwing;
- an unrelated additive change coexisting with a pre-existing cycle does **not** abort, and the acyclic dependency is still ordered correctly.

All three fail on the pre-fix code with the exact reported error and pass after the fix.

### Verification
- `pnpm --filter @happyvertical/smrt-core test` → 1848 passed, 29 skipped, **0 failed**
- `pnpm --filter @happyvertical/smrt-cli test` → 332 passed, 2 skipped, **0 failed** (incl. atomic-migration tests)
- `pnpm --filter @happyvertical/smrt-core typecheck` → clean
- `biome check` → clean

Closes #1333.