### PR TITLE
fix(core): coerce empty-string FK values to NULL for uuid columns + 0.27 upgrade guide (whole-PR review C1/C2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 ## [Unreleased]
 
+### Breaking changes (0.27.0 — relationships-v2)
+
+0.27.0 is the relationships-v2 breaking release. It renames several columns
+(R3: `Tag.parentSlug→parentId`, `Fact.parentId→previousFactId`,
+`Asset.parentId→sourceAssetId`, the Folder split), makes `id`/FK columns native
+`uuid` on PostgreSQL (R11), adopts `@foreignKey()`/`@crossPackageRef()` across
+models (R1), extracts `SmrtPolymorphicAssociation` (R4), qualifies the
+`_meta_type` STI discriminator (R5-canon), enforces tenant isolation in
+`loadRelated()` (R8), and changes the `SmrtJunction` API
+(`getForX`→`byLeft`/`byRight`, options-object `attach`/`detach`).
+
+**Existing databases require a manual DATA migration** (column-rename backfills
++ TEXT→uuid conversion) because `smrt db:migrate` is additive-only and cannot
+rename columns or change types. A runnable helper ships as
+`smrt db:migrate-uuid`. **See [`UPGRADE-0.27.md`](./UPGRADE-0.27.md) for the
+full guide and migration checklist.** Consumers must also re-run
+`smrt docs:claude` to regenerate the downstream `.claude/smrt-framework.md`.
+
 ### Features
 
 * **core:** add 0 vs 0.0 heuristic for integer/decimal type inference

--- a/UPGRADE-0.27.md
+++ b/UPGRADE-0.27.md
@@ -31,7 +31,7 @@ just build, run `smrt db:migrate`, and regenerate your downstream docs.
 | **R3 renames** | `Tag.parentSlug → parentId`; `Fact.parentId → previousFactId`; `Asset.parentId → sourceAssetId`; Folder split out of the `assets` table into its own `folders` table. | **Data migration** — backfill renamed columns (§3.1). |
 | **R4** | `AssetAssociation` (and any generic/provenance link) now extends the new `SmrtPolymorphicAssociation` base — a `(metaType, metaId)` + `role` polymorphic link. | None unless you subclassed the old shape; rebuild. |
 | **R5-canon** | STI discriminator `_meta_type` is now the **qualified** name (`@happyvertical/smrt-content:Article`), and registry/STI lookups return qualified names. | **Data migration** — upgrade legacy bare `_meta_type` values (handled by `smrt db:migrate --repair-data`). |
-| **R8** | `loadRelated()` / `loadRelatedMany()` enforce **tenant isolation** — resolving from a tenant-scoped object into a different non-null tenant throws `TenantIsolationError`. Pass `{ bypassTenantGuard: true }` for deliberate cross-tenant flows. | Audit deliberate cross-tenant relationship loads. |
+| **R8** | `loadRelated()` / `loadRelatedMany()` enforce **tenant isolation** — resolving from a tenant-scoped object into a different non-null tenant throws `TenantIsolationError`. Pass `{ allowCrossTenant: true }` for deliberate cross-tenant flows. | Audit deliberate cross-tenant relationship loads. |
 | **R10** | `@oneToMany` relationships generate **child accessor** methods. | None; additive. |
 | **R11** | `id` and declared-FK (`@foreignKey` / `@crossPackageRef`) columns are **native `uuid`** on PostgreSQL / DuckDB (`TEXT` on SQLite). | **Data migration** — convert TEXT id/FK columns to `uuid` (§3.2). |
 | **SmrtJunction** | The base junction API is `byLeft()` / `byRight()` (was `getForX()`), and `attach()` / `detach()` take **positional** `(leftId, rightId, opts)` with an **options object** for extra fields (was positional extras). | Update call-sites (§2). |
@@ -75,7 +75,7 @@ WHERE filter. See `packages/core/src/junction.ts`.
 const related = await obj.loadRelated('ownerId');
 
 // Opt out for admin / cross-tenant tooling:
-const related = await obj.loadRelated('ownerId', { bypassTenantGuard: true });
+const related = await obj.loadRelated('ownerId', { allowCrossTenant: true });
 ```
 
 ---
@@ -197,7 +197,7 @@ This rewrites `.claude/smrt-framework.md` from the installed package
 
 - [ ] `pnpm install && npm run build`
 - [ ] Update SmrtJunction call-sites (`getForX` → `byLeft`/`byRight`; options-object `attach`/`detach`).
-- [ ] Audit deliberate cross-tenant `loadRelated()` calls; add `{ bypassTenantGuard: true }` where intended.
+- [ ] Audit deliberate cross-tenant `loadRelated()` calls; add `{ allowCrossTenant: true }` where intended.
 - [ ] Back up the database.
 - [ ] `smrt db:migrate` (structural) then `smrt db:migrate --repair-data` (`_meta_type`).
 - [ ] `smrt db:migrate-uuid --dry-run` (review), then apply the R3 rename backfills (§3.1).

--- a/UPGRADE-0.27.md
+++ b/UPGRADE-0.27.md
@@ -1,0 +1,206 @@
+# Upgrading to SMRT 0.27.0 (relationships-v2)
+
+0.27.0 is the **relationships-v2** breaking release. It consolidates how SMRT
+declares and resolves relationships across every `@happyvertical/smrt-*`
+package. The code changes are mostly transparent at the API level, but **two of
+them require a manual DATA migration** on existing databases:
+
+1. several columns are **renamed** (R3), and
+2. `id` / foreign-key columns become **native `uuid`** on PostgreSQL (R11).
+
+The structural migration (`smrt db:migrate`) is **additive** — it adds new
+columns and indexes but cannot rename a column or change a column's type in
+place. So on an existing database it will add the new (empty) columns and leave
+the old ones orphaned. **Without the data migration in this guide you will lose
+data** (the new column stays empty; the old column is dropped or ignored).
+
+If you are starting a fresh database, none of the data-migration steps apply —
+just build, run `smrt db:migrate`, and regenerate your downstream docs.
+
+> Validated consumers (anytown.ai, ergot.io) ran the data migration below
+> successfully against real production data. The runnable helper
+> (`smrt db:migrate-uuid`) is extracted from their migration scripts.
+
+---
+
+## 1. Breaking changes at a glance
+
+| Area | Change | Action needed |
+|------|--------|---------------|
+| **R1** | Domain models now declare FKs with `@foreignKey()` (same-package) / `@crossPackageRef()` (cross-package) instead of plain string ids. | None at the call-site; affects schema (see R11). |
+| **R3 renames** | `Tag.parentSlug → parentId`; `Fact.parentId → previousFactId`; `Asset.parentId → sourceAssetId`; Folder split out of the `assets` table into its own `folders` table. | **Data migration** — backfill renamed columns (§3.1). |
+| **R4** | `AssetAssociation` (and any generic/provenance link) now extends the new `SmrtPolymorphicAssociation` base — a `(metaType, metaId)` + `role` polymorphic link. | None unless you subclassed the old shape; rebuild. |
+| **R5-canon** | STI discriminator `_meta_type` is now the **qualified** name (`@happyvertical/smrt-content:Article`), and registry/STI lookups return qualified names. | **Data migration** — upgrade legacy bare `_meta_type` values (handled by `smrt db:migrate --repair-data`). |
+| **R8** | `loadRelated()` / `loadRelatedMany()` enforce **tenant isolation** — resolving from a tenant-scoped object into a different non-null tenant throws `TenantIsolationError`. Pass `{ bypassTenantGuard: true }` for deliberate cross-tenant flows. | Audit deliberate cross-tenant relationship loads. |
+| **R10** | `@oneToMany` relationships generate **child accessor** methods. | None; additive. |
+| **R11** | `id` and declared-FK (`@foreignKey` / `@crossPackageRef`) columns are **native `uuid`** on PostgreSQL / DuckDB (`TEXT` on SQLite). | **Data migration** — convert TEXT id/FK columns to `uuid` (§3.2). |
+| **SmrtJunction** | The base junction API is `byLeft()` / `byRight()` (was `getForX()`), and `attach()` / `detach()` take **positional** `(leftId, rightId, opts)` with an **options object** for extra fields (was positional extras). | Update call-sites (§2). |
+
+### Empty-string FK default → NULL (framework fix, no action)
+
+A declared FK left at its TypeScript default `''` (e.g. a root entity whose
+optional self-reference is never set — `Fact.previousFactId` on a root fact)
+used to fail to insert on PostgreSQL with `invalid input syntax for type uuid`.
+0.27.0 coerces `''` → `NULL` for uuid columns in the ORM save path, so this
+works transparently. No consumer change required.
+
+---
+
+## 2. Code-level API changes
+
+### SmrtJunction: `getForX` → `byLeft` / `byRight`, options-object attach/detach
+
+```ts
+// Before
+const rows = await links.getForContent(contentId);
+await links.attach(contentId, assetId, 'thumbnail', 0); // positional extras
+
+// After
+const rows = await links.byLeft(contentId);            // or byRight(assetId)
+await links.attach(contentId, assetId, {               // options object
+  relationship: 'thumbnail',
+  sortOrder: 0,
+});
+await links.detach(contentId, assetId, { relationship: 'thumbnail' });
+```
+
+`byLeft(leftId, opts?)` / `byRight(rightId, opts?)` return junction rows ordered
+by the subclass's `sortField` (default `sortOrder`). `opts` is an additional
+WHERE filter. See `packages/core/src/junction.ts`.
+
+### loadRelated tenant guard (R8)
+
+```ts
+// Throws TenantIsolationError if `related` lives in a different non-null tenant:
+const related = await obj.loadRelated('ownerId');
+
+// Opt out for admin / cross-tenant tooling:
+const related = await obj.loadRelated('ownerId', { bypassTenantGuard: true });
+```
+
+---
+
+## 3. Data migration (existing databases)
+
+Run these **after** `smrt db:migrate` has added the new columns. All steps are
+**idempotent** — safe to re-run. Always do a `--dry-run` first and take a
+backup.
+
+```bash
+# 0. Apply the additive structural migration first.
+smrt db:migrate
+
+# (also upgrades legacy bare _meta_type discriminators to qualified form)
+smrt db:migrate --repair-data
+```
+
+### 3.1 Backfill the R3 column renames
+
+Each rename added a new empty column and left the old one in place. Copy the
+data across and drop the old column. Only run the renames for the models your
+project actually uses.
+
+| Model | Old column | New column |
+|-------|-----------|-----------|
+| Tag | `parent_slug` | `parent_id` |
+| Fact | `parent_id` | `previous_fact_id` |
+| Asset | `parent_id` | `source_asset_id` |
+
+Using the bundled helper (`smrt db:migrate-uuid`, see §3.3), scoped to each
+table:
+
+```bash
+# Dry-run everything first.
+smrt db:migrate-uuid --skip-convert --dry-run \
+  --rename "tags.parent_slug:parent_id,facts.parent_id:previous_fact_id,assets.parent_id:source_asset_id"
+
+# Apply.
+smrt db:migrate-uuid --skip-convert \
+  --rename "tags.parent_slug:parent_id,facts.parent_id:previous_fact_id,assets.parent_id:source_asset_id"
+```
+
+> **Tag note:** the old `parent_slug` held a *slug*, while the new `parent_id`
+> holds the parent's `id`. A straight column copy is only correct if your
+> existing `parent_slug` values already store ids. If they store genuine slugs,
+> resolve slug → id first (a short project script joining `tags` to itself on
+> `slug`), then drop `parent_slug`. The bundled helper does a verbatim copy; use
+> it only when the source already holds ids.
+
+> **Folder split (R3-D):** Folder rows moved from the shared `assets` table
+> (`type_slug='folder'`) to a dedicated `folders` table. If you have Folder data
+> in `assets`, migrate those rows into `folders` with a project script before
+> dropping the old discriminator rows — this split is data-shaped per project
+> and is not auto-handled.
+
+### 3.2 Convert TEXT id/FK columns to native `uuid` (PostgreSQL)
+
+On PostgreSQL, `id` and declared-FK columns should be promoted from `TEXT` to
+native `uuid`. The bundled helper is **self-classifying**: it converts a column
+only when **every** non-empty value is a canonical UUID, and **skips** any
+column with a genuine non-uuid value (slugs, external ids like
+`'google-weather'`, legacy unhyphenated ids, analytics measurement ids, …),
+leaving those as `TEXT`.
+
+```bash
+# See exactly what would convert / be skipped — no changes.
+smrt db:migrate-uuid --dry-run
+
+# Apply (renames + conversion in one go if you also pass --rename).
+smrt db:migrate-uuid
+```
+
+SQLite stores SMRT uuid columns as `TEXT` and DuckDB accepts uuid strings
+transparently, so the conversion pass is a no-op there — the helper reports this
+and exits cleanly.
+
+### 3.3 The migration helper: `smrt db:migrate-uuid`
+
+`smrt db:migrate-uuid` (in `@happyvertical/smrt-cli`) bundles both steps:
+
+| Flag | Effect |
+|------|--------|
+| `--rename "old:new[,old2:new2]"` | Backfill renamed columns: copy `old → new` where `new` is still empty (cast to `uuid` if `new` is already a uuid column), then `DROP COLUMN old`. Use `--table <name>` to scope, or `table.old:new` per entry. |
+| `--table <name>` | Default table for `--rename` entries that omit one. |
+| `--skip-convert` | Run only the renames; skip the TEXT→uuid conversion. |
+| `--dry-run` | Print the SQL without executing. |
+| `-v, --verbose` | Detailed output. |
+
+Both steps run inside a single transaction and roll back on error.
+
+**If you need behavior the helper doesn't cover** (slug→id resolution, the
+Folder split, bespoke skip rules), the self-classifying conversion is a short,
+auditable pattern you can adapt. The canonical reference is the validated
+consumers' scripts (e.g. anytown's
+`apps/dashboard/scripts/{migrate-uuid-columns.ts,backfill-asset-source-id.ts}`):
+scan `information_schema.columns` for TEXT `id`/`*_id` columns, count
+non-empty-non-uuid values per column, and run
+`ALTER COLUMN <c> TYPE uuid USING NULLIF(btrim(<c>), '')::uuid` only for the
+columns where that count is zero (dropping any `''` default first).
+
+---
+
+## 4. After upgrading
+
+Regenerate the downstream framework doc so your project's `.claude/` reflects
+the 0.27.0 package docs:
+
+```bash
+smrt docs:claude
+```
+
+This rewrites `.claude/smrt-framework.md` from the installed package
+`CLAUDE.md` files with updated version tables.
+
+---
+
+## Migration checklist
+
+- [ ] `pnpm install && npm run build`
+- [ ] Update SmrtJunction call-sites (`getForX` → `byLeft`/`byRight`; options-object `attach`/`detach`).
+- [ ] Audit deliberate cross-tenant `loadRelated()` calls; add `{ bypassTenantGuard: true }` where intended.
+- [ ] Back up the database.
+- [ ] `smrt db:migrate` (structural) then `smrt db:migrate --repair-data` (`_meta_type`).
+- [ ] `smrt db:migrate-uuid --dry-run` (review), then apply the R3 rename backfills (§3.1).
+- [ ] `smrt db:migrate-uuid --dry-run` then apply the TEXT→uuid conversion on PostgreSQL (§3.2).
+- [ ] Handle project-shaped data (Tag slug→id, Folder split) if applicable.
+- [ ] `smrt docs:claude` to regenerate the downstream doc.

--- a/packages/cli/src/commands/__tests__/db-migrate-uuid.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-uuid.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from 'vitest';
-import { dbMigrateUuidCommand, parseRenameSpecs } from '../db-migrate-uuid.js';
+import { clearCache, setConfig } from '@happyvertical/smrt-config';
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildDeclaredUuidColumnSet,
+  dbMigrateUuidCommand,
+  type LiveTextColumn,
+  parseRenameSpecs,
+  planUuidConversions,
+} from '../db-migrate-uuid.js';
 import { utilityCommands } from '../utilities.js';
 
 describe('db:migrate-uuid command', () => {
@@ -54,4 +63,401 @@ describe('db:migrate-uuid command', () => {
       ).toThrow(/no table/);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Fix C (#1338): TEXT→uuid conversion is gated on the SMRT-declared schema.
+  // Only columns the manifest declares `type: 'UUID'` are eligible — a column
+  // the schema intentionally keeps TEXT (external_id, message_id, provider ids)
+  // is NEVER converted even when its current data happens to be uuid-shaped,
+  // and non-SMRT tables (absent from the manifest) drop out automatically.
+  // -------------------------------------------------------------------------
+  describe('buildDeclaredUuidColumnSet', () => {
+    it('collects only columns whose declared type is UUID (table|column keys)', () => {
+      const declared = buildDeclaredUuidColumnSet({
+        things: {
+          columns: {
+            id: { type: 'UUID' },
+            owner_id: { type: 'UUID' },
+            // schema-intentional TEXT id that merely holds uuid-shaped values
+            external_id: { type: 'TEXT' },
+            slug: { type: 'TEXT' },
+          },
+        },
+        widgets: {
+          columns: {
+            id: { type: 'UUID' },
+            // a non-uuid id column
+            message_id: { type: 'TEXT' },
+          },
+        },
+      });
+
+      expect([...declared].sort()).toEqual(
+        ['things|id', 'things|owner_id', 'widgets|id'].sort(),
+      );
+      expect(declared.has('things|external_id')).toBe(false);
+      expect(declared.has('widgets|message_id')).toBe(false);
+    });
+
+    it('is case-insensitive on the declared type string', () => {
+      const declared = buildDeclaredUuidColumnSet({
+        things: { columns: { id: { type: 'uuid' } } },
+      });
+      expect(declared.has('things|id')).toBe(true);
+    });
+
+    it('returns an empty set for an empty / undefined manifest (fail-closed input)', () => {
+      expect(buildDeclaredUuidColumnSet({}).size).toBe(0);
+      expect(
+        buildDeclaredUuidColumnSet(
+          undefined as unknown as Record<string, never>,
+        ).size,
+      ).toBe(0);
+    });
+  });
+
+  describe('planUuidConversions', () => {
+    const declared = new Set<string>(['things|id', 'things|owner_id']);
+
+    it('converts ONLY schema-declared-UUID columns that also hold all-uuid data', () => {
+      const live: LiveTextColumn[] = [
+        // declared UUID + clean data → convert
+        { table: 'things', column: 'id', hasDefault: true, nonUuid: 0 },
+        { table: 'things', column: 'owner_id', hasDefault: false, nonUuid: 0 },
+        // NOT declared UUID, but its data IS all uuid-shaped → still NOT converted
+        {
+          table: 'things',
+          column: 'external_id',
+          hasDefault: false,
+          nonUuid: 0,
+        },
+      ];
+
+      const plan = planUuidConversions(live, declared);
+
+      expect(plan.convert.map((c) => `${c.table}.${c.column}`).sort()).toEqual([
+        'things.id',
+        'things.owner_id',
+      ]);
+      // external_id is left as TEXT precisely because the schema does not
+      // declare it UUID, even though every value is a canonical UUID today.
+      expect(plan.skipNotDeclared.map((c) => `${c.table}.${c.column}`)).toEqual(
+        ['things.external_id'],
+      );
+      expect(plan.skipDirtyData).toEqual([]);
+      // hasDefault is carried through so the handler can DROP DEFAULT first.
+      expect(plan.convert.find((c) => c.column === 'id')?.hasDefault).toBe(
+        true,
+      );
+    });
+
+    it('skips a declared-UUID column whose data still has non-uuid values', () => {
+      const live: LiveTextColumn[] = [
+        { table: 'things', column: 'id', hasDefault: false, nonUuid: 3 },
+      ];
+      const plan = planUuidConversions(live, declared);
+      expect(plan.convert).toEqual([]);
+      expect(plan.skipDirtyData).toEqual([
+        { table: 'things', column: 'id', nonUuid: 3 },
+      ]);
+      expect(plan.skipNotDeclared).toEqual([]);
+    });
+
+    it('converts nothing when the declared-UUID set is empty (fail-closed)', () => {
+      const live: LiveTextColumn[] = [
+        { table: 'things', column: 'id', hasDefault: false, nonUuid: 0 },
+        {
+          table: 'things',
+          column: 'external_id',
+          hasDefault: false,
+          nonUuid: 0,
+        },
+      ];
+      const plan = planUuidConversions(live, new Set());
+      expect(plan.convert).toEqual([]);
+      expect(plan.skipNotDeclared.map((c) => c.column).sort()).toEqual([
+        'external_id',
+        'id',
+      ]);
+    });
+  });
 });
+
+// ---------------------------------------------------------------------------
+// Fix C (#1338) end-to-end against a REAL Postgres database.
+//
+// Runs only when DATABASE_URL is set (the repo's `isPostgresAvailable()`
+// convention — skipped in environments without a Postgres). The database is
+// real; only the manifest source (ObjectRegistry.getAllSchemasAsDefinitions) is
+// provided directly, exactly as a built manifest would supply it.
+//
+// Proves: a live TEXT `external_id` column holding all-uuid-shaped values is
+// NOT converted (the schema declares it TEXT), while a declared-UUID FK column
+// (`owner_id`) and the primary `id` — both holding all-uuid data — ARE.
+// ---------------------------------------------------------------------------
+const hasPostgres = Boolean(process.env.DATABASE_URL);
+const describePostgres = hasPostgres ? describe : describe.skip;
+
+describePostgres('db:migrate-uuid declared-UUID gating (real Postgres)', () => {
+  // Unique per run so concurrent / leftover tables can't collide.
+  const tableName = `mu_things_${Math.random().toString(36).slice(2, 8)}`;
+  let getAllSchemasSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+  // The handler's `finally` ends the shared connection pool keyed by URL, so we
+  // re-acquire a fresh handle for every setup / assertion query rather than
+  // holding a long-lived connection the handler would close underneath us.
+  async function freshDb(): Promise<any> {
+    return getDatabase({
+      type: 'postgres',
+      url: process.env.DATABASE_URL as string,
+    });
+  }
+
+  async function dataType(column: string): Promise<string | undefined> {
+    const db = await freshDb();
+    const { rows } = await db.query(
+      `SELECT data_type FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2`,
+      tableName,
+      column,
+    );
+    return (rows as any[])[0]?.data_type;
+  }
+
+  beforeEach(async () => {
+    const db = await freshDb();
+    await db.query(`DROP TABLE IF EXISTS "${tableName}"`);
+    // All three id/FK columns are plain TEXT in the live DB and hold
+    // canonical-UUID-shaped values. external_id is the column the schema keeps
+    // as TEXT on purpose.
+    await db.query(
+      `CREATE TABLE "${tableName}" (
+         id text PRIMARY KEY,
+         owner_id text,
+         external_id text
+       )`,
+    );
+    await db.query(
+      `INSERT INTO "${tableName}" (id, owner_id, external_id) VALUES ($1, $2, $3)`,
+      '11111111-1111-1111-1111-111111111111',
+      '22222222-2222-2222-2222-222222222222',
+      '33333333-3333-3333-3333-333333333333',
+    );
+
+    // Inject DB config the handler reads via getPackageConfig('cli', …).
+    clearCache();
+    setConfig({
+      packages: {
+        cli: {
+          database: { type: 'postgres', url: process.env.DATABASE_URL },
+        },
+      },
+    } as any);
+
+    // Provide the declared schema directly (only `${tableName}`), so the gating
+    // sees id + owner_id as UUID and external_id as TEXT. autoDiscoverAndLoad
+    // still runs but cannot override this spy.
+    getAllSchemasSpy = vi
+      .spyOn(ObjectRegistry, 'getAllSchemasAsDefinitions')
+      .mockReturnValue({
+        [tableName]: {
+          tableName,
+          ddl: '',
+          columns: {
+            id: { type: 'UUID', primaryKey: true },
+            owner_id: { type: 'UUID' },
+            external_id: { type: 'TEXT' },
+          },
+          indexes: [],
+          triggers: [],
+          foreignKeys: [],
+          version: '',
+          dependencies: [],
+        },
+      } as any);
+  });
+
+  afterEach(async () => {
+    getAllSchemasSpy?.mockRestore();
+    try {
+      const db = await freshDb();
+      await db.query(`DROP TABLE IF EXISTS "${tableName}"`);
+    } catch {
+      // ignore
+    }
+    clearCache();
+  });
+
+  it('converts the declared-UUID id/FK columns but leaves the declared-TEXT external_id as TEXT', async () => {
+    // Fail-before guard: all three start as TEXT.
+    expect(await dataType('id')).toBe('text');
+    expect(await dataType('owner_id')).toBe('text');
+    expect(await dataType('external_id')).toBe('text');
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await dbMigrateUuidCommand.handler([], { 'dry-run': false });
+
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+
+    // Declared UUID + all-uuid data → converted to native uuid.
+    expect(await dataType('id')).toBe('uuid');
+    expect(await dataType('owner_id')).toBe('uuid');
+    // Declared TEXT (even though every value is uuid-shaped) → untouched —
+    // THIS is the over-conversion the fix prevents (data-shape alone is not
+    // enough; the schema must declare the column UUID).
+    expect(await dataType('external_id')).toBe('text');
+  }, 30_000);
+});
+
+// ---------------------------------------------------------------------------
+// Fix B (#1338): rename + convert share ONE transaction.
+//
+// When both phases run in one invocation, a conversion failure must roll the
+// already-applied rename (which DROPs the old column) back too — the command's
+// documented atomicity promise. Before the fix the rename phase COMMITted on
+// its own, so a later conversion failure left a half-applied migration with the
+// old column gone. We force a conversion failure (a view depends on a
+// declared-UUID column, so `ALTER COLUMN … TYPE uuid` errors) and assert the
+// rename was rolled back.
+// ---------------------------------------------------------------------------
+describePostgres(
+  'db:migrate-uuid rename+convert atomicity (real Postgres)',
+  () => {
+    const tableName = `mu_atomic_${Math.random().toString(36).slice(2, 8)}`;
+    const viewName = `${tableName}_v`;
+    let getAllSchemasSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+    async function freshDb(): Promise<any> {
+      return getDatabase({
+        type: 'postgres',
+        url: process.env.DATABASE_URL as string,
+      });
+    }
+
+    async function columnExists(column: string): Promise<boolean> {
+      const db = await freshDb();
+      const { rows } = await db.query(
+        `SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2`,
+        tableName,
+        column,
+      );
+      return (rows as any[]).length > 0;
+    }
+
+    async function dataType(column: string): Promise<string | undefined> {
+      const db = await freshDb();
+      const { rows } = await db.query(
+        `SELECT data_type FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2`,
+        tableName,
+        column,
+      );
+      return (rows as any[])[0]?.data_type;
+    }
+
+    beforeEach(async () => {
+      const db = await freshDb();
+      await db.query(`DROP VIEW IF EXISTS "${viewName}"`);
+      await db.query(`DROP TABLE IF EXISTS "${tableName}"`);
+      // old_ref → parent_id is the R3-style rename (both TEXT, uuid-shaped data).
+      // poison_id is declared UUID with clean data, but a view depends on it so
+      // its `ALTER COLUMN … TYPE uuid` will FAIL — forcing the conversion phase
+      // to error AFTER the rename has run inside the shared transaction.
+      await db.query(
+        `CREATE TABLE "${tableName}" (
+         id text PRIMARY KEY,
+         old_ref text,
+         parent_id text,
+         poison_id text
+       )`,
+      );
+      await db.query(
+        `INSERT INTO "${tableName}" (id, old_ref, parent_id, poison_id) VALUES ($1, $2, $3, $4)`,
+        '11111111-1111-1111-1111-111111111111',
+        '22222222-2222-2222-2222-222222222222',
+        null,
+        '33333333-3333-3333-3333-333333333333',
+      );
+      await db.query(
+        `CREATE VIEW "${viewName}" AS SELECT poison_id FROM "${tableName}"`,
+      );
+
+      clearCache();
+      setConfig({
+        packages: {
+          cli: {
+            database: { type: 'postgres', url: process.env.DATABASE_URL },
+          },
+        },
+      } as any);
+
+      getAllSchemasSpy = vi
+        .spyOn(ObjectRegistry, 'getAllSchemasAsDefinitions')
+        .mockReturnValue({
+          [tableName]: {
+            tableName,
+            ddl: '',
+            columns: {
+              id: { type: 'UUID', primaryKey: true },
+              parent_id: { type: 'UUID' },
+              poison_id: { type: 'UUID' },
+            },
+            indexes: [],
+            triggers: [],
+            foreignKeys: [],
+            version: '',
+            dependencies: [],
+          },
+        } as any);
+    });
+
+    afterEach(async () => {
+      getAllSchemasSpy?.mockRestore();
+      try {
+        const db = await freshDb();
+        await db.query(`DROP VIEW IF EXISTS "${viewName}"`);
+        await db.query(`DROP TABLE IF EXISTS "${tableName}"`);
+      } catch {
+        // ignore
+      }
+      clearCache();
+    });
+
+    it('rolls the rename back when the conversion phase fails (single transaction)', async () => {
+      // Fail-before guard: rename source present, nothing converted yet.
+      expect(await columnExists('old_ref')).toBe(true);
+      expect(await dataType('parent_id')).toBe('text');
+      expect(await dataType('poison_id')).toBe('text');
+
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      process.exitCode = undefined;
+
+      // Both phases run: rename old_ref→parent_id (backfill + DROP old_ref), then
+      // convert id/parent_id/poison_id. poison_id's ALTER fails (view depends on
+      // it), so the WHOLE transaction — including the rename — must roll back.
+      await dbMigrateUuidCommand.handler([], {
+        rename: 'old_ref:parent_id',
+        table: tableName,
+      });
+
+      const exitCode = process.exitCode;
+      process.exitCode = undefined;
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+
+      // The command reported failure …
+      expect(exitCode).toBe(1);
+      // … and the rename was rolled back: old_ref still exists, parent_id still
+      // empty + TEXT, nothing converted. No half-applied migration.
+      expect(await columnExists('old_ref')).toBe(true);
+      expect(await dataType('parent_id')).toBe('text');
+      expect(await dataType('poison_id')).toBe('text');
+      expect(await dataType('id')).toBe('text');
+    }, 30_000);
+  },
+);

--- a/packages/cli/src/commands/__tests__/db-migrate-uuid.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-uuid.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { dbMigrateUuidCommand, parseRenameSpecs } from '../db-migrate-uuid.js';
+import { utilityCommands } from '../utilities.js';
+
+describe('db:migrate-uuid command', () => {
+  it('is registered in the utility command map', () => {
+    expect(utilityCommands['db:migrate-uuid']).toBe(dbMigrateUuidCommand);
+    expect(dbMigrateUuidCommand.name).toBe('db:migrate-uuid');
+    expect(dbMigrateUuidCommand.aliases).toContain('migrate-uuid');
+  });
+
+  describe('parseRenameSpecs', () => {
+    it('returns no specs for an empty arg', () => {
+      expect(parseRenameSpecs(undefined, undefined)).toEqual([]);
+      expect(parseRenameSpecs('', 'assets')).toEqual([]);
+    });
+
+    it('parses a single old:new pair against the default --table', () => {
+      expect(parseRenameSpecs('parent_id:source_asset_id', 'assets')).toEqual([
+        { table: 'assets', from: 'parent_id', to: 'source_asset_id' },
+      ]);
+    });
+
+    it('parses multiple comma-separated pairs', () => {
+      expect(
+        parseRenameSpecs('parent_slug:parent_id,old_ref:new_ref', 'tags'),
+      ).toEqual([
+        { table: 'tags', from: 'parent_slug', to: 'parent_id' },
+        { table: 'tags', from: 'old_ref', to: 'new_ref' },
+      ]);
+    });
+
+    it('supports per-entry table via "table.old:new" overriding the default', () => {
+      expect(
+        parseRenameSpecs(
+          'tags.parent_slug:parent_id,facts.parent_id:previous_fact_id',
+          'assets',
+        ),
+      ).toEqual([
+        { table: 'tags', from: 'parent_slug', to: 'parent_id' },
+        { table: 'facts', from: 'parent_id', to: 'previous_fact_id' },
+      ]);
+    });
+
+    it('throws when a pair is malformed', () => {
+      expect(() => parseRenameSpecs('parent_id', 'assets')).toThrow(
+        /Invalid --rename entry/,
+      );
+    });
+
+    it('throws when no table can be resolved for a pair', () => {
+      expect(() =>
+        parseRenameSpecs('parent_id:source_asset_id', undefined),
+      ).toThrow(/no table/);
+    });
+  });
+});

--- a/packages/cli/src/commands/db-migrate-uuid.ts
+++ b/packages/cli/src/commands/db-migrate-uuid.ts
@@ -599,16 +599,30 @@ async function loadDeclaredUuidColumns(): Promise<Set<string>> {
   // so this only works when run from the project root. A discovery failure is
   // non-fatal: the registry may already be populated; we still read it below
   // and the empty-set fail-closed gate in the handler is the safety net.
+  let discoveryFailed = false;
   try {
     await autoDiscoverAndLoad();
   } catch (error) {
+    discoveryFailed = true;
     console.warn(
       `Failed to auto-discover SMRT manifests for declared-UUID gating: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
   try {
     const schemaDefinitions = ObjectRegistry.getAllSchemasAsDefinitions();
-    return buildDeclaredUuidColumnSet(schemaDefinitions);
+    const declared = buildDeclaredUuidColumnSet(schemaDefinitions);
+    // The empty-set fail-closed gate only fires when NOTHING is declared. A
+    // partial discovery failure can leave a non-empty-but-incomplete set, which
+    // slips past that gate and silently leaves some declared-UUID columns as
+    // TEXT (recoverable false-negatives). Surface that explicitly.
+    if (discoveryFailed && declared.size > 0) {
+      console.warn(
+        'Manifest discovery partially failed — the declared-UUID set may be INCOMPLETE; ' +
+          'some packages may not have been scanned, so some uuid columns could be silently left as TEXT. ' +
+          'Resolve the discovery error above and re-run from the project root before trusting the conversion.',
+      );
+    }
+    return declared;
   } catch (error) {
     console.warn(
       `Failed to read declared schema for UUID gating: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/cli/src/commands/db-migrate-uuid.ts
+++ b/packages/cli/src/commands/db-migrate-uuid.ts
@@ -17,14 +17,39 @@
  *
  *  2. **TEXT → native uuid conversion**. Most existing `id`/FK columns already
  *     hold canonical UUID strings in TEXT columns and can be promoted to native
- *     `uuid`. This command is *self-classifying*: a column is converted only if
- *     EVERY non-empty value is a canonical UUID. Columns with even one genuine
- *     non-uuid value (slugs, external ids like `'google-weather'`, legacy
- *     unhyphenated ids, analytics measurement ids, …) are SKIPPED and left as
- *     TEXT.
+ *     `uuid`. Conversion is gated on TWO independent checks, BOTH of which must
+ *     pass for a column to be converted:
  *
- * Both steps run inside a single transaction and are idempotent — re-running is
- * a no-op once the renames are done and the columns are already `uuid`.
+ *       (a) **Schema-declared UUID** — the column is one the SMRT manifest
+ *           declares as a `UUID` type (primary `id`, `@foreignKey()` /
+ *           `@crossPackageRef()` columns). The declared types come from
+ *           `ObjectRegistry.getAllSchemasAsDefinitions()` — the SAME source
+ *           `smrt db:migrate` / `db:diff` use. Columns the schema intentionally
+ *           keeps TEXT (`external_id`, `message_id`, provider/oauth ids, …) are
+ *           NEVER converted even when their current data happens to be
+ *           uuid-shaped, because a future non-uuid insert must still succeed.
+ *           Tables not present in the manifest (non-SMRT tables in the `public`
+ *           schema) drop out automatically.
+ *
+ *       (b) **Data-shape** — every non-empty value is already a canonical UUID.
+ *           A declared-UUID column that still holds genuine non-uuid values
+ *           (legacy unhyphenated ids, partially-migrated data, …) is SKIPPED and
+ *           reported so the operator can clean it before re-running.
+ *
+ *     **Fail-closed:** if the manifest/registry can't be loaded or declares no
+ *     UUID columns, NOTHING is converted (the operator is told to run from the
+ *     project root). There is deliberately no name-regex fallback — over-
+ *     converting a TEXT column the schema tolerates as TEXT (the differ treats
+ *     uuid/text as equivalent, so it would never self-repair) is irreversible
+ *     prod-data damage.
+ *
+ * When BOTH the rename backfills and the uuid conversion run in one invocation
+ * they share a SINGLE transaction (one `BEGIN`, one `COMMIT`, one `ROLLBACK` on
+ * any failure) so a conversion failure can never leave a half-applied migration
+ * with the old columns already dropped. Postgres DDL is transactional, so this
+ * holds. With `--skip-convert` the rename phase commits on its own. Both steps
+ * are idempotent — re-running is a no-op once the renames are done and the
+ * columns are already `uuid`.
  *
  * PostgreSQL only: SQLite and DuckDB store SMRT uuid columns as TEXT (SQLite)
  * or accept uuid strings transparently, so no `ALTER COLUMN TYPE uuid` step is
@@ -40,7 +65,9 @@
  *   smrt db:migrate-uuid --rename "parent_slug:parent_id" --table tags --skip-convert
  */
 
+import { ObjectRegistry } from '@happyvertical/smrt-core';
 import type { CLICommand } from '../cli-generator.js';
+import { autoDiscoverAndLoad } from '../discovery/index.js';
 import {
   closeDatabaseConnection,
   formatDatabaseDisplayUrl,
@@ -48,6 +75,110 @@ import {
 
 const UUID_RE =
   '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';
+
+/**
+ * Build the set of schema-declared UUID columns from a manifest's
+ * `getAllSchemasAsDefinitions()` output.
+ *
+ * Only columns whose declared `type === 'UUID'` are included. The returned set
+ * uses `${table}|${column}` keys for O(1) membership tests. Pure and
+ * DB-independent so the gating semantics can be unit-tested without a database.
+ */
+export function buildDeclaredUuidColumnSet(
+  schemaDefinitions: Record<
+    string,
+    { columns?: Record<string, { type?: string }> }
+  >,
+): Set<string> {
+  const declared = new Set<string>();
+  for (const [tableName, def] of Object.entries(schemaDefinitions ?? {})) {
+    const columns = def?.columns ?? {};
+    for (const [columnName, columnDef] of Object.entries(columns)) {
+      if (String(columnDef?.type).toUpperCase() === 'UUID') {
+        declared.add(declaredUuidKey(tableName, columnName));
+      }
+    }
+  }
+  return declared;
+}
+
+function declaredUuidKey(table: string, column: string): string {
+  return `${table}|${column}`;
+}
+
+/** A live TEXT column scheduled for `ALTER COLUMN … TYPE uuid`. */
+interface ConvertCandidate {
+  table: string;
+  column: string;
+  hasDefault: boolean;
+}
+
+/**
+ * A live TEXT `id`/FK column discovered in the database, annotated with how
+ * many of its non-empty values are NOT canonical UUIDs.
+ */
+export interface LiveTextColumn {
+  table: string;
+  column: string;
+  hasDefault: boolean;
+  /** Count of non-empty values that are not canonical UUIDs. */
+  nonUuid: number;
+}
+
+/**
+ * The outcome of classifying live TEXT columns against the declared-UUID set.
+ */
+export interface ConversionPlan {
+  convert: ConvertCandidate[];
+  /** Declared-UUID columns whose data still has non-uuid values. */
+  skipDirtyData: Array<{ table: string; column: string; nonUuid: number }>;
+  /** Live TEXT columns the schema does NOT declare as UUID (left as TEXT). */
+  skipNotDeclared: Array<{ table: string; column: string }>;
+}
+
+/**
+ * Decide which live TEXT columns to convert to native `uuid`.
+ *
+ * A column is converted ONLY if BOTH gates pass:
+ *   1. it is in the schema-declared-UUID set, AND
+ *   2. all of its non-empty values are already canonical UUIDs.
+ *
+ * Declared-UUID columns with dirty data are reported in `skipDirtyData`;
+ * undeclared columns (schema-intentional TEXT, or non-SMRT tables) are reported
+ * in `skipNotDeclared`. Pure so the gating can be unit-tested without a DB.
+ */
+export function planUuidConversions(
+  liveColumns: LiveTextColumn[],
+  declaredUuid: Set<string>,
+): ConversionPlan {
+  const convert: ConvertCandidate[] = [];
+  const skipDirtyData: ConversionPlan['skipDirtyData'] = [];
+  const skipNotDeclared: ConversionPlan['skipNotDeclared'] = [];
+
+  for (const col of liveColumns) {
+    if (!declaredUuid.has(declaredUuidKey(col.table, col.column))) {
+      // Gate 1 failed: schema does not declare this column UUID. Leave as TEXT.
+      skipNotDeclared.push({ table: col.table, column: col.column });
+      continue;
+    }
+    if (col.nonUuid > 0) {
+      // Gate 2 failed: declared UUID but data is not all-uuid. Operator cleans.
+      skipDirtyData.push({
+        table: col.table,
+        column: col.column,
+        nonUuid: col.nonUuid,
+      });
+      continue;
+    }
+    convert.push({
+      table: col.table,
+      column: col.column,
+      hasDefault: col.hasDefault,
+    });
+  }
+
+  return { convert, skipDirtyData, skipNotDeclared };
+}
 
 function quoteIdent(value: string): string {
   return `"${value.replaceAll('"', '""')}"`;
@@ -96,16 +227,10 @@ export function parseRenameSpecs(
   return specs;
 }
 
-interface ConvertCandidate {
-  table: string;
-  column: string;
-  hasDefault: boolean;
-}
-
 export const dbMigrateUuidCommand: CLICommand = {
   name: 'db:migrate-uuid',
   description:
-    'Backfill R3 column renames and convert UUID-shaped TEXT id/FK columns to native uuid (Postgres). Run after db:migrate.',
+    'Backfill R3 column renames and convert schema-declared-UUID TEXT id/FK columns to native uuid (Postgres). Run from the project root, after db:migrate.',
   aliases: ['migrate-uuid', 'db-migrate-uuid'],
   args: [],
   options: {
@@ -170,156 +295,161 @@ export const dbMigrateUuidCommand: CLICommand = {
 
       const isPostgres = dbType === 'postgres' || /^postgres/i.test(dbUrl);
 
-      // -------------------------------------------------------------------
-      // Step 1: rename backfills (copy old → new where new is empty, drop old)
-      // -------------------------------------------------------------------
-      if (renameSpecs.length > 0) {
-        console.log(
-          `${dryRun ? 'DRY RUN — would apply' : 'Applying'} ${renameSpecs.length} rename backfill(s):`,
-        );
+      const runRenames = renameSpecs.length > 0;
+      const skipConvert = Boolean(options['skip-convert']);
+      // The TEXT→uuid conversion only does work on Postgres (other dialects
+      // store SMRT uuid columns as TEXT already).
+      const runConvert = !skipConvert && isPostgres;
 
-        if (!dryRun) await db.query('BEGIN');
-        try {
-          for (const spec of renameSpecs) {
-            const t = quoteIdent(spec.table);
-            const from = quoteIdent(spec.from);
-            const to = quoteIdent(spec.to);
+      // When BOTH phases will execute for real, run them inside ONE transaction
+      // so a conversion failure rolls the dropped rename columns back too — the
+      // command's documented atomicity guarantee. Postgres DDL is transactional.
+      // A dry run executes nothing, so there is no transaction to share.
+      const sharedTxn = runRenames && runConvert && !dryRun;
+      // True once a BEGIN has been issued that is NOT owned by an inner phase.
+      let openTxn = false;
 
-            // Skip if the old column is already gone (idempotent re-run).
-            const fromExists = await columnExists(
-              db,
-              isPostgres,
-              spec.table,
-              spec.from,
-            );
-            if (!fromExists) {
-              console.log(
-                `  - ${spec.table}.${spec.from} → ${spec.to}: source column absent (already migrated), skipping.`,
-              );
-              continue;
-            }
-            const toExists = await columnExists(
-              db,
-              isPostgres,
-              spec.table,
-              spec.to,
-            );
-            if (!toExists) {
-              throw new Error(
-                `${spec.table}.${spec.to} is missing. Run \`smrt db:migrate\` first to add it, then re-run.`,
-              );
-            }
-
-            const toIsUuid =
-              isPostgres && (await columnIsUuid(db, spec.table, spec.to));
-            const copyExpr = toIsUuid
-              ? isPostgres
-                ? `NULLIF(btrim(${from}), '')::uuid`
-                : `NULLIF(btrim(${from}), '')`
-              : isPostgres
-                ? `NULLIF(btrim(${from}), '')`
-                : `NULLIF(trim(${from}), '')`;
-
-            // Only copy where the destination is still empty so re-runs are safe.
-            const update = `UPDATE ${t} SET ${to} = ${copyExpr} WHERE ${nullifEmpty(isPostgres, from)} IS NOT NULL AND ${to} IS NULL`;
-            const drop = `ALTER TABLE ${t} DROP COLUMN ${from}`;
-
-            console.log(`  ${update};`);
-            console.log(`  ${drop};`);
-            if (!dryRun) {
-              await db.query(update);
-              await db.query(drop);
-            }
+      try {
+        // -----------------------------------------------------------------
+        // Step 1: rename backfills (copy old → new where new is empty, drop old)
+        // -----------------------------------------------------------------
+        if (runRenames) {
+          if (sharedTxn) {
+            await db.query('BEGIN');
+            openTxn = true;
           }
-          if (!dryRun) await db.query('COMMIT');
-        } catch (error) {
-          if (!dryRun) {
-            try {
-              await db.query('ROLLBACK');
-            } catch {
-              // ignore
-            }
-          }
-          throw error;
+          await applyRenameBackfills(db, isPostgres, renameSpecs, dryRun, {
+            ownTransaction: !sharedTxn,
+          });
         }
-        console.log();
-      }
 
-      // -------------------------------------------------------------------
-      // Step 2: TEXT → native uuid conversion (Postgres only)
-      // -------------------------------------------------------------------
-      if (options['skip-convert']) {
-        console.log('Skipping TEXT→uuid conversion (--skip-convert).\n');
-        return;
-      }
+        // -----------------------------------------------------------------
+        // Step 2: TEXT → native uuid conversion (Postgres only)
+        // -----------------------------------------------------------------
+        if (skipConvert) {
+          console.log('Skipping TEXT→uuid conversion (--skip-convert).\n');
+          return;
+        }
 
-      if (!isPostgres) {
-        console.log(
-          `Database type "${dbType}" has no native uuid column type that needs converting; uuid conversion is a no-op.\n`,
+        if (!isPostgres) {
+          console.log(
+            `Database type "${dbType}" has no native uuid column type that needs converting; uuid conversion is a no-op.\n`,
+          );
+          return;
+        }
+
+        // Gate (a): load the SMRT-declared schema (same source db:migrate /
+        // db:diff use) and collect the columns the manifest declares as native
+        // UUID. The manifest is resolved relative to process.cwd() — the
+        // operator MUST run this from the project root.
+        const declaredUuid = await loadDeclaredUuidColumns();
+
+        // Fail-closed: with no declared-UUID columns we convert NOTHING rather
+        // than fall back to a name-regex that would over-convert
+        // schema-intentional TEXT columns (the differ tolerates uuid/text drift,
+        // so it would never self-repair the damage). #1338 codex P1.
+        if (declaredUuid.size === 0) {
+          console.log(
+            'No schema-declared UUID columns found in the loaded manifest.',
+          );
+          console.log(
+            'Skipping TEXT→uuid conversion (fail-closed). Run this command from\n' +
+              'the project root so the SMRT manifest can be discovered, then re-run.\n',
+          );
+          if (openTxn && !dryRun) {
+            // Commit the renames that already ran rather than discard them.
+            await db.query('COMMIT');
+            openTxn = false;
+          }
+          return;
+        }
+
+        // Scan every public TEXT id/FK column, then keep only those the schema
+        // declares UUID (gate a). Within a shared transaction this scan runs
+        // AFTER the renames so dropped/added columns are reflected.
+        const { rows: candidates } = await db.query(
+          `SELECT table_name, column_name, (column_default IS NOT NULL) AS has_default
+             FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND data_type = 'text'
+              AND (column_name = 'id' OR column_name ~* '(_id|Id)$')
+            ORDER BY table_name, column_name`,
         );
-        return;
-      }
 
-      // All TEXT id / FK columns, with whether they carry a column default.
-      const { rows: candidates } = await db.query(
-        `SELECT table_name, column_name, (column_default IS NOT NULL) AS has_default
-           FROM information_schema.columns
-          WHERE table_schema = 'public'
-            AND data_type = 'text'
-            AND (column_name = 'id' OR column_name ~* '(_id|Id)$')
-          ORDER BY table_name, column_name`,
-      );
-
-      const convert: ConvertCandidate[] = [];
-      const skip: Array<{ table: string; column: string; nonUuid: number }> =
-        [];
-
-      for (const row of candidates as any[]) {
-        const t = quoteIdent(row.table_name);
-        const c = quoteIdent(row.column_name);
-        const { rows } = await db.query(
-          `SELECT count(*)::text AS n
-             FROM ${t}
-            WHERE nullif(btrim(${c}), '') IS NOT NULL
-              AND btrim(${c}) !~* '${UUID_RE}'`,
-        );
-        const nonUuid = Number((rows as any[])[0]?.n ?? '0');
-        if (nonUuid === 0) {
-          convert.push({
+        const liveColumns: LiveTextColumn[] = [];
+        for (const row of candidates as any[]) {
+          // Gate (b) data-shape: only count rows for columns we might convert.
+          // For columns the schema does not declare UUID we skip the (possibly
+          // expensive) full-column scan entirely — they can never convert.
+          const declared = declaredUuid.has(
+            `${row.table_name}|${row.column_name}`,
+          );
+          let nonUuid = 0;
+          if (declared) {
+            const t = quoteIdent(row.table_name);
+            const c = quoteIdent(row.column_name);
+            const { rows } = await db.query(
+              `SELECT count(*)::text AS n
+                 FROM ${t}
+                WHERE nullif(btrim(${c}), '') IS NOT NULL
+                  AND btrim(${c}) !~* '${UUID_RE}'`,
+            );
+            nonUuid = Number((rows as any[])[0]?.n ?? '0');
+          }
+          liveColumns.push({
             table: row.table_name,
             column: row.column_name,
             hasDefault: Boolean(row.has_default),
-          });
-        } else {
-          skip.push({
-            table: row.table_name,
-            column: row.column_name,
             nonUuid,
           });
         }
-      }
 
-      console.log(
-        `Found ${(candidates as any[]).length} TEXT id/FK column(s): ${convert.length} convertible, ${skip.length} skipped.`,
-      );
-      if (skip.length > 0) {
-        console.log('\nSKIP (genuine non-UUID values, left as TEXT):');
-        for (const s of skip) {
-          console.log(`  - ${s.table}.${s.column} (${s.nonUuid} non-uuid)`);
+        const { convert, skipDirtyData, skipNotDeclared } = planUuidConversions(
+          liveColumns,
+          declaredUuid,
+        );
+
+        console.log(
+          `Found ${(candidates as any[]).length} TEXT id/FK column(s): ${convert.length} convertible, ${skipDirtyData.length + skipNotDeclared.length} skipped.`,
+        );
+        if (skipDirtyData.length > 0) {
+          console.log(
+            '\nSKIP (declared UUID but data still has non-UUID values — clean these first):',
+          );
+          for (const s of skipDirtyData) {
+            console.log(`  - ${s.table}.${s.column} (${s.nonUuid} non-uuid)`);
+          }
         }
-      }
+        if (skipNotDeclared.length > 0) {
+          console.log(
+            '\nSKIP (not declared UUID by the SMRT schema, left as TEXT):',
+          );
+          for (const s of skipNotDeclared) {
+            console.log(`  - ${s.table}.${s.column}`);
+          }
+        }
 
-      if (convert.length === 0) {
-        console.log('\nNothing to convert. Done.\n');
-        return;
-      }
+        if (convert.length === 0) {
+          console.log('\nNothing to convert. Done.\n');
+          if (openTxn && !dryRun) {
+            // Commit any renames that ran in the shared transaction.
+            await db.query('COMMIT');
+            openTxn = false;
+          }
+          return;
+        }
 
-      console.log(
-        `\n${dryRun ? 'DRY RUN — would run' : 'Applying'} ${convert.length} conversion(s):`,
-      );
+        console.log(
+          `\n${dryRun ? 'DRY RUN — would run' : 'Applying'} ${convert.length} conversion(s):`,
+        );
 
-      if (!dryRun) await db.query('BEGIN');
-      try {
+        // Open a conversion-only transaction when we are NOT already inside the
+        // shared rename+convert transaction.
+        if (!sharedTxn && !dryRun) {
+          await db.query('BEGIN');
+          openTxn = true;
+        }
+
         for (const { table, column, hasDefault } of convert) {
           const t = quoteIdent(table);
           const c = quoteIdent(column);
@@ -332,19 +462,27 @@ export const dbMigrateUuidCommand: CLICommand = {
           console.log(`  ${alter};`);
           if (!dryRun) await db.query(alter);
         }
+
         if (!dryRun) {
-          await db.query('COMMIT');
+          // Commit the (possibly shared) transaction once, after conversions.
+          if (openTxn) {
+            await db.query('COMMIT');
+            openTxn = false;
+          }
           console.log(`\n✓ Converted ${convert.length} column(s) to uuid.\n`);
         } else {
           console.log('\nDry run complete — no changes applied.\n');
         }
       } catch (error) {
-        if (!dryRun) {
+        // One rollback unwinds whatever transaction is open — the shared
+        // rename+convert transaction or a phase-owned one.
+        if (openTxn && !dryRun) {
           try {
             await db.query('ROLLBACK');
           } catch {
             // ignore
           }
+          openTxn = false;
         }
         throw error;
       }
@@ -363,6 +501,120 @@ function nullifEmpty(isPostgres: boolean, quotedCol: string): string {
   return isPostgres
     ? `nullif(btrim(${quotedCol}), '')`
     : `nullif(trim(${quotedCol}), '')`;
+}
+
+/**
+ * Apply the R3 rename backfills: copy `old → new` where `new` is still empty,
+ * then drop `old`. Idempotent (a missing source column is skipped).
+ *
+ * When `ownTransaction` is true this wraps the work in its own
+ * `BEGIN`/`COMMIT`/`ROLLBACK`. When false the caller owns the surrounding
+ * transaction (the shared rename+convert transaction) and is responsible for
+ * commit/rollback — so a conversion failure later can roll these renames back
+ * too. A dry run executes nothing regardless.
+ */
+async function applyRenameBackfills(
+  db: any,
+  isPostgres: boolean,
+  renameSpecs: RenameSpec[],
+  dryRun: boolean,
+  { ownTransaction }: { ownTransaction: boolean },
+): Promise<void> {
+  console.log(
+    `${dryRun ? 'DRY RUN — would apply' : 'Applying'} ${renameSpecs.length} rename backfill(s):`,
+  );
+
+  const useOwnTxn = ownTransaction && !dryRun;
+  if (useOwnTxn) await db.query('BEGIN');
+  try {
+    for (const spec of renameSpecs) {
+      const t = quoteIdent(spec.table);
+      const from = quoteIdent(spec.from);
+      const to = quoteIdent(spec.to);
+
+      // Skip if the old column is already gone (idempotent re-run).
+      const fromExists = await columnExists(
+        db,
+        isPostgres,
+        spec.table,
+        spec.from,
+      );
+      if (!fromExists) {
+        console.log(
+          `  - ${spec.table}.${spec.from} → ${spec.to}: source column absent (already migrated), skipping.`,
+        );
+        continue;
+      }
+      const toExists = await columnExists(db, isPostgres, spec.table, spec.to);
+      if (!toExists) {
+        throw new Error(
+          `${spec.table}.${spec.to} is missing. Run \`smrt db:migrate\` first to add it, then re-run.`,
+        );
+      }
+
+      const toIsUuid =
+        isPostgres && (await columnIsUuid(db, spec.table, spec.to));
+      const copyExpr = toIsUuid
+        ? isPostgres
+          ? `NULLIF(btrim(${from}), '')::uuid`
+          : `NULLIF(btrim(${from}), '')`
+        : isPostgres
+          ? `NULLIF(btrim(${from}), '')`
+          : `NULLIF(trim(${from}), '')`;
+
+      // Only copy where the destination is still empty so re-runs are safe.
+      const update = `UPDATE ${t} SET ${to} = ${copyExpr} WHERE ${nullifEmpty(isPostgres, from)} IS NOT NULL AND ${to} IS NULL`;
+      const drop = `ALTER TABLE ${t} DROP COLUMN ${from}`;
+
+      console.log(`  ${update};`);
+      console.log(`  ${drop};`);
+      if (!dryRun) {
+        await db.query(update);
+        await db.query(drop);
+      }
+    }
+    if (useOwnTxn) await db.query('COMMIT');
+  } catch (error) {
+    if (useOwnTxn) {
+      try {
+        await db.query('ROLLBACK');
+      } catch {
+        // ignore
+      }
+    }
+    throw error;
+  }
+  console.log();
+}
+
+/**
+ * Discover + load the SMRT manifest (cwd-relative, exactly like `db:diff`) and
+ * return the set of `${table}|${column}` keys the schema declares as native
+ * `UUID`. Returns an empty set when no manifest is found or it declares no UUID
+ * columns — the caller treats that as fail-closed (convert nothing).
+ */
+async function loadDeclaredUuidColumns(): Promise<Set<string>> {
+  // Populate the ObjectRegistry from manifests in the project cwd /
+  // node_modules. ManifestBuilder + registry are cwd-relative (#1331/#1332),
+  // so this only works when run from the project root. A discovery failure is
+  // non-fatal: the registry may already be populated; we still read it below
+  // and the empty-set fail-closed gate in the handler is the safety net.
+  try {
+    await autoDiscoverAndLoad();
+  } catch (error) {
+    console.warn(
+      `Failed to auto-discover SMRT manifests for declared-UUID gating: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  try {
+    const schemaDefinitions = ObjectRegistry.getAllSchemasAsDefinitions();
+    return buildDeclaredUuidColumnSet(schemaDefinitions);
+  } catch (error) {
+    console.warn(
+      `Failed to read declared schema for UUID gating: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return new Set<string>();
+  }
 }
 
 async function columnExists(

--- a/packages/cli/src/commands/db-migrate-uuid.ts
+++ b/packages/cli/src/commands/db-migrate-uuid.ts
@@ -1,0 +1,402 @@
+/**
+ * db:migrate-uuid Command
+ *
+ * relationships-v2 (0.27.0) data migration helper.
+ *
+ * The 0.27.0 release makes `@foreignKey()` / `@crossPackageRef()` (and primary
+ * `id`) columns native `uuid` on PostgreSQL. The structural migration
+ * (`smrt db:migrate`) is *additive* — it cannot rename or change a column's
+ * type in place — so two pieces of per-project DATA migration remain:
+ *
+ *  1. **R3 column renames** (e.g. `tags.parent_slug → parent_id`,
+ *     `facts.parent_id → previous_fact_id`, `assets.parent_id →
+ *     source_asset_id`). The new column is added empty and the old column is
+ *     left orphaned. Use `--rename "old:new[,old2:new2]"` (optionally with
+ *     `--table <name>`) to copy old → new (only where new is still empty) and
+ *     drop the old column.
+ *
+ *  2. **TEXT → native uuid conversion**. Most existing `id`/FK columns already
+ *     hold canonical UUID strings in TEXT columns and can be promoted to native
+ *     `uuid`. This command is *self-classifying*: a column is converted only if
+ *     EVERY non-empty value is a canonical UUID. Columns with even one genuine
+ *     non-uuid value (slugs, external ids like `'google-weather'`, legacy
+ *     unhyphenated ids, analytics measurement ids, …) are SKIPPED and left as
+ *     TEXT.
+ *
+ * Both steps run inside a single transaction and are idempotent — re-running is
+ * a no-op once the renames are done and the columns are already `uuid`.
+ *
+ * PostgreSQL only: SQLite and DuckDB store SMRT uuid columns as TEXT (SQLite)
+ * or accept uuid strings transparently, so no `ALTER COLUMN TYPE uuid` step is
+ * needed there. On a non-Postgres database this command performs the rename
+ * backfills (if requested) and then reports that the uuid conversion is a no-op.
+ *
+ * Run AFTER `smrt db:migrate`.
+ *
+ * Usage:
+ *   smrt db:migrate-uuid --dry-run
+ *   smrt db:migrate-uuid
+ *   smrt db:migrate-uuid --rename "parent_id:source_asset_id" --table assets
+ *   smrt db:migrate-uuid --rename "parent_slug:parent_id" --table tags --skip-convert
+ */
+
+import type { CLICommand } from '../cli-generator.js';
+import {
+  closeDatabaseConnection,
+  formatDatabaseDisplayUrl,
+} from './db-command-utils.js';
+
+const UUID_RE =
+  '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';
+
+function quoteIdent(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+interface RenameSpec {
+  table: string;
+  from: string;
+  to: string;
+}
+
+/**
+ * Parse `--rename "old:new,old2:new2"` plus the optional default `--table`
+ * into structured rename specs. A pair may carry its own table via
+ * `table.old:new`; otherwise it falls back to `--table`.
+ */
+export function parseRenameSpecs(
+  renameArg: string | undefined,
+  defaultTable: string | undefined,
+): RenameSpec[] {
+  if (!renameArg) return [];
+  const specs: RenameSpec[] = [];
+  for (const raw of renameArg.split(',')) {
+    const pair = raw.trim();
+    if (!pair) continue;
+    const [lhs, to] = pair.split(':').map((s) => s.trim());
+    if (!lhs || !to) {
+      throw new Error(
+        `Invalid --rename entry "${pair}". Expected "old:new" or "table.old:new".`,
+      );
+    }
+    let table = defaultTable;
+    let from = lhs;
+    const dot = lhs.indexOf('.');
+    if (dot !== -1) {
+      table = lhs.slice(0, dot);
+      from = lhs.slice(dot + 1);
+    }
+    if (!table) {
+      throw new Error(
+        `--rename entry "${pair}" has no table. Pass --table <name> or use "table.old:new".`,
+      );
+    }
+    specs.push({ table, from, to });
+  }
+  return specs;
+}
+
+interface ConvertCandidate {
+  table: string;
+  column: string;
+  hasDefault: boolean;
+}
+
+export const dbMigrateUuidCommand: CLICommand = {
+  name: 'db:migrate-uuid',
+  description:
+    'Backfill R3 column renames and convert UUID-shaped TEXT id/FK columns to native uuid (Postgres). Run after db:migrate.',
+  aliases: ['migrate-uuid', 'db-migrate-uuid'],
+  args: [],
+  options: {
+    rename: {
+      type: 'string',
+      description:
+        'Comma-separated old:new column renames to backfill, e.g. "parent_id:source_asset_id". Use --table to scope, or "table.old:new" per entry.',
+    },
+    table: {
+      type: 'string',
+      description: 'Default table for --rename entries that omit one.',
+    },
+    'skip-convert': {
+      type: 'boolean',
+      description:
+        'Only run the --rename backfills; skip the TEXT→uuid conversion pass.',
+      default: false,
+    },
+    'dry-run': {
+      type: 'boolean',
+      description: 'Show the SQL that would run without executing it.',
+      default: false,
+    },
+    verbose: {
+      type: 'boolean',
+      description: 'Show detailed output.',
+      default: false,
+      short: 'v',
+    },
+  },
+  handler: async (_args: string[], options: any) => {
+    const dryRun = Boolean(options['dry-run']);
+    let db: any;
+
+    try {
+      // 1. Load CLI config + validate DB.
+      const { getPackageConfig } = await import('@happyvertical/smrt-config');
+      const { DEFAULT_CLI_CONFIG } = await import('../config.js');
+      const config = getPackageConfig('cli', DEFAULT_CLI_CONFIG);
+
+      if (!config.database?.url || config.database.url === ':memory:') {
+        console.error(
+          '\n❌ Database configuration required for db:migrate-uuid',
+        );
+        console.error('\nConfigure database in smrt.config.js.\n');
+        process.exit(1);
+      }
+
+      const dbUrl = config.database.url;
+      const dbType = config.database.type || 'sqlite';
+
+      // 2. Parse rename specs early so input errors fail before connecting.
+      const renameSpecs = parseRenameSpecs(options.rename, options.table);
+
+      console.log('\n🔑 UUID column migration\n');
+
+      const { getDatabase } = await import('@happyvertical/sql');
+      db = await getDatabase({ type: dbType, url: dbUrl });
+      console.log(
+        `✓ Connected to ${formatDatabaseDisplayUrl(dbType, dbUrl)}\n`,
+      );
+
+      const isPostgres = dbType === 'postgres' || /^postgres/i.test(dbUrl);
+
+      // -------------------------------------------------------------------
+      // Step 1: rename backfills (copy old → new where new is empty, drop old)
+      // -------------------------------------------------------------------
+      if (renameSpecs.length > 0) {
+        console.log(
+          `${dryRun ? 'DRY RUN — would apply' : 'Applying'} ${renameSpecs.length} rename backfill(s):`,
+        );
+
+        if (!dryRun) await db.query('BEGIN');
+        try {
+          for (const spec of renameSpecs) {
+            const t = quoteIdent(spec.table);
+            const from = quoteIdent(spec.from);
+            const to = quoteIdent(spec.to);
+
+            // Skip if the old column is already gone (idempotent re-run).
+            const fromExists = await columnExists(
+              db,
+              isPostgres,
+              spec.table,
+              spec.from,
+            );
+            if (!fromExists) {
+              console.log(
+                `  - ${spec.table}.${spec.from} → ${spec.to}: source column absent (already migrated), skipping.`,
+              );
+              continue;
+            }
+            const toExists = await columnExists(
+              db,
+              isPostgres,
+              spec.table,
+              spec.to,
+            );
+            if (!toExists) {
+              throw new Error(
+                `${spec.table}.${spec.to} is missing. Run \`smrt db:migrate\` first to add it, then re-run.`,
+              );
+            }
+
+            const toIsUuid =
+              isPostgres && (await columnIsUuid(db, spec.table, spec.to));
+            const copyExpr = toIsUuid
+              ? isPostgres
+                ? `NULLIF(btrim(${from}), '')::uuid`
+                : `NULLIF(btrim(${from}), '')`
+              : isPostgres
+                ? `NULLIF(btrim(${from}), '')`
+                : `NULLIF(trim(${from}), '')`;
+
+            // Only copy where the destination is still empty so re-runs are safe.
+            const update = `UPDATE ${t} SET ${to} = ${copyExpr} WHERE ${nullifEmpty(isPostgres, from)} IS NOT NULL AND ${to} IS NULL`;
+            const drop = `ALTER TABLE ${t} DROP COLUMN ${from}`;
+
+            console.log(`  ${update};`);
+            console.log(`  ${drop};`);
+            if (!dryRun) {
+              await db.query(update);
+              await db.query(drop);
+            }
+          }
+          if (!dryRun) await db.query('COMMIT');
+        } catch (error) {
+          if (!dryRun) {
+            try {
+              await db.query('ROLLBACK');
+            } catch {
+              // ignore
+            }
+          }
+          throw error;
+        }
+        console.log();
+      }
+
+      // -------------------------------------------------------------------
+      // Step 2: TEXT → native uuid conversion (Postgres only)
+      // -------------------------------------------------------------------
+      if (options['skip-convert']) {
+        console.log('Skipping TEXT→uuid conversion (--skip-convert).\n');
+        return;
+      }
+
+      if (!isPostgres) {
+        console.log(
+          `Database type "${dbType}" has no native uuid column type that needs converting; uuid conversion is a no-op.\n`,
+        );
+        return;
+      }
+
+      // All TEXT id / FK columns, with whether they carry a column default.
+      const { rows: candidates } = await db.query(
+        `SELECT table_name, column_name, (column_default IS NOT NULL) AS has_default
+           FROM information_schema.columns
+          WHERE table_schema = 'public'
+            AND data_type = 'text'
+            AND (column_name = 'id' OR column_name ~* '(_id|Id)$')
+          ORDER BY table_name, column_name`,
+      );
+
+      const convert: ConvertCandidate[] = [];
+      const skip: Array<{ table: string; column: string; nonUuid: number }> =
+        [];
+
+      for (const row of candidates as any[]) {
+        const t = quoteIdent(row.table_name);
+        const c = quoteIdent(row.column_name);
+        const { rows } = await db.query(
+          `SELECT count(*)::text AS n
+             FROM ${t}
+            WHERE nullif(btrim(${c}), '') IS NOT NULL
+              AND btrim(${c}) !~* '${UUID_RE}'`,
+        );
+        const nonUuid = Number((rows as any[])[0]?.n ?? '0');
+        if (nonUuid === 0) {
+          convert.push({
+            table: row.table_name,
+            column: row.column_name,
+            hasDefault: Boolean(row.has_default),
+          });
+        } else {
+          skip.push({
+            table: row.table_name,
+            column: row.column_name,
+            nonUuid,
+          });
+        }
+      }
+
+      console.log(
+        `Found ${(candidates as any[]).length} TEXT id/FK column(s): ${convert.length} convertible, ${skip.length} skipped.`,
+      );
+      if (skip.length > 0) {
+        console.log('\nSKIP (genuine non-UUID values, left as TEXT):');
+        for (const s of skip) {
+          console.log(`  - ${s.table}.${s.column} (${s.nonUuid} non-uuid)`);
+        }
+      }
+
+      if (convert.length === 0) {
+        console.log('\nNothing to convert. Done.\n');
+        return;
+      }
+
+      console.log(
+        `\n${dryRun ? 'DRY RUN — would run' : 'Applying'} ${convert.length} conversion(s):`,
+      );
+
+      if (!dryRun) await db.query('BEGIN');
+      try {
+        for (const { table, column, hasDefault } of convert) {
+          const t = quoteIdent(table);
+          const c = quoteIdent(column);
+          if (hasDefault) {
+            const dropDefault = `ALTER TABLE ${t} ALTER COLUMN ${c} DROP DEFAULT`;
+            console.log(`  ${dropDefault};`);
+            if (!dryRun) await db.query(dropDefault);
+          }
+          const alter = `ALTER TABLE ${t} ALTER COLUMN ${c} TYPE uuid USING NULLIF(btrim(${c}), '')::uuid`;
+          console.log(`  ${alter};`);
+          if (!dryRun) await db.query(alter);
+        }
+        if (!dryRun) {
+          await db.query('COMMIT');
+          console.log(`\n✓ Converted ${convert.length} column(s) to uuid.\n`);
+        } else {
+          console.log('\nDry run complete — no changes applied.\n');
+        }
+      } catch (error) {
+        if (!dryRun) {
+          try {
+            await db.query('ROLLBACK');
+          } catch {
+            // ignore
+          }
+        }
+        throw error;
+      }
+    } catch (error) {
+      console.error(
+        `\n❌ uuid migration failed: ${error instanceof Error ? error.message : String(error)}\n`,
+      );
+      process.exitCode = 1;
+    } finally {
+      await closeDatabaseConnection(db);
+    }
+  },
+};
+
+function nullifEmpty(isPostgres: boolean, quotedCol: string): string {
+  return isPostgres
+    ? `nullif(btrim(${quotedCol}), '')`
+    : `nullif(trim(${quotedCol}), '')`;
+}
+
+async function columnExists(
+  db: any,
+  isPostgres: boolean,
+  table: string,
+  column: string,
+): Promise<boolean> {
+  if (isPostgres) {
+    const { rows } = await db.query(
+      `SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = '${table.replaceAll("'", "''")}'
+          AND column_name = '${column.replaceAll("'", "''")}'`,
+    );
+    return (rows as any[]).length > 0;
+  }
+  // SQLite / DuckDB: PRAGMA-style introspection.
+  try {
+    const { rows } = await db.query(`PRAGMA table_info(${quoteIdent(table)})`);
+    return (rows as any[]).some((r) => r.name === column);
+  } catch {
+    return false;
+  }
+}
+
+async function columnIsUuid(
+  db: any,
+  table: string,
+  column: string,
+): Promise<boolean> {
+  const { rows } = await db.query(
+    `SELECT data_type FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = '${table.replaceAll("'", "''")}'
+        AND column_name = '${column.replaceAll("'", "''")}'`,
+  );
+  return (rows as any[])[0]?.data_type === 'uuid';
+}

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -37,6 +37,7 @@ import {
   shouldApplySchemaMigrations,
   shouldFailDbMigrate,
 } from './db-migrate-actions.js';
+import { dbMigrateUuidCommand } from './db-migrate-uuid.js';
 import { dbRollbackCommand } from './db-rollback.js';
 import { dbStatusCommand } from './db-status.js';
 import { exportCommand } from './export.js';
@@ -2438,6 +2439,7 @@ export default testManifest;
   'db:diff': dbDiffCommand,
   'db:rollback': dbRollbackCommand,
   'db:generate': dbGenerateCommand,
+  'db:migrate-uuid': dbMigrateUuidCommand,
 
   // Configuration commands
   'config:export': configExportCommand,

--- a/packages/core/src/__tests__/hierarchical.test.ts
+++ b/packages/core/src/__tests__/hierarchical.test.ts
@@ -175,6 +175,59 @@ describe('SmrtHierarchical', () => {
       const descendants = await root.getDescendants();
       expect(descendants.find((n) => n.id === orphan.id)).toBeUndefined();
     });
+
+    // Regression (codex review P2): a single BFS level expands to one
+    // `parent_id IN (?, ?, …)` with one bind param per frontier id. The
+    // generic `collection.list()` does NOT chunk array-valued WHERE clauses,
+    // so a level wider than the backend's SQLITE_MAX_VARIABLE_NUMBER throws
+    // (`too many SQL variables` / `SQLITE_RANGE`) before traversal completes.
+    // The bundled @libsql/client build caps at 32766, so we go above that to
+    // prove the frontier is chunked. Children are inserted via raw SQL — the
+    // per-row create()/save() path would dominate the runtime at this width.
+    it('returns all descendants when a level exceeds the bind-variable limit', async () => {
+      // > 32766 (modern libSQL SQLITE_MAX_VARIABLE_NUMBER); also > 999 (legacy
+      // SQLite) and many multiples of IN_LIST_CHUNK_SIZE (900).
+      const WIDE = 33000;
+      const root = await nodes.create({ name: 'wide-root' });
+      await root.save();
+
+      const db = (nodes as unknown as { db: { query: Function } }).db;
+      const now = new Date().toISOString();
+      // Batch raw inserts so we don't blow the bind limit during setup either.
+      const COLS_PER_ROW = 6; // id, slug, context, parent_id, name, (created/updated default)
+      const ROWS_PER_INSERT = Math.floor(900 / COLS_PER_ROW);
+      let inserted = 0;
+      while (inserted < WIDE) {
+        const batch = Math.min(ROWS_PER_INSERT, WIDE - inserted);
+        const tuples: string[] = [];
+        const params: string[] = [];
+        for (let i = 0; i < batch; i++) {
+          const n = inserted + i;
+          tuples.push('(?, ?, ?, ?, ?, ?, ?)');
+          params.push(
+            `wide-${n}`, // id
+            `wide-child-${n}`, // slug
+            '', // context
+            root.id as string, // parent_id
+            `wide-child-${n}`, // name
+            now, // created_at
+            now, // updated_at
+          );
+        }
+        await db.query(
+          `INSERT INTO hierarchical_test_nodes (id, slug, context, parent_id, name, created_at, updated_at) VALUES ${tuples.join(', ')}`,
+          ...params,
+        );
+        inserted += batch;
+      }
+
+      const descendants = await root.getDescendants();
+      expect(descendants).toHaveLength(WIDE);
+      const returnedIds = new Set(descendants.map((n) => n.id));
+      expect(returnedIds.size).toBe(WIDE);
+      expect(returnedIds.has('wide-0')).toBe(true);
+      expect(returnedIds.has(`wide-${WIDE - 1}`)).toBe(true);
+    }, 120_000);
   });
 
   describe('getHierarchy', () => {

--- a/packages/core/src/__tests__/hierarchical.test.ts
+++ b/packages/core/src/__tests__/hierarchical.test.ts
@@ -194,7 +194,7 @@ describe('SmrtHierarchical', () => {
       const db = (nodes as unknown as { db: { query: Function } }).db;
       const now = new Date().toISOString();
       // Batch raw inserts so we don't blow the bind limit during setup either.
-      const COLS_PER_ROW = 6; // id, slug, context, parent_id, name, (created/updated default)
+      const COLS_PER_ROW = 7; // id, slug, context, parent_id, name, created_at, updated_at
       const ROWS_PER_INSERT = Math.floor(900 / COLS_PER_ROW);
       let inserted = 0;
       while (inserted < WIDE) {

--- a/packages/core/src/__tests__/uuid-empty-fk-coercion.test.ts
+++ b/packages/core/src/__tests__/uuid-empty-fk-coercion.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Regression test for the whole-PR review C1/M1 blocker.
+ *
+ * `@foreignKey()` / `@crossPackageRef()` fields generate native `UUID` columns
+ * (R11). Their TypeScript default is the empty string (`''`), which is NOT a
+ * valid UUID literal. On a native-uuid dialect (Postgres, DuckDB) inserting
+ * `''` into a `uuid` column fails with `invalid input syntax for type uuid`.
+ *
+ * This bites every optional/unset declared-FK field — most importantly ROOT
+ * entities whose optional self-reference is never set (e.g. a root Fact with no
+ * predecessor: `previousFactId` stays `''`). The save path must coerce `''` →
+ * `NULL` for UUID columns before the INSERT/UPDATE.
+ *
+ * The fix lives in `SmrtObject.coerceEmptyUuidValuesToNull()` (object.ts),
+ * called from `save()`.
+ *
+ * Two layers of coverage:
+ *  1. Save path on real in-memory SQLite (the mandated test DB): a root entity
+ *     with an unset optional uuid FK must persist the column as SQL NULL, not
+ *     `''`. Fails-before (value is `''`), passes-after (value is NULL). SQLite
+ *     maps UUID→TEXT, so this isolates the *coercion* independent of dialect.
+ *  2. Native-uuid dialect proof on DuckDB: binding `''` into a real `uuid`
+ *     column throws; `NULL` succeeds. This documents the exact failure the
+ *     coercion prevents on Postgres/DuckDB.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SmrtCollection } from '../collection.js';
+import { foreignKey, SmrtObject, smrt } from '../index.js';
+import { ObjectRegistry } from '../registry';
+import { getTestDatabase } from '../testing/database';
+
+// A class with a self-referential optional FK that defaults to '' — the exact
+// shape of facts/src/fact.ts `previousFactId`. Declared FKs become native UUID
+// columns under R11.
+@smrt()
+class RootableNode extends SmrtObject {
+  name: string = '';
+
+  @foreignKey('RootableNode')
+  predecessorId: string = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name) this.name = options.name;
+    if (options.predecessorId) this.predecessorId = options.predecessorId;
+  }
+}
+
+class RootableNodeCollection extends SmrtCollection<RootableNode> {
+  static readonly _itemClass = RootableNode;
+}
+
+describe('UUID FK empty-string coercion (whole-PR review C1/M1)', () => {
+  describe('save path coerces "" → NULL for the uuid FK column', () => {
+    let db: Awaited<ReturnType<typeof getTestDatabase>>;
+    let collection: RootableNodeCollection;
+
+    beforeEach(async () => {
+      ObjectRegistry.registerCollection('RootableNode', RootableNodeCollection);
+      db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+      collection = await RootableNodeCollection.create({ db });
+    });
+
+    afterEach(async () => {
+      if (db && typeof db.close === 'function') {
+        try {
+          await db.close();
+        } catch {
+          // ignore
+        }
+      }
+    });
+
+    it('persists NULL (not "") for an unset optional uuid FK on a ROOT entity', async () => {
+      const root = await collection.create({
+        slug: 'root-node',
+        name: 'Root',
+        // predecessorId intentionally left at its '' default
+      });
+      await root.save();
+
+      // Read the raw column value: before the fix this is the empty string,
+      // which on a native-uuid dialect would have thrown on INSERT.
+      const result = await db.query(
+        'SELECT predecessor_id FROM rootable_nodes WHERE slug = ?',
+        ['root-node'],
+      );
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0].predecessor_id).toBeNull();
+    });
+
+    it('still persists a real uuid FK when predecessorId is set', async () => {
+      const parent = await collection.create({
+        slug: 'parent-node',
+        name: 'Parent',
+      });
+      await parent.save();
+
+      const child = await collection.create({
+        slug: 'child-node',
+        name: 'Child',
+        predecessorId: parent.id,
+      });
+      await child.save();
+
+      const result = await db.query(
+        'SELECT predecessor_id FROM rootable_nodes WHERE slug = ?',
+        ['child-node'],
+      );
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0].predecessor_id).toBe(parent.id);
+    });
+  });
+
+  describe('native-uuid dialect (DuckDB) failure mode the coercion prevents', () => {
+    let db: Awaited<ReturnType<typeof getDatabase>>;
+
+    beforeEach(async () => {
+      db = await getDatabase({ type: 'duckdb', url: ':memory:' });
+      await db.query(
+        'CREATE TABLE uuid_probe (id UUID PRIMARY KEY, ref UUID)',
+        [],
+      );
+    });
+
+    afterEach(async () => {
+      if (db && typeof db.close === 'function') {
+        try {
+          await db.close();
+        } catch {
+          // ignore
+        }
+      }
+    });
+
+    it('rejects "" but accepts NULL for a native uuid column', async () => {
+      const id1 = randomUUID();
+      // Empty string into a native uuid column is the failure the coercion fixes.
+      await expect(
+        db.query('INSERT INTO uuid_probe (id, ref) VALUES (?, ?)', [id1, '']),
+      ).rejects.toThrow();
+
+      // NULL (what the coercion produces) inserts cleanly.
+      const id2 = randomUUID();
+      await expect(
+        db.query('INSERT INTO uuid_probe (id, ref) VALUES (?, ?)', [id2, null]),
+      ).resolves.toBeDefined();
+
+      const result = await db.query('SELECT ref FROM uuid_probe WHERE id = ?', [
+        id2,
+      ]);
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0].ref).toBeNull();
+    });
+  });
+});

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -18,28 +18,7 @@ import {
   toCamelCase,
   toSnakeCase,
 } from './utils';
-
-/**
- * Maximum size of an `IN (?, ?, ...)` placeholder list per query.
- *
- * SQLite's default `SQLITE_MAX_VARIABLE_NUMBER` is 999. Postgres allows up to
- * 65535 bind parameters per query, but a more conservative chunk size keeps
- * planner time predictable across backends. Hitting this cap inside the
- * relationship loaders is a real risk now that batch eager loading is
- * supported — pages of >999 source rows would otherwise throw
- * `SQLITE_RANGE: bind or column index out of range`.
- */
-const IN_LIST_CHUNK_SIZE = 900;
-
-function chunkArray<T>(items: T[], size: number): T[][] {
-  if (items.length === 0) return [];
-  if (size <= 0) return [items];
-  const chunks: T[][] = [];
-  for (let i = 0; i < items.length; i += size) {
-    chunks.push(items.slice(i, i + size));
-  }
-  return chunks;
-}
+import { chunkArray, IN_LIST_CHUNK_SIZE } from './utils/chunk';
 
 /**
  * Resolve _meta_type in WHERE clause from simple class name to qualified name (Issue #713)

--- a/packages/core/src/hierarchical.ts
+++ b/packages/core/src/hierarchical.ts
@@ -38,6 +38,7 @@
 import type { SmrtCollection } from './collection';
 import { SmrtObject } from './object';
 import { ObjectRegistry } from './registry';
+import { chunkArray, IN_LIST_CHUNK_SIZE } from './utils/chunk';
 
 /**
  * Aggregate hierarchy view: ancestors (root-first), self, and all descendants
@@ -178,6 +179,14 @@ export class SmrtHierarchical extends SmrtObject {
    * on the previous level's IDs — eliminates the recursive-per-child N+1
    * pattern the duplicated implementations used.
    *
+   * Each level's frontier is chunked at `IN_LIST_CHUNK_SIZE` before being
+   * expanded into a `parent_id IN (?, ?, …)` clause: the generic
+   * `collection.list()` does NOT chunk array-valued WHERE clauses, so a level
+   * wider than the backend's `SQLITE_MAX_VARIABLE_NUMBER` (999 on legacy
+   * SQLite, 32766 on modern builds) would otherwise throw before traversal
+   * completes. Mirrors the chunking the relationship/junction loaders in
+   * `collection.ts` already do.
+   *
    * Cycle-safe via a visited Set keyed on row id.
    */
   async getDescendants(): Promise<this[]> {
@@ -188,17 +197,24 @@ export class SmrtHierarchical extends SmrtObject {
     let frontier: string[] = [this.id];
 
     while (frontier.length > 0) {
-      const children = (await collection.list({
-        where: { parentId: frontier },
-      })) as this[];
-
       const next: string[] = [];
-      for (const child of children) {
-        if (!child.id || visited.has(child.id)) continue;
-        visited.add(child.id);
-        descendants.push(child);
-        next.push(child.id);
+
+      // Chunk the frontier so each query stays under the bind-variable cap.
+      // Children are merged into the same BFS level in chunk order, so the
+      // overall ordering remains breadth-first.
+      for (const idChunk of chunkArray(frontier, IN_LIST_CHUNK_SIZE)) {
+        const children = (await collection.list({
+          where: { parentId: idChunk },
+        })) as this[];
+
+        for (const child of children) {
+          if (!child.id || visited.has(child.id)) continue;
+          visited.add(child.id);
+          descendants.push(child);
+          next.push(child.id);
+        }
       }
+
       frontier = next;
     }
 

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -1250,6 +1250,115 @@ export class SmrtObject extends SmrtClass {
   }
 
   /**
+   * Resolve the set of snake_case column names whose database type is `UUID`
+   * for the table this object writes to.
+   *
+   * Declared foreign keys (`@foreignKey()`) and cross-package references
+   * (`@crossPackageRef()`) generate native `UUID` columns (R11). Their default
+   * declared value in TypeScript is the empty string (`''`), which is not a
+   * valid UUID literal. Postgres rejects `''` on a `uuid` column with
+   * `invalid input syntax for type uuid`, so any optional/unset declared FK
+   * (a root entity's self-reference, an optional cross-package link, etc.)
+   * would fail to insert. We coerce `''` → `NULL` for these columns before
+   * binding (see {@link coerceEmptyUuidValuesToNull}); this method tells that
+   * coercion which columns are UUID-typed.
+   *
+   * Resolution prefers the built schema (`getSchema().columns`), which already
+   * reflects all reconciliation — e.g. a `@foreignKey()` whose target class
+   * uses `idType: 'text'` is downgraded to `TEXT` and is therefore correctly
+   * excluded here. For STI children, columns live on the STI base table, so we
+   * union the base schema's columns. When no built schema is available (pure
+   * runtime-registered classes without a manifest) we fall back to field
+   * metadata, mirroring the schema-builder's field→SQL mapping.
+   */
+  private async resolveUuidColumnNames(
+    className: string,
+  ): Promise<Set<string>> {
+    const uuidColumns = new Set<string>();
+
+    const collectFromSchema = (schemaName: string | null | undefined): void => {
+      if (!schemaName) return;
+      const schema = ObjectRegistry.getSchema(schemaName);
+      const columns = schema?.columns;
+      if (!columns) return;
+      for (const [columnName, columnDef] of Object.entries(columns)) {
+        if ((columnDef as { type?: string })?.type === 'UUID') {
+          uuidColumns.add(columnName);
+        }
+      }
+    };
+
+    // Own schema (covers non-STI and STI-base classes).
+    collectFromSchema(className);
+
+    // STI children: FK columns are declared on the base table.
+    const qualifiedName = this.getResolvedQualifiedName();
+    if (ObjectRegistry.getTableStrategy(qualifiedName) === 'sti') {
+      collectFromSchema(ObjectRegistry.getSTIBase(qualifiedName));
+    }
+
+    if (uuidColumns.size > 0) {
+      return uuidColumns;
+    }
+
+    // Fallback: derive UUID columns from field metadata when no built schema
+    // is available. Mirrors schema-builder's field→SQL mapping so that a
+    // text-id cross-package ref is not treated as UUID.
+    try {
+      const fields = await ObjectRegistry.getAllFields(className);
+      for (const [fieldName, field] of fields.entries()) {
+        if (!field) continue;
+        const type = field.type;
+        if (type !== 'foreignKey' && type !== 'crossPackageRef') {
+          continue;
+        }
+        const metaSqlType = field._meta?.sqlType;
+        if (metaSqlType) {
+          if (metaSqlType === 'UUID') {
+            uuidColumns.add(toSnakeCase(fieldName));
+          }
+          continue;
+        }
+        const isTextIdCrossRef =
+          type === 'crossPackageRef' &&
+          (field._meta?.idType === 'text' || field.idType === 'text');
+        if (!isTextIdCrossRef) {
+          uuidColumns.add(toSnakeCase(fieldName));
+        }
+      }
+    } catch {
+      // Best-effort fallback; never let UUID-column resolution block a save.
+    }
+
+    return uuidColumns;
+  }
+
+  /**
+   * Coerce empty-string values to `NULL` for UUID-typed columns in the
+   * snake_cased write payload.
+   *
+   * Framework-level fix for the whole class of bug where a declared FK field
+   * defaults to `''` (the natural TypeScript default for `string`) and is left
+   * unset on insert — e.g. creating a ROOT entity whose optional self-reference
+   * (`previousFactId`, `parentPartnerId`, …) is empty. On Postgres `uuid`
+   * columns, `''` raises `invalid input syntax for type uuid`. Coercing to
+   * `NULL` here fixes every such field uniformly without per-field type churn
+   * or consumer-facing type changes. Mutates `data` in place.
+   */
+  private async coerceEmptyUuidValuesToNull(
+    className: string,
+    data: Record<string, any>,
+  ): Promise<void> {
+    const uuidColumns = await this.resolveUuidColumnNames(className);
+    if (uuidColumns.size === 0) return;
+    for (const columnName of uuidColumns) {
+      if (data[columnName] === '') {
+        data[columnName] = null;
+      }
+    }
+  }
+
+  /**
    * Persists this object to the database using an upsert (insert or update).
    *
    * Steps performed on every save:
@@ -1389,6 +1498,13 @@ export class SmrtObject extends SmrtClass {
           data[toSnakeCase(key)] = value;
         }
       }
+
+      // Coerce empty-string values to NULL for native UUID columns (declared
+      // FKs / cross-package refs). The TypeScript default for an unset
+      // `string`-typed FK is `''`, which Postgres rejects on a `uuid` column
+      // ("invalid input syntax for type uuid"). This framework-level coercion
+      // fixes every optional/unset declared-FK field uniformly.
+      await this.coerceEmptyUuidValuesToNull(className, data);
 
       // Get conflict columns from registry (supports custom columns for junction tables)
       const conflictColumns = ObjectRegistry.getConflictColumns(className);

--- a/packages/core/src/utils/chunk.ts
+++ b/packages/core/src/utils/chunk.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared helpers for capping `IN (?, ?, ...)` placeholder lists so a single
+ * query never exceeds the backend's bind-variable limit.
+ *
+ * Used by the relationship/junction loaders in `collection.ts` and by the
+ * BFS frontier in `SmrtHierarchical.getDescendants()` — any code path that
+ * expands an unbounded array of ids into one `column IN (...)` clause.
+ */
+
+/**
+ * Maximum size of an `IN (?, ?, ...)` placeholder list per query.
+ *
+ * `SQLITE_MAX_VARIABLE_NUMBER` is 999 on SQLite builds older than 3.32 and
+ * 32766 on newer ones; Postgres allows up to 65535 bind parameters. Capping
+ * at a conservative 900 stays under the legacy SQLite limit AND keeps planner
+ * time predictable across every backend, so callers don't have to know which
+ * build they're talking to. Exceeding the cap throws
+ * `SQLITE_RANGE: bind or column index out of range` (or
+ * `SQLITE_ERROR: too many SQL variables`) before the query runs, which is why
+ * every loader that builds an IN-list from caller- or data-sized arrays must
+ * chunk through this value.
+ */
+export const IN_LIST_CHUNK_SIZE = 900;
+
+/**
+ * Split `items` into contiguous batches of at most `size` elements.
+ *
+ * - Empty input yields `[]` (no empty batch).
+ * - A non-positive `size` is treated as "no chunking" and returns a single
+ *   batch containing every item, matching the previous inline behavior in
+ *   `collection.ts`.
+ */
+export function chunkArray<T>(items: T[], size: number): T[][] {
+  if (items.length === 0) return [];
+  if (size <= 0) return [items];
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}


### PR DESCRIPTION
Resolves the two **BLOCKING** findings from the final whole-PR review of `feat/relationships-v2` before it can merge + publish the 0.27.0 breaking release.

## BLOCKER 1 (C1/M1) — FK fields defaulting to `''` break inserts on uuid columns

`@foreignKey()` / `@crossPackageRef()` fields generate native **uuid** columns (R11), but their TypeScript default is the empty string. On Postgres, `''` on a `uuid` column raises `invalid input syntax for type uuid`, so creating a ROOT entity whose optional self-reference is unset (e.g. a root `Fact` with `previousFactId` left at `''`) fails on INSERT. The app-data-migration validations don't catch it — they migrate existing rows, not new inserts.

**Blast radius:** 67 declared-FK fields default to `''` across 13 packages. Confirmed that **only declared FKs** (`foreignKey`/`crossPackageRef` field types) become uuid columns — plain `*Id: string = ''` fields stay TEXT (`mapFieldTypeToSQL`), so the scope is exactly the declared-FK set.

**Fix — framework-level coercion** (preferred over a 67-field type sweep): `SmrtObject.coerceEmptyUuidValuesToNull()` in the ORM save path coerces `''` → `NULL` for any column whose resolved schema type is `UUID`, before the INSERT/UPDATE. It reads UUID-ness from the built schema's reconciled column types (so a `@foreignKey` whose target uses `idType: 'text'` correctly stays TEXT and is left alone), with a field-metadata fallback for runtime-registered classes. No per-field type churn, no consumer-facing type changes — fixes every optional/unset declared FK uniformly.

**Regression test** (`packages/core/src/__tests__/uuid-empty-fk-coercion.test.ts`):
- Save path on in-memory SQLite: a root entity with an unset optional uuid FK persists `NULL` (not `''`). **Fails-before** (value is `''`), **passes-after**.
- DuckDB native-uuid probe: `''` into a `uuid` column throws; `NULL` succeeds — documents the exact failure the coercion prevents.

## BLOCKER 2 (C2/H1/H4) — R3 rename migration + upgrade guide

The differ is additive-only (no `rename_column` change type), so a consumer upgrading would get the new column empty + the old column orphaned = silent data loss. SMRT shipped no guidance.

Adds:
- **`UPGRADE-0.27.md`** — enumerates the breaking changes (R1 FK decorators, R3 renames + Folder split, R4 `SmrtPolymorphicAssociation`, R5-canon qualified `_meta_type`, R8 `loadRelated` tenant guard, R10 child accessors, R11 native uuid; SmrtJunction `getForX`→`byLeft`/`byRight` + options-object attach/detach), documents the required DATA migration (R3 rename backfills + TEXT→uuid conversion) with a runnable per-project pattern, and notes consumers must re-run `smrt docs:claude`.
- A **`## Breaking changes (0.27.0)`** section in the root `CHANGELOG.md` pointing to the guide.
- A generic **`smrt db:migrate-uuid`** CLI helper (`packages/cli/src/commands/db-migrate-uuid.ts`) extracted from the validated consumers' scripts: self-classifying TEXT→uuid conversion (converts only columns where every non-empty value is a canonical UUID; skips slugs/external ids) + `--rename old:new` backfills (copy old→new where new is empty, drop old). `--dry-run`, `--table`, `--skip-convert`.

## Validation

- `pnpm --filter @happyvertical/smrt-core test` — **1862 passed**, 29 skipped (incl. new regression test)
- `pnpm --filter @happyvertical/smrt-cli test` — **339 passed** (incl. 7 new `db:migrate-uuid` tests)
- `pnpm --filter @happyvertical/smrt-facts test` — **150 passed**
- typecheck (core + cli) and biome on touched files: clean
- Pre-existing `commerce/payment-ledger.test.ts` failures (4) are unrelated — verified they also fail on pristine `origin/feat/relationships-v2`.