### PR TITLE
feat(tooling): elevation design-token ratchet (#1373)

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -193,6 +193,12 @@ jobs:
       - name: Check raw border-radius
         run: node scripts/check-radius.mjs
 
+      # Bans raw downward neutral box-shadows in component CSS. Strict (fails)
+      # for UI packages; report-only elsewhere until later phases of the
+      # design-token sweep (issue #1373). Node-only, no deps.
+      - name: Check raw drop-shadows (elevation)
+        run: node scripts/check-elevation.mjs
+
   test:
     name: Validate Changes
     uses: ./.github/workflows/test-suite.yml

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -151,6 +151,16 @@ pre-push:
         Snap to the scale: border-radius: var(--smrt-radius-<name>, <value>).
         Run: node scripts/check-radius.mjs
 
+    elevation:
+      # Bans raw downward neutral box-shadows in component CSS. Strict for UI
+      # packages, report-only elsewhere until later phases of #1373. No deps.
+      run: node scripts/check-elevation.mjs
+      fail_text: |
+        ❌ Raw drop-shadow found in a strict UI package!
+
+        Map to the depth scale: box-shadow: var(--smrt-elevation-<n>, <value>).
+        Run: node scripts/check-elevation.mjs
+
     validate-all-workflows:
       run: |
         echo "🔍 Validating ALL workflow files before push..."

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "check:z-index": "node scripts/check-z-index.mjs",
     "check:spacing": "node scripts/check-spacing.mjs",
     "check:radius": "node scripts/check-radius.mjs",
+    "check:elevation": "node scripts/check-elevation.mjs",
     "knowledge:check": "tsx scripts/check-knowledge.ts",
     "changeset": "changeset",
     "changeset:auto": "npx tsx scripts/auto-changeset.ts",

--- a/packages/assets/src/svelte/playground/AssetDetailPreview.svelte
+++ b/packages/assets/src/svelte/playground/AssetDetailPreview.svelte
@@ -96,7 +96,7 @@ function handleEdit() {
     border-radius: 1rem;
     background: color-mix(in srgb, var(--smrt-color-surface) 92%, transparent);
     border: 1px solid var(--smrt-color-outline-variant, rgba(15, 23, 34, 0.08));
-    box-shadow: 0 18px 38px color-mix(in srgb, var(--smrt-color-shadow) 8%, transparent);
+    box-shadow: var(--smrt-elevation-5, 0 18px 38px color-mix(in srgb, var(--smrt-color-shadow) 8%, transparent));
   }
 
   .preview-card h4,

--- a/packages/assets/src/svelte/playground/CreateAssetModalPreview.svelte
+++ b/packages/assets/src/svelte/playground/CreateAssetModalPreview.svelte
@@ -91,7 +91,7 @@ function handleCreate(data: {
     border-radius: 1rem;
     background: color-mix(in srgb, var(--smrt-color-surface) 92%, transparent);
     border: 1px solid var(--smrt-color-outline-variant, rgba(15, 23, 34, 0.08));
-    box-shadow: 0 18px 38px color-mix(in srgb, var(--smrt-color-shadow) 8%, transparent);
+    box-shadow: var(--smrt-elevation-5, 0 18px 38px color-mix(in srgb, var(--smrt-color-shadow) 8%, transparent));
   }
 
   .preview-card h4,

--- a/packages/assets/src/svelte/routes/AssetManagerRoute.svelte
+++ b/packages/assets/src/svelte/routes/AssetManagerRoute.svelte
@@ -152,7 +152,7 @@ const customActions = [
     border: 1px solid var(--smrt-color-outline-variant, #dbe3ef);
     border-radius: 1rem;
     padding: 1.25rem;
-    box-shadow: 0 10px 30px color-mix(in srgb, var(--smrt-color-shadow) 6%, transparent);
+    box-shadow: var(--smrt-elevation-5, 0 10px 30px color-mix(in srgb, var(--smrt-color-shadow) 6%, transparent));
   }
 
   .assets-route__panel h2 {

--- a/packages/chat/src/svelte/components/agent/AgentChat.svelte
+++ b/packages/chat/src/svelte/components/agent/AgentChat.svelte
@@ -429,7 +429,7 @@ $effect(() => {
     padding: 0;
     width: min(420px, 90vw);
     max-height: 60vh;
-    box-shadow: 0 8px 32px color-mix(in srgb, var(--smrt-color-shadow) 18%, transparent);
+    box-shadow: var(--smrt-elevation-5, 0 8px 32px color-mix(in srgb, var(--smrt-color-shadow) 18%, transparent));
     background: var(--smrt-color-surface, #fefbff);
     color: var(--smrt-color-on-surface, #1a1c1e);
   }

--- a/packages/content/src/routes/+layout.svelte
+++ b/packages/content/src/routes/+layout.svelte
@@ -78,7 +78,7 @@ const navItems = [
     position: sticky;
     top: 0;
     z-index: var(--smrt-z-index-sticky, 1100);
-    box-shadow: 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow) 6%, transparent);
+    box-shadow: var(--smrt-elevation-1, 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow) 6%, transparent));
   }
 
   .header-inner {

--- a/packages/content/src/routes/api-explorer/+page.svelte
+++ b/packages/content/src/routes/api-explorer/+page.svelte
@@ -602,7 +602,7 @@ function closeTry() {
     border: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
     border-radius: 1rem;
     padding: 1.5rem;
-    box-shadow: 0 2px 8px color-mix(in srgb, var(--smrt-color-shadow) 4%, transparent);
+    box-shadow: var(--smrt-elevation-3, 0 2px 8px color-mix(in srgb, var(--smrt-color-shadow) 4%, transparent));
   }
 
   .endpoints-panel h2 {

--- a/packages/content/src/svelte/components/ContentBodyEditor.svelte
+++ b/packages/content/src/svelte/components/ContentBodyEditor.svelte
@@ -1390,7 +1390,7 @@ function handleEditorDragEnd() {
     border-radius: var(--smrt-radius-full, 9999px);
     background: color-mix(in srgb, var(--smrt-color-surface) 96%, transparent);
     color: var(--smrt-color-on-surface);
-    box-shadow: 0 0.75rem 1.75rem color-mix(in srgb, var(--smrt-color-shadow) 18%, transparent);
+    box-shadow: var(--smrt-elevation-5, 0 0.75rem 1.75rem color-mix(in srgb, var(--smrt-color-shadow) 18%, transparent));
     transform: translateX(-50%);
     backdrop-filter: blur(10px);
   }
@@ -1432,7 +1432,7 @@ function handleEditorDragEnd() {
     border: 1px solid var(--smrt-color-outline-variant);
     border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-surface);
-    box-shadow: 0 0.45rem 1rem color-mix(in srgb, var(--smrt-color-shadow) 18%, transparent);
+    box-shadow: var(--smrt-elevation-4, 0 0.45rem 1rem color-mix(in srgb, var(--smrt-color-shadow) 18%, transparent));
     cursor: nwse-resize;
   }
 

--- a/packages/content/src/svelte/components/ContentEditor.svelte
+++ b/packages/content/src/svelte/components/ContentEditor.svelte
@@ -1959,7 +1959,7 @@ function removeAsset(id: string) {
     border: 1px solid var(--smrt-color-outline-variant, #e2e8f0);
     margin-top: 1rem;
     border-radius: 0.75rem;
-    box-shadow: 0 4px 6px -1px color-mix(in srgb, var(--smrt-color-shadow) 5%, transparent), 0 2px 4px -1px color-mix(in srgb, var(--smrt-color-shadow) 3%, transparent);
+    box-shadow: var(--smrt-elevation-2, 0 4px 6px -1px color-mix(in srgb, var(--smrt-color-shadow) 5%, transparent), 0 2px 4px -1px color-mix(in srgb, var(--smrt-color-shadow) 3%, transparent));
     /* Svelte built-in slide animations will be handled if implemented */
   }
 

--- a/packages/images/src/svelte/components/AssetsGallery.svelte
+++ b/packages/images/src/svelte/components/AssetsGallery.svelte
@@ -337,7 +337,7 @@ function handleDragStart(event: DragEvent, image: ImageLike) {
     background: var(--smrt-color-surface-container, #1a1a1a);
     border-radius: var(--smrt-radius-lg, 8px);
     border: 1px solid var(--smrt-color-surface-container-high, #2a2a2a);
-    box-shadow: 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow) 12%, transparent), 0 1px 2px color-mix(in srgb, var(--smrt-color-shadow) 24%, transparent);
+    box-shadow: var(--smrt-elevation-1, 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow) 12%, transparent), 0 1px 2px color-mix(in srgb, var(--smrt-color-shadow) 24%, transparent));
     overflow: hidden;
     color: inherit;
     text-align: left;
@@ -351,7 +351,7 @@ function handleDragStart(event: DragEvent, image: ImageLike) {
   .gallery-item.selectable:hover, .gallery-item.selectable:focus {
     transform: translateY(-2px);
     border-color: var(--smrt-color-primary, #3b82f6);
-    box-shadow: 0 3px 6px color-mix(in srgb, var(--smrt-color-shadow) 16%, transparent), 0 3px 6px color-mix(in srgb, var(--smrt-color-shadow) 23%, transparent);
+    box-shadow: var(--smrt-elevation-2, 0 3px 6px color-mix(in srgb, var(--smrt-color-shadow) 16%, transparent), 0 3px 6px color-mix(in srgb, var(--smrt-color-shadow) 23%, transparent));
     outline: none;
   }
 

--- a/packages/images/src/svelte/components/ImageEditor.svelte
+++ b/packages/images/src/svelte/components/ImageEditor.svelte
@@ -357,7 +357,7 @@ async function handleAIEdit() {
   .mode-selector button.active {
     background: var(--smrt-color-surface-container, #1a1a1a);
     color: var(--smrt-color-on-surface, #fff);
-    box-shadow: 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow) 20%, transparent);
+    box-shadow: var(--smrt-elevation-1, 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow) 20%, transparent));
   }
 
   .tool-section h4 {

--- a/packages/images/src/svelte/routes/ImageStudioRoute.svelte
+++ b/packages/images/src/svelte/routes/ImageStudioRoute.svelte
@@ -165,7 +165,7 @@ function handleEditorSave(image: StudioImage) {
     border-radius: 1rem;
     border: 1px solid color-mix(in srgb, var(--smrt-color-outline-variant) 18%, transparent);
     background: color-mix(in srgb, var(--smrt-color-surface-container) 72%, transparent);
-    box-shadow: 0 24px 60px color-mix(in srgb, var(--smrt-color-shadow) 35%, transparent);
+    box-shadow: var(--smrt-elevation-5, 0 24px 60px color-mix(in srgb, var(--smrt-color-shadow) 35%, transparent));
     overflow: hidden;
   }
 

--- a/packages/products/src/app/layouts/AppLayout.svelte
+++ b/packages/products/src/app/layouts/AppLayout.svelte
@@ -56,7 +56,7 @@ const { children }: Props = $props();
   .app-header {
     background: white;
     border-bottom: 1px solid var(--smrt-color-outline-variant, #e2e8f0);
-    box-shadow: 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow, #000) 10%, transparent);
+    box-shadow: var(--smrt-elevation-1, 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow, #000) 10%, transparent));
     position: sticky;
     top: 0;
     z-index: var(--smrt-z-index-sticky, 1100);

--- a/packages/products/src/lib/components/ProductCard.svelte
+++ b/packages/products/src/lib/components/ProductCard.svelte
@@ -61,12 +61,12 @@ const { product, onEdit, onDelete }: Props = $props();
     border-radius: var(--smrt-radius-md, 8px);
     padding: 1rem;
     background: white;
-    box-shadow: 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow, #000) 10%, transparent);
+    box-shadow: var(--smrt-elevation-1, 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow, #000) 10%, transparent));
     transition: box-shadow 0.2s;
   }
 
   .product-card:hover {
-    box-shadow: 0 4px 6px color-mix(in srgb, var(--smrt-color-shadow, #000) 10%, transparent);
+    box-shadow: var(--smrt-elevation-2, 0 4px 6px color-mix(in srgb, var(--smrt-color-shadow, #000) 10%, transparent));
   }
   
   .product-header {

--- a/packages/products/src/lib/components/auto-generated/AutoForm.svelte
+++ b/packages/products/src/lib/components/auto-generated/AutoForm.svelte
@@ -147,7 +147,7 @@ function _getFieldType(
     padding: 1.5rem;
     background: white;
     border-radius: var(--smrt-radius-md, 8px);
-    box-shadow: 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow, #000) 10%, transparent);
+    box-shadow: var(--smrt-elevation-1, 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow, #000) 10%, transparent));
   }
 
   .form-header {

--- a/packages/smrt-svelte/src/components/forms/Form.svelte
+++ b/packages/smrt-svelte/src/components/forms/Form.svelte
@@ -669,7 +669,7 @@ function getFormData(): Record<string, unknown> {
   .mode-btn.active {
     background: var(--smrt-color-surface, #fff);
     color: var(--smrt-color-primary, #3b82f6);
-    box-shadow: 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow) 10%, transparent);
+    box-shadow: var(--smrt-elevation-1, 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow) 10%, transparent));
   }
 
   .form-listen-btn {

--- a/packages/smrt-svelte/src/components/forms/FormMicButton.svelte
+++ b/packages/smrt-svelte/src/components/forms/FormMicButton.svelte
@@ -146,7 +146,7 @@ function handleClick() {
     border-radius: 0.375rem;
     white-space: nowrap;
     z-index: var(--smrt-z-index-tooltip, 1600);
-    box-shadow: 0 4px 6px -1px color-mix(in srgb, var(--smrt-color-shadow) 10%, transparent);
+    box-shadow: var(--smrt-elevation-2, 0 4px 6px -1px color-mix(in srgb, var(--smrt-color-shadow) 10%, transparent));
   }
 
   .tooltip::before {

--- a/packages/smrt-svelte/src/components/forms/Toggle.svelte
+++ b/packages/smrt-svelte/src/components/forms/Toggle.svelte
@@ -136,8 +136,7 @@ const sizeClasses = {
     position: absolute;
     background: var(--smrt-color-surface, #ffffff);
     border-radius: var(--smrt-radius-full, 9999px);
-    box-shadow: 0 1px 3px
-      color-mix(in srgb, var(--smrt-color-shadow) 20%, transparent);
+    box-shadow: var(--smrt-elevation-1, 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow) 20%, transparent));
     transition: transform var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
   }
 

--- a/scripts/check-elevation.mjs
+++ b/scripts/check-elevation.mjs
@@ -51,10 +51,34 @@ const STRICT_PACKAGES = new Set([
 /** Dev/playground hosts skipped entirely (matches the other token ratchets). */
 const SCOPE_EXCLUDED_PACKAGES = new Set(['smrt-playground']);
 
+/** Assumed root font size, to compare rem/em depths against the px scale. */
+const ROOT_PX = 16;
+/** A single CSS length: unitless `0`, or a px/rem/em number (decimals/sign ok). */
+const LEN = String.raw`(?:0|[+-]?\d*\.?\d+(?:px|rem|em))`;
+
+/** Parse a CSS length token to px (rem/em × ROOT_PX); NaN if unrecognized. */
+function lengthToPx(token) {
+  if (/^[+-]?0(?:px|rem|em)?$/i.test(token)) return 0;
+  const m = token.match(/^([+-]?\d*\.?\d+)(px|rem|em)$/i);
+  if (!m) return Number.NaN;
+  const n = Number(m[1]);
+  return m[2].toLowerCase() === 'px' ? n : n * ROOT_PX;
+}
+
+/** All lengths in a value, in px (rem/em converted), by absolute magnitude. */
+function allLengthsPx(value) {
+  const out = [];
+  for (const m of value.matchAll(/([+-]?\d*\.?\d+)(px|rem|em)\b/gi)) {
+    const n = Number(m[1]);
+    out.push(Math.abs(m[2].toLowerCase() === 'px' ? n : n * ROOT_PX));
+  }
+  return out;
+}
+
 /** Map a drop-shadow value to var(--smrt-elevation-<n>, <original>) by depth. */
 function snap(value) {
   const v = value.trim();
-  const pxs = [...v.matchAll(/(\d+)px/g)].map((m) => Number(m[1]));
+  const pxs = allLengthsPx(v);
   const max = pxs.length ? Math.max(...pxs) : 0;
   let lvl;
   if (max <= 3) lvl = 1;
@@ -65,16 +89,12 @@ function snap(value) {
   return `var(--smrt-elevation-${lvl}, ${v})`;
 }
 
-/** Parse a CSS length token (`0`, `12px`, `-2px`) to a number; NaN if unknown. */
-function lengthToPx(token) {
-  if (/^0(?:px)?$/.test(token)) return 0;
-  const m = token.match(/^(-?\d+)px$/);
-  return m ? Number(m[1]) : Number.NaN;
-}
-
 /** Accent/brand color roles — a tinted glow, not neutral depth. */
 const ACCENT_COLOR_RE =
   /--smrt-color-(?:primary|secondary|tertiary|accent|error|danger|success|warning|info)\b/;
+
+/** First shadow layer: offsetX offsetY blur, each a px/rem/em/0 length. */
+const FIRST_LAYER_RE = new RegExp(`^(${LEN})\\s+(${LEN})\\s+(${LEN})`, 'i');
 
 /**
  * True iff `value` is a standard downward, neutral elevation drop-shadow that
@@ -88,7 +108,7 @@ function isDropShadow(value) {
   if (/var\(\s*--smrt-elevation-/.test(v)) return false;
   if (ACCENT_COLOR_RE.test(v)) return false; // brand-tinted glow, not depth
   // First layer: offsetX offsetY blur [spread] color.
-  const m = v.match(/^(0|-?\d+px)\s+(0|-?\d+px)\s+(0|\d+px)/);
+  const m = v.match(FIRST_LAYER_RE);
   if (!m) return false; // not a plain shadow (e.g. a bare var()/keyword)
   const x = lengthToPx(m[1]);
   const y = lengthToPx(m[2]);

--- a/scripts/check-elevation.mjs
+++ b/scripts/check-elevation.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+/**
+ * Raw box-shadow (elevation) ratchet for SMRT UI packages.
+ *
+ * Bans hardcoded DROP-SHADOW box-shadows inside CSS contexts of `.svelte`/`.css`
+ * files, steering authors to the `--smrt-elevation-{1..5}` depth scale (issue
+ * #1373, parent epic #1354). Policy: map each drop-shadow to its nearest
+ * elevation level (by depth), preserving the original as the var() fallback.
+ *
+ * IMPORTANT — only standard downward, neutral depth shadows are flagged. The
+ * `--smrt-elevation-*` scale is downward-only (zero X offset, positive Y) and
+ * neutral-colored, so the following are legitimately bespoke and NOT flagged:
+ *   - Focus rings (`0 0 0 Npx <color>` — zero blur): a focus indicator, not
+ *     elevation. These belong to the color/focus surface, not the depth scale.
+ *   - `inset` shadows (inner borders/grooves) — not elevation.
+ *   - Directional shadows: nonzero X offset (e.g. a `-24px 0 40px` drawer cast)
+ *     or non-positive Y offset (e.g. a `0 -2px 12px` upward toast cast) — these
+ *     cast sideways/upward and cannot map to the downward scale.
+ *   - Accent-colored glows (e.g. `... --smrt-color-primary 40%`): a brand-tinted
+ *     hover effect, a different design intent than neutral depth.
+ *   - `box-shadow: none`, and values already using `var(--smrt-elevation-*)`.
+ *
+ * For each violation the check prints the suggested level so migration is
+ * mechanical: `box-shadow: var(--smrt-elevation-<n>, <original>)`.
+ *
+ * Phased rollout: strict (ERROR) for STRICT_PACKAGES; report-only elsewhere.
+ * Run: `node scripts/check-elevation.mjs` or `pnpm check:elevation`.  Exit 0/1.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative, resolve, sep } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const PACKAGES = join(ROOT, 'packages');
+
+/** Packages held to ERROR. Everything else is report-only for now (#1373). */
+const STRICT_PACKAGES = new Set([
+  'smrt-svelte',
+  'content',
+  'products',
+  'assets',
+  'chat',
+  'images',
+  'users',
+  'subscriptions',
+  'projects',
+  'messages',
+  'agents',
+]);
+
+/** Dev/playground hosts skipped entirely (matches the other token ratchets). */
+const SCOPE_EXCLUDED_PACKAGES = new Set(['smrt-playground']);
+
+/** Map a drop-shadow value to var(--smrt-elevation-<n>, <original>) by depth. */
+function snap(value) {
+  const v = value.trim();
+  const pxs = [...v.matchAll(/(\d+)px/g)].map((m) => Number(m[1]));
+  const max = pxs.length ? Math.max(...pxs) : 0;
+  let lvl;
+  if (max <= 3) lvl = 1;
+  else if (max <= 6) lvl = 2;
+  else if (max <= 12) lvl = 3;
+  else if (max <= 24) lvl = 4;
+  else lvl = 5;
+  return `var(--smrt-elevation-${lvl}, ${v})`;
+}
+
+/** Parse a CSS length token (`0`, `12px`, `-2px`) to a number; NaN if unknown. */
+function lengthToPx(token) {
+  if (/^0(?:px)?$/.test(token)) return 0;
+  const m = token.match(/^(-?\d+)px$/);
+  return m ? Number(m[1]) : Number.NaN;
+}
+
+/** Accent/brand color roles — a tinted glow, not neutral depth. */
+const ACCENT_COLOR_RE =
+  /--smrt-color-(?:primary|secondary|tertiary|accent|error|danger|success|warning|info)\b/;
+
+/**
+ * True iff `value` is a standard downward, neutral elevation drop-shadow that
+ * maps onto the `--smrt-elevation-*` scale. Excludes focus rings, insets,
+ * already-tokenized values, directional casts, and accent-colored glows.
+ */
+function isDropShadow(value) {
+  const v = value.trim();
+  if (/^none$/i.test(v)) return false;
+  if (/^inset\b/i.test(v)) return false;
+  if (/var\(\s*--smrt-elevation-/.test(v)) return false;
+  if (ACCENT_COLOR_RE.test(v)) return false; // brand-tinted glow, not depth
+  // First layer: offsetX offsetY blur [spread] color.
+  const m = v.match(/^(0|-?\d+px)\s+(0|-?\d+px)\s+(0|\d+px)/);
+  if (!m) return false; // not a plain shadow (e.g. a bare var()/keyword)
+  const x = lengthToPx(m[1]);
+  const y = lengthToPx(m[2]);
+  const blur = lengthToPx(m[3]);
+  if (Number.isNaN(x) || Number.isNaN(y) || Number.isNaN(blur)) return false;
+  if (x !== 0) return false; // directional (sideways cast) — not the scale
+  if (y <= 0) return false; // upward/flat cast — not downward depth
+  return blur > 0; // blur > 0 → real downward drop shadow
+}
+
+function listFiles(dir, exts) {
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+      out.push(...listFiles(full, exts));
+    } else if (exts.some((e) => entry.name.endsWith(e))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function toPosix(p) {
+  return p.split(sep).join('/');
+}
+function packageNameOf(relPath) {
+  return relPath.split(sep)[0];
+}
+function isInPackageSrc(relPath) {
+  const parts = toPosix(relPath).split('/');
+  return parts.length > 1 && parts[1] === 'src';
+}
+
+function extractStyleBlocks(source) {
+  const out = source.replace(/[^\n]/g, ' ').split('');
+  const re = /(<style\b[^>]*>)([\s\S]*?)(<\/style>)/gi;
+  for (const m of source.matchAll(re)) {
+    const innerStart = m.index + m[1].length;
+    const inner = m[2];
+    for (let k = 0; k < inner.length; k++) out[innerStart + k] = inner[k];
+  }
+  return out.join('');
+}
+
+function stripComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, (block) => block.replace(/[^\n]/g, ' '))
+    .replace(/(^|[^:])\/\/[^\n]*/g, (m, lead) =>
+      lead + ' '.repeat(m.length - lead.length),
+    );
+}
+
+const SHADOW_RE = /box-shadow\s*:\s*([^;}]+)/gi;
+
+function findViolations(file, source) {
+  let text = file.endsWith('.svelte') ? extractStyleBlocks(source) : source;
+  text = stripComments(text);
+  const hits = [];
+  for (const m of text.matchAll(SHADOW_RE)) {
+    const value = m[1].replace(/\s+/g, ' ').trim();
+    if (!isDropShadow(value)) continue;
+    const line = text.slice(0, m.index).split('\n').length;
+    hits.push({
+      line,
+      value: `${value.slice(0, 60)} → ${snap(value).split(',')[0]}, …)`,
+      snippet: value.slice(0, 90),
+    });
+  }
+  return hits;
+}
+
+const files = listFiles(PACKAGES, ['.svelte', '.css']);
+const strictViolations = [];
+const reportOnly = new Map();
+
+for (const file of files) {
+  const relPath = relative(PACKAGES, file);
+  if (!isInPackageSrc(relPath)) continue;
+  const pkg = packageNameOf(relPath);
+  if (SCOPE_EXCLUDED_PACKAGES.has(pkg)) continue;
+  const hits = findViolations(file, readFileSync(file, 'utf8'));
+  if (hits.length === 0) continue;
+  if (STRICT_PACKAGES.has(pkg)) strictViolations.push({ file: relPath, hits });
+  else reportOnly.set(pkg, (reportOnly.get(pkg) ?? 0) + hits.length);
+}
+
+if (reportOnly.size > 0) {
+  const total = [...reportOnly.values()].reduce((a, b) => a + b, 0);
+  console.warn(
+    `⚠ elevation-check: ${total} raw drop-shadow(s) in report-only ` +
+      'package(s) (not failing — later phases of #1373):',
+  );
+  for (const [pkg, count] of [...reportOnly.entries()].sort((a, b) => b[1] - a[1])) {
+    console.warn(`    ${pkg}: ${count}`);
+  }
+}
+
+if (strictViolations.length > 0) {
+  const total = strictViolations.reduce((n, v) => n + v.hits.length, 0);
+  console.error(
+    `\n✗ elevation-check: ${total} raw drop-shadow(s) in strict ` +
+      `package(s): ${[...STRICT_PACKAGES].join(', ')}`,
+  );
+  for (const { file, hits } of strictViolations) {
+    console.error(`  ${file}`);
+    for (const h of hits) console.error(`    L${h.line}: ${h.value}`);
+  }
+  console.error(
+    '\nMap drop-shadows to var(--smrt-elevation-<n>, <original>) by depth.',
+  );
+  console.error('Focus rings (0 0 0 Npx) and inset shadows are not elevation.');
+  process.exit(1);
+}
+
+console.log(
+  `✓ elevation-check: no raw drop-shadows in strict package(s): ${[
+    ...STRICT_PACKAGES,
+  ].join(', ')}`,
+);


### PR DESCRIPTION
## What

Adds the **elevation** design-token ratchet — the 5th of 6 S1 dimensions in the design-token sweep (#1373, epic #1354). Bans raw downward neutral box-shadows in component CSS and steers authors to the `--smrt-elevation-{1..5}` depth scale.

`scripts/check-elevation.mjs` suggests the snapped level per violation (by max-px depth) so migration is mechanical: `box-shadow: var(--smrt-elevation-<n>, <original>)`.

## Detection — only standard, downward, neutral depth shadows

Elevation is **not** a clean snap dimension. The `--smrt-elevation-*` scale is downward-only (zero X offset, positive Y) and neutral-colored, so these are legitimately bespoke and excluded **on principle** (not special-cased):

- **Focus rings** (`0 0 0 Npx` — zero blur) and **inset** shadows — not elevation.
- **Directional casts**: nonzero X offset or non-positive Y offset — e.g. an upward toast shadow (`0 -2px 12px`) or a sideways drawer shadow (`-24px 0 40px`). Can't map to a downward scale.
- **Accent-colored glows** (`--smrt-color-primary` etc.) — a brand-tinted hover effect, a different design intent than neutral depth.
- `box-shadow: none` and values already using `var(--smrt-elevation-*)`.

Of 22 raw box-shadows found, 4 fell into the excluded categories (2 directional, 2 accent glows); the remaining **18 standard drop-shadows** were migrated.

## Migration

18 drop-shadows across `smrt-svelte`, `content`, `products`, `assets`, `chat`, `images` wrapped in `var(--smrt-elevation-<n>, <original>)` — themed contexts pick up the token, standalone keeps the exact original look (including nested `var(--smrt-color-shadow, …)` and multi-layer fallbacks, which remain valid CSS).

Migration done with a deterministic span-replace script (masks `.svelte` to `<style>` blocks + blanks comments, same logic as the ratchet) — diff verified to contain **only** box-shadow value changes.

## Wiring

- `pnpm check:elevation`
- lefthook `pre-push`
- `on-pull-request` CI step

Strict (fails) for the UI packages in `STRICT_PACKAGES`; report-only elsewhere until later phases.

## Verification

- `node scripts/check-elevation.mjs` → clean for all strict packages
- `npm run build` → 50/50
- `node scripts/check-svelte-tokens.mjs` → all consumed `--smrt-*` tokens emitted
- `biome check` (read-only) on changed files → clean
- workflow validated with yamllint + actionlint

After this, only **typography** remains to close out S1 (#1373).