### PR TITLE
test(core): align full-registry integration with R5-canon + #1334 cycle-breaking

### DIFF
--- a/packages/core/src/__tests__/full-registry-integration.test.ts
+++ b/packages/core/src/__tests__/full-registry-integration.test.ts
@@ -132,27 +132,36 @@ describe('Issue #1008: Full registry integration (high object counts)', () => {
   // -----------------------------------------------------------------------
 
   it('should produce valid inheritance chains for all classes with extends', () => {
-    const classesWithExtends: string[] = [];
-    for (const [_key, registered] of ObjectRegistry.getAllClasses()) {
+    // R5-canon (commit f19552c0c): getInheritanceChain() entries are QUALIFIED
+    // names (`@package/name:ClassName`) whenever the registration has one, so
+    // the chain is unambiguous across packages with same-simple-name classes.
+    // Look the class up by qualified name and assert the chain terminates with
+    // that same qualified name (the class itself).
+    const classesWithExtends: Array<{
+      lookupKey: string;
+      expectedSelf: string;
+    }> = [];
+    for (const [key, registered] of ObjectRegistry.getAllClasses()) {
       if (
         registered.extends &&
         registered.extends !== 'SmrtObject' &&
         registered.extends !== 'SmrtClass' &&
         registered.extends !== 'SmrtCollection'
       ) {
-        classesWithExtends.push(registered.name || _key);
+        const lookupKey = registered.qualifiedName || registered.name || key;
+        classesWithExtends.push({ lookupKey, expectedSelf: lookupKey });
       }
     }
 
     // We should have many classes with inheritance relationships
     expect(classesWithExtends.length).toBeGreaterThan(0);
 
-    for (const className of classesWithExtends) {
-      const chain = ObjectRegistry.getInheritanceChain(className);
+    for (const { lookupKey, expectedSelf } of classesWithExtends) {
+      const chain = ObjectRegistry.getInheritanceChain(lookupKey);
       // Chain should include at least the class itself
       expect(chain.length).toBeGreaterThanOrEqual(1);
-      // The last element should be the class itself
-      expect(chain[chain.length - 1]).toBe(className);
+      // The last element is the class itself, emitted as its qualified name.
+      expect(chain[chain.length - 1]).toBe(expectedSelf);
     }
   });
 
@@ -178,19 +187,60 @@ describe('Issue #1008: Full registry integration (high object counts)', () => {
   // -----------------------------------------------------------------------
 
   it('should produce a valid topological ordering via getInitializationOrder()', () => {
-    // getInitializationOrder() throws if it detects cycles
+    // #1334 (commit 78b1340fd): getInitializationOrder() tolerates genuine
+    // foreign-key cycles by BREAKING them instead of throwing. SMRT emits no
+    // DB-level FOREIGN KEY constraints, so a cyclic pair has no valid strict
+    // linear order and needs none. The canonical case is smrt-chat:
+    // ChatMessage.threadId -> ChatThread and ChatThread.rootMessageId ->
+    // ChatMessage form a 2-cycle. A broken cycle's back-edge unavoidably
+    // violates strict topological order, so a blanket `depPos < classPos`
+    // assertion over ALL edges is invalid for cyclic graphs.
+    //
+    // The correct, stronger-than-blanket property: strict topological order
+    // holds for every ACYCLIC dependency edge; only edges whose endpoints are
+    // mutually reachable (i.e. part of a cycle) are exempt.
     const order = ObjectRegistry.getInitializationOrder();
 
-    // Should include all registered classes
+    // Should include all registered classes, exactly once each.
     expect(order.length).toBeGreaterThanOrEqual(1);
+    expect(new Set(order).size).toBe(order.length);
 
-    // Verify topological property: for each class at index i, all its
-    // dependencies must appear at indices < i
     const graph = ObjectRegistry.getDependencyGraph();
     const positionMap = new Map<string, number>();
     for (let i = 0; i < order.length; i++) {
       positionMap.set(order[i], i);
     }
+
+    // Every class in the dependency graph must appear in the ordering — the
+    // cycle-breaker must not drop a node.
+    for (const className of graph.keys()) {
+      expect(positionMap.has(className)).toBe(true);
+    }
+
+    // Is `target` reachable from `start` by following dependency edges?
+    // Used to detect cycle participation: an edge dep -> className is a cycle
+    // back-edge iff className is also reachable from dep.
+    const isReachable = (start: string, target: string): boolean => {
+      const seen = new Set<string>();
+      const stack = [start];
+      while (stack.length > 0) {
+        const node = stack.pop() as string;
+        for (const next of graph.get(node) ?? []) {
+          if (next === target) return true;
+          if (graph.has(next) && !seen.has(next)) {
+            seen.add(next);
+            stack.push(next);
+          }
+        }
+      }
+      return false;
+    };
+
+    // Track that we actually exercised both branches so the test stays
+    // meaningful: at least one strict acyclic edge must be checked, and the
+    // exemption only fires for genuine cycle back-edges.
+    let acyclicEdgesChecked = 0;
+    const exemptCycleEdges: string[] = [];
 
     for (const [className, deps] of graph) {
       const classPos = positionMap.get(className);
@@ -199,8 +249,31 @@ describe('Issue #1008: Full registry integration (high object counts)', () => {
       for (const dep of deps) {
         const depPos = positionMap.get(dep);
         if (depPos === undefined) continue;
+
+        // dep -> className participates in a cycle when className can also
+        // reach dep. Such a back-edge is expected to violate strict order.
+        if (isReachable(dep, className)) {
+          exemptCycleEdges.push(`${dep} -> ${className}`);
+          continue;
+        }
+
+        // Acyclic dependency: strict topological order MUST hold.
         expect(depPos).toBeLessThan(classPos);
+        acyclicEdgesChecked++;
       }
+    }
+
+    // The assertion is not vacuous: the vast majority of edges are acyclic.
+    expect(acyclicEdgesChecked).toBeGreaterThan(0);
+
+    // Only genuine cycle members may be exempt. In the current monorepo the
+    // sole foreign-key cycle is smrt-chat's ChatMessage <-> ChatThread pair,
+    // so every exempt edge must be between those two classes.
+    for (const edge of exemptCycleEdges) {
+      expect(
+        edge === 'ChatMessage -> ChatThread' ||
+          edge === 'ChatThread -> ChatMessage',
+      ).toBe(true);
     }
   });
 


### PR DESCRIPTION
## Summary

Fixes the two failing tests in `packages/core/src/__tests__/full-registry-integration.test.ts` (CI job "Validate Changes / Test Integration") that block the relationships-v2 0.27.0 release. This integration test loads ALL package manifests at once, exercising behavior the per-package suites never reach — which is why these slipped through.

**Rigorous diagnosis confirmed both failures are stale test expectations, not source bugs. No production code changed.**

## Failure 1 — inheritance chain (verdict: stale test)

The test asserted the chain's tail equals the **simple** class name. R5-canon (`f19552c0c`) deliberately changed `getInheritanceChain()` to emit **qualified** names (`@package/name:ClassName`) so chains are unambiguous across same-simple-name classes. The failing case was `@happyvertical/smrt-assets:AssetAssociation` vs expected `AssetAssociation`.

Fix: look the class up by its qualified name and assert the chain terminates with that same qualified name — mirroring the sibling "resolve all ambiguous simple names" test which already uses `registered.qualifiedName`.

## Failure 2 — topological ordering (verdict: legitimate broken-cycle back-edge — case b)

The test required `depPos < classPos` for **every** edge in `getDependencyGraph()`. `#1334` (`78b1340fd`) made `getInitializationOrder()` tolerate genuine FK cycles by breaking them instead of throwing; a broken cycle's back-edge unavoidably violates strict topological order, so a blanket assertion is invalid for cyclic graphs.

Evidence (printed via a diagnostic over the full 329-class graph):
- The single violating edge was `ChatMessage -> ChatThread` (pos 60 vs 59).
- `ChatThread.deps = [ChatRoom, ChatMessage]`, `ChatMessage.deps = [ChatRoom, ChatThread, AgentSession]` — they form a direct 2-cycle. Source: `ChatThread.rootMessageId @foreignKey('ChatMessage')` and `ChatMessage.threadId @foreignKey('ChatThread')`. This is the exact cycle `#1334`'s commit message names.
- Tarjan SCC over the whole graph found exactly **one** multi-node SCC: `{ChatThread, ChatMessage}`. No other cycles exist.

**Ruled out case (a) — name-form inconsistency:** both `getDependencyGraph()` and `getInitializationOrder()` derive names from `entry.name || _key` (simple names) in `relationship-graph.ts`. The init order is built directly from the graph's keys/values, so the name forms match exactly — there is no silent `positionMap` mismatch.

Fix: assert the correct weaker property — strict topological order holds for every **acyclic** dependency edge; only edges whose endpoints are mutually reachable (cycle members) are exempt, and exempt edges must be the known chat pair. Also assert every graph node appears exactly once in the order (the cycle-breaker must not drop a node) and that the acyclic-edge check is non-vacuous.

## Validation

- `npm run test:integration` (full-registry-integration + manifest-no-leak): **48 passed**
- `pnpm --filter @happyvertical/smrt-core test`: **1863 passed, 29 skipped, 0 failed**
- `pnpm --filter @happyvertical/smrt-core typecheck`: clean
- `npx @biomejs/biome ci --diagnostic-level=error .` (pre-push hook): **exit 0**
- `npx @biomejs/biome ci .` (root): **exit 0** (633 warnings / 6 infos are pre-existing on base, non-failing)
- `npx commitlint --from=origin/feat/relationships-v2 --to=HEAD`: clean

Note: the originally-listed `contentreferences/{detach,setLinks,unlink}/+server.ts` files no longer exist at this commit (route structure changed to `attach`/`[id]`); the only formatting the pre-push hook flagged was in the edited test file, which has been formatted.
