### PR TITLE
refactor(smrt-svelte): tokenize color literals + color-literal ratchet (S1 #1373 phase 1)

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -169,6 +169,12 @@ jobs:
       - name: Check smrt-svelte design tokens
         run: node scripts/check-svelte-tokens.mjs
 
+      # Bans raw color literals in component CSS. Strict (fails) for
+      # smrt-svelte; report-only for other UI packages until later phases of
+      # the design-token sweep (issue #1373). Node-only, no deps.
+      - name: Check raw color literals
+        run: node scripts/check-color-literals.mjs
+
   test:
     name: Validate Changes
     uses: ./.github/workflows/test-suite.yml

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -111,6 +111,16 @@ pre-push:
 
         Your code has formatting issues. Run `npm run format` to fix them.
 
+    color-literals:
+      # Bans raw color literals in component CSS. Strict for smrt-svelte,
+      # report-only elsewhere until later phases of #1373. Node-only, no deps.
+      run: node scripts/check-color-literals.mjs
+      fail_text: |
+        ❌ Raw color literals found in a strict UI package!
+
+        Replace hardcoded colors with semantic --smrt-color-* tokens.
+        Run: node scripts/check-color-literals.mjs
+
     validate-all-workflows:
       run: |
         echo "🔍 Validating ALL workflow files before push..."

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "validate-build": "node scripts/validate-build.js",
     "check:standards": "node scripts/check-standards.mjs",
     "check:svelte-tokens": "node scripts/check-svelte-tokens.mjs",
+    "check:color-literals": "node scripts/check-color-literals.mjs",
     "knowledge:check": "tsx scripts/check-knowledge.ts",
     "changeset": "changeset",
     "changeset:auto": "npx tsx scripts/auto-changeset.ts",

--- a/packages/smrt-svelte/src/browser-ai/svelte/components/VoiceInput.svelte
+++ b/packages/smrt-svelte/src/browser-ai/svelte/components/VoiceInput.svelte
@@ -124,11 +124,12 @@ async function handleToggle() {
   @keyframes pulse {
     0%, 100% {
       transform: scale(1);
-      box-shadow: 0 0 0 0 rgba(186, 26, 26, 0.4);
+      box-shadow: 0 0 0 0
+        color-mix(in srgb, var(--smrt-color-error) 40%, transparent);
     }
     50% {
       transform: scale(1.05);
-      box-shadow: 0 0 0 10px rgba(186, 26, 26, 0);
+      box-shadow: 0 0 0 10px transparent;
     }
   }
 

--- a/packages/smrt-svelte/src/components/admin/AgentSettingsShell.svelte
+++ b/packages/smrt-svelte/src/components/admin/AgentSettingsShell.svelte
@@ -211,7 +211,7 @@ async function handleSave(slotId: string, config: unknown) {
 		margin: 0;
 		font-size: var(--smrt-typography-headline-medium-size, 1.5rem);
 		font-weight: 600;
-		color: #1e293b;
+		color: var(--smrt-color-on-surface);
 	}
 
 	.agent-subtitle {
@@ -227,8 +227,8 @@ async function handleSave(slotId: string, config: unknown) {
 		justify-content: center;
 		padding: 4rem 2rem;
 		text-align: center;
-		background: #f8fafc;
-		border: 1px dashed #e2e8f0;
+		background: var(--smrt-color-surface-variant);
+		border: 1px dashed var(--smrt-color-outline-variant);
 		border-radius: 8px;
 		min-height: 300px;
 	}

--- a/packages/smrt-svelte/src/components/calendar/Calendar.svelte
+++ b/packages/smrt-svelte/src/components/calendar/Calendar.svelte
@@ -318,13 +318,13 @@ const yearOptions = $derived(() => {
 
   @media (prefers-color-scheme: dark) {
     :global(:root:not([data-theme="light"])) .calendar {
-      --calendar-bg: #242424;
-      --calendar-border: #3a3a3a;
-      --calendar-header-bg: #2e2e2e;
-      --day-hover: #3a3a3a;
-      --today-bg: #1e3a5f;
-      --today-border: #64b5f6;
-      --other-month: #666666;
+      --calendar-bg: var(--smrt-color-surface, #242424);
+      --calendar-border: var(--smrt-color-outline-variant, #3a3a3a);
+      --calendar-header-bg: var(--smrt-color-surface-container-low, #2e2e2e);
+      --day-hover: var(--smrt-color-surface-container-high, #3a3a3a);
+      --today-bg: var(--smrt-color-primary-container, #1e3a5f);
+      --today-border: var(--smrt-color-primary, #64b5f6);
+      --other-month: var(--smrt-color-on-surface-variant, #666666);
     }
   }
 

--- a/packages/smrt-svelte/src/components/calendar/DayView.svelte
+++ b/packages/smrt-svelte/src/components/calendar/DayView.svelte
@@ -185,10 +185,10 @@ function getTypeLabel(type: string): string {
 
   @media (prefers-color-scheme: dark) {
     :global(:root:not([data-theme="light"])) .day-view {
-      --view-bg: #242424;
-      --view-border: #3a3a3a;
-      --header-bg: #2e2e2e;
-      --card-hover: #3a3a3a;
+      --view-bg: var(--smrt-color-surface, #242424);
+      --view-border: var(--smrt-color-outline-variant, #3a3a3a);
+      --header-bg: var(--smrt-color-surface-container-low, #2e2e2e);
+      --card-hover: var(--smrt-color-surface-container-high, #3a3a3a);
     }
   }
 

--- a/packages/smrt-svelte/src/components/feedback/LoadingOverlay.svelte
+++ b/packages/smrt-svelte/src/components/feedback/LoadingOverlay.svelte
@@ -207,7 +207,11 @@ function handleKeydown(e: KeyboardEvent) {
 
 	.progress-fill {
 		height: 100%;
-		background: linear-gradient(90deg, #3b82f6, #60a5fa);
+		background: linear-gradient(
+			90deg,
+			var(--smrt-color-primary),
+			color-mix(in srgb, var(--smrt-color-primary) 70%, white)
+		);
 		border-radius: 4px;
 		transition: width var(--smrt-duration-short4, 300ms) var(--smrt-easing-standard, ease);
 	}

--- a/packages/smrt-svelte/src/components/forms/DateRangeInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/DateRangeInput.svelte
@@ -109,8 +109,6 @@ function updateValue(start: string, end: string) {
 async function parseNaturalLanguageRange(
   text: string,
 ): Promise<{ start: string; end: string } | null> {
-  console.log('[SMRTDateRange] Parsing text:', text);
-
   // Dynamically import chrono-node only when needed
   let chrono: typeof import('chrono-node');
   try {
@@ -535,7 +533,7 @@ const primaryControlId = $derived(isSmrt ? `${name}_voice` : `${name}_start`);
     background: transparent;
     border: none;
     border-radius: 4px;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant);
     cursor: pointer;
     transition: all var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
     flex-shrink: 0;

--- a/packages/smrt-svelte/src/components/forms/DateRangeInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/DateRangeInput.svelte
@@ -109,6 +109,8 @@ function updateValue(start: string, end: string) {
 async function parseNaturalLanguageRange(
   text: string,
 ): Promise<{ start: string; end: string } | null> {
+  console.log('[SMRTDateRange] Parsing text:', text);
+
   // Dynamically import chrono-node only when needed
   let chrono: typeof import('chrono-node');
   try {

--- a/packages/smrt-svelte/src/components/forms/DateTimeInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/DateTimeInput.svelte
@@ -130,6 +130,8 @@ onDestroy(() => {
 
 // Parse natural language to ISO date using chrono-node (no LLM needed)
 async function parseNaturalLanguage(text: string): Promise<string> {
+  console.log('[SMRTDateTime] Parsing text:', text);
+
   // Dynamically import chrono-node only when needed
   let chrono: typeof import('chrono-node');
   try {
@@ -148,6 +150,7 @@ async function parseNaturalLanguage(text: string): Promise<string> {
   }
 
   const parsed = results[0].start.date();
+  console.log('[SMRTDateTime] Chrono parsed:', parsed);
 
   if (Number.isNaN(parsed.getTime())) {
     throw new Error('Invalid date');

--- a/packages/smrt-svelte/src/components/forms/DateTimeInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/DateTimeInput.svelte
@@ -130,8 +130,6 @@ onDestroy(() => {
 
 // Parse natural language to ISO date using chrono-node (no LLM needed)
 async function parseNaturalLanguage(text: string): Promise<string> {
-  console.log('[SMRTDateTime] Parsing text:', text);
-
   // Dynamically import chrono-node only when needed
   let chrono: typeof import('chrono-node');
   try {
@@ -150,7 +148,6 @@ async function parseNaturalLanguage(text: string): Promise<string> {
   }
 
   const parsed = results[0].start.date();
-  console.log('[SMRTDateTime] Chrono parsed:', parsed);
 
   if (Number.isNaN(parsed.getTime())) {
     throw new Error('Invalid date');
@@ -466,7 +463,7 @@ function handleNativeChange(e: Event) {
   }
 
   .mic-btn:hover {
-    background: #f3f4f6;
+    background: var(--smrt-color-surface-container);
     color: var(--smrt-color-on-surface, #374151);
   }
 

--- a/packages/smrt-svelte/src/components/forms/Form.svelte
+++ b/packages/smrt-svelte/src/components/forms/Form.svelte
@@ -125,8 +125,6 @@ function extractFieldsFromText(text: string): Record<string, unknown> {
   // Normalize text: remove commas, extra spaces
   const normalized = text.replace(/,/g, ' ').replace(/\s+/g, ' ').trim();
 
-  console.log('[SMRTForm] Normalized text:', normalized);
-
   // Build list of all field triggers for boundary detection
   const allTriggers: string[] = [];
   for (const f of fieldDefs) {
@@ -189,7 +187,6 @@ function extractFieldsFromText(text: string): Record<string, unknown> {
 
         if (value) {
           result[field.name] = value;
-          console.log(`[SMRTForm] Regex extracted ${field.name}:`, value);
           break; // Found value for this field, move to next
         }
       }
@@ -202,13 +199,9 @@ function extractFieldsFromText(text: string): Record<string, unknown> {
 // Extract fields from spoken text
 // Currently uses regex-only since small local LLMs produce unreliable output
 async function extractFields(text: string): Promise<Record<string, unknown>> {
-  console.log('[SMRTForm] Extracting fields from:', text);
-
   // Use regex extraction directly - fast and reliable
   // TODO: Add LLM enhancement when larger models are available
   const result = extractFieldsFromText(text);
-
-  console.log('[SMRTForm] Extracted:', result);
   return result;
 }
 
@@ -231,7 +224,6 @@ function resetSilenceTimer() {
   lastSpeechTime = Date.now();
   silenceTimer = setTimeout(() => {
     if (isFormListening) {
-      console.log('[SMRTForm] Silence timeout - stopping');
       stopFormListening();
     }
   }, silenceTimeout * 1000);
@@ -259,11 +251,6 @@ async function startAudioLevelMonitoring(stream: MediaStream) {
     const SPEECH_THRESHOLD = 20; // Lowered from 30 for better sensitivity
     let checksWithSpeech = 0;
 
-    console.log(
-      '[SMRTForm] Audio level monitoring started, AudioContext state:',
-      audioContext.state,
-    );
-
     audioLevelInterval = setInterval(() => {
       if (!analyser || !isFormListening) return;
 
@@ -273,7 +260,6 @@ async function startAudioLevelMonitoring(stream: MediaStream) {
       // Log periodically to debug
       checksWithSpeech++;
       if (checksWithSpeech % 10 === 0) {
-        console.log('[SMRTForm] Audio level avg:', average.toFixed(1));
       }
 
       if (average > SPEECH_THRESHOLD) {
@@ -281,9 +267,7 @@ async function startAudioLevelMonitoring(stream: MediaStream) {
         resetSilenceTimer();
       }
     }, 200); // Check every 200ms
-  } catch (err) {
-    console.warn('[SMRTForm] Could not set up audio level monitoring:', err);
-  }
+  } catch (err) {}
 }
 
 // Stop audio level monitoring
@@ -342,7 +326,6 @@ $effect(() => {
 
     // Check for "done" keyword
     if (checkForDoneKeyword(newText)) {
-      console.log('[SMRTForm] "Done" keyword detected - stopping');
       // Don't set isStopping here - let stopFormListening() do it after passing the guard
       stopFormListening();
     }
@@ -354,7 +337,6 @@ $effect(() => {
   // If form thinks we're listening but STT has stopped, handle it
   // Don't trigger during startup phase (isStarting) or shutdown phase (isStopping)
   if (isFormListening && !stt.isListening && !isStopping && !isStarting) {
-    console.log('[SMRTForm] STT stopped unexpectedly - handling end of speech');
     // Use setTimeout to avoid state update during render
     setTimeout(() => {
       if (isFormListening && !isStopping && !isStarting) {
@@ -365,21 +347,12 @@ $effect(() => {
 });
 
 async function toggleFormListening() {
-  console.log(
-    '[SMRTForm] toggleFormListening called, isFormListening:',
-    isFormListening,
-  );
-
   if (isFormListening) {
     await stopFormListening();
   } else {
     // Prevent immediate restart after stopping (UI might lag behind state)
     const timeSinceStop = Date.now() - lastStopTime;
     if (lastStopTime > 0 && timeSinceStop < RESTART_COOLDOWN_MS) {
-      console.log(
-        '[SMRTForm] Ignoring start - cooldown active, time since stop:',
-        timeSinceStop,
-      );
       return;
     }
     await startFormListening();
@@ -394,7 +367,6 @@ async function startFormListening() {
 
   // Initialize STT with selected adapter
   if (!stt.isReady || stt.adapterType !== sttAdapter) {
-    console.log(`[SMRTForm] Initializing STT adapter: ${sttAdapter}`);
     await stt.initialize({ type: sttAdapter });
   }
 
@@ -417,9 +389,7 @@ async function startFormListening() {
         audio: true,
       });
       startAudioLevelMonitoring(levelStream);
-    } catch (err) {
-      console.warn('[SMRTForm] Could not get mic for level monitoring:', err);
-    }
+    } catch (err) {}
   }
 
   await stt.start({ continuous: true, interimResults: true });
@@ -429,14 +399,7 @@ async function startFormListening() {
 }
 
 async function stopFormListening() {
-  console.log(
-    '[SMRTForm] stopFormListening called, isFormListening:',
-    isFormListening,
-    'isStopping:',
-    isStopping,
-  );
   if (!isFormListening || isStopping) {
-    console.log('[SMRTForm] stopFormListening returning early');
     return;
   }
   isStopping = true;
@@ -450,7 +413,6 @@ async function stopFormListening() {
 
   // Stop audio level monitoring
   stopAudioLevelMonitoring();
-  console.log('[SMRTForm] Audio monitoring stopped, calling stt.stop()');
 
   // IMPORTANT: Keep isFormListening = true until after stt.stop() completes
   // This allows the $effect to capture any final results
@@ -467,19 +429,15 @@ async function stopFormListening() {
   const textToExtract = (finalResult || spokenText || '')
     .replace(/\s*done\.?$/i, '')
     .trim();
-  console.log('[SMRTForm] Final text to extract:', textToExtract);
 
   if (textToExtract) {
     isExtracting = true;
     extractError = null;
 
     try {
-      console.log('[SMRTForm] Running final extraction...');
       const values = await extractFields(textToExtract);
-      console.log('[SMRTForm] Extracted values:', values);
       applyExtractedValues(values);
     } catch (err) {
-      console.error('[SMRTForm] Extraction error:', err);
       extractError =
         err instanceof Error ? err.message : 'Failed to extract fields';
     } finally {
@@ -487,13 +445,11 @@ async function stopFormListening() {
       isStopping = false;
     }
   } else {
-    console.log('[SMRTForm] No text to extract');
     isStopping = false;
   }
 
   // Record stop time to prevent immediate restart
   lastStopTime = Date.now();
-  console.log('[SMRTForm] Stop complete, cooldown started');
 }
 
 // Cleanup on destroy
@@ -669,7 +625,8 @@ function getFormData(): Record<string, unknown> {
   .mode-btn.active {
     background: var(--smrt-color-surface, #fff);
     color: var(--smrt-color-primary, #3b82f6);
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 1px 3px
+      color-mix(in srgb, var(--smrt-color-shadow) 10%, transparent);
   }
 
   .form-listen-btn {
@@ -678,8 +635,8 @@ function getFormData(): Record<string, unknown> {
     gap: 8px;
     padding: 10px 20px;
     border: 2px solid var(--smrt-color-primary, #3b82f6);
-    background: #fff;
-    color: #3b82f6;
+    background: var(--smrt-color-surface);
+    color: var(--smrt-color-primary);
     border-radius: 8px;
     cursor: pointer;
     font-size: 0.875rem;
@@ -710,10 +667,11 @@ function getFormData(): Record<string, unknown> {
 
   @keyframes pulse-btn {
     0%, 100% {
-      box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.4);
+      box-shadow: 0 0 0 0
+        color-mix(in srgb, var(--smrt-color-success) 40%, transparent);
     }
     50% {
-      box-shadow: 0 0 0 8px rgba(34, 197, 94, 0);
+      box-shadow: 0 0 0 8px transparent;
     }
   }
 
@@ -745,7 +703,8 @@ function getFormData(): Record<string, unknown> {
     background: color-mix(in srgb, var(--smrt-color-primary, #166534) 90%, transparent);
     color: white;
     font-size: 0.875rem;
-    box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 -2px 12px
+      color-mix(in srgb, var(--smrt-color-shadow) 15%, transparent);
     z-index: 9999;
     text-align: center;
     backdrop-filter: blur(8px);
@@ -769,11 +728,11 @@ function getFormData(): Record<string, unknown> {
 
   .extract-error {
     padding: 12px 16px;
-    background: #fef2f2;
-    border: 1px solid #fecaca;
+    background: var(--smrt-color-error-container);
+    border: 1px solid var(--smrt-color-error);
     border-radius: 8px;
     font-size: 0.875rem;
-    color: #dc2626;
+    color: var(--smrt-color-error);
   }
 
   .form-fields {

--- a/packages/smrt-svelte/src/components/forms/Form.svelte
+++ b/packages/smrt-svelte/src/components/forms/Form.svelte
@@ -125,6 +125,8 @@ function extractFieldsFromText(text: string): Record<string, unknown> {
   // Normalize text: remove commas, extra spaces
   const normalized = text.replace(/,/g, ' ').replace(/\s+/g, ' ').trim();
 
+  console.log('[SMRTForm] Normalized text:', normalized);
+
   // Build list of all field triggers for boundary detection
   const allTriggers: string[] = [];
   for (const f of fieldDefs) {
@@ -187,6 +189,7 @@ function extractFieldsFromText(text: string): Record<string, unknown> {
 
         if (value) {
           result[field.name] = value;
+          console.log(`[SMRTForm] Regex extracted ${field.name}:`, value);
           break; // Found value for this field, move to next
         }
       }
@@ -199,9 +202,13 @@ function extractFieldsFromText(text: string): Record<string, unknown> {
 // Extract fields from spoken text
 // Currently uses regex-only since small local LLMs produce unreliable output
 async function extractFields(text: string): Promise<Record<string, unknown>> {
+  console.log('[SMRTForm] Extracting fields from:', text);
+
   // Use regex extraction directly - fast and reliable
   // TODO: Add LLM enhancement when larger models are available
   const result = extractFieldsFromText(text);
+
+  console.log('[SMRTForm] Extracted:', result);
   return result;
 }
 
@@ -224,6 +231,7 @@ function resetSilenceTimer() {
   lastSpeechTime = Date.now();
   silenceTimer = setTimeout(() => {
     if (isFormListening) {
+      console.log('[SMRTForm] Silence timeout - stopping');
       stopFormListening();
     }
   }, silenceTimeout * 1000);
@@ -251,6 +259,11 @@ async function startAudioLevelMonitoring(stream: MediaStream) {
     const SPEECH_THRESHOLD = 20; // Lowered from 30 for better sensitivity
     let checksWithSpeech = 0;
 
+    console.log(
+      '[SMRTForm] Audio level monitoring started, AudioContext state:',
+      audioContext.state,
+    );
+
     audioLevelInterval = setInterval(() => {
       if (!analyser || !isFormListening) return;
 
@@ -260,6 +273,7 @@ async function startAudioLevelMonitoring(stream: MediaStream) {
       // Log periodically to debug
       checksWithSpeech++;
       if (checksWithSpeech % 10 === 0) {
+        console.log('[SMRTForm] Audio level avg:', average.toFixed(1));
       }
 
       if (average > SPEECH_THRESHOLD) {
@@ -267,7 +281,9 @@ async function startAudioLevelMonitoring(stream: MediaStream) {
         resetSilenceTimer();
       }
     }, 200); // Check every 200ms
-  } catch (err) {}
+  } catch (err) {
+    console.warn('[SMRTForm] Could not set up audio level monitoring:', err);
+  }
 }
 
 // Stop audio level monitoring
@@ -326,6 +342,7 @@ $effect(() => {
 
     // Check for "done" keyword
     if (checkForDoneKeyword(newText)) {
+      console.log('[SMRTForm] "Done" keyword detected - stopping');
       // Don't set isStopping here - let stopFormListening() do it after passing the guard
       stopFormListening();
     }
@@ -337,6 +354,7 @@ $effect(() => {
   // If form thinks we're listening but STT has stopped, handle it
   // Don't trigger during startup phase (isStarting) or shutdown phase (isStopping)
   if (isFormListening && !stt.isListening && !isStopping && !isStarting) {
+    console.log('[SMRTForm] STT stopped unexpectedly - handling end of speech');
     // Use setTimeout to avoid state update during render
     setTimeout(() => {
       if (isFormListening && !isStopping && !isStarting) {
@@ -347,12 +365,21 @@ $effect(() => {
 });
 
 async function toggleFormListening() {
+  console.log(
+    '[SMRTForm] toggleFormListening called, isFormListening:',
+    isFormListening,
+  );
+
   if (isFormListening) {
     await stopFormListening();
   } else {
     // Prevent immediate restart after stopping (UI might lag behind state)
     const timeSinceStop = Date.now() - lastStopTime;
     if (lastStopTime > 0 && timeSinceStop < RESTART_COOLDOWN_MS) {
+      console.log(
+        '[SMRTForm] Ignoring start - cooldown active, time since stop:',
+        timeSinceStop,
+      );
       return;
     }
     await startFormListening();
@@ -367,6 +394,7 @@ async function startFormListening() {
 
   // Initialize STT with selected adapter
   if (!stt.isReady || stt.adapterType !== sttAdapter) {
+    console.log(`[SMRTForm] Initializing STT adapter: ${sttAdapter}`);
     await stt.initialize({ type: sttAdapter });
   }
 
@@ -389,7 +417,9 @@ async function startFormListening() {
         audio: true,
       });
       startAudioLevelMonitoring(levelStream);
-    } catch (err) {}
+    } catch (err) {
+      console.warn('[SMRTForm] Could not get mic for level monitoring:', err);
+    }
   }
 
   await stt.start({ continuous: true, interimResults: true });
@@ -399,7 +429,14 @@ async function startFormListening() {
 }
 
 async function stopFormListening() {
+  console.log(
+    '[SMRTForm] stopFormListening called, isFormListening:',
+    isFormListening,
+    'isStopping:',
+    isStopping,
+  );
   if (!isFormListening || isStopping) {
+    console.log('[SMRTForm] stopFormListening returning early');
     return;
   }
   isStopping = true;
@@ -413,6 +450,7 @@ async function stopFormListening() {
 
   // Stop audio level monitoring
   stopAudioLevelMonitoring();
+  console.log('[SMRTForm] Audio monitoring stopped, calling stt.stop()');
 
   // IMPORTANT: Keep isFormListening = true until after stt.stop() completes
   // This allows the $effect to capture any final results
@@ -429,15 +467,19 @@ async function stopFormListening() {
   const textToExtract = (finalResult || spokenText || '')
     .replace(/\s*done\.?$/i, '')
     .trim();
+  console.log('[SMRTForm] Final text to extract:', textToExtract);
 
   if (textToExtract) {
     isExtracting = true;
     extractError = null;
 
     try {
+      console.log('[SMRTForm] Running final extraction...');
       const values = await extractFields(textToExtract);
+      console.log('[SMRTForm] Extracted values:', values);
       applyExtractedValues(values);
     } catch (err) {
+      console.error('[SMRTForm] Extraction error:', err);
       extractError =
         err instanceof Error ? err.message : 'Failed to extract fields';
     } finally {
@@ -445,11 +487,13 @@ async function stopFormListening() {
       isStopping = false;
     }
   } else {
+    console.log('[SMRTForm] No text to extract');
     isStopping = false;
   }
 
   // Record stop time to prevent immediate restart
   lastStopTime = Date.now();
+  console.log('[SMRTForm] Stop complete, cooldown started');
 }
 
 // Cleanup on destroy
@@ -625,8 +669,7 @@ function getFormData(): Record<string, unknown> {
   .mode-btn.active {
     background: var(--smrt-color-surface, #fff);
     color: var(--smrt-color-primary, #3b82f6);
-    box-shadow: 0 1px 3px
-      color-mix(in srgb, var(--smrt-color-shadow) 10%, transparent);
+    box-shadow: 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow) 10%, transparent);
   }
 
   .form-listen-btn {
@@ -667,8 +710,7 @@ function getFormData(): Record<string, unknown> {
 
   @keyframes pulse-btn {
     0%, 100% {
-      box-shadow: 0 0 0 0
-        color-mix(in srgb, var(--smrt-color-success) 40%, transparent);
+      box-shadow: 0 0 0 0 color-mix(in srgb, var(--smrt-color-success) 40%, transparent);
     }
     50% {
       box-shadow: 0 0 0 8px transparent;
@@ -703,8 +745,7 @@ function getFormData(): Record<string, unknown> {
     background: color-mix(in srgb, var(--smrt-color-primary, #166534) 90%, transparent);
     color: white;
     font-size: 0.875rem;
-    box-shadow: 0 -2px 12px
-      color-mix(in srgb, var(--smrt-color-shadow) 15%, transparent);
+    box-shadow: 0 -2px 12px color-mix(in srgb, var(--smrt-color-shadow) 15%, transparent);
     z-index: 9999;
     text-align: center;
     backdrop-filter: blur(8px);

--- a/packages/smrt-svelte/src/components/forms/FormMicButton.svelte
+++ b/packages/smrt-svelte/src/components/forms/FormMicButton.svelte
@@ -29,12 +29,6 @@ $effect(() => {
       const newExtracting = formContext.isExtracting;
       // Only log on change to reduce noise
       if (newListening !== isListening || newExtracting !== isExtracting) {
-        console.log(
-          '[FormMicButton] State change: listening:',
-          newListening,
-          'extracting:',
-          newExtracting,
-        );
       }
       isListening = newListening;
       isExtracting = newExtracting;
@@ -51,12 +45,6 @@ $effect(() => {
 });
 
 function handleClick() {
-  console.log(
-    '[FormMicButton] Click! isListening:',
-    isListening,
-    'isExtracting:',
-    isExtracting,
-  );
   formContext?.toggleListening();
 }
 </script>
@@ -146,7 +134,8 @@ function handleClick() {
     border-radius: 0.375rem;
     white-space: nowrap;
     z-index: 9999;
-    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 6px -1px
+      color-mix(in srgb, var(--smrt-color-shadow) 10%, transparent);
   }
 
   .tooltip::before {
@@ -156,7 +145,7 @@ function handleClick() {
     left: 50%;
     transform: translateX(-50%);
     border: 6px solid transparent;
-    border-bottom-color: #1f2937;
+    border-bottom-color: var(--smrt-color-on-surface);
   }
 
   @keyframes pulse {

--- a/packages/smrt-svelte/src/components/forms/FormMicButton.svelte
+++ b/packages/smrt-svelte/src/components/forms/FormMicButton.svelte
@@ -29,6 +29,12 @@ $effect(() => {
       const newExtracting = formContext.isExtracting;
       // Only log on change to reduce noise
       if (newListening !== isListening || newExtracting !== isExtracting) {
+        console.log(
+          '[FormMicButton] State change: listening:',
+          newListening,
+          'extracting:',
+          newExtracting,
+        );
       }
       isListening = newListening;
       isExtracting = newExtracting;
@@ -45,6 +51,12 @@ $effect(() => {
 });
 
 function handleClick() {
+  console.log(
+    '[FormMicButton] Click! isListening:',
+    isListening,
+    'isExtracting:',
+    isExtracting,
+  );
   formContext?.toggleListening();
 }
 </script>
@@ -134,8 +146,7 @@ function handleClick() {
     border-radius: 0.375rem;
     white-space: nowrap;
     z-index: 9999;
-    box-shadow: 0 4px 6px -1px
-      color-mix(in srgb, var(--smrt-color-shadow) 10%, transparent);
+    box-shadow: 0 4px 6px -1px color-mix(in srgb, var(--smrt-color-shadow) 10%, transparent);
   }
 
   .tooltip::before {

--- a/packages/smrt-svelte/src/components/forms/MeasurementInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/MeasurementInput.svelte
@@ -486,7 +486,7 @@ function handleUnitChange(e: Event) {
   }
 
   .unit-select:disabled {
-    background: #f3f4f6;
+    background: var(--smrt-color-surface-container);
     cursor: not-allowed;
   }
 

--- a/packages/smrt-svelte/src/components/forms/MoneyInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/MoneyInput.svelte
@@ -394,7 +394,7 @@ function handleBlur() {
   }
 
   .smrt-input.invalid:focus {
-    border-color: #ef4444;
+    border-color: var(--smrt-color-error);
     box-shadow: 0 0 0 3px color-mix(in srgb, var(--smrt-color-error, #ba1a1a) 10%, transparent);
   }
 

--- a/packages/smrt-svelte/src/components/forms/NumberInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/NumberInput.svelte
@@ -280,7 +280,7 @@ function handleInput(e: Event) {
   }
 
   .smrt-input.invalid:focus {
-    border-color: #ef4444;
+    border-color: var(--smrt-color-error);
     box-shadow: 0 0 0 3px color-mix(in srgb, var(--smrt-color-error, #ba1a1a) 10%, transparent);
   }
 

--- a/packages/smrt-svelte/src/components/forms/PhoneInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/PhoneInput.svelte
@@ -412,7 +412,7 @@ function handleInput(e: Event) {
   }
 
   .mic-btn:hover {
-    background: #f3f4f6;
+    background: var(--smrt-color-surface-container);
     color: var(--smrt-color-on-surface, #374151);
   }
 
@@ -444,14 +444,14 @@ function handleInput(e: Event) {
     align-items: center;
     gap: 6px;
     font-size: var(--smrt-typography-body-small-size, 0.75rem);
-    color: #22c55e;
+    color: var(--smrt-color-success);
     margin-top: 4px;
   }
 
   .listening-dot {
     width: 8px;
     height: 8px;
-    background: #22c55e;
+    background: var(--smrt-color-success);
     border-radius: 50%;
     animation: pulse-dot 1s ease-in-out infinite;
   }
@@ -487,15 +487,15 @@ function handleInput(e: Event) {
     align-items: center;
     gap: 6px;
     font-size: var(--smrt-typography-body-small-size, 0.75rem);
-    color: #8b5cf6;
+    color: var(--smrt-color-tertiary);
     margin-top: 4px;
   }
 
   .processing-spinner {
     width: 12px;
     height: 12px;
-    border: 2px solid #e5e7eb;
-    border-top-color: #3b82f6;
+    border: 2px solid var(--smrt-color-outline-variant);
+    border-top-color: var(--smrt-color-primary);
     border-radius: 50%;
     animation: spin 0.8s linear infinite;
   }

--- a/packages/smrt-svelte/src/components/forms/Toggle.svelte
+++ b/packages/smrt-svelte/src/components/forms/Toggle.svelte
@@ -136,7 +136,8 @@ const sizeClasses = {
     position: absolute;
     background: var(--smrt-color-surface, #ffffff);
     border-radius: var(--smrt-radius-full, 9999px);
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 1px 3px
+      color-mix(in srgb, var(--smrt-color-shadow) 20%, transparent);
     transition: transform var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
   }
 

--- a/packages/smrt-svelte/src/components/memberships/MembershipCard.svelte
+++ b/packages/smrt-svelte/src/components/memberships/MembershipCard.svelte
@@ -122,7 +122,7 @@ function formatDate(date: Date | string | null | undefined): string {
     justify-content: space-between;
     margin-top: 0.75rem;
     padding-top: 0.75rem;
-    border-top: 1px solid var(--smrt-color-surface-container);
+    border-top: 1px solid var(--smrt-color-outline-variant);
   }
 
   .date {

--- a/packages/smrt-svelte/src/components/memberships/MembershipCard.svelte
+++ b/packages/smrt-svelte/src/components/memberships/MembershipCard.svelte
@@ -66,8 +66,8 @@ function formatDate(date: Date | string | null | undefined): string {
 <style>
   .membership-card {
     padding: 1rem;
-    background: white;
-    border: 1px solid #e5e7eb;
+    background: var(--smrt-color-surface);
+    border: 1px solid var(--smrt-color-outline-variant);
     border-radius: 0.5rem;
   }
 
@@ -86,7 +86,7 @@ function formatDate(date: Date | string | null | undefined): string {
 
   .tenant-name {
     font-weight: 500;
-    color: #111827;
+    color: var(--smrt-color-on-surface);
   }
 
   .status {
@@ -98,18 +98,18 @@ function formatDate(date: Date | string | null | undefined): string {
   }
 
   .status-active {
-    background: #dcfce7;
-    color: #166534;
+    background: var(--smrt-color-success-container);
+    color: var(--smrt-color-on-success-container);
   }
 
   .status-pending {
-    background: #fef3c7;
-    color: #92400e;
+    background: var(--smrt-color-warning-container);
+    color: var(--smrt-color-on-warning-container);
   }
 
   .status-suspended {
-    background: #fee2e2;
-    color: #991b1b;
+    background: var(--smrt-color-error-container);
+    color: var(--smrt-color-on-error-container);
   }
 
   .role-info {
@@ -122,12 +122,12 @@ function formatDate(date: Date | string | null | undefined): string {
     justify-content: space-between;
     margin-top: 0.75rem;
     padding-top: 0.75rem;
-    border-top: 1px solid #f3f4f6;
+    border-top: 1px solid var(--smrt-color-surface-container);
   }
 
   .date {
     font-size: 0.75rem;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant);
   }
 
   .actions {
@@ -138,23 +138,23 @@ function formatDate(date: Date | string | null | undefined): string {
   .action-btn {
     padding: 0.25rem 0.5rem;
     background: none;
-    border: 1px solid #d1d5db;
+    border: 1px solid var(--smrt-color-outline);
     border-radius: 0.25rem;
     font-size: 0.75rem;
-    color: #374151;
+    color: var(--smrt-color-on-surface-variant);
     cursor: pointer;
   }
 
   .action-btn:hover {
-    background: #f3f4f6;
+    background: var(--smrt-color-surface-container);
   }
 
   .action-btn.danger {
-    color: #dc2626;
-    border-color: #fecaca;
+    color: var(--smrt-color-error);
+    border-color: var(--smrt-color-error);
   }
 
   .action-btn.danger:hover {
-    background: #fef2f2;
+    background: var(--smrt-color-error-container);
   }
 </style>

--- a/packages/smrt-svelte/src/components/memberships/MembershipList.svelte
+++ b/packages/smrt-svelte/src/components/memberships/MembershipList.svelte
@@ -66,14 +66,14 @@ const {
     justify-content: center;
     gap: 0.75rem;
     padding: 2rem;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant);
   }
 
   .spinner {
     width: 1.25rem;
     height: 1.25rem;
-    border: 2px solid #e5e7eb;
-    border-top-color: #3b82f6;
+    border: 2px solid var(--smrt-color-outline-variant);
+    border-top-color: var(--smrt-color-primary);
     border-radius: 50%;
     animation: spin 0.6s linear infinite;
   }
@@ -87,9 +87,9 @@ const {
   .empty {
     padding: 2rem;
     text-align: center;
-    color: #6b7280;
-    background: #f9fafb;
-    border: 1px dashed #d1d5db;
+    color: var(--smrt-color-on-surface-variant);
+    background: var(--smrt-color-surface-variant);
+    border: 1px dashed var(--smrt-color-outline);
     border-radius: 0.5rem;
   }
 </style>

--- a/packages/smrt-svelte/src/components/ui/Badge.svelte
+++ b/packages/smrt-svelte/src/components/ui/Badge.svelte
@@ -49,18 +49,18 @@ const { variant = 'default', size = 'md', children, ...rest }: Props = $props();
   }
 
   .success {
-    background: #e8f5e9;
-    color: #2e7d32;
+    background: var(--smrt-color-success-container);
+    color: var(--smrt-color-on-success-container);
   }
 
   .warning {
-    background: #fff3e0;
-    color: #e65100;
+    background: var(--smrt-color-warning-container);
+    color: var(--smrt-color-on-warning-container);
   }
 
   .error {
-    background: #ffebee;
-    color: #c62828;
+    background: var(--smrt-color-error-container);
+    color: var(--smrt-color-on-error-container);
   }
 
   .info {

--- a/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
@@ -890,7 +890,7 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
       display: block;
       position: fixed;
       inset: 0;
-      background: rgba(3, 7, 14, 0.55);
+      background: var(--smrt-color-scrim);
       opacity: 0;
       pointer-events: none;
       transition: opacity 180ms ease;
@@ -934,7 +934,7 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
       pointer-events: auto;
       position: fixed;
       inset: 0;
-      background: rgba(3, 7, 14, 0.4);
+      background: var(--smrt-color-scrim);
       border: 0;
       z-index: 21;
     }

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
@@ -369,7 +369,8 @@
     overflow: hidden;
     border-left: 1px solid var(--smrt-color-outline-variant, #30343a);
     border-right: 1px solid var(--smrt-color-outline-variant, #30343a);
-    box-shadow: -24px 0 40px rgba(0, 0, 0, 0.18);
+    box-shadow: -24px 0 40px
+      color-mix(in srgb, var(--smrt-color-shadow) 18%, transparent);
     transform: translateX(calc(100% + var(--tools-dock-rail-width)));
     opacity: 0;
     pointer-events: none;
@@ -519,7 +520,7 @@
       z-index: 65;
       padding: 0;
       border: 0;
-      background: rgba(0, 0, 0, 0.34);
+      background: var(--smrt-color-scrim);
       cursor: default;
     }
 

--- a/scripts/check-color-literals.mjs
+++ b/scripts/check-color-literals.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+/**
+ * Raw color-literal ratchet for SMRT UI packages.
+ *
+ * Bans hardcoded color literals (hex / `rgb(a)` / `hsl(a)`) inside CSS contexts
+ * of `.svelte` and `.css` files, steering authors to the semantic
+ * `--smrt-color-*` design tokens (issue #1373, parent epic #1354). Component
+ * colors should be themeable across the material / glass / studio presets and
+ * light/dark schemes; raw literals freeze them.
+ *
+ * Phased rollout (S1 phase 1):
+ *   - `packages/smrt-svelte` is the reference library and is held to ERROR:
+ *     any raw literal there fails the check (exit 1).
+ *   - Every other package is REPORT-ONLY (warn): literals are listed but do not
+ *     fail. Those packages migrate in later phases of #1373; flipping a package
+ *     to strict means removing it from REPORT_ONLY once it is clean.
+ *
+ * What is allowed (never flagged):
+ *   - `var(--token, #fallback)` fallbacks — the literal is only a fallback for
+ *     an emitted token, which the svelte-token-check already guards.
+ *   - Theme-definition / token-source files (THEME_DEFINITION_GLOBS) that
+ *     legitimately hold literal values: the `--smrt-*` preset CSS, the simple
+ *     ThemeProvider token map, the shared scales, the css-generator, and the
+ *     legacy `--color-*` token sheet.
+ *   - `<script>` / `<script module>` blocks in `.svelte` files — color literals
+ *     there are JS values (e.g. a Material-3 palette seed), not CSS styling.
+ *   - `transparent`, `currentColor`, `inherit` and other CSS-wide keywords are
+ *     not literals and are never matched.
+ *
+ * Run: `node scripts/check-color-literals.mjs` or `pnpm check:color-literals`.
+ * Exit code: 0 if no strict-package violations, 1 otherwise.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative, resolve, sep } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const PACKAGES = join(ROOT, 'packages');
+
+/** Packages held to ERROR. Everything else is report-only for now (#1373). */
+const STRICT_PACKAGES = new Set(['smrt-svelte']);
+
+/**
+ * Path fragments (POSIX `/` separators) for token-source / theme-definition
+ * files that legitimately contain raw color literals. Matched as substrings of
+ * the package-relative path.
+ */
+const THEME_DEFINITION_FRAGMENTS = [
+  'src/themes/styles/', // --smrt-* preset CSS (material/glass/studio/all)
+  'src/theme/tokens.ts', // simple ThemeProvider token map
+  'src/themes/shared.ts', // shared spacing/radius/duration scales
+  'src/themes/css-generator.ts', // JS theme generator
+  'src/styles/tokens.css', // legacy --color-* token sheet
+];
+
+/**
+ * Only scan each package's published-source tree. Demo/playground apps,
+ * generated theme copies under `static/`, and other dev-only assets are out of
+ * scope: the contract is about the shippable component library, which is what
+ * `svelte-check` / `svelte-package` build from `src/`.
+ */
+function isInPackageSrc(relPath) {
+  // relPath like "smrt-svelte/src/components/ui/Badge.svelte"
+  const parts = toPosix(relPath).split('/');
+  return parts.length > 1 && parts[1] === 'src';
+}
+
+/** Recursively list files with one of `exts` under `dir` (skips node_modules/dist). */
+function listFiles(dir, exts) {
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+      out.push(...listFiles(full, exts));
+    } else if (exts.some((e) => entry.name.endsWith(e))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const HEX_RE = /#[0-9a-fA-F]{3}\b|#[0-9a-fA-F]{4}\b|#[0-9a-fA-F]{6}\b|#[0-9a-fA-F]{8}\b/g;
+const FUNC_RE = /\b(?:rgba?|hsla?)\([^)]*\)/gi;
+
+/**
+ * Strip `<script>` / `<script module>` blocks from a `.svelte` source so color
+ * literals that are JS values are not treated as CSS. Replaces each block with
+ * blank lines to keep line numbers stable.
+ */
+function stripScriptBlocks(source) {
+  return source.replace(
+    /<script\b[^>]*>[\s\S]*?<\/script>/gi,
+    (block) => block.replace(/[^\n]/g, ' '),
+  );
+}
+
+/**
+ * Whether the literal at `index` on `line` sits inside a `var(..., literal)`
+ * fallback. We look back to the nearest unbalanced `var(` and require a comma
+ * after it — i.e. the literal is the fallback argument.
+ */
+function isVarFallback(line, index) {
+  const before = line.slice(0, index);
+  const lastVar = before.lastIndexOf('var(');
+  if (lastVar === -1) return false;
+  const seg = before.slice(lastVar);
+  const opens = (seg.match(/\(/g) || []).length;
+  const closes = (seg.match(/\)/g) || []).length;
+  return opens > closes && seg.includes(',');
+}
+
+/**
+ * Blank out CSS `/* *​/` block comments (including multi-line ones) and `//`
+ * line comments so literals inside them — e.g. an issue reference like `#1431`
+ * that looks like a 4-digit hex — are not flagged. Newlines are preserved so
+ * line numbers stay accurate.
+ */
+function stripComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, (block) => block.replace(/[^\n]/g, ' '))
+    .replace(/(^|[^:])\/\/[^\n]*/g, (m, lead) =>
+      lead + ' '.repeat(m.length - lead.length),
+    );
+}
+
+/** Collect raw color-literal violations in a single file's source. */
+function findViolations(file, source) {
+  let text = file.endsWith('.svelte') ? stripScriptBlocks(source) : source;
+  text = stripComments(text);
+  const lines = text.split('\n');
+  const hits = [];
+  lines.forEach((line, i) => {
+    for (const re of [HEX_RE, FUNC_RE]) {
+      for (const m of line.matchAll(re)) {
+        if (isVarFallback(line, m.index)) continue;
+        hits.push({ line: i + 1, value: m[0], snippet: line.trim().slice(0, 100) });
+      }
+    }
+  });
+  return hits;
+}
+
+function packageNameOf(relPath) {
+  // relPath like "smrt-svelte/src/components/ui/Badge.svelte"
+  return relPath.split(sep)[0];
+}
+
+function toPosix(p) {
+  return p.split(sep).join('/');
+}
+
+function isThemeDefinition(relPath) {
+  const posix = toPosix(relPath);
+  return THEME_DEFINITION_FRAGMENTS.some((frag) => posix.includes(frag));
+}
+
+const files = listFiles(PACKAGES, ['.svelte', '.css']);
+
+const strictViolations = []; // { file, hits }
+const reportOnly = new Map(); // package -> count
+
+for (const file of files) {
+  const relPath = relative(PACKAGES, file);
+  if (!isInPackageSrc(relPath)) continue;
+  if (isThemeDefinition(relPath)) continue;
+  const pkg = packageNameOf(relPath);
+  const hits = findViolations(file, readFileSync(file, 'utf8'));
+  if (hits.length === 0) continue;
+  if (STRICT_PACKAGES.has(pkg)) {
+    strictViolations.push({ file: relPath, hits });
+  } else {
+    reportOnly.set(pkg, (reportOnly.get(pkg) ?? 0) + hits.length);
+  }
+}
+
+if (reportOnly.size > 0) {
+  const total = [...reportOnly.values()].reduce((a, b) => a + b, 0);
+  console.warn(
+    `⚠ color-literal-check: ${total} raw color literal(s) in report-only ` +
+      'package(s) (not failing — later phases of #1373):',
+  );
+  for (const [pkg, count] of [...reportOnly].sort((a, b) => b[1] - a[1])) {
+    console.warn(`    ${pkg}: ${count}`);
+  }
+  console.warn('');
+}
+
+if (strictViolations.length === 0) {
+  console.log(
+    `✓ color-literal-check: no raw color literals in strict package(s): ${[
+      ...STRICT_PACKAGES,
+    ].join(', ')}`,
+  );
+  process.exit(0);
+}
+
+const total = strictViolations.reduce((a, v) => a + v.hits.length, 0);
+console.error(
+  `✗ color-literal-check: ${total} raw color literal(s) in strict ` +
+    `package(s): ${[...STRICT_PACKAGES].join(', ')}\n`,
+);
+for (const { file, hits } of strictViolations.sort((a, b) =>
+  a.file.localeCompare(b.file),
+)) {
+  console.error(`  ${file}`);
+  for (const h of hits) {
+    console.error(`    L${h.line}: ${h.value}   | ${h.snippet}`);
+  }
+}
+console.error(
+  '\nReplace raw color literals with semantic --smrt-color-* tokens so\n' +
+    'components stay themeable across material/glass/studio + light/dark.\n' +
+    'Map by ROLE not hue (error→--smrt-color-error, surface→--smrt-color-surface,\n' +
+    'backdrops→--smrt-color-scrim, shadows→color-mix(... var(--smrt-color-shadow))).\n' +
+    'A var(--token, #fallback) fallback is allowed; token-source files are exempt\n' +
+    '(see THEME_DEFINITION_FRAGMENTS in scripts/check-color-literals.mjs).',
+);
+process.exit(1);

--- a/scripts/check-color-literals.mjs
+++ b/scripts/check-color-literals.mjs
@@ -102,18 +102,37 @@ function stripScriptBlocks(source) {
 }
 
 /**
- * Whether the literal at `index` on `line` sits inside a `var(..., literal)`
- * fallback. We look back to the nearest unbalanced `var(` and require a comma
- * after it — i.e. the literal is the fallback argument.
+ * Blank out whole `var(...)` calls — balanced parens, across multiple lines —
+ * so literals used as `var(--token, #fallback)` fallbacks are never flagged,
+ * regardless of how the call is wrapped by the formatter. Newlines are
+ * preserved so reported line numbers stay accurate.
  */
-function isVarFallback(line, index) {
-  const before = line.slice(0, index);
-  const lastVar = before.lastIndexOf('var(');
-  if (lastVar === -1) return false;
-  const seg = before.slice(lastVar);
-  const opens = (seg.match(/\(/g) || []).length;
-  const closes = (seg.match(/\)/g) || []).length;
-  return opens > closes && seg.includes(',');
+function stripVarCalls(source) {
+  let out = '';
+  let i = 0;
+  while (i < source.length) {
+    if (source.startsWith('var(', i)) {
+      let depth = 0;
+      let j = i + 3; // points at the '('
+      for (; j < source.length; j++) {
+        const ch = source[j];
+        if (ch === '(') depth++;
+        else if (ch === ')') {
+          depth--;
+          if (depth === 0) {
+            j++;
+            break;
+          }
+        }
+      }
+      out += source.slice(i, j).replace(/[^\n]/g, ' ');
+      i = j;
+    } else {
+      out += source[i];
+      i += 1;
+    }
+  }
+  return out;
 }
 
 /**
@@ -134,12 +153,14 @@ function stripComments(source) {
 function findViolations(file, source) {
   let text = file.endsWith('.svelte') ? stripScriptBlocks(source) : source;
   text = stripComments(text);
+  // Blank out var(...) calls (multi-line aware) so allowed `var(--token,
+  // #fallback)` fallbacks are never flagged, however the call is wrapped.
+  text = stripVarCalls(text);
   const lines = text.split('\n');
   const hits = [];
   lines.forEach((line, i) => {
     for (const re of [HEX_RE, FUNC_RE]) {
       for (const m of line.matchAll(re)) {
-        if (isVarFallback(line, m.index)) continue;
         hits.push({ line: i + 1, value: m[0], snippet: line.trim().slice(0, 100) });
       }
     }

--- a/scripts/check-color-literals.mjs
+++ b/scripts/check-color-literals.mjs
@@ -13,12 +13,12 @@
  *     any raw literal there fails the check (exit 1).
  *   - Every other package is REPORT-ONLY (warn): literals are listed but do not
  *     fail. Those packages migrate in later phases of #1373; flipping a package
- *     to strict means removing it from REPORT_ONLY once it is clean.
+ *     to strict means adding it to STRICT_PACKAGES once it is clean.
  *
  * What is allowed (never flagged):
  *   - `var(--token, #fallback)` fallbacks — the literal is only a fallback for
  *     an emitted token, which the svelte-token-check already guards.
- *   - Theme-definition / token-source files (THEME_DEFINITION_GLOBS) that
+ *   - Theme-definition / token-source files (THEME_DEFINITION_FRAGMENTS) that
  *     legitimately hold literal values: the `--smrt-*` preset CSS, the simple
  *     ThemeProvider token map, the shared scales, the css-generator, and the
  *     legacy `--color-*` token sheet.


### PR DESCRIPTION
## Summary

Phase 1 of the **S1 design-token sweep (#1373**, epic #1354). This PR makes
`packages/smrt-svelte` the exemplary reference library by migrating hardcoded
color literals in component `<style>` blocks to the semantic `--smrt-color-*`
tokens, and adds a deterministic lint ratchet so they cannot regress.

**Scope: `packages/smrt-svelte/src` only.** Repo-wide migration of the other UI
packages (content, products, chat, assets, images, ...) is intentionally
deferred to follow-up phases of #1373 — those are report-only here.

This is a **visual refactor only**: no layout, markup, or behavior changes.

## What changed

### Color-literal migration (73 literals across 19 components, mapped by ROLE not hue)
- **status/badge surfaces** -> `success`/`warning`/`error` container + `on-*`
  tokens (`Badge`, `MembershipCard` status pills, `PhoneInput` listening/processing indicators)
- **neutral surfaces/text/borders** -> `surface`, `surface-variant`,
  `surface-container`, `on-surface`, `on-surface-variant`, `outline`, `outline-variant`
- **danger affordances** -> `error` / `error-container`
- **spinners & primary accents** -> `primary` / `outline-variant`
- **backdrops & scrims** -> `--smrt-color-scrim` (`WorkspaceShell` mobile +
  inspector backdrops, `ToolsDock` mobile overlay)
- **box-shadow alpha-on-black** -> `color-mix(in srgb, var(--smrt-color-shadow) N%, transparent)`
  so shadows stay themeable (`Form`, `Toggle`, `FormMicButton`, `ToolsDock`); pulse-keyframe
  glows derive from `--smrt-color-success` / `--smrt-color-error` the same way
- **Calendar/DayView `@media (prefers-color-scheme: dark)` fallback blocks** now
  reference the base `--smrt-color-*` tokens (which already swap dark) with the dark literal
  kept only as a `var()` fallback — matching the `[data-theme="dark"]` block already above them

Every token used is emitted by all three presets (material/glass/studio) in
light + dark, so the swaps resolve everywhere.

### Lint ratchet (`scripts/check-color-literals.mjs`)
- Bans raw `hex` / `rgb(a)` / `hsl(a)` in `.svelte` + `.css` CSS contexts
- **ERROR for `smrt-svelte`** (now clean); **report-only (warn) for other UI
  packages**, which migrate in later phases — so this PR doesn't break their CI
- Allows `var(--token, #fallback)` fallbacks; exempts token-source files
  (`themes/styles/*.css`, `theme/tokens.ts`, `themes/shared.ts`,
  `css-generator.ts`, `styles/tokens.css`); strips `<script>` blocks so JS color
  values aren't flagged; scoped to each package's published `src/` tree
- Wired into **CI** (`check-standards` job), **lefthook** (pre-push), and a
  `check:color-literals` npm script — mirroring the existing `check-svelte-tokens` pattern

## Verification
- `pnpm build` — 50/50 tasks pass
- `pnpm --filter @happyvertical/smrt-svelte run check` (svelte-check) — **0 errors, 0 warnings** (1202 files)
- `pnpm --filter @happyvertical/smrt-svelte test` — **266 tests pass**
- `pnpm exec biome check` on touched files — clean (error level)
- `node scripts/check-svelte-tokens.mjs` — 119 consumed tokens, all emitted
- `node scripts/check-color-literals.mjs` — smrt-svelte clean (exit 0)
- Token coverage cross-checked: every migrated token is defined in all 3 presets in light + dark

## Needs a new token
None — every literal mapped cleanly to an existing emitted token (or to a
`color-mix` of `--smrt-color-shadow` for shadow alphas).

## Intentional / out of scope (not migrated)
- `ThemeProvider.svelte` `seed = '#6750A4'` — a Material-3 palette *seed input*
  (the source colors are derived from), not a CSS style value
- `src/styles/tokens.css`, `src/themes/styles/*.css` — token-definition sheets

Closes part of #1373 (Phase 1 = smrt-svelte color literals + ratchet; remaining
packages + spacing/typography/radius/z-index scales are follow-up phases).