### PR TITLE
fix(scanner): preserve tenant scoped uuid metadata

### DIFF
--- a/packages/scanner/src/__tests__/manifest-adapter.test.ts
+++ b/packages/scanner/src/__tests__/manifest-adapter.test.ts
@@ -165,6 +165,86 @@ describe('ManifestAdapter', () => {
       });
     });
 
+    describe('@tenantId decorator', () => {
+      it('should mark tenant ID fields as UUID tenant references', () => {
+        const field: RawFieldDefinition = {
+          name: 'tenantId',
+          accessibility: 'public',
+          typeAnnotation: 'string',
+          initializer: null,
+          optional: true,
+          hasDecimalPoint: false,
+          numericValue: null,
+          decorators: [
+            {
+              name: 'tenantId',
+              arguments: [''],
+            },
+          ],
+          isStatic: false,
+          readonly: false,
+          line: 1,
+        };
+
+        const result = adapter.convertField(field);
+
+        expect(result).toMatchObject({
+          type: 'text',
+          required: true,
+          _meta: {
+            sqlType: 'UUID',
+            __tenancy: {
+              isTenantIdField: true,
+              autoFilter: true,
+              required: true,
+              autoPopulate: true,
+              nullable: false,
+            },
+          },
+        });
+      });
+
+      it('should preserve nullable tenant ID decorator options', () => {
+        const field: RawFieldDefinition = {
+          name: 'tenantId',
+          accessibility: 'public',
+          typeAnnotation: 'string | null',
+          initializer: 'null',
+          optional: false,
+          hasDecimalPoint: false,
+          numericValue: null,
+          decorators: [
+            {
+              name: 'tenantId',
+              arguments: ['{ nullable: true, autoPopulate: false }'],
+            },
+          ],
+          isStatic: false,
+          readonly: false,
+          line: 1,
+        };
+
+        const result = adapter.convertField(field);
+
+        expect(result).toMatchObject({
+          type: 'text',
+          required: false,
+          _meta: {
+            sqlType: 'UUID',
+            nullable: true,
+            autoPopulate: false,
+            __tenancy: {
+              isTenantIdField: true,
+              autoFilter: true,
+              required: false,
+              autoPopulate: false,
+              nullable: true,
+            },
+          },
+        });
+      });
+    });
+
     describe('string literal union types', () => {
       it('should infer text for inline string literal union', () => {
         const field: RawFieldDefinition = {

--- a/packages/scanner/src/__tests__/oxc-parser.test.ts
+++ b/packages/scanner/src/__tests__/oxc-parser.test.ts
@@ -281,6 +281,28 @@ describe('OXC Parser', () => {
       expect(tagsField?.decorators[0].name).toBe('manyToMany');
     });
 
+    it('should merge @TenantScoped config into the class decorator config', () => {
+      const source = `
+        @TenantScoped({ mode: 'optional', allowSuperAdminBypass: true })
+        @smrt({ tableName: 'documents' })
+        class Document extends SmrtObject {
+          @tenantId({ nullable: true })
+          tenantId: string | null = null;
+        }
+      `;
+
+      const result = parseSource(source);
+
+      expect(result.classes).toHaveLength(1);
+      expect(result.classes[0].decoratorConfig).toMatchObject({
+        tableName: 'documents',
+        tenantScoped: {
+          mode: 'optional',
+          allowSuperAdminBypass: true,
+        },
+      });
+    });
+
     it('should handle parse errors gracefully', () => {
       const source = `
         @smrt()

--- a/packages/scanner/src/manifest-adapter.ts
+++ b/packages/scanner/src/manifest-adapter.ts
@@ -772,6 +772,35 @@ export class ManifestAdapter {
       };
     }
 
+    // @tenantId({ nullable?, required?, autoFilter?, autoPopulate? }) decorator
+    if (decorator.name === 'tenantId') {
+      const parsedOptions = this.parseFieldDecoratorOptions(
+        decorator.arguments[0],
+      );
+      const nullable = parsedOptions?.nullable === true;
+      const required =
+        parsedOptions?.required !== undefined
+          ? Boolean(parsedOptions.required)
+          : !nullable;
+
+      return {
+        type: 'text',
+        required,
+        _meta: {
+          sqlType: 'UUID',
+          ...(parsedOptions ?? {}),
+          __tenancy: {
+            isTenantIdField: true,
+            autoFilter: parsedOptions?.autoFilter ?? true,
+            required,
+            autoPopulate: parsedOptions?.autoPopulate ?? true,
+            nullable,
+          },
+        },
+        source: 'decorator',
+      };
+    }
+
     // @crossPackageRef('@pkg:Class', { validate?, unique?, nullable?, default?, description? }) decorator
     if (decorator.name === 'crossPackageRef') {
       const qualifiedName = stripQuotes(decorator.arguments[0]?.trim());

--- a/packages/scanner/src/oxc-parser.ts
+++ b/packages/scanner/src/oxc-parser.ts
@@ -854,10 +854,19 @@ function extractClassDeclaration(
   // Extract decorators
   const decorators = node.decorators || [];
   const smrtDecorator = decorators.find((d) => isSmrtDecorator(d));
+  const tenantScopedDecorator = decorators.find((d) =>
+    isNamedDecorator(d, 'TenantScoped'),
+  );
   const hasSmartDecorator = !!smrtDecorator;
-  const decoratorConfig = smrtDecorator
+  const smrtConfig = smrtDecorator
     ? extractDecoratorConfig(smrtDecorator, sourceText)
     : null;
+  const decoratorConfig = tenantScopedDecorator
+    ? {
+        ...(smrtConfig ?? {}),
+        tenantScoped: extractDecoratorConfig(tenantScopedDecorator, sourceText),
+      }
+    : smrtConfig;
 
   // Extract extends clause
   const { extendsClause, extendsTypeArg } = extractExtendsClause(
@@ -901,18 +910,22 @@ function extractClassDeclaration(
  * Check if a decorator is @smrt()
  */
 function isSmrtDecorator(decorator: Decorator): boolean {
+  return isNamedDecorator(decorator, 'smrt');
+}
+
+function isNamedDecorator(decorator: Decorator, name: string): boolean {
   const expr = decorator.expression;
 
-  // @smrt() - CallExpression
+  // @decoratorName() - CallExpression
   if (expr.type === 'CallExpression') {
     const callee = expr.callee;
-    if (callee.type === 'Identifier' && callee.name === 'smrt') {
+    if (callee.type === 'Identifier' && callee.name === name) {
       return true;
     }
   }
 
-  // @smrt - Identifier (no parentheses)
-  if (expr.type === 'Identifier' && expr.name === 'smrt') {
+  // @decoratorName - Identifier (no parentheses)
+  if (expr.type === 'Identifier' && expr.name === name) {
     return true;
   }
 

--- a/packages/subscriptions/src/__tests__/schema.test.ts
+++ b/packages/subscriptions/src/__tests__/schema.test.ts
@@ -1,0 +1,28 @@
+import { generateDDLForEngine, ObjectRegistry } from '@happyvertical/smrt-core';
+import { describe, expect, it } from 'vitest';
+import { TenantSubscription } from '../models/TenantSubscription.js';
+import { TenantUsageMetric } from '../models/TenantUsageMetric.js';
+
+describe('subscription schemas', () => {
+  it.each([
+    [TenantSubscription.name, '_smrt_tenant_subscriptions'],
+    [TenantUsageMetric.name, '_smrt_tenant_usage_metrics'],
+  ])('%s uses a native UUID tenant column without an empty default', (name, tableName) => {
+    const schema = ObjectRegistry.getSchema(name);
+
+    if (!schema) {
+      throw new Error(`Expected schema for ${name}`);
+    }
+
+    expect(schema.tableName).toBe(tableName);
+    expect(schema.columns.tenant_id).toMatchObject({
+      type: 'UUID',
+      referenceKind: 'tenantId',
+    });
+    expect(schema.columns.tenant_id.defaultValue).toBeUndefined();
+
+    const ddl = generateDDLForEngine(schema, 'postgres').createTable;
+    expect(ddl).toContain('"tenant_id" uuid');
+    expect(ddl).not.toContain('"tenant_id" uuid DEFAULT');
+  });
+});

--- a/packages/subscriptions/src/models/TenantSubscription.ts
+++ b/packages/subscriptions/src/models/TenantSubscription.ts
@@ -13,7 +13,7 @@ import { parseJsonObject, stringifyJson } from '../utils.js';
 })
 export class TenantSubscription extends SmrtObject {
   @tenantId()
-  tenantId: string = '';
+  tenantId?: string;
 
   @foreignKey('SubscriptionPlan')
   planId: string = '';

--- a/packages/subscriptions/src/models/TenantUsageMetric.ts
+++ b/packages/subscriptions/src/models/TenantUsageMetric.ts
@@ -12,7 +12,7 @@ import { parseJsonObject, stringifyJson } from '../utils.js';
 })
 export class TenantUsageMetric extends SmrtObject {
   @tenantId()
-  tenantId: string = '';
+  tenantId?: string;
 
   metricKey: string = '';
   quantity: number = 0.0;


### PR DESCRIPTION
## Summary
- Teach the OXC scanner to carry @TenantScoped(...) config into generated SMRT manifests
- Teach the manifest adapter to preserve @tenantId() UUID tenant metadata without empty defaults
- Remove empty-string tenantId initializers from subscription tenant records and add a schema regression test

## Validation
- pnpm --filter @happyvertical/smrt-scanner test
- pnpm --filter @happyvertical/smrt-scanner build
- pnpm --filter @happyvertical/smrt-subscriptions build
- pnpm --filter @happyvertical/smrt-subscriptions test
- pnpm --filter @happyvertical/smrt-subscriptions typecheck
- pnpm knowledge:check --changed --strict --format markdown
- pre-push: format-check, knowledge-check, validate-all-workflows