### PR TITLE
[codex] fix secrets key drift diagnostics

### DIFF
--- a/packages/secrets/AGENTS.md
+++ b/packages/secrets/AGENTS.md
@@ -21,6 +21,8 @@ Secret value → encrypted with TDEK (per-tenant Data Encryption Key)
 |--------|----------|
 | `store(name, value, options)` | Encrypt + save. Upsert if exists. Uses `context=tenantId` for per-tenant uniqueness. |
 | `retrieve(name)` | Decrypt + audit + increment accessCount |
+| `diagnoseTenantSecretKeyDrift(tenantId)` | Report active secret/key drift without exposing values. Checks `secrets`, SDK `tenant_encryption_keys`, and SMRT `tenant_keys`. |
+| `repairTenantSecretKeyDrift(tenantId, opts)` | Explicit repair path for unrecoverable drift. Use `dryRun` first; destructive cleanup requires `confirmDeleteUnrecoverableData: true`. |
 | `rotateKey()` | Create new TDEK, mark old as retired |
 | `reencryptAll()` | Decrypt with old TDEK, re-encrypt with new — **must call separately after rotateKey()** |
 | `disable(name)` / `enable(name)` | Toggle status |
@@ -30,6 +32,8 @@ Secret value → encrypted with TDEK (per-tenant Data Encryption Key)
 - **Key rotation doesn't auto-re-encrypt**: call `reencryptAll()` separately after `rotateKey()`
 - **retrieve() increments accessCount**: every read is tracked
 - **TenantKey NOT tenant-scoped**: it stores keys for tenants but isn't filtered by tenant context
+- **Two key tables**: `tenant_encryption_keys` is the lower-level SDK table used by `SecretService` encryption; `tenant_keys` is the SMRT model table. Drift diagnosis reports both so an empty `tenant_keys` view is not confused with missing SDK key material.
+- **Repair is destructive only by confirmation**: `repairTenantSecretKeyDrift()` deletes unrecoverable encrypted rows only when `confirmDeleteUnrecoverableData: true` is explicit. Do not silently discard encrypted secrets.
 - **Expired secrets filtered by default**: pass `includeExpired: true` to list them
 - **TenantKeyCollection.cleanupRetiredKeys()**: hard-deletes after 90 days
 - **Audit logging optional but default**: failures logged to console, not thrown

--- a/packages/secrets/README.md
+++ b/packages/secrets/README.md
@@ -45,6 +45,15 @@ await withTenant({ tenantId: 'tenant-123' }, async () => {
   // Query audit logs
   const logs = await service.getAuditLogs({ secretName: 'stripe-api-key' });
 
+  // Diagnose tenant secret/key drift without exposing values
+  const drift = await service.diagnoseTenantSecretKeyDrift('tenant-123');
+
+  // Preview and then explicitly repair unrecoverable drifted rows
+  await service.repairTenantSecretKeyDrift('tenant-123', { dryRun: true });
+  await service.repairTenantSecretKeyDrift('tenant-123', {
+    confirmDeleteUnrecoverableData: true,
+  });
+
   // Hard delete
   await service.delete('stripe-api-key');
 });
@@ -65,6 +74,20 @@ The AMK is loaded from `SMRT_SECRET_MASTER_KEY` (configurable via `amkEnvVar` op
 `rotateKey()` creates a new TDEK version and retires the old one. Existing secrets remain readable because retired keys are kept for decryption. Call `reencryptAll()` separately after rotation to re-encrypt all secrets with the new key. The method returns `{ success, failed }` counts.
 
 TenantKey statuses: `active` (current encryption key), `rotating` (transitional), `retired` (kept for decryption), `compromised` (should not be used).
+
+### Drift diagnosis and repair
+
+`diagnoseTenantSecretKeyDrift(tenantId)` reports tenant secret/key drift without
+returning secret values. It checks active `secrets` rows, lower-level
+`tenant_encryption_keys` rows used by `@happyvertical/secrets`, and SMRT-visible
+`tenant_keys` rows so operators can distinguish missing secrets from stale or
+unusable key material.
+
+`repairTenantSecretKeyDrift(tenantId, { dryRun: true })` previews rows that would
+be deleted. A destructive repair requires
+`confirmDeleteUnrecoverableData: true`; it deletes only encrypted secret/key rows
+identified as unrecoverable with the currently configured AMK. After repair,
+store fresh secret values with `storeForTenant()` or `store()`.
 
 ### Audit logging
 
@@ -96,7 +119,7 @@ The `Secret` and `TenantKey` models have no API or MCP exposure to prevent accid
 
 | Export | Description |
 |--------|------------|
-| `SecretService` | High-level API: store, retrieve, rotate, delete, audit |
+| `SecretService` | High-level API: store, retrieve, rotate, delete, audit, diagnose and repair key drift |
 
 ### Functions
 
@@ -110,7 +133,7 @@ The `Secret` and `TenantKey` models have no API or MCP exposure to prevent accid
 
 ### Key Types
 
-`SecretServiceOptions`, `StoreSecretOptions`, `RetrievedSecret`, `ListSecretsOptions`, `ListAuditLogsOptions`, `SecretStatus`, `SecretAuditAction`, `SecretAuditResult`, `TenantKeyStatus`, `ApplicationMasterKey`, `EncryptedEnvelope`, `TenantDataEncryptionKey`, `SecretStore`
+`SecretServiceOptions`, `StoreSecretOptions`, `RetrievedSecret`, `DiagnoseTenantSecretKeyDriftOptions`, `SecretKeyDriftReport`, `SecretKeyDriftIssue`, `RepairTenantSecretKeyDriftOptions`, `SecretKeyDriftRepairResult`, `ListSecretsOptions`, `ListAuditLogsOptions`, `SecretStatus`, `SecretAuditAction`, `SecretAuditResult`, `TenantKeyStatus`, `ApplicationMasterKey`, `EncryptedEnvelope`, `TenantDataEncryptionKey`, `SecretStore`
 
 ## Dependencies
 

--- a/packages/secrets/src/__tests__/secret-service.test.ts
+++ b/packages/secrets/src/__tests__/secret-service.test.ts
@@ -18,11 +18,16 @@ import {
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SecretCollection } from '../collections/SecretCollection.js';
-import { SecretService } from '../services/SecretService.js';
+import {
+  SecretKeyDriftError,
+  SecretService,
+} from '../services/SecretService.js';
 
 // Test AMK (64 hex chars = 32 bytes)
 const TEST_AMK =
   '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+const ROTATED_TEST_AMK =
+  'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
 
 describe('SecretService', () => {
   let db: DatabaseInterface;
@@ -308,6 +313,104 @@ describe('SecretService', () => {
         expect((await service.retrieve('secret-1')).value).toBe('value-1');
         expect((await service.retrieve('secret-2')).value).toBe('value-2');
       });
+    });
+  });
+
+  describe('Tenant key drift diagnostics', () => {
+    it('does not require destructive confirmation for no-op repair', async () => {
+      const repair = await service.repairTenantSecretKeyDrift('tenant-empty');
+
+      expect(repair.wouldDeleteSecrets).toBe(0);
+      expect(repair.wouldDeleteTenantEncryptionKeys).toBe(0);
+      expect(repair.deletedSecrets).toBe(0);
+      expect(repair.deletedTenantEncryptionKeys).toBe(0);
+    });
+
+    it('diagnoses active secrets with no active tenant encryption key', async () => {
+      await service.storeForTenant('tenant-1', 'api-key', 'secret-value');
+      await db.query(
+        'DELETE FROM "tenant_encryption_keys" WHERE tenant_id = ?',
+        'tenant-1',
+      );
+
+      const report = await service.diagnoseTenantSecretKeyDrift('tenant-1');
+      const codes = report.issues.map((issue) => issue.code);
+
+      expect(report.ok).toBe(false);
+      expect(report.summary.activeSecretCount).toBe(1);
+      expect(report.summary.activeTenantEncryptionKeyCount).toBe(0);
+      expect(codes).toContain('missing_active_tenant_encryption_key');
+      expect(codes).toContain('active_secrets_without_usable_active_key');
+      expect(codes).toContain('secret_envelope_missing_tenant_encryption_key');
+    });
+
+    it('reports stale key material and repairs only after explicit confirmation', async () => {
+      await service.storeForTenant('tenant-1', 'api-key', 'old-value');
+
+      process.env.SMRT_SECRET_MASTER_KEY = ROTATED_TEST_AMK;
+      const driftedService = await SecretService.create({ db });
+
+      const report = await driftedService.diagnoseTenantSecretKeyDrift(
+        'tenant-1',
+        { secretNames: ['api-key'] },
+      );
+      const codes = report.issues.map((issue) => issue.code);
+
+      expect(report.ok).toBe(false);
+      expect(codes).toContain('active_tenant_encryption_key_unwrap_failed');
+      expect(codes).toContain('secret_envelope_unwrap_failed');
+
+      await expect(
+        driftedService.storeForTenant('tenant-1', 'api-key', 'new-value'),
+      ).rejects.toBeInstanceOf(SecretKeyDriftError);
+
+      await expect(
+        driftedService.repairTenantSecretKeyDrift('tenant-1'),
+      ).rejects.toThrow('confirmDeleteUnrecoverableData');
+
+      const dryRun = await driftedService.repairTenantSecretKeyDrift(
+        'tenant-1',
+        {
+          dryRun: true,
+          secretNames: ['api-key'],
+        },
+      );
+      expect(dryRun.wouldDeleteSecrets).toBe(1);
+      expect(dryRun.wouldDeleteTenantEncryptionKeys).toBe(1);
+      expect(dryRun.deletedSecrets).toBe(0);
+      expect(dryRun.deletedTenantEncryptionKeys).toBe(0);
+
+      const repair = await driftedService.repairTenantSecretKeyDrift(
+        'tenant-1',
+        {
+          confirmDeleteUnrecoverableData: true,
+          secretNames: ['api-key'],
+        },
+      );
+      expect(repair.deletedSecrets).toBe(1);
+      expect(repair.deletedTenantEncryptionKeys).toBe(1);
+      expect(
+        repair.remainingIssues.some((issue) => issue.severity === 'error'),
+      ).toBe(false);
+
+      const logs = await withTenant({ tenantId: 'tenant-1' }, () =>
+        driftedService.getAuditLogs({ secretName: 'api-key' }),
+      );
+      expect(
+        logs.some(
+          (log) =>
+            log.action === 'delete' &&
+            log.details?.action === 'repairTenantSecretKeyDrift',
+        ),
+      ).toBe(true);
+
+      await driftedService.storeForTenant('tenant-1', 'api-key', 'new-value');
+      const retrieved = await driftedService.retrieveForTenant(
+        'tenant-1',
+        'api-key',
+      );
+
+      expect(retrieved.value).toBe('new-value');
     });
   });
 

--- a/packages/secrets/src/__tests__/secret-service.test.ts
+++ b/packages/secrets/src/__tests__/secret-service.test.ts
@@ -18,6 +18,7 @@ import {
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SecretCollection } from '../collections/SecretCollection.js';
+import { TenantKeyCollection } from '../collections/TenantKeyCollection.js';
 import {
   SecretKeyDriftError,
   SecretService,
@@ -344,6 +345,65 @@ describe('SecretService', () => {
       expect(codes).toContain('secret_envelope_missing_tenant_encryption_key');
     });
 
+    it('does not mark secrets unrecoverable when the AMK is unavailable', async () => {
+      await service.storeForTenant('tenant-1', 'api-key', 'old-value');
+
+      delete process.env.SMRT_SECRET_MASTER_KEY;
+      const noAmkService = await SecretService.create({ db });
+
+      const report = await noAmkService.diagnoseTenantSecretKeyDrift(
+        'tenant-1',
+        { secretNames: ['api-key'] },
+      );
+      const codes = report.issues.map((issue) => issue.code);
+      const destructiveIssues = report.issues.filter(
+        (issue) => issue.repairAction === 'delete-unrecoverable-secret',
+      );
+
+      expect(report.ok).toBe(false);
+      expect(codes).toContain('amk_unavailable');
+      expect(codes).not.toContain('secret_envelope_invalid_wrapped_key');
+      expect(codes).not.toContain('secret_envelope_unwrap_failed');
+      expect(destructiveIssues).toHaveLength(0);
+
+      const repair = await noAmkService.repairTenantSecretKeyDrift('tenant-1', {
+        confirmDeleteUnrecoverableData: true,
+        secretNames: ['api-key'],
+      });
+      expect(repair.deletedSecrets).toBe(0);
+      expect(repair.deletedTenantEncryptionKeys).toBe(0);
+
+      process.env.SMRT_SECRET_MASTER_KEY = TEST_AMK;
+      const restoredService = await SecretService.create({ db });
+      const retrieved = await restoredService.retrieveForTenant(
+        'tenant-1',
+        'api-key',
+      );
+      expect(retrieved.value).toBe('old-value');
+    });
+
+    it('surfaces tenant_keys diagnosis query failures', async () => {
+      await service.storeForTenant('tenant-1', 'api-key', 'secret-value');
+      const listKeyVersions = vi
+        .spyOn(TenantKeyCollection.prototype, 'listKeyVersions')
+        .mockRejectedValueOnce(new Error('tenant_keys unavailable'));
+
+      try {
+        const report = await service.diagnoseTenantSecretKeyDrift('tenant-1');
+        const codes = report.issues.map((issue) => issue.code);
+        const issue = report.issues.find(
+          (candidate) => candidate.code === 'smrt_tenant_keys_query_failed',
+        );
+
+        expect(report.ok).toBe(false);
+        expect(codes).toContain('smrt_tenant_keys_query_failed');
+        expect(codes).not.toContain('smrt_tenant_keys_not_mirrored');
+        expect(issue?.details?.error).toBe('tenant_keys unavailable');
+      } finally {
+        listKeyVersions.mockRestore();
+      }
+    });
+
     it('reports stale key material and repairs only after explicit confirmation', async () => {
       await service.storeForTenant('tenant-1', 'api-key', 'old-value');
 
@@ -380,6 +440,15 @@ describe('SecretService', () => {
       expect(dryRun.deletedSecrets).toBe(0);
       expect(dryRun.deletedTenantEncryptionKeys).toBe(0);
 
+      const transactionCapableDb = db as DatabaseInterface & {
+        transaction?: (
+          callback: (tx: DatabaseInterface) => Promise<unknown>,
+        ) => Promise<unknown>;
+      };
+      const transactionSpy =
+        typeof transactionCapableDb.transaction === 'function'
+          ? vi.spyOn(transactionCapableDb, 'transaction')
+          : null;
       const repair = await driftedService.repairTenantSecretKeyDrift(
         'tenant-1',
         {
@@ -389,6 +458,10 @@ describe('SecretService', () => {
       );
       expect(repair.deletedSecrets).toBe(1);
       expect(repair.deletedTenantEncryptionKeys).toBe(1);
+      if (transactionSpy) {
+        expect(transactionSpy).toHaveBeenCalledTimes(1);
+        transactionSpy.mockRestore();
+      }
       expect(
         repair.remainingIssues.some((issue) => issue.severity === 'error'),
       ).toBe(false);

--- a/packages/secrets/src/index.ts
+++ b/packages/secrets/src/index.ts
@@ -93,7 +93,16 @@ export {
 } from './models/TenantKey.js';
 // Service
 export {
+  type DiagnoseTenantSecretKeyDriftOptions,
+  type RepairTenantSecretKeyDriftOptions,
   type RetrievedSecret,
+  SecretKeyDriftError,
+  type SecretKeyDriftIssue,
+  type SecretKeyDriftIssueCode,
+  type SecretKeyDriftIssueSeverity,
+  type SecretKeyDriftRepairAction,
+  type SecretKeyDriftRepairResult,
+  type SecretKeyDriftReport,
   SecretService,
   type SecretServiceOptions,
   type StoreSecretOptions,

--- a/packages/secrets/src/services/SecretService.ts
+++ b/packages/secrets/src/services/SecretService.ts
@@ -8,9 +8,14 @@
 import '../__smrt-register__.js';
 
 import {
+  AMKUnavailableError,
+  DecryptionError,
   type EncryptedEnvelope,
+  EncryptionError,
+  EnvelopeEncryption,
   getSecretStore,
   type SecretStore,
+  TenantKeyMissingError,
 } from '@happyvertical/secrets';
 import {
   getCurrentTenant,
@@ -20,12 +25,14 @@ import {
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { SecretAuditLogCollection } from '../collections/SecretAuditLogCollection.js';
 import { SecretCollection } from '../collections/SecretCollection.js';
+import { TenantKeyCollection } from '../collections/TenantKeyCollection.js';
 import type { Secret } from '../models/Secret.js';
 import {
   createAuditEntry,
   type SecretAuditAction,
   type SecretAuditLog,
 } from '../models/SecretAuditLog.js';
+import type { TenantKey } from '../models/TenantKey.js';
 
 /**
  * Options for creating a SecretService
@@ -72,6 +79,134 @@ export interface RetrievedSecret {
   metadata: Record<string, unknown>;
 }
 
+export type SecretKeyDriftIssueSeverity = 'info' | 'warning' | 'error';
+
+export type SecretKeyDriftIssueCode =
+  | 'amk_unavailable'
+  | 'active_secrets_without_usable_active_key'
+  | 'missing_active_tenant_encryption_key'
+  | 'multiple_active_tenant_encryption_keys'
+  | 'active_tenant_encryption_key_amk_mismatch'
+  | 'active_tenant_encryption_key_unwrap_failed'
+  | 'secret_envelope_invalid_json'
+  | 'secret_envelope_invalid_wrapped_key'
+  | 'secret_envelope_missing_tenant_encryption_key'
+  | 'secret_envelope_unwrap_failed'
+  | 'smrt_tenant_keys_not_mirrored';
+
+export type SecretKeyDriftRepairAction =
+  | 'delete-unrecoverable-secret'
+  | 'delete-unusable-tenant-encryption-key'
+  | 'store-fresh-secret-value'
+  | 'none';
+
+export interface SecretKeyDriftIssue {
+  code: SecretKeyDriftIssueCode;
+  severity: SecretKeyDriftIssueSeverity;
+  message: string;
+  repairAction: SecretKeyDriftRepairAction;
+  secretId?: string;
+  secretName?: string;
+  keyId?: string;
+  sourceTable?: 'secrets' | 'tenant_encryption_keys' | 'tenant_keys';
+  details?: Record<string, string | number | boolean | null>;
+}
+
+export interface DiagnoseTenantSecretKeyDriftOptions {
+  /**
+   * Limit secret-envelope checks to these names. Tenant key checks still run.
+   */
+  secretNames?: string[];
+}
+
+export interface SecretKeyDriftReport {
+  tenantId: string;
+  checkedAt: Date;
+  ok: boolean;
+  summary: {
+    activeSecretCount: number;
+    tenantEncryptionKeyCount: number;
+    activeTenantEncryptionKeyCount: number;
+    usableActiveTenantEncryptionKeyCount: number;
+    smrtTenantKeyCount: number;
+    activeSmrtTenantKeyCount: number;
+  };
+  issues: SecretKeyDriftIssue[];
+}
+
+export interface RepairTenantSecretKeyDriftOptions
+  extends DiagnoseTenantSecretKeyDriftOptions {
+  /**
+   * Preview affected rows without deleting anything.
+   */
+  dryRun?: boolean;
+  /**
+   * Required for destructive repair. This deletes encrypted values/key rows
+   * that cannot be used with the currently configured AMK.
+   */
+  confirmDeleteUnrecoverableData?: boolean;
+}
+
+export interface SecretKeyDriftRepairResult {
+  tenantId: string;
+  dryRun: boolean;
+  issuesBefore: SecretKeyDriftIssue[];
+  remainingIssues: SecretKeyDriftIssue[];
+  wouldDeleteSecrets: number;
+  wouldDeleteTenantEncryptionKeys: number;
+  deletedSecrets: number;
+  deletedTenantEncryptionKeys: number;
+  secretNames: string[];
+  tenantEncryptionKeyIds: string[];
+}
+
+export class SecretKeyDriftError extends Error {
+  readonly code = 'SECRET_KEY_DRIFT';
+  readonly tenantId: string;
+  readonly report: SecretKeyDriftReport;
+  readonly cause?: Error;
+
+  constructor(
+    message: string,
+    tenantId: string,
+    report: SecretKeyDriftReport,
+    cause?: Error,
+  ) {
+    super(message);
+    this.name = 'SecretKeyDriftError';
+    this.tenantId = tenantId;
+    this.report = report;
+    this.cause = cause;
+  }
+}
+
+interface TenantEncryptionKeyRow {
+  id: string;
+  tenant_id: string;
+  wrapped_key: string;
+  amk_key_id: string;
+  status: string;
+  version: number;
+  rotate_after: string | null;
+  retired_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface SecretDiagnosisRow {
+  id: string;
+  name: string;
+  encrypted_value: string;
+  status: string;
+  tenant_id: string;
+}
+
+interface WrappedKeyCheck {
+  usable: boolean;
+  error?: string;
+  fingerprint?: string;
+}
+
 /**
  * SecretService provides high-level operations for managing per-tenant secrets.
  *
@@ -110,21 +245,33 @@ export interface RetrievedSecret {
  * ```
  */
 export class SecretService {
+  private db: DatabaseInterface;
   private secretStore: SecretStore;
   private secrets: SecretCollection;
+  private tenantKeys: TenantKeyCollection;
   private auditLogs: SecretAuditLogCollection;
   private auditEnabled: boolean;
+  private amkEnvVar: string;
+  private amkKeyId: string;
 
   private constructor(
+    db: DatabaseInterface,
     secretStore: SecretStore,
     secrets: SecretCollection,
+    tenantKeys: TenantKeyCollection,
     auditLogs: SecretAuditLogCollection,
     auditEnabled: boolean,
+    amkEnvVar: string,
+    amkKeyId: string,
   ) {
+    this.db = db;
     this.secretStore = secretStore;
     this.secrets = secrets;
+    this.tenantKeys = tenantKeys;
     this.auditLogs = auditLogs;
     this.auditEnabled = auditEnabled;
+    this.amkEnvVar = amkEnvVar;
+    this.amkKeyId = amkKeyId;
   }
 
   /**
@@ -152,9 +299,19 @@ export class SecretService {
     // Create collections - pass db directly (DatabaseConfig accepts DatabaseInterface)
     const baseOptions = { db };
     const secrets = await SecretCollection.create(baseOptions);
+    const tenantKeys = await TenantKeyCollection.create(baseOptions);
     const auditLogs = await SecretAuditLogCollection.create(baseOptions);
 
-    return new SecretService(secretStore, secrets, auditLogs, auditEnabled);
+    return new SecretService(
+      db,
+      secretStore,
+      secrets,
+      tenantKeys,
+      auditLogs,
+      auditEnabled,
+      amkEnvVar,
+      amkKeyId,
+    );
   }
 
   /**
@@ -222,6 +379,11 @@ export class SecretService {
       await this.audit(secret.id ?? null, name, userId, 'create', 'success');
       return secret;
     } catch (error) {
+      const classifiedError = await this.classifyTenantKeyFailure(
+        tenantId,
+        name,
+        error,
+      );
       await this.audit(
         null,
         name,
@@ -229,10 +391,10 @@ export class SecretService {
         isUpdate ? 'update' : 'create',
         'failure',
         {
-          error: (error as Error).message,
+          error: classifiedError.message,
         },
       );
-      throw error;
+      throw classifiedError;
     }
   }
 
@@ -316,13 +478,18 @@ export class SecretService {
         metadata: secret.metadata,
       };
     } catch (error) {
+      const classifiedError = await this.classifyTenantKeyFailure(
+        tenantId,
+        name,
+        error,
+      );
       // Only audit if we haven't already audited this error
       if (!audited) {
         await this.audit(null, name, userId, 'read', 'failure', {
-          error: (error as Error).message,
+          error: classifiedError.message,
         });
       }
-      throw error;
+      throw classifiedError;
     }
   }
 
@@ -334,6 +501,333 @@ export class SecretService {
     name: string,
   ): Promise<RetrievedSecret> {
     return withTenant({ tenantId }, () => this.retrieve(name));
+  }
+
+  /**
+   * Diagnose tenant secret/key drift without exposing decrypted values.
+   */
+  async diagnoseTenantSecretKeyDrift(
+    tenantId: string,
+    options: DiagnoseTenantSecretKeyDriftOptions = {},
+  ): Promise<SecretKeyDriftReport> {
+    const activeSecrets = await this.listActiveSecretRowsForDiagnosis(
+      tenantId,
+      options.secretNames,
+    );
+    const tenantEncryptionKeys =
+      await this.listTenantEncryptionKeyRows(tenantId);
+    const smrtTenantKeys = await this.listSmrtTenantKeysForDiagnosis(tenantId);
+    const issues: SecretKeyDriftIssue[] = [];
+
+    const activeTenantEncryptionKeys = tenantEncryptionKeys.filter(
+      (key) => key.status === 'active',
+    );
+    const activeSmrtTenantKeys = smrtTenantKeys.filter(
+      (key) => key.status === 'active',
+    );
+    const amk = this.getConfiguredAmkForDiagnosis();
+
+    if (!amk.usable) {
+      issues.push({
+        code: 'amk_unavailable',
+        severity: 'error',
+        message: amk.error ?? `AMK ${this.amkEnvVar} is unavailable`,
+        repairAction: 'none',
+        details: {
+          amkEnvVar: this.amkEnvVar,
+          amkKeyId: this.amkKeyId,
+        },
+      });
+    }
+
+    if (activeSecrets.length > 0 && activeTenantEncryptionKeys.length === 0) {
+      issues.push({
+        code: 'missing_active_tenant_encryption_key',
+        severity: 'error',
+        message:
+          'Active tenant secrets exist, but tenant_encryption_keys has no active key for encryption.',
+        repairAction: 'store-fresh-secret-value',
+        sourceTable: 'tenant_encryption_keys',
+        details: {
+          activeSecretCount: activeSecrets.length,
+        },
+      });
+    }
+
+    if (activeTenantEncryptionKeys.length > 1) {
+      issues.push({
+        code: 'multiple_active_tenant_encryption_keys',
+        severity: 'error',
+        message:
+          'tenant_encryption_keys has multiple active keys for this tenant; encryption may use an arbitrary active key.',
+        repairAction: 'none',
+        sourceTable: 'tenant_encryption_keys',
+        details: {
+          activeTenantEncryptionKeyCount: activeTenantEncryptionKeys.length,
+        },
+      });
+    }
+
+    const activeKeyChecks: WrappedKeyCheck[] = [];
+
+    for (const key of tenantEncryptionKeys) {
+      const check = amk.value
+        ? this.checkWrappedKey(key.wrapped_key, amk.value)
+        : { usable: false, error: amk.error };
+
+      if (key.status === 'active') {
+        activeKeyChecks.push(check);
+      }
+
+      if (key.status === 'active' && key.amk_key_id !== this.amkKeyId) {
+        issues.push({
+          code: 'active_tenant_encryption_key_amk_mismatch',
+          severity: 'warning',
+          message:
+            'Active tenant_encryption_keys row was wrapped by a different AMK key id than this SecretService is configured to use.',
+          repairAction: 'none',
+          keyId: key.id,
+          sourceTable: 'tenant_encryption_keys',
+          details: {
+            rowAmkKeyId: key.amk_key_id,
+            configuredAmkKeyId: this.amkKeyId,
+          },
+        });
+      }
+
+      if (key.status === 'active' && !check.usable && amk.value) {
+        issues.push({
+          code: 'active_tenant_encryption_key_unwrap_failed',
+          severity: 'error',
+          message:
+            'Active tenant_encryption_keys row cannot be unwrapped by the currently configured AMK.',
+          repairAction: 'delete-unusable-tenant-encryption-key',
+          keyId: key.id,
+          sourceTable: 'tenant_encryption_keys',
+          details: {
+            version: key.version,
+            error: check.error ?? null,
+          },
+        });
+      }
+    }
+
+    const usableActiveTenantEncryptionKeyCount = activeKeyChecks.filter(
+      (check) => check.usable,
+    ).length;
+
+    if (
+      activeSecrets.length > 0 &&
+      usableActiveTenantEncryptionKeyCount === 0
+    ) {
+      issues.push({
+        code: 'active_secrets_without_usable_active_key',
+        severity: 'error',
+        message:
+          'Active secrets exist, but no active tenant_encryption_keys row can be used with the current AMK.',
+        repairAction: 'store-fresh-secret-value',
+        sourceTable: 'tenant_encryption_keys',
+        details: {
+          activeSecretCount: activeSecrets.length,
+          activeTenantEncryptionKeyCount: activeTenantEncryptionKeys.length,
+        },
+      });
+    }
+
+    const keyFingerprintToRow = new Map<string, TenantEncryptionKeyRow>();
+    for (const key of tenantEncryptionKeys) {
+      const fingerprint = this.getWrappedKeyFingerprint(key.wrapped_key);
+      if (fingerprint) {
+        keyFingerprintToRow.set(fingerprint, key);
+      }
+    }
+
+    for (const secret of activeSecrets) {
+      const envelope = this.parseSecretEnvelopeForDiagnosis(secret, issues);
+      if (!envelope) continue;
+
+      const envelopeCheck = amk.value
+        ? this.checkWrappedKey(envelope.wrappedKey, amk.value)
+        : { usable: false, error: amk.error };
+
+      if (!envelopeCheck.fingerprint) {
+        issues.push({
+          code: 'secret_envelope_invalid_wrapped_key',
+          severity: 'error',
+          message:
+            'Secret encryptedValue contains an invalid wrapped key format.',
+          repairAction: 'delete-unrecoverable-secret',
+          secretId: secret.id,
+          secretName: secret.name,
+          sourceTable: 'secrets',
+          details: {
+            error: envelopeCheck.error ?? null,
+          },
+        });
+        continue;
+      }
+
+      const matchingKey = keyFingerprintToRow.get(envelopeCheck.fingerprint);
+      if (!matchingKey) {
+        issues.push({
+          code: 'secret_envelope_missing_tenant_encryption_key',
+          severity: 'error',
+          message:
+            'Secret envelope does not match any tenant_encryption_keys row for this tenant.',
+          repairAction: envelopeCheck.usable
+            ? 'none'
+            : 'delete-unrecoverable-secret',
+          secretId: secret.id,
+          secretName: secret.name,
+          sourceTable: 'secrets',
+        });
+      }
+
+      if (!envelopeCheck.usable && amk.value) {
+        issues.push({
+          code: 'secret_envelope_unwrap_failed',
+          severity: 'error',
+          message:
+            'Secret envelope cannot be unwrapped by the currently configured AMK.',
+          repairAction: 'delete-unrecoverable-secret',
+          secretId: secret.id,
+          secretName: secret.name,
+          keyId: matchingKey?.id,
+          sourceTable: 'secrets',
+          details: {
+            error: envelopeCheck.error ?? null,
+          },
+        });
+      }
+    }
+
+    if (
+      activeSecrets.length > 0 &&
+      tenantEncryptionKeys.length > 0 &&
+      smrtTenantKeys.length === 0
+    ) {
+      issues.push({
+        code: 'smrt_tenant_keys_not_mirrored',
+        severity: 'info',
+        message:
+          'SMRT tenant_keys has no rows for this tenant, while the lower-level tenant_encryption_keys table does. SecretService uses tenant_encryption_keys for encryption.',
+        repairAction: 'none',
+        sourceTable: 'tenant_keys',
+      });
+    }
+
+    return {
+      tenantId,
+      checkedAt: new Date(),
+      ok: !issues.some((issue) => issue.severity === 'error'),
+      summary: {
+        activeSecretCount: activeSecrets.length,
+        tenantEncryptionKeyCount: tenantEncryptionKeys.length,
+        activeTenantEncryptionKeyCount: activeTenantEncryptionKeys.length,
+        usableActiveTenantEncryptionKeyCount,
+        smrtTenantKeyCount: smrtTenantKeys.length,
+        activeSmrtTenantKeyCount: activeSmrtTenantKeys.length,
+      },
+      issues,
+    };
+  }
+
+  /**
+   * Diagnose drift for the current tenant context.
+   */
+  async diagnoseCurrentTenantSecretKeyDrift(
+    options: DiagnoseTenantSecretKeyDriftOptions = {},
+  ): Promise<SecretKeyDriftReport> {
+    return this.diagnoseTenantSecretKeyDrift(requireTenantId(), options);
+  }
+
+  /**
+   * Delete unrecoverable secret/key rows identified by diagnosis.
+   *
+   * This never attempts to recover or expose secret values. Use dryRun first
+   * to preview destructive changes.
+   */
+  async repairTenantSecretKeyDrift(
+    tenantId: string,
+    options: RepairTenantSecretKeyDriftOptions = {},
+  ): Promise<SecretKeyDriftRepairResult> {
+    const dryRun = options.dryRun ?? false;
+    const before = await this.diagnoseTenantSecretKeyDrift(tenantId, options);
+    const secretIds = new Set<string>();
+    const secretNames = new Map<string, string>();
+    const tenantEncryptionKeyIds = new Set<string>();
+
+    for (const issue of before.issues) {
+      if (
+        issue.repairAction === 'delete-unrecoverable-secret' &&
+        issue.secretId
+      ) {
+        secretIds.add(issue.secretId);
+        if (issue.secretName) {
+          secretNames.set(issue.secretId, issue.secretName);
+        }
+      }
+
+      if (
+        issue.repairAction === 'delete-unusable-tenant-encryption-key' &&
+        issue.keyId
+      ) {
+        tenantEncryptionKeyIds.add(issue.keyId);
+      }
+    }
+
+    const wouldDeleteSecrets = secretIds.size;
+    const wouldDeleteTenantEncryptionKeys = tenantEncryptionKeyIds.size;
+    const wouldDeleteUnrecoverableData =
+      wouldDeleteSecrets + wouldDeleteTenantEncryptionKeys > 0;
+
+    if (
+      !dryRun &&
+      wouldDeleteUnrecoverableData &&
+      !options.confirmDeleteUnrecoverableData
+    ) {
+      throw new Error(
+        'repairTenantSecretKeyDrift requires confirmDeleteUnrecoverableData: true before deleting encrypted secrets or tenant key rows.',
+      );
+    }
+
+    let deletedSecrets = 0;
+    let deletedTenantEncryptionKeys = 0;
+
+    if (!dryRun) {
+      deletedSecrets = await this.deleteRowsByIds(
+        'secrets',
+        tenantId,
+        secretIds,
+      );
+      deletedTenantEncryptionKeys = await this.deleteRowsByIds(
+        'tenant_encryption_keys',
+        tenantId,
+        tenantEncryptionKeyIds,
+      );
+      await this.auditSecretDriftRepairDeletes(
+        tenantId,
+        secretIds,
+        secretNames,
+      );
+    }
+
+    const after = dryRun
+      ? before
+      : await this.diagnoseTenantSecretKeyDrift(tenantId, options);
+
+    return {
+      tenantId,
+      dryRun,
+      issuesBefore: before.issues,
+      remainingIssues: after.issues,
+      wouldDeleteSecrets,
+      wouldDeleteTenantEncryptionKeys,
+      deletedSecrets,
+      deletedTenantEncryptionKeys,
+      secretNames: Array.from(secretNames.values()).sort(),
+      tenantEncryptionKeyIds: Array.from(tenantEncryptionKeyIds).sort(),
+    };
   }
 
   /**
@@ -508,6 +1002,257 @@ export class SecretService {
   }
 
   // Private methods
+
+  private async listActiveSecretRowsForDiagnosis(
+    tenantId: string,
+    secretNames?: string[],
+  ): Promise<SecretDiagnosisRow[]> {
+    const params: unknown[] = [tenantId];
+    let nameFilter = '';
+
+    if (secretNames && secretNames.length > 0) {
+      const placeholders = secretNames.map(() => '?').join(', ');
+      nameFilter = ` AND name IN (${placeholders})`;
+      params.push(...secretNames);
+    }
+
+    const result = await this.db.query(
+      `
+        SELECT id, name, encrypted_value, status, tenant_id
+        FROM "secrets"
+        WHERE tenant_id = ? AND status = 'active'${nameFilter}
+        ORDER BY name ASC
+      `,
+      ...params,
+    );
+
+    return this.rowsFromResult<SecretDiagnosisRow>(result);
+  }
+
+  private async listTenantEncryptionKeyRows(
+    tenantId: string,
+  ): Promise<TenantEncryptionKeyRow[]> {
+    const result = await this.db.query(
+      `
+        SELECT id, tenant_id, wrapped_key, amk_key_id, status, version,
+          rotate_after, retired_at, created_at, updated_at
+        FROM "tenant_encryption_keys"
+        WHERE tenant_id = ?
+        ORDER BY version DESC
+      `,
+      tenantId,
+    );
+
+    return this.rowsFromResult<TenantEncryptionKeyRow>(result);
+  }
+
+  private async listSmrtTenantKeysForDiagnosis(
+    tenantId: string,
+  ): Promise<TenantKey[]> {
+    try {
+      return await this.tenantKeys.listKeyVersions(tenantId);
+    } catch {
+      return [];
+    }
+  }
+
+  private getConfiguredAmkForDiagnosis():
+    | { usable: true; value: Buffer }
+    | { usable: false; error: string; value?: undefined } {
+    const keyHex = process.env[this.amkEnvVar];
+    if (!keyHex) {
+      return {
+        usable: false,
+        error: `Application Master Key not found in environment variable: ${this.amkEnvVar}`,
+      };
+    }
+
+    try {
+      return {
+        usable: true,
+        value: EnvelopeEncryption.parseHexKey(keyHex),
+      };
+    } catch (error) {
+      return {
+        usable: false,
+        error: `Invalid AMK in ${this.amkEnvVar}: ${
+          this.toError(error).message
+        }`,
+      };
+    }
+  }
+
+  private checkWrappedKey(wrappedKey: string, amk: Buffer): WrappedKeyCheck {
+    const fingerprint = this.getWrappedKeyFingerprint(wrappedKey);
+
+    try {
+      const parsed = EnvelopeEncryption.parseWrappedKey(wrappedKey);
+      const dataKey = EnvelopeEncryption.unwrapKey(
+        parsed.wrappedKey,
+        parsed.iv,
+        parsed.authTag,
+        amk,
+      );
+      dataKey.fill(0);
+      return { usable: true, fingerprint };
+    } catch (error) {
+      return {
+        usable: false,
+        fingerprint,
+        error: this.toError(error).message,
+      };
+    }
+  }
+
+  private getWrappedKeyFingerprint(wrappedKey: string): string | undefined {
+    try {
+      return EnvelopeEncryption.parseWrappedKey(wrappedKey).wrappedKey;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private parseSecretEnvelopeForDiagnosis(
+    secret: SecretDiagnosisRow,
+    issues: SecretKeyDriftIssue[],
+  ): EncryptedEnvelope | null {
+    try {
+      return JSON.parse(secret.encrypted_value) as EncryptedEnvelope;
+    } catch (error) {
+      issues.push({
+        code: 'secret_envelope_invalid_json',
+        severity: 'error',
+        message: 'Secret encryptedValue is not valid EncryptedEnvelope JSON.',
+        repairAction: 'delete-unrecoverable-secret',
+        secretId: secret.id,
+        secretName: secret.name,
+        sourceTable: 'secrets',
+        details: {
+          error: this.toError(error).message,
+        },
+      });
+      return null;
+    }
+  }
+
+  private async deleteRowsByIds(
+    tableName: 'secrets' | 'tenant_encryption_keys',
+    tenantId: string,
+    ids: Set<string>,
+  ): Promise<number> {
+    if (ids.size === 0) return 0;
+
+    const idList = Array.from(ids);
+    const placeholders = idList.map(() => '?').join(', ');
+    const result = await this.db.query(
+      `DELETE FROM "${tableName}" WHERE tenant_id = ? AND id IN (${placeholders})`,
+      tenantId,
+      ...idList,
+    );
+
+    return typeof result.rowCount === 'number'
+      ? result.rowCount
+      : idList.length;
+  }
+
+  private async auditSecretDriftRepairDeletes(
+    tenantId: string,
+    secretIds: Set<string>,
+    secretNames: Map<string, string>,
+  ): Promise<void> {
+    if (secretIds.size === 0) return;
+
+    const userId = this.getCurrentUserId();
+    await withTenant({ tenantId }, async () => {
+      for (const secretId of secretIds) {
+        await this.audit(
+          secretId,
+          secretNames.get(secretId) ?? '',
+          userId,
+          'delete',
+          'success',
+          {
+            action: 'repairTenantSecretKeyDrift',
+            reason: 'unrecoverable-secret-key-drift',
+          },
+        );
+      }
+    });
+  }
+
+  private rowsFromResult<T>(result: unknown): T[] {
+    if (Array.isArray(result)) return result as T[];
+    if (
+      result &&
+      typeof result === 'object' &&
+      Array.isArray((result as { rows?: unknown }).rows)
+    ) {
+      return (result as { rows: T[] }).rows;
+    }
+    return [];
+  }
+
+  private async classifyTenantKeyFailure(
+    tenantId: string,
+    secretName: string,
+    error: unknown,
+  ): Promise<Error> {
+    const normalized = this.toError(error);
+    if (!this.shouldClassifyTenantKeyFailure(normalized)) {
+      return normalized;
+    }
+
+    try {
+      const report = await this.diagnoseTenantSecretKeyDrift(tenantId, {
+        secretNames: [secretName],
+      });
+      const errorCodes = report.issues
+        .filter((issue) => issue.severity === 'error')
+        .map((issue) => issue.code);
+
+      if (errorCodes.length === 0) {
+        return normalized;
+      }
+
+      return new SecretKeyDriftError(
+        `Secret '${secretName}' for tenant '${tenantId}' failed because secret key drift was detected: ${[
+          ...new Set(errorCodes),
+        ].join(
+          ', ',
+        )}. Run diagnoseTenantSecretKeyDrift() for details and repairTenantSecretKeyDrift() for explicit cleanup of unrecoverable rows.`,
+        tenantId,
+        report,
+        normalized,
+      );
+    } catch {
+      return normalized;
+    }
+  }
+
+  private shouldClassifyTenantKeyFailure(error: Error): boolean {
+    const code = this.getSecretErrorCode(error);
+    if (error instanceof AMKUnavailableError || code === 'AMK_UNAVAILABLE') {
+      return false;
+    }
+
+    return (
+      error instanceof TenantKeyMissingError ||
+      error instanceof EncryptionError ||
+      error instanceof DecryptionError ||
+      code === 'TENANT_KEY_MISSING' ||
+      code === 'ENCRYPTION_FAILED' ||
+      code === 'DECRYPTION_FAILED'
+    );
+  }
+
+  private getSecretErrorCode(error: Error): string | undefined {
+    const code = (error as { code?: unknown }).code;
+    return typeof code === 'string' ? code : undefined;
+  }
+
+  private toError(error: unknown): Error {
+    return error instanceof Error ? error : new Error(String(error));
+  }
 
   private getCurrentUserId(): string {
     const ctx = getCurrentTenant();

--- a/packages/secrets/src/services/SecretService.ts
+++ b/packages/secrets/src/services/SecretService.ts
@@ -92,6 +92,7 @@ export type SecretKeyDriftIssueCode =
   | 'secret_envelope_invalid_wrapped_key'
   | 'secret_envelope_missing_tenant_encryption_key'
   | 'secret_envelope_unwrap_failed'
+  | 'smrt_tenant_keys_query_failed'
   | 'smrt_tenant_keys_not_mirrored';
 
 export type SecretKeyDriftRepairAction =
@@ -206,6 +207,17 @@ interface WrappedKeyCheck {
   error?: string;
   fingerprint?: string;
 }
+
+interface SmrtTenantKeyDiagnosisRows {
+  keys: TenantKey[];
+  error?: Error;
+}
+
+type TransactionCapableDatabase = DatabaseInterface & {
+  transaction?: <T>(
+    callback: (tx: DatabaseInterface) => Promise<T>,
+  ) => Promise<T>;
+};
 
 /**
  * SecretService provides high-level operations for managing per-tenant secrets.
@@ -516,7 +528,9 @@ export class SecretService {
     );
     const tenantEncryptionKeys =
       await this.listTenantEncryptionKeyRows(tenantId);
-    const smrtTenantKeys = await this.listSmrtTenantKeysForDiagnosis(tenantId);
+    const smrtTenantKeyRows =
+      await this.listSmrtTenantKeysForDiagnosis(tenantId);
+    const smrtTenantKeys = smrtTenantKeyRows.keys;
     const issues: SecretKeyDriftIssue[] = [];
 
     const activeTenantEncryptionKeys = tenantEncryptionKeys.filter(
@@ -550,6 +564,20 @@ export class SecretService {
         sourceTable: 'tenant_encryption_keys',
         details: {
           activeSecretCount: activeSecrets.length,
+        },
+      });
+    }
+
+    if (smrtTenantKeyRows.error) {
+      issues.push({
+        code: 'smrt_tenant_keys_query_failed',
+        severity: 'error',
+        message:
+          'Unable to query SMRT tenant_keys while diagnosing tenant secret key drift.',
+        repairAction: 'none',
+        sourceTable: 'tenant_keys',
+        details: {
+          error: smrtTenantKeyRows.error.message,
         },
       });
     }
@@ -646,9 +674,16 @@ export class SecretService {
       const envelope = this.parseSecretEnvelopeForDiagnosis(secret, issues);
       if (!envelope) continue;
 
+      const envelopeFingerprint = this.getWrappedKeyFingerprint(
+        envelope.wrappedKey,
+      );
       const envelopeCheck = amk.value
         ? this.checkWrappedKey(envelope.wrappedKey, amk.value)
-        : { usable: false, error: amk.error };
+        : {
+            usable: false,
+            error: amk.error,
+            fingerprint: envelopeFingerprint,
+          };
 
       if (!envelopeCheck.fingerprint) {
         issues.push({
@@ -674,9 +709,11 @@ export class SecretService {
           severity: 'error',
           message:
             'Secret envelope does not match any tenant_encryption_keys row for this tenant.',
-          repairAction: envelopeCheck.usable
+          repairAction: !amk.value
             ? 'none'
-            : 'delete-unrecoverable-secret',
+            : envelopeCheck.usable
+              ? 'none'
+              : 'delete-unrecoverable-secret',
           secretId: secret.id,
           secretName: secret.name,
           sourceTable: 'secrets',
@@ -704,7 +741,8 @@ export class SecretService {
     if (
       activeSecrets.length > 0 &&
       tenantEncryptionKeys.length > 0 &&
-      smrtTenantKeys.length === 0
+      smrtTenantKeys.length === 0 &&
+      !smrtTenantKeyRows.error
     ) {
       issues.push({
         code: 'smrt_tenant_keys_not_mirrored',
@@ -795,16 +833,32 @@ export class SecretService {
     let deletedTenantEncryptionKeys = 0;
 
     if (!dryRun) {
-      deletedSecrets = await this.deleteRowsByIds(
-        'secrets',
-        tenantId,
-        secretIds,
-      );
-      deletedTenantEncryptionKeys = await this.deleteRowsByIds(
-        'tenant_encryption_keys',
-        tenantId,
-        tenantEncryptionKeyIds,
-      );
+      const runDeletes = async (db: DatabaseInterface) => {
+        const deletedSecretRows = await this.deleteRowsByIds(
+          'secrets',
+          tenantId,
+          secretIds,
+          db,
+        );
+        const deletedTenantEncryptionKeyRows = await this.deleteRowsByIds(
+          'tenant_encryption_keys',
+          tenantId,
+          tenantEncryptionKeyIds,
+          db,
+        );
+        return {
+          deletedSecrets: deletedSecretRows,
+          deletedTenantEncryptionKeys: deletedTenantEncryptionKeyRows,
+        };
+      };
+      const txDb = this.db as TransactionCapableDatabase;
+      const deleteResult =
+        typeof txDb.transaction === 'function'
+          ? await txDb.transaction((db) => runDeletes(db))
+          : await runDeletes(this.db);
+
+      deletedSecrets = deleteResult.deletedSecrets;
+      deletedTenantEncryptionKeys = deleteResult.deletedTenantEncryptionKeys;
       await this.auditSecretDriftRepairDeletes(
         tenantId,
         secretIds,
@@ -1048,11 +1102,11 @@ export class SecretService {
 
   private async listSmrtTenantKeysForDiagnosis(
     tenantId: string,
-  ): Promise<TenantKey[]> {
+  ): Promise<SmrtTenantKeyDiagnosisRows> {
     try {
-      return await this.tenantKeys.listKeyVersions(tenantId);
-    } catch {
-      return [];
+      return { keys: await this.tenantKeys.listKeyVersions(tenantId) };
+    } catch (error) {
+      return { keys: [], error: this.toError(error) };
     }
   }
 
@@ -1139,12 +1193,13 @@ export class SecretService {
     tableName: 'secrets' | 'tenant_encryption_keys',
     tenantId: string,
     ids: Set<string>,
+    db: DatabaseInterface = this.db,
   ): Promise<number> {
     if (ids.size === 0) return 0;
 
     const idList = Array.from(ids);
     const placeholders = idList.map(() => '?').join(', ');
-    const result = await this.db.query(
+    const result = await db.query(
       `DELETE FROM "${tableName}" WHERE tenant_id = ? AND id IN (${placeholders})`,
       tenantId,
       ...idList,


### PR DESCRIPTION
Fixes #1353.

## Summary

Adds service-level diagnosis and explicit repair for tenant secret/key drift in `@happyvertical/smrt-secrets`.

- Adds `SecretService.diagnoseTenantSecretKeyDrift()` and `diagnoseCurrentTenantSecretKeyDrift()` to report active secrets, lower-level `tenant_encryption_keys`, and SMRT-visible `tenant_keys` state without exposing secret values.
- Adds `SecretService.repairTenantSecretKeyDrift()` with `dryRun` support and `confirmDeleteUnrecoverableData: true` required before deleting unrecoverable encrypted secret rows or stale tenant key rows.
- Wraps stale tenant key encryption/decryption failures in `SecretKeyDriftError` so callers can distinguish key drift from missing secret/config cases.
- Documents the two key tables and the explicit destructive repair path.

## Root Cause

The lower-level secret store uses `tenant_encryption_keys` for envelope encryption, while `smrt-secrets` also exposes a `tenant_keys` model table. When active secret rows remain but the lower-level tenant key row is stale or unusable with the current AMK, reads and writes surface as generic encryption/decryption failures. Consumers then misdiagnose the problem as missing integration configuration.

## Validation

- `pnpm --filter @happyvertical/smrt-secrets test`
- `pnpm --filter @happyvertical/smrt-secrets build`
- `pnpm --filter @happyvertical/smrt-secrets exec tsc --noEmit -p tsconfig.json`
- `pnpm exec biome check packages/secrets/src/services/SecretService.ts packages/secrets/src/__tests__/secret-service.test.ts packages/secrets/src/index.ts packages/secrets/README.md packages/secrets/AGENTS.md`
- `git diff --check`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

Note: root build regenerated unrelated `packages/content` API route source files locally; those generated changes were cleaned and are not part of this PR.