### PR TITLE
feat(tooling): typography design-token ratchet + smrt-svelte migration (#1373)

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -199,6 +199,12 @@ jobs:
       - name: Check raw drop-shadows (elevation)
         run: node scripts/check-elevation.mjs
 
+      # Bans raw font-size/weight/family in component CSS. Strict (fails) for
+      # smrt-svelte; report-only elsewhere until later phases of the
+      # design-token sweep (issue #1373). Node-only, no deps.
+      - name: Check raw typography
+        run: node scripts/check-typography.mjs
+
   test:
     name: Validate Changes
     uses: ./.github/workflows/test-suite.yml

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -161,6 +161,19 @@ pre-push:
         Map to the depth scale: box-shadow: var(--smrt-elevation-<n>, <value>).
         Run: node scripts/check-elevation.mjs
 
+    typography:
+      # Bans raw font-size/weight/family in component CSS. Strict for smrt-svelte,
+      # report-only elsewhere until later phases of #1373. Node-only, no deps.
+      run: node scripts/check-typography.mjs
+      fail_text: |
+        ❌ Raw typography found in a strict UI package!
+
+        Map each text element to its M3 role: font-size →
+        var(--smrt-typography-<role>-<size>-size, <value>); font-weight →
+        var(--smrt-typography-weight-<name>, <value>); font-family →
+        var(--smrt-font-family[-mono], <value>).
+        Run: node scripts/check-typography.mjs
+
     validate-all-workflows:
       run: |
         echo "🔍 Validating ALL workflow files before push..."

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "check:spacing": "node scripts/check-spacing.mjs",
     "check:radius": "node scripts/check-radius.mjs",
     "check:elevation": "node scripts/check-elevation.mjs",
+    "check:typography": "node scripts/check-typography.mjs",
     "knowledge:check": "tsx scripts/check-knowledge.ts",
     "changeset": "changeset",
     "changeset:auto": "npx tsx scripts/auto-changeset.ts",

--- a/packages/smrt-svelte/src/components/admin/AgentAdminPanel.svelte
+++ b/packages/smrt-svelte/src/components/admin/AgentAdminPanel.svelte
@@ -80,14 +80,14 @@ async function handleSave(newConfig: unknown) {
 	}
 
 	.no-panel-icon {
-		font-size: 2.5rem;
+		font-size: var(--smrt-typography-display-medium-size, 2.5rem);
 		margin-bottom: 1rem;
 		opacity: 0.5;
 	}
 
 	.no-panel-message {
 		margin: 0 0 0.5rem 0;
-		font-size: 0.9375rem;
+		font-size: var(--smrt-typography-body-large-size, 0.9375rem);
 		color: var(--smrt-color-on-surface-variant, #64748b);
 	}
 
@@ -95,13 +95,13 @@ async function handleSave(newConfig: unknown) {
 		background: var(--smrt-color-surface-container-high, #e2e8f0);
 		padding: var(--smrt-spacing-1, 0.125rem) var(--smrt-spacing-2, 0.375rem);
 		border-radius: var(--smrt-radius-small, 4px);
-		font-family: 'SF Mono', Monaco, Consolas, monospace;
-		font-size: 0.875rem;
+		font-family: var(--smrt-font-family-mono, 'SF Mono', Monaco, Consolas, monospace);
+		font-size: var(--smrt-typography-body-medium-size, 0.875rem);
 	}
 
 	.no-panel-hint {
 		margin: 0;
-		font-size: 0.8125rem;
+		font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
 		color: var(--smrt-color-on-surface-variant, #94a3b8);
 	}
 </style>

--- a/packages/smrt-svelte/src/components/admin/AgentAdminTabs.svelte
+++ b/packages/smrt-svelte/src/components/admin/AgentAdminTabs.svelte
@@ -189,7 +189,7 @@ async function handleSave(config: unknown) {
 		background: transparent;
 		color: var(--smrt-color-on-surface-variant, #64748b);
 		font-size: var(--smrt-typography-label-large-size, 0.875rem);
-		font-weight: 500;
+		font-weight: var(--smrt-typography-weight-medium, 500);
 		cursor: pointer;
 		border-bottom: 2px solid transparent;
 		margin-bottom: -1px;
@@ -218,7 +218,7 @@ async function handleSave(config: unknown) {
 	}
 
 	.tab-icon {
-		font-size: 1rem;
+		font-size: var(--smrt-typography-title-medium-size, 1rem);
 		opacity: 0.8;
 	}
 

--- a/packages/smrt-svelte/src/components/admin/AgentSettingsShell.svelte
+++ b/packages/smrt-svelte/src/components/admin/AgentSettingsShell.svelte
@@ -142,10 +142,10 @@ async function handleSave(slotId: string, config: unknown) {
 	.sidebar-title {
 		margin: 0 0 0.75rem 0;
 		padding: 0 0.5rem 0.75rem;
-		font-size: 0.75rem;
-		font-weight: 600;
+		font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+		font-weight: var(--smrt-typography-weight-semibold, 600);
 		text-transform: uppercase;
-		letter-spacing: 0.05em;
+		letter-spacing: var(--smrt-typography-label-medium-tracking, 0.05em);
 		color: var(--smrt-color-on-surface-variant, #64748b);
 		border-bottom: 1px solid var(--smrt-color-outline-variant, #e2e8f0);
 	}
@@ -187,13 +187,13 @@ async function handleSave(slotId: string, config: unknown) {
 	}
 
 	.agent-class {
-		font-size: 0.875rem;
-		font-weight: 600;
+		font-size: var(--smrt-typography-title-small-size, 0.875rem);
+		font-weight: var(--smrt-typography-weight-semibold, 600);
 		color: var(--smrt-color-on-surface, #1e293b);
 	}
 
 	.agent-name {
-		font-size: 0.75rem;
+		font-size: var(--smrt-typography-body-small-size, 0.75rem);
 		color: var(--smrt-color-on-surface-variant, #64748b);
 	}
 
@@ -210,7 +210,7 @@ async function handleSave(slotId: string, config: unknown) {
 	.agent-title {
 		margin: 0;
 		font-size: var(--smrt-typography-headline-medium-size, 1.5rem);
-		font-weight: 600;
+		font-weight: var(--smrt-typography-weight-semibold, 600);
 		color: var(--smrt-color-on-surface);
 	}
 
@@ -234,20 +234,20 @@ async function handleSave(slotId: string, config: unknown) {
 	}
 
 	.no-agents-icon {
-		font-size: 3rem;
+		font-size: var(--smrt-typography-display-medium-size, 3rem);
 		margin-bottom: 1rem;
 		opacity: 0.5;
 	}
 
 	.no-agents-message {
 		margin: 0 0 0.5rem 0;
-		font-size: 1rem;
+		font-size: var(--smrt-typography-body-large-size, 1rem);
 		color: var(--smrt-color-on-surface-variant, #64748b);
 	}
 
 	.no-agents-hint {
 		margin: 0;
-		font-size: 0.875rem;
+		font-size: var(--smrt-typography-body-medium-size, 0.875rem);
 		color: var(--smrt-color-on-surface-variant, #94a3b8);
 		max-width: 400px;
 	}

--- a/packages/smrt-svelte/src/components/calendar/Calendar.svelte
+++ b/packages/smrt-svelte/src/components/calendar/Calendar.svelte
@@ -470,7 +470,7 @@ const yearOptions = $derived(() => {
     gap: var(--smrt-spacing-1, 4px);
     justify-content: center;
     margin-top: auto;
-    font-size: 12px;
+    font-size: var(--smrt-typography-label-medium-size, 12px);
   }
 
   .event-icon {
@@ -478,7 +478,7 @@ const yearOptions = $derived(() => {
   }
 
   .event-more {
-    font-size: 10px;
+    font-size: var(--smrt-typography-label-small-size, 10px);
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
@@ -510,7 +510,7 @@ const yearOptions = $derived(() => {
     }
 
     .event-indicators {
-      font-size: 10px;
+      font-size: var(--smrt-typography-label-small-size, 10px);
     }
   }
 </style>

--- a/packages/smrt-svelte/src/components/calendar/DayView.svelte
+++ b/packages/smrt-svelte/src/components/calendar/DayView.svelte
@@ -228,7 +228,7 @@ function getTypeLabel(type: string): string {
   }
 
   .weather-icon {
-    font-size: 24px;
+    font-size: var(--smrt-typography-headline-small-size, 24px);
   }
 
   .weather-temps {
@@ -256,7 +256,7 @@ function getTypeLabel(type: string): string {
   }
 
   .empty-icon {
-    font-size: 48px;
+    font-size: var(--smrt-typography-display-medium-size, 48px);
     display: block;
     margin-bottom: var(--smrt-spacing-4, 1rem);
     opacity: 0.5;
@@ -286,7 +286,7 @@ function getTypeLabel(type: string): string {
   }
 
   .group-icon {
-    font-size: 20px;
+    font-size: var(--smrt-typography-title-large-size, 20px);
   }
 
   .group-count {

--- a/packages/smrt-svelte/src/components/data/DataTable.svelte
+++ b/packages/smrt-svelte/src/components/data/DataTable.svelte
@@ -337,7 +337,7 @@ const sizeClasses = {
 
   .data-table__caption {
     padding: var(--smrt-spacing-3, 0.75rem);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     text-align: left;
     color: var(--smrt-color-on-surface-variant, #6b7280);
     caption-side: top;
@@ -360,7 +360,7 @@ const sizeClasses = {
 
   .data-table__cell--header {
     padding: var(--smrt-spacing-3, 0.75rem) var(--smrt-spacing-4, 1rem);
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     text-align: left;
     white-space: nowrap;
     color: var(--smrt-color-on-surface, #111827);
@@ -379,7 +379,7 @@ const sizeClasses = {
     border: none;
     background: none;
     font: inherit;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: inherit;
     cursor: pointer;
   }
@@ -389,7 +389,7 @@ const sizeClasses = {
   }
 
   .data-table__sort-icon {
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
     opacity: 0.5;
   }
 

--- a/packages/smrt-svelte/src/components/display/ConfidenceBadge.svelte
+++ b/packages/smrt-svelte/src/components/display/ConfidenceBadge.svelte
@@ -102,8 +102,8 @@ const valueText = $derived(
     align-items: center;
     gap: 0.5rem;
     padding: 0.25rem 0.5rem;
-    font-size: 0.75rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
     border-radius: var(--smrt-radius-sm, 4px);
     background-color: var(--badge-bg);
     color: var(--badge-text);
@@ -114,13 +114,13 @@ const valueText = $derived(
 
   .confidence-badge.sm {
     padding: 0.125rem 0.375rem;
-    font-size: 0.625rem;
+    font-size: var(--smrt-typography-label-small-size, 0.625rem);
     min-width: 48px;
   }
 
   .confidence-badge.lg {
     padding: 0.375rem 0.75rem;
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
     min-width: 80px;
   }
 

--- a/packages/smrt-svelte/src/components/feedback/ConfirmDialog.svelte
+++ b/packages/smrt-svelte/src/components/feedback/ConfirmDialog.svelte
@@ -161,7 +161,7 @@ function handleKeydown(e: KeyboardEvent) {
     height: 40px;
     padding: 0 var(--smrt-spacing-6, 24px);
     font: var(--smrt-typography-label-large-font);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     border-radius: var(--smrt-radius-2xl, 24px);
     cursor: pointer;
     transition: all var(--smrt-duration-short3, 200ms) var(--smrt-easing-standard, ease);

--- a/packages/smrt-svelte/src/components/feedback/LoadingOverlay.svelte
+++ b/packages/smrt-svelte/src/components/feedback/LoadingOverlay.svelte
@@ -184,8 +184,8 @@ function handleKeydown(e: KeyboardEvent) {
 	}
 
 	.title {
-		font-size: 1.25rem;
-		font-weight: 600;
+		font-size: var(--smrt-typography-title-large-size, 1.25rem);
+		font-weight: var(--smrt-typography-weight-semibold, 600);
 		color: var(--smrt-color-on-surface, #1f2937);
 		margin: 0 0 var(--smrt-spacing-4, 16px);
 	}
@@ -217,8 +217,8 @@ function handleKeydown(e: KeyboardEvent) {
 	}
 
 	.progress-text {
-		font-size: 0.875rem;
-		font-weight: 600;
+		font-size: var(--smrt-typography-label-large-size, 0.875rem);
+		font-weight: var(--smrt-typography-weight-semibold, 600);
 		color: var(--smrt-color-primary, #3b82f6);
 		min-width: 40px;
 	}
@@ -232,7 +232,7 @@ function handleKeydown(e: KeyboardEvent) {
 	}
 
 	.item-badge {
-		font-size: 0.75rem;
+		font-size: var(--smrt-typography-label-medium-size, 0.75rem);
 		padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-3, 12px);
 		border-radius: var(--smrt-radius-full, 9999px);
 		background: var(--smrt-color-primary-container, #dcfce7);
@@ -240,7 +240,7 @@ function handleKeydown(e: KeyboardEvent) {
 	}
 
 	.error-message {
-		font-size: 0.875rem;
+		font-size: var(--smrt-typography-body-medium-size, 0.875rem);
 		color: var(--smrt-color-error, #ef4444);
 		margin: var(--smrt-spacing-4, 16px) 0 0;
 		padding: var(--smrt-spacing-3, 12px);
@@ -251,7 +251,7 @@ function handleKeydown(e: KeyboardEvent) {
 	.dismiss-btn {
 		margin-top: var(--smrt-spacing-5, 20px);
 		padding: var(--smrt-spacing-3, 12px) var(--smrt-spacing-5, 20px);
-		font-size: 0.875rem;
+		font-size: var(--smrt-typography-label-large-size, 0.875rem);
 		color: var(--smrt-color-on-surface-variant, #6b7280);
 		background: transparent;
 		border: 1px solid var(--smrt-color-outline-variant, #d1d5db);

--- a/packages/smrt-svelte/src/components/feedback/Modal.svelte
+++ b/packages/smrt-svelte/src/components/feedback/Modal.svelte
@@ -275,9 +275,9 @@ const sizeClasses = {
   .modal__title {
     margin: 0;
     font-size: var(--smrt-typography-headline-small-size, 1.125rem);
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-on-surface, #1b1b1f);
-    line-height: 1.4;
+    line-height: var(--smrt-typography-headline-small-line-height, 1.4);
   }
 
   .modal__close {

--- a/packages/smrt-svelte/src/components/feedback/ProgressBar.svelte
+++ b/packages/smrt-svelte/src/components/feedback/ProgressBar.svelte
@@ -118,7 +118,7 @@ const displayLabel = $derived.by(() => {
 
   .over-badge {
     font: var(--smrt-typography-label-small-font);
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-error, #ba1a1a);
   }
 

--- a/packages/smrt-svelte/src/components/forms/AddressInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/AddressInput.svelte
@@ -473,7 +473,7 @@ function handleCountryChange(e: Event) {
   }
 
   .validation-error {
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
     color: var(--smrt-color-error, #ba1a1a);
     margin-top: var(--smrt-spacing-1, 4px);
   }

--- a/packages/smrt-svelte/src/components/forms/CheckboxInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/CheckboxInput.svelte
@@ -175,7 +175,7 @@ function handleChange(e: Event) {
   }
 
   .label {
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     color: var(--smrt-color-on-surface);
     cursor: inherit;
   }

--- a/packages/smrt-svelte/src/components/forms/DateRangeInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/DateRangeInput.svelte
@@ -462,7 +462,7 @@ const primaryControlId = $derived(isSmrt ? `${name}_voice` : `${name}_start`);
     display: flex;
     align-items: center;
     gap: var(--smrt-spacing-2, 8px);
-    font-size: 1rem;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
   }
 
   .date-value {
@@ -471,7 +471,7 @@ const primaryControlId = $derived(isSmrt ? `${name}_voice` : `${name}_start`);
 
   .range-separator {
     color: var(--smrt-color-on-surface-variant, #9ca3af);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
   .placeholder {

--- a/packages/smrt-svelte/src/components/forms/FileUpload.svelte
+++ b/packages/smrt-svelte/src/components/forms/FileUpload.svelte
@@ -282,7 +282,7 @@ function formatFileSize(bytes: number): string {
   .drop-zone__hint {
     margin: 0;
     font: var(--smrt-typography-body-small-font);
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     color: var(--smrt-color-on-surface-variant, #49454f);
   }
 
@@ -292,7 +292,7 @@ function formatFileSize(bytes: number): string {
     background: var(--smrt-color-error-container, #f9dedc);
     color: var(--smrt-color-on-error-container, #410e0b);
     border-radius: var(--smrt-radius-sm, 0.25rem);
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
   }
 
   .file-list {
@@ -318,7 +318,7 @@ function formatFileSize(bytes: number): string {
 
   .file-list__name {
     flex: 1;
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     color: var(--smrt-color-on-surface, #1d1b20);
     overflow: hidden;
     text-overflow: ellipsis;
@@ -326,7 +326,7 @@ function formatFileSize(bytes: number): string {
   }
 
   .file-list__size {
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
     color: var(--smrt-color-on-surface-variant, #49454f);
     white-space: nowrap;
   }

--- a/packages/smrt-svelte/src/components/forms/Form.svelte
+++ b/packages/smrt-svelte/src/components/forms/Form.svelte
@@ -657,8 +657,8 @@ function getFormData(): Record<string, unknown> {
     color: var(--smrt-color-on-surface-variant, #6b7280);
     border-radius: var(--smrt-radius-md, 8px);
     cursor: pointer;
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
     transition: all var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
   }
 
@@ -682,8 +682,8 @@ function getFormData(): Record<string, unknown> {
     color: var(--smrt-color-primary);
     border-radius: var(--smrt-radius-md, 8px);
     cursor: pointer;
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
     transition: all var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
   }
 
@@ -744,7 +744,7 @@ function getFormData(): Record<string, unknown> {
        emitted `--smrt-color-primary` token instead. */
     background: color-mix(in srgb, var(--smrt-color-primary, #166534) 90%, transparent);
     color: white;
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     box-shadow: 0 -2px 12px color-mix(in srgb, var(--smrt-color-shadow) 15%, transparent);
     z-index: var(--smrt-z-index-toast, 1500);
     text-align: center;
@@ -772,7 +772,7 @@ function getFormData(): Record<string, unknown> {
     background: var(--smrt-color-error-container);
     border: 1px solid var(--smrt-color-error);
     border-radius: var(--smrt-radius-md, 8px);
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     color: var(--smrt-color-error);
   }
 

--- a/packages/smrt-svelte/src/components/forms/FormGroup.svelte
+++ b/packages/smrt-svelte/src/components/forms/FormGroup.svelte
@@ -36,8 +36,8 @@ const { label, id, error, hint, required = false, children }: Props = $props();
 
 	.form-label {
 		display: block;
-		font-size: 0.875rem;
-		font-weight: 500;
+		font-size: var(--smrt-typography-label-large-size, 0.875rem);
+		font-weight: var(--smrt-typography-weight-medium, 500);
 		color: var(--smrt-color-on-surface, #374151);
 		margin-bottom: 0.375rem;
 	}
@@ -49,13 +49,13 @@ const { label, id, error, hint, required = false, children }: Props = $props();
 
 	.form-hint {
 		margin: 0.25rem 0 0;
-		font-size: 0.75rem;
+		font-size: var(--smrt-typography-body-small-size, 0.75rem);
 		color: var(--smrt-color-on-surface-variant, #6b7280);
 	}
 
 	.form-error {
 		margin: 0.25rem 0 0;
-		font-size: 0.75rem;
+		font-size: var(--smrt-typography-body-small-size, 0.75rem);
 		color: var(--smrt-color-error, #ba1a1a);
 	}
 </style>

--- a/packages/smrt-svelte/src/components/forms/FormMicButton.svelte
+++ b/packages/smrt-svelte/src/components/forms/FormMicButton.svelte
@@ -141,8 +141,8 @@ function handleClick() {
     padding: 0.5rem 0.75rem;
     background: var(--smrt-color-on-surface, #1f2937);
     color: white;
-    font-size: 0.75rem;
-    font-weight: 400;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-normal, 400);
     border-radius: 0.375rem;
     white-space: nowrap;
     z-index: var(--smrt-z-index-tooltip, 1600);

--- a/packages/smrt-svelte/src/components/forms/Input.svelte
+++ b/packages/smrt-svelte/src/components/forms/Input.svelte
@@ -41,8 +41,8 @@ let {
 		display: block;
 		width: 100%;
 		padding: 0.5rem 0.75rem;
-		font-size: 0.875rem;
-		line-height: 1.5;
+		font-size: var(--smrt-typography-body-medium-size, 0.875rem);
+		line-height: var(--smrt-typography-body-medium-line-height, 1.5);
 		color: var(--smrt-color-on-surface, #1f2937);
 		background-color: var(--smrt-color-surface, #fff);
 		border: 1px solid var(--smrt-color-outline-variant, #d1d5db);

--- a/packages/smrt-svelte/src/components/forms/MoneyInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/MoneyInput.svelte
@@ -350,7 +350,7 @@ function handleBlur() {
     position: absolute;
     left: 12px;
     color: var(--smrt-color-on-surface-variant, #6b7280);
-    font-size: 1rem;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
     pointer-events: none;
   }
 
@@ -358,7 +358,7 @@ function handleBlur() {
     position: absolute;
     right: 12px;
     color: var(--smrt-color-on-surface-variant, #9ca3af);
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
     text-transform: uppercase;
     pointer-events: none;
   }

--- a/packages/smrt-svelte/src/components/forms/Select.svelte
+++ b/packages/smrt-svelte/src/components/forms/Select.svelte
@@ -38,8 +38,8 @@ let {
 		display: block;
 		width: 100%;
 		padding: 0.5rem 2rem 0.5rem 0.75rem;
-		font-size: 0.875rem;
-		line-height: 1.5;
+		font-size: var(--smrt-typography-body-medium-size, 0.875rem);
+		line-height: var(--smrt-typography-body-medium-line-height, 1.5);
 		color: var(--smrt-color-on-surface, #1f2937);
 		background-color: var(--smrt-color-surface, #fff);
 		background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%2379747e' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");

--- a/packages/smrt-svelte/src/components/forms/SelectInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/SelectInput.svelte
@@ -177,9 +177,9 @@ function handleChange(e: Event) {
   }
 
   .label {
-    font-size: 1rem;
-    line-height: 1.5;
-    letter-spacing: 0.5px;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
+    line-height: var(--smrt-typography-body-large-line-height, 1.5);
+    letter-spacing: var(--smrt-typography-body-large-tracking, 0.5px);
     color: var(--field-color);
     pointer-events: none;
     transition: all var(--smrt-duration-short3, 200ms) var(--smrt-easing-standard, cubic-bezier(0.2, 0, 0, 1));
@@ -194,9 +194,9 @@ function handleChange(e: Event) {
   .input {
     border: none;
     background: transparent;
-    font-size: 1rem;
-    line-height: 1.5;
-    letter-spacing: 0.5px;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
+    line-height: var(--smrt-typography-body-large-line-height, 1.5);
+    letter-spacing: var(--smrt-typography-body-large-tracking, 0.5px);
     color: var(--smrt-color-on-surface);
     width: 100%;
     padding: 0;
@@ -236,7 +236,7 @@ function handleChange(e: Event) {
 
   .supporting-text {
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-4, 16px) 0;
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
   }
 
   .info { color: var(--smrt-color-on-surface-variant); }

--- a/packages/smrt-svelte/src/components/forms/TextInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/TextInput.svelte
@@ -313,9 +313,9 @@ function handleInput(e: Event) {
   }
 
   .label {
-    font-size: 1rem;
-    line-height: 1.5;
-    letter-spacing: 0.5px;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
+    line-height: var(--smrt-typography-body-large-line-height, 1.5);
+    letter-spacing: var(--smrt-typography-body-large-tracking, 0.5px);
     color: var(--field-color);
     pointer-events: none;
     transition: all var(--smrt-duration-short3, 200ms) var(--smrt-easing-standard, cubic-bezier(0.2, 0, 0, 1));
@@ -331,9 +331,9 @@ function handleInput(e: Event) {
   .input {
     border: none;
     background: transparent;
-    font-size: 1rem;
-    line-height: 1.5;
-    letter-spacing: 0.5px;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
+    line-height: var(--smrt-typography-body-large-line-height, 1.5);
+    letter-spacing: var(--smrt-typography-body-large-tracking, 0.5px);
     color: var(--smrt-color-on-surface);
     width: 100%;
     padding: 0;
@@ -382,7 +382,7 @@ function handleInput(e: Event) {
 
   .supporting-text {
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-4, 16px) 0;
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
     min-height: 16px;
   }
 

--- a/packages/smrt-svelte/src/components/forms/Textarea.svelte
+++ b/packages/smrt-svelte/src/components/forms/Textarea.svelte
@@ -41,8 +41,8 @@ let {
 		display: block;
 		width: 100%;
 		padding: 0.5rem 0.75rem;
-		font-size: 0.875rem;
-		line-height: 1.5;
+		font-size: var(--smrt-typography-body-medium-size, 0.875rem);
+		line-height: var(--smrt-typography-body-medium-line-height, 1.5);
 		color: var(--smrt-color-on-surface, #1f2937);
 		background-color: var(--smrt-color-surface, #fff);
 		border: 1px solid var(--smrt-color-outline-variant, #d1d5db);

--- a/packages/smrt-svelte/src/components/forms/TextareaInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/TextareaInput.svelte
@@ -287,9 +287,9 @@ function handleInput(e: Event) {
   }
 
   .label {
-    font-size: 1rem;
-    line-height: 1.5;
-    letter-spacing: 0.5px;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
+    line-height: var(--smrt-typography-body-large-line-height, 1.5);
+    letter-spacing: var(--smrt-typography-body-large-tracking, 0.5px);
     color: var(--field-color);
     pointer-events: none;
     transition: all var(--smrt-duration-short3, 200ms) var(--smrt-easing-standard, cubic-bezier(0.2, 0, 0, 1));
@@ -305,9 +305,9 @@ function handleInput(e: Event) {
   .input {
     border: none;
     background: transparent;
-    font-size: 1rem;
-    line-height: 1.5;
-    letter-spacing: 0.5px;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
+    line-height: var(--smrt-typography-body-large-line-height, 1.5);
+    letter-spacing: var(--smrt-typography-body-large-tracking, 0.5px);
     color: var(--smrt-color-on-surface);
     width: 100%;
     padding: 0;
@@ -358,7 +358,7 @@ function handleInput(e: Event) {
 
   .supporting-text {
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-4, 16px) 0;
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
     min-height: 16px;
   }
 

--- a/packages/smrt-svelte/src/components/layout/EmptyState.svelte
+++ b/packages/smrt-svelte/src/components/layout/EmptyState.svelte
@@ -140,7 +140,7 @@ const icons = {
     font: var(--smrt-typography-title-large-font);
     color: var(--smrt-color-on-surface);
     margin: 0 0 0.75rem;
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
   .sm .empty-title {
@@ -156,7 +156,7 @@ const icons = {
     color: var(--smrt-color-on-surface-variant);
     margin: 0 0 2rem;
     max-width: 440px;
-    line-height: 1.5;
+    line-height: var(--smrt-typography-body-medium-line-height, 1.5);
   }
 
   .action-button {
@@ -167,7 +167,7 @@ const icons = {
     padding: 0 var(--smrt-spacing-6, 24px);
     height: 40px;
     font: var(--smrt-typography-label-large-font);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-primary);
     background-color: var(--smrt-color-primary);
     border: none;

--- a/packages/smrt-svelte/src/components/layout/SummaryCard.svelte
+++ b/packages/smrt-svelte/src/components/layout/SummaryCard.svelte
@@ -183,7 +183,7 @@ const isSvg = $derived(icon?.startsWith('<svg'));
 
   .card-value {
     font: var(--smrt-typography-headline-small-font);
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .color-default { color: var(--smrt-color-on-surface); }

--- a/packages/smrt-svelte/src/components/memberships/MembershipCard.svelte
+++ b/packages/smrt-svelte/src/components/memberships/MembershipCard.svelte
@@ -85,16 +85,16 @@ function formatDate(date: Date | string | null | undefined): string {
   }
 
   .tenant-name {
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-surface);
   }
 
   .status {
-    font-size: 0.625rem;
+    font-size: var(--smrt-typography-label-small-size, 0.625rem);
     padding: 0.125rem 0.375rem;
     border-radius: var(--smrt-radius-full, 9999px);
     text-transform: uppercase;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .status-active {
@@ -126,7 +126,7 @@ function formatDate(date: Date | string | null | undefined): string {
   }
 
   .date {
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
     color: var(--smrt-color-on-surface-variant);
   }
 
@@ -140,7 +140,7 @@ function formatDate(date: Date | string | null | undefined): string {
     background: none;
     border: 1px solid var(--smrt-color-outline);
     border-radius: 0.25rem;
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
     color: var(--smrt-color-on-surface-variant);
     cursor: pointer;
   }

--- a/packages/smrt-svelte/src/components/module/ModulePanel.svelte
+++ b/packages/smrt-svelte/src/components/module/ModulePanel.svelte
@@ -103,8 +103,8 @@ const slotMeta = $derived(moduleMeta?.uiSlots?.[slotId]);
 
   .module-panel-placeholder__title {
     margin: 0;
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-title-medium-size, 1rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-on-surface, #1e293b);
   }
 
@@ -119,13 +119,13 @@ const slotMeta = $derived(moduleMeta?.uiSlots?.[slotId]);
 
   .module-panel-placeholder__hint {
     margin: 0;
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     color: var(--smrt-color-on-surface-variant, #64748b);
   }
 
   .module-panel-placeholder__meta {
     margin: 0;
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
     color: var(--smrt-color-on-surface-variant, #94a3b8);
   }
 </style>

--- a/packages/smrt-svelte/src/components/nav/FilterChips.svelte
+++ b/packages/smrt-svelte/src/components/nav/FilterChips.svelte
@@ -94,7 +94,7 @@ function handleClick(value: string) {
     height: 32px;
     padding: 0 var(--smrt-spacing-4, 16px);
     font: var(--smrt-typography-label-large-font);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-surface-variant);
     background-color: transparent;
     border: 1px solid var(--smrt-color-outline);

--- a/packages/smrt-svelte/src/components/nav/Tabs.svelte
+++ b/packages/smrt-svelte/src/components/nav/Tabs.svelte
@@ -172,7 +172,7 @@ function handleKeydown(event: KeyboardEvent, tabId: string) {
     padding: 0 var(--smrt-spacing-4, 16px);
     height: 48px;
     font: var(--smrt-typography-title-small-font);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-surface-variant);
     background: transparent;
     border: none;

--- a/packages/smrt-svelte/src/components/roles/RoleBadge.svelte
+++ b/packages/smrt-svelte/src/components/roles/RoleBadge.svelte
@@ -41,7 +41,7 @@ const variantClass = $derived.by(() => {
     padding: 0 var(--smrt-spacing-3, 12px);
     height: 24px;
     font: var(--smrt-typography-label-large-font);
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     border-radius: var(--smrt-radius-md, 8px);
     white-space: nowrap;
     transition: all 200ms cubic-bezier(0.2, 0, 0, 1);
@@ -51,14 +51,14 @@ const variantClass = $derived.by(() => {
     padding: 0 var(--smrt-spacing-2, 8px);
     height: 20px;
     font: var(--smrt-typography-label-small-font);
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .role-badge.lg {
     padding: 0 var(--smrt-spacing-4, 16px);
     height: 32px;
     font: var(--smrt-typography-title-small-font);
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   /* Variant Colors using M3 roles */

--- a/packages/smrt-svelte/src/components/roles/RoleSelector.svelte
+++ b/packages/smrt-svelte/src/components/roles/RoleSelector.svelte
@@ -110,7 +110,7 @@ function handleKeydown(e: KeyboardEvent) {
     background: var(--smrt-color-surface, white);
     border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
     border-radius: var(--smrt-radius-small, 0.375rem);
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     cursor: pointer;
     text-align: left;
   }
@@ -174,7 +174,7 @@ function handleKeydown(e: KeyboardEvent) {
     padding: 0.5rem 0.75rem;
     background: none;
     border: none;
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     cursor: pointer;
     text-align: left;
   }
@@ -194,23 +194,23 @@ function handleKeydown(e: KeyboardEvent) {
   }
 
   .role-name {
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-surface, #111827);
     text-transform: capitalize;
   }
 
   .system-badge {
-    font-size: 0.625rem;
+    font-size: var(--smrt-typography-label-small-size, 0.625rem);
     padding: 0.125rem 0.375rem;
     background: var(--smrt-color-primary-container, #dbeafe);
     color: var(--smrt-color-on-primary-container, #1e40af);
     border-radius: var(--smrt-radius-full, 9999px);
     text-transform: uppercase;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .description {
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
     color: var(--smrt-color-on-surface-variant, #6b7280);
   }
 </style>

--- a/packages/smrt-svelte/src/components/theme/ThemeProvider.svelte
+++ b/packages/smrt-svelte/src/components/theme/ThemeProvider.svelte
@@ -66,6 +66,6 @@ const cssVariables = $derived.by(() => {
     /* Base typography and other global resets can go here later */
     color: var(--md-sys-color-on-background);
     background-color: var(--md-sys-color-background);
-    font-family: Roboto, sans-serif;
+    font-family: var(--smrt-font-family, Roboto, sans-serif);
   }
 </style>

--- a/packages/smrt-svelte/src/components/ui/Pagination.svelte
+++ b/packages/smrt-svelte/src/components/ui/Pagination.svelte
@@ -216,7 +216,7 @@ const isLastPage = $derived(currentPage === totalPages);
     padding: 0 var(--smrt-spacing-2, 0.5rem);
     border-radius: var(--smrt-radius-small, 0.25rem);
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     text-decoration: none;
     transition: background-color var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease), color var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
   }
@@ -279,7 +279,7 @@ const isLastPage = $derived(currentPage === totalPages);
     .page-link {
       min-width: 2rem;
       height: 2rem;
-      font-size: 0.8125rem;
+      font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
     }
 
     .nav-link {

--- a/packages/smrt-svelte/src/components/workspace/Breadcrumbs.svelte
+++ b/packages/smrt-svelte/src/components/workspace/Breadcrumbs.svelte
@@ -98,18 +98,18 @@ const lastIndex = $derived(crumbs.length - 1);
   .crumb-item {
     display: inline-flex;
     align-items: center;
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     color: var(--smrt-color-on-surface-variant);
   }
 
   .separator {
     margin: 0 0.5rem;
     color: var(--smrt-color-outline-variant);
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
   }
 
   .current {
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-surface);
   }
 
@@ -132,7 +132,7 @@ const lastIndex = $derived(crumbs.length - 1);
 
   @media (max-width: 640px) {
     .crumb-item {
-      font-size: 0.8125rem;
+      font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
     }
     .separator {
       margin: 0 0.35rem;

--- a/packages/smrt-svelte/src/components/workspace/NavTree.svelte
+++ b/packages/smrt-svelte/src/components/workspace/NavTree.svelte
@@ -243,7 +243,7 @@ function navChildrenId(href: string): string {
 
   .nav-item.parent-active {
     color: var(--smrt-color-on-surface);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
   .nav-icon-slot {
@@ -256,7 +256,7 @@ function navChildrenId(href: string): string {
   }
 
   .nav-icon-text {
-    font-size: 1rem;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
     line-height: 1;
   }
 
@@ -274,9 +274,9 @@ function navChildrenId(href: string): string {
     justify-content: center;
     min-width: 1.25rem;
     padding: 0 0.4rem;
-    font-size: 0.7rem;
-    font-weight: 600;
-    line-height: 1.2;
+    font-size: var(--smrt-typography-label-small-size, 0.7rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
+    line-height: var(--smrt-typography-label-small-line-height, 1.2);
     border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-secondary-container);
     color: var(--smrt-color-on-secondary-container);
@@ -285,7 +285,7 @@ function navChildrenId(href: string): string {
   .nav-chevron {
     flex-shrink: 0;
     color: var(--smrt-color-on-surface-variant);
-    font-size: 1rem;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
     line-height: 1;
     transform: rotate(0deg);
     transition:
@@ -301,31 +301,31 @@ function navChildrenId(href: string): string {
   /* Level 1 */
   .nav-item.level-1 {
     padding: 0.625rem 1rem;
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
   }
 
   /* Level 2 */
   .nav-item.level-2 {
     padding: 0.5rem 1rem 0.5rem 2.75rem;
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
   }
   .nav-item.level-2 .nav-icon-slot {
     width: 1rem;
   }
   .nav-item.level-2 .nav-icon-text {
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
   }
 
   /* Level 3 */
   .nav-item.level-3 {
     padding: 0.45rem 1rem 0.45rem 4rem;
-    font-size: 0.78rem;
+    font-size: var(--smrt-typography-body-small-size, 0.78rem);
   }
   .nav-item.level-3 .nav-icon-slot {
     width: 0.95rem;
   }
   .nav-item.level-3 .nav-icon-text {
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
   }
 
   /* Children containers — collapsed by default, shown when .expanded */

--- a/packages/smrt-svelte/src/components/workspace/RoleShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/RoleShell.svelte
@@ -302,7 +302,7 @@ function handleNavigate(): void {
   .smrt-role-shell-icon {
     display: inline-block;
     margin-right: 0.4rem;
-    font-size: 1.1rem;
+    font-size: var(--smrt-typography-title-medium-size, 1.1rem);
     line-height: 1;
     color: var(--smrt-role-color, var(--smrt-color-on-surface, #111827));
   }

--- a/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
@@ -493,23 +493,23 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
   .brand :global(h1),
   .brand h1 {
     margin: 0;
-    font-size: 1.25rem;
-    line-height: 1.1;
+    font-size: var(--smrt-typography-title-large-size, 1.25rem);
+    line-height: var(--smrt-typography-title-large-line-height, 1.1);
     color: var(--smrt-color-on-surface, #111827);
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .brand .subtitle {
     margin: 0;
     color: var(--smrt-color-on-surface-variant, #6b7280);
-    line-height: 1.4;
-    font-size: 0.9rem;
+    line-height: var(--smrt-typography-body-medium-line-height, 1.4);
+    font-size: var(--smrt-typography-body-medium-size, 0.9rem);
   }
 
   .eyebrow {
-    font-size: 0.7rem;
-    font-weight: 700;
-    letter-spacing: 0.12em;
+    font-size: var(--smrt-typography-label-small-size, 0.7rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
+    letter-spacing: var(--smrt-typography-label-small-tracking, 0.12em);
     text-transform: uppercase;
     color: var(--smrt-color-on-surface-variant, #6b7280);
   }
@@ -542,7 +542,7 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
   }
 
   .shell-toggle-glyph {
-    font-size: 1rem;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
     line-height: 1;
   }
 
@@ -628,8 +628,8 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
   }
 
   .mode-title {
-    font-size: 0.9rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-title-small-size, 0.9rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-on-surface, #111827);
   }
 
@@ -637,7 +637,7 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
     color: var(--smrt-color-on-surface-variant, #6b7280);
     max-width: 18rem;
     text-align: right;
-    font-size: 0.85rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.85rem);
   }
 
   .mode-badge {
@@ -649,8 +649,8 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
     border: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
     background: var(--smrt-color-surface-container, #f3f4f6);
     color: var(--smrt-color-on-surface, #111827);
-    font-size: 0.78rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-medium-size, 0.78rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     line-height: 1;
     white-space: nowrap;
   }
@@ -688,7 +688,7 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
     align-items: center;
     justify-content: center;
     cursor: pointer;
-    font-size: 1.1rem;
+    font-size: var(--smrt-typography-body-large-size, 1.1rem);
     line-height: 1;
   }
 
@@ -734,9 +734,9 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
   }
 
   .inspector-title {
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-on-surface, #111827);
-    font-size: 0.95rem;
+    font-size: var(--smrt-typography-title-medium-size, 0.95rem);
   }
 
   .inspector-close {
@@ -750,7 +750,7 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-size: 1.25rem;
+    font-size: var(--smrt-typography-title-large-size, 1.25rem);
     line-height: 1;
     cursor: pointer;
     transition:

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
@@ -329,8 +329,8 @@
   }
 
   .tools-dock__rail-glyph {
-    font-size: 0.95rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-body-large-size, 0.95rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
     line-height: 1;
   }
 
@@ -347,8 +347,8 @@
     border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-primary, #7dd3fc);
     color: var(--smrt-color-on-primary, #061014);
-    font-size: 0.58rem;
-    font-weight: 750;
+    font-size: var(--smrt-typography-label-small-size, 0.58rem);
+    font-weight: var(--smrt-typography-weight-bold, 750);
     line-height: 1;
   }
 
@@ -397,8 +397,8 @@
 
   .tools-dock__panel-header h3 {
     margin: 0;
-    font-size: 1.05rem;
-    line-height: 1.15;
+    font-size: var(--smrt-typography-title-medium-size, 1.05rem);
+    line-height: var(--smrt-typography-title-medium-line-height, 1.15);
   }
 
   .tools-dock__panel-body {
@@ -417,7 +417,7 @@
     background: var(--smrt-color-surface-container-high, #1d2228);
     color: inherit;
     cursor: pointer;
-    font-size: 1.2rem;
+    font-size: var(--smrt-typography-title-large-size, 1.2rem);
     line-height: 1;
   }
 
@@ -467,8 +467,8 @@
     border-radius: 0.6rem;
     padding: 0.45rem 0.7rem;
     cursor: pointer;
-    font-size: 0.84rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-large-size, 0.84rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .tools-dock__topbar-button.active,
@@ -485,7 +485,7 @@
     align-items: center;
     justify-content: center;
     line-height: 1;
-    font-size: 0.95rem;
+    font-size: var(--smrt-typography-body-large-size, 0.95rem);
   }
 
   .tools-dock--topbar .tools-dock__panel {

--- a/packages/smrt-svelte/src/themes/components/ColorSchemeToggle.svelte
+++ b/packages/smrt-svelte/src/themes/components/ColorSchemeToggle.svelte
@@ -195,7 +195,7 @@ const labels = {
   }
 
   .smrt-color-scheme-toggle__icon {
-    font-size: 1rem;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
     line-height: 1;
   }
 

--- a/packages/smrt-svelte/src/themes/components/ThemeSwitcher.svelte
+++ b/packages/smrt-svelte/src/themes/components/ThemeSwitcher.svelte
@@ -183,6 +183,6 @@ const themeIcons: Record<ThemePreset, string> = {
   }
 
   .smrt-theme-switcher__icon {
-    font-size: 1rem;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
   }
 </style>

--- a/scripts/check-typography.mjs
+++ b/scripts/check-typography.mjs
@@ -75,26 +75,22 @@ const SIZE_REMS = [...SIZE_TO_ROLES.keys()].map((k) => ({
   key: k,
 }));
 
-/** Parse a font-size token to rem (px ÷ 16); null if not an absolute length. */
-function fontSizeToRem(token) {
-  const t = token.trim();
-  let m = t.match(/^(\d*\.?\d+)rem$/i);
-  if (m) return Number(m[1]);
-  m = t.match(/^(\d*\.?\d+)px$/i);
-  if (m) return Number(m[1]) / ROOT_PX;
-  return null; // em/%/keyword/0 → not on the absolute rem scale
+/**
+ * The first hard-coded absolute length (px/rem) anywhere in a value, in rem;
+ * null if none. Matches even when wrapped — `var(--x, 16px)`, `calc(1rem + 2px)`
+ * — so non-token wrappers with a raw fallback can't bypass the check. (Approved
+ * `--smrt-typography-*` vars are already blanked before this runs.)
+ */
+function firstAbsoluteRem(value) {
+  const m = value.match(/(?<![\w.#-])(\d*\.?\d+)(px|rem)\b/i);
+  if (!m) return null;
+  return m[2].toLowerCase() === 'px' ? Number(m[1]) / ROOT_PX : Number(m[1]);
 }
 
-/** Suggest role tokens for a raw font-size. */
-function suggestSize(token) {
-  const rem = fontSizeToRem(token);
-  if (rem === null) return null;
+/** Candidate role-size names for a rem value: exact match, else nearest. */
+function rolesForRem(rem) {
   const key = `${rem}rem`;
-  if (SIZE_TO_ROLES.has(key)) {
-    const roles = SIZE_TO_ROLES.get(key);
-    return `${roles.map((r) => `--smrt-typography-${r}-size`).join(' | ')}`;
-  }
-  // Off-scale: nearest canonical size, flag as approximate.
+  if (SIZE_TO_ROLES.has(key)) return { roles: SIZE_TO_ROLES.get(key), exact: true };
   let best = SIZE_REMS[0];
   let bestDist = Number.POSITIVE_INFINITY;
   for (const s of SIZE_REMS) {
@@ -104,8 +100,25 @@ function suggestSize(token) {
       bestDist = d;
     }
   }
-  const roles = SIZE_TO_ROLES.get(best.key);
-  return `~${roles.map((r) => `--smrt-typography-${r}-size`).join(' | ')} (nearest ${best.key})`;
+  return { roles: SIZE_TO_ROLES.get(best.key), exact: false, nearest: best.key };
+}
+
+/** Suggest `-size` role tokens for a raw font-size value. */
+function suggestSize(value) {
+  const rem = firstAbsoluteRem(value);
+  if (rem === null) return null;
+  const { roles, exact, nearest } = rolesForRem(rem);
+  const names = roles.map((r) => `--smrt-typography-${r}-size`).join(' | ');
+  return exact ? names : `~${names} (nearest ${nearest})`;
+}
+
+/** Suggest `-font` shorthand role tokens for a raw `font:` shorthand value. */
+function suggestFontShorthand(value) {
+  const rem = firstAbsoluteRem(value);
+  if (rem === null) return 'var(--smrt-typography-<role>-<size>-font, <orig>)';
+  const { roles, exact, nearest } = rolesForRem(rem);
+  const names = roles.map((r) => `--smrt-typography-${r}-font`).join(' | ');
+  return exact ? names : `~${names} (nearest ${nearest})`;
 }
 
 /** font-weight number/keyword → named weight token. */
@@ -214,23 +227,34 @@ function stripTokenVars(source) {
 
 const KEYWORD_VALUES = new Set(['inherit', 'unset', 'initial', 'revert']);
 
+// Longhands. `font:` shorthand is matched separately (FONT_SHORTHAND_RE).
 const PROP_RE = /\b(font-size|font-weight|font-family)\s*:\s*([^;}{]+)/gi;
+// `font:` shorthand only — lookbehind rejects `font-*` longhands and custom
+// props like `--card-font:`; the shorthand packs size+weight+family at once.
+const FONT_SHORTHAND_RE = /(?<![\w-])font\s*:\s*([^;}{]+)/gi;
 
 function findViolations(file, source) {
   let text = file.endsWith('.svelte') ? extractStyleBlocks(source) : source;
   text = stripComments(text);
   text = stripTokenVars(text);
   const hits = [];
+  const push = (index, prop, value, suggestion) =>
+    hits.push({
+      line: text.slice(0, index).split('\n').length,
+      prop,
+      value: value.slice(0, 40),
+      suggestion,
+    });
   for (const m of text.matchAll(PROP_RE)) {
     const prop = m[1].toLowerCase();
     const value = m[2].replace(/\s+/g, ' ').trim();
     if (!value || KEYWORD_VALUES.has(value.toLowerCase())) continue;
-    // Anything still containing a token var() was a multi-part value we keep.
-    if (/var\(\s*--smrt-(typography|font-family)/.test(value)) continue;
     let suggestion = null;
     if (prop === 'font-size') {
-      // skip relative/zero/keyword sizes (em/%/0/larger/smaller)
-      if (fontSizeToRem(value) === null) continue;
+      // Flag iff a hard-coded absolute length remains (after token-stripping):
+      // catches bare `0.875rem`, wrapped `var(--x, 16px)`, and `calc(... + 2px)`.
+      // Pure relative/keyword sizes (em/%/0/inherit) are allowed.
+      if (firstAbsoluteRem(value) === null) continue;
       suggestion = suggestSize(value);
     } else if (prop === 'font-weight') {
       suggestion = suggestWeight(value);
@@ -238,13 +262,15 @@ function findViolations(file, source) {
     } else if (prop === 'font-family') {
       suggestion = suggestFamily(value);
     }
-    const line = text.slice(0, m.index).split('\n').length;
-    hits.push({
-      line,
-      prop,
-      value: value.slice(0, 40),
-      suggestion,
-    });
+    push(m.index, prop, value, suggestion);
+  }
+  // `font:` shorthand — a raw shorthand hard-codes size/weight/family at once.
+  for (const m of text.matchAll(FONT_SHORTHAND_RE)) {
+    const value = m[1].replace(/\s+/g, ' ').trim();
+    if (!value || KEYWORD_VALUES.has(value.toLowerCase())) continue;
+    // Allow when fully tokenized (the -font var was blanked → no raw length).
+    if (firstAbsoluteRem(value) === null) continue;
+    push(m.index, 'font', value, suggestFontShorthand(value));
   }
   return hits;
 }

--- a/scripts/check-typography.mjs
+++ b/scripts/check-typography.mjs
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+/**
+ * Raw typography ratchet for SMRT UI packages.
+ *
+ * Bans hardcoded `font-size`, `font-weight`, and `font-family` inside CSS
+ * contexts of `.svelte`/`.css` files, steering authors to the Material-3
+ * `--smrt-typography-*` role scale (issue #1373, parent epic #1354). Policy
+ * (user's call): FULL SEMANTIC PASS — every text element maps to its proper
+ * role variant (display/headline/title/body/label × large/medium/small), using
+ * the per-variant tokens with the original value preserved as the var()
+ * fallback. line-height + letter-spacing are migrated *with* an element's role
+ * (its `-line-height`/`-tracking`) but are NOT independently flagged here: raw
+ * line-height is frequently a layout reset (`1`, `normal`, `0`) and is
+ * ambiguous without an assigned role, so enforcing it standalone is noise.
+ *
+ * The same size often maps to several roles (e.g. `0.875rem` = title-small AND
+ * body-medium AND label-large), so font-size CANNOT be snapped deterministically
+ * — the check SUGGESTS the candidate roles and the author picks by semantics.
+ * font-weight maps cleanly to `--smrt-typography-weight-{normal|medium|semibold|
+ * bold}`; font-family to `--smrt-font-family` (or `-mono`).
+ *
+ * Allowed (never flagged): `var(--smrt-typography-*)` / `var(--smrt-font-family*)`,
+ * the `inherit`/`unset`/`initial` keywords, `font-size` in `em`/`%` (relative,
+ * usually icon-sizing) or `0`, and `<script>`/markup/comments.
+ *
+ * Phased rollout: strict (ERROR) for STRICT_PACKAGES; report-only elsewhere.
+ * Run: `node scripts/check-typography.mjs` or `pnpm check:typography`. Exit 0/1.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative, resolve, sep } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const PACKAGES = join(ROOT, 'packages');
+
+/** Packages held to ERROR. Everything else is report-only for now (#1373). */
+const STRICT_PACKAGES = new Set([
+  'smrt-svelte',
+]);
+
+/** Dev/playground hosts skipped entirely (matches the other token ratchets). */
+const SCOPE_EXCLUDED_PACKAGES = new Set(['smrt-playground']);
+
+/** Theme/token source files — they DEFINE the scale, so they emit raw values. */
+function isTokenSourceFile(relPath) {
+  const p = relPath.split(sep).join('/');
+  return (
+    p.includes('/src/theme/tokens.') ||
+    p.includes('/src/themes/shared.') ||
+    p.includes('/src/themes/css-generator.') ||
+    p.includes('/src/themes/styles/') ||
+    p.includes('/src/themes/create-theme.')
+  );
+}
+
+const ROOT_PX = 16;
+
+/** Canonical M3 size (rem) → candidate role-size variants (ties are real). */
+const SIZE_TO_ROLES = new Map([
+  ['3.5rem', ['display-large']],
+  ['2.75rem', ['display-medium']],
+  ['2.25rem', ['display-small']],
+  ['2rem', ['headline-large']],
+  ['1.75rem', ['headline-medium']],
+  ['1.5rem', ['headline-small']],
+  ['1.375rem', ['title-large']],
+  ['1rem', ['title-medium', 'body-large']],
+  ['0.875rem', ['title-small', 'body-medium', 'label-large']],
+  ['0.75rem', ['body-small', 'label-medium']],
+  ['0.6875rem', ['label-small']],
+]);
+/** Numeric rem of each canonical size, for nearest-match on off-scale values. */
+const SIZE_REMS = [...SIZE_TO_ROLES.keys()].map((k) => ({
+  rem: Number.parseFloat(k),
+  key: k,
+}));
+
+/** Parse a font-size token to rem (px ÷ 16); null if not an absolute length. */
+function fontSizeToRem(token) {
+  const t = token.trim();
+  let m = t.match(/^(\d*\.?\d+)rem$/i);
+  if (m) return Number(m[1]);
+  m = t.match(/^(\d*\.?\d+)px$/i);
+  if (m) return Number(m[1]) / ROOT_PX;
+  return null; // em/%/keyword/0 → not on the absolute rem scale
+}
+
+/** Suggest role tokens for a raw font-size. */
+function suggestSize(token) {
+  const rem = fontSizeToRem(token);
+  if (rem === null) return null;
+  const key = `${rem}rem`;
+  if (SIZE_TO_ROLES.has(key)) {
+    const roles = SIZE_TO_ROLES.get(key);
+    return `${roles.map((r) => `--smrt-typography-${r}-size`).join(' | ')}`;
+  }
+  // Off-scale: nearest canonical size, flag as approximate.
+  let best = SIZE_REMS[0];
+  let bestDist = Number.POSITIVE_INFINITY;
+  for (const s of SIZE_REMS) {
+    const d = Math.abs(s.rem - rem);
+    if (d < bestDist) {
+      best = s;
+      bestDist = d;
+    }
+  }
+  const roles = SIZE_TO_ROLES.get(best.key);
+  return `~${roles.map((r) => `--smrt-typography-${r}-size`).join(' | ')} (nearest ${best.key})`;
+}
+
+/** font-weight number/keyword → named weight token. */
+function suggestWeight(token) {
+  const t = token.trim().toLowerCase();
+  const map = { normal: 400, bold: 700, lighter: 300, bolder: 700 };
+  const n = t in map ? map[t] : Number.parseInt(t, 10);
+  if (Number.isNaN(n)) return null;
+  let name;
+  if (n <= 400) name = 'normal';
+  else if (n <= 500) name = 'medium';
+  else if (n <= 600) name = 'semibold';
+  else name = 'bold';
+  return `--smrt-typography-weight-${name}`;
+}
+
+/** font-family → sans or mono token. */
+function suggestFamily(token) {
+  return /\bmono(space)?\b|"SF Mono"|Consolas|Menlo|Courier/i.test(token)
+    ? '--smrt-font-family-mono'
+    : '--smrt-font-family';
+}
+
+function listFiles(dir, exts) {
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+      out.push(...listFiles(full, exts));
+    } else if (exts.some((e) => entry.name.endsWith(e))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function toPosix(p) {
+  return p.split(sep).join('/');
+}
+function packageNameOf(relPath) {
+  return relPath.split(sep)[0];
+}
+function isInPackageSrc(relPath) {
+  const parts = toPosix(relPath).split('/');
+  return parts.length > 1 && parts[1] === 'src';
+}
+
+function extractStyleBlocks(source) {
+  const out = source.replace(/[^\n]/g, ' ').split('');
+  const re = /(<style\b[^>]*>)([\s\S]*?)(<\/style>)/gi;
+  for (const m of source.matchAll(re)) {
+    const innerStart = m.index + m[1].length;
+    const inner = m[2];
+    for (let k = 0; k < inner.length; k++) out[innerStart + k] = inner[k];
+  }
+  return out.join('');
+}
+
+function stripComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, (block) => block.replace(/[^\n]/g, ' '))
+    .replace(/(^|[^:])\/\/[^\n]*/g, (m, lead) =>
+      lead + ' '.repeat(m.length - lead.length),
+    );
+}
+
+/** Blank `var(--smrt-typography-*)` / `var(--smrt-font-family*)` so they pass. */
+function stripTokenVars(source) {
+  let out = '';
+  let i = 0;
+  while (i < source.length) {
+    const isTokenVar = /^var\(\s*--smrt-(typography|font-family)/.test(
+      source.slice(i, i + 30),
+    );
+    if (isTokenVar) {
+      const start = source.indexOf('(', i);
+      let depth = 0;
+      let j = start;
+      for (; j < source.length; j++) {
+        const ch = source[j];
+        if (ch === '(') depth++;
+        else if (ch === ')') {
+          depth--;
+          if (depth === 0) {
+            j++;
+            break;
+          }
+        }
+      }
+      out += source.slice(i, j).replace(/[^\n]/g, ' ');
+      i = j;
+    } else {
+      out += source[i];
+      i += 1;
+    }
+  }
+  return out;
+}
+
+const KEYWORD_VALUES = new Set(['inherit', 'unset', 'initial', 'revert']);
+
+const PROP_RE = /\b(font-size|font-weight|font-family)\s*:\s*([^;}{]+)/gi;
+
+function findViolations(file, source) {
+  let text = file.endsWith('.svelte') ? extractStyleBlocks(source) : source;
+  text = stripComments(text);
+  text = stripTokenVars(text);
+  const hits = [];
+  for (const m of text.matchAll(PROP_RE)) {
+    const prop = m[1].toLowerCase();
+    const value = m[2].replace(/\s+/g, ' ').trim();
+    if (!value || KEYWORD_VALUES.has(value.toLowerCase())) continue;
+    // Anything still containing a token var() was a multi-part value we keep.
+    if (/var\(\s*--smrt-(typography|font-family)/.test(value)) continue;
+    let suggestion = null;
+    if (prop === 'font-size') {
+      // skip relative/zero/keyword sizes (em/%/0/larger/smaller)
+      if (fontSizeToRem(value) === null) continue;
+      suggestion = suggestSize(value);
+    } else if (prop === 'font-weight') {
+      suggestion = suggestWeight(value);
+      if (!suggestion) continue;
+    } else if (prop === 'font-family') {
+      suggestion = suggestFamily(value);
+    }
+    const line = text.slice(0, m.index).split('\n').length;
+    hits.push({
+      line,
+      prop,
+      value: value.slice(0, 40),
+      suggestion,
+    });
+  }
+  return hits;
+}
+
+const files = listFiles(PACKAGES, ['.svelte', '.css']);
+const strictViolations = [];
+const reportOnly = new Map();
+
+for (const file of files) {
+  const relPath = relative(PACKAGES, file);
+  if (!isInPackageSrc(relPath)) continue;
+  const pkg = packageNameOf(relPath);
+  if (SCOPE_EXCLUDED_PACKAGES.has(pkg)) continue;
+  if (isTokenSourceFile(relPath)) continue;
+  const hits = findViolations(file, readFileSync(file, 'utf8'));
+  if (hits.length === 0) continue;
+  if (STRICT_PACKAGES.has(pkg)) strictViolations.push({ file: relPath, hits });
+  else reportOnly.set(pkg, (reportOnly.get(pkg) ?? 0) + hits.length);
+}
+
+if (reportOnly.size > 0) {
+  const total = [...reportOnly.values()].reduce((a, b) => a + b, 0);
+  console.warn(
+    `⚠ typography-check: ${total} raw font-size/weight/family value(s) in ` +
+      'report-only package(s) (not failing — later phases of #1373):',
+  );
+  for (const [pkg, count] of [...reportOnly.entries()].sort((a, b) => b[1] - a[1])) {
+    console.warn(`    ${pkg}: ${count}`);
+  }
+}
+
+if (strictViolations.length > 0) {
+  const total = strictViolations.reduce((n, v) => n + v.hits.length, 0);
+  console.error(
+    `\n✗ typography-check: ${total} raw typography value(s) in strict ` +
+      `package(s): ${[...STRICT_PACKAGES].join(', ')}`,
+  );
+  for (const { file, hits } of strictViolations) {
+    console.error(`  ${file}`);
+    for (const h of hits) {
+      console.error(`    L${h.line}: ${h.prop}: ${h.value} → ${h.suggestion}`);
+    }
+  }
+  console.error(
+    '\nMap each text element to its M3 role: font-size →' +
+      ' var(--smrt-typography-<role>-<size>-size, <orig>), and apply the same' +
+      " role's -line-height/-weight/-tracking. font-weight →" +
+      ' var(--smrt-typography-weight-<name>, <orig>); font-family →' +
+      ' var(--smrt-font-family[-mono], <orig>).',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `✓ typography-check: no raw font-size/weight/family in strict package(s): ${[
+    ...STRICT_PACKAGES,
+  ].join(', ')}`,
+);


### PR DESCRIPTION
## What

Adds the **typography** ratchet — the **6th and final** S1 design-token dimension (#1373, epic #1354). Bans raw `font-size`/`font-weight`/`font-family` in component CSS and steers authors to the Material-3 `--smrt-typography-*` role scale.

This is **Phase 1**: the ratchet + wiring + full migration of the `smrt-svelte` foundation. Domain packages (~610 report-only values) follow in subsequent PRs.

## Policy — full semantic pass (per maintainer choice)

Unlike the five mechanical dimensions, typography can't be snapped deterministically: **the same size maps to multiple roles** (`0.875rem` = title-small *and* body-medium *and* label-large; `1rem` = title-medium *and* body-large). So every text element is mapped to its proper M3 role (display/headline/title/body/label × large/medium/small) **by semantics**, using the per-variant tokens with the original value preserved as the `var()` fallback.

- `font-size` → `var(--smrt-typography-<role>-<size>-size, <orig>)` — role assigned by selector/element/weight context (ratchet *suggests* candidates).
- `font-weight` → `var(--smrt-typography-weight-{normal|medium|semibold|bold}, <orig>)` — clean numeric snap.
- `font-family` → `var(--smrt-font-family[-mono], <orig>)`.
- `line-height` / `letter-spacing` → migrated alongside each element's assigned role (`-line-height`/`-tracking`), but **not independently failed** by the ratchet: raw `line-height` is frequently a layout reset (`1`/`normal`/`0`) and is ambiguous without a role.

Theme/token source files (`theme/tokens.ts`, `themes/shared.ts`, `css-generator.ts`, `styles/*.css`) are excluded — they *define* the scale.

## Phase 1 migration — smrt-svelte

141 enforced violations across ~42 components mapped to role tokens. Notable judgment calls: card/panel/dialog titles → `title-*`; running text/descriptions/input values → `body-*`; buttons/badges/chips/captions/timestamps → `label-*`; hero/empty-state glyphs → `display-*`; modal/section headings → `headline-*`. Odd weights (`700`/`750`) → `weight-bold`.

## Verification

- `node scripts/check-typography.mjs` → smrt-svelte clean (`✓ no raw font-size/weight/family`)
- **Deterministic scope-check**: every added *and* removed line under `packages/smrt-svelte` is a `font-size`/`font-weight`/`font-family`/`line-height`/`letter-spacing` declaration — no JS/markup/TS touched, no `console.*` removed, no reflows.
- `npm run build` → 50/50
- `node scripts/check-svelte-tokens.mjs` → 142 consumed `--smrt-*` tokens, all emitted
- `biome check` (read-only) on all 42 changed files → clean
- workflow validated with yamllint + actionlint

## Wiring

`pnpm check:typography` · lefthook pre-push · `on-pull-request` CI step. Strict for `smrt-svelte`; report-only elsewhere.

Completing typography across all packages closes #1373 (the last S1 dimension).