### PR TITLE
refactor: close out S1 — tokenize tail + scope the ratchet (#1373)

### DIFF
--- a/packages/projects/src/svelte/components/RejectDialog.svelte
+++ b/packages/projects/src/svelte/components/RejectDialog.svelte
@@ -137,7 +137,7 @@ $effect(() => {
     position: absolute;
     inset: 0;
     border: none;
-    background: rgba(0, 0, 0, 0.32);
+    background: var(--smrt-color-scrim, rgba(0, 0, 0, 0.32));
     cursor: pointer;
   }
 

--- a/packages/subscriptions/src/svelte/UsageThresholds.svelte
+++ b/packages/subscriptions/src/svelte/UsageThresholds.svelte
@@ -46,11 +46,11 @@ let {
   }
 
   .smrt-usage-thresholds__row.warn {
-    border-color: #d97706;
+    border-color: var(--smrt-color-warning, #d97706);
   }
 
   .smrt-usage-thresholds__row.blocked {
-    border-color: #dc2626;
+    border-color: var(--smrt-color-error, #dc2626);
   }
 
   .smrt-usage-thresholds__header {

--- a/packages/users/src/svelte/components/InviteUserModal.svelte
+++ b/packages/users/src/svelte/components/InviteUserModal.svelte
@@ -170,7 +170,7 @@ function handleKeydown(e: KeyboardEvent) {
     position: absolute;
     inset: 0;
     border: none;
-    background: rgba(0, 0, 0, 0.5);
+    background: var(--smrt-color-scrim, rgba(0, 0, 0, 0.5));
     cursor: pointer;
   }
 

--- a/packages/users/src/svelte/components/UserAvatar.svelte
+++ b/packages/users/src/svelte/components/UserAvatar.svelte
@@ -18,7 +18,11 @@ function getInitials(name: string): string {
     .slice(0, 2);
 }
 
-// Generate a consistent color based on name
+// Deterministic per-name avatar color (identicon-style): a fixed decorative
+// palette hashed by name for at-a-glance user differentiation. These are
+// intentionally NOT --smrt-color-* tokens — a variety palette, not themeable
+// semantic roles (cf. the channel-brand avatars in smrt-messages). Applied via
+// an inline style binding, so the color-literal ratchet does not scan them.
 function getColor(name: string): string {
   const colors = [
     '#ef4444',

--- a/scripts/check-color-literals.mjs
+++ b/scripts/check-color-literals.mjs
@@ -45,7 +45,18 @@ const STRICT_PACKAGES = new Set([
   'assets',
   'chat',
   'images',
+  'subscriptions',
+  'projects',
+  'users',
+  'messages',
 ]);
+
+/**
+ * Packages skipped entirely — dev/playground hosts, not shippable product
+ * component libraries (the ratchet's contract). Their chrome is dev tooling,
+ * not themeable product UI, so raw literals there are out of scope (#1373).
+ */
+const SCOPE_EXCLUDED_PACKAGES = new Set(['smrt-playground']);
 
 /**
  * Path fragments (POSIX `/` separators) for token-source / theme-definition
@@ -58,6 +69,17 @@ const THEME_DEFINITION_FRAGMENTS = [
   'src/themes/shared.ts', // shared spacing/radius/duration scales
   'src/themes/css-generator.ts', // JS theme generator
   'src/styles/tokens.css', // legacy --color-* token sheet
+];
+
+/**
+ * Files that legitimately hold intentional brand / 3rd-party fixed color
+ * literals which must NOT be tokenized (theming them would break recognition).
+ * Matched as substrings of the package-relative path.
+ */
+const BRAND_LITERAL_FRAGMENTS = [
+  // Channel-brand avatar colors (Slack purple, Twitter blue) kept for
+  // at-a-glance recognition; the generic email avatar is tokenized.
+  'messages/src/svelte/components/AccountAvatar.svelte',
 ];
 
 /**
@@ -221,8 +243,12 @@ const reportOnly = new Map(); // package -> count
 for (const file of files) {
   const relPath = relative(PACKAGES, file);
   if (!isInPackageSrc(relPath)) continue;
-  if (isThemeDefinition(relPath)) continue;
   const pkg = packageNameOf(relPath);
+  if (SCOPE_EXCLUDED_PACKAGES.has(pkg)) continue;
+  if (isThemeDefinition(relPath)) continue;
+  if (BRAND_LITERAL_FRAGMENTS.some((f) => toPosix(relPath).includes(f))) {
+    continue;
+  }
   const hits = findViolations(file, readFileSync(file, 'utf8'));
   if (hits.length === 0) continue;
   if (STRICT_PACKAGES.has(pkg)) {

--- a/scripts/check-color-literals.mjs
+++ b/scripts/check-color-literals.mjs
@@ -72,14 +72,18 @@ const THEME_DEFINITION_FRAGMENTS = [
 ];
 
 /**
- * Files that legitimately hold intentional brand / 3rd-party fixed color
- * literals which must NOT be tokenized (theming them would break recognition).
- * Matched as substrings of the package-relative path.
+ * Intentional brand / 3rd-party fixed color literals that must NOT be tokenized
+ * (theming them would break recognition). Scoped to specific files AND specific
+ * values: only these exact literals are exempt, so any OTHER raw literal
+ * introduced in the same file is still caught.
  */
-const BRAND_LITERAL_FRAGMENTS = [
-  // Channel-brand avatar colors (Slack purple, Twitter blue) kept for
-  // at-a-glance recognition; the generic email avatar is tokenized.
-  'messages/src/svelte/components/AccountAvatar.svelte',
+const BRAND_LITERAL_ALLOWLIST = [
+  {
+    // Channel-brand avatar colors (Slack purple, Twitter blue) kept for
+    // at-a-glance recognition; the generic email avatar is tokenized.
+    fragment: 'messages/src/svelte/components/AccountAvatar.svelte',
+    values: new Set(['#e8def8', '#4a1175', '#d3e8fd', '#0c4a6e']),
+  },
 ];
 
 /**
@@ -246,10 +250,15 @@ for (const file of files) {
   const pkg = packageNameOf(relPath);
   if (SCOPE_EXCLUDED_PACKAGES.has(pkg)) continue;
   if (isThemeDefinition(relPath)) continue;
-  if (BRAND_LITERAL_FRAGMENTS.some((f) => toPosix(relPath).includes(f))) {
-    continue;
+  let hits = findViolations(file, readFileSync(file, 'utf8'));
+  // Drop only the explicitly allow-listed brand literals (by value) so the file
+  // stays scanned — any other raw literal in it is still caught.
+  const allow = BRAND_LITERAL_ALLOWLIST.find((b) =>
+    toPosix(relPath).includes(b.fragment),
+  );
+  if (allow) {
+    hits = hits.filter((h) => !allow.values.has(h.value.toLowerCase()));
   }
-  const hits = findViolations(file, readFileSync(file, 'utf8'));
   if (hits.length === 0) continue;
   if (STRICT_PACKAGES.has(pkg)) {
     strictViolations.push({ file: relPath, hits });


### PR DESCRIPTION
**Closes out S1 (#1373)** — the design-token sweep.

## Final migrations (4 semantic literals)
- `subscriptions` UsageThresholds: warn/blocked row borders → `--smrt-color-warning` / `--smrt-color-error`
- `projects` RejectDialog + `users` InviteUserModal: modal overlays → `--smrt-color-scrim`

…and flips **subscriptions, projects, users, messages** to `STRICT_PACKAGES`.

## Ratchet scope decisions (non-product remainder)
- **smrt-playground excluded** (`SCOPE_EXCLUDED_PACKAGES`) — it's a dev/playground *host*, not a shippable product component library (matches the ratchet's stated contract).
- **Brand literals allowed** (`BRAND_LITERAL_FRAGMENTS`) — Slack/Twitter channel-avatar colors in `messages/AccountAvatar` are intentional brand colors kept for at-a-glance recognition (the generic email avatar stays tokenized).

## Result
**All 10 shippable UI packages are strict, with zero report-only literals.** S1 is complete: smrt-svelte, content, products, assets, chat, images, subscriptions, projects, users, messages.

Refs #1373.
