### PR TITLE
[codex] add SMRT subscriptions package

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -40,6 +40,7 @@
       "@happyvertical/smrt-properties",
       "@happyvertical/smrt-secrets",
       "@happyvertical/smrt-sites",
+      "@happyvertical/smrt-subscriptions",
       "@happyvertical/smrt-tags",
       "@happyvertical/smrt-tenancy",
       "@happyvertical/smrt-template-site-static-json",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ All `@happyvertical/smrt-*` packages are version-locked via changesets. pnpm wor
 | affiliates | Revenue sharing: multi-type partners, multi-tier commissions, payout processing |
 | ledgers | Double-entry accounting, balance enforcement (EPSILON=0.01), journal lifecycle |
 | analytics | GA4/Plausible: properties, data streams, server-side events, AI-powered reports |
+| subscriptions | Tenant subscription plans, feature grants, usage thresholds, and entitlement resolution |
 
 ### Domain
 | Package | Purpose |

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ All packages are published under `@happyvertical/smrt-*`. 38 packages total.
 | `smrt-affiliates` | Revenue sharing: multi-type partners, multi-tier commissions, payout processing |
 | `smrt-ledgers` | Double-entry accounting, balance enforcement (EPSILON=0.01), journal lifecycle |
 | `smrt-analytics` | GA4/Plausible: properties, data streams, server-side events, AI-powered reports |
+| `smrt-subscriptions` | Tenant subscription plans, feature grants, usage thresholds, and entitlement resolution |
 
 ### Domain
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const analysis = await product.analyze();
 
 ## Packages
 
-All packages are published under `@happyvertical/smrt-*`. 38 packages total.
+All packages are published under `@happyvertical/smrt-*`. 39 packages total.
 
 ### Foundation
 

--- a/packages/subscriptions/AGENTS.md
+++ b/packages/subscriptions/AGENTS.md
@@ -1,0 +1,21 @@
+# @happyvertical/smrt-subscriptions
+
+Tenant subscriptions, plan features, usage thresholds, and entitlement
+resolution for SMRT applications.
+
+## Validation
+
+```bash
+pnpm --filter @happyvertical/smrt-subscriptions test
+pnpm --filter @happyvertical/smrt-subscriptions typecheck
+pnpm --filter @happyvertical/smrt-subscriptions build
+```
+
+## Notes
+
+- Keep Stripe-specific fields as provider binding metadata. Runtime Stripe API
+  calls belong in the HappyVertical SDK accounting provider.
+- Thresholds are evaluated from tenant usage metrics and optional AI usage
+  summaries. Do not bypass tenant context in application code.
+- Subscription UI components should stay provider-neutral and receive actions
+  from the host app.

--- a/packages/subscriptions/CLAUDE.md
+++ b/packages/subscriptions/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/subscriptions/ambient.d.ts
+++ b/packages/subscriptions/ambient.d.ts
@@ -1,0 +1,5 @@
+declare module '*.svelte' {
+  import type { ComponentType } from 'svelte';
+  const component: ComponentType;
+  export default component;
+}

--- a/packages/subscriptions/package.json
+++ b/packages/subscriptions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-subscriptions",
-  "version": "0.27.8",
+  "version": "0.27.9",
   "description": "Tenant subscriptions, entitlement resolution, usage thresholds, and subscription UI for SMRT",
   "type": "module",
   "main": "./dist/index.js",
@@ -55,7 +55,7 @@
     "@happyvertical/smrt-svelte": "workspace:*",
     "@happyvertical/smrt-vitest": "workspace:*",
     "@sveltejs/package": "^2.5.7",
-    "@types/node": "25.0.9",
+    "@types/node": "24.10.9",
     "svelte": "^5.18.0",
     "svelte-check": "^4.3.5",
     "typescript": "^5.9.3",

--- a/packages/subscriptions/package.json
+++ b/packages/subscriptions/package.json
@@ -1,0 +1,84 @@
+{
+  "name": "@happyvertical/smrt-subscriptions",
+  "version": "0.27.8",
+  "description": "Tenant subscriptions, entitlement resolution, usage thresholds, and subscription UI for SMRT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "CLAUDE.md",
+    "AGENTS.md"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./manifest": "./dist/manifest.json",
+    "./manifest.json": "./dist/manifest.json",
+    "./svelte": {
+      "types": "./dist/svelte/index.d.ts",
+      "svelte": "./dist/svelte/index.js",
+      "import": "./dist/svelte/index.js"
+    }
+  },
+  "scripts": {
+    "build": "vite build --mode library && svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json",
+    "build:watch": "vite build --mode library --watch",
+    "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "clean": "rm -rf dist",
+    "dev": "vite dev",
+    "prepack": "node ../../scripts/prepack-package.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
+  },
+  "dependencies": {
+    "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-features": "workspace:*",
+    "@happyvertical/smrt-tenancy": "workspace:*"
+  },
+  "peerDependencies": {
+    "@happyvertical/smrt-svelte": "workspace:*",
+    "svelte": "^5.18.0"
+  },
+  "peerDependenciesMeta": {
+    "@happyvertical/smrt-svelte": {
+      "optional": true
+    },
+    "svelte": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@happyvertical/smrt-svelte": "workspace:*",
+    "@happyvertical/smrt-vitest": "workspace:*",
+    "@sveltejs/package": "^2.5.7",
+    "@types/node": "25.0.9",
+    "svelte": "^5.18.0",
+    "svelte-check": "^4.3.5",
+    "typescript": "^5.9.3",
+    "vite": "^7.3.1",
+    "vitest": "^4.0.17"
+  },
+  "keywords": [
+    "smrt",
+    "subscriptions",
+    "billing",
+    "entitlements",
+    "multi-tenant"
+  ],
+  "author": "HappyVertical",
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/smrt.git",
+    "directory": "packages/subscriptions"
+  }
+}

--- a/packages/subscriptions/package.json
+++ b/packages/subscriptions/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "@happyvertical/smrt-core": "workspace:*",
-    "@happyvertical/smrt-features": "workspace:*",
     "@happyvertical/smrt-tenancy": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/subscriptions/src/__smrt-register__.ts
+++ b/packages/subscriptions/src/__smrt-register__.ts
@@ -1,0 +1,5 @@
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+
+ObjectRegistry.registerPackageManifest(
+  new URL('./manifest.json', import.meta.url),
+);

--- a/packages/subscriptions/src/__tests__/subscription-resolver.test.ts
+++ b/packages/subscriptions/src/__tests__/subscription-resolver.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+import { SubscriptionPlan } from '../models/SubscriptionPlan.js';
+import { TenantSubscription } from '../models/TenantSubscription.js';
+import { SubscriptionResolver } from '../services/subscription-resolver.js';
+import { evaluateThreshold } from '../services/threshold-evaluator.js';
+import type { UsageSummary } from '../types.js';
+
+describe('smrt-subscriptions', () => {
+  it('stores plan feature grants and thresholds as typed accessors', () => {
+    const plan = new SubscriptionPlan({
+      planKey: 'growth',
+      name: 'Growth',
+    });
+
+    plan.setFeatureGrants([
+      'smrt:chat',
+      { featureKey: 'smrt:video', enabled: false },
+    ]);
+    plan.setThresholds([
+      {
+        metricKey: 'ai.tokens.total',
+        limit: 1000,
+        window: 'month',
+        enforcement: 'warn',
+      },
+    ]);
+
+    expect(plan.getFeatureKeys()).toEqual(['smrt:chat']);
+    expect(plan.getThresholds()).toHaveLength(1);
+    expect(plan.getThresholds()[0]?.metricKey).toBe('ai.tokens.total');
+  });
+
+  it('evaluates warn and block thresholds', () => {
+    const usage: UsageSummary = {
+      tenantId: 'tenant-1',
+      metricKey: 'messages.sent',
+      quantity: 90,
+      windowStart: new Date('2026-06-01T00:00:00Z'),
+      windowEnd: new Date('2026-07-01T00:00:00Z'),
+    };
+
+    expect(
+      evaluateThreshold(
+        {
+          metricKey: 'messages.sent',
+          limit: 100,
+          window: 'month',
+          enforcement: 'warn',
+        },
+        usage,
+      ),
+    ).toMatchObject({ state: 'warn', allowed: true, remaining: 10 });
+
+    expect(
+      evaluateThreshold(
+        {
+          metricKey: 'messages.sent',
+          limit: 90,
+          window: 'month',
+          enforcement: 'block',
+        },
+        usage,
+      ),
+    ).toMatchObject({ state: 'blocked', allowed: false, remaining: 0 });
+  });
+
+  it('resolves feature entitlements and threshold blocks', async () => {
+    const plan = new SubscriptionPlan({
+      planKey: 'pro',
+      name: 'Pro',
+      status: 'active',
+    });
+    Object.assign(plan, { id: 'plan-pro' });
+    plan.setFeatureGrants(['smrt:chat', 'smrt:projects']);
+    plan.setThresholds([
+      {
+        metricKey: 'ai.tokens.total',
+        limit: 100,
+        window: 'month',
+        enforcement: 'block',
+      },
+    ]);
+
+    const subscription = new TenantSubscription({
+      tenantId: 'tenant-1',
+      planId: 'plan-pro',
+      status: 'active',
+      currentPeriodEnd: new Date('2026-07-01T00:00:00Z'),
+    });
+    Object.assign(subscription, { id: 'sub-1' });
+
+    const resolver = new SubscriptionResolver({
+      plans: {
+        async get() {
+          return plan;
+        },
+      },
+      subscriptions: {
+        async findCurrentForTenant() {
+          return subscription;
+        },
+      },
+      usage: {
+        async summarize() {
+          return {
+            tenantId: 'tenant-1',
+            metricKey: 'ai.tokens.total',
+            quantity: 125,
+            windowStart: new Date('2026-06-01T00:00:00Z'),
+            windowEnd: new Date('2026-07-01T00:00:00Z'),
+          };
+        },
+      },
+    });
+
+    const resolution = await resolver.resolveTenantEntitlements('tenant-1', {
+      now: new Date('2026-06-15T00:00:00Z'),
+    });
+
+    expect(resolution).toMatchObject({
+      tenantId: 'tenant-1',
+      planKey: 'pro',
+      featureKeys: ['smrt:chat', 'smrt:projects'],
+      allowed: false,
+    });
+    expect(resolution.thresholdEvaluations[0]).toMatchObject({
+      state: 'blocked',
+      allowed: false,
+    });
+    await expect(
+      resolver.assertWithinThresholds('tenant-1', {
+        now: new Date('2026-06-15T00:00:00Z'),
+      }),
+    ).rejects.toThrow('ai.tokens.total');
+  });
+
+  it('returns a closed resolution without a subscription', async () => {
+    const resolver = new SubscriptionResolver({
+      plans: {
+        async get() {
+          return null;
+        },
+      },
+      subscriptions: {
+        async findCurrentForTenant() {
+          return null;
+        },
+      },
+      usage: {
+        async summarize() {
+          throw new Error('usage should not be read without a plan');
+        },
+      },
+    });
+
+    await expect(
+      resolver.resolveTenantEntitlements('tenant-1'),
+    ).resolves.toMatchObject({
+      tenantId: 'tenant-1',
+      status: 'none',
+      allowed: false,
+      featureKeys: [],
+    });
+  });
+});

--- a/packages/subscriptions/src/__tests__/subscription-resolver.test.ts
+++ b/packages/subscriptions/src/__tests__/subscription-resolver.test.ts
@@ -3,7 +3,8 @@ import { SubscriptionPlan } from '../models/SubscriptionPlan.js';
 import { TenantSubscription } from '../models/TenantSubscription.js';
 import { SubscriptionResolver } from '../services/subscription-resolver.js';
 import { evaluateThreshold } from '../services/threshold-evaluator.js';
-import type { UsageSummary } from '../types.js';
+import type { PlanThreshold, UsageSummary } from '../types.js';
+import { isValidThreshold } from '../utils.js';
 
 describe('smrt-subscriptions', () => {
   it('stores plan feature grants and thresholds as typed accessors', () => {
@@ -62,6 +63,68 @@ describe('smrt-subscriptions', () => {
         usage,
       ),
     ).toMatchObject({ state: 'blocked', allowed: false, remaining: 0 });
+
+    const zeroUsage: UsageSummary = {
+      ...usage,
+      quantity: 0,
+    };
+
+    expect(
+      evaluateThreshold(
+        {
+          metricKey: 'messages.sent',
+          limit: 0,
+          window: 'month',
+          enforcement: 'block',
+        },
+        zeroUsage,
+      ),
+    ).toMatchObject({ state: 'ok', allowed: true, remaining: 0 });
+
+    expect(
+      evaluateThreshold(
+        {
+          metricKey: 'messages.sent',
+          limit: 0,
+          window: 'month',
+          enforcement: 'block',
+        },
+        {
+          ...zeroUsage,
+          quantity: 1,
+        },
+      ),
+    ).toMatchObject({ state: 'blocked', allowed: false, remaining: 0 });
+  });
+
+  it('rejects malformed threshold values parsed from JSON', () => {
+    const validThreshold: PlanThreshold = {
+      metricKey: 'ai.tokens.total',
+      limit: 100,
+      window: 'month',
+      enforcement: 'warn',
+      warningRatio: 0.8,
+    };
+
+    expect(isValidThreshold(validThreshold)).toBe(true);
+    expect(
+      isValidThreshold({
+        ...validThreshold,
+        window: 'forever',
+      } as unknown as PlanThreshold),
+    ).toBe(false);
+    expect(
+      isValidThreshold({
+        ...validThreshold,
+        enforcement: 'disable',
+      } as unknown as PlanThreshold),
+    ).toBe(false);
+    expect(
+      isValidThreshold({
+        ...validThreshold,
+        warningRatio: 1.5,
+      }),
+    ).toBe(false);
   });
 
   it('resolves feature entitlements and threshold blocks', async () => {
@@ -161,5 +224,49 @@ describe('smrt-subscriptions', () => {
       allowed: false,
       featureKeys: [],
     });
+  });
+
+  it('uses the resolver time when selecting the current subscription', async () => {
+    const plan = new SubscriptionPlan({
+      planKey: 'pro',
+      name: 'Pro',
+      status: 'active',
+    });
+    Object.assign(plan, { id: 'plan-pro' });
+
+    const subscription = new TenantSubscription({
+      tenantId: 'tenant-1',
+      planId: 'plan-pro',
+      status: 'active',
+      currentPeriodEnd: new Date('2026-07-01T00:00:00Z'),
+    });
+    Object.assign(subscription, { id: 'sub-1' });
+
+    const expectedNow = new Date('2026-06-15T00:00:00Z');
+    let selectedAt: Date | undefined;
+    const resolver = new SubscriptionResolver({
+      plans: {
+        async get() {
+          return plan;
+        },
+      },
+      subscriptions: {
+        async findCurrentForTenant(_tenantId, now) {
+          selectedAt = now;
+          return subscription;
+        },
+      },
+      usage: {
+        async summarize() {
+          throw new Error('usage should not be read without thresholds');
+        },
+      },
+    });
+
+    await resolver.resolveTenantEntitlements('tenant-1', {
+      now: expectedNow,
+    });
+
+    expect(selectedAt).toBe(expectedNow);
   });
 });

--- a/packages/subscriptions/src/__tests__/usage-meter.test.ts
+++ b/packages/subscriptions/src/__tests__/usage-meter.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { TenantUsageMetricCollection } from '../collections/TenantUsageMetricCollection.js';
+import { TenantUsageMeter } from '../services/usage-meter.js';
+
+const AI_USAGE_DDL = `
+  CREATE TABLE IF NOT EXISTS _smrt_ai_usage (
+    id TEXT PRIMARY KEY,
+    provider TEXT NOT NULL,
+    model TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    prompt_tokens INTEGER,
+    completion_tokens INTEGER,
+    total_tokens INTEGER,
+    estimated_cost REAL,
+    duration INTEGER NOT NULL,
+    class_name TEXT,
+    tenant_id TEXT,
+    tags TEXT,
+    created_at TIMESTAMP NOT NULL
+  )
+`;
+
+interface SeedRow {
+  tenantId: string;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  estimatedCost: number;
+  createdAt: string;
+}
+
+async function seedAiUsage(
+  metrics: TenantUsageMetricCollection,
+  rows: SeedRow[],
+): Promise<void> {
+  let counter = 0;
+  for (const row of rows) {
+    counter += 1;
+    await metrics.db.query(
+      `INSERT INTO _smrt_ai_usage
+        (id, provider, model, operation, prompt_tokens, completion_tokens,
+         total_tokens, estimated_cost, duration, class_name, tenant_id, tags, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `usage-${counter}`,
+      'openai',
+      'gpt-test',
+      'do',
+      row.promptTokens,
+      row.completionTokens,
+      row.totalTokens,
+      row.estimatedCost,
+      0,
+      'TestClass',
+      row.tenantId,
+      null,
+      row.createdAt,
+    );
+  }
+}
+
+describe('TenantUsageMeter AI usage summaries', () => {
+  let metrics: TenantUsageMetricCollection;
+
+  beforeEach(async () => {
+    metrics = await TenantUsageMetricCollection.create({
+      db: { type: 'sqlite', url: ':memory:' },
+    });
+    await metrics.db.query(AI_USAGE_DDL);
+  });
+
+  afterEach(async () => {
+    await metrics.db.close?.();
+  });
+
+  it('sums persisted _smrt_ai_usage rows within the window for the tenant', async () => {
+    await seedAiUsage(metrics, [
+      {
+        tenantId: 'tenant-1',
+        promptTokens: 100,
+        completionTokens: 40,
+        totalTokens: 140,
+        estimatedCost: 0.5,
+        createdAt: '2026-06-10T12:00:00.000Z',
+      },
+      {
+        tenantId: 'tenant-1',
+        promptTokens: 60,
+        completionTokens: 20,
+        totalTokens: 80,
+        estimatedCost: 0.25,
+        createdAt: '2026-06-20T12:00:00.000Z',
+      },
+      // Outside the window — must be excluded.
+      {
+        tenantId: 'tenant-1',
+        promptTokens: 999,
+        completionTokens: 999,
+        totalTokens: 999,
+        estimatedCost: 9.99,
+        createdAt: '2026-07-05T12:00:00.000Z',
+      },
+      // Different tenant — must be excluded.
+      {
+        tenantId: 'tenant-2',
+        promptTokens: 500,
+        completionTokens: 500,
+        totalTokens: 500,
+        estimatedCost: 5,
+        createdAt: '2026-06-15T12:00:00.000Z',
+      },
+    ]);
+
+    const meter = new TenantUsageMeter(metrics);
+    const summary = await meter.summarizeAiUsage({
+      tenantId: 'tenant-1',
+      window: {
+        start: new Date('2026-06-01T00:00:00.000Z'),
+        end: new Date('2026-07-01T00:00:00.000Z'),
+      },
+    });
+
+    expect(summary).toMatchObject({
+      tenantId: 'tenant-1',
+      promptTokens: 160,
+      completionTokens: 60,
+      totalTokens: 220,
+      requestCount: 2,
+    });
+    expect(summary.estimatedCost).toBeCloseTo(0.75, 5);
+  });
+
+  it('maps ai.* metric keys onto the matching usage quantity', async () => {
+    await seedAiUsage(metrics, [
+      {
+        tenantId: 'tenant-1',
+        promptTokens: 30,
+        completionTokens: 10,
+        totalTokens: 40,
+        estimatedCost: 0.2,
+        createdAt: '2026-06-10T12:00:00.000Z',
+      },
+    ]);
+
+    const meter = new TenantUsageMeter(metrics);
+    const window = {
+      start: new Date('2026-06-01T00:00:00.000Z'),
+      end: new Date('2026-07-01T00:00:00.000Z'),
+    };
+
+    const totalTokens = await meter.summarize({
+      tenantId: 'tenant-1',
+      metricKey: 'ai.tokens.total',
+      window,
+    });
+    expect(totalTokens.quantity).toBe(40);
+
+    const requests = await meter.summarize({
+      tenantId: 'tenant-1',
+      metricKey: 'ai.requests',
+      window,
+    });
+    expect(requests.quantity).toBe(1);
+  });
+
+  it('returns zeroed totals when no usage matches', async () => {
+    const meter = new TenantUsageMeter(metrics);
+    const summary = await meter.summarizeAiUsage({
+      tenantId: 'tenant-unknown',
+      window: {
+        start: new Date('2026-06-01T00:00:00.000Z'),
+        end: new Date('2026-07-01T00:00:00.000Z'),
+      },
+    });
+
+    expect(summary).toMatchObject({
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+      estimatedCost: 0,
+      requestCount: 0,
+    });
+  });
+});

--- a/packages/subscriptions/src/collections/SubscriptionPlanCollection.ts
+++ b/packages/subscriptions/src/collections/SubscriptionPlanCollection.ts
@@ -1,0 +1,25 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { SubscriptionPlan } from '../models/SubscriptionPlan.js';
+
+export class SubscriptionPlanCollection extends SmrtCollection<SubscriptionPlan> {
+  static readonly _itemClass = SubscriptionPlan;
+
+  async findByPlanKey(planKey: string): Promise<SubscriptionPlan | null> {
+    const plans = await this.list({ where: { planKey }, limit: 1 });
+    return plans[0] ?? null;
+  }
+
+  async findActive(): Promise<SubscriptionPlan[]> {
+    return this.list({
+      where: { status: 'active' },
+      orderBy: 'sortOrder ASC',
+    });
+  }
+
+  async findByStripePriceId(
+    stripePriceId: string,
+  ): Promise<SubscriptionPlan | null> {
+    const plans = await this.list({ where: { stripePriceId }, limit: 1 });
+    return plans[0] ?? null;
+  }
+}

--- a/packages/subscriptions/src/collections/TenantSubscriptionCollection.ts
+++ b/packages/subscriptions/src/collections/TenantSubscriptionCollection.ts
@@ -1,0 +1,34 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { TenantSubscription } from '../models/TenantSubscription.js';
+
+export class TenantSubscriptionCollection extends SmrtCollection<TenantSubscription> {
+  static readonly _itemClass = TenantSubscription;
+
+  async findByTenant(tenantId: string): Promise<TenantSubscription[]> {
+    return this.list({
+      where: { tenantId },
+      orderBy: 'created_at DESC',
+    });
+  }
+
+  async findCurrentForTenant(
+    tenantId: string,
+  ): Promise<TenantSubscription | null> {
+    const subscriptions = await this.findByTenant(tenantId);
+    return (
+      subscriptions.find((subscription) => subscription.isEntitled()) ??
+      subscriptions[0] ??
+      null
+    );
+  }
+
+  async findByStripeSubscriptionId(
+    stripeSubscriptionId: string,
+  ): Promise<TenantSubscription | null> {
+    const subscriptions = await this.list({
+      where: { stripeSubscriptionId },
+      limit: 1,
+    });
+    return subscriptions[0] ?? null;
+  }
+}

--- a/packages/subscriptions/src/collections/TenantSubscriptionCollection.ts
+++ b/packages/subscriptions/src/collections/TenantSubscriptionCollection.ts
@@ -13,10 +13,11 @@ export class TenantSubscriptionCollection extends SmrtCollection<TenantSubscript
 
   async findCurrentForTenant(
     tenantId: string,
+    now = new Date(),
   ): Promise<TenantSubscription | null> {
     const subscriptions = await this.findByTenant(tenantId);
     return (
-      subscriptions.find((subscription) => subscription.isEntitled()) ??
+      subscriptions.find((subscription) => subscription.isEntitled(now)) ??
       subscriptions[0] ??
       null
     );

--- a/packages/subscriptions/src/collections/TenantUsageMetricCollection.ts
+++ b/packages/subscriptions/src/collections/TenantUsageMetricCollection.ts
@@ -1,0 +1,55 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { TenantUsageMetric } from '../models/TenantUsageMetric.js';
+import type {
+  RecordUsageOptions,
+  SummarizeUsageOptions,
+  UsageSummary,
+} from '../types.js';
+
+export class TenantUsageMetricCollection extends SmrtCollection<TenantUsageMetric> {
+  static readonly _itemClass = TenantUsageMetric;
+
+  async recordUsage(options: RecordUsageOptions): Promise<TenantUsageMetric> {
+    const metric = await this.create({
+      tenantId: options.tenantId,
+      metricKey: options.metricKey,
+      quantity: options.quantity,
+      windowStart: options.windowStart,
+      windowEnd: options.windowEnd,
+      source: options.source ?? '',
+      sourceId: options.sourceId ?? '',
+    });
+    metric.setDimensions(options.dimensions ?? {});
+    await metric.save();
+    return metric;
+  }
+
+  async findByTenantAndMetric(
+    tenantId: string,
+    metricKey: string,
+  ): Promise<TenantUsageMetric[]> {
+    return this.list({
+      where: { tenantId, metricKey },
+      orderBy: 'windowStart DESC',
+    });
+  }
+
+  async summarizeUsage(options: SummarizeUsageOptions): Promise<UsageSummary> {
+    const metrics = await this.list({
+      where: {
+        tenantId: options.tenantId,
+        metricKey: options.metricKey,
+        'windowStart <': options.window.end.toISOString(),
+        'windowEnd >': options.window.start.toISOString(),
+      },
+    });
+
+    return {
+      tenantId: options.tenantId,
+      metricKey: options.metricKey,
+      quantity: metrics.reduce((sum, metric) => sum + metric.quantity, 0),
+      windowStart: options.window.start,
+      windowEnd: options.window.end,
+    };
+  }
+}

--- a/packages/subscriptions/src/collections/TenantUsageMetricCollection.ts
+++ b/packages/subscriptions/src/collections/TenantUsageMetricCollection.ts
@@ -1,7 +1,9 @@
 import { SmrtCollection } from '@happyvertical/smrt-core';
 import { TenantUsageMetric } from '../models/TenantUsageMetric.js';
 import type {
+  AiUsageSummary,
   RecordUsageOptions,
+  SummarizeAiUsageOptions,
   SummarizeUsageOptions,
   UsageSummary,
 } from '../types.js';
@@ -52,4 +54,69 @@ export class TenantUsageMetricCollection extends SmrtCollection<TenantUsageMetri
       windowEnd: options.window.end,
     };
   }
+
+  /**
+   * Summarize persisted AI usage for a tenant within a window.
+   *
+   * Reads the framework `_smrt_ai_usage` system table via a raw aggregate
+   * query. This deliberately uses `this.db.query` rather than the inherited
+   * `query()`: those rows are framework usage records, not `TenantUsageMetric`
+   * instances, so model hydration would discard the aggregate columns. Tenant
+   * scoping is applied explicitly through the `tenant_id` filter.
+   *
+   * Named distinctly from the inherited `SmrtClass.summarizeAiUsage` (which
+   * returns grouped stats across all tenants) to avoid overriding it.
+   */
+  async summarizeTenantAiUsage(
+    options: SummarizeAiUsageOptions,
+  ): Promise<AiUsageSummary> {
+    const result = await this.db.query(
+      `SELECT
+          COALESCE(SUM(prompt_tokens), 0) AS prompt_tokens,
+          COALESCE(SUM(completion_tokens), 0) AS completion_tokens,
+          COALESCE(SUM(total_tokens), 0) AS total_tokens,
+          COALESCE(SUM(estimated_cost), 0) AS estimated_cost,
+          COUNT(*) AS request_count
+        FROM _smrt_ai_usage
+        WHERE tenant_id = ?
+          AND created_at >= ?
+          AND created_at < ?`,
+      options.tenantId,
+      options.window.start.toISOString(),
+      options.window.end.toISOString(),
+    );
+    const row = firstRow(result);
+
+    return {
+      tenantId: options.tenantId,
+      promptTokens: numberFromRow(row, 'prompt_tokens'),
+      completionTokens: numberFromRow(row, 'completion_tokens'),
+      totalTokens: numberFromRow(row, 'total_tokens'),
+      estimatedCost: numberFromRow(row, 'estimated_cost'),
+      requestCount: numberFromRow(row, 'request_count'),
+      windowStart: options.window.start,
+      windowEnd: options.window.end,
+    };
+  }
+}
+
+function firstRow(result: unknown): Record<string, unknown> {
+  const rows = Array.isArray(result)
+    ? (result as Record<string, unknown>[])
+    : ((result as { rows?: Record<string, unknown>[] })?.rows ?? []);
+  return (rows[0] ?? {}) as Record<string, unknown>;
+}
+
+function numberFromRow(row: Record<string, unknown>, key: string): number {
+  const value = row[key];
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'bigint') {
+    return Number(value);
+  }
+  if (typeof value === 'string') {
+    return Number.parseFloat(value) || 0;
+  }
+  return 0;
 }

--- a/packages/subscriptions/src/collections/TenantUsageMetricCollection.ts
+++ b/packages/subscriptions/src/collections/TenantUsageMetricCollection.ts
@@ -7,6 +7,7 @@ import type {
   SummarizeUsageOptions,
   UsageSummary,
 } from '../types.js';
+import { stringifyJson } from '../utils.js';
 
 export class TenantUsageMetricCollection extends SmrtCollection<TenantUsageMetric> {
   static readonly _itemClass = TenantUsageMetric;
@@ -20,9 +21,8 @@ export class TenantUsageMetricCollection extends SmrtCollection<TenantUsageMetri
       windowEnd: options.windowEnd,
       source: options.source ?? '',
       sourceId: options.sourceId ?? '',
+      dimensions: stringifyJson(options.dimensions ?? {}),
     });
-    metric.setDimensions(options.dimensions ?? {});
-    await metric.save();
     return metric;
   }
 

--- a/packages/subscriptions/src/collections/index.ts
+++ b/packages/subscriptions/src/collections/index.ts
@@ -1,0 +1,3 @@
+export { SubscriptionPlanCollection } from './SubscriptionPlanCollection.js';
+export { TenantSubscriptionCollection } from './TenantSubscriptionCollection.js';
+export { TenantUsageMetricCollection } from './TenantUsageMetricCollection.js';

--- a/packages/subscriptions/src/index.ts
+++ b/packages/subscriptions/src/index.ts
@@ -1,0 +1,58 @@
+/**
+ * @happyvertical/smrt-subscriptions
+ *
+ * Tenant subscription plans, feature grants, usage thresholds, and entitlement
+ * resolution for SMRT applications.
+ *
+ * @packageDocumentation
+ */
+
+import './__smrt-register__.js';
+
+export {
+  SubscriptionPlanCollection,
+  TenantSubscriptionCollection,
+  TenantUsageMetricCollection,
+} from './collections/index.js';
+export {
+  SubscriptionPlan,
+  TenantSubscription,
+  TenantUsageMetric,
+} from './models/index.js';
+export {
+  evaluateThreshold,
+  evaluateThresholds,
+  type SubscriptionPlanReader,
+  SubscriptionResolver,
+  type SubscriptionResolverReaders,
+  type TenantSubscriptionReader,
+  TenantUsageMeter,
+  type UsageSummaryReader,
+} from './services/index.js';
+export type {
+  AiUsageSummary,
+  BillingInterval,
+  EntitlementResolution,
+  JsonObject,
+  PlanFeatureGrant,
+  PlanThreshold,
+  RecordUsageOptions,
+  SubscriptionPlanStatus,
+  SubscriptionResolverOptions,
+  SubscriptionStatus,
+  SummarizeAiUsageOptions,
+  SummarizeUsageOptions,
+  ThresholdEnforcement,
+  ThresholdEvaluation,
+  ThresholdWindow,
+  UsageMeterOptions,
+  UsageMetricRecord,
+  UsageSummary,
+  UsageWindow,
+} from './types.js';
+export {
+  getWindowForThreshold,
+  getWindowKey,
+  isValidThreshold,
+  normalizeFeatureGrants,
+} from './utils.js';

--- a/packages/subscriptions/src/models/SubscriptionPlan.ts
+++ b/packages/subscriptions/src/models/SubscriptionPlan.ts
@@ -1,0 +1,112 @@
+import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import type {
+  BillingInterval,
+  JsonObject,
+  PlanFeatureGrant,
+  PlanThreshold,
+  SubscriptionPlanStatus,
+} from '../types.js';
+import {
+  normalizeFeatureGrants,
+  parseJsonArray,
+  parseJsonObject,
+  stringifyJson,
+} from '../utils.js';
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: '_smrt_subscription_plans',
+  api: { include: ['list', 'get', 'create', 'update'] },
+  cli: true,
+  mcp: { include: ['list', 'get'] },
+  conflictColumns: ['plan_key'],
+})
+export class SubscriptionPlan extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  planKey: string = '';
+  name: string = '';
+  description: string = '';
+  status: SubscriptionPlanStatus = 'active';
+  sortOrder: number = 0;
+  priceAmount: number = 0.0;
+  currency: string = 'USD';
+  billingInterval: BillingInterval = 'month';
+  externalProvider: string = 'stripe';
+  stripeProductId: string = '';
+  stripePriceId: string = '';
+  features: string = '[]';
+  thresholds: string = '[]';
+  metadata: string = '{}';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+    if (options.planKey !== undefined) this.planKey = options.planKey;
+    if (options.name !== undefined) this.name = options.name;
+    if (options.description !== undefined)
+      this.description = options.description;
+    if (options.status !== undefined) this.status = options.status;
+    if (options.sortOrder !== undefined) this.sortOrder = options.sortOrder;
+    if (options.priceAmount !== undefined)
+      this.priceAmount = options.priceAmount;
+    if (options.currency !== undefined) this.currency = options.currency;
+    if (options.billingInterval !== undefined) {
+      this.billingInterval = options.billingInterval;
+    }
+    if (options.externalProvider !== undefined) {
+      this.externalProvider = options.externalProvider;
+    }
+    if (options.stripeProductId !== undefined) {
+      this.stripeProductId = options.stripeProductId;
+    }
+    if (options.stripePriceId !== undefined) {
+      this.stripePriceId = options.stripePriceId;
+    }
+    if (options.features !== undefined) this.features = options.features;
+    if (options.thresholds !== undefined) this.thresholds = options.thresholds;
+    if (options.metadata !== undefined) this.metadata = options.metadata;
+  }
+
+  isActive(): boolean {
+    return this.status === 'active';
+  }
+
+  getFeatureGrants(): PlanFeatureGrant[] {
+    return normalizeFeatureGrants(
+      parseJsonArray<string | PlanFeatureGrant>(this.features),
+    );
+  }
+
+  setFeatureGrants(grants: Array<string | PlanFeatureGrant>): void {
+    this.features = stringifyJson(normalizeFeatureGrants(grants));
+  }
+
+  getFeatureKeys(): string[] {
+    return this.getFeatureGrants()
+      .filter((grant) => grant.enabled !== false)
+      .map((grant) => grant.featureKey);
+  }
+
+  getThresholds(): PlanThreshold[] {
+    return parseJsonArray<PlanThreshold>(this.thresholds).filter(
+      (threshold) => threshold.metricKey,
+    );
+  }
+
+  setThresholds(thresholds: PlanThreshold[]): void {
+    this.thresholds = stringifyJson(thresholds);
+  }
+
+  getMetadata(): JsonObject {
+    return parseJsonObject(this.metadata, {});
+  }
+
+  setMetadata(metadata: JsonObject): void {
+    this.metadata = stringifyJson(metadata);
+  }
+}
+
+export default SubscriptionPlan;

--- a/packages/subscriptions/src/models/TenantSubscription.ts
+++ b/packages/subscriptions/src/models/TenantSubscription.ts
@@ -1,0 +1,89 @@
+import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import type { JsonObject, SubscriptionStatus } from '../types.js';
+import { parseJsonObject, stringifyJson } from '../utils.js';
+
+@TenantScoped({ mode: 'required' })
+@smrt({
+  tableName: '_smrt_tenant_subscriptions',
+  api: { include: ['list', 'get', 'create', 'update'] },
+  cli: true,
+  mcp: { include: ['list', 'get'] },
+  conflictColumns: ['tenant_id'],
+})
+export class TenantSubscription extends SmrtObject {
+  @tenantId()
+  tenantId: string = '';
+
+  @foreignKey('SubscriptionPlan')
+  planId: string = '';
+
+  status: SubscriptionStatus = 'incomplete';
+  startedAt: Date = new Date();
+  currentPeriodStart: Date | null = null;
+  currentPeriodEnd: Date | null = null;
+  trialEndsAt: Date | null = null;
+  cancelAtPeriodEnd: boolean = false;
+  canceledAt: Date | null = null;
+  externalProvider: string = 'stripe';
+  stripeCustomerId: string = '';
+  stripeSubscriptionId: string = '';
+  stripeCheckoutSessionId: string = '';
+  metadata: string = '{}';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+    if (options.planId !== undefined) this.planId = options.planId;
+    if (options.status !== undefined) this.status = options.status;
+    if (options.startedAt !== undefined) this.startedAt = options.startedAt;
+    if (options.currentPeriodStart !== undefined) {
+      this.currentPeriodStart = options.currentPeriodStart;
+    }
+    if (options.currentPeriodEnd !== undefined) {
+      this.currentPeriodEnd = options.currentPeriodEnd;
+    }
+    if (options.trialEndsAt !== undefined)
+      this.trialEndsAt = options.trialEndsAt;
+    if (options.cancelAtPeriodEnd !== undefined) {
+      this.cancelAtPeriodEnd = options.cancelAtPeriodEnd;
+    }
+    if (options.canceledAt !== undefined) this.canceledAt = options.canceledAt;
+    if (options.externalProvider !== undefined) {
+      this.externalProvider = options.externalProvider;
+    }
+    if (options.stripeCustomerId !== undefined) {
+      this.stripeCustomerId = options.stripeCustomerId;
+    }
+    if (options.stripeSubscriptionId !== undefined) {
+      this.stripeSubscriptionId = options.stripeSubscriptionId;
+    }
+    if (options.stripeCheckoutSessionId !== undefined) {
+      this.stripeCheckoutSessionId = options.stripeCheckoutSessionId;
+    }
+    if (options.metadata !== undefined) this.metadata = options.metadata;
+  }
+
+  isEntitled(now = new Date()): boolean {
+    if (this.status !== 'active' && this.status !== 'trialing') {
+      return false;
+    }
+    if (
+      this.currentPeriodEnd &&
+      this.currentPeriodEnd.getTime() < now.getTime()
+    ) {
+      return false;
+    }
+    return true;
+  }
+
+  getMetadata(): JsonObject {
+    return parseJsonObject(this.metadata, {});
+  }
+
+  setMetadata(metadata: JsonObject): void {
+    this.metadata = stringifyJson(metadata);
+  }
+}
+
+export default TenantSubscription;

--- a/packages/subscriptions/src/models/TenantUsageMetric.ts
+++ b/packages/subscriptions/src/models/TenantUsageMetric.ts
@@ -1,0 +1,47 @@
+import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import type { JsonObject } from '../types.js';
+import { parseJsonObject, stringifyJson } from '../utils.js';
+
+@TenantScoped({ mode: 'required' })
+@smrt({
+  tableName: '_smrt_tenant_usage_metrics',
+  api: { include: ['list', 'get', 'create'] },
+  cli: true,
+  mcp: { include: ['list', 'get'] },
+})
+export class TenantUsageMetric extends SmrtObject {
+  @tenantId()
+  tenantId: string = '';
+
+  metricKey: string = '';
+  quantity: number = 0.0;
+  windowStart: Date = new Date();
+  windowEnd: Date = new Date();
+  source: string = '';
+  sourceId: string = '';
+  dimensions: string = '{}';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+    if (options.metricKey !== undefined) this.metricKey = options.metricKey;
+    if (options.quantity !== undefined) this.quantity = options.quantity;
+    if (options.windowStart !== undefined)
+      this.windowStart = options.windowStart;
+    if (options.windowEnd !== undefined) this.windowEnd = options.windowEnd;
+    if (options.source !== undefined) this.source = options.source;
+    if (options.sourceId !== undefined) this.sourceId = options.sourceId;
+    if (options.dimensions !== undefined) this.dimensions = options.dimensions;
+  }
+
+  getDimensions(): JsonObject {
+    return parseJsonObject(this.dimensions, {});
+  }
+
+  setDimensions(dimensions: JsonObject): void {
+    this.dimensions = stringifyJson(dimensions);
+  }
+}
+
+export default TenantUsageMetric;

--- a/packages/subscriptions/src/models/index.ts
+++ b/packages/subscriptions/src/models/index.ts
@@ -1,0 +1,3 @@
+export { SubscriptionPlan } from './SubscriptionPlan.js';
+export { TenantSubscription } from './TenantSubscription.js';
+export { TenantUsageMetric } from './TenantUsageMetric.js';

--- a/packages/subscriptions/src/services/index.ts
+++ b/packages/subscriptions/src/services/index.ts
@@ -1,0 +1,12 @@
+export {
+  type SubscriptionPlanReader,
+  SubscriptionResolver,
+  type SubscriptionResolverReaders,
+  type TenantSubscriptionReader,
+  type UsageSummaryReader,
+} from './subscription-resolver.js';
+export {
+  evaluateThreshold,
+  evaluateThresholds,
+} from './threshold-evaluator.js';
+export { TenantUsageMeter } from './usage-meter.js';

--- a/packages/subscriptions/src/services/subscription-resolver.ts
+++ b/packages/subscriptions/src/services/subscription-resolver.ts
@@ -1,0 +1,132 @@
+import type { SubscriptionPlan } from '../models/SubscriptionPlan.js';
+import type { TenantSubscription } from '../models/TenantSubscription.js';
+import type {
+  EntitlementResolution,
+  PlanThreshold,
+  SubscriptionResolverOptions,
+  UsageSummary,
+  UsageWindow,
+} from '../types.js';
+import { getWindowForThreshold, isValidThreshold } from '../utils.js';
+import { evaluateThreshold } from './threshold-evaluator.js';
+
+export interface SubscriptionPlanReader {
+  get(criteria: { id: string }): Promise<SubscriptionPlan | null>;
+}
+
+export interface TenantSubscriptionReader {
+  findCurrentForTenant(tenantId: string): Promise<TenantSubscription | null>;
+}
+
+export interface UsageSummaryReader {
+  summarize(options: {
+    tenantId: string;
+    metricKey: string;
+    window: UsageWindow;
+  }): Promise<UsageSummary>;
+}
+
+export interface SubscriptionResolverReaders {
+  plans: SubscriptionPlanReader;
+  subscriptions: TenantSubscriptionReader;
+  usage: UsageSummaryReader;
+}
+
+export class SubscriptionResolver {
+  constructor(private readonly readers: SubscriptionResolverReaders) {}
+
+  async resolveTenantEntitlements(
+    tenantId: string,
+    options: SubscriptionResolverOptions = {},
+  ): Promise<EntitlementResolution> {
+    const now = options.now ?? new Date();
+    const subscription =
+      await this.readers.subscriptions.findCurrentForTenant(tenantId);
+
+    if (!subscription) {
+      return emptyResolution(tenantId);
+    }
+
+    const plan = subscription.planId
+      ? await this.readers.plans.get({ id: subscription.planId })
+      : null;
+
+    if (!plan || !plan.isActive() || !subscription.isEntitled(now)) {
+      return {
+        ...emptyResolution(tenantId),
+        planId: plan?.id ?? subscription.planId ?? null,
+        planKey: plan?.planKey ?? null,
+        subscriptionId: subscription.id ?? null,
+        status: subscription.status,
+      };
+    }
+
+    const thresholds = plan.getThresholds().filter(isValidThreshold);
+    const thresholdEvaluations = [];
+
+    for (const threshold of thresholds) {
+      const window =
+        options.usageWindows?.[threshold.window] ??
+        getWindowForThreshold(threshold.window, now);
+      const usage = await this.readers.usage.summarize({
+        tenantId,
+        metricKey: threshold.metricKey,
+        window,
+      });
+      thresholdEvaluations.push(evaluateThreshold(threshold, usage));
+    }
+
+    return {
+      tenantId,
+      planId: plan.id ?? null,
+      planKey: plan.planKey,
+      subscriptionId: subscription.id ?? null,
+      status: subscription.status,
+      featureKeys: plan.getFeatureKeys(),
+      thresholds,
+      thresholdEvaluations,
+      allowed: thresholdEvaluations.every((evaluation) => evaluation.allowed),
+    };
+  }
+
+  async isFeatureEnabled(
+    tenantId: string,
+    featureKey: string,
+    options: SubscriptionResolverOptions = {},
+  ): Promise<boolean> {
+    const resolution = await this.resolveTenantEntitlements(tenantId, options);
+    return resolution.featureKeys.includes(featureKey);
+  }
+
+  async assertWithinThresholds(
+    tenantId: string,
+    options: SubscriptionResolverOptions = {},
+  ): Promise<void> {
+    const resolution = await this.resolveTenantEntitlements(tenantId, options);
+    const blocked = resolution.thresholdEvaluations.find(
+      (evaluation) => !evaluation.allowed,
+    );
+
+    if (blocked) {
+      throw new Error(
+        `Tenant ${tenantId} exceeded subscription threshold ${blocked.threshold.metricKey}`,
+      );
+    }
+  }
+}
+
+function emptyResolution(tenantId: string): EntitlementResolution {
+  return {
+    tenantId,
+    planId: null,
+    planKey: null,
+    subscriptionId: null,
+    status: 'none',
+    featureKeys: [],
+    thresholds: [],
+    thresholdEvaluations: [],
+    allowed: false,
+  };
+}
+
+export type { PlanThreshold };

--- a/packages/subscriptions/src/services/subscription-resolver.ts
+++ b/packages/subscriptions/src/services/subscription-resolver.ts
@@ -4,6 +4,7 @@ import type {
   EntitlementResolution,
   PlanThreshold,
   SubscriptionResolverOptions,
+  ThresholdEvaluation,
   UsageSummary,
   UsageWindow,
 } from '../types.js';
@@ -15,7 +16,10 @@ export interface SubscriptionPlanReader {
 }
 
 export interface TenantSubscriptionReader {
-  findCurrentForTenant(tenantId: string): Promise<TenantSubscription | null>;
+  findCurrentForTenant(
+    tenantId: string,
+    now?: Date,
+  ): Promise<TenantSubscription | null>;
 }
 
 export interface UsageSummaryReader {
@@ -40,8 +44,10 @@ export class SubscriptionResolver {
     options: SubscriptionResolverOptions = {},
   ): Promise<EntitlementResolution> {
     const now = options.now ?? new Date();
-    const subscription =
-      await this.readers.subscriptions.findCurrentForTenant(tenantId);
+    const subscription = await this.readers.subscriptions.findCurrentForTenant(
+      tenantId,
+      now,
+    );
 
     if (!subscription) {
       return emptyResolution(tenantId);
@@ -62,7 +68,7 @@ export class SubscriptionResolver {
     }
 
     const thresholds = plan.getThresholds().filter(isValidThreshold);
-    const thresholdEvaluations = [];
+    const thresholdEvaluations: ThresholdEvaluation[] = [];
 
     for (const threshold of thresholds) {
       const window =

--- a/packages/subscriptions/src/services/threshold-evaluator.ts
+++ b/packages/subscriptions/src/services/threshold-evaluator.ts
@@ -16,7 +16,10 @@ export function evaluateThreshold(
       : usage.quantity / threshold.limit;
   const warningRatio = threshold.warningRatio ?? 0.8;
   const blocked =
-    threshold.enforcement === 'block' && usage.quantity >= threshold.limit;
+    threshold.enforcement === 'block' &&
+    (threshold.limit === 0
+      ? usage.quantity > 0
+      : usage.quantity >= threshold.limit);
   const warned = !blocked && ratio >= warningRatio;
 
   return {

--- a/packages/subscriptions/src/services/threshold-evaluator.ts
+++ b/packages/subscriptions/src/services/threshold-evaluator.ts
@@ -1,0 +1,57 @@
+import type {
+  PlanThreshold,
+  ThresholdEvaluation,
+  UsageSummary,
+} from '../types.js';
+
+export function evaluateThreshold(
+  threshold: PlanThreshold,
+  usage: UsageSummary,
+): ThresholdEvaluation {
+  const ratio =
+    threshold.limit === 0
+      ? usage.quantity > 0
+        ? Infinity
+        : 0
+      : usage.quantity / threshold.limit;
+  const warningRatio = threshold.warningRatio ?? 0.8;
+  const blocked =
+    threshold.enforcement === 'block' && usage.quantity >= threshold.limit;
+  const warned = !blocked && ratio >= warningRatio;
+
+  return {
+    threshold,
+    usage,
+    ratio,
+    state: blocked ? 'blocked' : warned ? 'warn' : 'ok',
+    allowed: !blocked,
+    remaining: Math.max(0, threshold.limit - usage.quantity),
+  };
+}
+
+export function evaluateThresholds(
+  thresholds: PlanThreshold[],
+  usage: UsageSummary[],
+): ThresholdEvaluation[] {
+  const usageByMetric = new Map(
+    usage.map((summary) => [summary.metricKey, summary]),
+  );
+
+  return thresholds.map((threshold) => {
+    const summary =
+      usageByMetric.get(threshold.metricKey) ??
+      emptyUsageSummary(threshold.metricKey);
+    return evaluateThreshold(threshold, summary);
+  });
+}
+
+function emptyUsageSummary(metricKey: string): UsageSummary {
+  const now = new Date();
+  return {
+    tenantId: '',
+    metricKey,
+    quantity: 0,
+    windowStart: now,
+    windowEnd: now,
+  };
+}

--- a/packages/subscriptions/src/services/usage-meter.ts
+++ b/packages/subscriptions/src/services/usage-meter.ts
@@ -37,35 +37,7 @@ export class TenantUsageMeter {
   async summarizeAiUsage(
     options: SummarizeAiUsageOptions,
   ): Promise<AiUsageSummary> {
-    const rows = await this.metrics.query(
-      `SELECT
-          COALESCE(SUM(prompt_tokens), 0) AS prompt_tokens,
-          COALESCE(SUM(completion_tokens), 0) AS completion_tokens,
-          COALESCE(SUM(total_tokens), 0) AS total_tokens,
-          COALESCE(SUM(estimated_cost), 0) AS estimated_cost,
-          COUNT(*) AS request_count
-        FROM _smrt_ai_usage
-        WHERE tenant_id = ?
-          AND created_at >= ?
-          AND created_at < ?`,
-      [
-        options.tenantId,
-        options.window.start.toISOString(),
-        options.window.end.toISOString(),
-      ],
-    );
-    const row = (rows[0] ?? {}) as unknown as Record<string, unknown>;
-
-    return {
-      tenantId: options.tenantId,
-      promptTokens: numberFromRow(row, 'prompt_tokens'),
-      completionTokens: numberFromRow(row, 'completion_tokens'),
-      totalTokens: numberFromRow(row, 'total_tokens'),
-      estimatedCost: numberFromRow(row, 'estimated_cost'),
-      requestCount: numberFromRow(row, 'request_count'),
-      windowStart: options.window.start,
-      windowEnd: options.window.end,
-    };
+    return this.metrics.summarizeTenantAiUsage(options);
   }
 
   getOptions(): SmrtClassOptions {
@@ -100,18 +72,4 @@ export class TenantUsageMeter {
       windowEnd: options.window.end,
     };
   }
-}
-
-function numberFromRow(row: Record<string, unknown>, key: string): number {
-  const value = row[key];
-  if (typeof value === 'number') {
-    return value;
-  }
-  if (typeof value === 'bigint') {
-    return Number(value);
-  }
-  if (typeof value === 'string') {
-    return Number.parseFloat(value) || 0;
-  }
-  return 0;
 }

--- a/packages/subscriptions/src/services/usage-meter.ts
+++ b/packages/subscriptions/src/services/usage-meter.ts
@@ -1,0 +1,117 @@
+import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+import { TenantUsageMetricCollection } from '../collections/TenantUsageMetricCollection.js';
+import type {
+  AiUsageSummary,
+  RecordUsageOptions,
+  SummarizeAiUsageOptions,
+  SummarizeUsageOptions,
+  UsageSummary,
+} from '../types.js';
+
+export class TenantUsageMeter {
+  constructor(
+    private readonly metrics: TenantUsageMetricCollection,
+    private readonly classOptions: SmrtClassOptions = {},
+  ) {}
+
+  static async create(
+    classOptions: SmrtClassOptions = {},
+  ): Promise<TenantUsageMeter> {
+    const metrics = await TenantUsageMetricCollection.create(classOptions);
+    return new TenantUsageMeter(metrics, classOptions);
+  }
+
+  async record(options: RecordUsageOptions): Promise<void> {
+    await this.metrics.recordUsage(options);
+  }
+
+  async summarize(options: SummarizeUsageOptions): Promise<UsageSummary> {
+    const aiSummary = await this.trySummarizeAiMetric(options);
+    if (aiSummary) {
+      return aiSummary;
+    }
+
+    return this.metrics.summarizeUsage(options);
+  }
+
+  async summarizeAiUsage(
+    options: SummarizeAiUsageOptions,
+  ): Promise<AiUsageSummary> {
+    const rows = await this.metrics.query(
+      `SELECT
+          COALESCE(SUM(prompt_tokens), 0) AS prompt_tokens,
+          COALESCE(SUM(completion_tokens), 0) AS completion_tokens,
+          COALESCE(SUM(total_tokens), 0) AS total_tokens,
+          COALESCE(SUM(estimated_cost), 0) AS estimated_cost,
+          COUNT(*) AS request_count
+        FROM _smrt_ai_usage
+        WHERE tenant_id = ?
+          AND created_at >= ?
+          AND created_at < ?`,
+      [
+        options.tenantId,
+        options.window.start.toISOString(),
+        options.window.end.toISOString(),
+      ],
+    );
+    const row = (rows[0] ?? {}) as unknown as Record<string, unknown>;
+
+    return {
+      tenantId: options.tenantId,
+      promptTokens: numberFromRow(row, 'prompt_tokens'),
+      completionTokens: numberFromRow(row, 'completion_tokens'),
+      totalTokens: numberFromRow(row, 'total_tokens'),
+      estimatedCost: numberFromRow(row, 'estimated_cost'),
+      requestCount: numberFromRow(row, 'request_count'),
+      windowStart: options.window.start,
+      windowEnd: options.window.end,
+    };
+  }
+
+  getOptions(): SmrtClassOptions {
+    return this.classOptions;
+  }
+
+  private async trySummarizeAiMetric(
+    options: SummarizeUsageOptions,
+  ): Promise<UsageSummary | null> {
+    if (!options.metricKey.startsWith('ai.')) {
+      return null;
+    }
+
+    const summary = await this.summarizeAiUsage({
+      tenantId: options.tenantId,
+      window: options.window,
+    });
+
+    const quantityByMetric: Record<string, number> = {
+      'ai.tokens.prompt': summary.promptTokens,
+      'ai.tokens.completion': summary.completionTokens,
+      'ai.tokens.total': summary.totalTokens,
+      'ai.cost.estimated': summary.estimatedCost,
+      'ai.requests': summary.requestCount,
+    };
+
+    return {
+      tenantId: options.tenantId,
+      metricKey: options.metricKey,
+      quantity: quantityByMetric[options.metricKey] ?? 0,
+      windowStart: options.window.start,
+      windowEnd: options.window.end,
+    };
+  }
+}
+
+function numberFromRow(row: Record<string, unknown>, key: string): number {
+  const value = row[key];
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'bigint') {
+    return Number(value);
+  }
+  if (typeof value === 'string') {
+    return Number.parseFloat(value) || 0;
+  }
+  return 0;
+}

--- a/packages/subscriptions/src/svelte/PlanPicker.svelte
+++ b/packages/subscriptions/src/svelte/PlanPicker.svelte
@@ -15,6 +15,7 @@ let {
 <div class="smrt-plan-picker">
   {#each plans as plan (plan.id)}
     <button
+      aria-pressed={plan.planKey === selectedPlanKey}
       class:selected={plan.planKey === selectedPlanKey}
       class="smrt-plan-picker__plan"
       type="button"

--- a/packages/subscriptions/src/svelte/PlanPicker.svelte
+++ b/packages/subscriptions/src/svelte/PlanPicker.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+import type { SubscriptionPlan } from '../models/SubscriptionPlan.js';
+
+let {
+  plans = [],
+  selectedPlanKey = null,
+  onSelect,
+}: {
+  plans?: SubscriptionPlan[];
+  selectedPlanKey?: string | null;
+  onSelect?: (plan: SubscriptionPlan) => void;
+} = $props();
+</script>
+
+<div class="smrt-plan-picker">
+  {#each plans as plan (plan.id)}
+    <button
+      class:selected={plan.planKey === selectedPlanKey}
+      class="smrt-plan-picker__plan"
+      type="button"
+      onclick={() => onSelect?.(plan)}
+    >
+      <span class="smrt-plan-picker__name">{plan.name}</span>
+      <span class="smrt-plan-picker__price">
+        {new Intl.NumberFormat(undefined, {
+          style: 'currency',
+          currency: plan.currency,
+        }).format(plan.priceAmount)}
+        <small>/ {plan.billingInterval}</small>
+      </span>
+      {#if plan.description}
+        <span class="smrt-plan-picker__description">{plan.description}</span>
+      {/if}
+      <span class="smrt-plan-picker__features">
+        {plan.getFeatureKeys().length} features
+      </span>
+    </button>
+  {/each}
+</div>
+
+<style>
+  .smrt-plan-picker {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  }
+
+  .smrt-plan-picker__plan {
+    align-items: flex-start;
+    background: var(--smrt-surface, #fff);
+    border: 1px solid var(--smrt-border, #d8dde6);
+    border-radius: 8px;
+    color: inherit;
+    cursor: pointer;
+    display: grid;
+    gap: 0.45rem;
+    padding: 1rem;
+    text-align: left;
+  }
+
+  .smrt-plan-picker__plan.selected {
+    border-color: var(--smrt-primary, #2563eb);
+    box-shadow: 0 0 0 1px var(--smrt-primary, #2563eb);
+  }
+
+  .smrt-plan-picker__name {
+    font-weight: 650;
+  }
+
+  .smrt-plan-picker__price {
+    font-size: 1.25rem;
+    font-weight: 700;
+  }
+
+  .smrt-plan-picker__price small,
+  .smrt-plan-picker__description,
+  .smrt-plan-picker__features {
+    color: var(--smrt-muted, #64748b);
+    font-size: 0.875rem;
+  }
+</style>

--- a/packages/subscriptions/src/svelte/SubscriptionSummary.svelte
+++ b/packages/subscriptions/src/svelte/SubscriptionSummary.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+import type { EntitlementResolution } from '../types.js';
+
+let {
+  resolution = null,
+}: {
+  resolution?: EntitlementResolution | null;
+} = $props();
+</script>
+
+<section class="smrt-subscription-summary">
+  <div>
+    <p class="smrt-subscription-summary__label">Current plan</p>
+    <h2>{resolution?.planKey ?? 'No active plan'}</h2>
+  </div>
+  <dl>
+    <div>
+      <dt>Status</dt>
+      <dd>{resolution?.status ?? 'none'}</dd>
+    </div>
+    <div>
+      <dt>Features</dt>
+      <dd>{resolution?.featureKeys.length ?? 0}</dd>
+    </div>
+    <div>
+      <dt>Thresholds</dt>
+      <dd>{resolution?.thresholds.length ?? 0}</dd>
+    </div>
+  </dl>
+</section>
+
+<style>
+  .smrt-subscription-summary {
+    align-items: center;
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+  }
+
+  .smrt-subscription-summary h2,
+  .smrt-subscription-summary__label {
+    margin: 0;
+  }
+
+  .smrt-subscription-summary__label,
+  .smrt-subscription-summary dt {
+    color: var(--smrt-muted, #64748b);
+    font-size: 0.8rem;
+  }
+
+  .smrt-subscription-summary dl {
+    display: flex;
+    gap: 1rem;
+    margin: 0;
+  }
+
+  .smrt-subscription-summary dd {
+    font-weight: 650;
+    margin: 0;
+  }
+</style>

--- a/packages/subscriptions/src/svelte/UsageThresholds.svelte
+++ b/packages/subscriptions/src/svelte/UsageThresholds.svelte
@@ -20,6 +20,7 @@ let {
         <span>{evaluation.usage.quantity} / {evaluation.threshold.limit}</span>
       </div>
       <progress
+        aria-label={`${evaluation.threshold.label ?? evaluation.threshold.metricKey} usage`}
         max="1"
         value={Number.isFinite(evaluation.ratio)
           ? Math.min(1, evaluation.ratio)

--- a/packages/subscriptions/src/svelte/UsageThresholds.svelte
+++ b/packages/subscriptions/src/svelte/UsageThresholds.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+import type { ThresholdEvaluation } from '../types.js';
+
+let {
+  evaluations = [],
+}: {
+  evaluations?: ThresholdEvaluation[];
+} = $props();
+</script>
+
+<div class="smrt-usage-thresholds">
+  {#each evaluations as evaluation (`${evaluation.threshold.metricKey}:${evaluation.usage.windowStart.toISOString()}`)}
+    <article
+      class:warn={evaluation.state === 'warn'}
+      class:blocked={evaluation.state === 'blocked'}
+      class="smrt-usage-thresholds__row"
+    >
+      <div class="smrt-usage-thresholds__header">
+        <strong>{evaluation.threshold.label ?? evaluation.threshold.metricKey}</strong>
+        <span>{evaluation.usage.quantity} / {evaluation.threshold.limit}</span>
+      </div>
+      <progress
+        max="1"
+        value={Number.isFinite(evaluation.ratio)
+          ? Math.min(1, evaluation.ratio)
+          : 1}
+      ></progress>
+      <p>{evaluation.state}</p>
+    </article>
+  {/each}
+</div>
+
+<style>
+  .smrt-usage-thresholds {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .smrt-usage-thresholds__row {
+    border: 1px solid var(--smrt-border, #d8dde6);
+    border-radius: 8px;
+    display: grid;
+    gap: 0.45rem;
+    padding: 0.875rem;
+  }
+
+  .smrt-usage-thresholds__row.warn {
+    border-color: #d97706;
+  }
+
+  .smrt-usage-thresholds__row.blocked {
+    border-color: #dc2626;
+  }
+
+  .smrt-usage-thresholds__header {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .smrt-usage-thresholds p {
+    color: var(--smrt-muted, #64748b);
+    font-size: 0.875rem;
+    margin: 0;
+  }
+
+  .smrt-usage-thresholds progress {
+    inline-size: 100%;
+  }
+</style>

--- a/packages/subscriptions/src/svelte/index.ts
+++ b/packages/subscriptions/src/svelte/index.ts
@@ -1,0 +1,3 @@
+export { default as PlanPicker } from './PlanPicker.svelte';
+export { default as SubscriptionSummary } from './SubscriptionSummary.svelte';
+export { default as UsageThresholds } from './UsageThresholds.svelte';

--- a/packages/subscriptions/src/types.ts
+++ b/packages/subscriptions/src/types.ts
@@ -1,0 +1,115 @@
+import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+
+export type SubscriptionStatus =
+  | 'active'
+  | 'canceled'
+  | 'incomplete'
+  | 'past_due'
+  | 'trialing'
+  | 'unpaid';
+
+export type SubscriptionPlanStatus = 'active' | 'archived' | 'draft';
+
+export type BillingInterval = 'day' | 'week' | 'month' | 'year';
+
+export type ThresholdEnforcement = 'observe' | 'warn' | 'block';
+
+export type ThresholdWindow = 'day' | 'week' | 'month' | 'year' | 'rolling';
+
+export interface PlanFeatureGrant {
+  featureKey: string;
+  enabled?: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PlanThreshold {
+  metricKey: string;
+  limit: number;
+  window: ThresholdWindow;
+  enforcement: ThresholdEnforcement;
+  label?: string;
+  warningRatio?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface UsageWindow {
+  start: Date;
+  end: Date;
+}
+
+export interface UsageMetricRecord {
+  tenantId: string;
+  metricKey: string;
+  quantity: number;
+  windowStart: Date;
+  windowEnd: Date;
+  source?: string;
+  sourceId?: string;
+  dimensions?: Record<string, unknown>;
+}
+
+export interface UsageSummary {
+  tenantId: string;
+  metricKey: string;
+  quantity: number;
+  windowStart: Date;
+  windowEnd: Date;
+}
+
+export interface AiUsageSummary {
+  tenantId: string;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  estimatedCost: number;
+  requestCount: number;
+  windowStart: Date;
+  windowEnd: Date;
+}
+
+export interface ThresholdEvaluation {
+  threshold: PlanThreshold;
+  usage: UsageSummary;
+  ratio: number;
+  state: 'ok' | 'warn' | 'blocked';
+  allowed: boolean;
+  remaining: number;
+}
+
+export interface EntitlementResolution {
+  tenantId: string;
+  planId: string | null;
+  planKey: string | null;
+  subscriptionId: string | null;
+  status: SubscriptionStatus | 'none';
+  featureKeys: string[];
+  thresholds: PlanThreshold[];
+  thresholdEvaluations: ThresholdEvaluation[];
+  allowed: boolean;
+}
+
+export interface SubscriptionResolverOptions {
+  now?: Date;
+  usageWindows?: Partial<Record<ThresholdWindow, UsageWindow>>;
+}
+
+export interface UsageMeterOptions {
+  classOptions?: SmrtClassOptions;
+}
+
+export interface RecordUsageOptions extends UsageMetricRecord {}
+
+export interface SummarizeUsageOptions {
+  tenantId: string;
+  metricKey: string;
+  window: UsageWindow;
+}
+
+export interface SummarizeAiUsageOptions {
+  tenantId: string;
+  window: UsageWindow;
+}
+
+export type JsonObject = Record<string, unknown>;
+
+export type { SmrtClassOptions };

--- a/packages/subscriptions/src/utils.ts
+++ b/packages/subscriptions/src/utils.ts
@@ -1,0 +1,122 @@
+import type {
+  JsonObject,
+  PlanFeatureGrant,
+  PlanThreshold,
+  ThresholdWindow,
+  UsageWindow,
+} from './types.js';
+
+export function parseJsonArray<T>(value: string, fallback: T[] = []): T[] {
+  if (!value) {
+    return fallback;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed) ? (parsed as T[]) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function parseJsonObject<T extends JsonObject>(
+  value: string,
+  fallback: T,
+): T {
+  if (!value) {
+    return fallback;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as T)
+      : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function stringifyJson(value: unknown): string {
+  return JSON.stringify(value ?? null);
+}
+
+export function normalizeFeatureGrants(
+  grants: Array<string | PlanFeatureGrant>,
+): PlanFeatureGrant[] {
+  return grants.map((grant) =>
+    typeof grant === 'string' ? { featureKey: grant, enabled: true } : grant,
+  );
+}
+
+export function getWindowForThreshold(
+  thresholdWindow: ThresholdWindow,
+  now = new Date(),
+): UsageWindow {
+  switch (thresholdWindow) {
+    case 'day':
+      return utcWindow(now, 'day');
+    case 'week':
+      return utcWindow(now, 'week');
+    case 'month':
+      return utcWindow(now, 'month');
+    case 'year':
+      return utcWindow(now, 'year');
+    case 'rolling':
+      return {
+        start: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000),
+        end: now,
+      };
+  }
+}
+
+export function getWindowKey(window: UsageWindow): string {
+  return `${window.start.toISOString()}..${window.end.toISOString()}`;
+}
+
+export function isValidThreshold(threshold: PlanThreshold): boolean {
+  return (
+    typeof threshold.metricKey === 'string' &&
+    threshold.metricKey.length > 0 &&
+    Number.isFinite(threshold.limit) &&
+    threshold.limit >= 0
+  );
+}
+
+function utcWindow(now: Date, unit: 'day' | 'week' | 'month' | 'year') {
+  const start = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+
+  if (unit === 'week') {
+    const day = start.getUTCDay();
+    const mondayOffset = day === 0 ? -6 : 1 - day;
+    start.setUTCDate(start.getUTCDate() + mondayOffset);
+  }
+
+  if (unit === 'month') {
+    start.setUTCDate(1);
+  }
+
+  if (unit === 'year') {
+    start.setUTCMonth(0, 1);
+  }
+
+  const end = new Date(start);
+  switch (unit) {
+    case 'day':
+      end.setUTCDate(end.getUTCDate() + 1);
+      break;
+    case 'week':
+      end.setUTCDate(end.getUTCDate() + 7);
+      break;
+    case 'month':
+      end.setUTCMonth(end.getUTCMonth() + 1);
+      break;
+    case 'year':
+      end.setUTCFullYear(end.getUTCFullYear() + 1);
+      break;
+  }
+
+  return { start, end };
+}

--- a/packages/subscriptions/src/utils.ts
+++ b/packages/subscriptions/src/utils.ts
@@ -2,9 +2,23 @@ import type {
   JsonObject,
   PlanFeatureGrant,
   PlanThreshold,
+  ThresholdEnforcement,
   ThresholdWindow,
   UsageWindow,
 } from './types.js';
+
+const THRESHOLD_WINDOWS: ThresholdWindow[] = [
+  'day',
+  'week',
+  'month',
+  'year',
+  'rolling',
+];
+const THRESHOLD_ENFORCEMENTS: ThresholdEnforcement[] = [
+  'observe',
+  'warn',
+  'block',
+];
 
 export function parseJsonArray<T>(value: string, fallback: T[] = []): T[] {
   if (!value) {
@@ -79,7 +93,27 @@ export function isValidThreshold(threshold: PlanThreshold): boolean {
     typeof threshold.metricKey === 'string' &&
     threshold.metricKey.length > 0 &&
     Number.isFinite(threshold.limit) &&
-    threshold.limit >= 0
+    threshold.limit >= 0 &&
+    isThresholdWindow(threshold.window) &&
+    isThresholdEnforcement(threshold.enforcement) &&
+    (threshold.warningRatio === undefined ||
+      (Number.isFinite(threshold.warningRatio) &&
+        threshold.warningRatio >= 0 &&
+        threshold.warningRatio <= 1))
+  );
+}
+
+function isThresholdWindow(value: unknown): value is ThresholdWindow {
+  return (
+    typeof value === 'string' &&
+    THRESHOLD_WINDOWS.includes(value as ThresholdWindow)
+  );
+}
+
+function isThresholdEnforcement(value: unknown): value is ThresholdEnforcement {
+  return (
+    typeof value === 'string' &&
+    THRESHOLD_ENFORCEMENTS.includes(value as ThresholdEnforcement)
   );
 }
 

--- a/packages/subscriptions/tsconfig.json
+++ b/packages/subscriptions/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/svelte/**/*", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/subscriptions/tsconfig.svelte.json
+++ b/packages/subscriptions/tsconfig.svelte.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "types": ["node", "svelte"]
+  },
+  "include": ["src/**/*", "ambient.d.ts"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/subscriptions/vite.config.ts
+++ b/packages/subscriptions/vite.config.ts
@@ -1,0 +1,5 @@
+import { createPackageConfig } from '../../vite.config.base.js';
+
+export default createPackageConfig('subscriptions', {
+  svelte: 'svelte',
+});

--- a/packages/subscriptions/vitest.config.ts
+++ b/packages/subscriptions/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     environment: 'node',
     include: ['src/**/*.test.ts'],
     testTimeout: 60000,
+    hookTimeout: 60000,
     fileParallelism: false,
     pool: 'forks',
     poolOptions: {

--- a/packages/subscriptions/vitest.config.ts
+++ b/packages/subscriptions/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+import { smrtVitestPlugin } from '../vitest/src/index.ts';
+
+export default defineConfig({
+  plugins: [smrtVitestPlugin({ verbose: true })],
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    testTimeout: 60000,
+    fileParallelism: false,
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2035,9 +2035,6 @@ importers:
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
-      '@happyvertical/smrt-features':
-        specifier: workspace:*
-        version: link:../features
       '@happyvertical/smrt-tenancy':
         specifier: workspace:*
         version: link:../tenancy

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2030,6 +2030,46 @@ importers:
         specifier: ^4.0.17
         version: 4.0.17(@opentelemetry/api@1.9.1)(@types/node@24.10.9)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.2.0))(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/subscriptions:
+    dependencies:
+      '@happyvertical/smrt-core':
+        specifier: workspace:*
+        version: link:../core
+      '@happyvertical/smrt-features':
+        specifier: workspace:*
+        version: link:../features
+      '@happyvertical/smrt-tenancy':
+        specifier: workspace:*
+        version: link:../tenancy
+    devDependencies:
+      '@happyvertical/smrt-svelte':
+        specifier: workspace:*
+        version: link:../smrt-svelte
+      '@happyvertical/smrt-vitest':
+        specifier: workspace:*
+        version: link:../vitest
+      '@sveltejs/package':
+        specifier: ^2.5.7
+        version: 2.5.7(svelte@5.53.12)(typescript@5.9.3)
+      '@types/node':
+        specifier: 24.10.9
+        version: 24.10.9
+      svelte:
+        specifier: ^5.18.0
+        version: 5.53.12
+      svelte-check:
+        specifier: ^4.3.5
+        version: 4.4.4(picomatch@4.0.3)(svelte@5.53.12)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: ^4.0.17
+        version: 4.0.17(@opentelemetry/api@1.9.1)(@types/node@24.10.9)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.2.0))(tsx@4.21.0)(yaml@2.8.2)
+
   packages/tags:
     dependencies:
       '@happyvertical/ai':


### PR DESCRIPTION
## Summary
- add @happyvertical/smrt-subscriptions with subscription plans, tenant subscriptions, tenant usage metrics, and entitlement resolution
- add threshold evaluation backed by tenant usage metrics and _smrt_ai_usage summaries
- add provider-neutral Svelte components for plan selection, subscription summary, and threshold display
- update package inventory docs and lockfile

## Validation
- pnpm --filter @happyvertical/smrt-subscriptions test
- pnpm --filter @happyvertical/smrt-subscriptions typecheck
- pnpm --filter @happyvertical/smrt-subscriptions build
- pre-commit: knowledge check --changed --strict
- pre-push: format-check, knowledge-check --strict, workflow validation
