### PR TITLE
refactor(products): tokenize color literals (S1 #1373 phase 2)

### DIFF
--- a/packages/products/src/app/App.svelte
+++ b/packages/products/src/app/App.svelte
@@ -56,12 +56,12 @@ onMount(() => {
   .placeholder-page h2 {
     margin: 0 0 1rem 0;
     font-size: 2rem;
-    color: #1f2937;
+    color: var(--smrt-color-on-surface, #1f2937);
   }
-  
+
   .placeholder-page p {
     margin: 0;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
     font-size: 1.125rem;
   }
 </style>

--- a/packages/products/src/app/app.css
+++ b/packages/products/src/app/app.css
@@ -24,8 +24,8 @@ body {
     "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
     "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
-  background-color: #f9fafb;
-  color: #1f2937;
+  background-color: var(--smrt-color-surface-container-low, #f9fafb);
+  color: var(--smrt-color-on-surface, #1f2937);
 }
 
 img,
@@ -94,7 +94,7 @@ h3 {
 
 /* Focus styles */
 *:focus-visible {
-  outline: 2px solid #3b82f6;
+  outline: 2px solid var(--smrt-color-primary, #3b82f6);
   outline-offset: 2px;
 }
 

--- a/packages/products/src/app/layouts/AppLayout.svelte
+++ b/packages/products/src/app/layouts/AppLayout.svelte
@@ -50,13 +50,13 @@ const { children }: Props = $props();
     min-height: 100vh;
     display: flex;
     flex-direction: column;
-    background: #f9fafb;
+    background: var(--smrt-color-surface-container-low, #f9fafb);
   }
-  
+
   .app-header {
     background: white;
-    border-bottom: 1px solid #e2e8f0;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    border-bottom: 1px solid var(--smrt-color-outline-variant, #e2e8f0);
+    box-shadow: 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow, #000) 10%, transparent);
     position: sticky;
     top: 0;
     z-index: 100;
@@ -78,7 +78,7 @@ const { children }: Props = $props();
     gap: 0.5rem;
     font-size: 1.5rem;
     font-weight: 700;
-    color: #1f2937;
+    color: var(--smrt-color-on-surface, #1f2937);
   }
   
   .logo {
@@ -91,17 +91,17 @@ const { children }: Props = $props();
   }
   
   .nav-link {
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
     text-decoration: none;
     font-weight: 500;
     padding: 0.5rem 1rem;
     border-radius: 4px;
     transition: all 0.2s;
   }
-  
+
   .nav-link:hover {
-    color: #3b82f6;
-    background: #f3f4f6;
+    color: var(--smrt-color-primary, #3b82f6);
+    background: var(--smrt-color-surface-container, #f3f4f6);
   }
   
   .header-actions {
@@ -115,7 +115,7 @@ const { children }: Props = $props();
     align-items: center;
     gap: 0.5rem;
     font-size: 0.875rem;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
   }
   
   .status-dot {
@@ -125,7 +125,7 @@ const { children }: Props = $props();
   }
   
   .status-dot.online {
-    background: #10b981;
+    background: var(--smrt-color-success, #10b981);
     animation: pulse 2s infinite;
   }
   
@@ -141,7 +141,7 @@ const { children }: Props = $props();
   
   .app-footer {
     background: white;
-    border-top: 1px solid #e2e8f0;
+    border-top: 1px solid var(--smrt-color-outline-variant, #e2e8f0);
     margin-top: auto;
   }
   
@@ -156,7 +156,7 @@ const { children }: Props = $props();
   
   .footer-content p {
     margin: 0;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
     font-size: 0.875rem;
   }
   
@@ -166,14 +166,14 @@ const { children }: Props = $props();
   }
   
   .footer-links a {
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
     text-decoration: none;
     font-size: 0.875rem;
     transition: color 0.2s;
   }
-  
+
   .footer-links a:hover {
-    color: #3b82f6;
+    color: var(--smrt-color-primary, #3b82f6);
   }
   
   @media (max-width: 768px) {

--- a/packages/products/src/app/pages/DemoPage.svelte
+++ b/packages/products/src/app/pages/DemoPage.svelte
@@ -27,12 +27,10 @@ let _autoFormData = $state({ ...sampleProduct });
 let _customFormData = $state({ ...sampleProduct });
 
 function _handleAutoSubmit(data: ProductData) {
-  console.log('Auto form submitted:', data);
   _autoFormData = { ...data };
 }
 
 function _handleCustomSubmit(data: ProductData) {
-  console.log('Custom form submitted:', data);
   _customFormData = { ...data };
 }
 </script>
@@ -185,27 +183,31 @@ function _handleCustomSubmit(data: ProductData) {
 <style>
   .demo-page {
     min-height: 100vh;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: #1f2937;
+    background: linear-gradient(
+      135deg,
+      var(--smrt-color-primary, #667eea) 0%,
+      var(--smrt-color-primary-container, #764ba2) 100%
+    );
+    color: var(--smrt-color-on-surface, #1f2937);
   }
 
   .demo-header {
     text-align: center;
     padding: 2rem 1rem;
-    background: rgba(255, 255, 255, 0.95);
+    background: color-mix(in srgb, var(--smrt-color-surface, #fff) 95%, transparent);
     margin-bottom: 2rem;
   }
 
   .demo-header h1 {
     font-size: 2.5rem;
     font-weight: 700;
-    color: #1f2937;
+    color: var(--smrt-color-on-surface, #1f2937);
     margin: 0 0 0.5rem 0;
   }
 
   .demo-subtitle {
     font-size: 1.125rem;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
     margin: 0;
   }
 
@@ -219,7 +221,7 @@ function _handleCustomSubmit(data: ProductData) {
 
   .nav-btn {
     padding: 0.75rem 1.5rem;
-    background: rgba(255, 255, 255, 0.9);
+    background: color-mix(in srgb, var(--smrt-color-surface, #fff) 90%, transparent);
     border: 2px solid transparent;
     border-radius: 0.5rem;
     font-weight: 500;
@@ -234,8 +236,8 @@ function _handleCustomSubmit(data: ProductData) {
 
   .nav-btn.active {
     background: white;
-    border-color: #3b82f6;
-    color: #3b82f6;
+    border-color: var(--smrt-color-primary, #3b82f6);
+    color: var(--smrt-color-primary, #3b82f6);
   }
 
   .demo-content {
@@ -245,7 +247,7 @@ function _handleCustomSubmit(data: ProductData) {
   .demo-section {
     max-width: 1200px;
     margin: 0 auto;
-    background: rgba(255, 255, 255, 0.95);
+    background: color-mix(in srgb, var(--smrt-color-surface, #fff) 95%, transparent);
     border-radius: 1rem;
     padding: 2rem;
     margin-bottom: 2rem;
@@ -253,7 +255,7 @@ function _handleCustomSubmit(data: ProductData) {
 
   .section-description {
     font-size: 1rem;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
     margin-bottom: 2rem;
     text-align: center;
   }
@@ -267,7 +269,7 @@ function _handleCustomSubmit(data: ProductData) {
   .demo-column h3 {
     text-align: center;
     margin-bottom: 1rem;
-    color: #374151;
+    color: var(--smrt-color-on-surface, #374151);
   }
 
   .comparison-grid {
@@ -278,9 +280,9 @@ function _handleCustomSubmit(data: ProductData) {
 
   .comparison-column {
     padding: 1.5rem;
-    background: #f9fafb;
+    background: var(--smrt-color-surface-container-low, #f9fafb);
     border-radius: 0.5rem;
-    border: 1px solid #e5e7eb;
+    border: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
   }
 
   .comparison-column h3 {
@@ -298,11 +300,11 @@ function _handleCustomSubmit(data: ProductData) {
 
   .feature {
     font-size: 0.875rem;
-    color: #374151;
+    color: var(--smrt-color-on-surface, #374151);
   }
 
   .demo-footer {
-    background: rgba(255, 255, 255, 0.95);
+    background: color-mix(in srgb, var(--smrt-color-surface, #fff) 95%, transparent);
     padding: 2rem;
     margin-top: 2rem;
   }
@@ -317,7 +319,7 @@ function _handleCustomSubmit(data: ProductData) {
     font-size: 1.25rem;
     font-weight: 600;
     margin-bottom: 1rem;
-    color: #1f2937;
+    color: var(--smrt-color-on-surface, #1f2937);
   }
 
   .framework-info ul {
@@ -330,7 +332,7 @@ function _handleCustomSubmit(data: ProductData) {
 
   .framework-info li {
     padding: 0.75rem;
-    background: #f3f4f6;
+    background: var(--smrt-color-surface-container, #f3f4f6);
     border-radius: 0.375rem;
     font-size: 0.875rem;
   }

--- a/packages/products/src/app/pages/DemoPage.svelte
+++ b/packages/products/src/app/pages/DemoPage.svelte
@@ -27,10 +27,12 @@ let _autoFormData = $state({ ...sampleProduct });
 let _customFormData = $state({ ...sampleProduct });
 
 function _handleAutoSubmit(data: ProductData) {
+  console.log('Auto form submitted:', data);
   _autoFormData = { ...data };
 }
 
 function _handleCustomSubmit(data: ProductData) {
+  console.log('Custom form submitted:', data);
   _customFormData = { ...data };
 }
 </script>

--- a/packages/products/src/app/pages/ProductsPage.svelte
+++ b/packages/products/src/app/pages/ProductsPage.svelte
@@ -59,26 +59,26 @@
     margin: 0 0 0.5rem 0;
     font-size: 2.25rem;
     font-weight: 800;
-    color: #1f2937;
+    color: var(--smrt-color-on-surface, #1f2937);
   }
-  
+
   .page-description {
     margin: 0;
     font-size: 1.125rem;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
     max-width: 600px;
     margin: 0 auto;
     line-height: 1.6;
   }
-  
+
   .page-content {
     margin-bottom: 3rem;
   }
-  
+
   .integration-info {
     margin-top: 3rem;
     padding-top: 2rem;
-    border-top: 1px solid #e2e8f0;
+    border-top: 1px solid var(--smrt-color-outline-variant, #e2e8f0);
   }
   
   .info-cards {
@@ -91,21 +91,21 @@
     background: white;
     padding: 1.5rem;
     border-radius: 8px;
-    border: 1px solid #e2e8f0;
+    border: 1px solid var(--smrt-color-outline-variant, #e2e8f0);
     text-align: center;
   }
-  
+
   .info-card h3 {
     margin: 0 0 0.5rem 0;
     font-size: 1.125rem;
     font-weight: 600;
-    color: #1f2937;
+    color: var(--smrt-color-on-surface, #1f2937);
   }
-  
+
   .info-card p {
     margin: 0;
     font-size: 0.875rem;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
     line-height: 1.5;
   }
 </style>

--- a/packages/products/src/lib/components/ProductCard.svelte
+++ b/packages/products/src/lib/components/ProductCard.svelte
@@ -57,16 +57,16 @@ const { product, onEdit, onDelete }: Props = $props();
 
 <style>
   .product-card {
-    border: 1px solid #e2e8f0;
+    border: 1px solid var(--smrt-color-outline-variant, #e2e8f0);
     border-radius: 8px;
     padding: 1rem;
     background: white;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow, #000) 10%, transparent);
     transition: box-shadow 0.2s;
   }
-  
+
   .product-card:hover {
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 6px color-mix(in srgb, var(--smrt-color-shadow, #000) 10%, transparent);
   }
   
   .product-header {
@@ -80,26 +80,26 @@ const { product, onEdit, onDelete }: Props = $props();
     margin: 0;
     font-size: 1.125rem;
     font-weight: 600;
-    color: #1f2937;
+    color: var(--smrt-color-on-surface, #1f2937);
   }
-  
+
   .product-manufacturer {
     font-size: 0.875rem;
     font-weight: 500;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
   }
 
   .product-model {
     font-size: 0.875rem;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
     margin-bottom: 0.5rem;
   }
 
   .product-category {
     font-size: 0.75rem;
     font-weight: 500;
-    color: #374151;
-    background: #f3f4f6;
+    color: var(--smrt-color-on-surface, #374151);
+    background: var(--smrt-color-surface-container, #f3f4f6);
     padding: 0.25rem 0.5rem;
     border-radius: 4px;
     display: inline-block;
@@ -108,7 +108,7 @@ const { product, onEdit, onDelete }: Props = $props();
   
   .product-description {
     margin: 0.5rem 0;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
     font-size: 0.875rem;
     line-height: 1.4;
   }
@@ -126,19 +126,19 @@ const { product, onEdit, onDelete }: Props = $props();
   }
   
   .tag {
-    background: #f3f4f6;
-    color: #374151;
+    background: var(--smrt-color-surface-container, #f3f4f6);
+    color: var(--smrt-color-on-surface, #374151);
     padding: 0.125rem 0.5rem;
     border-radius: 9999px;
     font-size: 0.75rem;
   }
-  
+
   .product-actions {
     display: flex;
     gap: 0.5rem;
     margin-top: 1rem;
     padding-top: 0.75rem;
-    border-top: 1px solid #f3f4f6;
+    border-top: 1px solid var(--smrt-color-outline-variant, #f3f4f6);
   }
   
   .edit-btn, .delete-btn {
@@ -152,22 +152,22 @@ const { product, onEdit, onDelete }: Props = $props();
   }
   
   .edit-btn {
-    background: #f9fafb;
-    border-color: #d1d5db;
-    color: #374151;
+    background: var(--smrt-color-surface-container-low, #f9fafb);
+    border-color: var(--smrt-color-outline-variant, #d1d5db);
+    color: var(--smrt-color-on-surface, #374151);
   }
-  
+
   .edit-btn:hover {
-    background: #f3f4f6;
+    background: var(--smrt-color-surface-container, #f3f4f6);
   }
-  
+
   .delete-btn {
-    background: #fef2f2;
-    border-color: #fecaca;
-    color: #dc2626;
+    background: var(--smrt-color-error-container, #fef2f2);
+    border-color: var(--smrt-color-error, #fecaca);
+    color: var(--smrt-color-error, #dc2626);
   }
-  
+
   .delete-btn:hover {
-    background: #fee2e2;
+    background: var(--smrt-color-error-container, #fee2e2);
   }
 </style>

--- a/packages/products/src/lib/components/ProductForm.svelte
+++ b/packages/products/src/lib/components/ProductForm.svelte
@@ -170,7 +170,7 @@ function _handleSubmit(event: Event) {
     padding: 1.5rem;
     background: white;
     border-radius: 8px;
-    border: 1px solid #e2e8f0;
+    border: 1px solid var(--smrt-color-outline-variant, #e2e8f0);
   }
   
   .form-group {
@@ -187,27 +187,27 @@ function _handleSubmit(event: Event) {
     display: block;
     margin-bottom: 0.25rem;
     font-weight: 500;
-    color: #374151;
+    color: var(--smrt-color-on-surface, #374151);
     font-size: 0.875rem;
   }
-  
+
   .form-input, .form-textarea {
     width: 100%;
     padding: 0.5rem;
-    border: 1px solid #d1d5db;
+    border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
     border-radius: 4px;
     font-size: 0.875rem;
     transition: border-color 0.2s;
   }
-  
+
   .form-input:focus, .form-textarea:focus {
     outline: none;
-    border-color: #3b82f6;
-    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+    border-color: var(--smrt-color-primary, #3b82f6);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--smrt-color-primary, #3b82f6) 10%, transparent);
   }
-  
+
   .form-input.error {
-    border-color: #dc2626;
+    border-color: var(--smrt-color-error, #dc2626);
   }
   
   .form-textarea {
@@ -227,25 +227,25 @@ function _handleSubmit(event: Event) {
   }
   
   .form-hint {
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
     font-size: 0.75rem;
     margin-top: 0.25rem;
   }
-  
+
   .error-message {
-    color: #dc2626;
+    color: var(--smrt-color-error, #dc2626);
     font-size: 0.75rem;
     margin-top: 0.25rem;
     display: block;
   }
-  
+
   .form-actions {
     display: flex;
     gap: 0.75rem;
     justify-content: flex-end;
     margin-top: 1.5rem;
     padding-top: 1rem;
-    border-top: 1px solid #f3f4f6;
+    border-top: 1px solid var(--smrt-color-outline-variant, #f3f4f6);
   }
   
   .cancel-btn, .submit-btn {
@@ -260,22 +260,22 @@ function _handleSubmit(event: Event) {
   
   .cancel-btn {
     background: white;
-    border-color: #d1d5db;
-    color: #374151;
+    border-color: var(--smrt-color-outline-variant, #d1d5db);
+    color: var(--smrt-color-on-surface, #374151);
   }
-  
+
   .cancel-btn:hover:not(:disabled) {
-    background: #f9fafb;
+    background: var(--smrt-color-surface-container-low, #f9fafb);
   }
-  
+
   .submit-btn {
-    background: #3b82f6;
-    border-color: #3b82f6;
+    background: var(--smrt-color-primary, #3b82f6);
+    border-color: var(--smrt-color-primary, #3b82f6);
     color: white;
   }
-  
+
   .submit-btn:hover:not(:disabled) {
-    background: #2563eb;
+    background: var(--smrt-color-primary, #2563eb);
   }
   
   .submit-btn:disabled, .cancel-btn:disabled {

--- a/packages/products/src/lib/components/ProductForm.svelte
+++ b/packages/products/src/lib/components/ProductForm.svelte
@@ -271,7 +271,7 @@ function _handleSubmit(event: Event) {
   .submit-btn {
     background: var(--smrt-color-primary, #3b82f6);
     border-color: var(--smrt-color-primary, #3b82f6);
-    color: white;
+    color: var(--smrt-color-on-primary, white);
   }
 
   .submit-btn:hover:not(:disabled) {

--- a/packages/products/src/lib/components/TestComponent.svelte
+++ b/packages/products/src/lib/components/TestComponent.svelte
@@ -14,8 +14,8 @@ const { message = 'Hello Federation!' }: Props = $props();
 <style>
   .test-component {
     padding: 1rem;
-    border: 1px solid #ccc;
+    border: 1px solid var(--smrt-color-outline-variant, #ccc);
     border-radius: 4px;
-    background: #f9f9f9;
+    background: var(--smrt-color-surface-container-low, #f9f9f9);
   }
 </style>

--- a/packages/products/src/lib/components/auto-generated/AutoForm.svelte
+++ b/packages/products/src/lib/components/auto-generated/AutoForm.svelte
@@ -147,7 +147,7 @@ function _getFieldType(
     padding: 1.5rem;
     background: white;
     border-radius: 8px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow, #000) 10%, transparent);
   }
 
   .form-header {
@@ -158,13 +158,13 @@ function _getFieldType(
   .form-title {
     font-size: 1.5rem;
     font-weight: 600;
-    color: #1f2937;
+    color: var(--smrt-color-on-surface, #1f2937);
     margin: 0 0 0.5rem 0;
   }
 
   .form-subtitle {
     font-size: 0.875rem;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
     font-style: italic;
   }
 
@@ -179,11 +179,11 @@ function _getFieldType(
     gap: 0.75rem;
     margin-top: 1.5rem;
     padding-top: 1.5rem;
-    border-top: 1px solid #e5e7eb;
+    border-top: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
   }
 
   .submit-btn {
-    background: #3b82f6;
+    background: var(--smrt-color-primary, #3b82f6);
     color: white;
     border: none;
     padding: 0.75rem 1.5rem;
@@ -194,13 +194,13 @@ function _getFieldType(
   }
 
   .submit-btn:hover {
-    background: #2563eb;
+    background: var(--smrt-color-primary, #2563eb);
   }
 
   .reset-btn {
-    background: #f3f4f6;
-    color: #374151;
-    border: 1px solid #d1d5db;
+    background: var(--smrt-color-surface-container, #f3f4f6);
+    color: var(--smrt-color-on-surface, #374151);
+    border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
     padding: 0.75rem 1.5rem;
     border-radius: 0.375rem;
     font-weight: 500;
@@ -209,27 +209,27 @@ function _getFieldType(
   }
 
   .reset-btn:hover {
-    background: #e5e7eb;
+    background: var(--smrt-color-surface-container-high, #e5e7eb);
   }
 
   .form-debug {
     margin-top: 2rem;
     padding: 1rem;
-    background: #f9fafb;
+    background: var(--smrt-color-surface-container-low, #f9fafb);
     border-radius: 0.375rem;
-    border: 1px solid #e5e7eb;
+    border: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
   }
 
   .form-debug summary {
     cursor: pointer;
     font-weight: 500;
-    color: #374151;
+    color: var(--smrt-color-on-surface, #374151);
   }
 
   .form-debug pre {
     margin-top: 0.5rem;
     font-size: 0.75rem;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
     white-space: pre-wrap;
     word-break: break-word;
   }

--- a/packages/products/src/lib/components/auto-generated/AutoForm.svelte
+++ b/packages/products/src/lib/components/auto-generated/AutoForm.svelte
@@ -184,7 +184,7 @@ function _getFieldType(
 
   .submit-btn {
     background: var(--smrt-color-primary, #3b82f6);
-    color: white;
+    color: var(--smrt-color-on-primary, white);
     border: none;
     padding: 0.75rem 1.5rem;
     border-radius: 0.375rem;

--- a/packages/products/src/lib/components/auto-generated/FieldRenderer.svelte
+++ b/packages/products/src/lib/components/auto-generated/FieldRenderer.svelte
@@ -152,18 +152,18 @@ function _handleObjectInput(event: Event) {
 
   .field-label {
     font-weight: 500;
-    color: #374151;
+    color: var(--smrt-color-on-surface, #374151);
     font-size: 0.875rem;
   }
 
   .required {
-    color: #dc2626;
+    color: var(--smrt-color-error, #dc2626);
   }
 
   .field-input,
   .field-textarea {
     padding: 0.5rem 0.75rem;
-    border: 1px solid #d1d5db;
+    border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
     border-radius: 0.375rem;
     font-size: 0.875rem;
     transition: border-color 0.2s, box-shadow 0.2s;
@@ -172,8 +172,8 @@ function _handleObjectInput(event: Event) {
   .field-input:focus,
   .field-textarea:focus {
     outline: none;
-    border-color: #3b82f6;
-    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+    border-color: var(--smrt-color-primary, #3b82f6);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--smrt-color-primary, #3b82f6) 10%, transparent);
   }
 
   .field-textarea {
@@ -188,13 +188,13 @@ function _handleObjectInput(event: Event) {
 
   .field-hint {
     font-size: 0.75rem;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
     font-style: italic;
   }
 
   .field-input:read-only,
   .field-textarea:read-only {
-    background-color: #f9fafb;
+    background-color: var(--smrt-color-surface-container-low, #f9fafb);
     cursor: not-allowed;
   }
 </style>

--- a/packages/products/src/lib/features/CategoryManager.svelte
+++ b/packages/products/src/lib/features/CategoryManager.svelte
@@ -44,33 +44,33 @@ const _loading = $state(false);
   
   .manager-header h2 {
     margin: 0 0 0.5rem 0;
-    color: #1f2937;
+    color: var(--smrt-color-on-surface, #1f2937);
     font-size: 1.5rem;
     font-weight: 600;
   }
-  
+
   .manager-header p {
     margin: 0;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
   }
-  
+
   .placeholder-content {
-    background: #f9fafb;
-    border: 1px solid #e2e8f0;
+    background: var(--smrt-color-surface-container-low, #f9fafb);
+    border: 1px solid var(--smrt-color-outline-variant, #e2e8f0);
     border-radius: 8px;
     padding: 2rem;
     text-align: center;
   }
-  
+
   .placeholder-content p {
     margin: 0 0 1rem 0;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
   }
-  
+
   .placeholder-content ul {
     margin: 1rem 0 0 0;
     text-align: left;
     display: inline-block;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
   }
 </style>

--- a/packages/products/src/lib/features/ProductCatalog.svelte
+++ b/packages/products/src/lib/features/ProductCatalog.svelte
@@ -48,24 +48,20 @@ async function _handleDeleteProduct(id: string) {
   if (confirm('Are you sure you want to delete this product?')) {
     try {
       await productStore.deleteProduct(id);
-    } catch (error) {
-      console.error('Failed to delete product:', error);
-    }
+    } catch (error) {}
   }
 }
 
 async function _handleSubmitProduct(productData: Partial<ProductData>) {
   try {
-    if (editingProduct && editingProduct.id) {
+    if (editingProduct?.id) {
       await productStore.updateProduct(editingProduct.id, productData);
     } else {
       await productStore.createProduct(productData);
     }
     _showForm = false;
     editingProduct = null;
-  } catch (error) {
-    console.error('Failed to save product:', error);
-  }
+  } catch (error) {}
 }
 
 function _handleCancelForm() {
@@ -183,21 +179,21 @@ function _handleCancelForm() {
     align-items: center;
     margin-bottom: 1.5rem;
     padding-bottom: 1rem;
-    border-bottom: 2px solid #e2e8f0;
+    border-bottom: 2px solid var(--smrt-color-outline-variant, #e2e8f0);
   }
-  
+
   .catalog-header h2 {
     margin: 0;
-    color: #1f2937;
+    color: var(--smrt-color-on-surface, #1f2937);
     font-size: 1.875rem;
     font-weight: 700;
   }
-  
+
   .catalog-stats {
     display: flex;
     gap: 1.5rem;
     font-size: 0.875rem;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
   }
   
   .catalog-controls {
@@ -216,7 +212,7 @@ function _handleCancelForm() {
   
   .search-input, .category-filter {
     padding: 0.5rem;
-    border: 1px solid #d1d5db;
+    border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
     border-radius: 4px;
     font-size: 0.875rem;
   }
@@ -231,7 +227,7 @@ function _handleCancelForm() {
   }
   
   .create-btn {
-    background: #3b82f6;
+    background: var(--smrt-color-primary, #3b82f6);
     color: white;
     border: none;
     padding: 0.5rem 1rem;
@@ -240,9 +236,9 @@ function _handleCancelForm() {
     cursor: pointer;
     transition: background-color 0.2s;
   }
-  
+
   .create-btn:hover {
-    background: #2563eb;
+    background: var(--smrt-color-primary, #2563eb);
   }
   
   .products-grid {
@@ -254,26 +250,26 @@ function _handleCancelForm() {
   .loading-state, .error-state, .empty-state {
     text-align: center;
     padding: 3rem 1rem;
-    color: #6b7280;
+    color: var(--smrt-color-on-surface-variant, #6b7280);
   }
-  
+
   .error-state button {
     margin-top: 0.5rem;
-    background: #dc2626;
+    background: var(--smrt-color-error, #dc2626);
     color: white;
     border: none;
     padding: 0.5rem 1rem;
     border-radius: 4px;
     cursor: pointer;
   }
-  
+
   .form-overlay {
     position: fixed;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(0, 0, 0, 0.5);
+    background: var(--smrt-color-scrim, rgba(0, 0, 0, 0.5));
     display: flex;
     align-items: center;
     justify-content: center;
@@ -292,7 +288,7 @@ function _handleCancelForm() {
   .form-container h3 {
     margin: 0 0 1rem 0;
     padding: 1.5rem 1.5rem 0 1.5rem;
-    color: #1f2937;
+    color: var(--smrt-color-on-surface, #1f2937);
     font-size: 1.25rem;
     font-weight: 600;
   }

--- a/packages/products/src/lib/features/ProductCatalog.svelte
+++ b/packages/products/src/lib/features/ProductCatalog.svelte
@@ -232,7 +232,7 @@ function _handleCancelForm() {
   
   .create-btn {
     background: var(--smrt-color-primary, #3b82f6);
-    color: white;
+    color: var(--smrt-color-on-primary, white);
     border: none;
     padding: 0.5rem 1rem;
     border-radius: 4px;
@@ -260,7 +260,7 @@ function _handleCancelForm() {
   .error-state button {
     margin-top: 0.5rem;
     background: var(--smrt-color-error, #dc2626);
-    color: white;
+    color: var(--smrt-color-on-error, white);
     border: none;
     padding: 0.5rem 1rem;
     border-radius: 4px;

--- a/packages/products/src/lib/features/ProductCatalog.svelte
+++ b/packages/products/src/lib/features/ProductCatalog.svelte
@@ -48,20 +48,24 @@ async function _handleDeleteProduct(id: string) {
   if (confirm('Are you sure you want to delete this product?')) {
     try {
       await productStore.deleteProduct(id);
-    } catch (error) {}
+    } catch (error) {
+      console.error('Failed to delete product:', error);
+    }
   }
 }
 
 async function _handleSubmitProduct(productData: Partial<ProductData>) {
   try {
-    if (editingProduct?.id) {
+    if (editingProduct && editingProduct.id) {
       await productStore.updateProduct(editingProduct.id, productData);
     } else {
       await productStore.createProduct(productData);
     }
     _showForm = false;
     editingProduct = null;
-  } catch (error) {}
+  } catch (error) {
+    console.error('Failed to save product:', error);
+  }
 }
 
 function _handleCancelForm() {

--- a/scripts/check-color-literals.mjs
+++ b/scripts/check-color-literals.mjs
@@ -38,7 +38,7 @@ const ROOT = resolve(import.meta.dirname, '..');
 const PACKAGES = join(ROOT, 'packages');
 
 /** Packages held to ERROR. Everything else is report-only for now (#1373). */
-const STRICT_PACKAGES = new Set(['smrt-svelte']);
+const STRICT_PACKAGES = new Set(['smrt-svelte', 'products']);
 
 /**
  * Path fragments (POSIX `/` separators) for token-source / theme-definition


### PR DESCRIPTION
## S1 (#1373) Phase 2 — tokenize `@happyvertical/smrt-products` color literals + flip to strict

Phase 2 of the S1 design-token sweep (#1373, epic #1354). Phase 1 (smrt-svelte, #1443) established the pattern + the `scripts/check-color-literals.mjs` ratchet; this PR migrates `smrt-products` and adds it to the strict (ERROR) tier.

### What changed
- Replaced all **116** raw color literals (hex / `rgb(a)`) across `packages/products/src` (component `<style>` blocks + `app/app.css`) with semantic `--smrt-color-*` tokens.
- Added `'products'` to `STRICT_PACKAGES` in `scripts/check-color-literals.mjs`. `node scripts/check-color-literals.mjs` now lists products clean in the strict set (exit 0) and it no longer appears in the report-only warnings.

### Critical difference from phase 1 — the FALLBACK pattern
products had **0** existing `--smrt-color-*` usages and ships a **standalone app** (`app/`) that does **not** load the SMRT theme provider, so a bare `var(--smrt-color-x)` would resolve to nothing there and break colors. Every swap therefore uses the fallback form `var(--smrt-color-<role>, <original-literal>)`, keeping the exact original color as the fallback. The standalone app stays **pixel-identical**, while products becomes themeable when consumed inside a SMRT app.

### Role mapping (by role, not hue)
- neutral text / surfaces / borders → `on-surface`, `on-surface-variant`, `surface`, `surface-container`, `surface-container-low`/`-high`, `outline-variant`
- primary accents (buttons, focus rings, active nav, footer links) → `primary` / `primary-container`; DemoPage hero gradient stops → `primary` / `primary-container`
- danger affordances (delete button, validation, required marker) → `error` / `error-container`
- online status dot → `success`
- modal backdrop → `--smrt-color-scrim` (itself an `rgba(0,0,0,N)` overlay); fallback preserves the original `rgba(0,0,0,0.5)`
- box-shadow alpha-on-black → `color-mix(in srgb, var(--smrt-color-shadow, #000) N%, transparent)`; focus rings + translucent frosted panels use the same `color-mix` form over `--smrt-color-primary` / `--smrt-color-surface`, so the original alpha is preserved exactly via the fallback (phase-1 pattern)

### `app/app.css` — migrated, not excluded
Inspected first: it is ordinary global/reset + typography styling (body bg/text, focus outline). It does **not** define any `--smrt-color-*` or `:root` color tokens, so it was migrated with the fallback pattern. `THEME_DEFINITION_FRAGMENTS` is unchanged.

### Needs a new token?
None. Every role mapped cleanly onto an existing `--smrt-color-*` token. No new `--smrt-*` names were invented.

### Scope
Color values **only**. No JS/TS, logging, markup/DOM, component logic, or layout was touched — every diff line is a CSS color value inside a `<style>` / `.css` block. (One DemoPage gradient declaration is wrapped across lines because the fallbacks made it long; still the same single `background:` color declaration.) Pre-existing biome warnings (console usage / optional-chaining in `ProductCatalog.svelte` script) and pre-existing svelte-check errors (`$lib` resolution / `tsconfig.svelte.json` file-list scope) were **left untouched** — verified they are identical on `origin/main`.

### Verification
- `node scripts/check-color-literals.mjs` → products in strict list, 0 raw literals, **exit 0** ✓
- `pnpm build` → 50/50 tasks, products builds via `vite build --mode library` ✓
- svelte-check → **0 new** errors (baseline 35 errors / 12 warnings is identical with and without this change; all pre-existing `$lib` / tsconfig scope issues unrelated to CSS). products has no `check`/typecheck script (expected/exempted per task).
- `pnpm exec biome check` on touched files → clean (the 5 warnings are pre-existing `<script>`-block findings, not in any CSS I touched) ✓

Refs #1373.
