### PR TITLE
refactor(core): logging ratchet scaffolding + core runtime migration (S14 #1432 phase 1)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -34,7 +34,8 @@
       "recommended": true,
       "suspicious": {
         "noExplicitAny": "info",
-        "noArrayIndexKey": "warn"
+        "noArrayIndexKey": "warn",
+        "noConsole": "warn"
       },
       "correctness": {
         "noUnusedVariables": "warn",
@@ -78,7 +79,8 @@
         "rules": {
           "suspicious": {
             "noExplicitAny": "off",
-            "noArrayIndexKey": "off"
+            "noArrayIndexKey": "off",
+            "noConsole": "off"
           },
           "correctness": {
             "noUnusedVariables": "off",
@@ -166,11 +168,44 @@
       "linter": {
         "rules": {
           "suspicious": {
-            "noExplicitAny": "off"
+            "noExplicitAny": "off",
+            "noConsole": "off"
           },
           "correctness": {
             "noUnusedVariables": "off",
             "noUnusedFunctionParameters": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": [
+        "packages/*/bin/**/*.js",
+        "packages/*/scripts/**/*.{js,ts}",
+        "packages/*/playground/**/*.{js,ts}",
+        "scripts/**/*.{js,ts}",
+        "docs/src/**/*.{js,ts,tsx,jsx}"
+      ],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": [
+        "packages/core/src/object.ts",
+        "packages/core/src/collection.ts",
+        "packages/core/src/registry.ts",
+        "packages/core/src/class.ts",
+        "packages/core/src/dispatch/bus.ts"
+      ],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "error"
           }
         }
       }

--- a/packages/core/src/__tests__/class-ai-usage.test.ts
+++ b/packages/core/src/__tests__/class-ai-usage.test.ts
@@ -224,8 +224,13 @@ describe('SmrtClass AI usage tracking', () => {
       timestamp: new Date('2026-03-12T02:30:00.000Z'),
     });
 
+    // The warning is routed through @happyvertical/logger (S14 #1432), whose
+    // console transport prefixes the level (e.g. "[WARN] "), so assert on the
+    // message substring rather than an exact-match string.
     expect(warnSpy).toHaveBeenCalledWith(
-      '[smrt] AI usage handler failed for openai:gpt-4o-mini: handler exploded',
+      expect.stringContaining(
+        '[smrt] AI usage handler failed for openai:gpt-4o-mini: handler exploded',
+      ),
     );
   });
 

--- a/packages/core/src/class.ts
+++ b/packages/core/src/class.ts
@@ -2,7 +2,7 @@ import type { AIClientOptions } from '@happyvertical/ai';
 import { type AIClient, getAI } from '@happyvertical/ai';
 import type { FilesystemAdapterOptions } from '@happyvertical/files';
 import { FilesystemAdapter } from '@happyvertical/files';
-import type { LoggerConfig } from '@happyvertical/logger';
+import { createLogger, type LoggerConfig } from '@happyvertical/logger';
 import type {
   AiTokenUsage,
   AiUsageHandler,
@@ -42,6 +42,8 @@ import { ALL_SYSTEM_TABLES, SMRT_SCHEMA_VERSION } from './system/schema.js';
 
 const SYSTEM_TABLE_BOOTSTRAP_LOCK_SQL =
   "SELECT pg_advisory_xact_lock(hashtext('smrt'), hashtext('system-tables'))";
+
+const logger = createLogger({ level: 'info' });
 
 type DatabaseWithConfig = DatabaseInterface & {
   config?: {
@@ -902,7 +904,7 @@ export class SmrtClass {
         await tx.rollback();
       }
     } catch (rollbackError) {
-      console.warn(
+      logger.warn(
         `[smrt] Failed to rollback system table bootstrap transaction: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
       );
     }
@@ -976,14 +978,14 @@ export class SmrtClass {
             vector,
           );
         } else {
-          console.warn(
+          logger.warn(
             '[smrt] Embedding storage set to "native" but database has no vector capability. Falling back to JSON storage.',
           );
         }
       }
     } catch (error) {
       // Don't fail system table initialization for vector setup errors
-      console.warn(
+      logger.warn(
         `[smrt] Failed to initialize vector storage: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
@@ -1389,7 +1391,7 @@ export class SmrtClass {
 
     for (const result of results) {
       if (result.status === 'rejected') {
-        console.warn(
+        logger.warn(
           `[smrt] AI usage handler failed for ${normalizedEvent.provider}:${normalizedEvent.model}: ${
             result.reason instanceof Error
               ? result.reason.message

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -1,3 +1,4 @@
+import { createLogger } from '@happyvertical/logger';
 import { buildWhere } from '@happyvertical/sql';
 import type { SmrtClassOptions } from './class';
 import { SmrtClass } from './class';
@@ -19,6 +20,8 @@ import {
   toSnakeCase,
 } from './utils';
 import { chunkArray, IN_LIST_CHUNK_SIZE } from './utils/chunk';
+
+const logger = createLogger({ level: 'info' });
 
 /**
  * Resolve _meta_type in WHERE clause from simple class name to qualified name (Issue #713)
@@ -472,7 +475,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       typeof SmrtCollection._itemClass.prototype?.create === 'function';
 
     if (!hasCreateMethod) {
-      console.warn(
+      logger.warn(
         `Collection "${SmrtCollection.name}"._itemClass should have a create() method for optimal functionality`,
       );
     }
@@ -1038,7 +1041,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       );
 
       if (!relationship) {
-        console.warn(
+        logger.warn(
           `Relationship ${fieldName} not found on ${this._itemClass.name}, skipping eager load`,
         );
         continue;
@@ -1096,10 +1099,9 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
         this.options,
       );
     } catch (error) {
-      console.warn(
-        `Could not get collection for ${relationship.targetClass}:`,
+      logger.warn(`Could not get collection for ${relationship.targetClass}`, {
         error,
-      );
+      });
       return;
     }
 
@@ -1182,7 +1184,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       inverseCandidates[0];
 
     if (!inverseForeignKey) {
-      console.warn(
+      logger.warn(
         `Could not find inverse foreignKey for oneToMany ${fieldName}`,
       );
       return;
@@ -1203,10 +1205,9 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
         this.options,
       );
     } catch (error) {
-      console.warn(
-        `Could not get collection for ${relationship.targetClass}:`,
+      logger.warn(`Could not get collection for ${relationship.targetClass}`, {
         error,
-      );
+      });
       return;
     }
 
@@ -1275,9 +1276,9 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       targetColumn = join.targetColumn;
       targetClassName = join.targetClassName;
     } catch (error) {
-      console.warn(
-        `Could not resolve manyToMany join for ${fieldName} on ${this._itemClass.name}:`,
-        error,
+      logger.warn(
+        `Could not resolve manyToMany join for ${fieldName} on ${this._itemClass.name}`,
+        { error },
       );
       return;
     }
@@ -1328,9 +1329,9 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
         this.options,
       );
     } catch (error) {
-      console.warn(
-        `Could not get collection for manyToMany target ${targetClassName}:`,
-        error,
+      logger.warn(
+        `Could not get collection for manyToMany target ${targetClassName}`,
+        { error },
       );
       return;
     }
@@ -2689,10 +2690,9 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
             skipped++;
           }
         } catch (error) {
-          console.warn(
-            `Failed to generate embeddings for ${obj.id}:`,
-            error instanceof Error ? error.message : error,
-          );
+          logger.warn(`Failed to generate embeddings for ${obj.id}`, {
+            error: error instanceof Error ? error.message : error,
+          });
           skipped++;
         }
 

--- a/packages/core/src/dispatch/bus.ts
+++ b/packages/core/src/dispatch/bus.ts
@@ -24,6 +24,7 @@
  * ```
  */
 
+import { createLogger } from '@happyvertical/logger';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { getDatabase } from '@happyvertical/sql';
 import {
@@ -50,6 +51,8 @@ import type {
   DispatchRetryOptions,
   DispatchSubscribeOptions,
 } from './types.js';
+
+const logger = createLogger({ level: 'info' });
 
 /**
  * Registered in-memory handler
@@ -611,16 +614,16 @@ export class DispatchBus {
         // Handle both sync and async handlers
         if (result && typeof result.catch === 'function') {
           void result.catch((error: unknown) => {
-            console.error(
+            logger.error(
               `DispatchBus: Handler for "${registered.pattern}" failed`,
-              error,
+              { error },
             );
           });
         }
       } catch (error) {
-        console.error(
+        logger.error(
           `DispatchBus: Handler for "${registered.pattern}" failed`,
-          error,
+          { error },
         );
       }
     }

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -25,7 +25,12 @@ import {
 } from './tools/tool-executor';
 import { fieldsFromClass, tableNameFromClass, toSnakeCase } from './utils';
 
-const logger = createLogger({ level: 'info' });
+// DEBUG_STI raises the level to 'debug' so the env-gated STI hydration traces
+// below (logger.debug, inside `if (process.env.DEBUG_STI)` guards) actually emit;
+// otherwise they're filtered at the default 'info' level.
+const logger = createLogger({
+  level: process.env.DEBUG_STI ? 'debug' : 'info',
+});
 
 /**
  * Validate that _meta_type matches the expected class (Issue #713)

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -1,6 +1,7 @@
 // import type { AIMessageOptions } from '@happyvertical/ai';
 
 import type { AITool } from '@happyvertical/ai';
+import { createLogger } from '@happyvertical/logger';
 import type { SmrtClassOptions } from './class';
 import { SmrtClass } from './class';
 import { ContentHasher } from './embeddings/hash';
@@ -23,6 +24,8 @@ import {
   type ToolCallResult,
 } from './tools/tool-executor';
 import { fieldsFromClass, tableNameFromClass, toSnakeCase } from './utils';
+
+const logger = createLogger({ level: 'info' });
 
 /**
  * Validate that _meta_type matches the expected class (Issue #713)
@@ -106,7 +109,7 @@ function warnIfSkipRehydrateSet(): void {
   if (didWarnSkipRehydrate) return;
   didWarnSkipRehydrate = true;
   if (process.env.SMRT_SKIP_STI_REHYDRATE !== undefined) {
-    console.warn(
+    logger.warn(
       '[smrt] SMRT_SKIP_STI_REHYDRATE is set but has no effect since ' +
         'Release C (#1134). The flag is retired; unconditional STI ' +
         'descendant rehydration is the only behavior. Remove the env ' +
@@ -690,7 +693,7 @@ export class SmrtObject extends SmrtClass {
     const className = this.getResolvedClassName();
 
     if (process.env.DEBUG_STI) {
-      console.log('[loadDataFromDb] Loading:', {
+      logger.debug('[loadDataFromDb] Loading', {
         class: className,
         dataKeys: Object.keys(data),
         metaType: data._meta_type,
@@ -701,7 +704,7 @@ export class SmrtObject extends SmrtClass {
     const fields = await this.getFields();
 
     if (process.env.DEBUG_STI) {
-      console.log('[loadDataFromDb] Field definitions:', {
+      logger.debug('[loadDataFromDb] Field definitions', {
         class: className,
         fieldKeys: Object.keys(fields),
       });
@@ -721,7 +724,7 @@ export class SmrtObject extends SmrtClass {
     const isSTI = tableStrategy === 'sti';
 
     if (process.env.DEBUG_STI) {
-      console.log('[loadDataFromDb] After formatDataJs:', {
+      logger.debug('[loadDataFromDb] After formatDataJs', {
         class: className,
         isSTI,
         formattedDataKeys: Object.keys(formattedData),
@@ -756,7 +759,7 @@ export class SmrtObject extends SmrtClass {
     // No additional processing needed
 
     if (process.env.DEBUG_STI) {
-      console.log('[loadDataFromDb] Starting field hydration:', {
+      logger.debug('[loadDataFromDb] Starting field hydration', {
         class: className,
         fieldCount: Object.keys(fields).length,
       });
@@ -786,7 +789,7 @@ export class SmrtObject extends SmrtClass {
           const value = formattedData[field];
 
           if (process.env.DEBUG_STI && value !== undefined) {
-            console.log(`[loadDataFromDb] Setting field '${field}':`, {
+            logger.debug(`[loadDataFromDb] Setting field '${field}'`, {
               value,
               valueType: typeof value,
             });
@@ -797,14 +800,14 @@ export class SmrtObject extends SmrtClass {
         } else {
           skippedCount++;
           if (process.env.DEBUG_STI) {
-            console.log(`[loadDataFromDb] Skipping readonly field '${field}'`);
+            logger.debug(`[loadDataFromDb] Skipping readonly field '${field}'`);
           }
         }
       }
     }
 
     if (process.env.DEBUG_STI) {
-      console.log('[loadDataFromDb] Hydration complete:', {
+      logger.debug('[loadDataFromDb] Hydration complete', {
         class: className,
         hydratedCount,
         skippedCount,
@@ -1436,7 +1439,7 @@ export class SmrtObject extends SmrtClass {
         const usesSTI = tableStrategy === 'sti';
 
         if (hasOverride && usesSTI) {
-          console.warn(
+          logger.warn(
             `[SMRT STI Warning] ${this.constructor.name} overrides toJSON() but uses STI.\n` +
               `Ensure super.toJSON() is called or _meta_type is set manually.\n` +
               `This can cause "Missing _meta_type discriminator" errors.\n` +
@@ -1577,9 +1580,9 @@ export class SmrtObject extends SmrtClass {
           if (isStale) {
             // Generate embeddings in background to avoid blocking save
             this.generateEmbeddings().catch((error) => {
-              console.warn(
-                `Failed to auto-generate embeddings for ${this.constructor.name}:`,
-                error instanceof Error ? error.message : error,
+              logger.warn(
+                `Failed to auto-generate embeddings for ${this.constructor.name}`,
+                { error: error instanceof Error ? error.message : error },
               );
             });
           }
@@ -2010,7 +2013,7 @@ export class SmrtObject extends SmrtClass {
       if (typeof method === 'function') {
         await method.call(this);
       } else {
-        console.warn(
+        logger.warn(
           `Hook method '${hook}' not found on ${this.constructor.name}`,
         );
       }

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -28,6 +28,7 @@
  * ```
  */
 
+import { createLogger } from '@happyvertical/logger';
 import { applyOneToManyChildAccessors } from './child-accessors';
 import { SmrtCollection } from './collection';
 import { applyPendingDecoratorRegistrations } from './decorators/compatibility.js';
@@ -140,6 +141,8 @@ import {
   isQualifiedName,
   parseQualifiedName,
 } from './utils/qualified-names.js';
+
+const logger = createLogger({ level: 'info' });
 
 // Re-export the canonical collection-base detector so downstream tooling
 // (e.g. @happyvertical/smrt-vitest's manifest-based test-db builder) can share
@@ -2119,7 +2122,7 @@ export class ObjectRegistry {
       // Informational only — cycles are handled, not fatal. Surfacing the
       // involved classes helps operators understand why strict FK ordering
       // could not be honored for these tables.
-      console.warn(
+      logger.warn(
         `[ObjectRegistry] Foreign-key cycle(s) detected and broken for ordering: ${[
           ...cycleMembers,
         ].join(', ')}. Tables are created without strict cyclic ordering; ` +
@@ -2241,7 +2244,7 @@ export class ObjectRegistry {
         // extends a parent with the same className and only one is installed.
         // Longer cycles indicate misconfigured manifests.
         if (chain.length > 1) {
-          console.warn(
+          logger.warn(
             `[ObjectRegistry] Circular inheritance detected in chain: ${chain.join(' -> ')} -> ${current.name}. ` +
               `Check that '${current.extends ?? current.name}' resolves to the correct package class.`,
           );
@@ -2382,7 +2385,7 @@ export class ObjectRegistry {
               `  - Or set smrt.inheritance.onMissingAncestor='warn' in config`,
           );
         } else if (onMissingAncestor === 'warn') {
-          console.warn(`[ObjectRegistry] ${message}`);
+          logger.warn(`[ObjectRegistry] ${message}`);
         }
 
         continue;
@@ -2442,7 +2445,7 @@ export class ObjectRegistry {
         parentField.__tenancy?.isTenantIdField ||
         parentField._meta?.__tenancy?.isTenantIdField;
       if (!(isTenantField && fieldName === 'tenantId')) {
-        console.warn(
+        logger.warn(
           `Field type mismatch: "${fieldName}" is ${parentField.type} in parent but ${childField.type} in child. Using child type.`,
         );
       }


### PR DESCRIPTION
## Summary

**Phase 1** of sweep **S14 (#1432)** — rubric **dimension 9 (Errors & logging)**. Scaffolds the Biome `noConsole` ratchet repo-wide and migrates **smrt-core's runtime library logging** off `console.*` onto `@happyvertical/logger`.

This is the first increment of a phased rollout. It is intentionally **core-only**; the repo-wide migration and the global `noConsole` → error flip are a **follow-up** (flipping globally now would break the build on hundreds of existing violations).

## What's in this PR

### 1. Rule scaffolding (`biome.json`)
- `noConsole` = **warn** globally — visibility, non-breaking.
- **Scoped allowances** (`noConsole` off) where console output is legitimate: tests/specs, `*.config.*`, CLI `bin` entrypoints, dev `scripts/`, `playground/`, and the docs sandbox.
- `noConsole` = **error** scoped via a Biome override to the smrt-core runtime files migrated in this PR, ratcheting them so any reintroduced `console.*` fails CI.

### 2. Core runtime migration — 29 `console.*` calls → `@happyvertical/logger`
| File | Calls | Notes |
|------|-------|-------|
| `object.ts` | 11 | `DEBUG_STI` debug logs → `logger.debug`; STI/embedding/hook warnings → `logger.warn` |
| `collection.ts` | 8 | eager-load + embedding warnings → `logger.warn` |
| `registry.ts` | 4 | FK-cycle, circular-inheritance, missing-ancestor, field-type-mismatch → `logger.warn` |
| `class.ts` | 4 | bootstrap-rollback, vector-storage, AI-usage-handler warnings → `logger.warn` |
| `dispatch/bus.ts` | 2 | handler-failure errors → `logger.error` |

`@happyvertical/logger` was already a core dependency. Each file gets a module-scope `const logger = createLogger({ level: 'info' });` following the established convention (e.g. `content/contents.ts`).

### Out of scope (later phases)
Build-time tooling `console.*` (`vite-plugin/`, `manifest/generator.ts`, `generators/mcp.ts`, `scanner/manifest-generator.ts`, etc.) and not-yet-migrated core runtime files (`utils.ts`, `embeddings/`, `adapters/`, `schema/`, `migrations/`, …) stay at the global **warn** level for now.

## Verification
- `pnpm exec biome check packages/core/src` → 0 errors (296 warnings, all warn-level `noConsole`/pre-existing).
- `pnpm exec biome ci --diagnostic-level=error .` → clean repo-wide (1897 files, 0 errors).
- Ratchet sanity-checked: reintroducing a `console.log` in a migrated file produces a `noConsole` **error** (exit 1).
- `turbo typecheck --filter=@happyvertical/smrt-core` → pass.
- Core tests → **1878 passed**, 0 failed. One regression test (`class-ai-usage.test.ts`) updated to assert via `stringContaining`, since the logger console transport prefixes the level (`[WARN] `).

Refs #1432