### PR TITLE
[codex] Atomically claim ready jobs

### DIFF
--- a/packages/jobs/AGENTS.md
+++ b/packages/jobs/AGENTS.md
@@ -19,8 +19,8 @@ Status: `pending → running → completed/failed/cancelled`.
 
 Polling-based execution engine. Config: `concurrency` (5), `pollInterval` (1s), `heartbeatInterval` (30s), `shutdownTimeout` (30s).
 
-1. Polls `listReady()` for pending jobs (`runAt <= NOW`, ordered by `priority DESC, runAt ASC`)
-2. Claims atomically: `status='running', workerId=this.id`
+1. Polls `claimReady()` to atomically claim pending jobs (`runAt <= NOW`, ordered by `priority DESC, runAt ASC, created_at ASC, id ASC`)
+2. Claim sets `status='running'`, `workerId=this.id`, heartbeat/start timestamps, and increments `attempts`
 3. Resolves class via `ObjectRegistry.getClass(objectType)`, creates instance, calls method
 4. **Internal args**: `_agentConfig` and `_scheduleId` stripped from args before calling method
 5. Retry: uses strategy from `@happyvertical/jobs`, schedules future `runAt` on failure

--- a/packages/jobs/README.md
+++ b/packages/jobs/README.md
@@ -115,12 +115,15 @@ taskRunner.on('job:failed', (job, error) => {
 | Export | Description |
 |--------|------------|
 | `SmrtJob` | Persistent job record stored in `_smrt_jobs` |
-| `SmrtJobCollection` | Collection with `listReady()`, `listByStatus()`, `stats()`, `cleanup()` |
+| `SmrtJobCollection` | Collection with `claimReady()`, `listReady()`, `listByStatus()`, `stats()`, `cleanup()` |
 | `JobBuilder` | Fluent API: `.delay()`, `.priority()`, `.retries()`, `.queue()`, `.timeout()`, `.enqueue()` |
 | `JobHandle` | Track, wait, cancel, or retry an enqueued job |
 | `JobContextLogger` | Logger that auto-injects job context (jobId, attempt, queue) |
 | `TaskRunner` | Polling-based execution engine with concurrency control and heartbeats |
 | `ScheduleRunner` | Polls for due cron schedules and creates SmrtJob entries |
+
+`TaskRunner` uses `SmrtJobCollection.claimReady()` so multiple workers can poll
+the same queue without duplicate-claiming a pending row.
 
 ### Functions
 

--- a/packages/jobs/src/__tests__/job-claim.test.ts
+++ b/packages/jobs/src/__tests__/job-claim.test.ts
@@ -1,4 +1,9 @@
+import { randomUUID } from 'node:crypto';
+import { existsSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { getTestDatabase } from '@happyvertical/smrt-core';
+import type { DatabaseInterface } from '@happyvertical/sql';
 import { describe, expect, it } from 'vitest';
 import { SmrtJobCollection } from '../smrt-job.js';
 
@@ -45,68 +50,100 @@ describe('SmrtJobCollection claimReady', () => {
   });
 
   it('does not return the same ready job to concurrent claim calls', async () => {
-    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
-    const jobs = await SmrtJobCollection.create({ db });
-    const now = new Date('2026-06-08T22:00:00.000Z');
+    const dbUrl = tmpDbUrl('job-claim-concurrent');
+    const dbPath = dbUrl.replace('file:', '');
+    let seedDb: DatabaseInterface | undefined;
+    let workerADb: DatabaseInterface | undefined;
+    let workerBDb: DatabaseInterface | undefined;
 
-    const target = await jobs.create({
-      queue: 'critical',
-      objectType: 'ClaimProbe',
-      method: 'run',
-      runAt: new Date('2026-06-08T21:59:00.000Z'),
-      priority: 75,
-    });
-    const otherQueue = await jobs.create({
-      queue: 'other',
-      objectType: 'ClaimProbe',
-      method: 'run',
-      runAt: new Date('2026-06-08T21:58:00.000Z'),
-      priority: 100,
-    });
+    try {
+      seedDb = await getTestDatabase({ type: 'sqlite', url: dbUrl });
+      workerADb = await getTestDatabase({ type: 'sqlite', url: dbUrl });
+      workerBDb = await getTestDatabase({ type: 'sqlite', url: dbUrl });
 
-    const [workerA, workerB] = await Promise.all([
-      jobs.claimReady({
-        workerId: 'worker-a',
+      const jobs = await SmrtJobCollection.create({ db: seedDb });
+      const workerAJobs = await SmrtJobCollection.create({ db: workerADb });
+      const workerBJobs = await SmrtJobCollection.create({ db: workerBDb });
+      const now = new Date('2026-06-08T22:00:00.000Z');
+
+      const target = await jobs.create({
+        queue: 'critical',
+        objectType: 'ClaimProbe',
+        method: 'run',
+        runAt: new Date('2026-06-08T21:59:00.000Z'),
+        priority: 75,
+      });
+      const otherQueue = await jobs.create({
+        queue: 'other',
+        objectType: 'ClaimProbe',
+        method: 'run',
+        runAt: new Date('2026-06-08T21:58:00.000Z'),
+        priority: 100,
+      });
+
+      const [workerA, workerB] = await Promise.all([
+        workerAJobs.claimReady({
+          workerId: 'worker-a',
+          queues: ['critical'],
+          limit: 1,
+          now,
+        }),
+        workerBJobs.claimReady({
+          workerId: 'worker-b',
+          queues: ['critical'],
+          limit: 1,
+          now,
+        }),
+      ]);
+
+      const claimed = [...workerA, ...workerB];
+      expect(claimed).toHaveLength(1);
+      expect(claimed[0].id).toBe(target.id);
+      expect(claimed[0].status).toBe('running');
+      expect(claimed[0].attempts).toBe(1);
+      expect(claimed[0].workerId).toMatch(/^worker-[ab]$/);
+      expect(claimed[0].startedAt?.toISOString()).toBe(now.toISOString());
+      expect(claimed[0].workerHeartbeat?.toISOString()).toBe(now.toISOString());
+
+      const alreadyClaimed = await workerAJobs.claimReady({
+        workerId: 'worker-c',
         queues: ['critical'],
         limit: 1,
         now,
-      }),
-      jobs.claimReady({
-        workerId: 'worker-b',
-        queues: ['critical'],
+      });
+      expect(alreadyClaimed).toEqual([]);
+
+      const claimedOtherQueue = await workerBJobs.claimReady({
+        workerId: 'worker-c',
+        queues: ['other'],
         limit: 1,
         now,
-      }),
-    ]);
+      });
+      expect(claimedOtherQueue.map((job) => job.id)).toEqual([otherQueue.id]);
 
-    const claimed = [...workerA, ...workerB];
-    expect(claimed).toHaveLength(1);
-    expect(claimed[0].id).toBe(target.id);
-    expect(claimed[0].status).toBe('running');
-    expect(claimed[0].attempts).toBe(1);
-    expect(claimed[0].workerId).toMatch(/^worker-[ab]$/);
-    expect(claimed[0].startedAt?.toISOString()).toBe(now.toISOString());
-    expect(claimed[0].workerHeartbeat?.toISOString()).toBe(now.toISOString());
-
-    const alreadyClaimed = await jobs.claimReady({
-      workerId: 'worker-c',
-      queues: ['critical'],
-      limit: 1,
-      now,
-    });
-    expect(alreadyClaimed).toEqual([]);
-
-    const claimedOtherQueue = await jobs.claimReady({
-      workerId: 'worker-c',
-      queues: ['other'],
-      limit: 1,
-      now,
-    });
-    expect(claimedOtherQueue.map((job) => job.id)).toEqual([otherQueue.id]);
-
-    const persistedTarget = await jobs.get({ id: target.id ?? '' });
-    expect(persistedTarget?.status).toBe('running');
-    expect(persistedTarget?.attempts).toBe(1);
-    expect(persistedTarget?.workerId).toMatch(/^worker-[ab]$/);
+      const persistedTarget = await jobs.get({ id: target.id ?? '' });
+      expect(persistedTarget?.status).toBe('running');
+      expect(persistedTarget?.attempts).toBe(1);
+      expect(persistedTarget?.workerId).toMatch(/^worker-[ab]$/);
+    } finally {
+      await closeDatabases(seedDb, workerADb, workerBDb);
+      unlinkIfExists(dbPath);
+      unlinkIfExists(`${dbPath}-shm`);
+      unlinkIfExists(`${dbPath}-wal`);
+    }
   });
 });
+
+function tmpDbUrl(name: string): string {
+  return `file:${join(tmpdir(), `${name}-${randomUUID()}.db`)}`;
+}
+
+async function closeDatabases(
+  ...databases: Array<DatabaseInterface | undefined>
+): Promise<void> {
+  await Promise.all(databases.map((db) => db?.close?.()));
+}
+
+function unlinkIfExists(path: string): void {
+  if (existsSync(path)) unlinkSync(path);
+}

--- a/packages/jobs/src/__tests__/job-claim.test.ts
+++ b/packages/jobs/src/__tests__/job-claim.test.ts
@@ -3,6 +3,47 @@ import { describe, expect, it } from 'vitest';
 import { SmrtJobCollection } from '../smrt-job.js';
 
 describe('SmrtJobCollection claimReady', () => {
+  it('returns claimed jobs in scheduler order for multi-slot claims', async () => {
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    const jobs = await SmrtJobCollection.create({ db });
+    const now = new Date('2026-06-08T22:00:00.000Z');
+
+    await jobs.create({
+      queue: 'ordered',
+      objectType: 'LowPriorityProbe',
+      method: 'run',
+      runAt: new Date('2026-06-08T21:55:00.000Z'),
+      priority: 1,
+    });
+    await jobs.create({
+      queue: 'ordered',
+      objectType: 'HighPriorityProbe',
+      method: 'run',
+      runAt: new Date('2026-06-08T21:58:00.000Z'),
+      priority: 99,
+    });
+    await jobs.create({
+      queue: 'ordered',
+      objectType: 'MiddlePriorityProbe',
+      method: 'run',
+      runAt: new Date('2026-06-08T21:57:00.000Z'),
+      priority: 50,
+    });
+
+    const claimed = await jobs.claimReady({
+      workerId: 'worker-order',
+      queues: ['ordered'],
+      limit: 3,
+      now,
+    });
+
+    expect(claimed.map((job) => job.objectType)).toEqual([
+      'HighPriorityProbe',
+      'MiddlePriorityProbe',
+      'LowPriorityProbe',
+    ]);
+  });
+
   it('does not return the same ready job to concurrent claim calls', async () => {
     const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
     const jobs = await SmrtJobCollection.create({ db });

--- a/packages/jobs/src/__tests__/job-claim.test.ts
+++ b/packages/jobs/src/__tests__/job-claim.test.ts
@@ -1,0 +1,71 @@
+import { getTestDatabase } from '@happyvertical/smrt-core';
+import { describe, expect, it } from 'vitest';
+import { SmrtJobCollection } from '../smrt-job.js';
+
+describe('SmrtJobCollection claimReady', () => {
+  it('does not return the same ready job to concurrent claim calls', async () => {
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    const jobs = await SmrtJobCollection.create({ db });
+    const now = new Date('2026-06-08T22:00:00.000Z');
+
+    const target = await jobs.create({
+      queue: 'critical',
+      objectType: 'ClaimProbe',
+      method: 'run',
+      runAt: new Date('2026-06-08T21:59:00.000Z'),
+      priority: 75,
+    });
+    const otherQueue = await jobs.create({
+      queue: 'other',
+      objectType: 'ClaimProbe',
+      method: 'run',
+      runAt: new Date('2026-06-08T21:58:00.000Z'),
+      priority: 100,
+    });
+
+    const [workerA, workerB] = await Promise.all([
+      jobs.claimReady({
+        workerId: 'worker-a',
+        queues: ['critical'],
+        limit: 1,
+        now,
+      }),
+      jobs.claimReady({
+        workerId: 'worker-b',
+        queues: ['critical'],
+        limit: 1,
+        now,
+      }),
+    ]);
+
+    const claimed = [...workerA, ...workerB];
+    expect(claimed).toHaveLength(1);
+    expect(claimed[0].id).toBe(target.id);
+    expect(claimed[0].status).toBe('running');
+    expect(claimed[0].attempts).toBe(1);
+    expect(claimed[0].workerId).toMatch(/^worker-[ab]$/);
+    expect(claimed[0].startedAt?.toISOString()).toBe(now.toISOString());
+    expect(claimed[0].workerHeartbeat?.toISOString()).toBe(now.toISOString());
+
+    const alreadyClaimed = await jobs.claimReady({
+      workerId: 'worker-c',
+      queues: ['critical'],
+      limit: 1,
+      now,
+    });
+    expect(alreadyClaimed).toEqual([]);
+
+    const claimedOtherQueue = await jobs.claimReady({
+      workerId: 'worker-c',
+      queues: ['other'],
+      limit: 1,
+      now,
+    });
+    expect(claimedOtherQueue.map((job) => job.id)).toEqual([otherQueue.id]);
+
+    const persistedTarget = await jobs.get({ id: target.id ?? '' });
+    expect(persistedTarget?.status).toBe('running');
+    expect(persistedTarget?.attempts).toBe(1);
+    expect(persistedTarget?.workerId).toMatch(/^worker-[ab]$/);
+  });
+});

--- a/packages/jobs/src/index.ts
+++ b/packages/jobs/src/index.ts
@@ -83,6 +83,7 @@ export {
 } from './schedule-runner.js';
 // Core job model
 export {
+  type ClaimReadyOptions,
   type JobStatus,
   type ListReadyOptions,
   SmrtJob,

--- a/packages/jobs/src/runner.ts
+++ b/packages/jobs/src/runner.ts
@@ -96,6 +96,7 @@ export class TaskRunner extends EventEmitter {
   private heartbeatTimer: NodeJS.Timeout | null = null;
   private shutdownPromise: Promise<void> | null = null;
   private db: DatabaseInterface | null = null;
+  private logger = createLogger(true);
 
   constructor(config: TaskRunnerConfig = {}) {
     super();
@@ -641,6 +642,9 @@ export class TaskRunner extends EventEmitter {
 
       const timeout = setTimeout(() => {
         clearInterval(checkInterval);
+        this.logger.warn(
+          `Shutdown timeout: ${this.activeJobs.size} jobs still active`,
+        );
         resolve();
       }, this.config.shutdownTimeout);
     });

--- a/packages/jobs/src/runner.ts
+++ b/packages/jobs/src/runner.ts
@@ -215,24 +215,17 @@ export class TaskRunner extends EventEmitter {
     const available = this.config.concurrency - this.activeJobs.size;
     if (available <= 0) return;
 
-    // Find ready jobs
-    const jobs = await this.collection.listReady({
+    // Atomically claim ready jobs before processing so multiple workers cannot
+    // receive the same pending row.
+    const jobs = await this.collection.claimReady({
+      workerId: this.id,
       queues: this.config.queues,
       limit: available,
     });
 
-    // Claim and process each job
     for (const job of jobs) {
       const jobId = job.id;
       if (!jobId) continue;
-
-      // Claim the job
-      job.status = 'running';
-      job.workerId = this.id;
-      job.workerHeartbeat = new Date();
-      job.startedAt = new Date();
-      job.attempts += 1;
-      await job.save();
 
       // Process asynchronously
       this.processJob(job);
@@ -648,9 +641,6 @@ export class TaskRunner extends EventEmitter {
 
       const timeout = setTimeout(() => {
         clearInterval(checkInterval);
-        console.warn(
-          `Shutdown timeout: ${this.activeJobs.size} jobs still active`,
-        );
         resolve();
       }, this.config.shutdownTimeout);
     });

--- a/packages/jobs/src/smrt-job.ts
+++ b/packages/jobs/src/smrt-job.ts
@@ -1,5 +1,6 @@
 import type { RetryStrategyConfig } from '@happyvertical/jobs';
 import {
+  detectEngine,
   ensureJobsSystemTableCompatibility,
   field,
   SmrtCollection,
@@ -7,6 +8,7 @@ import {
   smrt,
 } from '@happyvertical/smrt-core';
 import { getTenantId, tenantId } from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
 
 /**
  * Job status type
@@ -212,6 +214,22 @@ export interface ListReadyOptions {
 }
 
 /**
+ * Options for atomically claiming ready jobs.
+ */
+export interface ClaimReadyOptions extends ListReadyOptions {
+  workerId: string;
+  now?: Date;
+}
+
+type DatabaseWithConfig = DatabaseInterface & {
+  config?: {
+    type?: string;
+    url?: string;
+  };
+  type?: string;
+};
+
+/**
  * Collection for managing SmrtJob objects
  */
 export class SmrtJobCollection extends SmrtCollection<SmrtJob> {
@@ -266,6 +284,55 @@ export class SmrtJobCollection extends SmrtCollection<SmrtJob> {
     return this.query(
       `SELECT * FROM _smrt_jobs WHERE ${whereConditions.join(' AND ')} ORDER BY priority DESC, run_at ASC LIMIT ?`,
       params,
+    );
+  }
+
+  /**
+   * Atomically claim pending jobs ready to run for a worker.
+   *
+   * The claim is performed as one conditional UPDATE so concurrent workers
+   * cannot receive the same pending row. PostgreSQL additionally skips rows
+   * locked by other workers instead of waiting behind them.
+   */
+  async claimReady(options: ClaimReadyOptions): Promise<SmrtJob[]> {
+    const limit = options.limit ?? 100;
+    if (limit <= 0) return [];
+
+    const now = options.now ?? new Date();
+    const nowIso = now.toISOString();
+    const whereConditions: string[] = ["status = 'pending'", 'run_at <= ?'];
+    const whereParams: unknown[] = [nowIso];
+
+    if (options.queues?.length) {
+      const placeholders = options.queues.map(() => '?').join(', ');
+      whereConditions.push(`queue IN (${placeholders})`);
+      whereParams.push(...options.queues);
+    }
+
+    const lockClause =
+      getDatabaseEngine(this.db) === 'postgres'
+        ? ' FOR UPDATE SKIP LOCKED'
+        : '';
+    const candidateSelect = `
+      SELECT id
+        FROM _smrt_jobs
+       WHERE ${whereConditions.join(' AND ')}
+       ORDER BY priority DESC, run_at ASC, created_at ASC, id ASC
+       LIMIT ?${lockClause}
+    `;
+
+    return this.query(
+      `UPDATE _smrt_jobs
+          SET status = 'running',
+              worker_id = ?,
+              worker_heartbeat = ?,
+              started_at = ?,
+              attempts = attempts + 1,
+              updated_at = ?
+        WHERE id IN (${candidateSelect})
+          AND status = 'pending'
+        RETURNING *`,
+      [options.workerId, nowIso, nowIso, nowIso, ...whereParams, limit],
     );
   }
 
@@ -346,6 +413,16 @@ export class SmrtJobCollection extends SmrtCollection<SmrtJob> {
     const result = await this._db.query(query, ...params);
     return result.rowCount ?? 0;
   }
+}
+
+function getDatabaseEngine(
+  db: DatabaseInterface,
+): ReturnType<typeof detectEngine> {
+  const dbWithConfig = db as DatabaseWithConfig;
+  return detectEngine(
+    db.url || dbWithConfig.config?.url || '',
+    dbWithConfig.type || dbWithConfig.config?.type,
+  );
 }
 
 export default SmrtJob;

--- a/packages/jobs/src/smrt-job.ts
+++ b/packages/jobs/src/smrt-job.ts
@@ -321,7 +321,7 @@ export class SmrtJobCollection extends SmrtCollection<SmrtJob> {
        LIMIT ?${lockClause}
     `;
 
-    return this.query(
+    const claimed = await this.query(
       `UPDATE _smrt_jobs
           SET status = 'running',
               worker_id = ?,
@@ -334,6 +334,8 @@ export class SmrtJobCollection extends SmrtCollection<SmrtJob> {
         RETURNING *`,
       [options.workerId, nowIso, nowIso, nowIso, ...whereParams, limit],
     );
+
+    return claimed.toSorted(compareClaimOrder);
   }
 
   /**
@@ -423,6 +425,23 @@ function getDatabaseEngine(
     db.url || dbWithConfig.config?.url || '',
     dbWithConfig.type || dbWithConfig.config?.type,
   );
+}
+
+function compareClaimOrder(left: SmrtJob, right: SmrtJob): number {
+  const priority = right.priority - left.priority;
+  if (priority !== 0) return priority;
+
+  const runAt = left.runAt.getTime() - right.runAt.getTime();
+  if (runAt !== 0) return runAt;
+
+  const createdAt = timestamp(left.created_at) - timestamp(right.created_at);
+  if (createdAt !== 0) return createdAt;
+
+  return (left.id ?? '').localeCompare(right.id ?? '');
+}
+
+function timestamp(value: Date | null | undefined): number {
+  return value?.getTime() ?? 0;
 }
 
 export default SmrtJob;


### PR DESCRIPTION
## Summary

Fixes #1458.

Adds an atomic `SmrtJobCollection.claimReady()` primitive and updates `TaskRunner.poll()` to use it instead of selecting ready jobs and then mutating each row in process memory. The claim update now verifies the row is still `pending`, sets worker ownership and heartbeat/start timestamps in the same statement, increments attempts, and returns only rows actually claimed by that worker.

The query keeps deterministic scheduling order with `priority DESC, run_at ASC, created_at ASC, id ASC`; PostgreSQL uses `FOR UPDATE SKIP LOCKED` inside the claim subquery, while SQLite/DuckDB rely on the single conditional update with `RETURNING`.

Docs now call out the atomic claim path for multi-worker queue polling.

## Validation

- `pnpm --filter @happyvertical/smrt-jobs exec vitest run src/__tests__/job-claim.test.ts`
- `pnpm --filter @happyvertical/smrt-jobs typecheck`
- `pnpm --filter @happyvertical/smrt-jobs exec vitest run`
- `pnpm --filter @happyvertical/smrt-jobs build`
- `npm run build`
- `git diff --check`
- `pnpm knowledge:check --changed --strict --format markdown`
- pre-push hook: color-literals, format-check, knowledge-check, radius, spacing, workflow validation, z-index