### PR TITLE
refactor(content): tokenize color literals + flip to strict (S1 #1373 phase 2)

### DIFF
--- a/packages/content/src/routes/+layout.svelte
+++ b/packages/content/src/routes/+layout.svelte
@@ -78,7 +78,7 @@ const navItems = [
     position: sticky;
     top: 0;
     z-index: 100;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+    box-shadow: 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow) 6%, transparent);
   }
 
   .header-inner {

--- a/packages/content/src/routes/api-explorer/+page.svelte
+++ b/packages/content/src/routes/api-explorer/+page.svelte
@@ -594,7 +594,7 @@ function closeTry() {
   }
 
   .group-btn.active .group-count {
-    background: rgba(0,0,0,0.08);
+    background: color-mix(in srgb, var(--smrt-color-shadow) 8%, transparent);
   }
 
   .endpoints-panel {
@@ -602,7 +602,7 @@ function closeTry() {
     border: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
     border-radius: 1rem;
     padding: 1.5rem;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+    box-shadow: 0 2px 8px color-mix(in srgb, var(--smrt-color-shadow) 4%, transparent);
   }
 
   .endpoints-panel h2 {

--- a/packages/content/src/svelte/components/ContentBodyEditor.svelte
+++ b/packages/content/src/svelte/components/ContentBodyEditor.svelte
@@ -1390,7 +1390,7 @@ function handleEditorDragEnd() {
     border-radius: 999px;
     background: color-mix(in srgb, var(--smrt-color-surface) 96%, transparent);
     color: var(--smrt-color-on-surface);
-    box-shadow: 0 0.75rem 1.75rem rgba(0, 0, 0, 0.18);
+    box-shadow: 0 0.75rem 1.75rem color-mix(in srgb, var(--smrt-color-shadow) 18%, transparent);
     transform: translateX(-50%);
     backdrop-filter: blur(10px);
   }
@@ -1432,7 +1432,7 @@ function handleEditorDragEnd() {
     border: 1px solid var(--smrt-color-outline-variant);
     border-radius: 999px;
     background: var(--smrt-color-surface);
-    box-shadow: 0 0.45rem 1rem rgba(0, 0, 0, 0.18);
+    box-shadow: 0 0.45rem 1rem color-mix(in srgb, var(--smrt-color-shadow) 18%, transparent);
     cursor: nwse-resize;
   }
 

--- a/packages/content/src/svelte/components/ContentClaimAuditTool.svelte
+++ b/packages/content/src/svelte/components/ContentClaimAuditTool.svelte
@@ -397,18 +397,18 @@ async function recheckFactClaims(claimIds: string[]) {
   }
 
   .pill--passed {
-    background: rgba(22, 163, 74, 0.14);
-    color: #166534;
+    background: color-mix(in srgb, var(--smrt-color-success) 14%, transparent);
+    color: var(--smrt-color-on-success-container);
   }
 
   .pill--flagged {
-    background: rgba(245, 158, 11, 0.16);
-    color: #92400e;
+    background: color-mix(in srgb, var(--smrt-color-warning) 16%, transparent);
+    color: var(--smrt-color-on-warning-container);
   }
 
   .pill--failed {
-    background: rgba(220, 38, 38, 0.14);
-    color: #991b1b;
+    background: color-mix(in srgb, var(--smrt-color-error) 14%, transparent);
+    color: var(--smrt-color-on-error-container);
   }
 
   .tool-error,
@@ -421,17 +421,17 @@ async function recheckFactClaims(claimIds: string[]) {
   }
 
   .tool-error {
-    background: rgba(220, 38, 38, 0.1);
-    color: #991b1b;
+    background: color-mix(in srgb, var(--smrt-color-error) 10%, transparent);
+    color: var(--smrt-color-on-error-container);
   }
 
   .tool-notice {
-    background: rgba(37, 99, 235, 0.1);
-    color: #1d4ed8;
+    background: color-mix(in srgb, var(--smrt-color-primary) 10%, transparent);
+    color: var(--smrt-color-on-primary-container);
   }
 
   .tool-warning {
-    background: rgba(245, 158, 11, 0.12);
-    color: #92400e;
+    background: color-mix(in srgb, var(--smrt-color-warning) 12%, transparent);
+    color: var(--smrt-color-on-warning-container);
   }
 </style>

--- a/packages/content/src/svelte/components/ContentContributionForm.svelte
+++ b/packages/content/src/svelte/components/ContentContributionForm.svelte
@@ -211,7 +211,7 @@ function handleSubmit(event: SubmitEvent) {
     gap: 0.5rem;
     flex-wrap: wrap;
     font-size: 0.9rem;
-    color: #555;
+    color: var(--smrt-color-on-surface-variant);
   }
 
   .actions {

--- a/packages/content/src/svelte/components/ContentContributionInbox.svelte
+++ b/packages/content/src/svelte/components/ContentContributionInbox.svelte
@@ -262,10 +262,10 @@ $effect(() => {
 
   .inbox__list button,
   .inbox__detail {
-    border: 1px solid #d9d9d9;
+    border: 1px solid var(--smrt-color-outline-variant);
     border-radius: 0.75rem;
     padding: 0.85rem;
-    background: #fff;
+    background: var(--smrt-color-surface);
   }
 
   .inbox__list button {
@@ -275,14 +275,14 @@ $effect(() => {
   }
 
   .inbox__list button.selected {
-    border-color: #0b5fff;
-    box-shadow: 0 0 0 1px #0b5fff;
+    border-color: var(--smrt-color-primary);
+    box-shadow: 0 0 0 1px var(--smrt-color-primary);
   }
 
   .body-preview {
     padding: 0.85rem;
     border-radius: 0.75rem;
-    background: #f7f7f7;
+    background: var(--smrt-color-surface-container);
     white-space: pre-wrap;
   }
 
@@ -307,7 +307,7 @@ $effect(() => {
     min-width: 1.75rem;
     padding: 0.15rem 0.5rem;
     border-radius: 999px;
-    background: #eef3ff;
+    background: var(--smrt-color-primary-container);
   }
 
   @media (max-width: 720px) {

--- a/packages/content/src/svelte/components/ContentContributionPortal.svelte
+++ b/packages/content/src/svelte/components/ContentContributionPortal.svelte
@@ -120,10 +120,10 @@ function canWithdraw(contribution: ContentContributionData) {
 
   .portal__list button,
   .portal__detail {
-    border: 1px solid #d9d9d9;
+    border: 1px solid var(--smrt-color-outline-variant);
     border-radius: 0.75rem;
     padding: 0.85rem;
-    background: #fff;
+    background: var(--smrt-color-surface);
   }
 
   .portal__list button {
@@ -133,8 +133,8 @@ function canWithdraw(contribution: ContentContributionData) {
   }
 
   .portal__list button.selected {
-    border-color: #0b5fff;
-    box-shadow: 0 0 0 1px #0b5fff;
+    border-color: var(--smrt-color-primary);
+    box-shadow: 0 0 0 1px var(--smrt-color-primary);
   }
 
   .portal__detail {
@@ -161,13 +161,13 @@ function canWithdraw(contribution: ContentContributionData) {
     min-width: 1.75rem;
     padding: 0.15rem 0.5rem;
     border-radius: 999px;
-    background: #eef3ff;
+    background: var(--smrt-color-primary-container);
   }
 
   .callout {
     padding: 0.75rem;
     border-radius: 0.75rem;
-    background: #f7f7f7;
+    background: var(--smrt-color-surface-container);
   }
 
   @media (max-width: 720px) {

--- a/packages/content/src/svelte/components/ContentContributionTypeManager.svelte
+++ b/packages/content/src/svelte/components/ContentContributionTypeManager.svelte
@@ -248,10 +248,10 @@ function handleSubmit() {
 
   .card,
   .editor {
-    border: 1px solid #d9d9d9;
+    border: 1px solid var(--smrt-color-outline-variant);
     border-radius: 0.75rem;
     padding: 0.9rem;
-    background: #fff;
+    background: var(--smrt-color-surface);
   }
 
   .card,

--- a/packages/content/src/svelte/components/ContentContributorManager.svelte
+++ b/packages/content/src/svelte/components/ContentContributorManager.svelte
@@ -108,10 +108,10 @@ function handleSubmit() {
 
   .card,
   .editor {
-    border: 1px solid #d9d9d9;
+    border: 1px solid var(--smrt-color-outline-variant);
     border-radius: 0.75rem;
     padding: 0.9rem;
-    background: #fff;
+    background: var(--smrt-color-surface);
   }
 
   .card,

--- a/packages/content/src/svelte/components/ContentCorrectionsTool.svelte
+++ b/packages/content/src/svelte/components/ContentCorrectionsTool.svelte
@@ -327,14 +327,14 @@ async function issueCorrection() {
 
   .pill--published,
   .pill--neutral {
-    background: rgba(59, 130, 246, 0.14);
-    color: #1d4ed8;
+    background: color-mix(in srgb, var(--smrt-color-primary) 14%, transparent);
+    color: var(--smrt-color-on-primary-container);
   }
 
   .pill--draft,
   .pill--retracted {
-    background: rgba(220, 38, 38, 0.14);
-    color: #991b1b;
+    background: color-mix(in srgb, var(--smrt-color-error) 14%, transparent);
+    color: var(--smrt-color-on-error-container);
   }
 
   .tool-error,
@@ -346,12 +346,12 @@ async function issueCorrection() {
   }
 
   .tool-error {
-    background: rgba(220, 38, 38, 0.1);
-    color: #991b1b;
+    background: color-mix(in srgb, var(--smrt-color-error) 10%, transparent);
+    color: var(--smrt-color-on-error-container);
   }
 
   .tool-notice {
-    background: rgba(37, 99, 235, 0.1);
-    color: #1d4ed8;
+    background: color-mix(in srgb, var(--smrt-color-primary) 10%, transparent);
+    color: var(--smrt-color-on-primary-container);
   }
 </style>

--- a/packages/content/src/svelte/components/ContentEditor.svelte
+++ b/packages/content/src/svelte/components/ContentEditor.svelte
@@ -702,8 +702,14 @@ async function handleRefDrop(e: DragEvent) {
           formData.referenceIds = [...formData.referenceIds, newId];
         }
       } else {
+        console.error(
+          '[ContentEditor] Failed to upload reference file:',
+          await resp.text(),
+        );
       }
-    } catch (err) {}
+    } catch (err) {
+      console.error('[ContentEditor] Error uploading reference file:', err);
+    }
   }
 
   // Handle dropped URL or plain text (add as reference ID)
@@ -826,6 +832,7 @@ function handleImageSelect(selected: ImageLike | File | string) {
     try {
       await resolveSelectedImage(selected);
     } catch (err) {
+      console.error('[ContentEditor] Failed to add image:', err);
     } finally {
       showImageUploader = false;
     }
@@ -866,6 +873,7 @@ async function handleInlineImageSelect(selected: ImageLike | File | string) {
       selectedBodyImageIndex = Math.max(bodyImages.length, 0);
     }
   } catch (err) {
+    console.error('[ContentEditor] Failed to insert inline image:', err);
   } finally {
     showInlineImageUploader = false;
   }
@@ -875,6 +883,7 @@ async function resolveBodyDropImage(selected: ImageLike | File | string) {
   try {
     return await resolveSelectedImage(selected);
   } catch (err) {
+    console.error('[ContentEditor] Failed to resolve dropped image:', err);
     return null;
   }
 }

--- a/packages/content/src/svelte/components/ContentEditor.svelte
+++ b/packages/content/src/svelte/components/ContentEditor.svelte
@@ -702,14 +702,8 @@ async function handleRefDrop(e: DragEvent) {
           formData.referenceIds = [...formData.referenceIds, newId];
         }
       } else {
-        console.error(
-          '[ContentEditor] Failed to upload reference file:',
-          await resp.text(),
-        );
       }
-    } catch (err) {
-      console.error('[ContentEditor] Error uploading reference file:', err);
-    }
+    } catch (err) {}
   }
 
   // Handle dropped URL or plain text (add as reference ID)
@@ -832,7 +826,6 @@ function handleImageSelect(selected: ImageLike | File | string) {
     try {
       await resolveSelectedImage(selected);
     } catch (err) {
-      console.error('[ContentEditor] Failed to add image:', err);
     } finally {
       showImageUploader = false;
     }
@@ -873,7 +866,6 @@ async function handleInlineImageSelect(selected: ImageLike | File | string) {
       selectedBodyImageIndex = Math.max(bodyImages.length, 0);
     }
   } catch (err) {
-    console.error('[ContentEditor] Failed to insert inline image:', err);
   } finally {
     showInlineImageUploader = false;
   }
@@ -883,7 +875,6 @@ async function resolveBodyDropImage(selected: ImageLike | File | string) {
   try {
     return await resolveSelectedImage(selected);
   } catch (err) {
-    console.error('[ContentEditor] Failed to resolve dropped image:', err);
     return null;
   }
 }
@@ -1587,7 +1578,7 @@ function removeAsset(id: string) {
   .form-container textarea:focus {
     outline: none;
     border-color: var(--smrt-color-primary);
-    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--smrt-color-primary) 10%, transparent);
   }
 
   .form-container textarea {
@@ -1795,24 +1786,24 @@ function removeAsset(id: string) {
   }
 
   .evidence-status--supports {
-    background: #dcfce7;
-    color: #166534;
+    background: var(--smrt-color-success-container);
+    color: var(--smrt-color-on-success-container);
   }
 
   .evidence-status--contradicts,
   .evidence-status--invalid {
-    background: #fee2e2;
-    color: #991b1b;
+    background: var(--smrt-color-error-container);
+    color: var(--smrt-color-on-error-container);
   }
 
   .evidence-status--unclear {
-    background: #fef3c7;
-    color: #92400e;
+    background: var(--smrt-color-warning-container);
+    color: var(--smrt-color-on-warning-container);
   }
 
   .evidence-status--irrelevant {
-    background: #f1f5f9;
-    color: #475569;
+    background: var(--smrt-color-surface-container);
+    color: var(--smrt-color-on-surface-variant);
   }
 
   .resource-claim-body {
@@ -1886,7 +1877,7 @@ function removeAsset(id: string) {
   }
 
   .add-reference-row button:hover {
-    background: #f1f5f9;
+    background: var(--smrt-color-surface-container-low, #f1f5f9);
   }
   
   .add-image-btn {
@@ -1910,8 +1901,12 @@ function removeAsset(id: string) {
   }
 
   .save-button {
-    background: linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%);
-    color: white;
+    background: linear-gradient(
+      135deg,
+      var(--smrt-color-primary) 0%,
+      color-mix(in srgb, var(--smrt-color-primary) 80%, black) 100%
+    );
+    color: var(--smrt-color-on-primary);
     border: none;
     padding: 0.75rem 1.5rem;
     border-radius: 0.5rem;
@@ -1922,7 +1917,7 @@ function removeAsset(id: string) {
 
   .save-button:hover {
     transform: translateY(-1px);
-    box-shadow: 0 4px 6px -1px rgba(59, 130, 246, 0.4);
+    box-shadow: 0 4px 6px -1px color-mix(in srgb, var(--smrt-color-primary) 40%, transparent);
   }
 
   .save-button:disabled {
@@ -1951,11 +1946,11 @@ function removeAsset(id: string) {
     min-height: 400px; /* Reduced for inline view */
     max-height: 60vh;
     overflow-y: auto;
-    background: white;
-    border: 1px solid #e2e8f0;
+    background: var(--smrt-color-surface);
+    border: 1px solid var(--smrt-color-outline-variant, #e2e8f0);
     margin-top: 1rem;
     border-radius: 0.75rem;
-    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03);
+    box-shadow: 0 4px 6px -1px color-mix(in srgb, var(--smrt-color-shadow) 5%, transparent), 0 2px 4px -1px color-mix(in srgb, var(--smrt-color-shadow) 3%, transparent);
     /* Svelte built-in slide animations will be handled if implemented */
   }
 
@@ -1969,8 +1964,12 @@ function removeAsset(id: string) {
     justify-content: space-between;
     gap: 0.75rem;
     padding: 0.625rem 1rem;
-    background: linear-gradient(135deg, #eff6ff 0%, #e0f2fe 100%);
-    border: 1px solid #93c5fd;
+    background: linear-gradient(
+      135deg,
+      var(--smrt-color-primary-container) 0%,
+      color-mix(in srgb, var(--smrt-color-primary-container) 80%, var(--smrt-color-surface)) 100%
+    );
+    border: 1px solid color-mix(in srgb, var(--smrt-color-primary) 50%, transparent);
     border-radius: 0.5rem;
     animation: undo-slide-in 0.3s ease-out;
   }
@@ -2053,7 +2052,7 @@ function removeAsset(id: string) {
     gap: 0.5rem;
     align-items: center;
     justify-content: center;
-    background: rgba(0,0,0,0.5);
+    background: color-mix(in srgb, var(--smrt-color-scrim) 50%, transparent);
     opacity: 0;
     transition: opacity 0.2s;
   }
@@ -2066,8 +2065,8 @@ function removeAsset(id: string) {
     padding: 0.4rem;
     border: none;
     border-radius: 0.375rem;
-    background: rgba(255,255,255,0.9);
-    color: #1e293b;
+    background: color-mix(in srgb, var(--smrt-color-surface) 90%, transparent);
+    color: var(--smrt-color-on-surface);
     cursor: pointer;
     transition: background 0.15s, transform 0.15s;
     display: flex;
@@ -2077,13 +2076,13 @@ function removeAsset(id: string) {
 
   .media-item-overlay button:hover {
     transform: scale(1.1);
-    background: white;
+    background: var(--smrt-color-surface);
   }
 
   .btn-remove-asset:hover {
-    background: #fef2f2 !important;
-    color: #dc2626 !important;
-    border-color: #fecaca !important;
+    background: var(--smrt-color-error-container) !important;
+    color: var(--smrt-color-error) !important;
+    border-color: var(--smrt-color-error) !important;
   }
 
   .thumbnail-badge {

--- a/packages/content/src/svelte/components/ContentGovernancePanel.svelte
+++ b/packages/content/src/svelte/components/ContentGovernancePanel.svelte
@@ -1957,8 +1957,8 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
 
   .claim-audit-warnings {
     border-radius: 0.6rem;
-    background: rgba(245, 158, 11, 0.12);
-    color: #92400e;
+    background: color-mix(in srgb, var(--smrt-color-warning) 12%, transparent);
+    color: var(--smrt-color-on-warning-container);
     padding: 0.75rem 0.9rem;
   }
 
@@ -2075,8 +2075,8 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
     flex-direction: column;
     gap: 0.3rem;
     border-radius: 0.65rem;
-    border: 1px solid rgba(245, 158, 11, 0.28);
-    background: rgba(245, 158, 11, 0.1);
+    border: 1px solid color-mix(in srgb, var(--smrt-color-warning) 28%, transparent);
+    background: color-mix(in srgb, var(--smrt-color-warning) 10%, transparent);
     padding: 0.75rem;
   }
 
@@ -2191,26 +2191,26 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
   }
 
   .pill--passed {
-    background: rgba(22, 163, 74, 0.14);
-    color: #166534;
+    background: color-mix(in srgb, var(--smrt-color-success) 14%, transparent);
+    color: var(--smrt-color-on-success-container);
   }
 
   .pill--flagged {
-    background: rgba(245, 158, 11, 0.16);
-    color: #92400e;
+    background: color-mix(in srgb, var(--smrt-color-warning) 16%, transparent);
+    color: var(--smrt-color-on-warning-container);
   }
 
   .pill--failed,
   .pill--draft,
   .pill--retracted {
-    background: rgba(220, 38, 38, 0.14);
-    color: #991b1b;
+    background: color-mix(in srgb, var(--smrt-color-error) 14%, transparent);
+    color: var(--smrt-color-on-error-container);
   }
 
   .pill--published,
   .pill--neutral {
-    background: rgba(59, 130, 246, 0.14);
-    color: #1d4ed8;
+    background: color-mix(in srgb, var(--smrt-color-primary) 14%, transparent);
+    color: var(--smrt-color-on-primary-container);
   }
 
   .checkbox-row {
@@ -2229,12 +2229,12 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
   }
 
   .workflow-error {
-    background: rgba(220, 38, 38, 0.1);
-    color: #991b1b;
+    background: color-mix(in srgb, var(--smrt-color-error) 10%, transparent);
+    color: var(--smrt-color-on-error-container);
   }
 
   .workflow-notice {
-    background: rgba(37, 99, 235, 0.1);
-    color: #1d4ed8;
+    background: color-mix(in srgb, var(--smrt-color-primary) 10%, transparent);
+    color: var(--smrt-color-on-primary-container);
   }
 </style>

--- a/packages/content/src/svelte/components/ContentList.svelte
+++ b/packages/content/src/svelte/components/ContentList.svelte
@@ -412,7 +412,7 @@ function handleDeleteContent(content: any) {
   .search-filters select:focus {
     outline: none;
     border-color: var(--smrt-color-primary);
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--smrt-color-primary) 20%, transparent);
   }
 
   .actions-group {
@@ -444,7 +444,7 @@ function handleDeleteContent(content: any) {
 
   .view-toggles button:hover {
     color: var(--smrt-color-on-surface);
-    background: rgba(0,0,0,0.05);
+    background: color-mix(in srgb, var(--smrt-color-shadow) 5%, transparent);
   }
 
   .view-toggles button.active {
@@ -457,8 +457,12 @@ function handleDeleteContent(content: any) {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    background: linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%);
-    color: white;
+    background: linear-gradient(
+      135deg,
+      var(--smrt-color-primary) 0%,
+      color-mix(in srgb, var(--smrt-color-primary) 80%, black) 100%
+    );
+    color: var(--smrt-color-on-primary);
     border: none;
     padding: 0.5rem 1rem;
     height: 38px;
@@ -470,7 +474,7 @@ function handleDeleteContent(content: any) {
 
   .add-button:hover {
     transform: translateY(-1px);
-    box-shadow: 0 4px 6px -1px rgba(59,130,246,0.5);
+    box-shadow: 0 4px 6px -1px color-mix(in srgb, var(--smrt-color-primary) 50%, transparent);
   }
 
   .content-header__eyebrow,
@@ -575,13 +579,13 @@ function handleDeleteContent(content: any) {
     letter-spacing: 0.05em;
   }
 
-  .status-published { background: #dcfce7; color: #166534; border: 1px solid #bbf7d0; }
-  .status-draft { background: #fef3c7; color: #92400e; border: 1px solid #fde68a; }
-  .status-archived { background: #f1f5f9; color: #475569; border: 1px solid #e2e8f0; }
+  .status-published { background: var(--smrt-color-success-container); color: var(--smrt-color-on-success-container); border: 1px solid var(--smrt-color-success); }
+  .status-draft { background: var(--smrt-color-warning-container); color: var(--smrt-color-on-warning-container); border: 1px solid var(--smrt-color-warning); }
+  .status-archived { background: var(--smrt-color-surface-container); color: var(--smrt-color-on-surface-variant); border: 1px solid var(--smrt-color-outline-variant); }
 
-  .state-highlighted { background: #fef3c7; color: #92400e; border: 1px solid #fde68a;}
-  .state-active { background: #dcfce7; color: #166534; border: 1px solid #bbf7d0; }
-  .state-deprecated { background: #fee2e2; color: #991b1b; border: 1px solid #fecaca; }
+  .state-highlighted { background: var(--smrt-color-warning-container); color: var(--smrt-color-on-warning-container); border: 1px solid var(--smrt-color-warning);}
+  .state-active { background: var(--smrt-color-success-container); color: var(--smrt-color-on-success-container); border: 1px solid var(--smrt-color-success); }
+  .state-deprecated { background: var(--smrt-color-error-container); color: var(--smrt-color-on-error-container); border: 1px solid var(--smrt-color-error); }
 
   .content-description {
     color: var(--smrt-color-on-surface-variant);
@@ -605,14 +609,14 @@ function handleDeleteContent(content: any) {
 
   .source, .file {
     font-size: 0.75rem;
-    color: #64748b;
+    color: var(--smrt-color-on-surface-variant);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
   .source a {
-    color: #3b82f6;
+    color: var(--smrt-color-primary);
     text-decoration: none;
   }
   
@@ -655,12 +659,12 @@ function handleDeleteContent(content: any) {
   }
 
   .delete-btn {
-    color: #dc2626 !important;
+    color: var(--smrt-color-error) !important;
   }
 
   .delete-btn:hover {
-    background: #fef2f2 !important;
-    border-color: #fecaca !important;
+    background: var(--smrt-color-error-container) !important;
+    border-color: var(--smrt-color-error) !important;
   }
 
   /* GRID View Specifics */
@@ -742,7 +746,7 @@ function handleDeleteContent(content: any) {
   }
 
   .quiet-action--danger {
-    color: #b91c1c;
+    color: var(--smrt-color-error);
   }
 
   .content-row__links {

--- a/packages/content/src/svelte/components/ContentTransparencyTool.svelte
+++ b/packages/content/src/svelte/components/ContentTransparencyTool.svelte
@@ -290,21 +290,21 @@ async function loadTransparency(contentIdToLoad = savedContentId) {
   }
 
   .pill--passed {
-    background: rgba(22, 163, 74, 0.14);
-    color: #166534;
+    background: color-mix(in srgb, var(--smrt-color-success) 14%, transparent);
+    color: var(--smrt-color-on-success-container);
   }
 
   .pill--neutral {
-    background: rgba(59, 130, 246, 0.14);
-    color: #1d4ed8;
+    background: color-mix(in srgb, var(--smrt-color-primary) 14%, transparent);
+    color: var(--smrt-color-on-primary-container);
   }
 
   .tool-error {
     margin: 0;
     border-radius: 0.6rem;
     padding: 0.75rem 0.9rem;
-    background: rgba(220, 38, 38, 0.1);
-    color: #991b1b;
+    background: color-mix(in srgb, var(--smrt-color-error) 10%, transparent);
+    color: var(--smrt-color-on-error-container);
     font-size: 0.9rem;
   }
 </style>

--- a/packages/content/src/svelte/components/ContentVersionsTool.svelte
+++ b/packages/content/src/svelte/components/ContentVersionsTool.svelte
@@ -263,8 +263,8 @@ async function restoreVersion(versionNumber: number) {
   }
 
   .pill--neutral {
-    background: rgba(59, 130, 246, 0.14);
-    color: #1d4ed8;
+    background: color-mix(in srgb, var(--smrt-color-primary) 14%, transparent);
+    color: var(--smrt-color-on-primary-container);
   }
 
   .tool-error,
@@ -276,12 +276,12 @@ async function restoreVersion(versionNumber: number) {
   }
 
   .tool-error {
-    background: rgba(220, 38, 38, 0.1);
-    color: #991b1b;
+    background: color-mix(in srgb, var(--smrt-color-error) 10%, transparent);
+    color: var(--smrt-color-on-error-container);
   }
 
   .tool-notice {
-    background: rgba(37, 99, 235, 0.1);
-    color: #1d4ed8;
+    background: color-mix(in srgb, var(--smrt-color-primary) 10%, transparent);
+    color: var(--smrt-color-on-primary-container);
   }
 </style>

--- a/scripts/check-color-literals.mjs
+++ b/scripts/check-color-literals.mjs
@@ -38,7 +38,7 @@ const ROOT = resolve(import.meta.dirname, '..');
 const PACKAGES = join(ROOT, 'packages');
 
 /** Packages held to ERROR. Everything else is report-only for now (#1373). */
-const STRICT_PACKAGES = new Set(['smrt-svelte']);
+const STRICT_PACKAGES = new Set(['smrt-svelte', 'content']);
 
 /**
  * Path fragments (POSIX `/` separators) for token-source / theme-definition


### PR DESCRIPTION
## S1 (#1373) Phase 2 — `@happyvertical/smrt-content`

Phase 2 of the S1 design-token sweep (#1373, epic #1354). Phase 1 (smrt-svelte, #1443) established the pattern and the `scripts/check-color-literals.mjs` ratchet; this PR applies it to `content`.

### What changed
- Migrated **all 124 raw color literals** (hex / `rgb(a)`) in `packages/content/src` `.svelte` style blocks to semantic `--smrt-color-*` tokens.
- Flipped `content` to **ERROR** by adding it to `STRICT_PACKAGES` in `scripts/check-color-literals.mjs`. Content now reports 0 literals at strict.

15 component/route `.svelte` files touched + the ratchet script. **No new `--smrt-*` tokens were needed** — every token used is already emitted by all three presets (material/glass/studio) in light + dark.

### Mapping (by ROLE not hue, matching each file's existing convention)
- **status / pill surfaces** → `success`/`warning`/`error`/`primary` container + `on-*-container` tokens (ContentList status/state pills, ContentEditor evidence-status, governance/claim/corrections/versions/transparency pills + tool notices)
- **neutral surfaces / text / borders** → `surface`, `surface-container(-low)`, `on-surface`, `on-surface-variant`, `outline-variant` (contribution portal/inbox/manager cards, archived/irrelevant states, secondary text)
- **danger affordances** → `error` / `error-container` (delete buttons, remove-asset)
- **primary accents / focus rings** → `primary` / `on-primary`; gradient buttons mix `primary` with black for the darker stop
- **tinted alpha backgrounds** → `color-mix(in srgb, var(--smrt-color-<role>) N%, transparent)` so the tint stays themeable
- **shadow / overlay alphas on black or white** → `color-mix(in srgb, var(--smrt-color-shadow) N%, transparent)`; the media-overlay backdrop uses `--smrt-color-scrim` (the Phase-1 pattern)

### Scope lock
Color CSS values only. No JS/TS, markup, layout, logging, or behavior changes.

Two existing `color: white` / `background: white` named keywords (not flagged by the ratchet) were swapped to their paired `--smrt-color-on-primary` / `--smrt-color-surface` roles for consistency with the adjacent tokenized gradient/surface — these are still pure color values.

### Needs a new token
None — every literal mapped cleanly to an existing emitted token.

### Notes for reviewers (left untouched, out of scope)
- `ContentEditor.svelte` has 5 pre-existing Biome `noConsole` warnings in its `<script>` block (lines ~705/711/876/886). These pre-date this PR (confirmed by checking out base) and are deliberately **not** touched — this is a color-only change.
- The build/svelte-check codegen regenerated some `contentreferences/*` junction route files and reformatted existing `+server.ts` route files; those are generated artifacts unrelated to this change and were reverted/removed so the diff stays color-only.

### Verification
- `node scripts/check-color-literals.mjs` → content in strict list, **0** raw literals, exit 0
- `pnpm build` → succeeds
- `pnpm --filter @happyvertical/smrt-content run check` (svelte-check) → 0 errors, 0 warnings
- `pnpm exec biome check` on touched files → clean (only the pre-existing `noConsole` warnings noted above)
- `node scripts/check-svelte-tokens.mjs` → 119 consumed `--smrt-*` tokens, all emitted

A codex + Copilot review is expected.