### PR TITLE
refactor: snap border-radius to --smrt-radius-* across UI packages (S1 #1373)

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -187,6 +187,12 @@ jobs:
       - name: Check raw spacing px
         run: node scripts/check-spacing.mjs
 
+      # Bans raw border-radius px/% in component CSS. Strict (fails) for UI
+      # packages; report-only elsewhere until later phases of the design-token
+      # sweep (issue #1373). Node-only, no deps.
+      - name: Check raw border-radius
+        run: node scripts/check-radius.mjs
+
   test:
     name: Validate Changes
     uses: ./.github/workflows/test-suite.yml

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -141,6 +141,16 @@ pre-push:
         Snap to the 4px grid: padding/margin/gap: var(--smrt-spacing-<n>, <px>).
         Run: node scripts/check-spacing.mjs
 
+    radius:
+      # Bans raw border-radius px/% in component CSS. Strict for UI packages,
+      # report-only elsewhere until later phases of #1373. Node-only, no deps.
+      run: node scripts/check-radius.mjs
+      fail_text: |
+        ❌ Raw border-radius found in a strict UI package!
+
+        Snap to the scale: border-radius: var(--smrt-radius-<name>, <value>).
+        Run: node scripts/check-radius.mjs
+
     validate-all-workflows:
       run: |
         echo "🔍 Validating ALL workflow files before push..."

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "check:color-literals": "node scripts/check-color-literals.mjs",
     "check:z-index": "node scripts/check-z-index.mjs",
     "check:spacing": "node scripts/check-spacing.mjs",
+    "check:radius": "node scripts/check-radius.mjs",
     "knowledge:check": "tsx scripts/check-knowledge.ts",
     "changeset": "changeset",
     "changeset:auto": "npx tsx scripts/auto-changeset.ts",

--- a/packages/agents/src/svelte/components/AgentRunHistory.svelte
+++ b/packages/agents/src/svelte/components/AgentRunHistory.svelte
@@ -205,7 +205,7 @@ function handleEntryClick(entry: AgentRunHistoryEntry) {
     height: 20px;
     border: 2px solid var(--smrt-color-outline-variant, #c4c6cf);
     border-top-color: var(--smrt-color-primary, #005ac1);
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     animation: spin 0.8s linear infinite;
   }
 

--- a/packages/agents/src/svelte/components/AgentScheduleList.svelte
+++ b/packages/agents/src/svelte/components/AgentScheduleList.svelte
@@ -350,7 +350,7 @@ function handleRunNow(schedule: AgentScheduleData, event: Event) {
     height: 20px;
     border: 2px solid var(--color-neutral-gray200, #e5e7eb);
     border-top-color: var(--color-primary, #3b82f6);
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     animation: spin 0.8s linear infinite;
   }
 

--- a/packages/analytics/src/svelte/EventsTable.svelte
+++ b/packages/analytics/src/svelte/EventsTable.svelte
@@ -121,7 +121,7 @@ function statusClass(status: string): string {
 	.status-pill {
 		display: inline-block;
 		padding: 0.125rem 0.5rem;
-		border-radius: 9999px;
+		border-radius: var(--smrt-radius-full, 9999px);
 		font-size: 0.6875rem;
 		font-weight: 500;
 	}

--- a/packages/analytics/src/svelte/PropertyStatusBadge.svelte
+++ b/packages/analytics/src/svelte/PropertyStatusBadge.svelte
@@ -25,7 +25,7 @@ const label = $derived(
 		align-items: center;
 		gap: 0.375rem;
 		padding: 0.25rem 0.625rem;
-		border-radius: 9999px;
+		border-radius: var(--smrt-radius-full, 9999px);
 		font-size: 0.75rem;
 		font-weight: 500;
 	}
@@ -33,7 +33,7 @@ const label = $derived(
 	.status-dot {
 		width: 0.5rem;
 		height: 0.5rem;
-		border-radius: 50%;
+		border-radius: var(--smrt-radius-full, 9999px);
 	}
 
 	.connected {

--- a/packages/analytics/src/svelte/TrendBadge.svelte
+++ b/packages/analytics/src/svelte/TrendBadge.svelte
@@ -22,7 +22,7 @@ const arrow = $derived(
 		align-items: center;
 		gap: 0.25rem;
 		padding: 0.125rem 0.5rem;
-		border-radius: 9999px;
+		border-radius: var(--smrt-radius-full, 9999px);
 		font-size: 0.75rem;
 		font-weight: 600;
 		line-height: 1;

--- a/packages/assets/src/svelte/ActionBar.svelte
+++ b/packages/assets/src/svelte/ActionBar.svelte
@@ -217,7 +217,7 @@ const count = $derived(selectedAssets.length);
 
   .confirm-card {
     background: var(--smrt-color-surface-container-high, #ffffff);
-    border-radius: 28px;
+    border-radius: var(--smrt-radius-3xl, 32px);
     padding: var(--smrt-spacing-6, 24px);
     max-width: 400px;
     width: 100%;
@@ -259,7 +259,7 @@ const count = $derived(selectedAssets.length);
     font-family: inherit;
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     font-weight: 500;
-    border-radius: 20px;
+    border-radius: var(--smrt-radius-2xl, 24px);
     cursor: pointer;
     border: none;
     transition: all 200ms ease;
@@ -294,7 +294,7 @@ const count = $derived(selectedAssets.length);
     height: 16px;
     border: 2px solid transparent;
     border-top-color: currentColor;
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     animation: spin 0.8s linear infinite;
   }
 

--- a/packages/assets/src/svelte/AssetDetail.svelte
+++ b/packages/assets/src/svelte/AssetDetail.svelte
@@ -417,7 +417,7 @@ function formatDate(date: Date | string | undefined): string {
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #6b7280);
     cursor: pointer;
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     flex-shrink: 0;
   }
 

--- a/packages/assets/src/svelte/AssetGrid.svelte
+++ b/packages/assets/src/svelte/AssetGrid.svelte
@@ -298,7 +298,7 @@ function getAltText(asset: PersistedAsset): string {
     height: 20px;
     border: 2px solid var(--smrt-color-outline-variant, #e5e7eb);
     border-top-color: var(--smrt-color-primary, #005ac1);
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     animation: spin 0.8s linear infinite;
   }
 

--- a/packages/assets/src/svelte/AssetList.svelte
+++ b/packages/assets/src/svelte/AssetList.svelte
@@ -350,7 +350,7 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
     display: inline-block;
     width: 8px;
     height: 8px;
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-outline, #9ca3af);
     margin-right: var(--smrt-spacing-1, 4px);
     vertical-align: middle;
@@ -398,7 +398,7 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
     height: 20px;
     border: 2px solid var(--smrt-color-outline-variant, #e5e7eb);
     border-top-color: var(--smrt-color-primary, #005ac1);
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     animation: spin 0.8s linear infinite;
   }
 

--- a/packages/assets/src/svelte/CreateAssetModal.svelte
+++ b/packages/assets/src/svelte/CreateAssetModal.svelte
@@ -317,7 +317,7 @@ const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #6b7280);
     cursor: pointer;
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
   }
 
   .create-modal__close:hover {
@@ -438,7 +438,7 @@ const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #6b7280);
     cursor: pointer;
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
   }
 
   .file-preview__remove:hover {

--- a/packages/assets/src/svelte/playground/AssetDetailPreview.svelte
+++ b/packages/assets/src/svelte/playground/AssetDetailPreview.svelte
@@ -114,7 +114,7 @@ function handleEdit() {
   button {
     justify-self: start;
     border: 0;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     padding: 0.75rem 1rem;
     font: inherit;
     font-weight: 600;

--- a/packages/assets/src/svelte/playground/CreateAssetModalPreview.svelte
+++ b/packages/assets/src/svelte/playground/CreateAssetModalPreview.svelte
@@ -112,7 +112,7 @@ function handleCreate(data: {
   button {
     justify-self: start;
     border: 0;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     padding: 0.75rem 1rem;
     font: inherit;
     font-weight: 600;

--- a/packages/chat/src/svelte/components/agent/AgentChat.svelte
+++ b/packages/chat/src/svelte/components/agent/AgentChat.svelte
@@ -253,7 +253,7 @@ $effect(() => {
     flex-direction: column;
     gap: var(--smrt-spacing-1, 4px);
     padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
-    border-radius: 10px;
+    border-radius: var(--smrt-radius-lg, 12px);
     word-break: break-word;
     font-size: 0.8125rem;
     line-height: 1.45;
@@ -262,13 +262,13 @@ $effect(() => {
   .agent-chat__bubble--user {
     background: var(--smrt-color-primary-container, #d6e3ff);
     color: var(--smrt-color-on-primary-container, #001a41);
-    border-bottom-right-radius: 3px;
+    border-bottom-right-radius: var(--smrt-radius-sm, 4px);
   }
 
   .agent-chat__bubble--agent {
     background: var(--smrt-color-surface-container-high, #e6e6ea);
     color: var(--smrt-color-on-surface, #1a1c1e);
-    border-bottom-left-radius: 3px;
+    border-bottom-left-radius: var(--smrt-radius-sm, 4px);
   }
 
   .agent-chat__msg--system .agent-chat__bubble {
@@ -323,7 +323,7 @@ $effect(() => {
   .agent-chat__input {
     flex: 1;
     border: none;
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
     font-size: 0.8125rem;
     line-height: 1.4;
@@ -353,7 +353,7 @@ $effect(() => {
     border: none;
     background: var(--smrt-color-primary, #005ac1);
     color: var(--smrt-color-on-primary, #ffffff);
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     cursor: pointer;
     flex-shrink: 0;
     transition: opacity 150ms;
@@ -377,7 +377,7 @@ $effect(() => {
     color: var(--smrt-color-on-success-container, #16a34a);
     background: var(--smrt-color-success-container, #f0fdf4);
     border: 1px solid var(--smrt-color-success, #bbf7d0);
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
   }
 
   .field-update-block {
@@ -397,7 +397,7 @@ $effect(() => {
   .markdown-block__content {
     margin: 0;
     padding: var(--smrt-spacing-3, 12px);
-    border-radius: 10px;
+    border-radius: var(--smrt-radius-lg, 12px);
     background: color-mix(in srgb, var(--smrt-color-surface-container-low, #f4f2f6) 85%, white);
     overflow-x: auto;
     white-space: pre-wrap;
@@ -411,7 +411,7 @@ $effect(() => {
     font-size: 0.625rem;
     font-weight: 600;
     border: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: none;
     color: var(--smrt-color-on-surface-variant, #43474e);
     cursor: pointer;
@@ -425,7 +425,7 @@ $effect(() => {
 
   .diff-dialog {
     border: none;
-    border-radius: 10px;
+    border-radius: var(--smrt-radius-lg, 12px);
     padding: 0;
     width: min(420px, 90vw);
     max-height: 60vh;
@@ -459,7 +459,7 @@ $effect(() => {
     cursor: pointer;
     color: var(--smrt-color-outline, #74777f);
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
   }
 
   .diff-dialog__close:hover {
@@ -496,7 +496,7 @@ $effect(() => {
     font-size: 0.75rem;
     line-height: 1.5;
     background: var(--smrt-color-surface-container-low, #f7f7fb);
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     white-space: pre-wrap;
     word-break: break-word;
     font-family: inherit;
@@ -517,7 +517,7 @@ $effect(() => {
   .thinking-dots span {
     width: 6px;
     height: 6px;
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-outline, #74777f);
     animation: thinking-bounce 1.2s ease-in-out infinite;
   }

--- a/packages/chat/src/svelte/components/dialogs/SearchMessages.svelte
+++ b/packages/chat/src/svelte/components/dialogs/SearchMessages.svelte
@@ -417,7 +417,7 @@ $effect(() => {
   .result-item__content :global(.highlight) {
     background: var(--smrt-color-tertiary-container, #c2f0dd);
     color: var(--smrt-color-on-tertiary-container, #002114);
-    border-radius: 2px;
+    border-radius: var(--smrt-radius-sm, 4px);
     padding: 0 0.125rem;
   }
 

--- a/packages/chat/src/svelte/components/layout/RoomList.svelte
+++ b/packages/chat/src/svelte/components/layout/RoomList.svelte
@@ -425,7 +425,7 @@ function formatTimestamp(date?: string | Date | null): string {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border-radius: 99px;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-primary, #005ac1);
     color: var(--smrt-color-on-primary, #fff);
     font: var(--smrt-typography-label-small-font, 500 0.6875rem / 1 sans-serif);

--- a/packages/content/src/routes/api-explorer/+page.svelte
+++ b/packages/content/src/routes/api-explorer/+page.svelte
@@ -588,7 +588,7 @@ function closeTry() {
   .group-count {
     background: var(--smrt-color-surface-variant, #e1e2ec);
     padding: 0.1rem 0.4rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     font-size: 0.7rem;
     font-weight: 600;
   }

--- a/packages/content/src/svelte/components/ContentAgentChat.svelte
+++ b/packages/content/src/svelte/components/ContentAgentChat.svelte
@@ -526,7 +526,7 @@ async function handleSendMessage(content: string) {
     height: 16px;
     border: 2px solid var(--smrt-color-outline-variant, #c4c6d0);
     border-top-color: var(--smrt-color-primary, #005ac1);
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     animation: spin 1s linear infinite;
     margin-right: var(--smrt-spacing-2, 8px);
     vertical-align: middle;
@@ -542,7 +542,7 @@ async function handleSendMessage(content: string) {
     background: var(--smrt-color-primary, #005ac1);
     color: var(--smrt-color-on-primary, #ffffff);
     border: none;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     cursor: pointer;
   }
 
@@ -554,7 +554,7 @@ async function handleSendMessage(content: string) {
   .smrt-select {
     width: 100%;
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     border: none;
     background: var(--smrt-color-surface-container-low, #f7f7fb);
     color: var(--smrt-color-on-surface, #1a1c1e);
@@ -609,7 +609,7 @@ async function handleSendMessage(content: string) {
     gap: var(--smrt-spacing-1, 4px);
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
-    border-radius: 5px;
+    border-radius: var(--smrt-radius-sm, 4px);
     background: none;
     color: var(--smrt-color-on-surface-variant, #43474e);
     font-size: 0.75rem;
@@ -640,7 +640,7 @@ async function handleSendMessage(content: string) {
     flex: 1;
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
-    border-radius: 5px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.8125rem;
     outline: none;
     background: var(--smrt-color-surface, #ffffff);

--- a/packages/content/src/svelte/components/ContentBodyEditor.svelte
+++ b/packages/content/src/svelte/components/ContentBodyEditor.svelte
@@ -1387,7 +1387,7 @@ function handleEditorDragEnd() {
     gap: 0.1rem;
     padding: 0.25rem;
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: color-mix(in srgb, var(--smrt-color-surface) 96%, transparent);
     color: var(--smrt-color-on-surface);
     box-shadow: 0 0.75rem 1.75rem color-mix(in srgb, var(--smrt-color-shadow) 18%, transparent);
@@ -1408,7 +1408,7 @@ function handleEditorDragEnd() {
   .image-control-popover button {
     width: 1.85rem;
     height: 1.85rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
   }
 
   .image-control-popover button:hover,
@@ -1430,7 +1430,7 @@ function handleEditorDragEnd() {
     width: 1.45rem;
     height: 1.45rem;
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-surface);
     box-shadow: 0 0.45rem 1rem color-mix(in srgb, var(--smrt-color-shadow) 18%, transparent);
     cursor: nwse-resize;

--- a/packages/content/src/svelte/components/ContentClaimAuditTool.svelte
+++ b/packages/content/src/svelte/components/ContentClaimAuditTool.svelte
@@ -389,7 +389,7 @@ async function recheckFactClaims(claimIds: string[]) {
   }
 
   .pill {
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     padding: 0.2rem 0.55rem;
     font-size: 0.75rem;
     font-weight: 700;

--- a/packages/content/src/svelte/components/ContentContributionInbox.svelte
+++ b/packages/content/src/svelte/components/ContentContributionInbox.svelte
@@ -306,7 +306,7 @@ $effect(() => {
     justify-content: center;
     min-width: 1.75rem;
     padding: 0.15rem 0.5rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-primary-container);
   }
 

--- a/packages/content/src/svelte/components/ContentContributionPortal.svelte
+++ b/packages/content/src/svelte/components/ContentContributionPortal.svelte
@@ -160,7 +160,7 @@ function canWithdraw(contribution: ContentContributionData) {
     justify-content: center;
     min-width: 1.75rem;
     padding: 0.15rem 0.5rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-primary-container);
   }
 

--- a/packages/content/src/svelte/components/ContentCorrectionsTool.svelte
+++ b/packages/content/src/svelte/components/ContentCorrectionsTool.svelte
@@ -318,7 +318,7 @@ async function issueCorrection() {
   }
 
   .pill {
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     padding: 0.2rem 0.55rem;
     font-size: 0.75rem;
     font-weight: 700;

--- a/packages/content/src/svelte/components/ContentEditor.svelte
+++ b/packages/content/src/svelte/components/ContentEditor.svelte
@@ -1616,7 +1616,7 @@ function removeAsset(id: string) {
     align-items: center;
     background: var(--smrt-color-surface);
     border: 1px solid var(--smrt-color-outline);
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     padding: 0.25rem 0.25rem 0.25rem 0.75rem;
     font-size: 0.875rem;
     color: var(--smrt-color-on-surface);
@@ -1784,7 +1784,7 @@ function removeAsset(id: string) {
   .evidence-status {
     align-items: center;
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     display: inline-flex;
     font-size: 0.75rem;
     font-weight: 800;

--- a/packages/content/src/svelte/components/ContentGovernancePanel.svelte
+++ b/packages/content/src/svelte/components/ContentGovernancePanel.svelte
@@ -2183,7 +2183,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
   }
 
   .pill {
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     padding: 0.2rem 0.55rem;
     font-size: 0.75rem;
     font-weight: 700;

--- a/packages/content/src/svelte/components/ContentImageChooser.svelte
+++ b/packages/content/src/svelte/components/ContentImageChooser.svelte
@@ -94,7 +94,7 @@ function cycle(delta: number) {
     border: 1px solid var(--smrt-color-outline-variant);
     background: var(--smrt-color-surface-container);
     color: var(--smrt-color-on-surface);
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     cursor: pointer;
   }
 
@@ -123,7 +123,7 @@ function cycle(delta: number) {
   .chooser-preview img {
     width: 2rem;
     height: 2rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     object-fit: cover;
     background: var(--smrt-color-surface-container-high);
   }

--- a/packages/content/src/svelte/components/ContentList.svelte
+++ b/packages/content/src/svelte/components/ContentList.svelte
@@ -489,7 +489,7 @@ function handleDeleteContent(content: any) {
   .type-pill {
     display: inline-flex;
     align-items: center;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     padding: 0.2rem 0.65rem;
     font-size: 0.72rem;
     font-weight: 700;
@@ -572,7 +572,7 @@ function handleDeleteContent(content: any) {
 
   .badge {
     padding: 0.25rem 0.6rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     font-size: 0.75rem;
     font-weight: 600;
     text-transform: uppercase;
@@ -732,7 +732,7 @@ function handleDeleteContent(content: any) {
     justify-content: center;
     min-height: 2.4rem;
     padding: 0 0.85rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     border: 1px solid var(--smrt-color-outline-variant);
     background: transparent;
     color: var(--smrt-color-on-surface);

--- a/packages/content/src/svelte/components/ContentReviewStatusTray.svelte
+++ b/packages/content/src/svelte/components/ContentReviewStatusTray.svelte
@@ -124,7 +124,7 @@ let {
     bottom: 0.35rem;
     width: 0.45rem;
     height: 0.45rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-outline);
   }
 

--- a/packages/content/src/svelte/components/ContentTransparencyReport.svelte
+++ b/packages/content/src/svelte/components/ContentTransparencyReport.svelte
@@ -242,7 +242,7 @@ function getFactLabel(fact: {
 
   .badge,
   .pill-list span {
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-surface-container-high);
     color: var(--smrt-color-on-surface);
     padding: 0.25rem 0.65rem;

--- a/packages/content/src/svelte/components/ContentTransparencyTool.svelte
+++ b/packages/content/src/svelte/components/ContentTransparencyTool.svelte
@@ -282,7 +282,7 @@ async function loadTransparency(contentIdToLoad = savedContentId) {
   }
 
   .pill {
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     padding: 0.2rem 0.55rem;
     font-size: 0.75rem;
     font-weight: 700;

--- a/packages/content/src/svelte/components/ContentVersionsTool.svelte
+++ b/packages/content/src/svelte/components/ContentVersionsTool.svelte
@@ -255,7 +255,7 @@ async function restoreVersion(versionNumber: number) {
   }
 
   .pill {
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     padding: 0.2rem 0.55rem;
     font-size: 0.75rem;
     font-weight: 700;

--- a/packages/content/src/svelte/routes/ContentContributionsRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentContributionsRoute.svelte
@@ -584,7 +584,7 @@ async function handleDeleteContributor(data: Record<string, any>) {
     justify-content: center;
     min-height: 2.5rem;
     padding: 0 1rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     border: 1px solid var(--smrt-color-outline-variant);
     background: color-mix(
       in srgb,
@@ -666,7 +666,7 @@ async function handleDeleteContributor(data: Record<string, any>) {
     align-items: center;
     min-height: 2rem;
     padding: 0 0.8rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: color-mix(
       in srgb,
       var(--smrt-color-surface-container-low) 90%,
@@ -725,7 +725,7 @@ async function handleDeleteContributor(data: Record<string, any>) {
 
   .inline-form button,
   .secondary {
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     border: 1px solid color-mix(
       in srgb,
       var(--smrt-color-primary) 35%,
@@ -744,7 +744,7 @@ async function handleDeleteContributor(data: Record<string, any>) {
     justify-content: center;
     min-width: 2rem;
     min-height: 2rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: color-mix(
       in srgb,
       var(--smrt-color-primary) 14%,

--- a/packages/content/src/svelte/routes/ContentFactsRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentFactsRoute.svelte
@@ -316,7 +316,7 @@ onMount(() => {
     justify-content: center;
     min-height: 2.5rem;
     padding: 0 1rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     border: 1px solid var(--smrt-color-outline-variant);
     background: color-mix(
       in srgb,
@@ -461,7 +461,7 @@ onMount(() => {
     align-items: center;
     min-height: 1.9rem;
     padding: 0 0.7rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-surface-container-low);
     font-size: 0.82rem;
   }
@@ -519,7 +519,7 @@ onMount(() => {
     align-items: center;
     min-height: 1.65rem;
     padding: 0 0.6rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: color-mix(
       in srgb,
       var(--smrt-color-primary) 12%,

--- a/packages/content/src/svelte/routes/ContentGovernanceRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentGovernanceRoute.svelte
@@ -152,7 +152,7 @@ const workspaceHref = $derived(
     justify-content: center;
     min-height: 2.5rem;
     padding: 0 1rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     border: 1px solid var(--smrt-color-outline-variant);
     background: color-mix(
       in srgb,

--- a/packages/content/src/svelte/routes/ContentWorkspaceRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentWorkspaceRoute.svelte
@@ -324,7 +324,7 @@ function closeForms() {
     justify-content: center;
     min-height: 2.5rem;
     padding: 0 1rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     border: 1px solid var(--smrt-color-outline-variant);
     background: color-mix(
       in srgb,
@@ -412,7 +412,7 @@ function closeForms() {
     background: transparent;
     color: var(--smrt-color-primary);
     padding: 0.65rem 0.95rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     font-weight: 600;
     cursor: pointer;
   }

--- a/packages/events/src/svelte/components/MeetingView.svelte
+++ b/packages/events/src/svelte/components/MeetingView.svelte
@@ -163,7 +163,7 @@ const hasDocuments = $derived(
     padding: var(--spacing-xs, 0.25rem) var(--spacing-sm, 0.5rem);
     background: var(--view-bg);
     border: 1px solid var(--view-border);
-    border-radius: var(--radius-full, 9999px);
+    border-radius: var(--smrt-radius-full, 9999px);
     font-size: var(--font-size-sm, 0.875rem);
     color: var(--color-text-secondary, #666);
     margin-bottom: var(--spacing-sm, 0.5rem);
@@ -223,7 +223,7 @@ const hasDocuments = $derived(
     padding: var(--spacing-md, 1rem);
     background: var(--view-bg);
     border: 1px solid var(--view-border);
-    border-radius: var(--radius-md, 8px);
+    border-radius: var(--smrt-radius-md, 8px);
     text-decoration: none;
     color: var(--color-text-primary, #333);
     transition: all var(--transition-fast, 150ms);

--- a/packages/images/src/svelte/components/AssetsGallery.svelte
+++ b/packages/images/src/svelte/components/AssetsGallery.svelte
@@ -277,7 +277,7 @@ function handleDragStart(event: DragEvent, image: ImageLike) {
     padding: 0.75rem 1.25rem;
     background: var(--smrt-color-surface-container-highest, #333);
     border: 1px solid var(--smrt-color-outline-variant, #444);
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     color: inherit;
     font-size: 0.95rem;
     transition: box-shadow 0.2s, border-color 0.2s;
@@ -318,7 +318,7 @@ function handleDragStart(event: DragEvent, image: ImageLike) {
     color: var(--smrt-color-error, #ef4444);
     background: color-mix(in srgb, var(--smrt-color-error) 10%, transparent);
     padding: 1rem;
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
   }
 
   .gallery-grid {
@@ -415,7 +415,7 @@ function handleDragStart(event: DragEvent, image: ImageLike) {
     background: var(--smrt-color-surface-container-high, #242424);
     color: var(--smrt-color-primary, #3b82f6);
     border: 1px solid var(--smrt-color-outline-variant, #444);
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     font-weight: 500;
     cursor: pointer;
     transition: background 0.2s;

--- a/packages/images/src/svelte/components/ImageEditor.svelte
+++ b/packages/images/src/svelte/components/ImageEditor.svelte
@@ -337,7 +337,7 @@ async function handleAIEdit() {
   .mode-selector {
     display: flex;
     background: var(--smrt-color-surface-container-high, #242424);
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     padding: 0.25rem;
     gap: 0.25rem;
   }
@@ -350,7 +350,7 @@ async function handleAIEdit() {
     color: var(--smrt-color-outline, #666);
     cursor: pointer;
     font-weight: 500;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     transition: all 0.2s;
   }
 
@@ -415,7 +415,7 @@ async function handleAIEdit() {
     color: var(--smrt-color-primary, #3b82f6);
     border: 1px solid var(--smrt-color-outline-variant, #444);
     padding: 0.6rem 1.2rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     font-weight: 500;
     cursor: pointer;
     transition: background 0.2s;
@@ -442,7 +442,7 @@ async function handleAIEdit() {
     color: white;
     border: none;
     padding: 0.6rem 1.5rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     font-weight: 500;
     cursor: pointer;
     transition: background 0.2s, opacity 0.2s;
@@ -467,7 +467,7 @@ async function handleAIEdit() {
     color: var(--smrt-color-error, #ef4444);
     background: color-mix(in srgb, var(--smrt-color-error) 10%, transparent);
     padding: 0.5rem;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.85rem;
   }
 
@@ -475,7 +475,7 @@ async function handleAIEdit() {
     color: var(--smrt-color-success, #22c55e);
     background: color-mix(in srgb, var(--smrt-color-success) 10%, transparent);
     padding: 0.5rem;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.85rem;
   }
 </style>

--- a/packages/images/src/svelte/components/ImageUploader.svelte
+++ b/packages/images/src/svelte/components/ImageUploader.svelte
@@ -574,7 +574,7 @@ onDestroy(() => {
     color: white;
     border: none;
     padding: 0.5rem 1.5rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     font-weight: 500;
     pointer-events: none; /* Let parent handle clicks */
   }
@@ -628,7 +628,7 @@ onDestroy(() => {
     color: white;
     border: none;
     padding: 1rem 3rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     font-size: 1.1rem;
     font-weight: 600;
     cursor: pointer;
@@ -657,7 +657,7 @@ onDestroy(() => {
     color: white;
     border: 1px solid var(--smrt-color-outline-variant, #444);
     padding: 0.5rem 1rem;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     cursor: pointer;
   }
 
@@ -794,7 +794,7 @@ onDestroy(() => {
     color: white;
     border: none;
     padding: 0.65rem 1.5rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     font-weight: 500;
     cursor: pointer;
     transition: filter 0.15s;
@@ -812,7 +812,7 @@ onDestroy(() => {
     color: var(--smrt-color-on-surface-variant, #ccc);
     border: 1px solid var(--smrt-color-outline-variant, #444);
     padding: 0.65rem 1.25rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     font-weight: 500;
     cursor: pointer;
     transition: all 0.2s;
@@ -887,7 +887,7 @@ onDestroy(() => {
     color: white;
     border: none;
     padding: 0.65rem 1.5rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     font-weight: 500;
     cursor: pointer;
     transition: filter 0.15s, opacity 0.15s;
@@ -912,7 +912,7 @@ onDestroy(() => {
     height: 14px;
     border: 2px solid color-mix(in srgb, var(--smrt-color-on-primary) 30%, transparent);
     border-top-color: white;
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     animation: spin 0.6s linear infinite;
   }
 </style>

--- a/packages/jobs/src/svelte/components/JobList.svelte
+++ b/packages/jobs/src/svelte/components/JobList.svelte
@@ -340,7 +340,7 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
     height: 20px;
     border: 2px solid var(--smrt-color-outline-variant, #c4c6cf);
     border-top-color: var(--smrt-color-primary, #005ac1);
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     animation: spin 0.8s linear infinite;
   }
 

--- a/packages/messages/src/svelte/components/AccountAvatar.svelte
+++ b/packages/messages/src/svelte/components/AccountAvatar.svelte
@@ -56,7 +56,7 @@ const _icon = $derived.by(() => {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-secondary-container, #d7e3f7);
     color: var(--smrt-color-on-secondary-container, #101c2b);
     font-weight: 500;

--- a/packages/messages/src/svelte/components/EmailAccountManager.svelte
+++ b/packages/messages/src/svelte/components/EmailAccountManager.svelte
@@ -348,7 +348,7 @@ function getProviderLabel(type: string): string {
 
   .add-btn {
     padding: 0.375rem 0.75rem;
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     border: 1px solid var(--smrt-color-primary, #005ac1);
     background: transparent;
     color: var(--smrt-color-primary, #005ac1);
@@ -368,7 +368,7 @@ function getProviderLabel(type: string): string {
   .entry-form {
     background: var(--smrt-color-surface-container, #f0f1f9);
     border: 1px solid var(--smrt-color-primary, #005ac1);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     padding: 1rem;
     display: flex;
     flex-direction: column;
@@ -411,7 +411,7 @@ function getProviderLabel(type: string): string {
   .form-input,
   .form-select {
     padding: 0.5rem 0.625rem;
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     border: 1px solid var(--smrt-color-outline-variant, #c2c7cf);
     background: var(--smrt-color-surface, #fefbff);
     color: var(--smrt-color-on-surface, #1a1c1e);
@@ -459,7 +459,7 @@ function getProviderLabel(type: string): string {
 
   .cancel-btn {
     padding: 0.375rem 0.75rem;
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     border: 1px solid var(--smrt-color-outline-variant, #c2c7cf);
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #43474e);
@@ -475,7 +475,7 @@ function getProviderLabel(type: string): string {
 
   .save-btn {
     padding: 0.375rem 0.75rem;
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     border: 1px solid var(--smrt-color-primary, #005ac1);
     background: var(--smrt-color-primary, #005ac1);
     color: var(--smrt-color-on-primary, #fff);
@@ -497,7 +497,7 @@ function getProviderLabel(type: string): string {
 
   .test-result {
     padding: 0.5rem 0.75rem;
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-size: 0.8125rem;
     display: flex;
     align-items: center;
@@ -535,7 +535,7 @@ function getProviderLabel(type: string): string {
     justify-content: space-between;
     background: var(--smrt-color-surface-container, #f0f1f9);
     border: 1px solid var(--smrt-color-outline-variant, #c2c7cf);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     padding: 0.75rem 1rem;
     cursor: pointer;
     transition: background 150ms ease, border-color 150ms ease;
@@ -580,7 +580,7 @@ function getProviderLabel(type: string): string {
     background: var(--smrt-color-surface, #fefbff);
     border: 1px solid var(--smrt-color-outline-variant, #c2c7cf);
     padding: 0.25rem 0.5rem;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     flex-shrink: 0;
     min-width: 2rem;
     text-align: center;
@@ -624,7 +624,7 @@ function getProviderLabel(type: string): string {
     color: var(--smrt-color-on-surface-variant, #43474e);
     background: var(--smrt-color-surface, #fefbff);
     padding: 0.125rem 0.5rem;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     flex-shrink: 0;
   }
 
@@ -633,13 +633,13 @@ function getProviderLabel(type: string): string {
     color: var(--smrt-color-on-surface-variant, #43474e);
     background: var(--smrt-color-surface-container-high, #e6e7ef);
     padding: 0.125rem 0.5rem;
-    border-radius: 9999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     flex-shrink: 0;
   }
 
   .test-btn {
     padding: 0.25rem 0.5rem;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     border: 1px solid var(--smrt-color-outline-variant, #c2c7cf);
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #43474e);
@@ -663,7 +663,7 @@ function getProviderLabel(type: string): string {
     font-size: 1rem;
     line-height: 1;
     padding: 0.125rem 0.5rem;
-    border-radius: 9999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     border: 1px solid transparent;
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #43474e);
@@ -684,6 +684,6 @@ function getProviderLabel(type: string): string {
     text-align: center;
     color: var(--smrt-color-on-surface-variant, #43474e);
     background: var(--smrt-color-surface-container, #f0f1f9);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
   }
 </style>

--- a/packages/messages/src/svelte/components/EmailFilterManager.svelte
+++ b/packages/messages/src/svelte/components/EmailFilterManager.svelte
@@ -373,7 +373,7 @@ function getPatternPlaceholder(type: string): string {
     gap: 0.25rem;
     background: var(--smrt-color-surface-container, #f0f1f9);
     padding: 0.25rem;
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
   }
 
   .section-btn {
@@ -382,7 +382,7 @@ function getPatternPlaceholder(type: string): string {
     gap: 0.375rem;
     padding: 0.375rem 0.75rem;
     border: none;
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #43474e);
     font-size: 0.8125rem;
@@ -404,7 +404,7 @@ function getPatternPlaceholder(type: string): string {
     font-size: 0.6875rem;
     background: var(--smrt-color-outline-variant, #c2c7cf);
     padding: 0.0625rem 0.375rem;
-    border-radius: 9999px;
+    border-radius: var(--smrt-radius-full, 9999px);
   }
 
   .section-content {
@@ -427,7 +427,7 @@ function getPatternPlaceholder(type: string): string {
 
   .add-btn {
     padding: 0.375rem 0.75rem;
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     border: 1px solid var(--smrt-color-primary, #005ac1);
     background: transparent;
     color: var(--smrt-color-primary, #005ac1);
@@ -447,7 +447,7 @@ function getPatternPlaceholder(type: string): string {
   .entry-form {
     background: var(--smrt-color-surface-container, #f0f1f9);
     border: 1px solid var(--smrt-color-primary, #005ac1);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     padding: 1rem;
     display: flex;
     flex-direction: column;
@@ -486,7 +486,7 @@ function getPatternPlaceholder(type: string): string {
   .form-input,
   .form-select {
     padding: 0.5rem 0.625rem;
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     border: 1px solid var(--smrt-color-outline-variant, #c2c7cf);
     background: var(--smrt-color-surface, #fefbff);
     color: var(--smrt-color-on-surface, #1a1c1e);
@@ -534,7 +534,7 @@ function getPatternPlaceholder(type: string): string {
 
   .cancel-btn {
     padding: 0.375rem 0.75rem;
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     border: 1px solid var(--smrt-color-outline-variant, #c2c7cf);
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #43474e);
@@ -550,7 +550,7 @@ function getPatternPlaceholder(type: string): string {
 
   .save-btn {
     padding: 0.375rem 0.75rem;
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     border: 1px solid var(--smrt-color-primary, #005ac1);
     background: var(--smrt-color-primary, #005ac1);
     color: var(--smrt-color-on-primary, #fff);
@@ -582,7 +582,7 @@ function getPatternPlaceholder(type: string): string {
     justify-content: space-between;
     background: var(--smrt-color-surface-container, #f0f1f9);
     border: 1px solid var(--smrt-color-outline-variant, #c2c7cf);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     padding: 0.75rem 1rem;
     transition: background 150ms ease, border-color 150ms ease;
   }
@@ -614,7 +614,7 @@ function getPatternPlaceholder(type: string): string {
     background: var(--smrt-color-surface, #fefbff);
     border: 1px solid var(--smrt-color-outline-variant, #c2c7cf);
     padding: 0.25rem 0.5rem;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     flex-shrink: 0;
     min-width: 2rem;
     text-align: center;
@@ -646,7 +646,7 @@ function getPatternPlaceholder(type: string): string {
     color: var(--smrt-color-tertiary, #6b5778);
     background: var(--smrt-color-tertiary-container, #f2daff);
     padding: 0.125rem 0.5rem;
-    border-radius: 9999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     flex-shrink: 0;
   }
 
@@ -655,7 +655,7 @@ function getPatternPlaceholder(type: string): string {
     color: var(--smrt-color-warning, #ca8a04);
     background: var(--smrt-color-warning-container, #fef9c3);
     padding: 0.125rem 0.5rem;
-    border-radius: 9999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     flex-shrink: 0;
   }
 
@@ -663,7 +663,7 @@ function getPatternPlaceholder(type: string): string {
     font-size: 1rem;
     line-height: 1;
     padding: 0.125rem 0.5rem;
-    border-radius: 9999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     border: 1px solid transparent;
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #43474e);
@@ -684,6 +684,6 @@ function getPatternPlaceholder(type: string): string {
     text-align: center;
     color: var(--smrt-color-on-surface-variant, #43474e);
     background: var(--smrt-color-surface-container, #f0f1f9);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
   }
 </style>

--- a/packages/messages/src/svelte/components/FolderNav.svelte
+++ b/packages/messages/src/svelte/components/FolderNav.svelte
@@ -152,7 +152,7 @@ function getFolderIcon(specialUse?: string): string {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border-radius: 99px;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-primary, #005ac1);
     color: var(--smrt-color-on-primary, #fff);
     font: var(--smrt-typography-label-small-font, 500 0.6875rem / 1 sans-serif);

--- a/packages/messages/src/svelte/components/MessageStatusIndicator.svelte
+++ b/packages/messages/src/svelte/components/MessageStatusIndicator.svelte
@@ -56,7 +56,7 @@ const {
   .unread .dot {
     width: 0.5rem;
     height: 0.5rem;
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-primary, #005ac1);
   }
 

--- a/packages/products/src/app/layouts/AppLayout.svelte
+++ b/packages/products/src/app/layouts/AppLayout.svelte
@@ -95,7 +95,7 @@ const { children }: Props = $props();
     text-decoration: none;
     font-weight: 500;
     padding: 0.5rem 1rem;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     transition: all 0.2s;
   }
 
@@ -121,7 +121,7 @@ const { children }: Props = $props();
   .status-dot {
     width: 8px;
     height: 8px;
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
   }
   
   .status-dot.online {

--- a/packages/products/src/app/pages/ProductsPage.svelte
+++ b/packages/products/src/app/pages/ProductsPage.svelte
@@ -90,7 +90,7 @@
   .info-card {
     background: white;
     padding: 1.5rem;
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     border: 1px solid var(--smrt-color-outline-variant, #e2e8f0);
     text-align: center;
   }

--- a/packages/products/src/lib/components/ProductCard.svelte
+++ b/packages/products/src/lib/components/ProductCard.svelte
@@ -58,7 +58,7 @@ const { product, onEdit, onDelete }: Props = $props();
 <style>
   .product-card {
     border: 1px solid var(--smrt-color-outline-variant, #e2e8f0);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     padding: 1rem;
     background: white;
     box-shadow: 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow, #000) 10%, transparent);
@@ -101,7 +101,7 @@ const { product, onEdit, onDelete }: Props = $props();
     color: var(--smrt-color-on-surface, #374151);
     background: var(--smrt-color-surface-container, #f3f4f6);
     padding: 0.25rem 0.5rem;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     display: inline-block;
     margin-bottom: 0.5rem;
   }
@@ -129,7 +129,7 @@ const { product, onEdit, onDelete }: Props = $props();
     background: var(--smrt-color-surface-container, #f3f4f6);
     color: var(--smrt-color-on-surface, #374151);
     padding: 0.125rem 0.5rem;
-    border-radius: 9999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     font-size: 0.75rem;
   }
 
@@ -143,7 +143,7 @@ const { product, onEdit, onDelete }: Props = $props();
   
   .edit-btn, .delete-btn {
     padding: 0.375rem 0.75rem;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.875rem;
     font-weight: 500;
     border: 1px solid;

--- a/packages/products/src/lib/components/ProductForm.svelte
+++ b/packages/products/src/lib/components/ProductForm.svelte
@@ -169,7 +169,7 @@ function _handleSubmit(event: Event) {
     max-width: 500px;
     padding: 1.5rem;
     background: white;
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     border: 1px solid var(--smrt-color-outline-variant, #e2e8f0);
   }
   
@@ -195,7 +195,7 @@ function _handleSubmit(event: Event) {
     width: 100%;
     padding: 0.5rem;
     border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.875rem;
     transition: border-color 0.2s;
   }
@@ -250,7 +250,7 @@ function _handleSubmit(event: Event) {
   
   .cancel-btn, .submit-btn {
     padding: 0.5rem 1rem;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.875rem;
     font-weight: 500;
     cursor: pointer;

--- a/packages/products/src/lib/components/TestComponent.svelte
+++ b/packages/products/src/lib/components/TestComponent.svelte
@@ -15,7 +15,7 @@ const { message = 'Hello Federation!' }: Props = $props();
   .test-component {
     padding: 1rem;
     border: 1px solid var(--smrt-color-outline-variant, #ccc);
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     background: var(--smrt-color-surface-container-low, #f9f9f9);
   }
 </style>

--- a/packages/products/src/lib/components/auto-generated/AutoForm.svelte
+++ b/packages/products/src/lib/components/auto-generated/AutoForm.svelte
@@ -146,7 +146,7 @@ function _getFieldType(
     margin: 0 auto;
     padding: 1.5rem;
     background: white;
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     box-shadow: 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow, #000) 10%, transparent);
   }
 

--- a/packages/products/src/lib/features/CategoryManager.svelte
+++ b/packages/products/src/lib/features/CategoryManager.svelte
@@ -57,7 +57,7 @@ const _loading = $state(false);
   .placeholder-content {
     background: var(--smrt-color-surface-container-low, #f9fafb);
     border: 1px solid var(--smrt-color-outline-variant, #e2e8f0);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     padding: 2rem;
     text-align: center;
   }

--- a/packages/products/src/lib/features/ProductCatalog.svelte
+++ b/packages/products/src/lib/features/ProductCatalog.svelte
@@ -217,7 +217,7 @@ function _handleCancelForm() {
   .search-input, .category-filter {
     padding: 0.5rem;
     border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.875rem;
   }
   
@@ -235,7 +235,7 @@ function _handleCancelForm() {
     color: var(--smrt-color-on-primary, white);
     border: none;
     padding: 0.5rem 1rem;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-weight: 500;
     cursor: pointer;
     transition: background-color 0.2s;
@@ -263,7 +263,7 @@ function _handleCancelForm() {
     color: var(--smrt-color-on-error, white);
     border: none;
     padding: 0.5rem 1rem;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     cursor: pointer;
   }
 
@@ -282,7 +282,7 @@ function _handleCancelForm() {
   
   .form-container {
     background: white;
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     max-width: 500px;
     width: 90vw;
     max-height: 90vh;

--- a/packages/smrt-svelte/playground/src/routes/ai/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/ai/+page.svelte
@@ -141,7 +141,7 @@ const caps = $derived(app.state.capabilities);
     padding: 8px 16px;
     background: var(--smrt-color-surface-container);
     color: var(--smrt-color-on-surface);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-weight: 600;
   }
 
@@ -164,7 +164,7 @@ const caps = $derived(app.state.capabilities);
   .cap-card {
     background: var(--smrt-color-surface);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     padding: 16px;
   }
 
@@ -212,7 +212,7 @@ const caps = $derived(app.state.capabilities);
     padding: 20px;
     background: var(--smrt-color-surface);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     text-decoration: none;
     transition: all 0.2s;
   }

--- a/packages/smrt-svelte/playground/src/routes/ai/llm/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/ai/llm/+page.svelte
@@ -216,7 +216,7 @@ function clearChat() {
     padding: 4px 8px;
     background: var(--smrt-color-primary-container);
     color: var(--smrt-color-on-primary-container);
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.75rem;
     font-weight: 500;
   }
@@ -225,7 +225,7 @@ function clearChat() {
     padding: 4px 12px;
     background: var(--smrt-color-surface-container);
     border: none;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     color: var(--smrt-color-on-surface-variant);
     cursor: pointer;
     font-size: 0.75rem;
@@ -234,7 +234,7 @@ function clearChat() {
   .chat-container {
     background: var(--smrt-color-surface);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 12px;
+    border-radius: var(--smrt-radius-lg, 12px);
     overflow: hidden;
   }
 
@@ -277,7 +277,7 @@ function clearChat() {
 
   .message-content {
     padding: 12px 16px;
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     background: var(--smrt-color-surface-container);
     line-height: 1.5;
     white-space: pre-wrap;
@@ -308,7 +308,7 @@ function clearChat() {
     flex: 1;
     padding: 12px 16px;
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-size: 0.875rem;
   }
 
@@ -322,7 +322,7 @@ function clearChat() {
     background: var(--smrt-color-primary);
     color: var(--smrt-color-on-primary);
     border: none;
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-weight: 500;
     cursor: pointer;
   }
@@ -337,7 +337,7 @@ function clearChat() {
     text-align: center;
     background: var(--smrt-color-error-container);
     border: 1px solid var(--smrt-color-error);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     color: var(--smrt-color-on-error-container);
   }
 
@@ -366,7 +366,7 @@ function clearChat() {
   .load-btn {
     padding: 8px 16px;
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     background: var(--smrt-color-surface);
     color: var(--smrt-color-on-surface);
     cursor: pointer;

--- a/packages/smrt-svelte/playground/src/routes/ai/pipeline/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/ai/pipeline/+page.svelte
@@ -212,7 +212,7 @@ function clearConversation() {
     padding: 40px;
     background: linear-gradient(135deg, var(--smrt-color-primary-container) 0%, var(--smrt-color-success-container, #f0fdf4) 100%);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 16px;
+    border-radius: var(--smrt-radius-xl, 16px);
   }
 
   .status {
@@ -252,7 +252,7 @@ function clearConversation() {
     padding: 4px 12px;
     background: var(--smrt-color-surface-container);
     border: none;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     color: var(--smrt-color-on-surface-variant);
     cursor: pointer;
     font-size: 0.75rem;
@@ -261,7 +261,7 @@ function clearConversation() {
   .conversation {
     background: var(--smrt-color-surface);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 12px;
+    border-radius: var(--smrt-radius-lg, 12px);
     min-height: 300px;
     padding: 16px;
   }
@@ -291,7 +291,7 @@ function clearConversation() {
   .message-content {
     flex: 1;
     padding: 12px 16px;
-    border-radius: 12px;
+    border-radius: var(--smrt-radius-lg, 12px);
     background: var(--smrt-color-surface-container);
     line-height: 1.5;
     white-space: pre-wrap;
@@ -319,7 +319,7 @@ function clearConversation() {
     text-align: center;
     background: var(--smrt-color-error-container);
     border: 1px solid var(--smrt-color-error);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     color: var(--smrt-color-on-error-container);
   }
 
@@ -331,7 +331,7 @@ function clearConversation() {
     padding: 24px;
     background: var(--smrt-color-surface);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 12px;
+    border-radius: var(--smrt-radius-lg, 12px);
   }
 
   .pipeline-step {
@@ -341,7 +341,7 @@ function clearConversation() {
     gap: 4px;
     padding: 16px 24px;
     background: var(--smrt-color-surface-container);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     transition: all 0.2s;
   }
 

--- a/packages/smrt-svelte/playground/src/routes/ai/stt/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/ai/stt/+page.svelte
@@ -133,7 +133,7 @@ function clearTranscriptions() {
     padding: 40px;
     background: var(--smrt-color-surface);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 12px;
+    border-radius: var(--smrt-radius-lg, 12px);
   }
 
   .status {
@@ -169,7 +169,7 @@ function clearTranscriptions() {
     padding: 4px 12px;
     background: var(--smrt-color-surface-container);
     border: none;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     color: var(--smrt-color-on-surface-variant);
     cursor: pointer;
     font-size: 0.75rem;
@@ -183,7 +183,7 @@ function clearTranscriptions() {
     list-style: none;
     background: var(--smrt-color-surface);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     overflow: hidden;
   }
 
@@ -206,7 +206,7 @@ function clearTranscriptions() {
     text-align: center;
     background: var(--smrt-color-error-container);
     border: 1px solid var(--smrt-color-error);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     color: var(--smrt-color-on-error-container);
   }
 

--- a/packages/smrt-svelte/playground/src/routes/ai/tts/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/ai/tts/+page.svelte
@@ -187,14 +187,14 @@ async function loadVoices() {
     padding: 24px;
     background: var(--smrt-color-surface);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 12px;
+    border-radius: var(--smrt-radius-lg, 12px);
   }
 
   textarea {
     width: 100%;
     padding: 12px;
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-family: inherit;
     font-size: 1rem;
     resize: vertical;
@@ -218,7 +218,7 @@ async function loadVoices() {
     background: var(--smrt-color-primary);
     color: var(--smrt-color-on-primary);
     border: none;
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-size: 1rem;
     font-weight: 500;
     cursor: pointer;
@@ -242,7 +242,7 @@ async function loadVoices() {
     background: var(--smrt-color-surface-container);
     color: var(--smrt-color-on-surface);
     border: none;
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-size: 1rem;
     cursor: pointer;
     transition: all 0.2s;
@@ -259,7 +259,7 @@ async function loadVoices() {
     padding: 24px;
     background: var(--smrt-color-surface);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 12px;
+    border-radius: var(--smrt-radius-lg, 12px);
   }
 
   .setting {
@@ -277,7 +277,7 @@ async function loadVoices() {
   .setting select {
     padding: 8px 12px;
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-size: 0.875rem;
   }
 
@@ -290,7 +290,7 @@ async function loadVoices() {
     padding: 8px 16px;
     background: var(--smrt-color-surface-container);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-size: 0.875rem;
     cursor: pointer;
     align-self: flex-start;
@@ -305,7 +305,7 @@ async function loadVoices() {
     text-align: center;
     background: var(--smrt-color-error-container);
     border: 1px solid var(--smrt-color-error);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     color: var(--smrt-color-on-error-container);
   }
 

--- a/packages/smrt-svelte/playground/src/routes/auth-socket/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/auth-socket/+page.svelte
@@ -157,7 +157,7 @@ function clearMessages() {
 
   .demo-section {
     background: var(--smrt-color-surface-container);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     padding: 20px;
     margin-bottom: 24px;
   }
@@ -217,7 +217,7 @@ function clearMessages() {
   .check {
     background: var(--smrt-color-surface);
     padding: 8px 16px;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     border: 1px solid var(--smrt-color-outline-variant);
   }
 
@@ -235,7 +235,7 @@ function clearMessages() {
 
   button {
     padding: 8px 16px;
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     border: 1px solid var(--smrt-color-outline-variant);
     background: var(--smrt-color-surface);
     cursor: pointer;
@@ -256,7 +256,7 @@ function clearMessages() {
   .message-log {
     margin-top: 20px;
     background: var(--smrt-color-surface-container);
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     padding: 16px;
     color: var(--smrt-color-on-surface-variant);
     font-family: monospace;
@@ -288,7 +288,7 @@ function clearMessages() {
     background: var(--smrt-color-surface-container);
     color: var(--smrt-color-on-surface-variant);
     padding: 16px;
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     overflow-x: auto;
     font-size: 0.875rem;
   }
@@ -300,7 +300,7 @@ function clearMessages() {
   p code {
     background: var(--smrt-color-surface-container-high);
     padding: 2px 6px;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     color: var(--smrt-color-on-surface);
   }
 </style>

--- a/packages/smrt-svelte/playground/src/routes/commerce/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/commerce/+page.svelte
@@ -371,7 +371,7 @@ function handleCreateInvoice(ids: string[]) {
   .invoice-demo {
     background: var(--smrt-color-surface);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     padding: 24px;
     display: flex;
     flex-direction: column;
@@ -391,14 +391,14 @@ function handleCreateInvoice(ids: string[]) {
   .status-controls select {
     padding: 6px 12px;
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.875rem;
   }
 
   .demo-box {
     background: var(--smrt-color-surface-container);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     padding: 16px;
   }
 
@@ -431,7 +431,7 @@ function handleCreateInvoice(ids: string[]) {
   code {
     background: var(--smrt-color-surface-container);
     padding: 2px 6px;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.8rem;
   }
 </style>

--- a/packages/smrt-svelte/playground/src/routes/data/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/data/+page.svelte
@@ -270,7 +270,7 @@ function handleRowClick(row: User) {
   .demo-box {
     background: var(--smrt-color-surface-container);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     padding: 16px;
     margin-bottom: 16px;
     overflow-x: auto;
@@ -293,7 +293,7 @@ function handleRowClick(row: User) {
     background: var(--smrt-color-primary);
     color: var(--smrt-color-on-primary);
     border: none;
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-size: 0.875rem;
     font-weight: 500;
     cursor: pointer;
@@ -325,7 +325,7 @@ function handleRowClick(row: User) {
   code {
     background: var(--smrt-color-surface-container);
     padding: 2px 6px;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.8rem;
   }
 </style>

--- a/packages/smrt-svelte/playground/src/routes/display/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/display/+page.svelte
@@ -364,7 +364,7 @@ const nextWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
   code {
     background: var(--smrt-color-surface-container);
     padding: 2px 6px;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.8rem;
   }
 </style>

--- a/packages/smrt-svelte/playground/src/routes/feedback/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/feedback/+page.svelte
@@ -332,7 +332,7 @@ async function handleLoadingConfirm() {
   .demo-box {
     background: var(--smrt-color-surface-container);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     padding: 16px;
     margin-bottom: 16px;
   }
@@ -365,7 +365,7 @@ async function handleLoadingConfirm() {
     background: var(--smrt-color-primary);
     color: var(--smrt-color-on-primary);
     border: none;
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-size: 0.875rem;
     font-weight: 500;
     cursor: pointer;
@@ -380,7 +380,7 @@ async function handleLoadingConfirm() {
     background: var(--smrt-color-error);
     color: var(--smrt-color-on-error);
     border: none;
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-size: 0.875rem;
     font-weight: 500;
     cursor: pointer;
@@ -395,7 +395,7 @@ async function handleLoadingConfirm() {
     background: var(--smrt-color-surface-container);
     color: var(--smrt-color-on-surface);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-size: 0.875rem;
     font-weight: 500;
     cursor: pointer;
@@ -434,7 +434,7 @@ async function handleLoadingConfirm() {
   code {
     background: var(--smrt-color-surface-container);
     padding: 2px 6px;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.8rem;
   }
 </style>

--- a/packages/smrt-svelte/playground/src/routes/forms/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/forms/+page.svelte
@@ -456,14 +456,14 @@ function handleSearch(value: string) {
     color: var(--smrt-color-on-surface-variant);
     background: var(--smrt-color-surface-container);
     padding: 12px 16px;
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     margin-bottom: 24px;
   }
 
   .control-panel {
     background: linear-gradient(135deg, var(--smrt-color-primary) 0%, var(--smrt-color-tertiary, #764ba2) 100%);
     color: var(--smrt-color-on-primary);
-    border-radius: 12px;
+    border-radius: var(--smrt-radius-lg, 12px);
     padding: 24px;
     margin-bottom: 24px;
   }
@@ -502,7 +502,7 @@ function handleSearch(value: string) {
   .control-group select {
     padding: 10px 12px;
     border: none;
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-size: 0.875rem;
     background: rgba(255, 255, 255, 0.9);
     color: var(--smrt-color-on-surface);
@@ -530,7 +530,7 @@ function handleSearch(value: string) {
     background: rgba(255, 255, 255, 0.2);
     color: var(--smrt-color-on-primary);
     border: 1px solid rgba(255, 255, 255, 0.3);
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-size: 0.875rem;
     cursor: pointer;
     transition: background 0.2s;
@@ -543,7 +543,7 @@ function handleSearch(value: string) {
   .demo-section {
     background: var(--smrt-color-surface);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 12px;
+    border-radius: var(--smrt-radius-lg, 12px);
     padding: 24px;
     margin-bottom: 24px;
   }
@@ -559,7 +559,7 @@ function handleSearch(value: string) {
     background: var(--smrt-color-primary);
     color: var(--smrt-color-on-primary);
     border: none;
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-size: 1rem;
     font-weight: 500;
     cursor: pointer;
@@ -575,7 +575,7 @@ function handleSearch(value: string) {
     padding: 16px;
     background: var(--smrt-color-success-container, #f0fdf4);
     border: 1px solid var(--smrt-color-success, #bbf7d0);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
   }
 
   .submitted-data h3 {
@@ -586,7 +586,7 @@ function handleSearch(value: string) {
   .submitted-data pre {
     background: var(--smrt-color-surface);
     padding: 12px;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.875rem;
     overflow-x: auto;
   }
@@ -633,7 +633,7 @@ function handleSearch(value: string) {
   .feature {
     padding: 16px;
     background: var(--smrt-color-surface-container);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
   }
 
   .feature ul {
@@ -662,7 +662,7 @@ function handleSearch(value: string) {
     font-family: monospace;
     background: var(--smrt-color-surface-container);
     padding: 4px 8px;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     display: inline-block;
     margin-right: 8px;
     margin-bottom: 8px;
@@ -671,7 +671,7 @@ function handleSearch(value: string) {
   .append-toggle {
     padding: 12px;
     background: var(--smrt-color-surface-container);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-size: 0.875rem;
   }
 
@@ -723,7 +723,7 @@ function handleSearch(value: string) {
     margin-top: 12px;
     padding: 12px;
     background: var(--smrt-color-surface-container);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     list-style: none;
   }
 

--- a/packages/smrt-svelte/playground/src/routes/forms/advanced/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/forms/advanced/+page.svelte
@@ -296,7 +296,7 @@ let measureUnit = $state<MeasurementUnit>('ft');
   .demo-box {
     background: var(--smrt-color-surface-container);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     padding: 20px;
     margin-bottom: 16px;
   }
@@ -316,7 +316,7 @@ let measureUnit = $state<MeasurementUnit>('ft');
     font-size: 0.75rem;
     background: var(--smrt-color-surface-container);
     padding: 12px;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     overflow-x: auto;
   }
 
@@ -349,7 +349,7 @@ let measureUnit = $state<MeasurementUnit>('ft');
   code {
     background: var(--smrt-color-surface-container);
     padding: 2px 6px;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.8rem;
   }
 </style>

--- a/packages/smrt-svelte/playground/src/routes/forms/construction/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/forms/construction/+page.svelte
@@ -285,7 +285,7 @@ const totalCost = $derived((laborCost ?? 0) + (materialCost ?? 0));
   .control-panel {
     background: linear-gradient(135deg, var(--smrt-color-success) 0%, var(--smrt-color-success) 100%);
     color: var(--smrt-color-on-success);
-    border-radius: 12px;
+    border-radius: var(--smrt-radius-lg, 12px);
     padding: 24px;
     margin-bottom: 24px;
   }
@@ -308,7 +308,7 @@ const totalCost = $derived((laborCost ?? 0) + (materialCost ?? 0));
     background: rgba(255, 255, 255, 0.2);
     color: var(--smrt-color-on-success);
     border: 1px solid rgba(255, 255, 255, 0.3);
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-size: 0.875rem;
     cursor: pointer;
     transition: background 0.2s;
@@ -321,7 +321,7 @@ const totalCost = $derived((laborCost ?? 0) + (materialCost ?? 0));
   .demo-section {
     background: var(--smrt-color-surface);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 12px;
+    border-radius: var(--smrt-radius-lg, 12px);
     padding: 24px;
     margin-bottom: 24px;
   }
@@ -357,7 +357,7 @@ const totalCost = $derived((laborCost ?? 0) + (materialCost ?? 0));
     margin-top: 16px;
     padding: 12px 16px;
     background: var(--smrt-color-success-container, #f0fdf4);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
   }
 
   .total-label {
@@ -382,7 +382,7 @@ const totalCost = $derived((laborCost ?? 0) + (materialCost ?? 0));
     background: var(--smrt-color-success);
     color: var(--smrt-color-on-success);
     border: none;
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-size: 1rem;
     font-weight: 500;
     cursor: pointer;
@@ -398,7 +398,7 @@ const totalCost = $derived((laborCost ?? 0) + (materialCost ?? 0));
     padding: 16px;
     background: var(--smrt-color-success-container, #f0fdf4);
     border: 1px solid var(--smrt-color-success, #bbf7d0);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
   }
 
   .submitted-data h3 {
@@ -411,7 +411,7 @@ const totalCost = $derived((laborCost ?? 0) + (materialCost ?? 0));
   .submitted-data pre {
     background: var(--smrt-color-surface);
     padding: 12px;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.875rem;
     overflow-x: auto;
   }
@@ -431,7 +431,7 @@ const totalCost = $derived((laborCost ?? 0) + (materialCost ?? 0));
     font-family: monospace;
     background: var(--smrt-color-surface-container);
     padding: 4px 8px;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     display: inline-block;
     margin-right: 8px;
     margin-bottom: 4px;

--- a/packages/smrt-svelte/playground/src/routes/foundation/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/foundation/+page.svelte
@@ -43,7 +43,7 @@ import { Icon, ripple } from '@happyvertical/smrt-svelte';
     color: var(--md-sys-color-on-primary);
     border: none;
     padding: 10px 20px;
-    border-radius: 20px;
+    border-radius: var(--smrt-radius-2xl, 24px);
     cursor: pointer;
   }
   .btn-secondary {
@@ -51,7 +51,7 @@ import { Icon, ripple } from '@happyvertical/smrt-svelte';
     color: var(--md-sys-color-on-secondary-container);
     border: none;
     padding: 10px 20px;
-    border-radius: 20px;
+    border-radius: var(--smrt-radius-2xl, 24px);
     cursor: pointer;
   }
   .surface {
@@ -61,7 +61,7 @@ import { Icon, ripple } from '@happyvertical/smrt-svelte';
     display: flex;
     align-items: center;
     justify-content: center;
-    border-radius: 12px;
+    border-radius: var(--smrt-radius-lg, 12px);
     cursor: pointer;
   }
   .icon-grid {
@@ -76,7 +76,7 @@ import { Icon, ripple } from '@happyvertical/smrt-svelte';
     gap: 8px;
     padding: 16px;
     background: var(--md-sys-color-surface-container-low);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
   }
   .icon-item span {
     font-size: 0.75rem;

--- a/packages/smrt-svelte/playground/src/routes/images/editor/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/images/editor/+page.svelte
@@ -86,7 +86,7 @@ function handleSave(image: any) {
   .success-panel pre {
     background: #000;
     padding: 1rem;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-family: monospace;
     font-size: 0.85rem;
     overflow-x: auto;

--- a/packages/smrt-svelte/playground/src/routes/images/uploader/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/images/uploader/+page.svelte
@@ -114,7 +114,7 @@ function handleSelect(result: any) {
   .json-state {
     background: #000;
     padding: 1rem;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-family: monospace;
     font-size: 0.85rem;
     overflow-x: auto;
@@ -133,7 +133,7 @@ function handleSelect(result: any) {
     background: rgba(34, 197, 94, 0.1);
     color: var(--smrt-color-success, #22c55e);
     padding: 0.75rem;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-weight: 500;
     text-align: center;
     border: 1px solid rgba(34, 197, 94, 0.2);
@@ -141,7 +141,7 @@ function handleSelect(result: any) {
 
   .image-preview {
     margin-top: 1rem;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     overflow: hidden;
     border: 1px dashed var(--smrt-color-outline-variant, #444);
     background: #000;

--- a/packages/smrt-svelte/playground/src/routes/layout/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/layout/+page.svelte
@@ -205,7 +205,7 @@ function handleAction() {
   .demo-box {
     background: var(--smrt-color-surface-container);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     padding: 16px;
     margin-bottom: 16px;
   }
@@ -228,7 +228,7 @@ function handleAction() {
     background: var(--smrt-color-primary);
     color: var(--smrt-color-on-primary);
     border: none;
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-size: 0.875rem;
     font-weight: 500;
     cursor: pointer;
@@ -243,7 +243,7 @@ function handleAction() {
     background: var(--smrt-color-surface);
     color: var(--smrt-color-on-surface);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-size: 0.875rem;
     font-weight: 500;
     cursor: pointer;
@@ -276,7 +276,7 @@ function handleAction() {
   code {
     background: var(--smrt-color-surface-container);
     padding: 2px 6px;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.8rem;
   }
 </style>

--- a/packages/smrt-svelte/playground/src/routes/navigation/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/navigation/+page.svelte
@@ -260,7 +260,7 @@ let activeProjectTab = $state('all');
   .demo-box {
     background: var(--smrt-color-surface-container);
     border: 1px solid var(--smrt-color-outline-variant);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     padding: 16px;
     margin-bottom: 16px;
   }
@@ -281,7 +281,7 @@ let activeProjectTab = $state('all');
     margin-top: 16px;
     padding: 16px;
     background: var(--smrt-color-surface);
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     border: 1px solid var(--smrt-color-outline-variant);
     color: var(--smrt-color-on-surface);
   }
@@ -289,7 +289,7 @@ let activeProjectTab = $state('all');
   .content-panel {
     padding: 16px;
     background: var(--smrt-color-surface);
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     border: 1px solid var(--smrt-color-outline-variant);
   }
 
@@ -328,7 +328,7 @@ let activeProjectTab = $state('all');
   code {
     background: var(--smrt-color-surface-container);
     padding: 2px 6px;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.8rem;
   }
 </style>

--- a/packages/smrt-svelte/playground/src/routes/roles/badge/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/roles/badge/+page.svelte
@@ -128,7 +128,7 @@ const sizes = ['sm', 'md', 'lg'] as const;
   code {
     background: var(--smrt-color-surface-container);
     padding: 2px 6px;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.8rem;
   }
 </style>

--- a/packages/smrt-svelte/playground/src/routes/users/avatar/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/users/avatar/+page.svelte
@@ -149,7 +149,7 @@ const sizes = ['sm', 'md', 'lg', 'xl'] as const;
   code {
     background: var(--smrt-color-surface-container);
     padding: 2px 6px;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.8rem;
   }
 </style>

--- a/packages/smrt-svelte/playground/src/routes/users/card/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/users/card/+page.svelte
@@ -162,7 +162,7 @@ let selectedId = $state<string | null>(null);
   code {
     background: var(--smrt-color-surface-container);
     padding: 2px 6px;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.8rem;
   }
 </style>

--- a/packages/smrt-svelte/src/components/admin/AgentAdminTabs.svelte
+++ b/packages/smrt-svelte/src/components/admin/AgentAdminTabs.svelte
@@ -256,7 +256,7 @@ async function handleSave(config: unknown) {
 		padding: 0.75rem 1rem;
 		background: var(--smrt-color-primary-container, #f0f9ff);
 		border-left: 3px solid var(--smrt-color-primary, #3b82f6);
-		border-radius: 0 6px 6px 0;
+		border-radius: 0 var(--smrt-radius-md, 8px) var(--smrt-radius-md, 8px) 0;
 		font-size: var(--smrt-typography-body-medium-size, 0.875rem);
 		color: var(--smrt-color-on-primary-container, #1e40af);
 	}

--- a/packages/smrt-svelte/src/components/admin/AgentSettingsShell.svelte
+++ b/packages/smrt-svelte/src/components/admin/AgentSettingsShell.svelte
@@ -164,7 +164,7 @@ async function handleSave(slotId: string, config: unknown) {
 		padding: 0.625rem 0.75rem;
 		border: none;
 		background: transparent;
-		border-radius: 6px;
+		border-radius: var(--smrt-radius-md, 8px);
 		cursor: pointer;
 		text-align: left;
 		width: 100%;
@@ -229,7 +229,7 @@ async function handleSave(slotId: string, config: unknown) {
 		text-align: center;
 		background: var(--smrt-color-surface-variant);
 		border: 1px dashed var(--smrt-color-outline-variant);
-		border-radius: 8px;
+		border-radius: var(--smrt-radius-md, 8px);
 		min-height: 300px;
 	}
 

--- a/packages/smrt-svelte/src/components/data/DataTable.svelte
+++ b/packages/smrt-svelte/src/components/data/DataTable.svelte
@@ -466,7 +466,7 @@ const sizeClasses = {
     height: 20px;
     border: 2px solid var(--smrt-color-outline-variant, #e5e7eb);
     border-top-color: var(--smrt-color-primary, #3b82f6);
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     animation: spin 0.8s linear infinite;
   }
 

--- a/packages/smrt-svelte/src/components/display/ConfidenceBadge.svelte
+++ b/packages/smrt-svelte/src/components/display/ConfidenceBadge.svelte
@@ -104,7 +104,7 @@ const valueText = $derived(
     padding: 0.25rem 0.5rem;
     font-size: 0.75rem;
     font-weight: 500;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     background-color: var(--badge-bg);
     color: var(--badge-text);
     position: relative;

--- a/packages/smrt-svelte/src/components/feedback/ConfirmDialog.svelte
+++ b/packages/smrt-svelte/src/components/feedback/ConfirmDialog.svelte
@@ -113,7 +113,7 @@ function handleKeydown(e: KeyboardEvent) {
 
   .dialog-content {
     background-color: var(--smrt-color-surface-container-high);
-    border-radius: 28px;
+    border-radius: var(--smrt-radius-3xl, 32px);
     padding: var(--smrt-spacing-6, 24px);
     max-width: 400px;
     width: 100%;
@@ -162,7 +162,7 @@ function handleKeydown(e: KeyboardEvent) {
     padding: 0 var(--smrt-spacing-6, 24px);
     font: var(--smrt-typography-label-large-font);
     font-weight: 500;
-    border-radius: 20px;
+    border-radius: var(--smrt-radius-2xl, 24px);
     cursor: pointer;
     transition: all var(--smrt-duration-short3, 200ms) var(--smrt-easing-standard, ease);
     border: none;
@@ -205,7 +205,7 @@ function handleKeydown(e: KeyboardEvent) {
     height: 18px;
     border: 2px solid transparent;
     border-top-color: currentColor;
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     animation: spin 0.8s linear infinite;
   }
 

--- a/packages/smrt-svelte/src/components/feedback/LoadingOverlay.svelte
+++ b/packages/smrt-svelte/src/components/feedback/LoadingOverlay.svelte
@@ -146,7 +146,7 @@ function handleKeydown(e: KeyboardEvent) {
 	.overlay-content {
 		position: relative;
 		background: var(--smrt-color-surface-container-high, white);
-		border-radius: 16px;
+		border-radius: var(--smrt-radius-xl, 16px);
 		padding: var(--smrt-spacing-8, 32px) var(--smrt-spacing-10, 40px);
 		max-width: 400px;
 		width: 90%;
@@ -201,7 +201,7 @@ function handleKeydown(e: KeyboardEvent) {
 		flex: 1;
 		height: 8px;
 		background: var(--smrt-color-surface-container-highest, #e5e7eb);
-		border-radius: 4px;
+		border-radius: var(--smrt-radius-sm, 4px);
 		overflow: hidden;
 	}
 
@@ -212,7 +212,7 @@ function handleKeydown(e: KeyboardEvent) {
 			var(--smrt-color-primary),
 			color-mix(in srgb, var(--smrt-color-primary) 70%, white)
 		);
-		border-radius: 4px;
+		border-radius: var(--smrt-radius-sm, 4px);
 		transition: width var(--smrt-duration-short4, 300ms) var(--smrt-easing-standard, ease);
 	}
 
@@ -234,7 +234,7 @@ function handleKeydown(e: KeyboardEvent) {
 	.item-badge {
 		font-size: 0.75rem;
 		padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-3, 12px);
-		border-radius: 9999px;
+		border-radius: var(--smrt-radius-full, 9999px);
 		background: var(--smrt-color-primary-container, #dcfce7);
 		color: var(--smrt-color-on-primary-container, #166534);
 	}
@@ -245,7 +245,7 @@ function handleKeydown(e: KeyboardEvent) {
 		margin: var(--smrt-spacing-4, 16px) 0 0;
 		padding: var(--smrt-spacing-3, 12px);
 		background: var(--smrt-color-error-container, #fef2f2);
-		border-radius: 8px;
+		border-radius: var(--smrt-radius-md, 8px);
 	}
 
 	.dismiss-btn {
@@ -255,7 +255,7 @@ function handleKeydown(e: KeyboardEvent) {
 		color: var(--smrt-color-on-surface-variant, #6b7280);
 		background: transparent;
 		border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
-		border-radius: 8px;
+		border-radius: var(--smrt-radius-md, 8px);
 		cursor: pointer;
 		transition: all var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
 	}

--- a/packages/smrt-svelte/src/components/feedback/ProgressBar.svelte
+++ b/packages/smrt-svelte/src/components/feedback/ProgressBar.svelte
@@ -126,7 +126,7 @@ const displayLabel = $derived.by(() => {
     width: 100%;
     height: 4px;
     background-color: var(--smrt-color-surface-container-highest, #e0e2ec);
-    border-radius: 2px;
+    border-radius: var(--smrt-radius-sm, 4px);
     overflow: hidden;
   }
 
@@ -136,7 +136,7 @@ const displayLabel = $derived.by(() => {
 
   .lg .progress-track {
     height: 8px;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
   }
 
   .progress-bar {

--- a/packages/smrt-svelte/src/components/forms/CheckboxInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/CheckboxInput.svelte
@@ -127,7 +127,7 @@ function handleChange(e: Event) {
     display: flex;
     align-items: center;
     justify-content: center;
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     margin: -10px; /* Offset the 40x40 container to align 18x18 checkbox */
   }
 
@@ -145,7 +145,7 @@ function handleChange(e: Event) {
     width: 18px;
     height: 18px;
     border: 2px solid var(--smrt-color-on-surface-variant);
-    border-radius: 2px;
+    border-radius: var(--smrt-radius-sm, 4px);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -196,7 +196,7 @@ function handleChange(e: Event) {
     left: 0;
     right: 0;
     bottom: 0;
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     pointer-events: none;
     transition: opacity var(--smrt-duration-short3, 200ms) var(--smrt-easing-standard, ease);
   }

--- a/packages/smrt-svelte/src/components/forms/DateRangeInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/DateRangeInput.svelte
@@ -534,7 +534,7 @@ const primaryControlId = $derived(isSmrt ? `${name}_voice` : `${name}_start`);
     justify-content: center;
     background: transparent;
     border: none;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     color: var(--smrt-color-on-surface-variant);
     cursor: pointer;
     transition: all var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);

--- a/packages/smrt-svelte/src/components/forms/DateTimeInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/DateTimeInput.svelte
@@ -459,7 +459,7 @@ function handleNativeChange(e: Event) {
     justify-content: center;
     background: transparent;
     border: none;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     color: var(--smrt-color-on-surface-variant, #6b7280);
     cursor: pointer;
     transition: all var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);

--- a/packages/smrt-svelte/src/components/forms/FileUpload.svelte
+++ b/packages/smrt-svelte/src/components/forms/FileUpload.svelte
@@ -339,7 +339,7 @@ function formatFileSize(bytes: number): string {
     height: 28px;
     padding: 0;
     border: none;
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #49454f);
     cursor: pointer;

--- a/packages/smrt-svelte/src/components/forms/Form.svelte
+++ b/packages/smrt-svelte/src/components/forms/Form.svelte
@@ -647,7 +647,7 @@ function getFormData(): Record<string, unknown> {
     display: flex;
     background: var(--smrt-color-surface-container-high, #f3f4f6);
     padding: var(--smrt-spacing-1, 4px);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
   }
 
   .mode-btn {
@@ -655,7 +655,7 @@ function getFormData(): Record<string, unknown> {
     border: none;
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #6b7280);
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     cursor: pointer;
     font-size: 0.875rem;
     font-weight: 500;
@@ -680,7 +680,7 @@ function getFormData(): Record<string, unknown> {
     border: 2px solid var(--smrt-color-primary, #3b82f6);
     background: var(--smrt-color-surface);
     color: var(--smrt-color-primary);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     cursor: pointer;
     font-size: 0.875rem;
     font-weight: 500;
@@ -771,7 +771,7 @@ function getFormData(): Record<string, unknown> {
     padding: var(--smrt-spacing-3, 12px) var(--smrt-spacing-4, 16px);
     background: var(--smrt-color-error-container);
     border: 1px solid var(--smrt-color-error);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     font-size: 0.875rem;
     color: var(--smrt-color-error);
   }

--- a/packages/smrt-svelte/src/components/forms/PhoneInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/PhoneInput.svelte
@@ -405,7 +405,7 @@ function handleInput(e: Event) {
     justify-content: center;
     background: transparent;
     border: none;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     color: var(--smrt-color-on-surface-variant, #6b7280);
     cursor: pointer;
     transition: all 0.2s;
@@ -452,7 +452,7 @@ function handleInput(e: Event) {
     width: 8px;
     height: 8px;
     background: var(--smrt-color-success);
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     animation: pulse-dot 1s ease-in-out infinite;
   }
 
@@ -496,7 +496,7 @@ function handleInput(e: Event) {
     height: 12px;
     border: 2px solid var(--smrt-color-outline-variant);
     border-top-color: var(--smrt-color-primary);
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     animation: spin 0.8s linear infinite;
   }
 

--- a/packages/smrt-svelte/src/components/forms/SelectInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/SelectInput.svelte
@@ -157,7 +157,7 @@ function handleChange(e: Event) {
     display: flex;
     align-items: center;
     background-color: var(--field-bg);
-    border-radius: 4px 4px 0 0;
+    border-radius: var(--smrt-radius-sm, 4px) var(--smrt-radius-sm, 4px) 0 0;
     min-height: 56px;
     padding: 0 var(--smrt-spacing-4, 16px);
     transition: background-color var(--smrt-duration-short3, 200ms) var(--smrt-easing-standard, cubic-bezier(0.2, 0, 0, 1));

--- a/packages/smrt-svelte/src/components/forms/TextInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/TextInput.svelte
@@ -293,7 +293,7 @@ function handleInput(e: Event) {
     display: flex;
     align-items: center;
     background-color: var(--field-bg);
-    border-radius: 4px 4px 0 0;
+    border-radius: var(--smrt-radius-sm, 4px) var(--smrt-radius-sm, 4px) 0 0;
     min-height: 56px;
     padding: 0 var(--smrt-spacing-4, 16px);
     transition: background-color var(--smrt-duration-short3, 200ms) var(--smrt-easing-standard, cubic-bezier(0.2, 0, 0, 1));
@@ -369,7 +369,7 @@ function handleInput(e: Event) {
     border: none;
     background: transparent;
     color: var(--field-color);
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     cursor: pointer;
     margin-right: -8px;
     transition: all 200ms;

--- a/packages/smrt-svelte/src/components/forms/TextareaInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/TextareaInput.svelte
@@ -268,7 +268,7 @@ function handleInput(e: Event) {
     display: flex;
     align-items: flex-start;
     background-color: var(--field-bg);
-    border-radius: 4px 4px 0 0;
+    border-radius: var(--smrt-radius-sm, 4px) var(--smrt-radius-sm, 4px) 0 0;
     min-height: 56px;
     padding: 0 var(--smrt-spacing-4, 16px);
     transition: background-color var(--smrt-duration-short3, 200ms) var(--smrt-easing-standard, cubic-bezier(0.2, 0, 0, 1));
@@ -344,7 +344,7 @@ function handleInput(e: Event) {
     border: none;
     background: transparent;
     color: var(--field-color);
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     cursor: pointer;
     margin-right: -8px;
     margin-top: var(--smrt-spacing-2, 8px);

--- a/packages/smrt-svelte/src/components/layout/EmptyState.svelte
+++ b/packages/smrt-svelte/src/components/layout/EmptyState.svelte
@@ -116,7 +116,7 @@ const icons = {
     margin-bottom: 2rem;
     background-color: var(--smrt-color-secondary-container);
     color: var(--smrt-color-on-secondary-container);
-    border-radius: 28px; /* M3 extra large shape */
+    border-radius: var(--smrt-radius-3xl, 32px); /* M3 extra large shape */
     padding: var(--smrt-spacing-6, 24px);
   }
 
@@ -124,7 +124,7 @@ const icons = {
     width: 64px;
     height: 64px;
     margin-bottom: 1.5rem;
-    border-radius: 16px;
+    border-radius: var(--smrt-radius-xl, 16px);
     padding: var(--smrt-spacing-4, 16px);
   }
 
@@ -132,7 +132,7 @@ const icons = {
     width: 120px;
     height: 120px;
     margin-bottom: 2.5rem;
-    border-radius: 32px;
+    border-radius: var(--smrt-radius-3xl, 32px);
     padding: var(--smrt-spacing-8, 32px);
   }
 
@@ -171,7 +171,7 @@ const icons = {
     color: var(--smrt-color-on-primary);
     background-color: var(--smrt-color-primary);
     border: none;
-    border-radius: 20px;
+    border-radius: var(--smrt-radius-2xl, 24px);
     text-decoration: none;
     cursor: pointer;
     transition: box-shadow 200ms, background-color 200ms;

--- a/packages/smrt-svelte/src/components/layout/PageHeader.svelte
+++ b/packages/smrt-svelte/src/components/layout/PageHeader.svelte
@@ -95,7 +95,7 @@ const {
     text-decoration: none;
     margin-bottom: 0.75rem;
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px) var(--smrt-spacing-1, 4px) var(--smrt-spacing-1, 4px);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     margin-left: -4px; /* Align icon with text below */
     transition: background-color 200ms;
   }

--- a/packages/smrt-svelte/src/components/layout/SummaryCard.svelte
+++ b/packages/smrt-svelte/src/components/layout/SummaryCard.svelte
@@ -112,7 +112,7 @@ const isSvg = $derived(icon?.startsWith('<svg'));
     gap: 1rem;
     padding: 1rem 1.25rem;
     background-color: var(--smrt-color-surface-container-low);
-    border-radius: 12px;
+    border-radius: var(--smrt-radius-lg, 12px);
     text-decoration: none;
     color: var(--smrt-color-on-surface);
     transition: all 200ms cubic-bezier(0.2, 0, 0, 1);
@@ -138,7 +138,7 @@ const isSvg = $derived(icon?.startsWith('<svg'));
     width: 3rem;
     height: 3rem;
     background-color: var(--smrt-color-surface-container-high);
-    border-radius: 12px;
+    border-radius: var(--smrt-radius-lg, 12px);
     color: var(--smrt-color-primary);
     flex-shrink: 0;
   }
@@ -178,7 +178,7 @@ const isSvg = $derived(icon?.startsWith('<svg'));
     font: var(--smrt-typography-label-small-font);
     background-color: var(--smrt-color-primary);
     color: var(--smrt-color-on-primary);
-    border-radius: 9999px;
+    border-radius: var(--smrt-radius-full, 9999px);
   }
 
   .card-value {

--- a/packages/smrt-svelte/src/components/memberships/MembershipCard.svelte
+++ b/packages/smrt-svelte/src/components/memberships/MembershipCard.svelte
@@ -92,7 +92,7 @@ function formatDate(date: Date | string | null | undefined): string {
   .status {
     font-size: 0.625rem;
     padding: 0.125rem 0.375rem;
-    border-radius: 9999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     text-transform: uppercase;
     font-weight: 600;
   }

--- a/packages/smrt-svelte/src/components/memberships/MembershipList.svelte
+++ b/packages/smrt-svelte/src/components/memberships/MembershipList.svelte
@@ -74,7 +74,7 @@ const {
     height: 1.25rem;
     border: 2px solid var(--smrt-color-outline-variant);
     border-top-color: var(--smrt-color-primary);
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     animation: spin 0.6s linear infinite;
   }
 

--- a/packages/smrt-svelte/src/components/nav/FilterChips.svelte
+++ b/packages/smrt-svelte/src/components/nav/FilterChips.svelte
@@ -98,7 +98,7 @@ function handleClick(value: string) {
     color: var(--smrt-color-on-surface-variant);
     background-color: transparent;
     border: 1px solid var(--smrt-color-outline);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     cursor: pointer;
     transition: all 200ms cubic-bezier(0.2, 0, 0, 1);
     white-space: nowrap;

--- a/packages/smrt-svelte/src/components/nav/Tabs.svelte
+++ b/packages/smrt-svelte/src/components/nav/Tabs.svelte
@@ -229,7 +229,7 @@ function handleKeydown(event: KeyboardEvent, tabId: string) {
     bottom: 0;
     height: 3px;
     background-color: var(--smrt-color-primary);
-    border-radius: 3px 3px 0 0;
+    border-radius: var(--smrt-radius-sm, 4px) var(--smrt-radius-sm, 4px) 0 0;
     transition: width 200ms, opacity 200ms;
     width: 0;
     opacity: 0;

--- a/packages/smrt-svelte/src/components/roles/RoleBadge.svelte
+++ b/packages/smrt-svelte/src/components/roles/RoleBadge.svelte
@@ -42,7 +42,7 @@ const variantClass = $derived.by(() => {
     height: 24px;
     font: var(--smrt-typography-label-large-font);
     font-weight: 600;
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     white-space: nowrap;
     transition: all 200ms cubic-bezier(0.2, 0, 0, 1);
   }

--- a/packages/smrt-svelte/src/components/roles/RoleSelector.svelte
+++ b/packages/smrt-svelte/src/components/roles/RoleSelector.svelte
@@ -204,7 +204,7 @@ function handleKeydown(e: KeyboardEvent) {
     padding: 0.125rem 0.375rem;
     background: var(--smrt-color-primary-container, #dbeafe);
     color: var(--smrt-color-on-primary-container, #1e40af);
-    border-radius: 9999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     text-transform: uppercase;
     font-weight: 600;
   }

--- a/packages/smrt-svelte/src/components/ui/Button.svelte
+++ b/packages/smrt-svelte/src/components/ui/Button.svelte
@@ -190,7 +190,7 @@ const linkProps = $derived(() => {
     height: 1em;
     border: 2px solid currentColor;
     border-right-color: transparent;
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     animation: spin 0.75s linear infinite;
   }
 

--- a/packages/smrt-svelte/src/components/workspace/Breadcrumbs.svelte
+++ b/packages/smrt-svelte/src/components/workspace/Breadcrumbs.svelte
@@ -127,7 +127,7 @@ const lastIndex = $derived(crumbs.length - 1);
   .crumb-link:focus-visible {
     outline: 2px solid var(--smrt-color-primary);
     outline-offset: 2px;
-    border-radius: 2px;
+    border-radius: var(--smrt-radius-sm, 4px);
   }
 
   @media (max-width: 640px) {

--- a/packages/smrt-svelte/src/components/workspace/NavTree.svelte
+++ b/packages/smrt-svelte/src/components/workspace/NavTree.svelte
@@ -277,7 +277,7 @@ function navChildrenId(href: string): string {
     font-size: 0.7rem;
     font-weight: 600;
     line-height: 1.2;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-secondary-container);
     color: var(--smrt-color-on-secondary-container);
   }

--- a/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
@@ -658,7 +658,7 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
   .mode-dot {
     width: 0.55rem;
     height: 0.55rem;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-on-surface-variant, #9ca3af);
     flex-shrink: 0;
   }

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
@@ -344,7 +344,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-primary, #7dd3fc);
     color: var(--smrt-color-on-primary, #061014);
     font-size: 0.58rem;

--- a/packages/social/src/svelte/components/SocialAccountSettings.svelte
+++ b/packages/social/src/svelte/components/SocialAccountSettings.svelte
@@ -151,7 +151,7 @@ function statusLabel(account: SocialAccountSettingsItem): string {
 
   .account-row {
     border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     background: var(--smrt-color-surface, #fff);
     padding: 1rem;
   }
@@ -164,7 +164,7 @@ function statusLabel(account: SocialAccountSettingsItem): string {
 
   .account-title span,
   .status {
-    border-radius: 999px;
+    border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-surface-container, #f3f4f6);
     color: var(--smrt-color-on-surface-variant, #4b5563);
     font-size: 0.75rem;
@@ -188,7 +188,7 @@ function statusLabel(account: SocialAccountSettingsItem): string {
   button,
   a {
     border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
-    border-radius: 6px;
+    border-radius: var(--smrt-radius-md, 8px);
     background: var(--smrt-color-surface, #fff);
     color: var(--smrt-color-on-surface, #111827);
     cursor: pointer;
@@ -220,7 +220,7 @@ function statusLabel(account: SocialAccountSettingsItem): string {
 
   .empty {
     border: 1px dashed var(--smrt-color-outline-variant, #d1d5db);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     color: var(--smrt-color-on-surface-variant, #6b7280);
     padding: 1.25rem;
     text-align: center;

--- a/packages/subscriptions/src/svelte/PlanPicker.svelte
+++ b/packages/subscriptions/src/svelte/PlanPicker.svelte
@@ -50,7 +50,7 @@ let {
     align-items: flex-start;
     background: var(--smrt-surface, #fff);
     border: 1px solid var(--smrt-border, #d8dde6);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     color: inherit;
     cursor: pointer;
     display: grid;

--- a/packages/subscriptions/src/svelte/UsageThresholds.svelte
+++ b/packages/subscriptions/src/svelte/UsageThresholds.svelte
@@ -39,7 +39,7 @@ let {
 
   .smrt-usage-thresholds__row {
     border: 1px solid var(--smrt-border, #d8dde6);
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
     display: grid;
     gap: 0.45rem;
     padding: 0.875rem;

--- a/packages/template-sveltekit/template/src/routes/+page.svelte
+++ b/packages/template-sveltekit/template/src/routes/+page.svelte
@@ -75,7 +75,7 @@
     margin: 2rem 0;
     padding: 1rem;
     background: #f5f5f5;
-    border-radius: 8px;
+    border-radius: var(--smrt-radius-md, 8px);
   }
 
   .error {
@@ -86,14 +86,14 @@
     font-size: 0.8em;
     background: #e0e0e0;
     padding: 2px 8px;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     margin-left: 8px;
   }
 
   code {
     background: #e0e0e0;
     padding: 2px 6px;
-    border-radius: 4px;
+    border-radius: var(--smrt-radius-sm, 4px);
     font-size: 0.9em;
   }
 

--- a/packages/tenancy/src/svelte/components/TenantCard.svelte
+++ b/packages/tenancy/src/svelte/components/TenantCard.svelte
@@ -135,7 +135,7 @@ function getColor(name: string): string {
     gap: var(--smrt-spacing-4, 16px);
     padding: var(--smrt-spacing-4, 16px);
     background-color: var(--smrt-color-surface-container-low);
-    border-radius: 12px;
+    border-radius: var(--smrt-radius-lg, 12px);
     color: var(--smrt-color-on-surface);
     transition: all 200ms cubic-bezier(0.2, 0, 0, 1);
     position: relative;
@@ -163,7 +163,7 @@ function getColor(name: string): string {
     justify-content: center;
     width: 48px;
     height: 48px;
-    border-radius: 12px;
+    border-radius: var(--smrt-radius-lg, 12px);
     color: white;
     font: var(--smrt-typography-title-medium-font);
     font-weight: 600;
@@ -195,7 +195,7 @@ function getColor(name: string): string {
     height: 18px;
     display: inline-flex;
     align-items: center;
-    border-radius: 9px;
+    border-radius: var(--smrt-radius-md, 8px);
     text-transform: uppercase;
     font-weight: 600;
     flex-shrink: 0;
@@ -250,7 +250,7 @@ function getColor(name: string): string {
     height: 32px;
     background: transparent;
     border: none;
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     cursor: pointer;
     color: var(--smrt-color-on-surface-variant);
     position: relative;

--- a/packages/users/src/svelte/components/UserCard.svelte
+++ b/packages/users/src/svelte/components/UserCard.svelte
@@ -75,7 +75,7 @@ const statusClass = $derived.by(() => {
     gap: var(--smrt-spacing-4, 16px);
     padding: var(--smrt-spacing-3, 12px) var(--smrt-spacing-4, 16px);
     background-color: var(--smrt-color-surface-container-low);
-    border-radius: 12px;
+    border-radius: var(--smrt-radius-lg, 12px);
     width: 100%;
     text-align: left;
     cursor: default;
@@ -142,7 +142,7 @@ const statusClass = $derived.by(() => {
     align-items: center;
     background-color: var(--smrt-color-surface-container-highest);
     color: var(--smrt-color-on-surface-variant);
-    border-radius: 10px;
+    border-radius: var(--smrt-radius-lg, 12px);
     text-transform: capitalize;
   }
 
@@ -152,7 +152,7 @@ const statusClass = $derived.by(() => {
     height: 20px;
     display: inline-flex;
     align-items: center;
-    border-radius: 10px;
+    border-radius: var(--smrt-radius-lg, 12px);
     text-transform: capitalize;
     font-weight: 600;
   }

--- a/packages/users/src/svelte/components/UserList.svelte
+++ b/packages/users/src/svelte/components/UserList.svelte
@@ -76,7 +76,7 @@ const {
     height: 1.25rem;
     border: 2px solid var(--smrt-color-outline-variant, #c4c6cf);
     border-top-color: var(--smrt-color-primary, #005ac1);
-    border-radius: 50%;
+    border-radius: var(--smrt-radius-full, 9999px);
     animation: spin 0.6s linear infinite;
   }
 

--- a/packages/users/src/svelte/components/UserMenu.svelte
+++ b/packages/users/src/svelte/components/UserMenu.svelte
@@ -191,7 +191,7 @@ function getInitials(name: string): string {
     padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
     background: transparent;
     border: none;
-    border-radius: 20px;
+    border-radius: var(--smrt-radius-2xl, 24px);
     cursor: pointer;
     transition: background-color var(--smrt-duration-short3, 200ms) var(--smrt-easing-standard, ease);
     color: var(--smrt-color-on-surface);

--- a/scripts/check-radius.mjs
+++ b/scripts/check-radius.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+/**
+ * Raw border-radius ratchet for SMRT UI packages.
+ *
+ * Bans hardcoded `px`/`%` values in `border-radius` (and its longhands) inside
+ * CSS contexts of `.svelte` and `.css` files, steering authors to the named
+ * `--smrt-radius-*` scale (issue #1373, parent epic #1354). Policy: SNAP TO
+ * SCALE — every radius maps to its nearest `--smrt-radius-*` token. Pill/circle
+ * values (`%`, or large px like `999px`/`9999px`) map to `--smrt-radius-full`.
+ *
+ * Scale (px @16px root): none=0, sm=4, md=8, lg=12, xl=16, 2xl=24, 3xl=32,
+ * full=9999 (pill/circle). For each violation the check prints the suggested
+ * token so migration is mechanical.
+ *
+ * Allowed (never flagged): `var(--smrt-radius-*, <fallback>)`, `0` (unitless),
+ * any value inside `calc(...)`, and `<script>`/markup/comments.
+ *
+ * Phased rollout: strict (ERROR) for STRICT_PACKAGES; report-only elsewhere.
+ * Run: `node scripts/check-radius.mjs` or `pnpm check:radius`.  Exit 0/1.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative, resolve, sep } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const PACKAGES = join(ROOT, 'packages');
+
+/** Packages held to ERROR. Everything else is report-only for now (#1373). */
+const STRICT_PACKAGES = new Set([
+  'smrt-svelte',
+  'content',
+  'messages',
+  'products',
+  'images',
+  'chat',
+  'assets',
+  'users',
+  'tenancy',
+  'social',
+  'analytics',
+  'subscriptions',
+  'events',
+  'agents',
+]);
+
+/** Dev/playground hosts skipped entirely (matches the other token ratchets). */
+const SCOPE_EXCLUDED_PACKAGES = new Set(['smrt-playground']);
+
+/** Named radius scale as [px@16root, name]; `full` handled separately. */
+const RADIUS_TOKENS = [
+  [0, 'none'],
+  [4, 'sm'],
+  [8, 'md'],
+  [12, 'lg'],
+  [16, 'xl'],
+  [24, '2xl'],
+  [32, '3xl'],
+];
+/** px at/above this (or any `%`) is a pill/circle → `full`. */
+const FULL_THRESHOLD = 40;
+
+/** Snap a radius value (e.g. "8px", "50%", "999px") to a --smrt-radius-* token. */
+function snap(raw) {
+  if (raw.endsWith('%')) return 'var(--smrt-radius-full, 9999px)';
+  const px = Number.parseInt(raw, 10);
+  if (px >= FULL_THRESHOLD) return 'var(--smrt-radius-full, 9999px)';
+  let best = RADIUS_TOKENS[0];
+  let bestDist = Number.POSITIVE_INFINITY;
+  for (const [v, n] of RADIUS_TOKENS) {
+    const d = Math.abs(v - px);
+    if (d < bestDist || (d === bestDist && v > best[0])) {
+      best = [v, n];
+      bestDist = d;
+    }
+  }
+  if (px > 0 && best[1] === 'none') best = [4, 'sm']; // keep a small radius
+  return `var(--smrt-radius-${best[1]}, ${best[0]}px)`;
+}
+
+function listFiles(dir, exts) {
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+      out.push(...listFiles(full, exts));
+    } else if (exts.some((e) => entry.name.endsWith(e))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function toPosix(p) {
+  return p.split(sep).join('/');
+}
+function packageNameOf(relPath) {
+  return relPath.split(sep)[0];
+}
+function isInPackageSrc(relPath) {
+  const parts = toPosix(relPath).split('/');
+  return parts.length > 1 && parts[1] === 'src';
+}
+
+/** Keep only `<style>` block contents for `.svelte` (blank script + markup). */
+function extractStyleBlocks(source) {
+  const out = source.replace(/[^\n]/g, ' ').split('');
+  const re = /(<style\b[^>]*>)([\s\S]*?)(<\/style>)/gi;
+  for (const m of source.matchAll(re)) {
+    const innerStart = m.index + m[1].length;
+    const inner = m[2];
+    for (let k = 0; k < inner.length; k++) out[innerStart + k] = inner[k];
+  }
+  return out.join('');
+}
+
+function stripComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, (block) => block.replace(/[^\n]/g, ' '))
+    .replace(/(^|[^:])\/\/[^\n]*/g, (m, lead) =>
+      lead + ' '.repeat(m.length - lead.length),
+    );
+}
+
+/** Blank `calc(...)` and `var(--smrt-radius-*, ...)`; NOT other var() (bypass). */
+function stripAllowedCalls(source) {
+  let out = '';
+  let i = 0;
+  while (i < source.length) {
+    const isCalc = source.startsWith('calc(', i);
+    const isRadiusVar = /^var\(\s*--smrt-radius-/.test(source.slice(i, i + 22));
+    if (isCalc || isRadiusVar) {
+      const start = source.indexOf('(', i);
+      let depth = 0;
+      let j = start;
+      for (; j < source.length; j++) {
+        const ch = source[j];
+        if (ch === '(') depth++;
+        else if (ch === ')') {
+          depth--;
+          if (depth === 0) {
+            j++;
+            break;
+          }
+        }
+      }
+      out += source.slice(i, j).replace(/[^\n]/g, ' ');
+      i = j;
+    } else {
+      out += source[i];
+      i += 1;
+    }
+  }
+  return out;
+}
+
+const RADIUS_PROP_RE =
+  /\bborder(?:-(?:top|bottom|start|end)-(?:left|right|start|end))?-radius\s*:\s*([^;}]+)/gi;
+const VAL_RE = /(?<![\d.\-])(\d+(?:px)?%?|\d+px)/gi;
+
+function findViolations(file, source) {
+  let text = file.endsWith('.svelte') ? extractStyleBlocks(source) : source;
+  text = stripComments(text);
+  text = stripAllowedCalls(text);
+  const lines = text.split('\n');
+  const hits = [];
+  lines.forEach((line, i) => {
+    for (const decl of line.matchAll(RADIUS_PROP_RE)) {
+      const value = decl[1];
+      for (const v of value.matchAll(/(?<![\d.\-])(\d+)(px|%)/gi)) {
+        const n = Number(v[1]);
+        if (v[2] === 'px' && n === 0) continue;
+        hits.push({
+          line: i + 1,
+          value: `${v[0]} → ${snap(v[0])}`,
+          snippet: line.trim().slice(0, 100),
+        });
+      }
+    }
+  });
+  return hits;
+}
+
+const files = listFiles(PACKAGES, ['.svelte', '.css']);
+const strictViolations = [];
+const reportOnly = new Map();
+
+for (const file of files) {
+  const relPath = relative(PACKAGES, file);
+  if (!isInPackageSrc(relPath)) continue;
+  const pkg = packageNameOf(relPath);
+  if (SCOPE_EXCLUDED_PACKAGES.has(pkg)) continue;
+  const hits = findViolations(file, readFileSync(file, 'utf8'));
+  if (hits.length === 0) continue;
+  if (STRICT_PACKAGES.has(pkg)) strictViolations.push({ file: relPath, hits });
+  else reportOnly.set(pkg, (reportOnly.get(pkg) ?? 0) + hits.length);
+}
+
+if (reportOnly.size > 0) {
+  const total = [...reportOnly.values()].reduce((a, b) => a + b, 0);
+  console.warn(
+    `⚠ radius-check: ${total} raw border-radius value(s) in report-only ` +
+      'package(s) (not failing — later phases of #1373):',
+  );
+  for (const [pkg, count] of [...reportOnly.entries()].sort((a, b) => b[1] - a[1])) {
+    console.warn(`    ${pkg}: ${count}`);
+  }
+}
+
+if (strictViolations.length > 0) {
+  const total = strictViolations.reduce((n, v) => n + v.hits.length, 0);
+  console.error(
+    `\n✗ radius-check: ${total} raw border-radius value(s) in strict ` +
+      `package(s): ${[...STRICT_PACKAGES].join(', ')}`,
+  );
+  for (const { file, hits } of strictViolations) {
+    console.error(`  ${file}`);
+    for (const h of hits) console.error(`    L${h.line}: ${h.value}   | ${h.snippet}`);
+  }
+  console.error('\nSnap each radius to the suggested --smrt-radius-* token.');
+  process.exit(1);
+}
+
+console.log(
+  `✓ radius-check: no raw border-radius in strict package(s): ${[
+    ...STRICT_PACKAGES,
+  ].join(', ')}`,
+);

--- a/scripts/check-radius.mjs
+++ b/scripts/check-radius.mjs
@@ -162,7 +162,6 @@ function stripAllowedCalls(source) {
 
 const RADIUS_PROP_RE =
   /\bborder(?:-(?:top|bottom|start|end)-(?:left|right|start|end))?-radius\s*:\s*([^;}]+)/gi;
-const VAL_RE = /(?<![\d.\-])(\d+(?:px)?%?|\d+px)/gi;
 
 function findViolations(file, source) {
   let text = file.endsWith('.svelte') ? extractStyleBlocks(source) : source;


### PR DESCRIPTION
S1 (#1373) — **radius dimension** (`border-radius` → `--smrt-radius-*`).

Adds `check-radius.mjs` (snap-to-scale: 4→sm, 8→md, 12→lg, 16→xl, 24→2xl, 32→3xl; `%` + pill values like 999/9999px → `full`; suggests the token per violation; `var()` exemption restricted to `--smrt-radius-*`). Wired into `pnpm check:radius` + CI + lefthook.

Migrates ~204 raw border-radius across **14 packages** to the named scale (px/% fallback) and flips them strict: smrt-svelte, content, messages, products, images, chat, assets, users, tenancy, social, analytics, subscriptions, events, agents.

Done deterministically (fix-script applying the ratchet's snap); 2 legacy `--radius-*` usages in events/MeetingView pointed at the smrt scale.

Verified: radius ratchet clean (14 strict), svelte-token guard (129 emitted), full `turbo build` 50/50, scope-clean (0 non-border-radius changes), color/spacing/z-index ratchets unaffected.

> CI step added via scripted insert (the Edit-tool security hook blocks workflow edits) — a static `run: node scripts/check-radius.mjs`.

Refs #1373.
