### PR TITLE
refactor: adopt --smrt-z-index-* scale across UI packages (S1 #1373 phase 2)

### DIFF
--- a/packages/chat/src/svelte/components/dialogs/RoomCreateDialog.svelte
+++ b/packages/chat/src/svelte/components/dialogs/RoomCreateDialog.svelte
@@ -203,7 +203,7 @@ $effect(() => {
     align-items: center;
     justify-content: center;
     padding: 1rem;
-    z-index: 1000;
+    z-index: var(--smrt-z-index-dialog, 1300);
     position: relative;
   }
 

--- a/packages/chat/src/svelte/components/shared/MentionAutocomplete.svelte
+++ b/packages/chat/src/svelte/components/shared/MentionAutocomplete.svelte
@@ -112,7 +112,7 @@ function highlightMatch(
     border: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
     border-radius: var(--smrt-radius-medium, 8px);
     box-shadow: var(--smrt-elevation-level2, 0 2px 8px rgba(0, 0, 0, 0.15));
-    z-index: 100;
+    z-index: var(--smrt-z-index-dropdown, 1000);
     padding: 4px;
     display: flex;
     flex-direction: column;

--- a/packages/chat/src/svelte/components/tabs/ChatTabs.svelte
+++ b/packages/chat/src/svelte/components/tabs/ChatTabs.svelte
@@ -71,7 +71,7 @@ const collapsedTabs = $derived(tabs.filter((t) => !t.isExpanded));
     align-items: flex-end;
     gap: 8px;
     padding: 0 16px;
-    z-index: 1000;
+    z-index: var(--smrt-z-index-sticky, 1100);
     pointer-events: none;
   }
 

--- a/packages/content/src/routes/+layout.svelte
+++ b/packages/content/src/routes/+layout.svelte
@@ -77,7 +77,7 @@ const navItems = [
     border-bottom: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
     position: sticky;
     top: 0;
-    z-index: 100;
+    z-index: var(--smrt-z-index-sticky, 1100);
     box-shadow: 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow) 6%, transparent);
   }
 

--- a/packages/products/src/app/layouts/AppLayout.svelte
+++ b/packages/products/src/app/layouts/AppLayout.svelte
@@ -59,7 +59,7 @@ const { children }: Props = $props();
     box-shadow: 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow, #000) 10%, transparent);
     position: sticky;
     top: 0;
-    z-index: 100;
+    z-index: var(--smrt-z-index-sticky, 1100);
   }
   
   .header-content {

--- a/packages/products/src/lib/features/ProductCatalog.svelte
+++ b/packages/products/src/lib/features/ProductCatalog.svelte
@@ -277,7 +277,7 @@ function _handleCancelForm() {
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
+    z-index: var(--smrt-z-index-dialog, 1300);
   }
   
   .form-container {

--- a/packages/projects/src/svelte/components/RejectDialog.svelte
+++ b/packages/projects/src/svelte/components/RejectDialog.svelte
@@ -130,7 +130,7 @@ $effect(() => {
     align-items: center;
     justify-content: center;
     padding: 1rem;
-    z-index: 1000;
+    z-index: var(--smrt-z-index-dialog, 1300);
   }
 
   .dialog-overlay {

--- a/packages/users/src/svelte/components/InviteUserModal.svelte
+++ b/packages/users/src/svelte/components/InviteUserModal.svelte
@@ -163,7 +163,7 @@ function handleKeydown(e: KeyboardEvent) {
     align-items: center;
     justify-content: center;
     padding: 1rem;
-    z-index: 100;
+    z-index: var(--smrt-z-index-dialog, 1300);
   }
 
   .modal-overlay {

--- a/packages/users/src/svelte/components/UserMenu.svelte
+++ b/packages/users/src/svelte/components/UserMenu.svelte
@@ -241,7 +241,7 @@ function getInitials(name: string): string {
     background-color: var(--smrt-color-surface-container);
     border-radius: var(--smrt-radius-medium, 4px);
     box-shadow: var(--smrt-elevation-level2);
-    z-index: 50;
+    z-index: var(--smrt-z-index-dropdown, 1000);
     padding: 4px 0;
     overflow: hidden;
   }

--- a/scripts/check-z-index.mjs
+++ b/scripts/check-z-index.mjs
@@ -38,7 +38,14 @@ const PACKAGES = join(ROOT, 'packages');
 const THRESHOLD = 50;
 
 /** Packages held to ERROR. Everything else is report-only for now (#1373). */
-const STRICT_PACKAGES = new Set(['smrt-svelte']);
+const STRICT_PACKAGES = new Set([
+  'smrt-svelte',
+  'chat',
+  'products',
+  'users',
+  'content',
+  'projects',
+]);
 
 /**
  * Packages skipped entirely — dev/playground hosts, not shippable product


### PR DESCRIPTION
S1 (#1373) — **z-index phase 2**: migrate the remaining global-layer z-index values and flip the rest of the UI packages to strict.

| Package | Spot | → Layer |
|---|---|---|
| chat | RoomCreateDialog backdrop | dialog |
| chat | MentionAutocomplete | dropdown |
| chat | ChatTabs (fixed dock) | sticky |
| products | ProductCatalog form-overlay | dialog |
| products | AppLayout header (sticky) | sticky |
| users | InviteUserModal backdrop | dialog |
| users | UserMenu dropdown | dropdown |
| content | +layout header (sticky) | sticky |
| projects | RejectDialog backdrop | dialog |

Flips chat/products/users/content/projects to `STRICT_PACKAGES`. **All 6 UI packages with global-layer z-index are now strict; 0 report-only.** Local component-internal stacking (< 50) stays a plain number. Fallbacks use each token's real value.

Refs #1373.
