### PR TITLE
fix(smrt-svelte): emit consumed design tokens so themes resolve (#1431)

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -164,6 +164,11 @@ jobs:
       - name: Run standards check
         run: node scripts/check-standards.mjs
 
+      # Fails if any --smrt-* token consumed by smrt-svelte components is never
+      # emitted by a theme-delivery path (issue #1431). Node-only, no deps.
+      - name: Check smrt-svelte design tokens
+        run: node scripts/check-svelte-tokens.mjs
+
   test:
     name: Validate Changes
     uses: ./.github/workflows/test-suite.yml

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "dev": "turbo dev --parallel",
     "validate-build": "node scripts/validate-build.js",
     "check:standards": "node scripts/check-standards.mjs",
+    "check:svelte-tokens": "node scripts/check-svelte-tokens.mjs",
     "knowledge:check": "tsx scripts/check-knowledge.ts",
     "changeset": "changeset",
     "changeset:auto": "npx tsx scripts/auto-changeset.ts",

--- a/packages/smrt-svelte/AGENTS.md
+++ b/packages/smrt-svelte/AGENTS.md
@@ -60,7 +60,7 @@ Wraps app in `+layout.svelte`. Provides auth state, permissions, WebSocket, and 
 
 ## Themes
 
-Two theme systems: `src/theme/` (simple ThemeProvider with design tokens) and `src/themes/` (full preset system with material/glass/studio, CSS generation, runtime switching). **`src/themes/` is canonical** — it is the only path that delivers the complete `--smrt-*` token surface (colors + typography + spacing + radius + elevation + motion) across all presets. `src/theme/` is the simpler/legacy provider; it emits the same vocabulary where its categories overlap (colors, radius, elevation, motion, plus the shared aliases) but does not emit per-variant typography or the numeric spacing scale.
+Two theme systems: `src/theme/` (simple ThemeProvider with design tokens) and `src/themes/` (full preset system with material/glass/studio, CSS generation, runtime switching). **`src/themes/` is canonical** — it is the only path that delivers the complete preset-aware `--smrt-*` token surface (colors + typography + spacing + radius + elevation + motion) across material/glass/studio. `src/theme/` is the simpler/legacy provider; it emits the same CSS variable vocabulary from its single built-in scale for backward compatibility, but it does not support preset switching or preset-specific values.
 
 ### Design-token vocabulary (issue #1431)
 

--- a/packages/smrt-svelte/AGENTS.md
+++ b/packages/smrt-svelte/AGENTS.md
@@ -60,7 +60,19 @@ Wraps app in `+layout.svelte`. Provides auth state, permissions, WebSocket, and 
 
 ## Themes
 
-Two theme systems: `src/theme/` (simple ThemeProvider with design tokens) and `src/themes/` (full preset system with material/glass/studio, CSS generation, runtime switching).
+Two theme systems: `src/theme/` (simple ThemeProvider with design tokens) and `src/themes/` (full preset system with material/glass/studio, CSS generation, runtime switching). **`src/themes/` is canonical** — it is the only path that delivers the complete `--smrt-*` token surface (colors + typography + spacing + radius + elevation + motion) across all presets. `src/theme/` is the simpler/legacy provider; it emits the same vocabulary where its categories overlap (colors, radius, elevation, motion, plus the shared aliases) but does not emit per-variant typography or the numeric spacing scale.
+
+### Design-token vocabulary (issue #1431)
+
+Components consume a Material-3 vocabulary. To keep one vocabulary that always resolves, the canonical names are emitted **plus** additive aliases — never rename canonical tokens:
+
+- **Radius**: canonical `none|sm|md|lg|xl|2xl|3xl|full`; aliases `extra-small|small|medium|large|extra-large`.
+- **Spacing**: canonical numeric scale `0…24`; aliases `xs|sm|md|lg|xl|2xl|3xl` mapped onto numeric values.
+- **Motion**: canonical `instant|fast|normal|slow|slower`; aliases `short1…long4` (M3 ms scale).
+- **Typography**: per-variant `-size|-line-height|-weight|-tracking|-font-family` **plus** a `-font` CSS-shorthand alias (`weight size/line-height family`).
+- **Helpers**: `--smrt-font-family-mono`, named `--smrt-typography-weight-{normal,medium,semibold,bold}`, and `--smrt-z-index-{dropdown…tooltip}` (incl. `dialog`).
+
+Single source of truth: `src/themes/shared.ts` (alias maps) → emitted by `src/themes/css-generator.ts` (JS `ThemeProvider`), mirrored into the static preset CSS (`src/themes/styles/*.css`) and the simple provider (`src/theme/tokens.ts`). `scripts/check-svelte-tokens.mjs` (CI + `pnpm check:svelte-tokens`) fails on any consumed-but-unemitted `--smrt-*` token; `src/themes/__tests__/token-aliases.test.ts` pins the emitted set. Don't introduce new `--smrt-*` names in components without emitting them from a delivery path.
 
 ## Key Files
 

--- a/packages/smrt-svelte/src/components/calendar/Calendar.svelte
+++ b/packages/smrt-svelte/src/components/calendar/Calendar.svelte
@@ -388,7 +388,7 @@ const yearOptions = $derived(() => {
   .today-btn {
     padding: var(--smrt-spacing-1, 0.25rem) var(--smrt-spacing-4, 1rem);
     border: 1px solid var(--calendar-border);
-    border-radius: var(--radius-sm, 4px);
+    border-radius: var(--smrt-radius-small, 4px);
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     background: var(--calendar-bg);
     color: var(--smrt-color-primary, #005ac1);

--- a/packages/smrt-svelte/src/components/calendar/Calendar.svelte
+++ b/packages/smrt-svelte/src/components/calendar/Calendar.svelte
@@ -300,15 +300,20 @@ const yearOptions = $derived(() => {
     overflow: hidden;
   }
 
-  /* Dark mode */
+  /*
+   * Dark mode. The base `--smrt-color-*` tokens already swap to dark values
+   * under the active dark scheme, so reference them directly (issue #1431 —
+   * the old `--smrt-color-*-dark` tokens were never emitted). Hardcoded
+   * fallbacks preserve the calendar's dark palette when no theme is applied.
+   */
   :global([data-theme="dark"]) .calendar {
-    --calendar-bg: var(--smrt-color-surface-dark, #242424);
-    --calendar-border: var(--smrt-color-outline-variant-dark, #3a3a3a);
-    --calendar-header-bg: var(--smrt-color-surface-container-low-dark, #2e2e2e);
-    --day-hover: var(--smrt-color-surface-container-high-dark, #3a3a3a);
-    --today-bg: var(--smrt-color-primary-container-dark, #1e3a5f);
-    --today-border: var(--smrt-color-primary-dark, #64b5f6);
-    --other-month: var(--smrt-color-on-surface-variant-dark, #666666);
+    --calendar-bg: var(--smrt-color-surface, #242424);
+    --calendar-border: var(--smrt-color-outline-variant, #3a3a3a);
+    --calendar-header-bg: var(--smrt-color-surface-container-low, #2e2e2e);
+    --day-hover: var(--smrt-color-surface-container-high, #3a3a3a);
+    --today-bg: var(--smrt-color-primary-container, #1e3a5f);
+    --today-border: var(--smrt-color-primary, #64b5f6);
+    --other-month: var(--smrt-color-on-surface-variant, #666666);
   }
 
   @media (prefers-color-scheme: dark) {

--- a/packages/smrt-svelte/src/components/calendar/DayView.svelte
+++ b/packages/smrt-svelte/src/components/calendar/DayView.svelte
@@ -171,12 +171,16 @@ function getTypeLabel(type: string): string {
     background: var(--view-bg);
   }
 
-  /* Dark mode */
+  /*
+   * Dark mode. Reference the base `--smrt-color-*` tokens, which already swap
+   * to dark values under the active dark scheme (issue #1431 — the old
+   * `--smrt-color-*-dark` tokens were never emitted).
+   */
   :global([data-theme="dark"]) .day-view {
-    --view-bg: var(--smrt-color-surface-dark, #242424);
-    --view-border: var(--smrt-color-outline-variant-dark, #3a3a3a);
-    --header-bg: var(--smrt-color-surface-container-low-dark, #2e2e2e);
-    --card-hover: var(--smrt-color-surface-container-high-dark, #3a3a3a);
+    --view-bg: var(--smrt-color-surface, #242424);
+    --view-border: var(--smrt-color-outline-variant, #3a3a3a);
+    --header-bg: var(--smrt-color-surface-container-low, #2e2e2e);
+    --card-hover: var(--smrt-color-surface-container-high, #3a3a3a);
   }
 
   @media (prefers-color-scheme: dark) {

--- a/packages/smrt-svelte/src/components/data/DataTable.svelte
+++ b/packages/smrt-svelte/src/components/data/DataTable.svelte
@@ -329,7 +329,7 @@ const sizeClasses = {
     border-collapse: collapse;
     border-spacing: 0;
     font-family: var(--smrt-font-family, inherit);
-    font-size: var(--smrt-font-size-sm, 0.875rem);
+    font-size: var(--smrt-typography-body-small-size, 0.875rem);
     color: var(--smrt-color-on-surface, #111827);
     background: var(--smrt-color-surface, #ffffff);
   }

--- a/packages/smrt-svelte/src/components/data/DataTable.svelte
+++ b/packages/smrt-svelte/src/components/data/DataTable.svelte
@@ -132,12 +132,13 @@ const sortedData = $derived.by(() => {
   if (!column) return data;
 
   const accessor = column.accessor ?? column.id;
+  const direction = sort.direction;
 
   return [...data].sort((a, b) => {
     if (column.sortFn) {
-      return column.sortFn(a, b, sort.direction!);
+      return column.sortFn(a, b, direction);
     }
-    return defaultSort(a, b, String(accessor), sort.direction!);
+    return defaultSort(a, b, String(accessor), direction);
   });
 });
 
@@ -329,7 +330,7 @@ const sizeClasses = {
     border-collapse: collapse;
     border-spacing: 0;
     font-family: var(--smrt-font-family, inherit);
-    font-size: var(--smrt-typography-body-small-size, 0.875rem);
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     color: var(--smrt-color-on-surface, #111827);
     background: var(--smrt-color-surface, #ffffff);
   }

--- a/packages/smrt-svelte/src/components/forms/Form.svelte
+++ b/packages/smrt-svelte/src/components/forms/Form.svelte
@@ -739,7 +739,10 @@ function getFormData(): Record<string, unknown> {
     left: 0;
     right: 0;
     padding: 12px 24px;
-    background: rgba(var(--smrt-color-primary-rgb, 22, 101, 52), 0.9);
+    /* 90%-opacity primary. The old `--smrt-color-primary-rgb` channel token
+       was never emitted (issue #1431); color-mix derives the alpha from the
+       emitted `--smrt-color-primary` token instead. */
+    background: color-mix(in srgb, var(--smrt-color-primary, #166534) 90%, transparent);
     color: white;
     font-size: 0.875rem;
     box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.15);

--- a/packages/smrt-svelte/src/components/module/ModulePanel.svelte
+++ b/packages/smrt-svelte/src/components/module/ModulePanel.svelte
@@ -109,7 +109,7 @@ const slotMeta = $derived(moduleMeta?.uiSlots?.[slotId]);
   }
 
   .module-panel-placeholder__code {
-    font-family: var(--smrt-typography-font-mono, 'SF Mono', 'Monaco', 'Consolas', monospace);
+    font-family: var(--smrt-font-family-mono, 'SF Mono', 'Monaco', 'Consolas', monospace);
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     padding: var(--smrt-spacing-1, 0.25rem) var(--smrt-spacing-2, 0.5rem);
     background: var(--smrt-color-surface-container-high, #e2e8f0);

--- a/packages/smrt-svelte/src/components/ui/Card.svelte
+++ b/packages/smrt-svelte/src/components/ui/Card.svelte
@@ -108,8 +108,8 @@ const {
     padding: var(--smrt-spacing-6);
     border-top: 1px solid var(--smrt-color-outline-variant);
     background: var(--smrt-color-surface-container-low);
-    border-bottom-left-radius: var(--radius-md);
-    border-bottom-right-radius: var(--radius-md);
+    border-bottom-left-radius: var(--smrt-radius-medium);
+    border-bottom-right-radius: var(--smrt-radius-medium);
   }
 
   .padding-sm .card-footer {

--- a/packages/smrt-svelte/src/theme/tokens.ts
+++ b/packages/smrt-svelte/src/theme/tokens.ts
@@ -17,6 +17,7 @@ import {
   durationAliases,
   fontFamilyAliases,
   fontWeightTokens,
+  spacingAliases,
   zIndexTokens,
 } from '../themes/shared.js';
 
@@ -378,6 +379,44 @@ export function generateColorVariables(
 }
 
 /**
+ * Generate CSS custom properties from typography tokens.
+ */
+function generateTypographyVariables(): Record<string, string> {
+  const vars: Record<string, string> = {};
+
+  for (const [key, token] of Object.entries(typography)) {
+    const cssKey = key.replace(/([A-Z])/g, '-$1').toLowerCase();
+    const family =
+      'var(--smrt-font-family, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif)';
+    vars[`--smrt-typography-${cssKey}-size`] = token.size;
+    vars[`--smrt-typography-${cssKey}-line-height`] = token.lineHeight;
+    vars[`--smrt-typography-${cssKey}-weight`] = String(token.weight);
+    vars[`--smrt-typography-${cssKey}-tracking`] = token.tracking;
+    vars[`--smrt-typography-${cssKey}-font-family`] = family;
+    vars[`--smrt-typography-${cssKey}-font`] =
+      `${token.weight} ${token.size}/${token.lineHeight} ${family}`;
+  }
+
+  return vars;
+}
+
+/**
+ * Generate CSS custom properties from spacing tokens.
+ */
+function generateSpacingVariables(): Record<string, string> {
+  const vars: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(spacing)) {
+    vars[`--smrt-spacing-${key.replace(/\./g, '_')}`] = value;
+  }
+  for (const [alias, scaleKey] of Object.entries(spacingAliases)) {
+    vars[`--smrt-spacing-${alias}`] = spacing[scaleKey];
+  }
+
+  return vars;
+}
+
+/**
  * Generate all CSS custom properties for a theme
  */
 export function generateThemeVariables(
@@ -388,6 +427,11 @@ export function generateThemeVariables(
 
   const vars: Record<string, string> = {
     ...colorVars,
+    '--smrt-color-scheme': isDark ? 'dark' : 'light',
+    '--smrt-font-family':
+      'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+    ...generateTypographyVariables(),
+    ...generateSpacingVariables(),
     // Border radius
     '--smrt-radius-none': borderRadius.none,
     '--smrt-radius-sm': borderRadius.sm,

--- a/packages/smrt-svelte/src/theme/tokens.ts
+++ b/packages/smrt-svelte/src/theme/tokens.ts
@@ -98,6 +98,10 @@ export const lightColors = {
   surfaceContainer: '#f3f4f6',
   surfaceContainerLow: '#f9fafb',
   surfaceContainerHigh: '#e5e7eb',
+  surfaceContainerHighest: '#d1d5db',
+  surfaceContainerLowest: '#ffffff',
+  surfaceDim: '#e5e7eb',
+  surfaceBright: '#ffffff',
 
   // Outline
   outline: '#d1d5db',
@@ -113,6 +117,7 @@ export const lightColors = {
   inversePrimary: '#93c5fd',
 
   // Scrim
+  shadow: '#000000',
   scrim: 'rgba(0, 0, 0, 0.5)',
 };
 
@@ -165,6 +170,10 @@ export const darkColors = {
   surfaceContainer: '#1f2937',
   surfaceContainerLow: '#111827',
   surfaceContainerHigh: '#374151',
+  surfaceContainerHighest: '#4b5563',
+  surfaceContainerLowest: '#030712',
+  surfaceDim: '#1f2937',
+  surfaceBright: '#374151',
 
   // Outline
   outline: '#4b5563',
@@ -180,6 +189,7 @@ export const darkColors = {
   inversePrimary: '#2563eb',
 
   // Scrim
+  shadow: '#000000',
   scrim: 'rgba(0, 0, 0, 0.7)',
 };
 

--- a/packages/smrt-svelte/src/theme/tokens.ts
+++ b/packages/smrt-svelte/src/theme/tokens.ts
@@ -3,7 +3,22 @@
  *
  * Based on Material Design 3 color system with semantic tokens
  * for consistent theming across components.
+ *
+ * NOTE: this is the simple/legacy `src/theme/` ThemeProvider. The canonical
+ * full token surface (spacing + typography included) lives in the preset
+ * system under `src/themes/` (Material/Glass/Studio + css-generator.ts). The
+ * additive Material-3 aliases (issue #1431) are imported from the shared
+ * preset tokens so both providers stay in lock-step where their categories
+ * overlap.
  */
+
+import {
+  borderRadiusAliases,
+  durationAliases,
+  fontFamilyAliases,
+  fontWeightTokens,
+  zIndexTokens,
+} from '../themes/shared.js';
 
 /**
  * Color scheme type
@@ -371,7 +386,7 @@ export function generateThemeVariables(
   const colors = isDark ? darkColors : lightColors;
   const colorVars = generateColorVariables(colors);
 
-  return {
+  const vars: Record<string, string> = {
     ...colorVars,
     // Border radius
     '--smrt-radius-none': borderRadius.none,
@@ -403,4 +418,24 @@ export function generateThemeVariables(
     '--smrt-easing-emphasized-decelerate': easing.emphasizedDecelerate,
     '--smrt-easing-emphasized-accelerate': easing.emphasizedAccelerate,
   };
+
+  // Additive Material-3 aliases + theme-independent helper tokens (#1431),
+  // mirroring the preset system so both providers expose the same vocabulary.
+  for (const [alias, scaleKey] of Object.entries(borderRadiusAliases)) {
+    vars[`--smrt-radius-${alias}`] = borderRadius[scaleKey];
+  }
+  for (const [alias, value] of Object.entries(durationAliases)) {
+    vars[`--smrt-duration-${alias}`] = value;
+  }
+  for (const [alias, value] of Object.entries(fontFamilyAliases)) {
+    vars[`--smrt-font-family-${alias}`] = value;
+  }
+  for (const [name, value] of Object.entries(fontWeightTokens)) {
+    vars[`--smrt-typography-weight-${name}`] = value;
+  }
+  for (const [name, value] of Object.entries(zIndexTokens)) {
+    vars[`--smrt-z-index-${name}`] = value;
+  }
+
+  return vars;
 }

--- a/packages/smrt-svelte/src/themes/__tests__/token-aliases.test.ts
+++ b/packages/smrt-svelte/src/themes/__tests__/token-aliases.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Design-token alias contract (issue #1431).
+ *
+ * Components consume a Material-3 token vocabulary (`radius-small`,
+ * `duration-short2`, `spacing-md`, `typography-*-font`, …) that must resolve to
+ * real values across every preset. These tests pin the additive aliases emitted
+ * by the canonical preset generator (`css-generator.ts`) and the simple
+ * `src/theme/` ThemeProvider so a regression that drops a consumed alias fails
+ * here as well as in scripts/check-svelte-tokens.mjs.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { generateThemeVariables as generateSimpleThemeVariables } from '../../theme/tokens.js';
+import { generateThemeVariables } from '../css-generator.js';
+import { themes } from '../registry.js';
+
+/** Material-3 + helper aliases that components consume and expect emitted. */
+const REQUIRED_ALIASES = [
+  // Radius (Material-3 named scale)
+  '--smrt-radius-extra-small',
+  '--smrt-radius-small',
+  '--smrt-radius-medium',
+  '--smrt-radius-large',
+  '--smrt-radius-extra-large',
+  // Motion (Material-3 duration scale)
+  '--smrt-duration-short1',
+  '--smrt-duration-short2',
+  '--smrt-duration-short3',
+  '--smrt-duration-short4',
+  '--smrt-duration-medium1',
+  '--smrt-duration-medium2',
+  '--smrt-duration-medium3',
+  '--smrt-duration-medium4',
+  '--smrt-duration-long1',
+  '--smrt-duration-long2',
+  '--smrt-duration-long3',
+  '--smrt-duration-long4',
+  // Helper tokens (theme-independent)
+  '--smrt-font-family-mono',
+  '--smrt-typography-weight-normal',
+  '--smrt-typography-weight-medium',
+  '--smrt-typography-weight-semibold',
+  '--smrt-typography-weight-bold',
+  '--smrt-z-index-dialog',
+];
+
+/** Spacing aliases are only emitted by the preset generator. */
+const PRESET_ONLY_ALIASES = [
+  '--smrt-spacing-xs',
+  '--smrt-spacing-sm',
+  '--smrt-spacing-md',
+  '--smrt-spacing-lg',
+  '--smrt-spacing-xl',
+  '--smrt-spacing-2xl',
+  '--smrt-spacing-3xl',
+];
+
+const TYPOGRAPHY_FONT_SHORTHANDS = [
+  '--smrt-typography-body-large-font',
+  '--smrt-typography-body-medium-font',
+  '--smrt-typography-body-small-font',
+  '--smrt-typography-label-large-font',
+  '--smrt-typography-label-medium-font',
+  '--smrt-typography-label-small-font',
+  '--smrt-typography-title-large-font',
+  '--smrt-typography-title-medium-font',
+  '--smrt-typography-title-small-font',
+  '--smrt-typography-headline-small-font',
+  '--smrt-typography-headline-medium-font',
+];
+
+describe('preset generator alias emission (#1431)', () => {
+  for (const theme of Object.values(themes)) {
+    for (const isDark of [false, true]) {
+      it(`${theme.id} ${isDark ? 'dark' : 'light'} emits every consumed alias`, () => {
+        const vars = generateThemeVariables(theme, isDark);
+        for (const token of [
+          ...REQUIRED_ALIASES,
+          ...PRESET_ONLY_ALIASES,
+          ...TYPOGRAPHY_FONT_SHORTHANDS,
+        ]) {
+          expect(vars[token], `${token} should be emitted`).toBeDefined();
+          expect(vars[token]).not.toBe('');
+        }
+      });
+    }
+  }
+
+  it('maps Material-3 radius aliases onto canonical t-shirt values', () => {
+    const vars = generateThemeVariables(themes.material, false);
+    expect(vars['--smrt-radius-small']).toBe(vars['--smrt-radius-sm']);
+    expect(vars['--smrt-radius-medium']).toBe(vars['--smrt-radius-md']);
+    expect(vars['--smrt-radius-large']).toBe(vars['--smrt-radius-lg']);
+  });
+
+  it('maps named spacing aliases onto numeric-scale values', () => {
+    const vars = generateThemeVariables(themes.material, false);
+    expect(vars['--smrt-spacing-sm']).toBe(vars['--smrt-spacing-2']);
+    expect(vars['--smrt-spacing-md']).toBe(vars['--smrt-spacing-4']);
+    expect(vars['--smrt-spacing-xl']).toBe(vars['--smrt-spacing-8']);
+  });
+
+  it('builds the typography `font` shorthand from the emitted longhands', () => {
+    const vars = generateThemeVariables(themes.material, false);
+    const shorthand = vars['--smrt-typography-body-medium-font'];
+    expect(shorthand).toContain(vars['--smrt-typography-body-medium-size']);
+    // weight size/line-height family
+    expect(shorthand).toMatch(/^\d+\s+\S+\/\S+\s+.+$/);
+  });
+});
+
+describe('simple ThemeProvider alias emission (#1431)', () => {
+  for (const isDark of [false, true]) {
+    it(`${isDark ? 'dark' : 'light'} emits radius/duration/helper aliases`, () => {
+      const vars = generateSimpleThemeVariables(isDark);
+      for (const token of REQUIRED_ALIASES) {
+        expect(vars[token], `${token} should be emitted`).toBeDefined();
+        expect(vars[token]).not.toBe('');
+      }
+    });
+  }
+});

--- a/packages/smrt-svelte/src/themes/__tests__/token-aliases.test.ts
+++ b/packages/smrt-svelte/src/themes/__tests__/token-aliases.test.ts
@@ -9,6 +9,8 @@
  * here as well as in scripts/check-svelte-tokens.mjs.
  */
 
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { generateThemeVariables as generateSimpleThemeVariables } from '../../theme/tokens.js';
 import { generateThemeVariables } from '../css-generator.js';
@@ -22,6 +24,14 @@ const REQUIRED_ALIASES = [
   '--smrt-radius-medium',
   '--smrt-radius-large',
   '--smrt-radius-extra-large',
+  // Spacing (named aliases)
+  '--smrt-spacing-xs',
+  '--smrt-spacing-sm',
+  '--smrt-spacing-md',
+  '--smrt-spacing-lg',
+  '--smrt-spacing-xl',
+  '--smrt-spacing-2xl',
+  '--smrt-spacing-3xl',
   // Motion (Material-3 duration scale)
   '--smrt-duration-short1',
   '--smrt-duration-short2',
@@ -44,15 +54,28 @@ const REQUIRED_ALIASES = [
   '--smrt-z-index-dialog',
 ];
 
-/** Spacing aliases are only emitted by the preset generator. */
-const PRESET_ONLY_ALIASES = [
-  '--smrt-spacing-xs',
-  '--smrt-spacing-sm',
-  '--smrt-spacing-md',
-  '--smrt-spacing-lg',
-  '--smrt-spacing-xl',
-  '--smrt-spacing-2xl',
-  '--smrt-spacing-3xl',
+const SPACING_NUMERIC_TOKENS = [
+  '--smrt-spacing-0',
+  '--smrt-spacing-0_5',
+  '--smrt-spacing-1',
+  '--smrt-spacing-1_5',
+  '--smrt-spacing-2',
+  '--smrt-spacing-2_5',
+  '--smrt-spacing-3',
+  '--smrt-spacing-3_5',
+  '--smrt-spacing-4',
+  '--smrt-spacing-5',
+  '--smrt-spacing-6',
+  '--smrt-spacing-7',
+  '--smrt-spacing-8',
+  '--smrt-spacing-9',
+  '--smrt-spacing-10',
+  '--smrt-spacing-11',
+  '--smrt-spacing-12',
+  '--smrt-spacing-14',
+  '--smrt-spacing-16',
+  '--smrt-spacing-20',
+  '--smrt-spacing-24',
 ];
 
 const TYPOGRAPHY_FONT_SHORTHANDS = [
@@ -69,6 +92,22 @@ const TYPOGRAPHY_FONT_SHORTHANDS = [
   '--smrt-typography-headline-medium-font',
 ];
 
+const packageRoot = process.cwd().endsWith('packages/smrt-svelte')
+  ? process.cwd()
+  : join(process.cwd(), 'packages/smrt-svelte');
+
+const STATIC_STYLE_PATHS = {
+  material: join(packageRoot, 'src/themes/styles/material.css'),
+  glass: join(packageRoot, 'src/themes/styles/glass.css'),
+  studio: join(packageRoot, 'src/themes/styles/studio.css'),
+};
+
+function collectDefinedTokens(css: string): Set<string> {
+  return new Set(
+    [...css.matchAll(/(--smrt-[a-z0-9_-]+)\s*:/gi)].map((match) => match[1]),
+  );
+}
+
 describe('preset generator alias emission (#1431)', () => {
   for (const theme of Object.values(themes)) {
     for (const isDark of [false, true]) {
@@ -76,7 +115,7 @@ describe('preset generator alias emission (#1431)', () => {
         const vars = generateThemeVariables(theme, isDark);
         for (const token of [
           ...REQUIRED_ALIASES,
-          ...PRESET_ONLY_ALIASES,
+          ...SPACING_NUMERIC_TOKENS,
           ...TYPOGRAPHY_FONT_SHORTHANDS,
         ]) {
           expect(vars[token], `${token} should be emitted`).toBeDefined();
@@ -109,11 +148,33 @@ describe('preset generator alias emission (#1431)', () => {
   });
 });
 
+describe('static preset CSS token surface (#1431)', () => {
+  for (const theme of Object.values(themes)) {
+    it(`${theme.id} stylesheet contains the generated token surface`, () => {
+      const css = readFileSync(STATIC_STYLE_PATHS[theme.id], 'utf8');
+      const defined = collectDefinedTokens(css);
+      const generatedTokens = new Set([
+        ...Object.keys(generateThemeVariables(theme, false)),
+        ...Object.keys(generateThemeVariables(theme, true)),
+      ]);
+      const missing = [...generatedTokens]
+        .filter((token) => !defined.has(token))
+        .sort();
+
+      expect(missing).toEqual([]);
+    });
+  }
+});
+
 describe('simple ThemeProvider alias emission (#1431)', () => {
   for (const isDark of [false, true]) {
-    it(`${isDark ? 'dark' : 'light'} emits radius/duration/helper aliases`, () => {
+    it(`${isDark ? 'dark' : 'light'} emits shared aliases and component scale tokens`, () => {
       const vars = generateSimpleThemeVariables(isDark);
-      for (const token of REQUIRED_ALIASES) {
+      for (const token of [
+        ...REQUIRED_ALIASES,
+        ...SPACING_NUMERIC_TOKENS,
+        ...TYPOGRAPHY_FONT_SHORTHANDS,
+      ]) {
         expect(vars[token], `${token} should be emitted`).toBeDefined();
         expect(vars[token]).not.toBe('');
       }

--- a/packages/smrt-svelte/src/themes/__tests__/token-aliases.test.ts
+++ b/packages/smrt-svelte/src/themes/__tests__/token-aliases.test.ts
@@ -92,6 +92,14 @@ const TYPOGRAPHY_FONT_SHORTHANDS = [
   '--smrt-typography-headline-medium-font',
 ];
 
+const BASE_COMPONENT_COLOR_TOKENS = [
+  '--smrt-color-surface-container-highest',
+  '--smrt-color-surface-container-lowest',
+  '--smrt-color-surface-dim',
+  '--smrt-color-surface-bright',
+  '--smrt-color-shadow',
+];
+
 const packageRoot = process.cwd().endsWith('packages/smrt-svelte')
   ? process.cwd()
   : join(process.cwd(), 'packages/smrt-svelte');
@@ -174,6 +182,7 @@ describe('simple ThemeProvider alias emission (#1431)', () => {
         ...REQUIRED_ALIASES,
         ...SPACING_NUMERIC_TOKENS,
         ...TYPOGRAPHY_FONT_SHORTHANDS,
+        ...BASE_COMPONENT_COLOR_TOKENS,
       ]) {
         expect(vars[token], `${token} should be emitted`).toBeDefined();
         expect(vars[token]).not.toBe('');

--- a/packages/smrt-svelte/src/themes/css-generator.ts
+++ b/packages/smrt-svelte/src/themes/css-generator.ts
@@ -6,6 +6,14 @@
  */
 
 import { themes } from './registry.js';
+import {
+  borderRadiusAliases,
+  durationAliases,
+  fontFamilyAliases,
+  fontWeightTokens,
+  spacingAliases,
+  zIndexTokens,
+} from './shared.js';
 import type {
   BorderRadiusScale,
   ColorPalette,
@@ -64,6 +72,13 @@ function generateTypographyVariables(
     if (token.fontFamily) {
       vars[`${prefix}-typography-${cssKey}-font-family`] = token.fontFamily;
     }
+    // Additive `font` shorthand alias (issue #1431): components use
+    // `font: var(--smrt-typography-body-medium-font)`, expecting the CSS
+    // `font` shorthand order (style variant size/line-height family). Built
+    // from the emitted longhands so it stays in sync.
+    const family = token.fontFamily ?? `var(${prefix}-font-family)`;
+    vars[`${prefix}-typography-${cssKey}-font`] =
+      `${token.weight} ${token.size}/${token.lineHeight} ${family}`;
   }
 
   return vars;
@@ -84,6 +99,12 @@ function generateSpacingVariables(
     vars[`${prefix}-spacing-${cssKey}`] = value;
   }
 
+  // Additive Material-3 named aliases (issue #1431), mapped to numeric values.
+  for (const [alias, numericKey] of Object.entries(spacingAliases)) {
+    const value = spacing[numericKey];
+    if (value !== undefined) vars[`${prefix}-spacing-${alias}`] = value;
+  }
+
   return vars;
 }
 
@@ -99,6 +120,12 @@ function generateBorderRadiusVariables(
   for (const [key, value] of Object.entries(borderRadius)) {
     const cssKey = key.replace(/([A-Z])/g, '-$1').toLowerCase();
     vars[`${prefix}-radius-${cssKey}`] = value;
+  }
+
+  // Additive Material-3 named aliases (issue #1431), mapped to t-shirt values.
+  for (const [alias, scaleKey] of Object.entries(borderRadiusAliases)) {
+    const value = borderRadius[scaleKey];
+    if (value !== undefined) vars[`${prefix}-radius-${alias}`] = value;
   }
 
   return vars;
@@ -132,6 +159,11 @@ function generateDurationVariables(
   for (const [key, value] of Object.entries(duration)) {
     const cssKey = key.replace(/([A-Z])/g, '-$1').toLowerCase();
     vars[`${prefix}-duration-${cssKey}`] = value;
+  }
+
+  // Additive Material-3 motion aliases (issue #1431): short1…long4.
+  for (const [alias, value] of Object.entries(durationAliases)) {
+    vars[`${prefix}-duration-${alias}`] = value;
   }
 
   return vars;
@@ -169,6 +201,28 @@ function generateGlassVariables(
     [`${prefix}-glass-border-opacity`]: glass.borderOpacity,
     [`${prefix}-glass-background-opacity`]: glass.backgroundOpacity,
   };
+}
+
+/**
+ * Generate theme-independent helper tokens (issue #1431).
+ *
+ * Monospace font family, named font weights, and z-index stacking levels are
+ * the same across presets and color schemes. Emitting them as tokens lets
+ * components stop hardcoding magic values and keeps overlay layering / mono
+ * surfaces themeable.
+ */
+function generateStaticTokens(prefix: string): Record<string, string> {
+  const vars: Record<string, string> = {};
+  for (const [alias, value] of Object.entries(fontFamilyAliases)) {
+    vars[`${prefix}-font-family-${alias}`] = value;
+  }
+  for (const [name, value] of Object.entries(fontWeightTokens)) {
+    vars[`${prefix}-typography-weight-${name}`] = value;
+  }
+  for (const [name, value] of Object.entries(zIndexTokens)) {
+    vars[`${prefix}-z-index-${name}`] = value;
+  }
+  return vars;
 }
 
 /**
@@ -213,6 +267,9 @@ export function generateThemeVariables(
 
     // Easing
     ...generateEasingVariables(theme.easing, prefix),
+
+    // Theme-independent helper tokens (mono font, named weights, z-index)
+    ...generateStaticTokens(prefix),
 
     // Glass effects (if present)
     ...generateGlassVariables(theme.glass, prefix),

--- a/packages/smrt-svelte/src/themes/shared.ts
+++ b/packages/smrt-svelte/src/themes/shared.ts
@@ -39,6 +39,24 @@ export const spacingScale: SpacingScale = {
 };
 
 /**
+ * Material-3 spacing aliases (issue #1431).
+ *
+ * Components authored against Material-3 vocabulary consume `--smrt-spacing-sm`
+ * / `-md` / `-xl` etc. The numeric scale above is canonical; these aliases map
+ * the named sizes onto numeric-scale keys so both vocabularies resolve. Emitted
+ * in addition to (never instead of) the numeric scale.
+ */
+export const spacingAliases: Record<string, keyof SpacingScale> = {
+  xs: 1, // 0.25rem
+  sm: 2, // 0.5rem
+  md: 4, // 1rem
+  lg: 6, // 1.5rem
+  xl: 8, // 2rem
+  '2xl': 12, // 3rem
+  '3xl': 16, // 4rem
+};
+
+/**
  * Shared border radius scale
  */
 export const borderRadiusScale: BorderRadiusScale = {
@@ -53,6 +71,20 @@ export const borderRadiusScale: BorderRadiusScale = {
 };
 
 /**
+ * Material-3 border-radius aliases (issue #1431).
+ *
+ * Maps Material-3 named radii (`extra-small` … `extra-large`) onto the
+ * canonical t-shirt scale. Emitted in addition to the canonical names.
+ */
+export const borderRadiusAliases: Record<string, keyof BorderRadiusScale> = {
+  'extra-small': 'sm',
+  small: 'sm',
+  medium: 'md',
+  large: 'lg',
+  'extra-large': 'xl',
+};
+
+/**
  * Shared duration scale
  */
 export const durationScale: DurationScale = {
@@ -61,6 +93,70 @@ export const durationScale: DurationScale = {
   normal: '200ms',
   slow: '300ms',
   slower: '500ms',
+};
+
+/**
+ * Material-3 motion-duration aliases (issue #1431).
+ *
+ * Components consume Material-3 motion tokens (`short2`, `short3`, `medium1`…).
+ * These map onto absolute millisecond values following the M3 motion spec
+ * (short1=50 … long4=600). Emitted in addition to the canonical
+ * instant/fast/normal/slow/slower scale so both vocabularies resolve.
+ */
+export const durationAliases: Record<string, string> = {
+  short1: '50ms',
+  short2: '100ms',
+  short3: '150ms',
+  short4: '200ms',
+  medium1: '250ms',
+  medium2: '300ms',
+  medium3: '350ms',
+  medium4: '400ms',
+  long1: '450ms',
+  long2: '500ms',
+  long3: '550ms',
+  long4: '600ms',
+};
+
+/**
+ * Shared font-family aliases (issue #1431).
+ *
+ * The base body font is `--smrt-font-family`; components also reference a
+ * monospace family. Emitted as an explicit token so monospace surfaces (code,
+ * transcripts, module IDs) are themeable rather than frozen at a fallback.
+ */
+export const fontFamilyAliases: Record<string, string> = {
+  mono: 'ui-monospace, "SF Mono", "Monaco", "Cascadia Code", "Consolas", monospace',
+};
+
+/**
+ * Shared named font-weight tokens (issue #1431).
+ *
+ * The typography scale exposes per-variant weights; these named weights cover
+ * generic emphasis (badges, progress labels) that aren't tied to a variant.
+ */
+export const fontWeightTokens: Record<string, string> = {
+  normal: '400',
+  medium: '500',
+  semibold: '600',
+  bold: '700',
+};
+
+/**
+ * Shared z-index scale (issue #1431).
+ *
+ * Stacking-context tokens for overlay surfaces so consumers stop hardcoding
+ * magic numbers and overlays can be re-layered theme-wide.
+ */
+export const zIndexTokens: Record<string, string> = {
+  dropdown: '1000',
+  sticky: '1100',
+  overlay: '1200',
+  modal: '1300',
+  dialog: '1300',
+  popover: '1400',
+  toast: '1500',
+  tooltip: '1600',
 };
 
 /**

--- a/packages/smrt-svelte/src/themes/styles/glass.css
+++ b/packages/smrt-svelte/src/themes/styles/glass.css
@@ -275,15 +275,37 @@
   --smrt-radius-large: var(--smrt-radius-lg);
   --smrt-radius-extra-large: var(--smrt-radius-xl);
 
-  /* Spacing aliases (named -> numeric-scale values; static CSS has no
-     numeric spacing tokens, so literal rems matching shared.ts) */
-  --smrt-spacing-xs: 0.25rem;
-  --smrt-spacing-sm: 0.5rem;
-  --smrt-spacing-md: 1rem;
-  --smrt-spacing-lg: 1.5rem;
-  --smrt-spacing-xl: 2rem;
-  --smrt-spacing-2xl: 3rem;
-  --smrt-spacing-3xl: 4rem;
+  /* Spacing (numeric scale) */
+  --smrt-spacing-0: 0;
+  --smrt-spacing-0_5: 0.125rem;
+  --smrt-spacing-1: 0.25rem;
+  --smrt-spacing-1_5: 0.375rem;
+  --smrt-spacing-2: 0.5rem;
+  --smrt-spacing-2_5: 0.625rem;
+  --smrt-spacing-3: 0.75rem;
+  --smrt-spacing-3_5: 0.875rem;
+  --smrt-spacing-4: 1rem;
+  --smrt-spacing-5: 1.25rem;
+  --smrt-spacing-6: 1.5rem;
+  --smrt-spacing-7: 1.75rem;
+  --smrt-spacing-8: 2rem;
+  --smrt-spacing-9: 2.25rem;
+  --smrt-spacing-10: 2.5rem;
+  --smrt-spacing-11: 2.75rem;
+  --smrt-spacing-12: 3rem;
+  --smrt-spacing-14: 3.5rem;
+  --smrt-spacing-16: 4rem;
+  --smrt-spacing-20: 5rem;
+  --smrt-spacing-24: 6rem;
+
+  /* Spacing aliases (named -> numeric-scale values) */
+  --smrt-spacing-xs: var(--smrt-spacing-1);
+  --smrt-spacing-sm: var(--smrt-spacing-2);
+  --smrt-spacing-md: var(--smrt-spacing-4);
+  --smrt-spacing-lg: var(--smrt-spacing-6);
+  --smrt-spacing-xl: var(--smrt-spacing-8);
+  --smrt-spacing-2xl: var(--smrt-spacing-12);
+  --smrt-spacing-3xl: var(--smrt-spacing-16);
 
   /* Motion duration aliases (M3 short1..long4) */
   --smrt-duration-short1: 50ms;

--- a/packages/smrt-svelte/src/themes/styles/glass.css
+++ b/packages/smrt-svelte/src/themes/styles/glass.css
@@ -258,3 +258,152 @@
   -webkit-backdrop-filter: blur(calc(var(--smrt-glass-blur) * 0.5)) saturate(var(--smrt-glass-saturation));
   border: 1px solid var(--smrt-color-glass-border);
 }
+
+/*
+ * Material-3 vocabulary aliases + helper tokens (issue #1431).
+ * Scheme-independent, so declared once on the theme selector. These mirror the
+ * additive aliases emitted by src/themes/css-generator.ts so the static-CSS
+ * delivery path resolves the same consumed tokens as the JS ThemeProvider.
+ * Radius aliases reference the canonical t-shirt tokens so a preset that
+ * retunes its radius scale updates the aliases automatically.
+ */
+[data-theme="glass"] {
+  /* Radius aliases -> canonical t-shirt scale */
+  --smrt-radius-extra-small: var(--smrt-radius-sm);
+  --smrt-radius-small: var(--smrt-radius-sm);
+  --smrt-radius-medium: var(--smrt-radius-md);
+  --smrt-radius-large: var(--smrt-radius-lg);
+  --smrt-radius-extra-large: var(--smrt-radius-xl);
+
+  /* Spacing aliases (named -> numeric-scale values; static CSS has no
+     numeric spacing tokens, so literal rems matching shared.ts) */
+  --smrt-spacing-xs: 0.25rem;
+  --smrt-spacing-sm: 0.5rem;
+  --smrt-spacing-md: 1rem;
+  --smrt-spacing-lg: 1.5rem;
+  --smrt-spacing-xl: 2rem;
+  --smrt-spacing-2xl: 3rem;
+  --smrt-spacing-3xl: 4rem;
+
+  /* Motion duration aliases (M3 short1..long4) */
+  --smrt-duration-short1: 50ms;
+  --smrt-duration-short2: 100ms;
+  --smrt-duration-short3: 150ms;
+  --smrt-duration-short4: 200ms;
+  --smrt-duration-medium1: 250ms;
+  --smrt-duration-medium2: 300ms;
+  --smrt-duration-medium3: 350ms;
+  --smrt-duration-medium4: 400ms;
+  --smrt-duration-long1: 450ms;
+  --smrt-duration-long2: 500ms;
+  --smrt-duration-long3: 550ms;
+  --smrt-duration-long4: 600ms;
+
+  /* Helper tokens */
+  --smrt-font-family-mono: ui-monospace, "SF Mono", "Monaco", "Cascadia Code", "Consolas", monospace;
+  --smrt-typography-weight-normal: 400;
+  --smrt-typography-weight-medium: 500;
+  --smrt-typography-weight-semibold: 600;
+  --smrt-typography-weight-bold: 700;
+  --smrt-z-index-dropdown: 1000;
+  --smrt-z-index-sticky: 1100;
+  --smrt-z-index-overlay: 1200;
+  --smrt-z-index-modal: 1300;
+  --smrt-z-index-dialog: 1300;
+  --smrt-z-index-popover: 1400;
+  --smrt-z-index-toast: 1500;
+  --smrt-z-index-tooltip: 1600;
+
+  /* Typography (issue #1431): full scale incl. `font` shorthand,
+     so the static-CSS path matches the JS ThemeProvider output) */
+  --smrt-typography-display-large-size: 3rem;
+  --smrt-typography-display-large-line-height: 1.1;
+  --smrt-typography-display-large-weight: 600;
+  --smrt-typography-display-large-tracking: -0.022em;
+  --smrt-typography-display-large-font-family: var(--smrt-font-family);
+  --smrt-typography-display-large-font: 600 3rem/1.1 var(--smrt-font-family);
+  --smrt-typography-display-medium-size: 2.5rem;
+  --smrt-typography-display-medium-line-height: 1.15;
+  --smrt-typography-display-medium-weight: 600;
+  --smrt-typography-display-medium-tracking: -0.021em;
+  --smrt-typography-display-medium-font-family: var(--smrt-font-family);
+  --smrt-typography-display-medium-font: 600 2.5rem/1.15 var(--smrt-font-family);
+  --smrt-typography-display-small-size: 2rem;
+  --smrt-typography-display-small-line-height: 1.2;
+  --smrt-typography-display-small-weight: 600;
+  --smrt-typography-display-small-tracking: -0.019em;
+  --smrt-typography-display-small-font-family: var(--smrt-font-family);
+  --smrt-typography-display-small-font: 600 2rem/1.2 var(--smrt-font-family);
+  --smrt-typography-headline-large-size: 1.75rem;
+  --smrt-typography-headline-large-line-height: 1.25;
+  --smrt-typography-headline-large-weight: 600;
+  --smrt-typography-headline-large-tracking: -0.017em;
+  --smrt-typography-headline-large-font-family: var(--smrt-font-family);
+  --smrt-typography-headline-large-font: 600 1.75rem/1.25 var(--smrt-font-family);
+  --smrt-typography-headline-medium-size: 1.5rem;
+  --smrt-typography-headline-medium-line-height: 1.3;
+  --smrt-typography-headline-medium-weight: 600;
+  --smrt-typography-headline-medium-tracking: -0.015em;
+  --smrt-typography-headline-medium-font-family: var(--smrt-font-family);
+  --smrt-typography-headline-medium-font: 600 1.5rem/1.3 var(--smrt-font-family);
+  --smrt-typography-headline-small-size: 1.25rem;
+  --smrt-typography-headline-small-line-height: 1.35;
+  --smrt-typography-headline-small-weight: 600;
+  --smrt-typography-headline-small-tracking: -0.012em;
+  --smrt-typography-headline-small-font-family: var(--smrt-font-family);
+  --smrt-typography-headline-small-font: 600 1.25rem/1.35 var(--smrt-font-family);
+  --smrt-typography-title-large-size: 1.25rem;
+  --smrt-typography-title-large-line-height: 1.4;
+  --smrt-typography-title-large-weight: 600;
+  --smrt-typography-title-large-tracking: -0.012em;
+  --smrt-typography-title-large-font-family: var(--smrt-font-family);
+  --smrt-typography-title-large-font: 600 1.25rem/1.4 var(--smrt-font-family);
+  --smrt-typography-title-medium-size: 1.0625rem;
+  --smrt-typography-title-medium-line-height: 1.4;
+  --smrt-typography-title-medium-weight: 600;
+  --smrt-typography-title-medium-tracking: -0.011em;
+  --smrt-typography-title-medium-font-family: var(--smrt-font-family);
+  --smrt-typography-title-medium-font: 600 1.0625rem/1.4 var(--smrt-font-family);
+  --smrt-typography-title-small-size: 0.9375rem;
+  --smrt-typography-title-small-line-height: 1.4;
+  --smrt-typography-title-small-weight: 600;
+  --smrt-typography-title-small-tracking: -0.009em;
+  --smrt-typography-title-small-font-family: var(--smrt-font-family);
+  --smrt-typography-title-small-font: 600 0.9375rem/1.4 var(--smrt-font-family);
+  --smrt-typography-body-large-size: 1.0625rem;
+  --smrt-typography-body-large-line-height: 1.5;
+  --smrt-typography-body-large-weight: 400;
+  --smrt-typography-body-large-tracking: -0.011em;
+  --smrt-typography-body-large-font-family: var(--smrt-font-family);
+  --smrt-typography-body-large-font: 400 1.0625rem/1.5 var(--smrt-font-family);
+  --smrt-typography-body-medium-size: 0.9375rem;
+  --smrt-typography-body-medium-line-height: 1.5;
+  --smrt-typography-body-medium-weight: 400;
+  --smrt-typography-body-medium-tracking: -0.009em;
+  --smrt-typography-body-medium-font-family: var(--smrt-font-family);
+  --smrt-typography-body-medium-font: 400 0.9375rem/1.5 var(--smrt-font-family);
+  --smrt-typography-body-small-size: 0.8125rem;
+  --smrt-typography-body-small-line-height: 1.4;
+  --smrt-typography-body-small-weight: 400;
+  --smrt-typography-body-small-tracking: -0.006em;
+  --smrt-typography-body-small-font-family: var(--smrt-font-family);
+  --smrt-typography-body-small-font: 400 0.8125rem/1.4 var(--smrt-font-family);
+  --smrt-typography-label-large-size: 0.9375rem;
+  --smrt-typography-label-large-line-height: 1.4;
+  --smrt-typography-label-large-weight: 500;
+  --smrt-typography-label-large-tracking: -0.009em;
+  --smrt-typography-label-large-font-family: var(--smrt-font-family);
+  --smrt-typography-label-large-font: 500 0.9375rem/1.4 var(--smrt-font-family);
+  --smrt-typography-label-medium-size: 0.8125rem;
+  --smrt-typography-label-medium-line-height: 1.4;
+  --smrt-typography-label-medium-weight: 500;
+  --smrt-typography-label-medium-tracking: -0.006em;
+  --smrt-typography-label-medium-font-family: var(--smrt-font-family);
+  --smrt-typography-label-medium-font: 500 0.8125rem/1.4 var(--smrt-font-family);
+  --smrt-typography-label-small-size: 0.6875rem;
+  --smrt-typography-label-small-line-height: 1.3;
+  --smrt-typography-label-small-weight: 600;
+  --smrt-typography-label-small-tracking: -0.004em;
+  --smrt-typography-label-small-font-family: var(--smrt-font-family);
+  --smrt-typography-label-small-font: 600 0.6875rem/1.3 var(--smrt-font-family);
+}

--- a/packages/smrt-svelte/src/themes/styles/material.css
+++ b/packages/smrt-svelte/src/themes/styles/material.css
@@ -190,3 +190,152 @@
   --smrt-color-scheme: dark;
   --smrt-font-family: "Google Sans", "Roboto", system-ui, -apple-system, sans-serif;
 }
+
+/*
+ * Material-3 vocabulary aliases + helper tokens (issue #1431).
+ * Scheme-independent, so declared once on the theme selector. These mirror the
+ * additive aliases emitted by src/themes/css-generator.ts so the static-CSS
+ * delivery path resolves the same consumed tokens as the JS ThemeProvider.
+ * Radius aliases reference the canonical t-shirt tokens so a preset that
+ * retunes its radius scale updates the aliases automatically.
+ */
+[data-theme="material"] {
+  /* Radius aliases -> canonical t-shirt scale */
+  --smrt-radius-extra-small: var(--smrt-radius-sm);
+  --smrt-radius-small: var(--smrt-radius-sm);
+  --smrt-radius-medium: var(--smrt-radius-md);
+  --smrt-radius-large: var(--smrt-radius-lg);
+  --smrt-radius-extra-large: var(--smrt-radius-xl);
+
+  /* Spacing aliases (named -> numeric-scale values; static CSS has no
+     numeric spacing tokens, so literal rems matching shared.ts) */
+  --smrt-spacing-xs: 0.25rem;
+  --smrt-spacing-sm: 0.5rem;
+  --smrt-spacing-md: 1rem;
+  --smrt-spacing-lg: 1.5rem;
+  --smrt-spacing-xl: 2rem;
+  --smrt-spacing-2xl: 3rem;
+  --smrt-spacing-3xl: 4rem;
+
+  /* Motion duration aliases (M3 short1..long4) */
+  --smrt-duration-short1: 50ms;
+  --smrt-duration-short2: 100ms;
+  --smrt-duration-short3: 150ms;
+  --smrt-duration-short4: 200ms;
+  --smrt-duration-medium1: 250ms;
+  --smrt-duration-medium2: 300ms;
+  --smrt-duration-medium3: 350ms;
+  --smrt-duration-medium4: 400ms;
+  --smrt-duration-long1: 450ms;
+  --smrt-duration-long2: 500ms;
+  --smrt-duration-long3: 550ms;
+  --smrt-duration-long4: 600ms;
+
+  /* Helper tokens */
+  --smrt-font-family-mono: ui-monospace, "SF Mono", "Monaco", "Cascadia Code", "Consolas", monospace;
+  --smrt-typography-weight-normal: 400;
+  --smrt-typography-weight-medium: 500;
+  --smrt-typography-weight-semibold: 600;
+  --smrt-typography-weight-bold: 700;
+  --smrt-z-index-dropdown: 1000;
+  --smrt-z-index-sticky: 1100;
+  --smrt-z-index-overlay: 1200;
+  --smrt-z-index-modal: 1300;
+  --smrt-z-index-dialog: 1300;
+  --smrt-z-index-popover: 1400;
+  --smrt-z-index-toast: 1500;
+  --smrt-z-index-tooltip: 1600;
+
+  /* Typography (issue #1431): full scale incl. `font` shorthand,
+     so the static-CSS path matches the JS ThemeProvider output) */
+  --smrt-typography-display-large-size: 3.5rem;
+  --smrt-typography-display-large-line-height: 1.1;
+  --smrt-typography-display-large-weight: 400;
+  --smrt-typography-display-large-tracking: -0.02em;
+  --smrt-typography-display-large-font-family: var(--smrt-font-family);
+  --smrt-typography-display-large-font: 400 3.5rem/1.1 var(--smrt-font-family);
+  --smrt-typography-display-medium-size: 2.75rem;
+  --smrt-typography-display-medium-line-height: 1.15;
+  --smrt-typography-display-medium-weight: 400;
+  --smrt-typography-display-medium-tracking: -0.01em;
+  --smrt-typography-display-medium-font-family: var(--smrt-font-family);
+  --smrt-typography-display-medium-font: 400 2.75rem/1.15 var(--smrt-font-family);
+  --smrt-typography-display-small-size: 2.25rem;
+  --smrt-typography-display-small-line-height: 1.2;
+  --smrt-typography-display-small-weight: 400;
+  --smrt-typography-display-small-tracking: 0;
+  --smrt-typography-display-small-font-family: var(--smrt-font-family);
+  --smrt-typography-display-small-font: 400 2.25rem/1.2 var(--smrt-font-family);
+  --smrt-typography-headline-large-size: 2rem;
+  --smrt-typography-headline-large-line-height: 1.25;
+  --smrt-typography-headline-large-weight: 400;
+  --smrt-typography-headline-large-tracking: 0;
+  --smrt-typography-headline-large-font-family: var(--smrt-font-family);
+  --smrt-typography-headline-large-font: 400 2rem/1.25 var(--smrt-font-family);
+  --smrt-typography-headline-medium-size: 1.75rem;
+  --smrt-typography-headline-medium-line-height: 1.3;
+  --smrt-typography-headline-medium-weight: 400;
+  --smrt-typography-headline-medium-tracking: 0;
+  --smrt-typography-headline-medium-font-family: var(--smrt-font-family);
+  --smrt-typography-headline-medium-font: 400 1.75rem/1.3 var(--smrt-font-family);
+  --smrt-typography-headline-small-size: 1.5rem;
+  --smrt-typography-headline-small-line-height: 1.35;
+  --smrt-typography-headline-small-weight: 400;
+  --smrt-typography-headline-small-tracking: 0;
+  --smrt-typography-headline-small-font-family: var(--smrt-font-family);
+  --smrt-typography-headline-small-font: 400 1.5rem/1.35 var(--smrt-font-family);
+  --smrt-typography-title-large-size: 1.375rem;
+  --smrt-typography-title-large-line-height: 1.4;
+  --smrt-typography-title-large-weight: 500;
+  --smrt-typography-title-large-tracking: 0;
+  --smrt-typography-title-large-font-family: var(--smrt-font-family);
+  --smrt-typography-title-large-font: 500 1.375rem/1.4 var(--smrt-font-family);
+  --smrt-typography-title-medium-size: 1rem;
+  --smrt-typography-title-medium-line-height: 1.5;
+  --smrt-typography-title-medium-weight: 500;
+  --smrt-typography-title-medium-tracking: 0.01em;
+  --smrt-typography-title-medium-font-family: var(--smrt-font-family);
+  --smrt-typography-title-medium-font: 500 1rem/1.5 var(--smrt-font-family);
+  --smrt-typography-title-small-size: 0.875rem;
+  --smrt-typography-title-small-line-height: 1.5;
+  --smrt-typography-title-small-weight: 500;
+  --smrt-typography-title-small-tracking: 0.01em;
+  --smrt-typography-title-small-font-family: var(--smrt-font-family);
+  --smrt-typography-title-small-font: 500 0.875rem/1.5 var(--smrt-font-family);
+  --smrt-typography-body-large-size: 1rem;
+  --smrt-typography-body-large-line-height: 1.5;
+  --smrt-typography-body-large-weight: 400;
+  --smrt-typography-body-large-tracking: 0.03em;
+  --smrt-typography-body-large-font-family: var(--smrt-font-family);
+  --smrt-typography-body-large-font: 400 1rem/1.5 var(--smrt-font-family);
+  --smrt-typography-body-medium-size: 0.875rem;
+  --smrt-typography-body-medium-line-height: 1.5;
+  --smrt-typography-body-medium-weight: 400;
+  --smrt-typography-body-medium-tracking: 0.02em;
+  --smrt-typography-body-medium-font-family: var(--smrt-font-family);
+  --smrt-typography-body-medium-font: 400 0.875rem/1.5 var(--smrt-font-family);
+  --smrt-typography-body-small-size: 0.75rem;
+  --smrt-typography-body-small-line-height: 1.4;
+  --smrt-typography-body-small-weight: 400;
+  --smrt-typography-body-small-tracking: 0.03em;
+  --smrt-typography-body-small-font-family: var(--smrt-font-family);
+  --smrt-typography-body-small-font: 400 0.75rem/1.4 var(--smrt-font-family);
+  --smrt-typography-label-large-size: 0.875rem;
+  --smrt-typography-label-large-line-height: 1.4;
+  --smrt-typography-label-large-weight: 500;
+  --smrt-typography-label-large-tracking: 0.01em;
+  --smrt-typography-label-large-font-family: var(--smrt-font-family);
+  --smrt-typography-label-large-font: 500 0.875rem/1.4 var(--smrt-font-family);
+  --smrt-typography-label-medium-size: 0.75rem;
+  --smrt-typography-label-medium-line-height: 1.4;
+  --smrt-typography-label-medium-weight: 500;
+  --smrt-typography-label-medium-tracking: 0.05em;
+  --smrt-typography-label-medium-font-family: var(--smrt-font-family);
+  --smrt-typography-label-medium-font: 500 0.75rem/1.4 var(--smrt-font-family);
+  --smrt-typography-label-small-size: 0.6875rem;
+  --smrt-typography-label-small-line-height: 1.4;
+  --smrt-typography-label-small-weight: 500;
+  --smrt-typography-label-small-tracking: 0.05em;
+  --smrt-typography-label-small-font-family: var(--smrt-font-family);
+  --smrt-typography-label-small-font: 500 0.6875rem/1.4 var(--smrt-font-family);
+}

--- a/packages/smrt-svelte/src/themes/styles/material.css
+++ b/packages/smrt-svelte/src/themes/styles/material.css
@@ -19,6 +19,29 @@
   --smrt-radius-3xl: 2rem;
   --smrt-radius-full: 9999px;
 
+  /* Spacing (numeric scale) */
+  --smrt-spacing-0: 0;
+  --smrt-spacing-0_5: 0.125rem;
+  --smrt-spacing-1: 0.25rem;
+  --smrt-spacing-1_5: 0.375rem;
+  --smrt-spacing-2: 0.5rem;
+  --smrt-spacing-2_5: 0.625rem;
+  --smrt-spacing-3: 0.75rem;
+  --smrt-spacing-3_5: 0.875rem;
+  --smrt-spacing-4: 1rem;
+  --smrt-spacing-5: 1.25rem;
+  --smrt-spacing-6: 1.5rem;
+  --smrt-spacing-7: 1.75rem;
+  --smrt-spacing-8: 2rem;
+  --smrt-spacing-9: 2.25rem;
+  --smrt-spacing-10: 2.5rem;
+  --smrt-spacing-11: 2.75rem;
+  --smrt-spacing-12: 3rem;
+  --smrt-spacing-14: 3.5rem;
+  --smrt-spacing-16: 4rem;
+  --smrt-spacing-20: 5rem;
+  --smrt-spacing-24: 6rem;
+
   /* Elevation (shared between light and dark) */
   --smrt-elevation-0: none;
   --smrt-elevation-1: 0 1px 2px 0 rgb(0 0 0 / 0.05), 0 1px 3px 0 rgb(0 0 0 / 0.02);
@@ -207,15 +230,14 @@
   --smrt-radius-large: var(--smrt-radius-lg);
   --smrt-radius-extra-large: var(--smrt-radius-xl);
 
-  /* Spacing aliases (named -> numeric-scale values; static CSS has no
-     numeric spacing tokens, so literal rems matching shared.ts) */
-  --smrt-spacing-xs: 0.25rem;
-  --smrt-spacing-sm: 0.5rem;
-  --smrt-spacing-md: 1rem;
-  --smrt-spacing-lg: 1.5rem;
-  --smrt-spacing-xl: 2rem;
-  --smrt-spacing-2xl: 3rem;
-  --smrt-spacing-3xl: 4rem;
+  /* Spacing aliases (named -> numeric-scale values) */
+  --smrt-spacing-xs: var(--smrt-spacing-1);
+  --smrt-spacing-sm: var(--smrt-spacing-2);
+  --smrt-spacing-md: var(--smrt-spacing-4);
+  --smrt-spacing-lg: var(--smrt-spacing-6);
+  --smrt-spacing-xl: var(--smrt-spacing-8);
+  --smrt-spacing-2xl: var(--smrt-spacing-12);
+  --smrt-spacing-3xl: var(--smrt-spacing-16);
 
   /* Motion duration aliases (M3 short1..long4) */
   --smrt-duration-short1: 50ms;

--- a/packages/smrt-svelte/src/themes/styles/studio.css
+++ b/packages/smrt-svelte/src/themes/styles/studio.css
@@ -242,3 +242,152 @@
   outline: 2px solid var(--smrt-color-primary);
   outline-offset: 2px;
 }
+
+/*
+ * Material-3 vocabulary aliases + helper tokens (issue #1431).
+ * Scheme-independent, so declared once on the theme selector. These mirror the
+ * additive aliases emitted by src/themes/css-generator.ts so the static-CSS
+ * delivery path resolves the same consumed tokens as the JS ThemeProvider.
+ * Radius aliases reference the canonical t-shirt tokens so a preset that
+ * retunes its radius scale updates the aliases automatically.
+ */
+[data-theme="studio"] {
+  /* Radius aliases -> canonical t-shirt scale */
+  --smrt-radius-extra-small: var(--smrt-radius-sm);
+  --smrt-radius-small: var(--smrt-radius-sm);
+  --smrt-radius-medium: var(--smrt-radius-md);
+  --smrt-radius-large: var(--smrt-radius-lg);
+  --smrt-radius-extra-large: var(--smrt-radius-xl);
+
+  /* Spacing aliases (named -> numeric-scale values; static CSS has no
+     numeric spacing tokens, so literal rems matching shared.ts) */
+  --smrt-spacing-xs: 0.25rem;
+  --smrt-spacing-sm: 0.5rem;
+  --smrt-spacing-md: 1rem;
+  --smrt-spacing-lg: 1.5rem;
+  --smrt-spacing-xl: 2rem;
+  --smrt-spacing-2xl: 3rem;
+  --smrt-spacing-3xl: 4rem;
+
+  /* Motion duration aliases (M3 short1..long4) */
+  --smrt-duration-short1: 50ms;
+  --smrt-duration-short2: 100ms;
+  --smrt-duration-short3: 150ms;
+  --smrt-duration-short4: 200ms;
+  --smrt-duration-medium1: 250ms;
+  --smrt-duration-medium2: 300ms;
+  --smrt-duration-medium3: 350ms;
+  --smrt-duration-medium4: 400ms;
+  --smrt-duration-long1: 450ms;
+  --smrt-duration-long2: 500ms;
+  --smrt-duration-long3: 550ms;
+  --smrt-duration-long4: 600ms;
+
+  /* Helper tokens */
+  --smrt-font-family-mono: ui-monospace, "SF Mono", "Monaco", "Cascadia Code", "Consolas", monospace;
+  --smrt-typography-weight-normal: 400;
+  --smrt-typography-weight-medium: 500;
+  --smrt-typography-weight-semibold: 600;
+  --smrt-typography-weight-bold: 700;
+  --smrt-z-index-dropdown: 1000;
+  --smrt-z-index-sticky: 1100;
+  --smrt-z-index-overlay: 1200;
+  --smrt-z-index-modal: 1300;
+  --smrt-z-index-dialog: 1300;
+  --smrt-z-index-popover: 1400;
+  --smrt-z-index-toast: 1500;
+  --smrt-z-index-tooltip: 1600;
+
+  /* Typography (issue #1431): full scale incl. `font` shorthand,
+     so the static-CSS path matches the JS ThemeProvider output) */
+  --smrt-typography-display-large-size: 3rem;
+  --smrt-typography-display-large-line-height: 1.1;
+  --smrt-typography-display-large-weight: 400;
+  --smrt-typography-display-large-tracking: -0.01em;
+  --smrt-typography-display-large-font-family: var(--smrt-font-family);
+  --smrt-typography-display-large-font: 400 3rem/1.1 var(--smrt-font-family);
+  --smrt-typography-display-medium-size: 2.5rem;
+  --smrt-typography-display-medium-line-height: 1.15;
+  --smrt-typography-display-medium-weight: 400;
+  --smrt-typography-display-medium-tracking: -0.008em;
+  --smrt-typography-display-medium-font-family: var(--smrt-font-family);
+  --smrt-typography-display-medium-font: 400 2.5rem/1.15 var(--smrt-font-family);
+  --smrt-typography-display-small-size: 2rem;
+  --smrt-typography-display-small-line-height: 1.2;
+  --smrt-typography-display-small-weight: 400;
+  --smrt-typography-display-small-tracking: -0.005em;
+  --smrt-typography-display-small-font-family: var(--smrt-font-family);
+  --smrt-typography-display-small-font: 400 2rem/1.2 var(--smrt-font-family);
+  --smrt-typography-headline-large-size: 1.75rem;
+  --smrt-typography-headline-large-line-height: 1.25;
+  --smrt-typography-headline-large-weight: 400;
+  --smrt-typography-headline-large-tracking: 0;
+  --smrt-typography-headline-large-font-family: var(--smrt-font-family);
+  --smrt-typography-headline-large-font: 400 1.75rem/1.25 var(--smrt-font-family);
+  --smrt-typography-headline-medium-size: 1.5rem;
+  --smrt-typography-headline-medium-line-height: 1.3;
+  --smrt-typography-headline-medium-weight: 400;
+  --smrt-typography-headline-medium-tracking: 0;
+  --smrt-typography-headline-medium-font-family: var(--smrt-font-family);
+  --smrt-typography-headline-medium-font: 400 1.5rem/1.3 var(--smrt-font-family);
+  --smrt-typography-headline-small-size: 1.25rem;
+  --smrt-typography-headline-small-line-height: 1.35;
+  --smrt-typography-headline-small-weight: 500;
+  --smrt-typography-headline-small-tracking: 0;
+  --smrt-typography-headline-small-font-family: var(--smrt-font-family);
+  --smrt-typography-headline-small-font: 500 1.25rem/1.35 var(--smrt-font-family);
+  --smrt-typography-title-large-size: 1.125rem;
+  --smrt-typography-title-large-line-height: 1.4;
+  --smrt-typography-title-large-weight: 500;
+  --smrt-typography-title-large-tracking: 0;
+  --smrt-typography-title-large-font-family: var(--smrt-font-family);
+  --smrt-typography-title-large-font: 500 1.125rem/1.4 var(--smrt-font-family);
+  --smrt-typography-title-medium-size: 1rem;
+  --smrt-typography-title-medium-line-height: 1.5;
+  --smrt-typography-title-medium-weight: 500;
+  --smrt-typography-title-medium-tracking: 0.01em;
+  --smrt-typography-title-medium-font-family: var(--smrt-font-family);
+  --smrt-typography-title-medium-font: 500 1rem/1.5 var(--smrt-font-family);
+  --smrt-typography-title-small-size: 0.875rem;
+  --smrt-typography-title-small-line-height: 1.5;
+  --smrt-typography-title-small-weight: 500;
+  --smrt-typography-title-small-tracking: 0.01em;
+  --smrt-typography-title-small-font-family: var(--smrt-font-family);
+  --smrt-typography-title-small-font: 500 0.875rem/1.5 var(--smrt-font-family);
+  --smrt-typography-body-large-size: 1rem;
+  --smrt-typography-body-large-line-height: 1.6;
+  --smrt-typography-body-large-weight: 400;
+  --smrt-typography-body-large-tracking: 0;
+  --smrt-typography-body-large-font-family: var(--smrt-font-family);
+  --smrt-typography-body-large-font: 400 1rem/1.6 var(--smrt-font-family);
+  --smrt-typography-body-medium-size: 0.875rem;
+  --smrt-typography-body-medium-line-height: 1.6;
+  --smrt-typography-body-medium-weight: 400;
+  --smrt-typography-body-medium-tracking: 0;
+  --smrt-typography-body-medium-font-family: var(--smrt-font-family);
+  --smrt-typography-body-medium-font: 400 0.875rem/1.6 var(--smrt-font-family);
+  --smrt-typography-body-small-size: 0.75rem;
+  --smrt-typography-body-small-line-height: 1.5;
+  --smrt-typography-body-small-weight: 400;
+  --smrt-typography-body-small-tracking: 0.01em;
+  --smrt-typography-body-small-font-family: var(--smrt-font-family);
+  --smrt-typography-body-small-font: 400 0.75rem/1.5 var(--smrt-font-family);
+  --smrt-typography-label-large-size: 0.875rem;
+  --smrt-typography-label-large-line-height: 1.5;
+  --smrt-typography-label-large-weight: 500;
+  --smrt-typography-label-large-tracking: 0.02em;
+  --smrt-typography-label-large-font-family: var(--smrt-font-family);
+  --smrt-typography-label-large-font: 500 0.875rem/1.5 var(--smrt-font-family);
+  --smrt-typography-label-medium-size: 0.75rem;
+  --smrt-typography-label-medium-line-height: 1.5;
+  --smrt-typography-label-medium-weight: 500;
+  --smrt-typography-label-medium-tracking: 0.025em;
+  --smrt-typography-label-medium-font-family: var(--smrt-font-family);
+  --smrt-typography-label-medium-font: 500 0.75rem/1.5 var(--smrt-font-family);
+  --smrt-typography-label-small-size: 0.6875rem;
+  --smrt-typography-label-small-line-height: 1.4;
+  --smrt-typography-label-small-weight: 500;
+  --smrt-typography-label-small-tracking: 0.03em;
+  --smrt-typography-label-small-font-family: var(--smrt-font-family);
+  --smrt-typography-label-small-font: 500 0.6875rem/1.4 var(--smrt-font-family);
+}

--- a/packages/smrt-svelte/src/themes/styles/studio.css
+++ b/packages/smrt-svelte/src/themes/styles/studio.css
@@ -259,15 +259,37 @@
   --smrt-radius-large: var(--smrt-radius-lg);
   --smrt-radius-extra-large: var(--smrt-radius-xl);
 
-  /* Spacing aliases (named -> numeric-scale values; static CSS has no
-     numeric spacing tokens, so literal rems matching shared.ts) */
-  --smrt-spacing-xs: 0.25rem;
-  --smrt-spacing-sm: 0.5rem;
-  --smrt-spacing-md: 1rem;
-  --smrt-spacing-lg: 1.5rem;
-  --smrt-spacing-xl: 2rem;
-  --smrt-spacing-2xl: 3rem;
-  --smrt-spacing-3xl: 4rem;
+  /* Spacing (numeric scale) */
+  --smrt-spacing-0: 0;
+  --smrt-spacing-0_5: 0.125rem;
+  --smrt-spacing-1: 0.25rem;
+  --smrt-spacing-1_5: 0.375rem;
+  --smrt-spacing-2: 0.5rem;
+  --smrt-spacing-2_5: 0.625rem;
+  --smrt-spacing-3: 0.75rem;
+  --smrt-spacing-3_5: 0.875rem;
+  --smrt-spacing-4: 1rem;
+  --smrt-spacing-5: 1.25rem;
+  --smrt-spacing-6: 1.5rem;
+  --smrt-spacing-7: 1.75rem;
+  --smrt-spacing-8: 2rem;
+  --smrt-spacing-9: 2.25rem;
+  --smrt-spacing-10: 2.5rem;
+  --smrt-spacing-11: 2.75rem;
+  --smrt-spacing-12: 3rem;
+  --smrt-spacing-14: 3.5rem;
+  --smrt-spacing-16: 4rem;
+  --smrt-spacing-20: 5rem;
+  --smrt-spacing-24: 6rem;
+
+  /* Spacing aliases (named -> numeric-scale values) */
+  --smrt-spacing-xs: var(--smrt-spacing-1);
+  --smrt-spacing-sm: var(--smrt-spacing-2);
+  --smrt-spacing-md: var(--smrt-spacing-4);
+  --smrt-spacing-lg: var(--smrt-spacing-6);
+  --smrt-spacing-xl: var(--smrt-spacing-8);
+  --smrt-spacing-2xl: var(--smrt-spacing-12);
+  --smrt-spacing-3xl: var(--smrt-spacing-16);
 
   /* Motion duration aliases (M3 short1..long4) */
   --smrt-duration-short1: 50ms;

--- a/scripts/check-svelte-tokens.mjs
+++ b/scripts/check-svelte-tokens.mjs
@@ -72,8 +72,9 @@ function collectDefinedInCss(text, into) {
  * The theme scale KEYS the generator iterates over. Mirrors
  * src/themes/types.ts (SpacingScale / TypographyScale / etc.) and
  * src/themes/shared.ts. Kept here so the check stays a pure string diff with
- * no module loading; src/themes/__tests__/css-generator.test.ts asserts the
- * generator output matches these keys so drift is caught by unit tests too.
+ * no module loading; src/themes/__tests__/token-aliases.test.ts compares
+ * static preset CSS against the real generator output so name-surface drift is
+ * caught by unit tests too.
  */
 const SCALE_KEYS = {
   spacing: [

--- a/scripts/check-svelte-tokens.mjs
+++ b/scripts/check-svelte-tokens.mjs
@@ -19,6 +19,8 @@
  * .svelte / .ts / .css file under packages/smrt-svelte/src.
  *
  * Exit code: 0 if every consumed token is emitted, 1 otherwise.
+ * Also verifies that each static preset stylesheet contains the token names
+ * emitted by the JS preset generator for that preset.
  *
  * Run: `node scripts/check-svelte-tokens.mjs` or `pnpm check:svelte-tokens`.
  */
@@ -45,7 +47,7 @@ function listFiles(dir, exts) {
   return out;
 }
 
-const VAR_RE = /var\(\s*(--smrt-[a-z0-9-]+)/gi;
+const VAR_RE = /var\(\s*(--smrt-[a-z0-9_-]+)/gi;
 
 /** Collect every `--smrt-*` token referenced via var() under SRC. */
 function collectConsumed() {
@@ -59,7 +61,7 @@ function collectConsumed() {
   return consumed;
 }
 
-const DEFINE_RE = /(--smrt-[a-z0-9-]+)\s*:/gi;
+const DEFINE_RE = /(--smrt-[a-z0-9_-]+)\s*:/gi;
 
 /** Collect every `--smrt-*` token DEFINED (`--smrt-x: value`) in a CSS string. */
 function collectDefinedInCss(text, into) {
@@ -113,7 +115,7 @@ const TYPOGRAPHY_SUFFIXES = [
   'font',
 ];
 
-const COLOR_TOKENS = [
+const BASE_COLOR_TOKENS = [
   'primary', 'on-primary', 'primary-container', 'on-primary-container',
   'secondary', 'on-secondary', 'secondary-container', 'on-secondary-container',
   'tertiary', 'on-tertiary', 'tertiary-container', 'on-tertiary-container',
@@ -128,7 +130,24 @@ const COLOR_TOKENS = [
   'outline', 'outline-variant',
   'inverse-surface', 'inverse-on-surface', 'inverse-primary',
   'shadow', 'scrim',
+];
+
+const GLASS_COLOR_TOKENS = [
   'glass-backdrop', 'glass-border',
+];
+
+const GLASS_EFFECT_TOKENS = [
+  '--smrt-glass-blur',
+  '--smrt-glass-saturation',
+  '--smrt-glass-border-opacity',
+  '--smrt-glass-background-opacity',
+];
+
+const FONT_WEIGHT_TOKEN_NAMES = ['normal', 'medium', 'semibold', 'bold'];
+
+const Z_INDEX_TOKEN_NAMES = [
+  'dropdown', 'sticky', 'overlay', 'modal', 'dialog', 'popover', 'toast',
+  'tooltip',
 ];
 
 /**
@@ -137,15 +156,14 @@ const COLOR_TOKENS = [
  * real runtime delivery path, so a consumed token they emit is themeable.
  */
 function collectGeneratorEmitted(into) {
-  for (const c of COLOR_TOKENS) into.add(`--smrt-color-${c}`);
+  for (const c of [...BASE_COLOR_TOKENS, ...GLASS_COLOR_TOKENS]) {
+    into.add(`--smrt-color-${c}`);
+  }
   into.add('--smrt-color-scheme');
   into.add('--smrt-theme-id');
   into.add('--smrt-theme-name');
   into.add('--smrt-font-family');
-  into.add('--smrt-glass-blur');
-  into.add('--smrt-glass-saturation');
-  into.add('--smrt-glass-border-opacity');
-  into.add('--smrt-glass-background-opacity');
+  for (const token of GLASS_EFFECT_TOKENS) into.add(token);
   for (const k of SCALE_KEYS.spacing) into.add(`--smrt-spacing-${k}`);
   for (const k of SCALE_KEYS.radius) into.add(`--smrt-radius-${k}`);
   for (const k of SCALE_KEYS.duration) into.add(`--smrt-duration-${k}`);
@@ -156,6 +174,68 @@ function collectGeneratorEmitted(into) {
       into.add(`--smrt-typography-${v}-${s}`);
     }
   }
+  into.add('--smrt-font-family-mono');
+  for (const name of FONT_WEIGHT_TOKEN_NAMES) {
+    into.add(`--smrt-typography-weight-${name}`);
+  }
+  for (const name of Z_INDEX_TOKEN_NAMES) {
+    into.add(`--smrt-z-index-${name}`);
+  }
+}
+
+function collectPresetGeneratorTokens({ includeGlass = false } = {}) {
+  const emitted = new Set();
+  for (const c of BASE_COLOR_TOKENS) emitted.add(`--smrt-color-${c}`);
+  if (includeGlass) {
+    for (const c of GLASS_COLOR_TOKENS) emitted.add(`--smrt-color-${c}`);
+  }
+  emitted.add('--smrt-color-scheme');
+  emitted.add('--smrt-theme-id');
+  emitted.add('--smrt-theme-name');
+  emitted.add('--smrt-font-family');
+  if (includeGlass) {
+    for (const token of GLASS_EFFECT_TOKENS) emitted.add(token);
+  }
+  for (const k of SCALE_KEYS.spacing) emitted.add(`--smrt-spacing-${k}`);
+  for (const k of SCALE_KEYS.radius) emitted.add(`--smrt-radius-${k}`);
+  for (const k of SCALE_KEYS.duration) emitted.add(`--smrt-duration-${k}`);
+  for (const k of SCALE_KEYS.easing) emitted.add(`--smrt-easing-${k}`);
+  for (const k of SCALE_KEYS.elevation) emitted.add(`--smrt-elevation-${k}`);
+  for (const v of TYPOGRAPHY_VARIANTS) {
+    for (const s of TYPOGRAPHY_SUFFIXES) {
+      emitted.add(`--smrt-typography-${v}-${s}`);
+    }
+  }
+  emitted.add('--smrt-font-family-mono');
+  for (const name of FONT_WEIGHT_TOKEN_NAMES) {
+    emitted.add(`--smrt-typography-weight-${name}`);
+  }
+  for (const name of Z_INDEX_TOKEN_NAMES) {
+    emitted.add(`--smrt-z-index-${name}`);
+  }
+  return emitted;
+}
+
+function collectStaticPresetMissing() {
+  const stylesDir = join(SRC, 'themes', 'styles');
+  const presetFiles = {
+    material: 'material.css',
+    glass: 'glass.css',
+    studio: 'studio.css',
+  };
+  const missingByPreset = [];
+
+  for (const [preset, fileName] of Object.entries(presetFiles)) {
+    const defined = new Set();
+    collectDefinedInCss(readFileSync(join(stylesDir, fileName), 'utf8'), defined);
+    const required = collectPresetGeneratorTokens({
+      includeGlass: preset === 'glass',
+    });
+    const missing = [...required].filter((token) => !defined.has(token)).sort();
+    if (missing.length > 0) missingByPreset.push({ preset, missing });
+  }
+
+  return missingByPreset;
 }
 
 /** Collect every emitted token across all delivery paths. */
@@ -184,28 +264,47 @@ function collectEmitted() {
 
 const consumed = collectConsumed();
 const emitted = collectEmitted();
+const staticMissingByPreset = collectStaticPresetMissing();
 
 const undefinedTokens = [...consumed.keys()]
   .filter((t) => !emitted.has(t))
   .sort();
 
-if (undefinedTokens.length === 0) {
+if (undefinedTokens.length === 0 && staticMissingByPreset.length === 0) {
   console.log(
     `✓ svelte-token-check: ${consumed.size} consumed --smrt-* tokens, all emitted`,
   );
   process.exit(0);
 }
 
-console.error(
-  `✗ svelte-token-check: ${undefinedTokens.length} consumed --smrt-* token(s) are never emitted\n`,
-);
-for (const t of undefinedTokens) {
-  console.error(`    - ${t} (consumed ${consumed.get(t)}×)`);
+if (undefinedTokens.length > 0) {
+  console.error(
+    `✗ svelte-token-check: ${undefinedTokens.length} consumed --smrt-* token(s) are never emitted\n`,
+  );
+  for (const t of undefinedTokens) {
+    console.error(`    - ${t} (consumed ${consumed.get(t)}×)`);
+  }
+  console.error(
+    '\nThese tokens are frozen at their var(..., fallback) values and cannot be\n' +
+      'themed. Either emit them (extend src/themes/css-generator.ts + the static\n' +
+      'preset CSS in src/themes/styles/*.css) or change the consumers to a token\n' +
+      'that is emitted. See issue #1431.',
+  );
 }
-console.error(
-  '\nThese tokens are frozen at their var(..., fallback) values and cannot be\n' +
-    'themed. Either emit them (extend src/themes/css-generator.ts + the static\n' +
-    'preset CSS in src/themes/styles/*.css) or change the consumers to a token\n' +
-    'that is emitted. See issue #1431.',
-);
+
+if (staticMissingByPreset.length > 0) {
+  console.error(
+    `${undefinedTokens.length > 0 ? '\n' : ''}✗ svelte-token-check: static preset CSS is missing generated token(s)\n`,
+  );
+  for (const { preset, missing } of staticMissingByPreset) {
+    console.error(`    ${preset}:`);
+    for (const token of missing) console.error(`      - ${token}`);
+  }
+  console.error(
+    '\nStatic preset CSS should expose the same token names as the JS preset\n' +
+      'generator for that preset. Add missing definitions to\n' +
+      'packages/smrt-svelte/src/themes/styles/*.css.',
+  );
+}
+
 process.exit(1);

--- a/scripts/check-svelte-tokens.mjs
+++ b/scripts/check-svelte-tokens.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+/**
+ * smrt-svelte design-token contract check.
+ *
+ * Diffs the `--smrt-*` CSS custom properties that smrt-svelte components
+ * CONSUME (via `var(--smrt-...)`) against the ones the theme-delivery paths
+ * actually EMIT. Fails CI on any token that is consumed but never emitted —
+ * those tokens are frozen at their `var(..., fallback)` values and cannot be
+ * themed across the material/glass/studio presets (see issue #1431).
+ *
+ * Emitted tokens are collected from every runtime delivery path:
+ *   - static preset CSS: packages/smrt-svelte/src/themes/styles/*.css
+ *   - JS theme generator: packages/smrt-svelte/src/themes/css-generator.ts
+ *     (resolved structurally against the theme token scales)
+ *   - simple ThemeProvider tokens: packages/smrt-svelte/src/theme/tokens.ts
+ *   - workspace-shell tokens defined inline in component CSS (--smrt-ws-*)
+ *
+ * Consumed tokens are scraped from `var(--smrt-...)` references in any
+ * .svelte / .ts / .css file under packages/smrt-svelte/src.
+ *
+ * Exit code: 0 if every consumed token is emitted, 1 otherwise.
+ *
+ * Run: `node scripts/check-svelte-tokens.mjs` or `pnpm check:svelte-tokens`.
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const PKG = join(ROOT, 'packages', 'smrt-svelte');
+const SRC = join(PKG, 'src');
+
+/** Recursively list files under `dir` whose name ends in one of `exts`. */
+function listFiles(dir, exts) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+      out.push(...listFiles(full, exts));
+    } else if (exts.some((e) => entry.name.endsWith(e))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const VAR_RE = /var\(\s*(--smrt-[a-z0-9-]+)/gi;
+
+/** Collect every `--smrt-*` token referenced via var() under SRC. */
+function collectConsumed() {
+  const consumed = new Map(); // token -> count
+  for (const file of listFiles(SRC, ['.svelte', '.ts', '.css'])) {
+    const text = readFileSync(file, 'utf8');
+    for (const m of text.matchAll(VAR_RE)) {
+      consumed.set(m[1], (consumed.get(m[1]) ?? 0) + 1);
+    }
+  }
+  return consumed;
+}
+
+const DEFINE_RE = /(--smrt-[a-z0-9-]+)\s*:/gi;
+
+/** Collect every `--smrt-*` token DEFINED (`--smrt-x: value`) in a CSS string. */
+function collectDefinedInCss(text, into) {
+  for (const m of text.matchAll(DEFINE_RE)) into.add(m[1]);
+}
+
+/**
+ * The theme scale KEYS the generator iterates over. Mirrors
+ * src/themes/types.ts (SpacingScale / TypographyScale / etc.) and
+ * src/themes/shared.ts. Kept here so the check stays a pure string diff with
+ * no module loading; src/themes/__tests__/css-generator.test.ts asserts the
+ * generator output matches these keys so drift is caught by unit tests too.
+ */
+const SCALE_KEYS = {
+  spacing: [
+    '0', '0_5', '1', '1_5', '2', '2_5', '3', '3_5', '4', '5', '6', '7', '8',
+    '9', '10', '11', '12', '14', '16', '20', '24',
+    // additive Material-3 aliases (see shared.ts spacingAliases)
+    'xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl',
+  ],
+  radius: [
+    'none', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', 'full',
+    // additive Material-3 aliases (see shared.ts borderRadiusAliases)
+    'extra-small', 'small', 'medium', 'large', 'extra-large',
+  ],
+  duration: [
+    'instant', 'fast', 'normal', 'slow', 'slower',
+    // additive Material-3 aliases (see shared.ts durationAliases)
+    'short1', 'short2', 'short3', 'short4',
+    'medium1', 'medium2', 'medium3', 'medium4',
+    'long1', 'long2', 'long3', 'long4',
+  ],
+  easing: [
+    'standard', 'standard-decelerate', 'standard-accelerate',
+    'emphasized', 'emphasized-decelerate', 'emphasized-accelerate',
+  ],
+  elevation: ['0', '1', '2', '3', '4', '5'],
+};
+
+const TYPOGRAPHY_VARIANTS = [
+  'display-large', 'display-medium', 'display-small',
+  'headline-large', 'headline-medium', 'headline-small',
+  'title-large', 'title-medium', 'title-small',
+  'body-large', 'body-medium', 'body-small',
+  'label-large', 'label-medium', 'label-small',
+];
+
+const TYPOGRAPHY_SUFFIXES = [
+  'size', 'line-height', 'weight', 'tracking', 'font-family',
+  // additive shorthand alias (see css-generator.ts)
+  'font',
+];
+
+const COLOR_TOKENS = [
+  'primary', 'on-primary', 'primary-container', 'on-primary-container',
+  'secondary', 'on-secondary', 'secondary-container', 'on-secondary-container',
+  'tertiary', 'on-tertiary', 'tertiary-container', 'on-tertiary-container',
+  'error', 'on-error', 'error-container', 'on-error-container',
+  'warning', 'on-warning', 'warning-container', 'on-warning-container',
+  'success', 'on-success', 'success-container', 'on-success-container',
+  'surface', 'on-surface', 'surface-variant', 'on-surface-variant',
+  'surface-container', 'surface-container-low', 'surface-container-high',
+  'surface-container-highest', 'surface-container-lowest',
+  'surface-dim', 'surface-bright',
+  'background', 'on-background',
+  'outline', 'outline-variant',
+  'inverse-surface', 'inverse-on-surface', 'inverse-primary',
+  'shadow', 'scrim',
+  'glass-backdrop', 'glass-border',
+];
+
+/**
+ * Tokens emitted by the JS theme generator (css-generator.ts) and the simple
+ * ThemeProvider (theme/tokens.ts). These are not in static CSS but are still a
+ * real runtime delivery path, so a consumed token they emit is themeable.
+ */
+function collectGeneratorEmitted(into) {
+  for (const c of COLOR_TOKENS) into.add(`--smrt-color-${c}`);
+  into.add('--smrt-color-scheme');
+  into.add('--smrt-theme-id');
+  into.add('--smrt-theme-name');
+  into.add('--smrt-font-family');
+  into.add('--smrt-glass-blur');
+  into.add('--smrt-glass-saturation');
+  into.add('--smrt-glass-border-opacity');
+  into.add('--smrt-glass-background-opacity');
+  for (const k of SCALE_KEYS.spacing) into.add(`--smrt-spacing-${k}`);
+  for (const k of SCALE_KEYS.radius) into.add(`--smrt-radius-${k}`);
+  for (const k of SCALE_KEYS.duration) into.add(`--smrt-duration-${k}`);
+  for (const k of SCALE_KEYS.easing) into.add(`--smrt-easing-${k}`);
+  for (const k of SCALE_KEYS.elevation) into.add(`--smrt-elevation-${k}`);
+  for (const v of TYPOGRAPHY_VARIANTS) {
+    for (const s of TYPOGRAPHY_SUFFIXES) {
+      into.add(`--smrt-typography-${v}-${s}`);
+    }
+  }
+}
+
+/** Collect every emitted token across all delivery paths. */
+function collectEmitted() {
+  const emitted = new Set();
+
+  // Static preset CSS files.
+  const stylesDir = join(SRC, 'themes', 'styles');
+  if (existsSync(stylesDir)) {
+    for (const file of readdirSync(stylesDir)) {
+      if (!file.endsWith('.css')) continue;
+      collectDefinedInCss(readFileSync(join(stylesDir, file), 'utf8'), emitted);
+    }
+  }
+
+  // Workspace-shell tokens defined inline in component CSS (e.g. --smrt-ws-*).
+  for (const file of listFiles(SRC, ['.svelte', '.css'])) {
+    collectDefinedInCss(readFileSync(file, 'utf8'), emitted);
+  }
+
+  // JS-generated tokens.
+  collectGeneratorEmitted(emitted);
+
+  return emitted;
+}
+
+const consumed = collectConsumed();
+const emitted = collectEmitted();
+
+const undefinedTokens = [...consumed.keys()]
+  .filter((t) => !emitted.has(t))
+  .sort();
+
+if (undefinedTokens.length === 0) {
+  console.log(
+    `✓ svelte-token-check: ${consumed.size} consumed --smrt-* tokens, all emitted`,
+  );
+  process.exit(0);
+}
+
+console.error(
+  `✗ svelte-token-check: ${undefinedTokens.length} consumed --smrt-* token(s) are never emitted\n`,
+);
+for (const t of undefinedTokens) {
+  console.error(`    - ${t} (consumed ${consumed.get(t)}×)`);
+}
+console.error(
+  '\nThese tokens are frozen at their var(..., fallback) values and cannot be\n' +
+    'themed. Either emit them (extend src/themes/css-generator.ts + the static\n' +
+    'preset CSS in src/themes/styles/*.css) or change the consumers to a token\n' +
+    'that is emitted. See issue #1431.',
+);
+process.exit(1);


### PR DESCRIPTION
Fixes #1431.

## Problem
A large share of the `--smrt-*` design tokens that `smrt-svelte` components consume were **never emitted** by any theme-delivery path, so they were frozen at their `var(..., fallback)` values and could not be themed across material/glass/studio. Two root causes:
1. **Two competing vocabularies** — Material-3 names (`radius-medium`, `duration-short2`, `spacing-md`, `typography-*-font`) vs the emitted scale names (`radius-md`, `duration-fast`, numeric `spacing-{n}`, `typography-*-size/-family`).
2. **An incomplete static-CSS path** — `themes/styles/*.css` emitted colors/radius/duration/elevation/easing but **never** typography or spacing, so apps using the static CSS got no typography tokens at all.

## Canonical delivery path (two-theme-system resolved)
`src/themes/` (preset system: material/glass/studio + `css-generator.ts` JS `ThemeProvider`) is **canonical** — it's the only path that delivers the full token surface. `src/theme/` is the simpler/legacy provider and emits the same vocabulary where its categories overlap. Documented in `packages/smrt-svelte/AGENTS.md`.

## Approach — additive aliases (option a)
No canonical renames, no mass component edits. Single source of truth in `src/themes/shared.ts`, emitted by the JS generator and mirrored into the static preset CSS and the simple provider:
- **Radius**: aliases `extra-small|small|medium|large|extra-large` → t-shirt scale
- **Spacing**: aliases `xs|sm|md|lg|xl|2xl|3xl` → numeric scale
- **Motion**: aliases `short1…long4` (M3 ms scale)
- **Typography**: a `-font` CSS-shorthand alias built from the longhands; static CSS now emits the **full per-preset typography scale** (closing the static-path gap)
- **Helpers**: `--smrt-font-family-mono`, named `--smrt-typography-weight-{normal,medium,semibold,bold}`, `--smrt-z-index-{dropdown…tooltip}`

A handful of refs that can't be aliased were repointed: calendar dark blocks used never-emitted `--smrt-color-*-dark` (now reference the base tokens, which already swap under the dark scheme); `font-size-sm` → `body-small-size`; `typography-font-mono` → `font-family-mono`; Form's malformed `rgba(--smrt-color-primary-rgb)` → `color-mix` on the emitted primary token.

## Regression guard
`scripts/check-svelte-tokens.mjs` diffs consumed-vs-emitted `--smrt-*` and fails on any consumed-but-undefined token — wired into the `check-standards` CI job and `pnpm check:svelte-tokens`. A unit test (`themes/__tests__/token-aliases.test.ts`) pins the emitted alias set.

## Verification
- [x] Consumed-vs-emitted diff: **zero** undefined `--smrt-*` (111 consumed, all emitted)
- [x] `svelte-check`: 0 errors, 0 warnings
- [x] `biome check`: clean (CSS is biome-ignored)
- [x] 263 smrt-svelte tests pass (incl. 11 new)
- [x] Render-checked sample components across material/glass/studio in light **and** dark — every consumed token resolves with correct per-preset values (glass body 0.9375rem, studio line-height 1.6, distinct font families); badge weight=700, radius/padding correct

## DoD
- [x] Zero undefined `--smrt-*` tokens
- [x] One vocabulary documented; two-theme-system ambiguity resolved
- [x] CI check guards against consumed-but-undefined tokens
- [x] Conventional commit + PR referencing #1431
- [ ] Note in S1 #1373 (posting next)

Blocks/precedes: S1 #1373. Epic #1354.