### PR TITLE
fix(smrt-svelte): raise vitest hookTimeout to 30s to unblock workspace suites

### DIFF
--- a/packages/smrt-svelte/vitest.config.ts
+++ b/packages/smrt-svelte/vitest.config.ts
@@ -26,6 +26,20 @@ export default defineConfig({
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.ts'],
     testTimeout: 30000,
+    // Match testTimeout. The smrt-vitest setup file
+    // (`@happyvertical/smrt-vitest/setup`) registers an async `afterAll` that
+    // dynamically loads `@happyvertical/smrt-core`'s table-cache module
+    // (falling back to a tsx on-the-fly transpile of the core source when the
+    // built export isn't resolvable in the worker). That module work is fast
+    // locally but can exceed the 10s `hookTimeout` default in constrained CI —
+    // where this package's two largest suites (RoleShell, define-tools-dock)
+    // timed out the teardown hook even though every test body passed
+    // (issue #1426). Other packages hitting the same setup hook already raise
+    // this (core: 120000; ads/assets/ledgers/products/vitest: 30000+);
+    // smrt-svelte previously bumped only testTimeout and left hookTimeout at
+    // the default. Surfaced repo-wide by the Vitest 4 upgrade shifting test
+    // isolation/contention timing.
+    hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
     poolOptions: {


### PR DESCRIPTION
## Summary
Fixes the main-wide CI failure tracked in #1426 where two `smrt-svelte` workspace suites fail in `Validate Changes / Test Packages`:

- `packages/smrt-svelte/src/components/workspace/__tests__/RoleShell.test.ts`
- `packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts`

## Root cause (not a component/test bug)
The CI signature is **`Error: Hook timed out in 10000ms`** with **all 252 tests passing** (`Test Files: 2 failed | 14 passed`, `Tests: 252 passed`). It's a **teardown-hook timeout**, not an assertion drift or a `RoleShell`/`defineToolsDock` regression.

The `@happyvertical/smrt-vitest` setup file injected into every suite registers an async `afterAll` that dynamically loads `@happyvertical/smrt-core`'s table-cache module (falling back to a **tsx on-the-fly transpile** of the core source when the built export isn't resolvable in the worker). That module work is fast locally but can exceed the **10s `hookTimeout` default** under constrained CI — and this package's two largest suites are the ones that tip over.

`vitest.config.ts` already raised `testTimeout` to `30000` but **left `hookTimeout` at the `10000` default** — an oversight. Every other package that hits the same setup hook already compensates:

| package | hookTimeout |
|---|---|
| core | 120000 (*"Hooks can include module setup in constrained CI"*) |
| ads / assets / ledgers / products / vitest | 30000+ |
| **smrt-svelte (before)** | **default 10000** |

It became **main-wide** after the Vitest 4 upgrade (`vitest@4.0.17`) shifted test isolation/contention timing, so it's red on every branch running this suite — including #1419 and #1424 which contain zero smrt-svelte changes.

## Fix
Set `hookTimeout: 30000` to match `testTimeout` and the repo convention. No tests are skipped, weakened, or deleted — all 16 files / 252 tests still run and assert.

## Verification (local)
- Both target suites: **2 files / 72 tests pass**.
- Full `smrt-svelte` suite: **16 files / 252 tests pass**.
- `svelte-check`: **0 errors, 0 warnings**.
- **Mechanism proof** (throwaway spec, not committed): an ~11s `afterAll`
  - **fails** at `--hookTimeout=10000` → `Hook timed out in 10000ms`, `Test Files 1 failed | Tests 1 passed` (the exact CI signature), and
  - **passes** at the new `hookTimeout: 30000`.

## Note (out of scope)
The config still carries a now-deprecated `poolOptions: { forks: { singleFork: true } }` that Vitest 4 ignores (it emits a `DEPRECATED` warning). That's a separate, harmless config-drift item — left untouched here to keep this fix surgical and reviewable.

Closes #1426