### PR TITLE
fix(core): treat SmrtJunction collections as collections in schema gen

### DIFF
--- a/packages/core/src/__tests__/issue-1342-junction-collection-schema-drop.test.ts
+++ b/packages/core/src/__tests__/issue-1342-junction-collection-schema-drop.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Regression for #1342: cross-package junction tables (e.g. smrt-places
+ * `place_assets`) lose their FK / junction columns in the vitest
+ * lazy-table-creation path, while a structurally identical junction (e.g.
+ * smrt-profiles `profile_assets`) keeps them.
+ *
+ * Root cause: `isCollectionRegistration()` only treated a registration as a
+ * collection when its `extends` chain reached `SmrtCollection`. Junction
+ * collections extend `SmrtJunction` (which extends `SmrtCollection`), but the
+ * manifest records the *direct* parent `SmrtJunction`, and `SmrtJunction` is a
+ * framework base that is not itself registered in a consumer's registry — so
+ * the chain walk could not reach `SmrtCollection`. The junction Collection was
+ * therefore mistaken for a regular table-bearing class.
+ *
+ * `getTestDatabase()` iterates every registered class. When the junction
+ * Collection registration was iterated *before* its item class (purely a
+ * function of registration / iteration order — the only thing that differs
+ * between `place_assets` and `profile_assets` on the published packages), it
+ * created the table from its own empty field set (base columns only) and
+ * marked the table created. The real item class, carrying the full junction
+ * schema, was then deduplicated out and never applied — yielding a
+ * base-columns-only `place_assets` table missing place_id / asset_id /
+ * relationship / sort_order / tenant_id.
+ *
+ * The fix teaches collection detection that `SmrtJunction` is a collection
+ * base, so the junction Collection always redirects to its item class
+ * regardless of iteration order.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { clearManifestCache } from '../manifest/manifest-loader.js';
+import { ObjectRegistry } from '../registry.js';
+import { snapshotObjectRegistryState } from '../test-utils.js';
+import { getTestDatabase } from '../testing/database.js';
+
+const PKG = '@happyvertical/smrt-junction-fixture';
+
+/**
+ * Item-class manifest entry carrying the full junction schema, mirroring the
+ * published `PlaceAsset` / `ProfileAsset` shape (FK + cross-package ref +
+ * regular junction columns).
+ */
+function junctionItemManifest(itemName: string, ownerColumn: string) {
+  return {
+    className: itemName,
+    qualifiedName: `${PKG}:${itemName}`,
+    collection: `${itemName.toLowerCase()}s`,
+    filePath: `/src/models/${itemName}.ts`,
+    packageName: PKG,
+    extends: 'SmrtObject',
+    fields: {
+      tenantId: { type: 'text', required: false },
+      [`${ownerColumn}Id`]: {
+        type: 'foreignKey',
+        required: true,
+        related: 'JunctionFixtureOwner',
+        _meta: { required: true },
+      },
+      assetId: {
+        type: 'crossPackageRef',
+        required: true,
+        related: '@happyvertical/smrt-assets-fixture:JunctionFixtureAsset',
+      },
+      relationship: { type: 'text', required: true, _meta: { required: true } },
+      sortOrder: { type: 'integer', required: true, default: 0 },
+    },
+    methods: {},
+    decoratorConfig: {
+      tableName: `${ownerColumn}_assets`,
+      conflictColumns: [`${ownerColumn}_id`, 'asset_id', 'relationship'],
+      api: false,
+      mcp: false,
+      cli: false,
+    },
+    schema: {
+      tableName: `${ownerColumn}_assets`,
+      ddl: '',
+      columns: {
+        id: { type: 'UUID', primaryKey: true, notNull: true },
+        slug: { type: 'TEXT', notNull: true },
+        context: { type: 'TEXT', notNull: true, defaultValue: '' },
+        created_at: { type: 'TIMESTAMP', notNull: true },
+        updated_at: { type: 'TIMESTAMP', notNull: true },
+        tenant_id: { type: 'TEXT' },
+        [`${ownerColumn}_id`]: { type: 'UUID', notNull: true },
+        asset_id: { type: 'UUID', notNull: true },
+        relationship: { type: 'TEXT', notNull: true },
+        sort_order: { type: 'INTEGER', notNull: true, defaultValue: 0 },
+      },
+      indexes: [],
+      triggers: [],
+      foreignKeys: [],
+      dependencies: [],
+      version: '1.0.0',
+    },
+  };
+}
+
+/**
+ * Junction Collection manifest stub, as the published manifest ships it:
+ * `extends: 'SmrtJunction'`, a base-columns-only schema, and a `tableName`
+ * that points at the junction table.
+ */
+function junctionCollectionManifest(itemName: string, tableName: string) {
+  return {
+    className: `${itemName}Collection`,
+    qualifiedName: `${PKG}:${itemName}Collection`,
+    collection: `${itemName.toLowerCase()}s`,
+    filePath: `/src/collections/${itemName}Collection.ts`,
+    packageName: PKG,
+    extends: 'SmrtJunction',
+    extendsTypeArg: itemName,
+    fields: {},
+    methods: {},
+    decoratorConfig: {
+      tableName,
+      api: false,
+      mcp: false,
+      cli: false,
+    },
+    schema: {
+      tableName,
+      ddl: '',
+      columns: {
+        id: { type: 'UUID', primaryKey: true, notNull: true },
+        slug: { type: 'TEXT', notNull: true },
+        context: { type: 'TEXT', notNull: true, defaultValue: '' },
+        created_at: { type: 'TIMESTAMP', notNull: true },
+        updated_at: { type: 'TIMESTAMP', notNull: true },
+      },
+      indexes: [],
+      triggers: [],
+      foreignKeys: [],
+      dependencies: [],
+      version: '1.0.0',
+    },
+  };
+}
+
+async function tableColumns(db: any, table: string): Promise<string[]> {
+  const res = await db.query(`PRAGMA table_info(${table})`);
+  const rows = Array.isArray(res) ? res : (res.rows ?? []);
+  return rows.map((r: any) => r.name);
+}
+
+describe('#1342 junction Collection schema drop', () => {
+  let restoreRegistry: () => void;
+
+  beforeAll(() => {
+    restoreRegistry = snapshotObjectRegistryState();
+  });
+
+  afterEach(() => {
+    ObjectRegistry.clear();
+    clearManifestCache();
+  });
+
+  afterAll(() => {
+    restoreRegistry();
+    clearManifestCache();
+  });
+
+  it('keeps junction columns when the Collection registers before its item class', async () => {
+    ObjectRegistry.clear();
+    clearManifestCache();
+
+    // The order that reproduces the bug: the junction Collection stub is
+    // registered (and therefore iterated by getTestDatabase) BEFORE the real
+    // item class. This is exactly the asymmetry between place_assets (broken)
+    // and profile_assets (works by luck of order) on the published packages.
+    ObjectRegistry.registerFromManifest(
+      'PlaceFixtureAssetCollection',
+      junctionCollectionManifest('PlaceFixtureAsset', 'place_fixture_assets'),
+      PKG,
+    );
+    ObjectRegistry.registerFromManifest(
+      'PlaceFixtureAsset',
+      junctionItemManifest('PlaceFixtureAsset', 'place_fixture'),
+      PKG,
+    );
+
+    const db = await getTestDatabase();
+    const cols = await tableColumns(db, 'place_fixture_assets');
+
+    expect(cols).toContain('place_fixture_id');
+    expect(cols).toContain('asset_id');
+    expect(cols).toContain('relationship');
+    expect(cols).toContain('sort_order');
+    expect(cols).toContain('tenant_id');
+  });
+
+  it('also keeps junction columns when the item class registers first (control)', async () => {
+    ObjectRegistry.clear();
+    clearManifestCache();
+
+    // Item first, Collection second (the order that already worked for
+    // profile_assets). Asserting it here guards against a fix that only moves
+    // the breakage to the other order.
+    ObjectRegistry.registerFromManifest(
+      'ProfileFixtureAsset',
+      junctionItemManifest('ProfileFixtureAsset', 'profile_fixture'),
+      PKG,
+    );
+    ObjectRegistry.registerFromManifest(
+      'ProfileFixtureAssetCollection',
+      junctionCollectionManifest(
+        'ProfileFixtureAsset',
+        'profile_fixture_assets',
+      ),
+      PKG,
+    );
+
+    const db = await getTestDatabase();
+    const cols = await tableColumns(db, 'profile_fixture_assets');
+
+    expect(cols).toContain('profile_fixture_id');
+    expect(cols).toContain('asset_id');
+    expect(cols).toContain('relationship');
+    expect(cols).toContain('sort_order');
+    expect(cols).toContain('tenant_id');
+  });
+});

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -141,6 +141,16 @@ import {
   parseQualifiedName,
 } from './utils/qualified-names.js';
 
+// Re-export the canonical collection-base detector so downstream tooling
+// (e.g. @happyvertical/smrt-vitest's manifest-based test-db builder) can share
+// the single source of truth instead of maintaining a drift-prone copy. The
+// junction-collection schema-drop bug (#1342) half-survived precisely because
+// a second copy of this detector existed; exporting it publicly kills that
+// drift class. See `./registry/collection-resolution.ts`.
+export {
+  isSmrtCollectionExtendsName,
+  SMRT_COLLECTION_BASE_NAMES,
+} from './registry/collection-resolution';
 // Re-export types for backward compatibility
 export type {
   RelationshipMetadata,

--- a/packages/core/src/registry/collection-resolution.ts
+++ b/packages/core/src/registry/collection-resolution.ts
@@ -28,8 +28,23 @@ export interface CollectionRegistrationLookup {
  * `packages/core/src/junction.ts`. (`SmrtHierarchical` and
  * `SmrtPolymorphicAssociation` extend `SmrtObject`, not `SmrtCollection`, so
  * they deliberately do NOT belong here.)
+ *
+ * A new framework collection base must also be added to the other parallel
+ * framework-base lists so it is recognized everywhere it matters:
+ * - `FRAMEWORK_BASE_CLASSES` in
+ *   `packages/scanner/src/inheritance-resolver.ts` (scanner chain termination).
+ * - `FRAMEWORK_ABSTRACT_BASE_NAMES` in
+ *   `packages/core/src/scanner/manifest-generator.ts` (field-merge skipping).
+ *
+ * Downstream tooling that needs this detector (e.g. @happyvertical/smrt-vitest)
+ * should IMPORT it from `@happyvertical/smrt-core` rather than keep a copy — a
+ * duplicate detector is exactly how the #1342 junction schema-drop bug
+ * half-survived the original core fix.
  */
-const SMRT_COLLECTION_BASE_NAMES = ['SmrtCollection', 'SmrtJunction'] as const;
+export const SMRT_COLLECTION_BASE_NAMES = [
+  'SmrtCollection',
+  'SmrtJunction',
+] as const;
 
 export function isSmrtCollectionExtendsName(
   extendsName: string | undefined,

--- a/packages/core/src/registry/collection-resolution.ts
+++ b/packages/core/src/registry/collection-resolution.ts
@@ -9,12 +9,36 @@ export interface CollectionRegistrationLookup {
   getInheritanceChain: (className: string) => string[];
 }
 
+/**
+ * Framework base classes that ARE collections (extend `SmrtCollection`).
+ *
+ * `SmrtJunction` is an abstract collection base — junction collections declare
+ * `extends SmrtJunction<Item>`, and the manifest records that *direct* parent.
+ * `SmrtJunction` is itself never registered in a consumer's registry, so the
+ * inheritance-chain walk in `isCollectionRegistration()` cannot reach
+ * `SmrtCollection` through it. Recognizing the junction base by name here is
+ * what keeps a junction Collection classified as a collection (and therefore
+ * redirected to its item class for schema generation) regardless of
+ * registration order. Without it, a junction Collection that is iterated
+ * before its item class is mistaken for a regular table-bearing class and
+ * creates a base-columns-only table, dropping the junction's FK columns
+ * (#1342 — `place_assets` vs `profile_assets` asymmetry).
+ *
+ * Keep in sync with the collection bases that extend `SmrtCollection` in
+ * `packages/core/src/junction.ts`. (`SmrtHierarchical` and
+ * `SmrtPolymorphicAssociation` extend `SmrtObject`, not `SmrtCollection`, so
+ * they deliberately do NOT belong here.)
+ */
+const SMRT_COLLECTION_BASE_NAMES = ['SmrtCollection', 'SmrtJunction'] as const;
+
 export function isSmrtCollectionExtendsName(
   extendsName: string | undefined,
 ): boolean {
-  return (
-    extendsName === 'SmrtCollection' ||
-    extendsName?.endsWith(':SmrtCollection') === true
+  if (!extendsName) {
+    return false;
+  }
+  return SMRT_COLLECTION_BASE_NAMES.some(
+    (base) => extendsName === base || extendsName.endsWith(`:${base}`),
   );
 }
 

--- a/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
+++ b/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
@@ -475,6 +475,75 @@ describe('createIsolatedTestDbFromManifest', () => {
         await cleanup();
       }
     });
+
+    // Regression for #1342: a junction Collection (`extends: 'SmrtJunction'`)
+    // ships with a base-columns-only schema, while its item class carries the
+    // full FK / junction columns under the SAME table name. When a consumer
+    // filters by the junction Collection name, the manifest test-db builder
+    // must classify it as a collection and redirect to the item class. The
+    // detector previously only recognized `SmrtCollection`, so the junction
+    // Collection was mistaken for a regular table-bearing class and created a
+    // base-columns-only `place_assets` table, dropping place_id / asset_id /
+    // relationship / sort_order. See packages/core's
+    // issue-1342-junction-collection-schema-drop.test.ts for the core path.
+    it('should map junction Collection filters to their item schema (#1342)', async () => {
+      const manifestPath = join(testDir, 'junction-collection-filter.json');
+      const manifest = {
+        packageName: '@test/places',
+        objects: {
+          // Junction Collection stub as the published manifest ships it:
+          // extends 'SmrtJunction', base-columns-only schema, tableName points
+          // at the junction table. Listed BEFORE its item class to reproduce
+          // the iteration order that broke place_assets.
+          '@test/places:PlaceAssetCollection': {
+            className: 'PlaceAssetCollection',
+            extends: 'SmrtJunction',
+            extendsTypeArg: 'PlaceAsset',
+            schema: {
+              tableName: 'place_assets',
+              ddl: 'CREATE TABLE IF NOT EXISTS "place_assets" ("id" TEXT PRIMARY KEY NOT NULL, "slug" TEXT NOT NULL, "context" TEXT NOT NULL DEFAULT \'\', "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp, "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp);',
+            },
+          },
+          // Item class carrying the full junction schema (FK + cross-package
+          // ref + regular junction columns) under the same table.
+          '@test/places:PlaceAsset': {
+            className: 'PlaceAsset',
+            extends: 'SmrtObject',
+            schema: {
+              tableName: 'place_assets',
+              ddl: 'CREATE TABLE IF NOT EXISTS "place_assets" ("id" TEXT PRIMARY KEY NOT NULL, "slug" TEXT NOT NULL, "context" TEXT NOT NULL DEFAULT \'\', "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp, "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp, "tenant_id" TEXT, "place_id" TEXT NOT NULL, "asset_id" TEXT NOT NULL, "relationship" TEXT NOT NULL, "sort_order" INTEGER NOT NULL DEFAULT 0);',
+            },
+          },
+        },
+      };
+
+      writeFileSync(manifestPath, JSON.stringify(manifest));
+
+      const { baseDb, cleanup } = await createIsolatedTestDbFromManifest({
+        manifestPath,
+        includeObjects: ['PlaceAssetCollection'],
+      });
+
+      try {
+        const columnsResult = await baseDb.query(
+          `PRAGMA table_info('place_assets')`,
+        );
+        const columns = Array.isArray(columnsResult)
+          ? columnsResult
+          : columnsResult.rows;
+        const columnNames = columns.map((row: { name: string }) => row.name);
+
+        // The full junction columns from the item class must be present — not
+        // just the Collection stub's base columns.
+        expect(columnNames).toContain('place_id');
+        expect(columnNames).toContain('asset_id');
+        expect(columnNames).toContain('relationship');
+        expect(columnNames).toContain('sort_order');
+        expect(columnNames).toContain('tenant_id');
+      } finally {
+        await cleanup();
+      }
+    });
   });
 
   describe('STI deduplication', () => {

--- a/packages/vitest/src/test-db.ts
+++ b/packages/vitest/src/test-db.ts
@@ -34,6 +34,14 @@ import { randomUUID } from 'node:crypto';
 import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+// Share the canonical collection-base detector with core instead of keeping a
+// local copy. A second copy is exactly how the #1342 junction schema-drop bug
+// half-survived: the core fix taught `collection-resolution.ts` to recognize
+// `SmrtJunction`, but this manifest-based test-db builder kept an older copy
+// that only knew `SmrtCollection`, so junction Collections filtered through
+// `createIsolatedTestDbFromManifest({ includeObjects: [...] })` were still
+// misclassified as table-bearing and lost their FK/junction columns.
+import { isSmrtCollectionExtendsName } from '@happyvertical/smrt-core';
 import type {
   DatabaseInterfaceWithTransaction,
   TransactionHandle,
@@ -747,13 +755,6 @@ function mergeIndexes(
     }
   }
   return merged;
-}
-
-function isSmrtCollectionExtendsName(extendsName: string | undefined): boolean {
-  return (
-    extendsName === 'SmrtCollection' ||
-    extendsName?.endsWith(':SmrtCollection') === true
-  );
 }
 
 function getPackageNameFromKey(key: string): string | undefined {


### PR DESCRIPTION
## Summary

Fixes a SMRT 0.27.0 bug surfaced by the ergot.io canary: the cross-package junction `place_assets` (smrt-places `PlaceAsset`) drops its FK/junction columns in the **vitest in-memory lazy-table-creation path** when consuming the published packages, while the structurally identical `profile_assets` (smrt-profiles `ProfileAsset`) works fine. `smrt db:migrate` (prod/dev) was unaffected — only the registered-schema → `getTestDatabase()` path drops columns.

## Root cause

`isCollectionRegistration()` (`packages/core/src/registry/collection-resolution.ts`) only classified a registration as a collection when its `extends` chain reached `SmrtCollection`. Junction collections declare `extends SmrtJunction<Item>`, and the manifest records that **direct** parent. `SmrtJunction` (which extends `SmrtCollection`) is a framework abstract base that is never itself registered in a consumer's registry, so the inheritance-chain walk could not reach `SmrtCollection` through it. The junction Collection (`PlaceAssetCollection`) was therefore mistaken for a regular table-bearing class.

`getTestDatabase()` iterates **every** registered class and dedups by table. When the junction Collection registration is iterated **before** its item class, it creates the table from its own empty field set (base columns only: `id, slug, context, created_at, updated_at`) and marks the table created. The real item class — carrying the full junction schema — is then deduplicated out and never applied.

The **only** difference between `place_assets` (broken) and `profile_assets` (works) is registration/iteration order:

| order | result |
|---|---|
| `PlaceAssetCollection` then `PlaceAsset` | base columns only (BUG) |
| `ProfileAsset` then `ProfileAssetCollection` | full schema (works by luck) |

This affects every junction in the framework (`content_assets`, `product_assets`, `event_assets`, `fact_contents`, `asset_associations`, …) — `profile_assets` only escaped by iteration order.

### Evidence (registry state was complete; only the created table dropped columns)

For `PlaceAsset`: `registered.fields`, `getAllFields()`, and `registered.schema.columns` were **all complete** — yet the created `place_assets` table had only base columns. The drop is not field hydration; it is the junction Collection creating a base-only table first.

## Fix

Recognize `SmrtJunction` as a collection base in `isSmrtCollectionExtendsName`, so a junction Collection always redirects to its item class for schema generation regardless of iteration order. `SmrtHierarchical` and `SmrtPolymorphicAssociation` extend `SmrtObject` (not `SmrtCollection`) and are deliberately excluded.

## Test evidence

- New regression test `issue-1342-junction-collection-schema-drop.test.ts` (real DB, real registry — no mocking): the Collection-before-item case **failed before** (`expected [...] to include 'place_fixture_id'`) and **passes after**; an item-first control guards against moving the breakage.
- Validated against the **published 0.27.0** places/profiles/assets manifests with the built core: `place_assets`, `profile_assets`, and `asset_associations` all hydrate their full junction schemas.
- Full `@happyvertical/smrt-core` suite: **1865 passed**, 0 failed. `@happyvertical/smrt-content` junction suite: 264 passed.

## Downstream note

Once 0.27.1 ships, ergot's `ensurePlaceAssetsColumns` backstop in `packages/imago-core/src/db.ts` can be removed (not touched here). No ergot changes in this PR.