### PR TITLE
[codex] release smrt dev mcp project tools

### DIFF
--- a/packages/smrt-dev-mcp/AGENTS.md
+++ b/packages/smrt-dev-mcp/AGENTS.md
@@ -9,6 +9,7 @@ deterministic SMRT ecosystem knowledge, and portable agent workflows.
 |------|---------|
 | `generate-smrt-class` | Generates `@smrt()` class with fields, decorator config, imports |
 | `introspect-project` | Scans project directory for SMRT objects, returns class/field/relationship report |
+| `review-smrt-project` | Advisory downstream ecosystem alignment review for dependencies, storage, app shell, auth/tenancy, and manifest generation |
 | `reflect-knowledge` | Reports deterministic SMRT + HappyVertical SDK knowledge coverage and freshness |
 | `reflect-domain-knowledge` | Reports downstream/domain artifact coverage and freshness |
 | `check-knowledge-freshness` | Runs deterministic agent-doc and stale-reference checks |
@@ -52,8 +53,9 @@ Skill-aware harnesses can parse the frontmatter; other harnesses can ignore it.
 - `src/knowledge/index.ts` — deterministic SMRT, SDK, and downstream domain knowledge discovery
 - `src/agent-skills.ts` — bundled skill registry and file loader
 - `agent-skills/smrt-code-review/SKILL.md` — downstream SMRT review procedure
-- `src/tools/generate-smrt-class.ts` — class generation logic
-- `src/tools/introspect-project.ts` — project scanning (uses scanner package)
+- `src/tools/generate-smrt-class.ts` — class generation logic and package-ready templates
+- `src/tools/introspect-project.ts` — manifest-first project scanning, falling back to `@happyvertical/smrt-scanner`
+- `src/tools/review-smrt-project.ts` — advisory ecosystem-alignment checks for downstream projects
 
 ## Gotchas
 

--- a/packages/smrt-dev-mcp/README.md
+++ b/packages/smrt-dev-mcp/README.md
@@ -102,8 +102,15 @@ Generate a complete SMRT class with `@smrt()` decorator, fields, and imports.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `className` | `string` | Yes | Class name (PascalCase) |
-| `properties` | `array` | Yes | Property definitions (`name`, `type`, `required?`, `description?`) |
+| `properties` | `array` | Yes | Property definitions (`name`, `type`, `required?`, `nullable?`, `description?`, `defaultValue?`) |
 | `baseClass` | `string` | No | `'SmrtObject'` (default) or `'SmrtCollection'` |
+| `template` | `string` | No | `basic`, `global-catalog`, `optional-catalog`, `tenant-project-object`, `tenant-event-log-object`, or `cross-package-reference` |
+| `tableName` | `string` | No | Explicit `@smrt({ tableName })` value |
+| `conflictColumns` | `string[]` | No | Explicit upsert natural key columns |
+| `tenantScoped` | `boolean/object` | No | Add `@TenantScoped(...)`; object supports `mode`, `field`, and bypass/filter options |
+| `includeTenantIdField` | `boolean` | No | Emit a matching `@tenantId()` field |
+| `relationships` | `array` | No | Relationship definitions for `foreignKey`, `crossPackageRef`, `oneToMany`, or `manyToMany` |
+| `includeCompanionSnippets` | `boolean` | No | Append package wiring notes |
 | `includeApiConfig` | `boolean` | No | Include REST API config (default: true) |
 | `includeMcpConfig` | `boolean` | No | Include MCP config (default: true) |
 | `includeCliConfig` | `boolean` | No | Include CLI config (default: true) |
@@ -112,13 +119,33 @@ Supported property types: `text`, `integer`, `decimal`, `boolean`, `datetime`, `
 
 ### `introspect-project`
 
-Scan a project directory for SMRT objects and return a class/field/relationship report.
+Scan a project directory for SMRT objects and return a manifest-equivalent
+class/field/relationship report. Discovery prefers `.smrt/manifest.json`, then
+`dist/manifest.json`, then `src/manifest/manifest.json`; when no artifact is
+available it falls back to `@happyvertical/smrt-scanner`.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `directory` | `string` | No | Project directory (default: cwd) |
+| `manifestPath` | `string` | No | Explicit manifest artifact path |
 | `includeFields` | `boolean` | No | Include field details |
 | `includeRelationships` | `boolean` | No | Analyze relationships |
+| `includeMethods` | `boolean` | No | Include public method details |
+
+### `review-smrt-project`
+
+Run an advisory downstream ecosystem review. The tool scans package manifests
+and source imports for missing HappyVertical dependencies, direct storage
+bypasses, custom HTTP shells, custom object manifest generation, local
+auth/tenancy/audit seams, and UI shell drift. It returns deterministic findings
+and suggested follow-up issue titles; it does not modify files.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `directory` | `string` | No | Project directory (default: cwd) |
+| `rootDir` | `string` | No | Compatibility alias for `directory` |
+| `includeSourceEvidence` | `boolean` | No | Include file/line evidence (default: true) |
+| `maxFindings` | `number` | No | Limit findings returned |
 
 ### `reflect-knowledge`
 

--- a/packages/smrt-dev-mcp/package.json
+++ b/packages/smrt-dev-mcp/package.json
@@ -51,6 +51,7 @@
   },
   "dependencies": {
     "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-scanner": "workspace:*",
     "@happyvertical/smrt-types": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.25.2"
   },

--- a/packages/smrt-dev-mcp/src/index.test.ts
+++ b/packages/smrt-dev-mcp/src/index.test.ts
@@ -1,5 +1,10 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { TOOLS } from './index.js';
+import { SERVER_VERSION, TOOLS } from './index.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 describe('smrt-dev-mcp tools', () => {
   it('lists deterministic knowledge, review, and architecture tools', () => {
@@ -15,7 +20,16 @@ describe('smrt-dev-mcp tools', () => {
     expect(names).toContain('build-architecture-context');
     expect(names).toContain('build-domain-architecture-context');
     expect(names).toContain('smrt-architecture');
+    expect(names).toContain('review-smrt-project');
     expect(names).toContain('list-agent-skills');
     expect(names).toContain('get-agent-skill');
+  });
+
+  it('advertises the package version', () => {
+    const packageJson = JSON.parse(
+      readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'),
+    ) as { version: string };
+
+    expect(SERVER_VERSION).toBe(packageJson.version);
   });
 });

--- a/packages/smrt-dev-mcp/src/index.ts
+++ b/packages/smrt-dev-mcp/src/index.ts
@@ -4,7 +4,8 @@
  * review/architecture prompt bundles, and portable agent skills.
  */
 
-import { realpathSync } from 'node:fs';
+import { readFileSync, realpathSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -29,10 +30,14 @@ import {
   smrtArchitecture,
   smrtReview,
 } from './knowledge/index.js';
-import { generateSmrtClass, introspectProject } from './tools/index.js';
+import {
+  generateSmrtClass,
+  introspectProject,
+  reviewSmrtProject,
+} from './tools/index.js';
 
 const SERVER_NAME = 'smrt-dev-mcp';
-const SERVER_VERSION = '0.1.0';
+export const SERVER_VERSION = readPackageVersion();
 const DEBUG = process.env.DEBUG === 'true';
 const REVIEW_SKILL_NAME = 'smrt-code-review';
 const REVIEW_SKILL_URI = `smrt-dev-mcp://agent-skills/${REVIEW_SKILL_NAME}`;
@@ -77,7 +82,17 @@ export const TOOLS = [
                 ],
               },
               required: { type: 'boolean' },
+              nullable: { type: 'boolean' },
               description: { type: 'string' },
+              defaultValue: {
+                oneOf: [
+                  { type: 'string' },
+                  { type: 'number' },
+                  { type: 'boolean' },
+                  { type: 'object' },
+                  { type: 'null' },
+                ],
+              },
             },
             required: ['name', 'type'],
           },
@@ -87,6 +102,68 @@ export const TOOLS = [
           enum: ['SmrtObject', 'SmrtCollection'],
           default: 'SmrtObject',
         },
+        template: {
+          type: 'string',
+          enum: [
+            'basic',
+            'global-catalog',
+            'optional-catalog',
+            'tenant-project-object',
+            'tenant-event-log-object',
+            'cross-package-reference',
+          ],
+          default: 'basic',
+        },
+        tableName: { type: 'string' },
+        conflictColumns: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+        tenantScoped: {
+          oneOf: [
+            { type: 'boolean' },
+            {
+              type: 'object',
+              properties: {
+                mode: { type: 'string', enum: ['required', 'optional'] },
+                field: { type: 'string' },
+                autoFilter: { type: 'boolean' },
+                autoPopulate: { type: 'boolean' },
+                allowSuperAdminBypass: { type: 'boolean' },
+              },
+            },
+          ],
+        },
+        includeTenantIdField: { type: 'boolean' },
+        relationships: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              type: {
+                type: 'string',
+                enum: [
+                  'foreignKey',
+                  'crossPackageRef',
+                  'oneToMany',
+                  'manyToMany',
+                ],
+              },
+              related: { type: 'string' },
+              required: { type: 'boolean' },
+              nullable: { type: 'boolean' },
+              description: { type: 'string' },
+              validate: { type: 'boolean' },
+              foreignKey: { type: 'string' },
+              through: { type: 'string' },
+              sourceKey: { type: 'string' },
+              targetKey: { type: 'string' },
+            },
+            required: ['name', 'type', 'related'],
+          },
+        },
+        includeCompanionSnippets: { type: 'boolean', default: false },
         includeApiConfig: { type: 'boolean', default: true },
         includeMcpConfig: { type: 'boolean', default: true },
         includeCliConfig: { type: 'boolean', default: true },
@@ -105,6 +182,11 @@ export const TOOLS = [
           type: 'string',
           description: 'Project directory (default: cwd)',
         },
+        manifestPath: {
+          type: 'string',
+          description:
+            'Optional manifest path. Defaults to .smrt/manifest.json, dist/manifest.json, then source scanning.',
+        },
         includeFields: {
           type: 'boolean',
           description: 'Include field details',
@@ -112,6 +194,37 @@ export const TOOLS = [
         includeRelationships: {
           type: 'boolean',
           description: 'Analyze relationships',
+        },
+        includeMethods: {
+          type: 'boolean',
+          description: 'Include public method details',
+        },
+      },
+    },
+  },
+  {
+    name: 'review-smrt-project',
+    description:
+      'Advisory ecosystem alignment review for downstream SMRT projects',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        directory: {
+          type: 'string',
+          description: 'Project directory (default: cwd)',
+        },
+        rootDir: {
+          type: 'string',
+          description: 'Compatibility alias for directory',
+        },
+        includeSourceEvidence: {
+          type: 'boolean',
+          description: 'Include file and line evidence in findings',
+          default: true,
+        },
+        maxFindings: {
+          type: 'number',
+          description: 'Optional maximum number of findings to return',
         },
       },
     },
@@ -600,6 +713,10 @@ async function main() {
           result = await introspectProject(args as any);
           break;
 
+        case 'review-smrt-project':
+          result = await reviewSmrtProject(args as any);
+          break;
+
         case 'reflect-knowledge': {
           const index = await buildKnowledgeIndex(args as any);
           const freshness = await checkKnowledgeFreshnessFromIndex(
@@ -778,6 +895,21 @@ function isEntrypoint(): boolean {
     return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(entry);
   } catch {
     return import.meta.url === pathToFileURL(entry).href;
+  }
+}
+
+function readPackageVersion(): string {
+  try {
+    const packageRoot = dirname(fileURLToPath(import.meta.url));
+    const packageJsonPath = join(packageRoot, '..', 'package.json');
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
+      version?: unknown;
+    };
+    return typeof packageJson.version === 'string'
+      ? packageJson.version
+      : '0.0.0';
+  } catch {
+    return '0.0.0';
   }
 }
 

--- a/packages/smrt-dev-mcp/src/mcp-stdio.test.ts
+++ b/packages/smrt-dev-mcp/src/mcp-stdio.test.ts
@@ -68,6 +68,7 @@ describe('smrt-dev-mcp stdio server', () => {
         'build-domain-architecture-context',
         'smrt-review',
         'smrt-architecture',
+        'review-smrt-project',
         'list-agent-skills',
         'get-agent-skill',
       ]),

--- a/packages/smrt-dev-mcp/src/tools/generate-smrt-class.test.ts
+++ b/packages/smrt-dev-mcp/src/tools/generate-smrt-class.test.ts
@@ -152,6 +152,103 @@ describe('generateSmrtClass', () => {
     });
   });
 
+  describe('Current Package Patterns', () => {
+    it('should generate tenant-scoped package-ready objects', async () => {
+      const result = await generateSmrtClass({
+        className: 'ProjectTask',
+        template: 'tenant-project-object',
+        tableName: 'project_tasks',
+        conflictColumns: ['tenant_id', 'slug'],
+        properties: [
+          { name: 'title', type: 'text', required: true },
+          { name: 'priority', type: 'integer' },
+        ],
+      });
+
+      expect(result).toContain(
+        "import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy'",
+      );
+      expect(result).toContain('@TenantScoped(');
+      expect(result).toContain('"mode": "required"');
+      expect(result).toContain('@tenantId()');
+      expect(result).toContain("tenantId: string = ''");
+      expect(result).toContain('"tableName": "project_tasks"');
+      expect(result).toContain('"conflictColumns"');
+      expect(result).toContain('"tenant_id"');
+    });
+
+    it('should generate same-package and cross-package relationships', async () => {
+      const result = await generateSmrtClass({
+        className: 'Order',
+        properties: [{ name: 'orderNumber', type: 'text', required: true }],
+        relationships: [
+          {
+            name: 'customerId',
+            type: 'foreignKey',
+            related: 'Customer',
+            required: true,
+          },
+          {
+            name: 'profileId',
+            type: 'crossPackageRef',
+            related: '@happyvertical/smrt-profiles:Profile',
+            nullable: true,
+          },
+        ],
+      });
+
+      expect(result).toContain('field, foreignKey, crossPackageRef');
+      expect(result).toContain('@foreignKey("Customer", {"required":true})');
+      expect(result).toContain("customerId: string = ''");
+      expect(result).toContain(
+        '@crossPackageRef("@happyvertical/smrt-profiles:Profile", {"nullable":true})',
+      );
+      expect(result).toContain('profileId: string | null = null');
+    });
+
+    it('should include a tenant id field by default for tenant-scoped generation', async () => {
+      const result = await generateSmrtClass({
+        className: 'TenantNote',
+        tenantScoped: true,
+        properties: [{ name: 'body', type: 'text' }],
+      });
+
+      expect(result).toContain(
+        "import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy'",
+      );
+      expect(result).toContain('@tenantId()');
+      expect(result).toContain("tenantId: string = ''");
+    });
+
+    it('should avoid unused tenantId imports when the tenant field is explicitly disabled', async () => {
+      const result = await generateSmrtClass({
+        className: 'TenantView',
+        tenantScoped: true,
+        includeTenantIdField: false,
+        properties: [{ name: 'name', type: 'text' }],
+      });
+
+      expect(result).toContain(
+        "import { TenantScoped } from '@happyvertical/smrt-tenancy'",
+      );
+      expect(result).not.toContain('tenantId }');
+      expect(result).not.toContain('@tenantId()');
+    });
+
+    it('should include companion snippets when requested', async () => {
+      const result = await generateSmrtClass({
+        className: 'CatalogEntry',
+        template: 'global-catalog',
+        properties: [{ name: 'name', type: 'text' }],
+        includeCompanionSnippets: true,
+      });
+
+      expect(result).toContain('Package wiring:');
+      expect(result).toContain('Export CatalogEntry');
+      expect(result).toContain('"slug"');
+    });
+  });
+
   describe('Base Class Selection', () => {
     it('should extend SmrtObject by default', async () => {
       const result = await generateSmrtClass({

--- a/packages/smrt-dev-mcp/src/tools/generate-smrt-class.ts
+++ b/packages/smrt-dev-mcp/src/tools/generate-smrt-class.ts
@@ -1,27 +1,94 @@
 /**
  * Generate SMRT Class Tool
- * Creates a complete SMRT class with decorator configuration
+ * Creates a package-ready SMRT class using current object-package patterns.
  */
+
+type PropertyType =
+  | 'text'
+  | 'integer'
+  | 'decimal'
+  | 'boolean'
+  | 'datetime'
+  | 'json';
+type BaseClass = 'SmrtObject' | 'SmrtCollection';
+type TemplateVariant =
+  | 'basic'
+  | 'global-catalog'
+  | 'optional-catalog'
+  | 'tenant-project-object'
+  | 'tenant-event-log-object'
+  | 'cross-package-reference';
+type RelationshipType =
+  | 'foreignKey'
+  | 'crossPackageRef'
+  | 'oneToMany'
+  | 'manyToMany';
 
 interface PropertyDefinition {
   name: string;
-  type: 'text' | 'integer' | 'decimal' | 'boolean' | 'datetime' | 'json';
+  type: PropertyType;
   required?: boolean;
+  nullable?: boolean;
   description?: string;
+  defaultValue?: unknown;
+}
+
+interface RelationshipDefinition {
+  name: string;
+  type: RelationshipType;
+  related: string;
+  required?: boolean;
+  nullable?: boolean;
+  description?: string;
+  validate?: boolean;
+  foreignKey?: string;
+  through?: string;
+  sourceKey?: string;
+  targetKey?: string;
+}
+
+interface TenantScopedDefinition {
+  mode?: 'required' | 'optional';
+  field?: string;
+  autoFilter?: boolean;
+  autoPopulate?: boolean;
+  allowSuperAdminBypass?: boolean;
 }
 
 interface GenerateSmrtClassArgs {
   className: string;
   properties: PropertyDefinition[];
-  baseClass?: 'SmrtObject' | 'SmrtCollection';
+  baseClass?: BaseClass;
+  template?: TemplateVariant;
+  tableName?: string;
+  conflictColumns?: string[];
+  tenantScoped?: boolean | TenantScopedDefinition;
+  includeTenantIdField?: boolean;
+  relationships?: RelationshipDefinition[];
   includeApiConfig?: boolean;
   includeMcpConfig?: boolean;
   includeCliConfig?: boolean;
+  includeCompanionSnippets?: boolean;
 }
 
-// Map field types to TypeScript types and default values
+interface NormalizedGenerateSmrtClassArgs {
+  className: string;
+  properties: PropertyDefinition[];
+  baseClass: BaseClass;
+  template: TemplateVariant;
+  tableName?: string;
+  conflictColumns: string[];
+  tenantScoped?: TenantScopedDefinition;
+  includeTenantIdField: boolean;
+  relationships: RelationshipDefinition[];
+  includeApiConfig: boolean;
+  includeMcpConfig: boolean;
+  includeCliConfig: boolean;
+  includeCompanionSnippets: boolean;
+}
+
 const TYPE_MAPPING: Record<
-  PropertyDefinition['type'],
+  PropertyType,
   { tsType: string; defaultValue: string }
 > = {
   text: { tsType: 'string', defaultValue: "''" },
@@ -35,89 +102,298 @@ const TYPE_MAPPING: Record<
 export async function generateSmrtClass(
   args: GenerateSmrtClassArgs,
 ): Promise<string> {
+  const normalized = normalizeArgs(args);
   const {
     className,
     properties,
-    baseClass = 'SmrtObject',
-    includeApiConfig = true,
-    includeMcpConfig = true,
-    includeCliConfig = true,
-  } = args;
+    relationships,
+    baseClass,
+    tableName,
+    conflictColumns,
+    tenantScoped,
+    includeTenantIdField,
+    includeApiConfig,
+    includeMcpConfig,
+    includeCliConfig,
+    includeCompanionSnippets,
+  } = normalized;
 
-  // Generate imports
-  const coreImports = [baseClass, 'smrt'];
-
-  const needsFieldDecorator = properties.some(
-    (p) => p.required || p.description,
-  );
-  if (needsFieldDecorator) {
-    coreImports.push('field');
+  const coreImports = new Set<string>([baseClass, 'smrt']);
+  if (needsFieldDecorator(properties)) coreImports.add('field');
+  for (const relationship of relationships) {
+    coreImports.add(relationship.type);
   }
 
   const imports = [
-    `import { ${coreImports.join(', ')} } from '@happyvertical/smrt-core';`,
+    `import { ${Array.from(coreImports).join(', ')} } from '@happyvertical/smrt-core';`,
   ];
 
-  // Generate decorator configuration
-  const decoratorConfig: any = {};
-
-  if (includeApiConfig) {
-    decoratorConfig.api = {
-      include: ['list', 'get', 'create', 'update'],
-      exclude: ['delete'], // Safe default
-    };
+  if (tenantScoped) {
+    const tenancyImports = ['TenantScoped'];
+    if (includeTenantIdField) tenancyImports.push('tenantId');
+    imports.push(
+      `import { ${tenancyImports.join(', ')} } from '@happyvertical/smrt-tenancy';`,
+    );
   }
 
-  if (includeMcpConfig) {
-    decoratorConfig.mcp = {
-      include: ['list', 'get'], // Read-only by default for AI
-    };
-  }
+  const decoratorLines = [
+    ...(tenantScoped
+      ? [`@TenantScoped(${renderObjectLiteral({ ...tenantScoped })})`]
+      : []),
+    renderSmrtDecorator({
+      includeApiConfig,
+      includeMcpConfig,
+      includeCliConfig,
+      tableName,
+      conflictColumns,
+    }),
+  ];
 
-  if (includeCliConfig) {
-    decoratorConfig.cli = true;
-  }
+  const classMembers = [
+    ...(includeTenantIdField && tenantScoped
+      ? [renderTenantIdField(tenantScoped)]
+      : []),
+    ...properties.map(renderProperty),
+    ...relationships.map(renderRelationship),
+  ].filter(Boolean);
 
-  const decoratorString =
-    Object.keys(decoratorConfig).length > 0
-      ? `@smrt(${JSON.stringify(decoratorConfig, null, 2)})`
-      : '@smrt()';
+  const companionSnippets = includeCompanionSnippets
+    ? `\n${renderCompanionSnippets(className, Boolean(tenantScoped))}`
+    : '';
 
-  // Generate property definitions using TypeScript types and @field decorator
-  const propertyDefinitions = properties
-    .map((prop) => {
-      const { tsType, defaultValue } = TYPE_MAPPING[prop.type];
-      const options: any = {};
+  return `${imports.join('\n')}
 
-      if (prop.required) options.required = true;
-      if (prop.description) options.description = prop.description;
-
-      // Add JSDoc comment if description provided
-      const jsdoc = prop.description ? `  /** ${prop.description} */\n` : '';
-
-      // Use @field decorator if constraints are needed
-      const decorator =
-        Object.keys(options).length > 0
-          ? `  @field(${JSON.stringify(options)})\n`
-          : '';
-
-      return `${jsdoc}${decorator}  ${prop.name}: ${tsType} = ${defaultValue};`;
-    })
-    .join('\n\n');
-
-  // Generate complete class
-  const classCode = `${imports.join('\n')}
-
-${decoratorString}
+${decoratorLines.join('\n')}
 export class ${className} extends ${baseClass} {
-${propertyDefinitions}
+${classMembers.join('\n\n')}
 
   constructor(options: any = {}) {
     super(options);
     Object.assign(this, options);
   }
 }
-`;
+${companionSnippets}`;
+}
 
-  return classCode;
+function normalizeArgs(
+  args: GenerateSmrtClassArgs,
+): NormalizedGenerateSmrtClassArgs {
+  const template = args.template ?? 'basic';
+  const templateDefaults = defaultsForTemplate(template);
+  const tenantScoped =
+    args.tenantScoped === true
+      ? (templateDefaults.tenantScoped ?? { mode: 'required' as const })
+      : args.tenantScoped === false
+        ? undefined
+        : (args.tenantScoped ?? templateDefaults.tenantScoped);
+
+  return {
+    className: args.className,
+    properties: args.properties,
+    baseClass: args.baseClass ?? 'SmrtObject',
+    template,
+    tableName: args.tableName ?? templateDefaults.tableName,
+    conflictColumns:
+      args.conflictColumns ?? templateDefaults.conflictColumns ?? [],
+    tenantScoped: normalizeTenantScoped(tenantScoped),
+    includeTenantIdField:
+      args.includeTenantIdField ??
+      templateDefaults.includeTenantIdField ??
+      Boolean(tenantScoped),
+    relationships: args.relationships ?? [],
+    includeApiConfig: args.includeApiConfig ?? true,
+    includeMcpConfig: args.includeMcpConfig ?? true,
+    includeCliConfig: args.includeCliConfig ?? true,
+    includeCompanionSnippets: args.includeCompanionSnippets ?? false,
+  };
+}
+
+function defaultsForTemplate(template: TemplateVariant): {
+  tableName?: string;
+  conflictColumns?: string[];
+  tenantScoped?: TenantScopedDefinition;
+  includeTenantIdField?: boolean;
+} {
+  switch (template) {
+    case 'optional-catalog':
+      return {
+        tenantScoped: { mode: 'optional' },
+        includeTenantIdField: true,
+        conflictColumns: ['tenant_id', 'slug'],
+      };
+    case 'tenant-project-object':
+      return {
+        tenantScoped: { mode: 'required' },
+        includeTenantIdField: true,
+      };
+    case 'tenant-event-log-object':
+      return {
+        tenantScoped: { mode: 'optional' },
+        includeTenantIdField: true,
+      };
+    case 'global-catalog':
+      return { conflictColumns: ['slug'] };
+    case 'cross-package-reference':
+    case 'basic':
+      return {};
+  }
+}
+
+function normalizeTenantScoped(
+  value: boolean | TenantScopedDefinition | undefined,
+): TenantScopedDefinition | undefined {
+  if (!value) return undefined;
+  return {
+    mode: typeof value === 'object' ? (value.mode ?? 'required') : 'required',
+    field: typeof value === 'object' ? (value.field ?? 'tenantId') : 'tenantId',
+    autoFilter: typeof value === 'object' ? value.autoFilter : undefined,
+    autoPopulate: typeof value === 'object' ? value.autoPopulate : undefined,
+    allowSuperAdminBypass:
+      typeof value === 'object' ? value.allowSuperAdminBypass : undefined,
+  };
+}
+
+function renderSmrtDecorator(options: {
+  includeApiConfig: boolean;
+  includeMcpConfig: boolean;
+  includeCliConfig: boolean;
+  tableName?: string;
+  conflictColumns: string[];
+}): string {
+  const decoratorConfig: Record<string, unknown> = {};
+
+  if (options.tableName) {
+    decoratorConfig.tableName = options.tableName;
+  }
+
+  if (options.conflictColumns.length > 0) {
+    decoratorConfig.conflictColumns = options.conflictColumns;
+  }
+
+  if (options.includeApiConfig) {
+    decoratorConfig.api = {
+      include: ['list', 'get', 'create', 'update'],
+      exclude: ['delete'],
+    };
+  }
+
+  if (options.includeMcpConfig) {
+    decoratorConfig.mcp = {
+      include: ['list', 'get'],
+    };
+  }
+
+  if (options.includeCliConfig) {
+    decoratorConfig.cli = true;
+  }
+
+  return Object.keys(decoratorConfig).length > 0
+    ? `@smrt(${JSON.stringify(decoratorConfig, null, 2)})`
+    : '@smrt()';
+}
+
+function renderTenantIdField(tenantScoped: TenantScopedDefinition): string {
+  const nullable = tenantScoped.mode === 'optional';
+  const field = tenantScoped.field ?? 'tenantId';
+  return nullable
+    ? `  @tenantId({ nullable: true })\n  ${field}: string | null = null;`
+    : `  @tenantId()\n  ${field}: string = '';`;
+}
+
+function renderProperty(prop: PropertyDefinition): string {
+  const mapping = TYPE_MAPPING[prop.type];
+  const nullable = prop.nullable === true;
+  const tsType = nullable ? `${mapping.tsType} | null` : mapping.tsType;
+  const defaultValue =
+    prop.defaultValue !== undefined
+      ? renderLiteral(prop.defaultValue)
+      : nullable
+        ? 'null'
+        : mapping.defaultValue;
+  const fieldOptions = compactObject({
+    required: prop.required,
+    nullable: prop.nullable,
+    description: prop.description,
+  });
+  const jsdoc = prop.description ? `  /** ${prop.description} */\n` : '';
+  const decorator =
+    Object.keys(fieldOptions).length > 0
+      ? `  @field(${JSON.stringify(fieldOptions)})\n`
+      : '';
+
+  return `${jsdoc}${decorator}  ${prop.name}: ${tsType} = ${defaultValue};`;
+}
+
+function renderRelationship(relationship: RelationshipDefinition): string {
+  const options = compactObject({
+    required: relationship.required,
+    nullable: relationship.nullable,
+    description: relationship.description,
+    validate: relationship.validate,
+    foreignKey: relationship.foreignKey,
+    through: relationship.through,
+    sourceKey: relationship.sourceKey,
+    targetKey: relationship.targetKey,
+  });
+  const args = [
+    renderLiteral(relationship.related),
+    ...(Object.keys(options).length > 0 ? [JSON.stringify(options)] : []),
+  ];
+  const decorator = `@${relationship.type}(${args.join(', ')})`;
+  const fieldType =
+    relationship.type === 'oneToMany' || relationship.type === 'manyToMany'
+      ? 'unknown[]'
+      : relationship.nullable
+        ? 'string | null'
+        : 'string';
+  const defaultValue =
+    relationship.type === 'oneToMany' || relationship.type === 'manyToMany'
+      ? '[]'
+      : relationship.nullable
+        ? 'null'
+        : "''";
+
+  return `  ${decorator}\n  ${relationship.name}: ${fieldType} = ${defaultValue};`;
+}
+
+function needsFieldDecorator(properties: PropertyDefinition[]): boolean {
+  return properties.some(
+    (property) =>
+      property.required !== undefined ||
+      property.nullable !== undefined ||
+      property.description !== undefined,
+  );
+}
+
+function renderCompanionSnippets(
+  className: string,
+  usesTenantScoped: boolean,
+): string {
+  const dependencyNote = usesTenantScoped
+    ? `\n * - Ensure package.json declares "@happyvertical/smrt-tenancy".`
+    : '';
+  return `/*
+ * Package wiring:
+ * - Export ${className} from the package entrypoint used by consumers.
+ * - Import this module from any package registration file that eagerly loads objects.${dependencyNote}
+ */`;
+}
+
+function renderObjectLiteral(value: Record<string, unknown>): string {
+  return JSON.stringify(compactObject(value), null, 2);
+}
+
+function renderLiteral(value: unknown): string {
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (value === null) return 'null';
+  return JSON.stringify(value, null, 2);
+}
+
+function compactObject<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  ) as T;
 }

--- a/packages/smrt-dev-mcp/src/tools/index.ts
+++ b/packages/smrt-dev-mcp/src/tools/index.ts
@@ -5,3 +5,4 @@
 
 export { generateSmrtClass } from './generate-smrt-class.js';
 export { introspectProject } from './introspect-project.js';
+export { reviewSmrtProject } from './review-smrt-project.js';

--- a/packages/smrt-dev-mcp/src/tools/introspect-project.test.ts
+++ b/packages/smrt-dev-mcp/src/tools/introspect-project.test.ts
@@ -207,6 +207,115 @@ export class Model extends SmrtObject {
       expect(parsed.objects[0].fields).toContain('active: boolean');
     });
 
+    it('should use scanner inference for multi-class downstream-style files', async () => {
+      await writeFile(
+        join(tmpDir, 'models.ts'),
+        `
+import { crossPackageRef, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+
+@TenantScoped({ mode: 'optional' })
+@smrt({ tableName: 'tectum_projects', conflictColumns: ['tenant_id', 'slug'] })
+export class TectumProject extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+  name = '';
+  count = 0;
+  price = 0.0;
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile')
+  ownerProfileId: string | null = null;
+
+  isReady() {
+    if (this.name) return true;
+    return false;
+  }
+}
+
+@smrt()
+export class TectumTask extends SmrtObject {
+  @foreignKey('TectumProject')
+  projectId: string = '';
+  title: string = '';
+}
+        `.trim(),
+      );
+
+      const result = await introspectProject({
+        directory: tmpDir,
+        includeFields: true,
+        includeRelationships: true,
+      });
+
+      const parsed = JSON.parse(result);
+      expect(parsed.manifestSource).toBe('scanner');
+      expect(parsed.objectCount).toBe(2);
+
+      const project = parsed.objects.find(
+        (obj: any) => obj.className === 'TectumProject',
+      );
+      expect(project.fields).toContain('count: integer');
+      expect(project.fields).toContain('price: decimal');
+      expect(project.relationships).toContain(
+        'ownerProfileId -> @happyvertical/smrt-profiles:Profile (crossPackageRef)',
+      );
+      expect(project.conflictColumns).toEqual(['tenant_id', 'slug']);
+      expect(project.tableName).toBe('tectum_projects');
+      expect(project.tenantScope).toMatchObject({
+        source: 'TenantScoped',
+        mode: 'optional',
+        field: 'tenantId',
+      });
+      expect(project.methods).toContain('isReady()');
+      expect(project.methods).not.toContain('if()');
+    });
+
+    it('should finalize scanner fallback manifests before reporting schema details', async () => {
+      await writeFile(
+        join(tmpDir, 'package.json'),
+        JSON.stringify({ name: '@test/tenant-app', version: '1.0.0' }),
+      );
+      await writeFile(
+        join(tmpDir, 'tenant-project.ts'),
+        `
+import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+
+@smrt({ tenantScoped: true, tableName: 'tenant_projects' })
+export class TenantProject extends SmrtObject {
+  name: string = '';
+}
+        `.trim(),
+      );
+
+      const result = await introspectProject({
+        directory: tmpDir,
+        includeFields: true,
+      });
+
+      const parsed = JSON.parse(result);
+      const project = parsed.objects.find(
+        (obj: any) => obj.className === 'TenantProject',
+      );
+
+      expect(parsed.manifestSource).toBe('scanner');
+      expect(project.fields).toContain('tenantId: text');
+      expect(project.fieldDetails).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'tenantId',
+            type: 'text',
+            meta: expect.objectContaining({
+              generated: true,
+              source: 'tenantScoped_decorator',
+            }),
+          }),
+        ]),
+      );
+      expect(project.schema.columns.tenant_id).toEqual(
+        expect.objectContaining({ type: 'TEXT' }),
+      );
+      expect(project.tableName).toBe('tenant_projects');
+    });
+
     it('should not extract fields when disabled', async () => {
       await writeFile(
         join(tmpDir, 'model.ts'),
@@ -486,6 +595,61 @@ export class Configured extends SmrtObject {
 
       const parsed = JSON.parse(result);
       expect(parsed.objects[0].decoratorConfig).toBeDefined();
+    });
+
+    it('should prefer generated manifest artifacts with schema indexes', async () => {
+      await mkdir(join(tmpDir, '.smrt'), { recursive: true });
+      await writeFile(
+        join(tmpDir, '.smrt', 'manifest.json'),
+        JSON.stringify(
+          {
+            version: '1.0.0',
+            packageName: '@test/downstream',
+            packageVersion: '1.2.3',
+            objects: {
+              '@test/downstream:IndexedThing': {
+                name: 'indexedthing',
+                className: 'IndexedThing',
+                qualifiedName: '@test/downstream:IndexedThing',
+                collection: 'indexed_things',
+                filePath: 'src/indexed-thing.ts',
+                decoratorConfig: { tableName: 'indexed_things' },
+                fields: {
+                  name: { type: 'text', required: true },
+                },
+                methods: {},
+                schema: {
+                  tableName: 'indexed_things',
+                  columns: { name: { type: 'TEXT', notNull: true } },
+                  indexes: [
+                    {
+                      name: 'idx_indexed_things_name',
+                      columns: ['name'],
+                      unique: true,
+                    },
+                  ],
+                  version: 'schema-hash',
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const result = await introspectProject({ directory: tmpDir });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.manifestSource).toBe('manifest');
+      expect(parsed.packageName).toBe('@test/downstream');
+      expect(parsed.objects[0].indexes).toEqual([
+        {
+          name: 'idx_indexed_things_name',
+          columns: ['name'],
+          unique: true,
+        },
+      ]);
     });
 
     it('should handle empty decorator', async () => {

--- a/packages/smrt-dev-mcp/src/tools/introspect-project.ts
+++ b/packages/smrt-dev-mcp/src/tools/introspect-project.ts
@@ -1,25 +1,134 @@
 /**
  * Project Introspection Tool
- * Scans project directory for SMRT objects and analyzes structure
+ * Returns a manifest-equivalent inventory of SMRT objects in a project.
  */
 
-import { readdir, readFile } from 'node:fs/promises';
-import { join, relative } from 'node:path';
+import type { Dirent } from 'node:fs';
+import { access, readdir, readFile } from 'node:fs/promises';
+import { isAbsolute, join, relative, resolve } from 'node:path';
+import {
+  ManifestGenerator,
+  type SmartObjectManifest,
+} from '@happyvertical/smrt-core/scanner';
+import type { ScanError } from '@happyvertical/smrt-scanner';
+import { ManifestAdapter, OxcScanner } from '@happyvertical/smrt-scanner';
 
 interface IntrospectProjectArgs {
   directory?: string;
+  manifestPath?: string;
   includeFields?: boolean;
   includeRelationships?: boolean;
+  includeMethods?: boolean;
 }
 
-interface SmrtObjectInfo {
-  className: string;
-  filePath: string;
-  decoratorConfig?: any;
-  fields?: Array<{ name: string; type: string }>;
-  methods?: Array<{ name: string; isAsync: boolean }>;
-  relationships?: Array<{ field: string; relatedClass: string; type: string }>;
+type DiagnosticSeverity = 'error' | 'warning' | 'info';
+
+interface Diagnostic {
+  severity: DiagnosticSeverity;
+  message: string;
+  filePath?: string;
+  line?: number;
+  column?: number;
 }
+
+interface ManifestLike {
+  version?: string;
+  packageName?: string;
+  packageVersion?: string;
+  objects?: Record<string, ManifestObject>;
+}
+
+interface ManifestObject {
+  name?: string;
+  className: string;
+  qualifiedName?: string;
+  collection?: string;
+  filePath: string;
+  packageName?: string;
+  packageVersion?: string;
+  importPath?: string;
+  modulePath?: string;
+  exportName?: string;
+  collectionExportName?: string;
+  fields?: Record<string, ManifestField>;
+  methods?: Record<string, ManifestMethod>;
+  decoratorConfig?: Record<string, unknown>;
+  extends?: string;
+  extendsTypeArg?: string;
+  schema?: ManifestSchema;
+  staticProperties?: Record<string, unknown>;
+  validationRules?: Record<string, unknown>;
+}
+
+interface ManifestField {
+  type: string;
+  required?: boolean;
+  default?: unknown;
+  related?: string;
+  description?: string;
+  _meta?: Record<string, unknown>;
+  transient?: boolean;
+}
+
+interface ManifestMethod {
+  name?: string;
+  async?: boolean;
+  parameters?: Array<{
+    name: string;
+    type?: string;
+    optional?: boolean;
+    default?: unknown;
+  }>;
+  returnType?: string;
+  description?: string;
+  isStatic?: boolean;
+  isPublic?: boolean;
+}
+
+interface ManifestSchema {
+  tableName?: string;
+  ddl?: string;
+  columns?: Record<string, unknown>;
+  indexes?: Array<{
+    name?: string;
+    columns?: string[];
+    unique?: boolean;
+    where?: string;
+    jsonPath?: unknown;
+  }>;
+  version?: string;
+}
+
+interface PackageMetadata {
+  name?: string;
+  version?: string;
+  json?: Record<string, unknown>;
+}
+
+const DEFAULT_MANIFEST_PATHS = [
+  '.smrt/manifest.json',
+  'dist/manifest.json',
+  'src/manifest/manifest.json',
+];
+
+const SCAN_EXCLUDE = [
+  '**/node_modules/**',
+  '**/dist/**',
+  '**/build/**',
+  '**/.git/**',
+  '**/.smrt/**',
+  '**/*.d.ts',
+  '**/*.test.ts',
+  '**/*.spec.ts',
+  '**/__tests__/**',
+];
+
+const RELATIONSHIP_TYPES = new Set([
+  'foreignKey',
+  'crossPackageRef',
+  'oneToMany',
+  'manyToMany',
+]);
 
 export async function introspectProject(
   args: IntrospectProjectArgs,
@@ -28,218 +137,515 @@ export async function introspectProject(
     directory = process.cwd(),
     includeFields = true,
     includeRelationships = true,
+    includeMethods = true,
   } = args;
+  const projectPath = resolve(directory);
 
-  const objects: SmrtObjectInfo[] = [];
-
-  // Recursively scan directory for TypeScript files
-  async function scanDirectory(dir: string): Promise<void> {
-    try {
-      const entries = await readdir(dir, { withFileTypes: true });
-
-      for (const entry of entries) {
-        const fullPath = join(dir, entry.name);
-
-        // Skip node_modules, dist, and hidden directories
-        if (entry.isDirectory()) {
-          if (
-            !['node_modules', 'dist', '.git', '.smrt'].includes(entry.name) &&
-            !entry.name.startsWith('.')
-          ) {
-            await scanDirectory(fullPath);
-          }
-        } else if (
-          entry.isFile() &&
-          (entry.name.endsWith('.ts') || entry.name.endsWith('.js'))
-        ) {
-          // Skip test files and declaration files
-          if (
-            !entry.name.endsWith('.test.ts') &&
-            !entry.name.endsWith('.spec.ts') &&
-            !entry.name.endsWith('.d.ts')
-          ) {
-            await analyzeFile(fullPath);
-          }
-        }
-      }
-    } catch (error) {
-      // Silently skip directories we can't read
-    }
+  const exists = await pathExists(projectPath);
+  if (!exists) {
+    return JSON.stringify(
+      {
+        projectPath,
+        manifestSource: 'none',
+        objectCount: 0,
+        objects: [],
+        diagnostics: [
+          {
+            severity: 'warning',
+            message: `Project directory does not exist: ${projectPath}`,
+          },
+        ],
+      },
+      null,
+      2,
+    );
   }
 
-  async function analyzeFile(filePath: string): Promise<void> {
-    try {
-      const content = await readFile(filePath, 'utf-8');
+  const packageMetadata = await readPackageMetadata(projectPath);
+  const tenantScopes = await scanTenantScopes(projectPath);
+  const manifestResult =
+    (await loadManifestArtifact(projectPath, args.manifestPath)) ??
+    (await scanSourceManifest(projectPath, packageMetadata));
 
-      // Check if file contains @smrt() decorator
-      if (!content.includes('@smrt')) {
-        return;
-      }
+  const objects = Object.entries(manifestResult.manifest.objects ?? {})
+    .map(([manifestKey, object]) =>
+      formatObject({
+        manifestKey,
+        object,
+        projectPath,
+        includeFields,
+        includeRelationships,
+        includeMethods,
+        tenantScope: tenantScopes.get(object.className),
+      }),
+    )
+    .sort((left, right) => left.className.localeCompare(right.className));
 
-      // Extract class name (basic regex for now)
-      const classMatch = content.match(
-        /export\s+class\s+(\w+)\s+extends\s+(\w+)/,
-      );
-      if (!classMatch) {
-        return;
-      }
-
-      const className = classMatch[1];
-      // const baseClass = classMatch[2]; // Reserved for future use
-      const relativePath = relative(directory, filePath);
-
-      const objInfo: SmrtObjectInfo = {
-        className,
-        filePath: relativePath,
-      };
-
-      // Extract decorator configuration
-      const decoratorMatch = content.match(
-        /@smrt\(([\s\S]*?)\)\s*export\s+class/,
-      );
-      if (decoratorMatch?.[1].trim()) {
-        try {
-          // Try to parse decorator config (simplified)
-          objInfo.decoratorConfig =
-            'Configuration found (parsing not fully implemented)';
-        } catch {
-          objInfo.decoratorConfig = 'Unable to parse';
-        }
-      }
-
-      // Extract fields if requested
-      if (includeFields) {
-        objInfo.fields = [];
-
-        // Pattern 1: TypeScript property declarations (new decorator pattern)
-        // Example: name: string = ''; or price: number = 0.0;
-        const tsFieldMatches = content.matchAll(
-          /^\s*(?:@\w+\([^)]*\)\s*)*((?:(?:public|private|protected|readonly|static|declare|abstract|override|accessor)\s+)*)(\w+)(?::\s*([\w| ]+)(?:<[^>]+>)?)?\s*=\s*([^;\n]+)/gm,
-        );
-        for (const match of tsFieldMatches) {
-          const modifiers = match[1] ?? '';
-          const fieldName = match[2];
-          const tsType = match[3]?.trim() ?? inferTypeFromDefault(match[4]);
-
-          // Skip constructor, methods, and non-persisted class members.
-          if (fieldName === 'constructor') continue;
-          if (
-            /\b(static|private|protected|declare|abstract)\b/.test(modifiers)
-          ) {
-            continue;
-          }
-
-          // Map TypeScript types to field types
-          let fieldType = tsType;
-          if (tsType === 'string') fieldType = 'text';
-          else if (tsType === 'number') {
-            // Check if it's decimal (0.0) or integer (0)
-            const valueMatch = content.match(
-              new RegExp(`${fieldName}:\\s*number\\s*=\\s*([\\d.]+)`),
-            );
-            fieldType = valueMatch?.[1].includes('.') ? 'decimal' : 'integer';
-          } else if (tsType === 'boolean') fieldType = 'boolean';
-          else if (tsType === 'Date') fieldType = 'datetime';
-          else if (tsType === 'any' || tsType === 'object') fieldType = 'json';
-
-          objInfo.fields.push({
-            name: fieldName,
-            type: fieldType,
-          });
-        }
-      }
-
-      // Extract methods
-      const methodMatches = content.matchAll(
-        /^\s*(async\s+)?(\w+)\s*\([^)]*\)\s*[:{]/gm,
-      );
-      objInfo.methods = [];
-      for (const match of methodMatches) {
-        const methodName = match[2];
-        // Skip constructor
-        if (methodName !== 'constructor') {
-          objInfo.methods.push({
-            name: methodName,
-            isAsync: !!match[1],
-          });
-        }
-      }
-
-      // Extract relationships if requested
-      if (includeRelationships) {
-        objInfo.relationships = [];
-        const decoratorMatches = content.matchAll(
-          /@(foreignKey|crossPackageRef|oneToMany|manyToMany)\(([^)]*)\)\s*(\w+)\s*[:=]/g,
-        );
-        for (const match of decoratorMatches) {
-          objInfo.relationships.push({
-            field: match[3],
-            type: match[1],
-            relatedClass: cleanRelatedClass(match[2]),
-          });
-        }
-
-        const assignmentMatches = content.matchAll(
-          /(\w+)\s*=\s*(foreignKey|oneToMany|manyToMany)\((\w+)/g,
-        );
-        for (const match of assignmentMatches) {
-          objInfo.relationships.push({
-            field: match[1],
-            type: match[2],
-            relatedClass: match[3],
-          });
-        }
-      }
-
-      objects.push(objInfo);
-    } catch (error) {
-      // Silently skip files we can't process
-    }
-  }
-
-  // Start scanning
-  await scanDirectory(directory);
-
-  // Format output
   const output = {
-    projectPath: directory,
+    projectPath,
+    manifestSource: manifestResult.source,
+    manifestPath:
+      'path' in manifestResult
+        ? relative(projectPath, manifestResult.path)
+        : undefined,
+    packageName:
+      manifestResult.manifest.packageName ?? packageMetadata.name ?? undefined,
+    packageVersion:
+      manifestResult.manifest.packageVersion ??
+      packageMetadata.version ??
+      undefined,
     objectCount: objects.length,
-    objects: objects.map((obj) => ({
-      className: obj.className,
-      filePath: obj.filePath,
-      ...(obj.decoratorConfig && { decoratorConfig: obj.decoratorConfig }),
-      ...(obj.fields &&
-        obj.fields.length > 0 && {
-          fields: obj.fields.map((f) => `${f.name}: ${f.type}`).join(', '),
-        }),
-      ...(obj.methods &&
-        obj.methods.length > 0 && {
-          methods: obj.methods
-            .map((m) => `${m.isAsync ? 'async ' : ''}${m.name}()`)
-            .join(', '),
-        }),
-      ...(obj.relationships &&
-        obj.relationships.length > 0 && {
-          relationships: obj.relationships
-            .map((r) => `${r.field} -> ${r.relatedClass} (${r.type})`)
-            .join(', '),
-        }),
-    })),
+    scannedFileCount: manifestResult.scannedFileCount,
+    parseTimeMs: manifestResult.parseTimeMs,
+    objects,
+    diagnostics: manifestResult.diagnostics,
   };
 
   return JSON.stringify(output, null, 2);
 }
 
-function inferTypeFromDefault(value: string): string {
-  const trimmed = value.trim();
-  if (trimmed.startsWith("'") || trimmed.startsWith('"')) return 'string';
-  if (trimmed === 'true' || trimmed === 'false') return 'boolean';
-  if (/^\d+\.\d+/.test(trimmed) || /^\d+$/.test(trimmed)) return 'number';
-  if (trimmed.startsWith('new Date')) return 'Date';
-  return 'any';
+async function loadManifestArtifact(
+  projectPath: string,
+  manifestPath: string | undefined,
+): Promise<
+  | {
+      source: 'manifest';
+      path: string;
+      manifest: ManifestLike;
+      diagnostics: Diagnostic[];
+      scannedFileCount?: number;
+      parseTimeMs?: number;
+    }
+  | undefined
+> {
+  const candidates = manifestPath
+    ? [resolve(projectPath, manifestPath)]
+    : DEFAULT_MANIFEST_PATHS.map((candidate) => join(projectPath, candidate));
+
+  const diagnostics: Diagnostic[] = [];
+  for (const candidate of candidates) {
+    if (!(await pathExists(candidate))) {
+      continue;
+    }
+
+    try {
+      const parsed = JSON.parse(await readFile(candidate, 'utf-8')) as unknown;
+      if (isManifestLike(parsed)) {
+        return {
+          source: 'manifest',
+          path: candidate,
+          manifest: parsed,
+          diagnostics,
+        };
+      }
+
+      diagnostics.push({
+        severity: 'warning',
+        filePath: candidate,
+        message: 'Manifest artifact is present but does not contain objects.',
+      });
+    } catch (error) {
+      diagnostics.push({
+        severity: 'error',
+        filePath: candidate,
+        message: `Unable to parse manifest artifact: ${messageFromError(error)}`,
+      });
+    }
+  }
+
+  return manifestPath
+    ? {
+        source: 'manifest',
+        path: resolve(projectPath, manifestPath),
+        manifest: { objects: {} },
+        diagnostics: [
+          ...diagnostics,
+          {
+            severity: 'warning',
+            filePath: resolve(projectPath, manifestPath),
+            message: 'Requested manifest artifact was not found.',
+          },
+        ],
+      }
+    : undefined;
 }
 
-function cleanRelatedClass(value: string): string {
-  const firstArg = value.split(',')[0]?.trim() ?? '';
-  return firstArg.replace(/^['"`]/, '').replace(/['"`]$/, '');
+async function scanSourceManifest(
+  projectPath: string,
+  packageMetadata: PackageMetadata,
+): Promise<{
+  source: 'scanner';
+  manifest: ManifestLike;
+  diagnostics: Diagnostic[];
+  scannedFileCount: number;
+  parseTimeMs: number;
+}> {
+  const scanner = new OxcScanner({
+    cwd: projectPath,
+    include: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    exclude: SCAN_EXCLUDE,
+  });
+  const { results, resolved } = await scanner.scanAndResolve();
+  const adapter = new ManifestAdapter();
+  const manifest = adapter.toManifest(
+    resolved.filter((classDef) => classDef.hasSmartDecorator),
+    {
+      packageName: packageMetadata.name,
+      packageVersion: packageMetadata.version,
+      typeAliases: results.typeAliases,
+    },
+  ) as ManifestLike;
+  finalizeScannerManifest(manifest, packageMetadata);
+
+  return {
+    source: 'scanner',
+    manifest,
+    diagnostics: results.errors.map(scanErrorToDiagnostic),
+    scannedFileCount: results.fileCount,
+    parseTimeMs: Math.round(results.totalParseTimeMs),
+  };
+}
+
+function finalizeScannerManifest(
+  manifest: ManifestLike,
+  packageMetadata: PackageMetadata,
+): void {
+  const manifestGen = new ManifestGenerator();
+  const fullManifest = manifest as unknown as SmartObjectManifest;
+  withSuppressedConsoleLog(() => {
+    manifestGen.injectTenantScopedFields(fullManifest);
+    manifestGen.mergeInheritedFields(fullManifest);
+    manifestGen.generateValidationRules(fullManifest);
+    manifestGen.generateSchemas(fullManifest);
+    manifestGen.assertTenantScopedSchemaContract(fullManifest);
+    manifestGen.generateAgentManifests(
+      fullManifest,
+      packageMetadata.name,
+      packageMetadata.json,
+    );
+  });
+}
+
+function withSuppressedConsoleLog<T>(callback: () => T): T {
+  const originalLog = console.log;
+  console.log = () => undefined;
+  try {
+    return callback();
+  } finally {
+    console.log = originalLog;
+  }
+}
+
+function formatObject({
+  manifestKey,
+  object,
+  projectPath,
+  includeFields,
+  includeRelationships,
+  includeMethods,
+  tenantScope,
+}: {
+  manifestKey: string;
+  object: ManifestObject;
+  projectPath: string;
+  includeFields: boolean;
+  includeRelationships: boolean;
+  includeMethods: boolean;
+  tenantScope?: Record<string, unknown>;
+}) {
+  const fieldDetails = Object.entries(object.fields ?? {}).map(
+    ([name, field]) => ({
+      name,
+      type: field.type,
+      ...(field.required !== undefined ? { required: field.required } : {}),
+      ...(field.default !== undefined ? { default: field.default } : {}),
+      ...(field.related ? { related: field.related } : {}),
+      ...(field.description ? { description: field.description } : {}),
+      ...(field._meta ? { meta: field._meta } : {}),
+      ...(field.transient !== undefined ? { transient: field.transient } : {}),
+    }),
+  );
+  const relationshipDetails = fieldDetails
+    .filter((field) => RELATIONSHIP_TYPES.has(field.type))
+    .map((field) => ({
+      field: field.name,
+      relatedClass: field.related ?? '',
+      type: field.type,
+      ...(field.meta ? { meta: field.meta } : {}),
+    }));
+  const methodDetails = Object.entries(object.methods ?? {}).map(
+    ([name, method]) => ({
+      name: method.name ?? name,
+      isAsync: method.async === true,
+      isStatic: method.isStatic === true,
+      isPublic: method.isPublic !== false,
+      parameters: method.parameters ?? [],
+      returnType: method.returnType ?? 'unknown',
+      ...(method.description ? { description: method.description } : {}),
+    }),
+  );
+
+  const decoratorConfig = object.decoratorConfig ?? {};
+  const effectiveTenantScope =
+    tenantScope ?? normalizeTenantScopedConfig(decoratorConfig.tenantScoped);
+  const schema = object.schema;
+
+  return compactObject({
+    manifestKey,
+    name: object.name,
+    className: object.className,
+    qualifiedName: object.qualifiedName,
+    filePath: sanitizePath(projectPath, object.filePath),
+    packageName: object.packageName,
+    packageVersion: object.packageVersion,
+    importPath: object.importPath,
+    modulePath: object.modulePath,
+    exportName: object.exportName,
+    collectionExportName: object.collectionExportName,
+    collection: object.collection,
+    extends: object.extends,
+    extendsTypeArg: object.extendsTypeArg,
+    tableName:
+      schema?.tableName ??
+      stringFromConfig(decoratorConfig.tableName) ??
+      object.collection,
+    tableStrategy: stringFromConfig(decoratorConfig.tableStrategy) ?? 'cti',
+    conflictColumns: arrayFromConfig(decoratorConfig.conflictColumns),
+    tenantScope: effectiveTenantScope,
+    decoratorConfig,
+    schema: schema
+      ? {
+          tableName: schema.tableName,
+          columns: schema.columns,
+          indexes: schema.indexes ?? [],
+          version: schema.version,
+        }
+      : undefined,
+    indexes: schema?.indexes ?? [],
+    staticProperties: object.staticProperties,
+    validationRules: object.validationRules,
+    ...(includeFields && {
+      fields: fieldDetails
+        .map((field) => `${field.name}: ${field.type}`)
+        .join(', '),
+      fieldDetails,
+    }),
+    ...(includeRelationships &&
+      relationshipDetails.length > 0 && {
+        relationships: relationshipDetails
+          .map(
+            (relationship) =>
+              `${relationship.field} -> ${relationship.relatedClass} (${relationship.type})`,
+          )
+          .join(', '),
+        relationshipDetails,
+      }),
+    ...(includeMethods &&
+      methodDetails.length > 0 && {
+        methods: methodDetails
+          .map((method) => `${method.isAsync ? 'async ' : ''}${method.name}()`)
+          .join(', '),
+        methodDetails,
+      }),
+  });
+}
+
+async function scanTenantScopes(
+  projectPath: string,
+): Promise<Map<string, Record<string, unknown>>> {
+  const files = await listSourceFiles(projectPath);
+  const scopes = new Map<string, Record<string, unknown>>();
+
+  await Promise.all(
+    files.map(async (filePath) => {
+      const content = await readFile(filePath, 'utf-8');
+      const classMatches = content.matchAll(/class\s+([A-Za-z_]\w*)\b/g);
+      for (const match of classMatches) {
+        const className = match[1];
+        if (!className || match.index === undefined) continue;
+        const prefix = content.slice(
+          Math.max(0, match.index - 800),
+          match.index,
+        );
+        const tenantMatches = Array.from(
+          prefix.matchAll(/@TenantScoped\s*\(([\s\S]*?)\)/g),
+        );
+        const tenantMatch = tenantMatches.at(-1);
+        if (!tenantMatch) continue;
+        scopes.set(className, {
+          source: 'TenantScoped',
+          ...parseTenantScopedOptions(tenantMatch[1]),
+        });
+      }
+    }),
+  );
+
+  return scopes;
+}
+
+async function listSourceFiles(projectPath: string): Promise<string[]> {
+  const files: string[] = [];
+
+  async function visit(dir: string): Promise<void> {
+    let entries: Dirent[];
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (
+          [
+            'node_modules',
+            'dist',
+            'build',
+            '.git',
+            '.smrt',
+            '__tests__',
+          ].includes(entry.name) ||
+          entry.name.startsWith('.')
+        ) {
+          continue;
+        }
+        await visit(fullPath);
+        continue;
+      }
+
+      if (
+        entry.isFile() &&
+        /\.(tsx?|jsx?)$/.test(entry.name) &&
+        !entry.name.endsWith('.d.ts') &&
+        !entry.name.endsWith('.test.ts') &&
+        !entry.name.endsWith('.spec.ts')
+      ) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  await visit(projectPath);
+  return files;
+}
+
+function parseTenantScopedOptions(raw: string): Record<string, unknown> {
+  const mode = raw.match(/mode\s*:\s*['"`](required|optional)['"`]/)?.[1];
+  const field = raw.match(/field\s*:\s*['"`]([A-Za-z_]\w*)['"`]/)?.[1];
+  const allowSuperAdminBypass = raw.match(
+    /allowSuperAdminBypass\s*:\s*(true|false)/,
+  )?.[1];
+  const autoFilter = raw.match(/autoFilter\s*:\s*(true|false)/)?.[1];
+  const autoPopulate = raw.match(/autoPopulate\s*:\s*(true|false)/)?.[1];
+
+  return compactObject({
+    mode: mode ?? 'required',
+    field: field ?? 'tenantId',
+    autoFilter: autoFilter === undefined ? undefined : autoFilter === 'true',
+    autoPopulate:
+      autoPopulate === undefined ? undefined : autoPopulate === 'true',
+    allowSuperAdminBypass:
+      allowSuperAdminBypass === undefined
+        ? undefined
+        : allowSuperAdminBypass === 'true',
+  });
+}
+
+function normalizeTenantScopedConfig(
+  tenantScoped: unknown,
+): Record<string, unknown> | undefined {
+  if (!tenantScoped) return undefined;
+  const options =
+    typeof tenantScoped === 'object' && !Array.isArray(tenantScoped)
+      ? (tenantScoped as Record<string, unknown>)
+      : {};
+  return {
+    source: 'smrt',
+    mode: options.mode ?? 'required',
+    field: options.field ?? 'tenantId',
+    autoFilter: options.autoFilter ?? true,
+    autoPopulate: options.autoPopulate ?? true,
+    allowSuperAdminBypass: options.allowSuperAdminBypass ?? false,
+  };
+}
+
+async function readPackageMetadata(
+  projectPath: string,
+): Promise<PackageMetadata> {
+  const packageJsonPath = join(projectPath, 'package.json');
+  if (!(await pathExists(packageJsonPath))) return {};
+
+  try {
+    const json = JSON.parse(await readFile(packageJsonPath, 'utf-8')) as Record<
+      string,
+      unknown
+    >;
+    return {
+      name: typeof json.name === 'string' ? json.name : undefined,
+      version: typeof json.version === 'string' ? json.version : undefined,
+      json,
+    };
+  } catch {
+    return {};
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isManifestLike(value: unknown): value is ManifestLike {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    !!(value as ManifestLike).objects &&
+    typeof (value as ManifestLike).objects === 'object'
+  );
+}
+
+function scanErrorToDiagnostic(error: ScanError): Diagnostic {
+  return {
+    severity: error.severity,
+    message: error.message,
+    filePath: error.filePath,
+    line: error.line,
+    column: error.column,
+  };
+}
+
+function sanitizePath(projectPath: string, filePath: string): string {
+  const absolute = isAbsolute(filePath)
+    ? filePath
+    : resolve(projectPath, filePath);
+  const relativePath = relative(projectPath, absolute);
+  if (!relativePath.startsWith('..')) {
+    return relativePath || filePath;
+  }
+  return filePath;
+}
+
+function stringFromConfig(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function arrayFromConfig(value: unknown): string[] | undefined {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : undefined;
+}
+
+function compactObject<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  ) as T;
+}
+
+function messageFromError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/smrt-dev-mcp/src/tools/review-smrt-project.test.ts
+++ b/packages/smrt-dev-mcp/src/tools/review-smrt-project.test.ts
@@ -1,0 +1,141 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { reviewSmrtProject } from './review-smrt-project.js';
+
+describe('reviewSmrtProject', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = join(tmpdir(), `smrt-review-project-test-${Date.now()}`);
+    await mkdir(tmpDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reports downstream ecosystem alignment findings', async () => {
+    await writeFile(
+      join(tmpDir, 'package.json'),
+      JSON.stringify(
+        {
+          name: '@test/downstream',
+          version: '1.0.0',
+          dependencies: {
+            vite: '^7.0.0',
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    await mkdir(join(tmpDir, 'src'), { recursive: true });
+    await writeFile(
+      join(tmpDir, 'src', 'model.ts'),
+      `
+import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { Profile } from '@happyvertical/smrt-profiles';
+
+@smrt()
+export class Project extends SmrtObject {
+  ownerProfileId: string = '';
+  name = Profile.name;
+}
+      `.trim(),
+    );
+    await writeFile(
+      join(tmpDir, 'src', 'manifest-writer.ts'),
+      `
+import { writeFile } from 'node:fs/promises';
+
+export async function writeManifest() {
+  await writeFile('.smrt/manifest.json', JSON.stringify({ objects: {} }));
+}
+      `.trim(),
+    );
+    await writeFile(
+      join(tmpDir, 'src', 'server.ts'),
+      `
+import { createServer } from 'node:http';
+createServer((_req, res) => res.end('ok'));
+      `.trim(),
+    );
+    await writeFile(
+      join(tmpDir, 'src', 'auth.ts'),
+      `
+export const sessions = [{ tenantId: 'tenant-1', role: 'admin' }];
+      `.trim(),
+    );
+    await writeFile(
+      join(tmpDir, 'src', 'App.svelte'),
+      `<script lang="ts">export let name = 'demo';</script><h1>{name}</h1>`,
+    );
+
+    const result = await reviewSmrtProject({ directory: tmpDir });
+    const parsed = JSON.parse(result);
+    const codes = parsed.findings.map((finding: any) => finding.code);
+
+    expect(parsed.packageCount).toBe(1);
+    expect(codes).toContain('missing-happyvertical-dependencies');
+    expect(codes).toContain('custom-object-manifest-generation');
+    expect(codes).toContain('direct-storage-bypass');
+    expect(codes).toContain('custom-http-shell');
+    expect(codes).toContain('local-auth-tenancy');
+    expect(codes).toContain('missing-smrt-svelte-shell');
+    expect(parsed.summary.high).toBeGreaterThanOrEqual(1);
+    expect(parsed.suggestedFollowUpIssues.length).toBe(parsed.findings.length);
+  });
+
+  it('can omit source evidence for compact output', async () => {
+    await writeFile(
+      join(tmpDir, 'package.json'),
+      JSON.stringify({ name: '@test/compact', dependencies: {} }),
+    );
+    await mkdir(join(tmpDir, 'src'), { recursive: true });
+    await writeFile(
+      join(tmpDir, 'src', 'model.ts'),
+      `
+import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+@smrt()
+export class Compact extends SmrtObject {}
+      `.trim(),
+    );
+
+    const result = await reviewSmrtProject({
+      directory: tmpDir,
+      includeSourceEvidence: false,
+    });
+    const parsed = JSON.parse(result);
+
+    expect(parsed.findings[0]).not.toHaveProperty('evidence');
+  });
+
+  it('reports package-level router dependencies once per package', async () => {
+    await writeFile(
+      join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: '@test/router-app',
+        dependencies: { express: '^5.0.0' },
+      }),
+    );
+    await mkdir(join(tmpDir, 'src'), { recursive: true });
+    await writeFile(join(tmpDir, 'src', 'a.ts'), 'export const a = 1;');
+    await writeFile(join(tmpDir, 'src', 'b.ts'), 'export const b = 2;');
+
+    const result = await reviewSmrtProject({ directory: tmpDir });
+    const parsed = JSON.parse(result);
+    const httpShellFindings = parsed.findings.filter(
+      (finding: any) => finding.code === 'custom-http-shell',
+    );
+
+    expect(httpShellFindings).toHaveLength(1);
+    expect(httpShellFindings[0].evidence).toEqual([
+      expect.objectContaining({
+        filePath: 'package.json',
+        detail: 'Declares custom router package(s): express.',
+      }),
+    ]);
+  });
+});

--- a/packages/smrt-dev-mcp/src/tools/review-smrt-project.ts
+++ b/packages/smrt-dev-mcp/src/tools/review-smrt-project.ts
@@ -1,0 +1,716 @@
+/**
+ * Ecosystem-aware downstream project review.
+ * Advisory only: scans manifests and source files, then reports alignment risks.
+ */
+
+import { type Dirent, existsSync } from 'node:fs';
+import { access, readdir, readFile } from 'node:fs/promises';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+
+interface ReviewSmrtProjectArgs {
+  directory?: string;
+  rootDir?: string;
+  includeSourceEvidence?: boolean;
+  maxFindings?: number;
+}
+
+type Severity = 'high' | 'medium' | 'low';
+
+interface Evidence {
+  filePath: string;
+  line?: number;
+  detail: string;
+}
+
+interface Finding {
+  severity: Severity;
+  area:
+    | 'dependencies'
+    | 'storage'
+    | 'api-shell'
+    | 'manifest'
+    | 'auth-tenancy'
+    | 'ui-shell';
+  code: string;
+  title: string;
+  evidence: Evidence[];
+  recommendation: string;
+  suggestedIssueTitle: string;
+}
+
+interface PackageInventory {
+  name: string;
+  path: string;
+  private?: boolean;
+  scripts: string[];
+  declaredHappyVerticalDependencies: string[];
+  importedHappyVerticalPackages: string[];
+  missingHappyVerticalDependencies: string[];
+  hasSvelteKit: boolean;
+  hasSmrtSvelte: boolean;
+}
+
+interface PackageContext {
+  directory: string;
+  relativePath: string;
+  packageJsonPath: string;
+  json: Record<string, unknown>;
+  dependencies: Set<string>;
+  scripts: Record<string, unknown>;
+  imports: Map<string, Evidence[]>;
+  sourceFiles: SourceFile[];
+}
+
+interface SourceFile {
+  path: string;
+  packageDir: string;
+  content: string;
+}
+
+const SOURCE_EXTENSIONS = /\.(tsx?|jsx?|svelte)$/;
+const SKIP_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  '.git',
+  '.smrt',
+  '.svelte-kit',
+  'coverage',
+]);
+const DEPENDENCY_SECTIONS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+];
+const SMRT_PACKAGE_PREFIX = '@happyvertical/smrt-';
+const HAPPYVERTICAL_PACKAGE_PREFIX = '@happyvertical/';
+
+export async function reviewSmrtProject(
+  args: ReviewSmrtProjectArgs,
+): Promise<string> {
+  const projectPath = resolve(args.directory ?? args.rootDir ?? process.cwd());
+  if (!(await pathExists(projectPath))) {
+    return JSON.stringify(
+      {
+        projectPath,
+        packageCount: 0,
+        packages: [],
+        findings: [],
+        summary: { high: 0, medium: 0, low: 0 },
+        diagnostics: [
+          {
+            severity: 'warning',
+            message: `Project directory does not exist: ${projectPath}`,
+          },
+        ],
+      },
+      null,
+      2,
+    );
+  }
+
+  const packageContexts = await buildPackageContexts(projectPath);
+  const sourceFiles = await listSourceFiles(projectPath, packageContexts);
+  await attachSourceFiles(sourceFiles, packageContexts, projectPath);
+
+  const findings = limitFindings(
+    [
+      ...findMissingHappyVerticalDependencies(packageContexts),
+      ...findCustomManifestGeneration(sourceFiles, projectPath),
+      ...findDirectStorageBypasses(sourceFiles, packageContexts, projectPath),
+      ...findCustomHttpShells(sourceFiles, packageContexts, projectPath),
+      ...findLocalAuthTenancy(sourceFiles, packageContexts, projectPath),
+      ...findUiShellDrift(packageContexts, projectPath),
+      ...findMissingManifestArtifacts(
+        sourceFiles,
+        packageContexts,
+        projectPath,
+      ),
+    ],
+    args.maxFindings,
+  );
+
+  const packages = packageContexts
+    .map(packageInventory)
+    .sort((left, right) => left.path.localeCompare(right.path));
+  const summary = summarizeFindings(findings);
+
+  return JSON.stringify(
+    {
+      projectPath,
+      packageCount: packages.length,
+      packages,
+      findings:
+        args.includeSourceEvidence === false
+          ? findings.map(({ evidence: _evidence, ...finding }) => finding)
+          : findings,
+      summary,
+      referenceChecks: [
+        'Prefer SMRT scanner/runtime manifests over custom manifest builders.',
+        'Prefer SvelteKit plus @happyvertical/smrt-svelte for app shells.',
+        'Prefer @happyvertical/sql and @happyvertical/files/assets/content over direct durable node:fs storage.',
+        'Prefer smrt-users, smrt-tenancy, and profile/audit packages over local static auth seams.',
+      ],
+      suggestedFollowUpIssues: findings.map((finding) => ({
+        title: finding.suggestedIssueTitle,
+        severity: finding.severity,
+        area: finding.area,
+      })),
+    },
+    null,
+    2,
+  );
+}
+
+async function buildPackageContexts(
+  projectPath: string,
+): Promise<PackageContext[]> {
+  const packageJsonPaths = await listPackageJsonFiles(projectPath);
+  const contexts = await Promise.all(
+    packageJsonPaths.map(async (packageJsonPath) => {
+      const json = JSON.parse(
+        await readFile(packageJsonPath, 'utf-8'),
+      ) as Record<string, unknown>;
+      const directory = dirname(packageJsonPath);
+      return {
+        directory,
+        relativePath: relative(projectPath, directory) || '.',
+        packageJsonPath,
+        json,
+        dependencies: collectDependencies(json),
+        scripts: isRecord(json.scripts)
+          ? (json.scripts as Record<string, unknown>)
+          : {},
+        imports: new Map<string, Evidence[]>(),
+        sourceFiles: [],
+      };
+    }),
+  );
+
+  if (contexts.length === 0) {
+    contexts.push({
+      directory: projectPath,
+      relativePath: '.',
+      packageJsonPath: join(projectPath, 'package.json'),
+      json: {},
+      dependencies: new Set(),
+      scripts: {},
+      imports: new Map(),
+      sourceFiles: [],
+    });
+  }
+
+  return contexts.sort(
+    (left, right) => left.directory.length - right.directory.length,
+  );
+}
+
+async function listPackageJsonFiles(projectPath: string): Promise<string[]> {
+  const files: string[] = [];
+  await visit(projectPath, async (filePath, entryName) => {
+    if (entryName === 'package.json') files.push(filePath);
+  });
+  return files;
+}
+
+async function listSourceFiles(
+  projectPath: string,
+  packages: PackageContext[],
+): Promise<SourceFile[]> {
+  const files: SourceFile[] = [];
+  await visit(projectPath, async (filePath, entryName) => {
+    if (!SOURCE_EXTENSIONS.test(entryName)) return;
+    if (
+      entryName.endsWith('.d.ts') ||
+      entryName.endsWith('.test.ts') ||
+      entryName.endsWith('.spec.ts')
+    ) {
+      return;
+    }
+
+    const packageDir = findOwningPackage(filePath, packages).directory;
+    const content = await readFile(filePath, 'utf-8');
+    files.push({ path: filePath, packageDir, content });
+  });
+  return files;
+}
+
+async function attachSourceFiles(
+  sourceFiles: SourceFile[],
+  packages: PackageContext[],
+  projectPath: string,
+): Promise<void> {
+  for (const sourceFile of sourceFiles) {
+    const owner = packages.find(
+      (pkg) => pkg.directory === sourceFile.packageDir,
+    );
+    if (!owner) continue;
+    owner.sourceFiles.push(sourceFile);
+    for (const importedPackage of extractImports(sourceFile.content)) {
+      if (!importedPackage.startsWith(HAPPYVERTICAL_PACKAGE_PREFIX)) continue;
+      const evidence = {
+        filePath: relative(projectPath, sourceFile.path),
+        line: lineNumber(sourceFile.content, importedPackage),
+        detail: `Imports ${importedPackage}`,
+      };
+      const existing = owner.imports.get(importedPackage) ?? [];
+      existing.push(evidence);
+      owner.imports.set(importedPackage, existing);
+    }
+  }
+}
+
+function findMissingHappyVerticalDependencies(
+  packages: PackageContext[],
+): Finding[] {
+  return packages.flatMap((pkg) => {
+    const ownName =
+      typeof pkg.json.name === 'string' ? pkg.json.name : undefined;
+    const missing = Array.from(pkg.imports.keys()).filter(
+      (importedPackage) =>
+        importedPackage !== ownName && !pkg.dependencies.has(importedPackage),
+    );
+    if (missing.length === 0) return [];
+
+    const hasSmrtMissing = missing.some((name) =>
+      name.startsWith(SMRT_PACKAGE_PREFIX),
+    );
+    return [
+      {
+        severity: hasSmrtMissing ? 'high' : 'medium',
+        area: 'dependencies',
+        code: 'missing-happyvertical-dependencies',
+        title: `${packageLabel(pkg)} imports HappyVertical packages that package.json does not declare`,
+        evidence: missing.flatMap((name) => pkg.imports.get(name) ?? []),
+        recommendation:
+          'Declare every imported @happyvertical package in the owning package manifest so downstream installs and generated knowledge stay reproducible.',
+        suggestedIssueTitle: `Declare missing HappyVertical dependencies in ${packageLabel(pkg)}`,
+      },
+    ];
+  });
+}
+
+function findCustomManifestGeneration(
+  sourceFiles: SourceFile[],
+  projectPath: string,
+): Finding[] {
+  return sourceFiles
+    .filter(
+      (file) =>
+        /manifest\.json/.test(file.content) &&
+        /objects\s*:/.test(file.content) &&
+        /\b(writeFile|writeFileSync)\b/.test(file.content) &&
+        !/@happyvertical\/smrt-scanner/.test(file.content),
+    )
+    .map((file) => ({
+      severity: 'high',
+      area: 'manifest',
+      code: 'custom-object-manifest-generation',
+      title: 'Custom SMRT object manifest generation detected',
+      evidence: [
+        {
+          filePath: relative(projectPath, file.path),
+          line: lineNumber(file.content, 'manifest.json'),
+          detail:
+            'Writes a manifest.json object inventory outside the SMRT scanner/runtime path.',
+        },
+      ],
+      recommendation:
+        'Use the SMRT scanner/runtime manifest path so defaults, relationships, schemas, tenant fields, and cross-package references match framework behavior.',
+      suggestedIssueTitle:
+        'Replace custom object manifest generation with SMRT scanner/runtime manifest generation',
+    }));
+}
+
+function findDirectStorageBypasses(
+  sourceFiles: SourceFile[],
+  packages: PackageContext[],
+  projectPath: string,
+): Finding[] {
+  return sourceFiles.flatMap((file) => {
+    const owner = findOwningPackage(file.path, packages);
+    const usesFs =
+      /from\s+['"](?:node:fs|node:fs\/promises|fs|fs\/promises)['"]|require\(['"](?:node:fs|node:fs\/promises|fs|fs\/promises)['"]\)/.test(
+        file.content,
+      );
+    const writesDurableData =
+      /\b(writeFile|appendFile|mkdir|rm|rename)\b/.test(file.content) &&
+      /(\.json|data|storage|persist|cache|db)/i.test(file.content);
+    const usesDirectSql =
+      /from\s+['"](?:better-sqlite3|sqlite3|pg|mysql2?|knex|drizzle-orm)['"]/.test(
+        file.content,
+      );
+    if ((!usesFs || !writesDurableData) && !usesDirectSql) return [];
+
+    const hasApprovedStorage =
+      owner.dependencies.has('@happyvertical/sql') ||
+      owner.dependencies.has('@happyvertical/files') ||
+      owner.dependencies.has('@happyvertical/smrt-assets') ||
+      owner.dependencies.has('@happyvertical/smrt-content');
+
+    if (hasApprovedStorage) return [];
+
+    return [
+      {
+        severity: 'medium',
+        area: 'storage',
+        code: 'direct-storage-bypass',
+        title: `${packageLabel(owner)} appears to bypass HappyVertical storage packages`,
+        evidence: [
+          {
+            filePath: relative(projectPath, file.path),
+            line: lineNumber(
+              file.content,
+              usesDirectSql ? 'sqlite' : 'writeFile',
+            ),
+            detail: usesDirectSql
+              ? 'Imports a direct SQL/storage library without @happyvertical/sql.'
+              : 'Uses node:fs-style durable writes without @happyvertical/files/assets/content.',
+          },
+        ],
+        recommendation:
+          'Route durable data through @happyvertical/sql, @happyvertical/files, SMRT assets, or SMRT content unless this is explicitly build-only tooling.',
+        suggestedIssueTitle: `Review direct storage usage in ${packageLabel(owner)}`,
+      },
+    ];
+  });
+}
+
+function findCustomHttpShells(
+  sourceFiles: SourceFile[],
+  packages: PackageContext[],
+  projectPath: string,
+): Finding[] {
+  const evidenceByPackage = new Map<PackageContext, Evidence[]>();
+
+  for (const pkg of packages) {
+    if (pkg.dependencies.has('@sveltejs/kit')) continue;
+
+    const routerDependencies = ['express', 'fastify', 'hono', 'koa'].filter(
+      (dep) => pkg.dependencies.has(dep),
+    );
+    if (routerDependencies.length === 0) continue;
+
+    appendEvidence(evidenceByPackage, pkg, {
+      filePath: relative(projectPath, pkg.packageJsonPath),
+      detail: `Declares custom router package(s): ${routerDependencies.join(', ')}.`,
+    });
+  }
+
+  for (const file of sourceFiles) {
+    const owner = findOwningPackage(file.path, packages);
+    if (owner.dependencies.has('@sveltejs/kit')) continue;
+
+    const usesNodeHttp =
+      /from\s+['"](?:node:http|http|node:https|https)['"]|createServer\s*\(/.test(
+        file.content,
+      );
+    if (!usesNodeHttp) continue;
+
+    appendEvidence(evidenceByPackage, owner, {
+      filePath: relative(projectPath, file.path),
+      line: lineNumber(file.content, 'createServer'),
+      detail:
+        'Custom HTTP routing found without the SvelteKit/SMRT app-shell dependency pattern.',
+    });
+  }
+
+  return Array.from(evidenceByPackage.entries()).map(([owner, evidence]) => ({
+    severity: 'medium',
+    area: 'api-shell',
+    code: 'custom-http-shell',
+    title: `${packageLabel(owner)} uses a custom HTTP shell`,
+    evidence,
+    recommendation:
+      'Compare the app shell against the Anytown/Ergot SvelteKit + SMRT shell pattern before adding custom HTTP infrastructure.',
+    suggestedIssueTitle: `Align ${packageLabel(owner)} app shell with SMRT/SvelteKit conventions`,
+  }));
+}
+
+function appendEvidence(
+  evidenceByPackage: Map<PackageContext, Evidence[]>,
+  pkg: PackageContext,
+  evidence: Evidence,
+): void {
+  const existing = evidenceByPackage.get(pkg);
+  if (existing) {
+    existing.push(evidence);
+    return;
+  }
+
+  evidenceByPackage.set(pkg, [evidence]);
+}
+
+function findLocalAuthTenancy(
+  sourceFiles: SourceFile[],
+  packages: PackageContext[],
+  projectPath: string,
+): Finding[] {
+  return sourceFiles.flatMap((file) => {
+    const owner = findOwningPackage(file.path, packages);
+    const pathSignal = /(auth|tenant|audit|session|rbac|user)/i.test(file.path);
+    const codeSignal =
+      /\b(tenantId|tenant|role|permission|session|auditLog|apiKey)\b/.test(
+        file.content,
+      );
+    if (!pathSignal || !codeSignal) return [];
+
+    const hasApprovedPackages =
+      owner.dependencies.has('@happyvertical/smrt-users') ||
+      owner.dependencies.has('@happyvertical/smrt-tenancy') ||
+      owner.dependencies.has('@happyvertical/smrt-profiles');
+    if (hasApprovedPackages) return [];
+
+    return [
+      {
+        severity: 'medium',
+        area: 'auth-tenancy',
+        code: 'local-auth-tenancy',
+        title: `${packageLabel(owner)} contains local auth/tenancy/audit logic`,
+        evidence: [
+          {
+            filePath: relative(projectPath, file.path),
+            line: lineNumber(file.content, 'tenant'),
+            detail:
+              'Auth, tenancy, session, role, or audit terminology appears without smrt-users/smrt-tenancy/smrt-profiles dependencies.',
+          },
+        ],
+        recommendation:
+          'Add explicit adapters to smrt-users, smrt-tenancy, and profile/audit models or document why this local implementation is intentionally isolated.',
+        suggestedIssueTitle: `Review auth and tenancy adapters in ${packageLabel(owner)}`,
+      },
+    ];
+  });
+}
+
+function findUiShellDrift(
+  packages: PackageContext[],
+  projectPath: string,
+): Finding[] {
+  return packages.flatMap((pkg) => {
+    const hasUiSource = pkg.sourceFiles.some((file) =>
+      file.path.endsWith('.svelte'),
+    );
+    const likelyUiPackage =
+      hasUiSource ||
+      /(?:web|ui|app|site|frontend)/i.test(packageLabel(pkg)) ||
+      pkg.dependencies.has('svelte') ||
+      pkg.dependencies.has('vite');
+    if (!likelyUiPackage) return [];
+    if (pkg.dependencies.has('@happyvertical/smrt-svelte')) return [];
+
+    return [
+      {
+        severity: 'low',
+        area: 'ui-shell',
+        code: 'missing-smrt-svelte-shell',
+        title: `${packageLabel(pkg)} looks like UI work without @happyvertical/smrt-svelte`,
+        evidence: [
+          {
+            filePath: relative(projectPath, pkg.packageJsonPath),
+            detail:
+              'UI-facing package does not declare @happyvertical/smrt-svelte.',
+          },
+        ],
+        recommendation:
+          'Use @happyvertical/smrt-svelte and the SvelteKit shell pattern for downstream app UI unless this package is intentionally framework-agnostic.',
+        suggestedIssueTitle: `Check SMRT Svelte shell alignment for ${packageLabel(pkg)}`,
+      },
+    ];
+  });
+}
+
+function findMissingManifestArtifacts(
+  sourceFiles: SourceFile[],
+  packages: PackageContext[],
+  projectPath: string,
+): Finding[] {
+  return packages.flatMap((pkg) => {
+    const hasSmrtSource = pkg.sourceFiles.some((file) =>
+      /@smrt\s*\(/.test(file.content),
+    );
+    if (!hasSmrtSource) return [];
+    const hasManifest =
+      sourceFiles.some(
+        (file) =>
+          file.packageDir === pkg.directory &&
+          /@happyvertical\/smrt-scanner/.test(file.content),
+      ) ||
+      pathExistsSyncHint(join(pkg.directory, '.smrt', 'manifest.json')) ||
+      pathExistsSyncHint(join(pkg.directory, 'dist', 'manifest.json'));
+    if (hasManifest) return [];
+
+    return [
+      {
+        severity: 'low',
+        area: 'manifest',
+        code: 'missing-generated-manifest-artifact',
+        title: `${packageLabel(pkg)} has @smrt objects but no generated manifest artifact was found`,
+        evidence: [
+          {
+            filePath: relative(projectPath, pkg.packageJsonPath),
+            detail:
+              'No .smrt/manifest.json or dist/manifest.json was visible during review.',
+          },
+        ],
+        recommendation:
+          'Run the package build/test manifest generation path and verify it uses the SMRT scanner/runtime manifest pipeline.',
+        suggestedIssueTitle: `Verify SMRT manifest generation for ${packageLabel(pkg)}`,
+      },
+    ];
+  });
+}
+
+async function visit(
+  dir: string,
+  onFile: (filePath: string, entryName: string) => Promise<void> | void,
+): Promise<void> {
+  let entries: Dirent[];
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      await visit(fullPath, onFile);
+      continue;
+    }
+    if (entry.isFile()) await onFile(fullPath, entry.name);
+  }
+}
+
+function collectDependencies(
+  packageJson: Record<string, unknown>,
+): Set<string> {
+  const dependencies = new Set<string>();
+  for (const sectionName of DEPENDENCY_SECTIONS) {
+    const section = packageJson[sectionName];
+    if (!isRecord(section)) continue;
+    for (const dependencyName of Object.keys(section)) {
+      dependencies.add(dependencyName);
+    }
+  }
+  return dependencies;
+}
+
+function extractImports(content: string): string[] {
+  const imports = new Set<string>();
+  const patterns = [
+    /(?:import|export)\s+(?:type\s+)?(?:[^'"]+\s+from\s+)?['"]([^'"]+)['"]/g,
+    /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+    /\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of content.matchAll(pattern)) {
+      const imported = normalizePackageImport(match[1]);
+      if (imported) imports.add(imported);
+    }
+  }
+  return Array.from(imports);
+}
+
+function normalizePackageImport(value: string | undefined): string | undefined {
+  if (!value || value.startsWith('.') || value.startsWith('/'))
+    return undefined;
+  if (value.startsWith('@')) {
+    const [scope, name] = value.split('/');
+    return scope && name ? `${scope}/${name}` : value;
+  }
+  return value.split('/')[0];
+}
+
+function findOwningPackage(
+  filePath: string,
+  packages: PackageContext[],
+): PackageContext {
+  const normalized = resolve(filePath);
+  const matches = packages
+    .filter(
+      (pkg) =>
+        normalized === pkg.directory ||
+        normalized.startsWith(`${pkg.directory}${sep}`),
+    )
+    .sort((left, right) => right.directory.length - left.directory.length);
+  return matches[0] ?? packages[0];
+}
+
+function packageInventory(pkg: PackageContext): PackageInventory {
+  const declaredHappyVerticalDependencies = Array.from(pkg.dependencies)
+    .filter((dependency) => dependency.startsWith(HAPPYVERTICAL_PACKAGE_PREFIX))
+    .sort();
+  const importedHappyVerticalPackages = Array.from(pkg.imports.keys()).sort();
+  const ownName = typeof pkg.json.name === 'string' ? pkg.json.name : undefined;
+  return {
+    name: packageLabel(pkg),
+    path: pkg.relativePath,
+    private:
+      typeof pkg.json.private === 'boolean' ? pkg.json.private : undefined,
+    scripts: Object.keys(pkg.scripts).sort(),
+    declaredHappyVerticalDependencies,
+    importedHappyVerticalPackages,
+    missingHappyVerticalDependencies: importedHappyVerticalPackages.filter(
+      (name) => name !== ownName && !pkg.dependencies.has(name),
+    ),
+    hasSvelteKit: pkg.dependencies.has('@sveltejs/kit'),
+    hasSmrtSvelte: pkg.dependencies.has('@happyvertical/smrt-svelte'),
+  };
+}
+
+function summarizeFindings(findings: Finding[]): Record<Severity, number> {
+  return findings.reduce(
+    (summary, finding) => {
+      summary[finding.severity]++;
+      return summary;
+    },
+    { high: 0, medium: 0, low: 0 },
+  );
+}
+
+function limitFindings(
+  findings: Finding[],
+  maxFindings: number | undefined,
+): Finding[] {
+  const sorted = findings.sort(
+    (left, right) =>
+      severityRank(left.severity) - severityRank(right.severity) ||
+      left.area.localeCompare(right.area) ||
+      left.title.localeCompare(right.title),
+  );
+  return maxFindings && maxFindings > 0 ? sorted.slice(0, maxFindings) : sorted;
+}
+
+function severityRank(severity: Severity): number {
+  return severity === 'high' ? 0 : severity === 'medium' ? 1 : 2;
+}
+
+function packageLabel(pkg: PackageContext): string {
+  return typeof pkg.json.name === 'string' ? pkg.json.name : pkg.relativePath;
+}
+
+function lineNumber(content: string, needle: string): number | undefined {
+  const index = content.indexOf(needle);
+  if (index < 0) return undefined;
+  return content.slice(0, index).split('\n').length;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pathExistsSyncHint(path: string): boolean {
+  return existsSync(path);
+}

--- a/packages/smrt-dev-mcp/vite.config.ts
+++ b/packages/smrt-dev-mcp/vite.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
       external: [
         /^@modelcontextprotocol\/sdk/,
         /^@happyvertical\/smrt-core/,
+        /^@happyvertical\/smrt-scanner/,
         /^node:/,
       ],
       output: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1830,6 +1830,9 @@ importers:
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
+      '@happyvertical/smrt-scanner':
+        specifier: workspace:*
+        version: link:../scanner
       '@happyvertical/smrt-types':
         specifier: workspace:*
         version: link:../types


### PR DESCRIPTION
## Summary

Implements #1347, #1348, #1349, and #1350 as a single `@happyvertical/smrt-dev-mcp` release bundle.

- Expands `generate-smrt-class` with package-ready templates, tenant-scoped generation, relationship decorators, table/conflict options, nullable/default support, and companion wiring notes.
- Reworks `introspect-project` to prefer generated SMRT manifest artifacts and fall back to `@happyvertical/smrt-scanner` with the same manifest finalization path for schemas, tenant fields, validation, and agent manifests.
- Adds `review-smrt-project` for deterministic downstream ecosystem alignment checks around dependencies, storage, app shells, auth/tenancy, UI shell drift, and manifest generation.
- Updates MCP registration, stdio/tool tests, docs, package dependency metadata, and lockfile entries.

## Root Cause

The prior dev MCP tools still used older local heuristics for project scanning and class generation, so downstream agents could miss manifest-level details such as generated schema indexes, tenant-scoped fields, and cross-package relationship metadata. There was also no advisory project-review tool for catching common downstream SMRT ecosystem drift.

## Validation

- `pnpm --filter @happyvertical/smrt-dev-mcp test`
- `pnpm --filter @happyvertical/smrt-dev-mcp build`
- `git diff --check`
- pre-commit: forbidden artifacts, Biome format, changed-file strict knowledge freshness
- pre-push: full Biome format check, full strict knowledge freshness, workflow validation

Closes #1347.
Closes #1348.
Closes #1349.
Closes #1350.