### PR TITLE
refactor: snap spacing px to --smrt-spacing-* across UI packages (S1 #1373 phase 2)

### DIFF
--- a/packages/assets/src/svelte/ActionBar.svelte
+++ b/packages/assets/src/svelte/ActionBar.svelte
@@ -152,7 +152,7 @@ const count = $derived(selectedAssets.length);
   }
 
   .action-bar__clear {
-    padding: 2px 8px;
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border: none;
     background: transparent;
     font-family: inherit;
@@ -175,7 +175,7 @@ const count = $derived(selectedAssets.length);
   .action-btn {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
+    gap: var(--smrt-spacing-1, 4px);
     height: 32px;
     padding: 0 var(--smrt-spacing-3, 0.75rem);
     font-family: inherit;
@@ -218,7 +218,7 @@ const count = $derived(selectedAssets.length);
   .confirm-card {
     background: var(--smrt-color-surface-container-high, #ffffff);
     border-radius: 28px;
-    padding: 24px;
+    padding: var(--smrt-spacing-6, 24px);
     max-width: 400px;
     width: 100%;
     box-shadow: var(--smrt-elevation-level3);
@@ -231,14 +231,14 @@ const count = $derived(selectedAssets.length);
   }
 
   .confirm-title {
-    margin: 0 0 16px;
+    margin: 0 0 var(--smrt-spacing-4, 16px);
     font-size: 1.125rem;
     font-weight: 600;
     color: var(--smrt-color-on-surface, #111827);
   }
 
   .confirm-message {
-    margin: 0 0 24px;
+    margin: 0 0 var(--smrt-spacing-6, 24px);
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     color: var(--smrt-color-on-surface-variant, #6b7280);
     line-height: 1.5;
@@ -247,15 +247,15 @@ const count = $derived(selectedAssets.length);
   .confirm-actions {
     display: flex;
     justify-content: flex-end;
-    gap: 8px;
+    gap: var(--smrt-spacing-2, 8px);
   }
 
   .confirm-btn {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
+    gap: var(--smrt-spacing-2, 8px);
     height: 40px;
-    padding: 0 24px;
+    padding: 0 var(--smrt-spacing-6, 24px);
     font-family: inherit;
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     font-weight: 500;

--- a/packages/assets/src/svelte/AssetDetail.svelte
+++ b/packages/assets/src/svelte/AssetDetail.svelte
@@ -527,7 +527,7 @@ function formatDate(date: Date | string | undefined): string {
     font-weight: 400;
     font-size: 0.7rem;
     color: var(--smrt-color-error, #dc2626);
-    margin-left: 4px;
+    margin-left: var(--smrt-spacing-1, 4px);
   }
 
   .form-input, .form-textarea {
@@ -563,7 +563,7 @@ function formatDate(date: Date | string | undefined): string {
   .metadata-item {
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: var(--smrt-spacing-1, 4px);
   }
 
   .metadata-label {
@@ -590,7 +590,7 @@ function formatDate(date: Date | string | undefined): string {
   .quick-btn {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
+    gap: var(--smrt-spacing-1, 4px);
     height: 32px;
     padding: 0 var(--smrt-spacing-3, 0.75rem);
     font-family: inherit;

--- a/packages/assets/src/svelte/AssetGrid.svelte
+++ b/packages/assets/src/svelte/AssetGrid.svelte
@@ -255,7 +255,7 @@ function getAltText(asset: PersistedAsset): string {
     display: flex;
     align-items: center;
     gap: var(--smrt-spacing-1, 0.25rem);
-    margin-top: 2px;
+    margin-top: var(--smrt-spacing-1, 4px);
   }
 
   .asset-card__type {
@@ -271,7 +271,7 @@ function getAltText(asset: PersistedAsset): string {
     position: absolute;
     top: var(--smrt-spacing-2, 0.5rem);
     right: var(--smrt-spacing-2, 0.5rem);
-    padding: 2px 6px;
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     font-size: 0.65rem;
     font-weight: 600;
     border-radius: var(--smrt-radius-small, 0.25rem);

--- a/packages/assets/src/svelte/AssetList.svelte
+++ b/packages/assets/src/svelte/AssetList.svelte
@@ -326,7 +326,7 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
 
   .type-badge {
     display: inline-block;
-    padding: 2px 6px;
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     font-size: 0.65rem;
     font-weight: 700;
     text-transform: uppercase;
@@ -352,7 +352,7 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
     height: 8px;
     border-radius: 50%;
     background: var(--smrt-color-outline, #9ca3af);
-    margin-right: 4px;
+    margin-right: var(--smrt-spacing-1, 4px);
     vertical-align: middle;
   }
 
@@ -364,7 +364,7 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
   .sort-btn {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
+    gap: var(--smrt-spacing-1, 4px);
     padding: 0;
     border: none;
     background: transparent;

--- a/packages/assets/src/svelte/CreateAssetModal.svelte
+++ b/packages/assets/src/svelte/CreateAssetModal.svelte
@@ -423,7 +423,7 @@ const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
     display: block;
     font-size: 0.75rem;
     color: var(--smrt-color-error, #dc2626);
-    margin-top: 2px;
+    margin-top: var(--smrt-spacing-1, 4px);
   }
 
   .file-preview__remove {
@@ -469,7 +469,7 @@ const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
     font-weight: 400;
     font-size: 0.75rem;
     color: var(--smrt-color-error, #dc2626);
-    margin-left: 4px;
+    margin-left: var(--smrt-spacing-1, 4px);
   }
 
   .form-input, .form-textarea {

--- a/packages/chat/src/svelte/components/agent/AgentChat.svelte
+++ b/packages/chat/src/svelte/components/agent/AgentChat.svelte
@@ -219,10 +219,10 @@ $effect(() => {
   .agent-chat__messages {
     flex: 1;
     overflow-y: auto;
-    padding: 8px 10px;
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
     display: flex;
     flex-direction: column-reverse;
-    gap: 6px;
+    gap: var(--smrt-spacing-2, 8px);
   }
 
   .agent-chat__msg {
@@ -245,14 +245,14 @@ $effect(() => {
 
   .agent-chat__tool-row {
     width: 100%;
-    padding: 2px 0;
+    padding: var(--smrt-spacing-1, 4px) 0;
   }
 
   .agent-chat__bubble {
     display: flex;
     flex-direction: column;
-    gap: 2px;
-    padding: 8px 12px;
+    gap: var(--smrt-spacing-1, 4px);
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
     border-radius: 10px;
     word-break: break-word;
     font-size: 0.8125rem;
@@ -305,8 +305,8 @@ $effect(() => {
   .agent-chat__input-bar {
     display: flex;
     align-items: flex-end;
-    gap: 6px;
-    padding: 8px 10px;
+    gap: var(--smrt-spacing-2, 8px);
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
     background: var(--smrt-color-surface, #fefbff);
     flex-shrink: 0;
   }
@@ -314,7 +314,7 @@ $effect(() => {
   .agent-chat__inactive-notice {
     flex: 1;
     text-align: center;
-    padding: 6px;
+    padding: var(--smrt-spacing-2, 8px);
     font-size: 0.75rem;
     color: var(--smrt-color-outline, #74777f);
     font-style: italic;
@@ -324,7 +324,7 @@ $effect(() => {
     flex: 1;
     border: none;
     border-radius: 8px;
-    padding: 7px 10px;
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
     font-size: 0.8125rem;
     line-height: 1.4;
     color: var(--smrt-color-on-surface, #1a1c1e);
@@ -371,7 +371,7 @@ $effect(() => {
   .applied-badge {
     display: inline-flex;
     align-items: center;
-    padding: 2px 8px;
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     font-size: 0.6875rem;
     font-weight: 600;
     color: var(--smrt-color-on-success-container, #16a34a);
@@ -383,20 +383,20 @@ $effect(() => {
   .field-update-block {
     display: flex;
     align-items: center;
-    gap: 6px;
-    padding: 4px 0;
+    gap: var(--smrt-spacing-2, 8px);
+    padding: var(--smrt-spacing-1, 4px) 0;
   }
 
   .markdown-block {
     display: flex;
     flex-direction: column;
-    gap: 8px;
-    padding: 4px 0;
+    gap: var(--smrt-spacing-2, 8px);
+    padding: var(--smrt-spacing-1, 4px) 0;
   }
 
   .markdown-block__content {
     margin: 0;
-    padding: 12px;
+    padding: var(--smrt-spacing-3, 12px);
     border-radius: 10px;
     background: color-mix(in srgb, var(--smrt-color-surface-container-low, #f4f2f6) 85%, white);
     overflow-x: auto;
@@ -407,7 +407,7 @@ $effect(() => {
   }
 
   .diff-btn {
-    padding: 2px 8px;
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     font-size: 0.625rem;
     font-weight: 600;
     border: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
@@ -442,7 +442,7 @@ $effect(() => {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 12px 16px;
+    padding: var(--smrt-spacing-3, 12px) var(--smrt-spacing-4, 16px);
     border-bottom: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
   }
 
@@ -458,7 +458,7 @@ $effect(() => {
     font-size: 1rem;
     cursor: pointer;
     color: var(--smrt-color-outline, #74777f);
-    padding: 2px 6px;
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border-radius: 4px;
   }
 
@@ -467,13 +467,13 @@ $effect(() => {
   }
 
   .diff-dialog__body {
-    padding: 12px 16px;
+    padding: var(--smrt-spacing-3, 12px) var(--smrt-spacing-4, 16px);
     overflow-y: auto;
     max-height: calc(60vh - 60px);
   }
 
   .diff-field {
-    margin-bottom: 10px;
+    margin-bottom: var(--smrt-spacing-3, 12px);
   }
 
   .diff-field:last-child {
@@ -487,12 +487,12 @@ $effect(() => {
     text-transform: uppercase;
     letter-spacing: 0.04em;
     color: var(--smrt-color-outline, #74777f);
-    margin-bottom: 4px;
+    margin-bottom: var(--smrt-spacing-1, 4px);
   }
 
   .diff-field__value {
     margin: 0;
-    padding: 6px 10px;
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
     font-size: 0.75rem;
     line-height: 1.5;
     background: var(--smrt-color-surface-container-low, #f7f7fb);
@@ -505,12 +505,12 @@ $effect(() => {
   }
 
   .agent-chat__thinking {
-    padding: 10px 14px;
+    padding: var(--smrt-spacing-3, 12px) var(--smrt-spacing-4, 16px);
   }
 
   .thinking-dots {
     display: inline-flex;
-    gap: 4px;
+    gap: var(--smrt-spacing-1, 4px);
     align-items: center;
   }
 

--- a/packages/chat/src/svelte/components/agent/AgentSelector.svelte
+++ b/packages/chat/src/svelte/components/agent/AgentSelector.svelte
@@ -61,8 +61,8 @@ const { agents, onselect }: Props = $props();
   .agent-selector {
     display: flex;
     flex-direction: column;
-    gap: 16px;
-    padding: 16px;
+    gap: var(--smrt-spacing-4, 16px);
+    padding: var(--smrt-spacing-4, 16px);
   }
 
   .agent-selector__title {
@@ -74,14 +74,14 @@ const { agents, onselect }: Props = $props();
   .agent-selector__grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-    gap: 12px;
+    gap: var(--smrt-spacing-3, 12px);
   }
 
   .agent-selector__card {
     display: flex;
     align-items: flex-start;
-    gap: 12px;
-    padding: 16px;
+    gap: var(--smrt-spacing-3, 12px);
+    padding: var(--smrt-spacing-4, 16px);
     background: var(--smrt-color-surface-container-low, #f7f7fb);
     border: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
     border-radius: var(--smrt-radius-large, 12px);
@@ -115,7 +115,7 @@ const { agents, onselect }: Props = $props();
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: var(--smrt-spacing-1, 4px);
     min-width: 0;
   }
 
@@ -141,7 +141,7 @@ const { agents, onselect }: Props = $props();
     font: var(--smrt-typography-label-small-font, 500 0.6875rem/1 sans-serif);
     color: var(--smrt-color-outline, #74777f);
     background: var(--smrt-color-surface-variant, #e1e2ec);
-    padding: 2px 8px;
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border-radius: var(--smrt-radius-full, 9999px);
   }
 
@@ -149,7 +149,7 @@ const { agents, onselect }: Props = $props();
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 40px;
+    padding: var(--smrt-spacing-10, 40px);
   }
 
   .agent-selector__empty-text {

--- a/packages/chat/src/svelte/components/agent/AgentSessionPanel.svelte
+++ b/packages/chat/src/svelte/components/agent/AgentSessionPanel.svelte
@@ -137,7 +137,7 @@ const statusLabel: Record<string, string> = {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 16px;
+    padding: var(--smrt-spacing-4, 16px);
     border-bottom: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
     flex-shrink: 0;
   }
@@ -174,18 +174,18 @@ const statusLabel: Record<string, string> = {
   .session-panel__list {
     flex: 1;
     overflow-y: auto;
-    padding: 8px;
+    padding: var(--smrt-spacing-2, 8px);
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: var(--smrt-spacing-1, 4px);
   }
 
   .session-panel__item {
     display: flex;
     align-items: flex-start;
-    gap: 10px;
+    gap: var(--smrt-spacing-3, 12px);
     width: 100%;
-    padding: 10px;
+    padding: var(--smrt-spacing-3, 12px);
     border: none;
     background: transparent;
     border-radius: var(--smrt-radius-medium, 8px);
@@ -216,7 +216,7 @@ const statusLabel: Record<string, string> = {
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: var(--smrt-spacing-1, 4px);
     min-width: 0;
   }
 
@@ -224,7 +224,7 @@ const statusLabel: Record<string, string> = {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 8px;
+    gap: var(--smrt-spacing-2, 8px);
   }
 
   .session-panel__item-name {
@@ -243,12 +243,12 @@ const statusLabel: Record<string, string> = {
   .session-panel__item-meta {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: var(--smrt-spacing-2, 8px);
   }
 
   .session-panel__item-status {
     font: var(--smrt-typography-label-small-font, 500 0.6875rem/1 sans-serif);
-    padding: 2px 6px;
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-surface-variant, #e1e2ec);
     color: var(--smrt-color-on-surface-variant, #43474e);
@@ -277,14 +277,14 @@ const statusLabel: Record<string, string> = {
   .session-panel__item-tools {
     display: flex;
     flex-wrap: wrap;
-    gap: 4px;
-    margin-top: 2px;
+    gap: var(--smrt-spacing-1, 4px);
+    margin-top: var(--smrt-spacing-1, 4px);
   }
 
   .session-panel__tool-chip {
     font-size: 0.625rem;
     font-weight: 500;
-    padding: 1px 6px;
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border-radius: var(--smrt-radius-small, 4px);
     background: var(--smrt-color-surface-container-highest, #dddde1);
     color: var(--smrt-color-on-surface-variant, #43474e);

--- a/packages/chat/src/svelte/components/agent/ToolCallDisplay.svelte
+++ b/packages/chat/src/svelte/components/agent/ToolCallDisplay.svelte
@@ -151,9 +151,9 @@ function formatDuration(ms: number | undefined): string {
   .tool-call__header {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: var(--smrt-spacing-2, 8px);
     width: 100%;
-    padding: 8px 12px;
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
     border: none;
     background: var(--smrt-color-surface-container-low, #f7f7fb);
     cursor: pointer;
@@ -209,7 +209,7 @@ function formatDuration(ms: number | undefined): string {
   .tool-call__header-right {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: var(--smrt-spacing-2, 8px);
     flex-shrink: 0;
   }
 
@@ -233,10 +233,10 @@ function formatDuration(ms: number | undefined): string {
   }
 
   .tool-call__body {
-    padding: 8px 12px 12px;
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px) var(--smrt-spacing-3, 12px);
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: var(--smrt-spacing-2, 8px);
     border-top: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
     background: var(--smrt-color-surface, #fefbff);
   }
@@ -244,7 +244,7 @@ function formatDuration(ms: number | undefined): string {
   .tool-call__section {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: var(--smrt-spacing-1, 4px);
   }
 
   .tool-call__section-label {
@@ -256,7 +256,7 @@ function formatDuration(ms: number | undefined): string {
 
   .tool-call__json {
     margin: 0;
-    padding: 8px;
+    padding: var(--smrt-spacing-2, 8px);
     border-radius: var(--smrt-radius-small, 4px);
     background: var(--smrt-color-surface-container-low, #f7f7fb);
     color: var(--smrt-color-on-surface, #1a1c1e);
@@ -283,8 +283,8 @@ function formatDuration(ms: number | undefined): string {
   .tool-call__running {
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 8px;
+    gap: var(--smrt-spacing-2, 8px);
+    padding: var(--smrt-spacing-2, 8px);
     font: var(--smrt-typography-body-small-font, 0.8125rem/1.4 sans-serif);
     color: var(--smrt-color-primary, #005ac1);
   }

--- a/packages/chat/src/svelte/components/messages/MessageInput.svelte
+++ b/packages/chat/src/svelte/components/messages/MessageInput.svelte
@@ -131,7 +131,7 @@ function handleInput() {
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 1px;
+    gap: var(--smrt-spacing-1, 4px);
     min-width: 0;
     border-left: 2px solid var(--smrt-color-primary, #005ac1);
     padding-left: var(--smrt-spacing-2, 0.375rem);

--- a/packages/chat/src/svelte/components/messages/MessageItem.svelte
+++ b/packages/chat/src/svelte/components/messages/MessageItem.svelte
@@ -245,7 +245,7 @@ function toggleReactionPicker() {
   .message-item__reply-preview {
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: var(--smrt-spacing-1, 4px);
     padding: var(--smrt-spacing-1, 0.25rem) var(--smrt-spacing-3, 0.75rem);
     border-left: 2px solid var(--smrt-color-primary, #005ac1);
     border-radius: var(--smrt-radius-small, 0.25rem);
@@ -284,7 +284,7 @@ function toggleReactionPicker() {
   }
 
   .message-item__tool-status {
-    padding: 1px 6px;
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border-radius: var(--smrt-radius-small, 0.25rem);
     font-size: 0.625rem;
     text-transform: uppercase;
@@ -328,8 +328,8 @@ function toggleReactionPicker() {
   .message-item__reaction {
     display: inline-flex;
     align-items: center;
-    gap: 3px;
-    padding: 2px 6px;
+    gap: var(--smrt-spacing-1, 4px);
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border: 1px solid var(--smrt-color-outline-variant, #c4c6cf);
     border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-surface, #ffffff);
@@ -378,14 +378,14 @@ function toggleReactionPicker() {
   .message-item__actions {
     display: flex;
     align-items: center;
-    gap: 2px;
+    gap: var(--smrt-spacing-1, 4px);
     position: absolute;
     top: 0;
     right: var(--smrt-spacing-4, 1rem);
     background: var(--smrt-color-surface, #ffffff);
     border: 1px solid var(--smrt-color-outline-variant, #c4c6cf);
     border-radius: var(--smrt-radius-small, 0.25rem);
-    padding: 2px;
+    padding: var(--smrt-spacing-1, 4px);
     box-shadow: var(--smrt-elevation-level1, 0 1px 3px rgba(0, 0, 0, 0.12));
   }
 

--- a/packages/chat/src/svelte/components/messages/ThreadPanel.svelte
+++ b/packages/chat/src/svelte/components/messages/ThreadPanel.svelte
@@ -110,7 +110,7 @@ const replyCount = $derived(
   }
 
   .thread-panel__resolved {
-    padding: 2px 8px;
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     font-size: var(--smrt-typography-body-small-size, 0.75rem);
     font-weight: 500;
     color: var(--smrt-color-on-success-container, #2e7d32);

--- a/packages/chat/src/svelte/components/shared/FileUpload.svelte
+++ b/packages/chat/src/svelte/components/shared/FileUpload.svelte
@@ -258,7 +258,7 @@ function getFileIcon(type: string): string {
     display: flex;
     align-items: center;
     gap: var(--smrt-spacing-2, 8px);
-    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-2, 8px);
+    padding: var(--smrt-spacing-2, 8px);
     border-radius: var(--smrt-radius-small, 4px);
     background: var(--smrt-color-surface, #fefbff);
   }

--- a/packages/chat/src/svelte/components/shared/FileUpload.svelte
+++ b/packages/chat/src/svelte/components/shared/FileUpload.svelte
@@ -187,7 +187,7 @@ function getFileIcon(type: string): string {
   .file-upload {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: var(--smrt-spacing-2, 8px);
   }
 
   .file-upload--disabled {
@@ -198,7 +198,7 @@ function getFileIcon(type: string): string {
   .file-upload__drop-zone {
     border: 2px dashed var(--smrt-color-outline-variant, #c4c6d0);
     border-radius: var(--smrt-radius-large, 12px);
-    padding: 20px;
+    padding: var(--smrt-spacing-5, 20px);
     text-align: center;
     transition:
       border-color var(--smrt-duration-short2, 150ms),
@@ -218,7 +218,7 @@ function getFileIcon(type: string): string {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 8px;
+    gap: var(--smrt-spacing-2, 8px);
     cursor: pointer;
   }
 
@@ -247,8 +247,8 @@ function getFileIcon(type: string): string {
   .file-upload__preview {
     display: flex;
     flex-direction: column;
-    gap: 4px;
-    padding: 8px;
+    gap: var(--smrt-spacing-1, 4px);
+    padding: var(--smrt-spacing-2, 8px);
     background: var(--smrt-color-surface-container-low, #f7f7fb);
     border-radius: var(--smrt-radius-medium, 8px);
     border: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
@@ -257,8 +257,8 @@ function getFileIcon(type: string): string {
   .file-upload__file {
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 6px 8px;
+    gap: var(--smrt-spacing-2, 8px);
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-2, 8px);
     border-radius: var(--smrt-radius-small, 4px);
     background: var(--smrt-color-surface, #fefbff);
   }
@@ -281,7 +281,7 @@ function getFileIcon(type: string): string {
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 1px;
+    gap: var(--smrt-spacing-1, 4px);
     min-width: 0;
   }
 
@@ -320,12 +320,12 @@ function getFileIcon(type: string): string {
 
   .file-upload__preview-actions {
     display: flex;
-    gap: 8px;
-    padding-top: 4px;
+    gap: var(--smrt-spacing-2, 8px);
+    padding-top: var(--smrt-spacing-1, 4px);
   }
 
   .file-upload__confirm-btn {
-    padding: 6px 16px;
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-4, 16px);
     border: none;
     border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-primary, #005ac1);
@@ -345,7 +345,7 @@ function getFileIcon(type: string): string {
   }
 
   .file-upload__clear-btn {
-    padding: 6px 16px;
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-4, 16px);
     border: 1px solid var(--smrt-color-outline, #74777f);
     border-radius: var(--smrt-radius-full, 9999px);
     background: transparent;
@@ -360,7 +360,7 @@ function getFileIcon(type: string): string {
   }
 
   .file-upload__error {
-    padding: 8px 12px;
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
     border-radius: var(--smrt-radius-small, 4px);
     background: var(--smrt-color-error-container, #ffdad6);
     color: var(--smrt-color-on-error-container, #410002);

--- a/packages/chat/src/svelte/components/shared/MentionAutocomplete.svelte
+++ b/packages/chat/src/svelte/components/shared/MentionAutocomplete.svelte
@@ -103,7 +103,7 @@ function highlightMatch(
     position: absolute;
     bottom: 100%;
     left: 0;
-    margin-bottom: 4px;
+    margin-bottom: var(--smrt-spacing-1, 4px);
     min-width: 200px;
     max-width: 320px;
     max-height: 240px;
@@ -113,7 +113,7 @@ function highlightMatch(
     border-radius: var(--smrt-radius-medium, 8px);
     box-shadow: var(--smrt-elevation-level2, 0 2px 8px rgba(0, 0, 0, 0.15));
     z-index: var(--smrt-z-index-dropdown, 1000);
-    padding: 4px;
+    padding: var(--smrt-spacing-1, 4px);
     display: flex;
     flex-direction: column;
   }
@@ -121,9 +121,9 @@ function highlightMatch(
   .mention-autocomplete__item {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: var(--smrt-spacing-2, 8px);
     width: 100%;
-    padding: 8px;
+    padding: var(--smrt-spacing-2, 8px);
     border: none;
     background: transparent;
     cursor: pointer;

--- a/packages/chat/src/svelte/components/shared/TypingIndicator.svelte
+++ b/packages/chat/src/svelte/components/shared/TypingIndicator.svelte
@@ -47,7 +47,7 @@ const label = $derived.by(() => {
   .typing__dots {
     display: inline-flex;
     align-items: center;
-    gap: 2px;
+    gap: var(--smrt-spacing-1, 4px);
   }
 
   .typing__dot {

--- a/packages/chat/src/svelte/components/tabs/ChatTab.svelte
+++ b/packages/chat/src/svelte/components/tabs/ChatTab.svelte
@@ -122,7 +122,7 @@ const {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 8px 12px;
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
     background: var(--smrt-color-primary, #005ac1);
     color: var(--smrt-color-on-primary, #ffffff);
     min-height: 44px;
@@ -131,7 +131,7 @@ const {
   .chat-tab__header-btn {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: var(--smrt-spacing-2, 8px);
     background: none;
     border: none;
     color: inherit;
@@ -156,7 +156,7 @@ const {
   .chat-tab__actions {
     display: flex;
     align-items: center;
-    gap: 4px;
+    gap: var(--smrt-spacing-1, 4px);
     flex-shrink: 0;
   }
 
@@ -191,8 +191,8 @@ const {
   .chat-tab--collapsed {
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 8px 12px;
+    gap: var(--smrt-spacing-2, 8px);
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
     background: var(--smrt-color-surface-container, #f0f0f4);
     border: none;
     border-radius: var(--smrt-radius-large, 12px) var(--smrt-radius-large, 12px) 0 0;
@@ -218,7 +218,7 @@ const {
     justify-content: center;
     min-width: 18px;
     height: 18px;
-    padding: 0 5px;
+    padding: 0 var(--smrt-spacing-1, 4px);
     border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-error, #ba1a1a);
     color: var(--smrt-color-on-error, #ffffff);

--- a/packages/chat/src/svelte/components/tabs/ChatTabList.svelte
+++ b/packages/chat/src/svelte/components/tabs/ChatTabList.svelte
@@ -60,7 +60,7 @@ const { tabs, onselect, onclose }: Props = $props();
   .tab-list {
     display: flex;
     align-items: flex-end;
-    gap: 4px;
+    gap: var(--smrt-spacing-1, 4px);
     pointer-events: auto;
   }
 
@@ -76,7 +76,7 @@ const { tabs, onselect, onclose }: Props = $props();
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 6px;
+    padding: var(--smrt-spacing-2, 8px);
     border: none;
     background: var(--smrt-color-surface-container, #f0f0f4);
     border-radius: var(--smrt-radius-full, 9999px);
@@ -105,7 +105,7 @@ const { tabs, onselect, onclose }: Props = $props();
     justify-content: center;
     min-width: 16px;
     height: 16px;
-    padding: 0 4px;
+    padding: 0 var(--smrt-spacing-1, 4px);
     border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-error, #ba1a1a);
     color: var(--smrt-color-on-error, #ffffff);

--- a/packages/chat/src/svelte/components/tabs/ChatTabs.svelte
+++ b/packages/chat/src/svelte/components/tabs/ChatTabs.svelte
@@ -69,8 +69,8 @@ const collapsedTabs = $derived(tabs.filter((t) => !t.isExpanded));
     right: 0;
     display: flex;
     align-items: flex-end;
-    gap: 8px;
-    padding: 0 16px;
+    gap: var(--smrt-spacing-2, 8px);
+    padding: 0 var(--smrt-spacing-4, 16px);
     z-index: var(--smrt-z-index-sticky, 1100);
     pointer-events: none;
   }
@@ -78,7 +78,7 @@ const collapsedTabs = $derived(tabs.filter((t) => !t.isExpanded));
   .chat-tabs__expanded {
     display: flex;
     align-items: flex-end;
-    gap: 8px;
+    gap: var(--smrt-spacing-2, 8px);
     pointer-events: auto;
   }
 </style>

--- a/packages/chat/src/svelte/components/tabs/MiniChat.svelte
+++ b/packages/chat/src/svelte/components/tabs/MiniChat.svelte
@@ -113,17 +113,17 @@ $effect(() => {
   .mini-chat__messages {
     flex: 1;
     overflow-y: auto;
-    padding: 8px;
+    padding: var(--smrt-spacing-2, 8px);
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: var(--smrt-spacing-2, 8px);
     scroll-behavior: smooth;
   }
 
   .mini-chat__msg {
     display: flex;
     align-items: flex-end;
-    gap: 6px;
+    gap: var(--smrt-spacing-2, 8px);
     max-width: 85%;
   }
 
@@ -135,8 +135,8 @@ $effect(() => {
   .mini-chat__bubble {
     display: flex;
     flex-direction: column;
-    gap: 2px;
-    padding: 6px 10px;
+    gap: var(--smrt-spacing-1, 4px);
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
     border-radius: var(--smrt-radius-medium, 8px);
     background: var(--smrt-color-surface-container, #f0f0f4);
     color: var(--smrt-color-on-surface, #1a1c1e);
@@ -182,8 +182,8 @@ $effect(() => {
   .mini-chat__input-bar {
     display: flex;
     align-items: center;
-    gap: 4px;
-    padding: 8px;
+    gap: var(--smrt-spacing-1, 4px);
+    padding: var(--smrt-spacing-2, 8px);
     border-top: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
     background: var(--smrt-color-surface, #fefbff);
   }
@@ -192,7 +192,7 @@ $effect(() => {
     flex: 1;
     border: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
     border-radius: var(--smrt-radius-full, 9999px);
-    padding: 6px 12px;
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
     font: var(--smrt-typography-body-small-font, 0.8125rem/1.4 sans-serif);
     color: var(--smrt-color-on-surface, #1a1c1e);
     background: var(--smrt-color-surface-container-low, #f7f7fb);

--- a/packages/content/src/svelte/components/ContentAgentChat.svelte
+++ b/packages/content/src/svelte/components/ContentAgentChat.svelte
@@ -528,7 +528,7 @@ async function handleSendMessage(content: string) {
     border-top-color: var(--smrt-color-primary, #005ac1);
     border-radius: 50%;
     animation: spin 1s linear infinite;
-    margin-right: 8px;
+    margin-right: var(--smrt-spacing-2, 8px);
     vertical-align: middle;
   }
   
@@ -547,13 +547,13 @@ async function handleSendMessage(content: string) {
   }
 
   .model-bar {
-    padding: 6px 10px;
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
     background: var(--smrt-color-surface-container-lowest, #ffffff);
   }
 
   .smrt-select {
     width: 100%;
-    padding: 5px 8px;
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border-radius: 6px;
     border: none;
     background: var(--smrt-color-surface-container-low, #f7f7fb);
@@ -594,8 +594,8 @@ async function handleSendMessage(content: string) {
   .topic-footer {
     display: flex;
     align-items: center;
-    gap: 6px;
-    padding: 6px 10px;
+    gap: var(--smrt-spacing-2, 8px);
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
     background: var(--smrt-color-surface-container-lowest, #ffffff);
   }
 
@@ -606,8 +606,8 @@ async function handleSendMessage(content: string) {
   .topic-action-btn {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
-    padding: 4px 8px;
+    gap: var(--smrt-spacing-1, 4px);
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
     border-radius: 5px;
     background: none;
@@ -624,7 +624,7 @@ async function handleSendMessage(content: string) {
   }
 
   .topic-cancel-btn {
-    padding: 4px 6px;
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border: none;
     color: var(--smrt-color-outline, #74777f);
   }
@@ -632,13 +632,13 @@ async function handleSendMessage(content: string) {
   .new-topic-row {
     display: flex;
     align-items: center;
-    gap: 6px;
+    gap: var(--smrt-spacing-2, 8px);
     width: 100%;
   }
 
   .new-topic-input {
     flex: 1;
-    padding: 4px 8px;
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
     border-radius: 5px;
     font-size: 0.8125rem;

--- a/packages/events/src/svelte/components/MeetingView.svelte
+++ b/packages/events/src/svelte/components/MeetingView.svelte
@@ -259,7 +259,7 @@ const hasDocuments = $derived(
     display: block;
     font-size: var(--font-size-sm, 0.875rem);
     color: var(--color-text-secondary, #666);
-    margin-top: 2px;
+    margin-top: var(--smrt-spacing-1, 4px);
   }
 
   .document-arrow {

--- a/packages/messages/src/svelte/components/AttachmentUpload.svelte
+++ b/packages/messages/src/svelte/components/AttachmentUpload.svelte
@@ -88,20 +88,20 @@ export interface Props {
   .attachment-upload {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: var(--smrt-spacing-2, 8px);
   }
 
   .attachment-list {
     display: flex;
     flex-wrap: wrap;
-    gap: 4px;
+    gap: var(--smrt-spacing-1, 4px);
   }
 
   .attachment-item {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
-    padding: 4px 8px;
+    gap: var(--smrt-spacing-2, 8px);
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border-radius: var(--smrt-radius-sm, 8px);
     background: var(--smrt-color-surface-variant, #e7e0ec);
     font-size: 13px;
@@ -121,7 +121,7 @@ export interface Props {
     background: none;
     border: none;
     cursor: pointer;
-    padding: 0 2px;
+    padding: 0 var(--smrt-spacing-1, 4px);
     color: var(--smrt-color-error, #ba1a1a);
     font-size: 14px;
   }
@@ -129,7 +129,7 @@ export interface Props {
   .drop-zone {
     border: 2px dashed var(--smrt-color-outline-variant, #cac4d0);
     border-radius: var(--smrt-radius-md, 12px);
-    padding: 12px;
+    padding: var(--smrt-spacing-3, 12px);
     text-align: center;
     transition: border-color var(--smrt-duration-short, 150ms) var(--smrt-easing-standard, ease);
   }

--- a/packages/messages/src/svelte/components/ComposeForm.svelte
+++ b/packages/messages/src/svelte/components/ComposeForm.svelte
@@ -258,16 +258,16 @@ export interface Props {
   .compose-form {
     display: flex;
     flex-direction: column;
-    gap: 8px;
-    padding: 16px;
+    gap: var(--smrt-spacing-2, 8px);
+    padding: var(--smrt-spacing-4, 16px);
     font-family: var(--smrt-typography-body, system-ui);
   }
 
   .field {
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 4px 0;
+    gap: var(--smrt-spacing-2, 8px);
+    padding: var(--smrt-spacing-1, 4px) 0;
     border-bottom: 1px solid var(--smrt-color-outline-variant, #cac4d0);
   }
 
@@ -284,14 +284,14 @@ export interface Props {
     outline: none;
     font-family: inherit;
     font-size: 14px;
-    padding: 6px 0;
+    padding: var(--smrt-spacing-2, 8px) 0;
     background: transparent;
     color: var(--smrt-color-on-surface, #1c1b1f);
   }
 
   .cc-toggles {
     display: flex;
-    gap: 8px;
+    gap: var(--smrt-spacing-2, 8px);
     justify-content: flex-end;
   }
 
@@ -312,7 +312,7 @@ export interface Props {
     width: 100%;
     border: 1px solid var(--smrt-color-outline-variant, #cac4d0);
     border-radius: var(--smrt-radius-md, 12px);
-    padding: 12px;
+    padding: var(--smrt-spacing-3, 12px);
     font-family: var(--smrt-typography-body, system-ui);
     font-size: 14px;
     resize: vertical;
@@ -330,7 +330,7 @@ export interface Props {
     text-align: right;
     font-size: 12px;
     color: var(--smrt-color-outline, #79747e);
-    padding-top: 4px;
+    padding-top: var(--smrt-spacing-1, 4px);
   }
 
   .char-count.over-limit {
@@ -340,12 +340,12 @@ export interface Props {
 
   .actions {
     display: flex;
-    gap: 8px;
-    padding-top: 8px;
+    gap: var(--smrt-spacing-2, 8px);
+    padding-top: var(--smrt-spacing-2, 8px);
   }
 
   .btn-primary {
-    padding: 8px 24px;
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-6, 24px);
     border-radius: var(--smrt-radius-full, 20px);
     border: none;
     background: var(--smrt-color-primary, #6750a4);
@@ -361,7 +361,7 @@ export interface Props {
   }
 
   .btn-secondary {
-    padding: 8px 16px;
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-4, 16px);
     border-radius: var(--smrt-radius-full, 20px);
     border: 1px solid var(--smrt-color-outline, #79747e);
     background: transparent;
@@ -372,7 +372,7 @@ export interface Props {
   }
 
   .btn-text {
-    padding: 8px 16px;
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-4, 16px);
     border: none;
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #49454f);

--- a/packages/messages/src/svelte/components/ForwardForm.svelte
+++ b/packages/messages/src/svelte/components/ForwardForm.svelte
@@ -83,8 +83,8 @@ export interface Props {
   .forward-form {
     display: flex;
     flex-direction: column;
-    gap: 8px;
-    padding: 12px;
+    gap: var(--smrt-spacing-2, 8px);
+    padding: var(--smrt-spacing-3, 12px);
     border: 1px solid var(--smrt-color-outline-variant, #cac4d0);
     border-radius: var(--smrt-radius-md, 12px);
     background: var(--smrt-color-surface, #fffbfe);
@@ -101,7 +101,7 @@ export interface Props {
     width: 100%;
     border: 1px solid var(--smrt-color-outline-variant, #cac4d0);
     border-radius: var(--smrt-radius-sm, 8px);
-    padding: 8px;
+    padding: var(--smrt-spacing-2, 8px);
     font-family: var(--smrt-typography-body, system-ui);
     font-size: 14px;
     resize: vertical;
@@ -114,7 +114,7 @@ export interface Props {
   }
 
   .forwarded-original {
-    padding: 8px;
+    padding: var(--smrt-spacing-2, 8px);
     background: var(--smrt-color-surface-variant, #e7e0ec);
     border-radius: var(--smrt-radius-sm, 8px);
     max-height: 300px;
@@ -131,11 +131,11 @@ export interface Props {
 
   .actions {
     display: flex;
-    gap: 8px;
+    gap: var(--smrt-spacing-2, 8px);
   }
 
   .btn-primary {
-    padding: 8px 24px;
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-6, 24px);
     border-radius: var(--smrt-radius-full, 20px);
     border: none;
     background: var(--smrt-color-primary, #6750a4);
@@ -151,7 +151,7 @@ export interface Props {
   }
 
   .btn-text {
-    padding: 8px 16px;
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-4, 16px);
     border: none;
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #49454f);

--- a/packages/messages/src/svelte/components/RecipientInput.svelte
+++ b/packages/messages/src/svelte/components/RecipientInput.svelte
@@ -84,8 +84,8 @@ export interface Props {
   .recipient-input {
     display: flex;
     align-items: flex-start;
-    gap: 8px;
-    padding: 4px 0;
+    gap: var(--smrt-spacing-2, 8px);
+    padding: var(--smrt-spacing-1, 4px) 0;
     border-bottom: 1px solid var(--smrt-color-outline-variant, #cac4d0);
   }
 
@@ -93,14 +93,14 @@ export interface Props {
     font-family: var(--smrt-typography-label, system-ui);
     font-size: 14px;
     color: var(--smrt-color-on-surface-variant, #49454f);
-    padding-top: 6px;
+    padding-top: var(--smrt-spacing-2, 8px);
     min-width: 32px;
   }
 
   .chips-container {
     display: flex;
     flex-wrap: wrap;
-    gap: 4px;
+    gap: var(--smrt-spacing-1, 4px);
     flex: 1;
     align-items: center;
   }
@@ -108,8 +108,8 @@ export interface Props {
   .chip {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
-    padding: 2px 4px 2px 8px;
+    gap: var(--smrt-spacing-1, 4px);
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-1, 4px) var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border-radius: var(--smrt-radius-sm, 8px);
     background: var(--smrt-color-secondary-container, #e8def8);
     color: var(--smrt-color-on-secondary-container, #1d192b);
@@ -126,7 +126,7 @@ export interface Props {
     background: none;
     border: none;
     cursor: pointer;
-    padding: 0 4px;
+    padding: 0 var(--smrt-spacing-1, 4px);
     font-size: 14px;
     color: inherit;
     opacity: 0.7;
@@ -143,7 +143,7 @@ export interface Props {
     outline: none;
     font-family: var(--smrt-typography-body, system-ui);
     font-size: 14px;
-    padding: 4px 0;
+    padding: var(--smrt-spacing-1, 4px) 0;
     background: transparent;
     color: var(--smrt-color-on-surface, #1c1b1f);
   }

--- a/packages/messages/src/svelte/components/ReplyForm.svelte
+++ b/packages/messages/src/svelte/components/ReplyForm.svelte
@@ -74,8 +74,8 @@ export interface Props {
   .reply-form {
     display: flex;
     flex-direction: column;
-    gap: 8px;
-    padding: 12px;
+    gap: var(--smrt-spacing-2, 8px);
+    padding: var(--smrt-spacing-3, 12px);
     border: 1px solid var(--smrt-color-outline-variant, #cac4d0);
     border-radius: var(--smrt-radius-md, 12px);
     background: var(--smrt-color-surface, #fffbfe);
@@ -92,7 +92,7 @@ export interface Props {
     width: 100%;
     border: 1px solid var(--smrt-color-outline-variant, #cac4d0);
     border-radius: var(--smrt-radius-sm, 8px);
-    padding: 8px;
+    padding: var(--smrt-spacing-2, 8px);
     font-family: var(--smrt-typography-body, system-ui);
     font-size: 14px;
     resize: vertical;
@@ -105,7 +105,7 @@ export interface Props {
   }
 
   .quoted-original {
-    padding: 8px;
+    padding: var(--smrt-spacing-2, 8px);
     border-left: 3px solid var(--smrt-color-outline-variant, #cac4d0);
     background: var(--smrt-color-surface-variant, #e7e0ec);
     border-radius: 0 var(--smrt-radius-sm, 8px) var(--smrt-radius-sm, 8px) 0;
@@ -123,11 +123,11 @@ export interface Props {
 
   .actions {
     display: flex;
-    gap: 8px;
+    gap: var(--smrt-spacing-2, 8px);
   }
 
   .btn-primary {
-    padding: 8px 24px;
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-6, 24px);
     border-radius: var(--smrt-radius-full, 20px);
     border: none;
     background: var(--smrt-color-primary, #6750a4);
@@ -143,7 +143,7 @@ export interface Props {
   }
 
   .btn-text {
-    padding: 8px 16px;
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-4, 16px);
     border: none;
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #49454f);

--- a/packages/messages/src/svelte/components/SendStatusBadge.svelte
+++ b/packages/messages/src/svelte/components/SendStatusBadge.svelte
@@ -40,7 +40,7 @@ export interface Props {
   .send-status-badge {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
+    gap: var(--smrt-spacing-1, 4px);
     border-radius: var(--smrt-radius-sm, 8px);
     border: 1px solid var(--badge-color);
     color: var(--badge-color);
@@ -49,12 +49,12 @@ export interface Props {
   }
 
   .sm {
-    padding: 2px 8px;
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     font-size: 11px;
   }
 
   .md {
-    padding: 4px 12px;
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-3, 12px);
     font-size: 13px;
   }
 

--- a/packages/tenancy/src/svelte/components/TenantCard.svelte
+++ b/packages/tenancy/src/svelte/components/TenantCard.svelte
@@ -132,8 +132,8 @@ function getColor(name: string): string {
   .tenant-card {
     display: flex;
     align-items: center;
-    gap: 16px;
-    padding: 16px;
+    gap: var(--smrt-spacing-4, 16px);
+    padding: var(--smrt-spacing-4, 16px);
     background-color: var(--smrt-color-surface-container-low);
     border-radius: 12px;
     color: var(--smrt-color-on-surface);
@@ -178,7 +178,7 @@ function getColor(name: string): string {
   .header {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: var(--smrt-spacing-2, 8px);
   }
 
   .name {
@@ -191,7 +191,7 @@ function getColor(name: string): string {
 
   .status {
     font: var(--smrt-typography-label-small-font);
-    padding: 0 6px;
+    padding: 0 var(--smrt-spacing-2, 8px);
     height: 18px;
     display: inline-flex;
     align-items: center;
@@ -219,7 +219,7 @@ function getColor(name: string): string {
   .slug {
     font: var(--smrt-typography-body-small-font);
     color: var(--smrt-color-on-surface-variant);
-    margin-top: 2px;
+    margin-top: var(--smrt-spacing-1, 4px);
   }
 
   .selected .slug {
@@ -228,7 +228,7 @@ function getColor(name: string): string {
   }
 
   .meta {
-    margin-top: 4px;
+    margin-top: var(--smrt-spacing-1, 4px);
   }
 
   .members {
@@ -238,7 +238,7 @@ function getColor(name: string): string {
 
   .actions {
     display: flex;
-    gap: 4px;
+    gap: var(--smrt-spacing-1, 4px);
     flex-shrink: 0;
   }
 

--- a/packages/users/src/svelte/components/UserCard.svelte
+++ b/packages/users/src/svelte/components/UserCard.svelte
@@ -72,8 +72,8 @@ const statusClass = $derived.by(() => {
   .user-card {
     display: flex;
     align-items: center;
-    gap: 16px;
-    padding: 12px 16px;
+    gap: var(--smrt-spacing-4, 16px);
+    padding: var(--smrt-spacing-3, 12px) var(--smrt-spacing-4, 16px);
     background-color: var(--smrt-color-surface-container-low);
     border-radius: 12px;
     width: 100%;
@@ -130,13 +130,13 @@ const statusClass = $derived.by(() => {
   .meta {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: var(--smrt-spacing-2, 8px);
     flex-shrink: 0;
   }
 
   .role {
     font: var(--smrt-typography-label-small-font);
-    padding: 0 8px;
+    padding: 0 var(--smrt-spacing-2, 8px);
     height: 20px;
     display: inline-flex;
     align-items: center;
@@ -148,7 +148,7 @@ const statusClass = $derived.by(() => {
 
   .status {
     font: var(--smrt-typography-label-small-font);
-    padding: 0 8px;
+    padding: 0 var(--smrt-spacing-2, 8px);
     height: 20px;
     display: inline-flex;
     align-items: center;

--- a/packages/users/src/svelte/components/UserMenu.svelte
+++ b/packages/users/src/svelte/components/UserMenu.svelte
@@ -187,8 +187,8 @@ function getInitials(name: string): string {
   .user-menu-trigger {
     display: flex;
     align-items: center;
-    gap: 12px;
-    padding: 8px 12px;
+    gap: var(--smrt-spacing-3, 12px);
+    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
     background: transparent;
     border: none;
     border-radius: 20px;
@@ -236,21 +236,21 @@ function getInitials(name: string): string {
     position: absolute;
     top: 100%;
     right: 0;
-    margin-top: 4px;
+    margin-top: var(--smrt-spacing-1, 4px);
     min-width: 200px;
     background-color: var(--smrt-color-surface-container);
     border-radius: var(--smrt-radius-medium, 4px);
     box-shadow: var(--smrt-elevation-level2);
     z-index: var(--smrt-z-index-dropdown, 1000);
-    padding: 4px 0;
+    padding: var(--smrt-spacing-1, 4px) 0;
     overflow: hidden;
   }
 
   .dropdown-item {
     display: flex;
     align-items: center;
-    gap: 12px;
-    padding: 12px 16px;
+    gap: var(--smrt-spacing-3, 12px);
+    padding: var(--smrt-spacing-3, 12px) var(--smrt-spacing-4, 16px);
     font: var(--smrt-typography-body-medium-font);
     color: var(--smrt-color-on-surface);
     text-decoration: none;
@@ -274,10 +274,10 @@ function getInitials(name: string): string {
   }
 
   .user-info {
-    padding: 12px 16px;
+    padding: var(--smrt-spacing-3, 12px) var(--smrt-spacing-4, 16px);
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: var(--smrt-spacing-1, 4px);
   }
 
   .user-info-name {
@@ -302,7 +302,7 @@ function getInitials(name: string): string {
   }
 
   .divider {
-    margin: 4px 0;
+    margin: var(--smrt-spacing-1, 4px) 0;
     border: none;
     border-top: 1px solid var(--smrt-color-outline-variant);
   }

--- a/scripts/check-spacing.mjs
+++ b/scripts/check-spacing.mjs
@@ -37,7 +37,16 @@ const ROOT = resolve(import.meta.dirname, '..');
 const PACKAGES = join(ROOT, 'packages');
 
 /** Packages held to ERROR. Everything else is report-only for now (#1373). */
-const STRICT_PACKAGES = new Set(['smrt-svelte']);
+const STRICT_PACKAGES = new Set([
+  'smrt-svelte',
+  'chat',
+  'messages',
+  'assets',
+  'users',
+  'content',
+  'events',
+  'tenancy',
+]);
 
 /** Dev/playground hosts skipped entirely (matches the color/z-index ratchets). */
 const SCOPE_EXCLUDED_PACKAGES = new Set(['smrt-playground']);


### PR DESCRIPTION
S1 (#1373) — **spacing phase 2**: migrate the remaining spacing px across the UI packages and flip them strict.

| Package | values |
|---|---|
| chat | 127 |
| messages | 57 |
| assets | 21 |
| users | 18 |
| content | 16 |
| tenancy | 7 |
| events | 1 |

All snapped to the 4px-grid `--smrt-spacing-*` scale (with px fallback), applied deterministically via the ratchet's snap suggestions. Flips the 7 packages to `STRICT_PACKAGES`.

**All 8 UI packages with spacing px are now strict; 0 report-only — the spacing dimension is complete.**

Verified: full `turbo build` 50/50, spacing ratchet clean (8 strict), svelte-token guard (127 emitted), scope-clean (spacing px only — 0 console/JS/other-property changes).

Refs #1373.
