### PR TITLE
feat(content): typography → M3 role tokens (#1373 Phase 2)

### DIFF
--- a/packages/content/src/routes/+layout.svelte
+++ b/packages/content/src/routes/+layout.svelte
@@ -92,8 +92,8 @@ const navItems = [
   }
 
   .brand {
-    font-size: 1.25rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-title-large-size, 1.25rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
     color: var(--smrt-color-on-surface, #1a1c1e);
     text-decoration: none;
     display: flex;
@@ -117,8 +117,8 @@ const navItems = [
     border-radius: 0.5rem;
     text-decoration: none;
     color: var(--smrt-color-on-surface-variant, #43474e);
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
     transition: all 0.15s ease;
     white-space: nowrap;
   }
@@ -131,11 +131,11 @@ const navItems = [
   .nav-tab.active {
     background: var(--smrt-color-primary-container, #d8e2ff);
     color: var(--smrt-color-on-primary-container, #001a41);
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .nav-icon {
-    font-size: 1rem;
+    font-size: var(--smrt-typography-title-medium-size, 1rem);
   }
 
   .header-status {
@@ -143,8 +143,8 @@ const navItems = [
     color: white;
     padding: 0.2rem 0.6rem;
     border-radius: 1rem;
-    font-size: 0.75rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     white-space: nowrap;
   }
 
@@ -160,7 +160,7 @@ const navItems = [
     text-align: center;
     padding: 1.25rem 0;
     color: var(--smrt-color-on-surface-variant, #74777f);
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
     opacity: 0.7;
   }
 </style>

--- a/packages/content/src/routes/api-explorer/+page.svelte
+++ b/packages/content/src/routes/api-explorer/+page.svelte
@@ -530,14 +530,14 @@ function closeTry() {
 
   .page-header h1 {
     margin: 0 0 0.5rem 0;
-    font-size: 2rem;
-    font-weight: 800;
+    font-size: var(--smrt-typography-headline-large-size, 2rem);
+    font-weight: var(--smrt-typography-weight-bold, 800);
   }
 
   .page-header p {
     margin: 0 auto;
     color: var(--smrt-color-on-surface-variant, #43474e);
-    font-size: 1.05rem;
+    font-size: var(--smrt-typography-body-large-size, 1.05rem);
     max-width: 600px;
   }
 
@@ -566,7 +566,7 @@ function closeTry() {
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #43474e);
     cursor: pointer;
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-label-large-size, 0.8125rem);
     text-align: left;
     transition: background 0.15s;
   }
@@ -578,10 +578,10 @@ function closeTry() {
   .group-btn.active {
     background: var(--smrt-color-primary-container, #d8e2ff);
     color: var(--smrt-color-on-primary-container, #001a41);
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
-  .group-icon { font-size: 1rem; }
+  .group-icon { font-size: var(--smrt-typography-title-medium-size, 1rem); }
 
   .group-label { flex: 1; }
 
@@ -589,8 +589,8 @@ function closeTry() {
     background: var(--smrt-color-surface-variant, #e1e2ec);
     padding: 0.1rem 0.4rem;
     border-radius: var(--smrt-radius-full, 9999px);
-    font-size: 0.7rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-small-size, 0.7rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .group-btn.active .group-count {
@@ -607,7 +607,7 @@ function closeTry() {
 
   .endpoints-panel h2 {
     margin: 0 0 1rem 0;
-    font-size: 1.25rem;
+    font-size: var(--smrt-typography-title-large-size, 1.25rem);
   }
 
   .endpoint-list {
@@ -623,7 +623,7 @@ function closeTry() {
     padding: 0.5rem 0.75rem;
     border-radius: 0.5rem;
     background: var(--smrt-color-surface-container-low, #f7f7fb);
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
     flex-wrap: wrap;
   }
 
@@ -633,15 +633,15 @@ function closeTry() {
     padding: 0.15rem 0.45rem;
     border-radius: 0.25rem;
     color: white;
-    font-size: 0.6875rem;
-    font-weight: 700;
-    font-family: monospace;
+    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
+    font-family: var(--smrt-font-family-mono, monospace);
     min-width: 3rem;
     justify-content: center;
   }
 
   .endpoint-path {
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
     color: var(--smrt-color-on-surface, #1a1c1e);
     word-break: break-all;
   }
@@ -649,7 +649,7 @@ function closeTry() {
   .endpoint-desc {
     flex: 1;
     color: var(--smrt-color-on-surface-variant, #74777f);
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
     text-align: right;
   }
 
@@ -659,8 +659,8 @@ function closeTry() {
     border-radius: 0.25rem;
     background: transparent;
     color: var(--smrt-color-primary, #005ac1);
-    font-size: 0.6875rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     cursor: pointer;
     transition: all 0.15s;
   }
@@ -688,14 +688,14 @@ function closeTry() {
 
   .try-header code {
     flex: 1;
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
   }
 
   .close-btn {
     border: none;
     background: none;
     cursor: pointer;
-    font-size: 1rem;
+    font-size: var(--smrt-typography-title-medium-size, 1rem);
     color: var(--smrt-color-on-surface-variant, #74777f);
     padding: 0.2rem 0.4rem;
     border-radius: 0.25rem;
@@ -715,8 +715,8 @@ function closeTry() {
   .try-result, .try-error {
     margin: 0;
     padding: 1rem;
-    font-size: 0.75rem;
-    line-height: 1.5;
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
+    line-height: var(--smrt-typography-body-small-line-height, 1.5);
     max-height: 400px;
     overflow: auto;
     white-space: pre-wrap;

--- a/packages/content/src/svelte/components/ContentAgentChat.svelte
+++ b/packages/content/src/svelte/components/ContentAgentChat.svelte
@@ -558,7 +558,7 @@ async function handleSendMessage(content: string) {
     border: none;
     background: var(--smrt-color-surface-container-low, #f7f7fb);
     color: var(--smrt-color-on-surface, #1a1c1e);
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
     outline: none;
     cursor: pointer;
   }
@@ -612,7 +612,7 @@ async function handleSendMessage(content: string) {
     border-radius: var(--smrt-radius-sm, 4px);
     background: none;
     color: var(--smrt-color-on-surface-variant, #43474e);
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
     cursor: pointer;
     white-space: nowrap;
     transition: background 0.15s;
@@ -641,7 +641,7 @@ async function handleSendMessage(content: string) {
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
     border-radius: var(--smrt-radius-sm, 4px);
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
     outline: none;
     background: var(--smrt-color-surface, #ffffff);
     color: var(--smrt-color-on-surface, #1a1c1e);

--- a/packages/content/src/svelte/components/ContentBodyEditor.svelte
+++ b/packages/content/src/svelte/components/ContentBodyEditor.svelte
@@ -1225,7 +1225,7 @@ function handleEditorDragEnd() {
     display: inline-flex;
     align-items: center;
     gap: 0.4rem;
-    font-size: 0.78rem;
+    font-size: var(--smrt-typography-label-medium-size, 0.78rem);
     color: var(--smrt-color-on-surface-variant);
   }
 
@@ -1243,8 +1243,8 @@ function handleEditorDragEnd() {
     padding: clamp(1rem, 2vw, 1.5rem);
     outline: none;
     color: var(--smrt-color-on-surface);
-    font-size: 1.05rem;
-    line-height: 1.65;
+    font-size: var(--smrt-typography-body-large-size, 1.05rem);
+    line-height: var(--smrt-typography-body-large-line-height, 1.65);
     overflow: auto;
     overflow-wrap: anywhere;
   }

--- a/packages/content/src/svelte/components/ContentClaimAuditTool.svelte
+++ b/packages/content/src/svelte/components/ContentClaimAuditTool.svelte
@@ -331,7 +331,7 @@ async function recheckFactClaims(claimIds: string[]) {
   .section-caption,
   .tool-card span {
     color: var(--smrt-color-on-surface-variant);
-    font-size: 0.85rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.85rem);
   }
 
   .tool-card {
@@ -380,7 +380,7 @@ async function recheckFactClaims(claimIds: string[]) {
     background: var(--smrt-color-surface);
     color: var(--smrt-color-on-surface);
     cursor: pointer;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .secondary-button:disabled {
@@ -391,8 +391,8 @@ async function recheckFactClaims(claimIds: string[]) {
   .pill {
     border-radius: var(--smrt-radius-full, 9999px);
     padding: 0.2rem 0.55rem;
-    font-size: 0.75rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
     text-transform: capitalize;
   }
 
@@ -417,7 +417,7 @@ async function recheckFactClaims(claimIds: string[]) {
     margin: 0;
     border-radius: 0.6rem;
     padding: 0.75rem 0.9rem;
-    font-size: 0.9rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.9rem);
   }
 
   .tool-error {

--- a/packages/content/src/svelte/components/ContentContributionForm.svelte
+++ b/packages/content/src/svelte/components/ContentContributionForm.svelte
@@ -210,7 +210,7 @@ function handleSubmit(event: SubmitEvent) {
     display: flex;
     gap: 0.5rem;
     flex-wrap: wrap;
-    font-size: 0.9rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.9rem);
     color: var(--smrt-color-on-surface-variant);
   }
 

--- a/packages/content/src/svelte/components/ContentCorrectionsTool.svelte
+++ b/packages/content/src/svelte/components/ContentCorrectionsTool.svelte
@@ -250,8 +250,8 @@ async function issueCorrection() {
 
   .workflow-field {
     color: var(--smrt-color-on-surface-variant);
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
   .workflow-field input,
@@ -274,7 +274,7 @@ async function issueCorrection() {
     background: var(--smrt-color-primary);
     color: var(--smrt-color-on-primary, white);
     cursor: pointer;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   button:disabled {
@@ -303,7 +303,7 @@ async function issueCorrection() {
   .empty-copy,
   .section-caption {
     color: var(--smrt-color-on-surface-variant);
-    font-size: 0.85rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.85rem);
   }
 
   .tool-card p {
@@ -320,8 +320,8 @@ async function issueCorrection() {
   .pill {
     border-radius: var(--smrt-radius-full, 9999px);
     padding: 0.2rem 0.55rem;
-    font-size: 0.75rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
     text-transform: capitalize;
   }
 
@@ -342,7 +342,7 @@ async function issueCorrection() {
     margin: 0;
     border-radius: 0.6rem;
     padding: 0.75rem 0.9rem;
-    font-size: 0.9rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.9rem);
   }
 
   .tool-error {

--- a/packages/content/src/svelte/components/ContentEditor.svelte
+++ b/packages/content/src/svelte/components/ContentEditor.svelte
@@ -1373,9 +1373,9 @@ function removeAsset(id: string) {
 
   .document-title-input {
     width: 100%;
-    font-size: 2.5rem;
-    font-weight: 800;
-    line-height: 1.2;
+    font-size: var(--smrt-typography-display-medium-size, 2.5rem);
+    font-weight: var(--smrt-typography-weight-bold, 800);
+    line-height: var(--smrt-typography-display-medium-line-height, 1.2);
     padding: 0;
     margin-bottom: 2rem;
     border: none;
@@ -1436,12 +1436,12 @@ function removeAsset(id: string) {
     left: 0.5rem;
     background: var(--smrt-color-surface); /* Matches main surface background */
     padding: 0 0.25rem;
-    font-size: 0.65rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-small-size, 0.65rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-outline);
     pointer-events: none;
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: var(--smrt-typography-label-small-tracking, 0.05em);
     z-index: 1;
   }
 
@@ -1451,8 +1451,8 @@ function removeAsset(id: string) {
     border: 1px solid var(--smrt-color-outline-variant);
     background: transparent;
     color: var(--smrt-color-on-surface);
-    font-size: 0.8125rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
     width: auto;
     font-family: inherit;
     box-sizing: border-box;
@@ -1488,8 +1488,8 @@ function removeAsset(id: string) {
     justify-content: space-between;
     align-items: center;
     padding: 0 0 1.25rem 0;
-    font-size: 1.5rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-headline-small-size, 1.5rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
     color: var(--smrt-color-on-surface);
     cursor: pointer;
     list-style: none; /* Hide default triangle */
@@ -1550,7 +1550,7 @@ function removeAsset(id: string) {
   .form-container h3 {
     margin: 0;
     color: var(--smrt-color-on-surface);
-    font-size: 1.5rem;
+    font-size: var(--smrt-typography-headline-small-size, 1.5rem);
   }
 
   .form-container form {
@@ -1563,8 +1563,8 @@ function removeAsset(id: string) {
     flex-direction: column;
     gap: 0.5rem;
     color: var(--smrt-color-on-surface-variant);
-    font-weight: 500;
-    font-size: 0.875rem;
+    font-weight: var(--smrt-typography-weight-medium, 500);
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
   }
 
   .form-container input,
@@ -1573,7 +1573,7 @@ function removeAsset(id: string) {
     padding: 0.75rem;
     border: 1px solid var(--smrt-color-outline);
     border-radius: 0.5rem;
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     transition: border-color 0.2s, box-shadow 0.2s;
     font-family: inherit;
     box-sizing: border-box;
@@ -1618,7 +1618,7 @@ function removeAsset(id: string) {
     border: 1px solid var(--smrt-color-outline);
     border-radius: var(--smrt-radius-full, 9999px);
     padding: 0.25rem 0.25rem 0.25rem 0.75rem;
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
     color: var(--smrt-color-on-surface);
   }
 
@@ -1627,7 +1627,7 @@ function removeAsset(id: string) {
     border: none;
     color: var(--smrt-color-outline);
     cursor: pointer;
-    font-size: 1.125rem;
+    font-size: var(--smrt-typography-title-medium-size, 1.125rem);
     line-height: 1;
     padding: 0 0.25rem;
     margin-left: 0.25rem;
@@ -1639,7 +1639,7 @@ function removeAsset(id: string) {
 
   .no-refs {
     color: var(--smrt-color-outline);
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     font-style: italic;
   }
 
@@ -1691,8 +1691,8 @@ function removeAsset(id: string) {
     border-radius: 0.375rem;
     color: var(--smrt-color-on-surface);
     cursor: pointer;
-    font-size: 0.75rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     padding: 0.25rem 0.5rem;
   }
 
@@ -1717,7 +1717,7 @@ function removeAsset(id: string) {
   .evidence-bulk-toolbar span,
   .evidence-message {
     color: var(--smrt-color-on-surface-variant);
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
   }
 
   .evidence-bulk-toolbar select {
@@ -1743,7 +1743,7 @@ function removeAsset(id: string) {
   .resource-claim-body,
   .resource-claim-more {
     color: var(--smrt-color-on-surface-variant);
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
   }
 
   .resource-claim-more {
@@ -1752,7 +1752,7 @@ function removeAsset(id: string) {
     background: transparent;
     padding: 0;
     cursor: pointer;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .resource-claim-list {
@@ -1786,8 +1786,8 @@ function removeAsset(id: string) {
     border: 1px solid var(--smrt-color-outline-variant);
     border-radius: var(--smrt-radius-full, 9999px);
     display: inline-flex;
-    font-size: 0.75rem;
-    font-weight: 800;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-bold, 800);
     height: 1.35rem;
     justify-content: center;
     line-height: 1;
@@ -1838,8 +1838,8 @@ function removeAsset(id: string) {
 
   .resource-claim-body dt {
     color: var(--smrt-color-outline);
-    font-size: 0.7rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-label-small-size, 0.7rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
     text-transform: uppercase;
   }
 
@@ -1855,8 +1855,8 @@ function removeAsset(id: string) {
 
   .evidence-detail span {
     color: var(--smrt-color-outline);
-    font-size: 0.75rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
   }
 
   .resource-claim-actions {
@@ -1882,7 +1882,7 @@ function removeAsset(id: string) {
     padding: 0 1rem;
     border-radius: 0.5rem;
     cursor: pointer;
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
   .add-reference-row button:hover {
@@ -1898,7 +1898,7 @@ function removeAsset(id: string) {
     padding: 0.75rem 1.25rem;
     border-radius: var(--smrt-radius-md, 0.5rem);
     color: var(--smrt-color-on-surface-variant, #475569);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     cursor: pointer;
     transition: all 0.2s;
   }
@@ -1919,7 +1919,7 @@ function removeAsset(id: string) {
     border: none;
     padding: 0.75rem 1.5rem;
     border-radius: 0.5rem;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     cursor: pointer;
     transition: transform 0.2s, box-shadow 0.2s;
   }
@@ -1941,12 +1941,12 @@ function removeAsset(id: string) {
     border: 1px solid var(--smrt-color-outline-variant);
     padding: 0.75rem 1.25rem;
     border-radius: 0.5rem;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     cursor: pointer;
   }
 
   .save-notice {
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     color: var(--smrt-color-primary, #3b82f6);
   }
 
@@ -1992,8 +1992,8 @@ function removeAsset(id: string) {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    font-size: 0.8125rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-primary);
   }
 
@@ -2007,8 +2007,8 @@ function removeAsset(id: string) {
     border: 1px solid var(--smrt-color-outline);
     padding: 0.375rem 0.875rem;
     border-radius: 0.375rem;
-    font-size: 0.8125rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-large-size, 0.8125rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     cursor: pointer;
     white-space: nowrap;
     transition: all 0.15s ease;
@@ -2100,12 +2100,12 @@ function removeAsset(id: string) {
     left: 0.25rem;
     background: var(--smrt-color-primary, #3b82f6);
     color: white;
-    font-size: 0.65rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-small-size, 0.65rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     padding: 0.15rem 0.4rem;
     border-radius: 0.25rem;
     text-transform: uppercase;
-    letter-spacing: 0.03em;
+    letter-spacing: var(--smrt-typography-label-small-tracking, 0.03em);
   }
 
   /* ── Drag & Drop Zones ── */

--- a/packages/content/src/svelte/components/ContentGovernanceAssignmentEditor.svelte
+++ b/packages/content/src/svelte/components/ContentGovernanceAssignmentEditor.svelte
@@ -172,7 +172,7 @@ function handleSubmit() {
   label {
     display: grid;
     gap: 0.35rem;
-    font-size: 0.9rem;
+    font-size: var(--smrt-typography-label-large-size, 0.9rem);
   }
 
   input,

--- a/packages/content/src/svelte/components/ContentGovernancePanel.svelte
+++ b/packages/content/src/svelte/components/ContentGovernancePanel.svelte
@@ -1780,8 +1780,8 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
     justify-content: space-between;
     align-items: center;
     padding: 0 0 1.25rem 0;
-    font-size: 1.5rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-headline-small-size, 1.5rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
     color: var(--smrt-color-on-surface);
     cursor: pointer;
     list-style: none; /* Hide default triangle */
@@ -1865,7 +1865,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
   .fact-result span,
   .fact-chip span {
     color: var(--smrt-color-on-surface-variant);
-    font-size: 0.85rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.85rem);
   }
 
   .fact-search,
@@ -1884,7 +1884,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
     justify-content: space-between;
     flex-wrap: wrap;
     color: var(--smrt-color-on-surface-variant);
-    font-size: 0.85rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.85rem);
   }
 
   .fact-search input,
@@ -1906,8 +1906,8 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
     flex-direction: column;
     gap: 0.4rem;
     color: var(--smrt-color-on-surface-variant);
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
   .fact-search button,
@@ -1918,7 +1918,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
     background: var(--smrt-color-primary);
     color: var(--smrt-color-on-primary, white);
     cursor: pointer;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .fact-search button:disabled,
@@ -2185,8 +2185,8 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
   .pill {
     border-radius: var(--smrt-radius-full, 9999px);
     padding: 0.2rem 0.55rem;
-    font-size: 0.75rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
     text-transform: capitalize;
   }
 
@@ -2225,7 +2225,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
     margin: 0;
     border-radius: 0.6rem;
     padding: 0.75rem 0.9rem;
-    font-size: 0.9rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.9rem);
   }
 
   .workflow-error {

--- a/packages/content/src/svelte/components/ContentGovernancePolicyEditor.svelte
+++ b/packages/content/src/svelte/components/ContentGovernancePolicyEditor.svelte
@@ -84,7 +84,7 @@ function handleSubmit() {
   label {
     display: grid;
     gap: 0.35rem;
-    font-size: 0.9rem;
+    font-size: var(--smrt-typography-label-large-size, 0.9rem);
   }
 
   input,

--- a/packages/content/src/svelte/components/ContentGovernanceProfileEditor.svelte
+++ b/packages/content/src/svelte/components/ContentGovernanceProfileEditor.svelte
@@ -150,7 +150,7 @@ function handleSubmit() {
   label {
     display: grid;
     gap: 0.35rem;
-    font-size: 0.9rem;
+    font-size: var(--smrt-typography-label-large-size, 0.9rem);
   }
 
   input,

--- a/packages/content/src/svelte/components/ContentImageBrowser.svelte
+++ b/packages/content/src/svelte/components/ContentImageBrowser.svelte
@@ -152,8 +152,8 @@ function handleSelect(selected: ImageLike | File | string) {
     border-radius: 0.375rem;
     background: var(--smrt-color-surface-container);
     color: var(--smrt-color-on-surface-variant);
-    font-size: 1.5rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-headline-small-size, 1.5rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
   }
 
   .asset-preview img {
@@ -171,7 +171,7 @@ function handleSelect(selected: ImageLike | File | string) {
   .asset-meta strong {
     overflow: hidden;
     color: var(--smrt-color-on-surface);
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-title-small-size, 0.875rem);
     text-overflow: ellipsis;
     white-space: nowrap;
   }
@@ -179,7 +179,7 @@ function handleSelect(selected: ImageLike | File | string) {
   .asset-meta span,
   .empty-state {
     color: var(--smrt-color-on-surface-variant);
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
   }
 
   .empty-state {
@@ -205,8 +205,8 @@ function handleSelect(selected: ImageLike | File | string) {
     color: var(--smrt-color-on-surface);
     cursor: pointer;
     font: inherit;
-    font-size: 0.875rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     padding: 0.5rem 0.875rem;
   }
 

--- a/packages/content/src/svelte/components/ContentImageChooser.svelte
+++ b/packages/content/src/svelte/components/ContentImageChooser.svelte
@@ -116,8 +116,8 @@ function cycle(delta: number) {
     align-items: center;
     gap: 0.45rem;
     padding: 0.25rem 0.65rem 0.25rem 0.3rem;
-    font-size: 0.82rem;
-    font-weight: 650;
+    font-size: var(--smrt-typography-label-large-size, 0.82rem);
+    font-weight: var(--smrt-typography-weight-bold, 650);
   }
 
   .chooser-preview img {

--- a/packages/content/src/svelte/components/ContentList.svelte
+++ b/packages/content/src/svelte/components/ContentList.svelte
@@ -402,7 +402,7 @@ function handleDeleteContent(content: any) {
     padding: 0.5rem 0.9rem;
     border: 1px solid var(--smrt-color-outline);
     border-radius: 0.5rem;
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     height: 38px;
     background: var(--smrt-color-surface-container-low);
     color: var(--smrt-color-on-surface);
@@ -467,7 +467,7 @@ function handleDeleteContent(content: any) {
     padding: 0.5rem 1rem;
     height: 38px;
     border-radius: 0.5rem;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     cursor: pointer;
     transition: transform 0.2s, box-shadow 0.2s;
   }
@@ -491,9 +491,9 @@ function handleDeleteContent(content: any) {
     align-items: center;
     border-radius: var(--smrt-radius-full, 9999px);
     padding: 0.2rem 0.65rem;
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.06em;
+    font-size: var(--smrt-typography-label-medium-size, 0.72rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
+    letter-spacing: var(--smrt-typography-label-medium-tracking, 0.06em);
     text-transform: uppercase;
     background: var(--smrt-color-surface-container-low);
     color: var(--smrt-color-on-surface-variant);
@@ -546,13 +546,13 @@ function handleDeleteContent(content: any) {
   .content-header h3 {
     margin: 0 0 0.25rem 0;
     color: var(--smrt-color-on-surface);
-    font-size: 1.25rem;
-    line-height: 1.3;
+    font-size: var(--smrt-typography-title-large-size, 1.25rem);
+    line-height: var(--smrt-typography-title-large-line-height, 1.3);
   }
 
   .author {
     color: var(--smrt-color-on-surface-variant);
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
   }
 
   .content-meta {
@@ -560,7 +560,7 @@ function handleDeleteContent(content: any) {
     justify-content: space-between;
     align-items: center;
     margin-bottom: 1rem;
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     color: var(--smrt-color-on-surface-variant);
   }
 
@@ -573,10 +573,10 @@ function handleDeleteContent(content: any) {
   .badge {
     padding: 0.25rem 0.6rem;
     border-radius: var(--smrt-radius-full, 9999px);
-    font-size: 0.75rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: var(--smrt-typography-label-medium-tracking, 0.05em);
   }
 
   .status-published { background: var(--smrt-color-success-container); color: var(--smrt-color-on-success-container); border: 1px solid var(--smrt-color-success); }
@@ -608,7 +608,7 @@ function handleDeleteContent(content: any) {
   }
 
   .source, .file {
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
     color: var(--smrt-color-on-surface-variant);
     white-space: nowrap;
     overflow: hidden;
@@ -640,8 +640,8 @@ function handleDeleteContent(content: any) {
     border-radius: 0.375rem;
     background: var(--smrt-color-surface-container-low);
     color: var(--smrt-color-on-surface);
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
     cursor: pointer;
     transition: all 0.2s;
     text-align: center;
@@ -693,8 +693,8 @@ function handleDeleteContent(content: any) {
 
   .content-row h3 {
     margin: 0;
-    font-size: 1.1rem;
-    line-height: 1.3;
+    font-size: var(--smrt-typography-title-medium-size, 1.1rem);
+    line-height: var(--smrt-typography-title-medium-line-height, 1.3);
   }
 
   .content-row__description {
@@ -712,10 +712,10 @@ function handleDeleteContent(content: any) {
   }
 
   .meta-label {
-    font-size: 0.72rem;
+    font-size: var(--smrt-typography-label-medium-size, 0.72rem);
     text-transform: uppercase;
-    letter-spacing: 0.06em;
-    font-weight: 700;
+    letter-spacing: var(--smrt-typography-label-medium-tracking, 0.06em);
+    font-weight: var(--smrt-typography-weight-bold, 700);
     color: var(--smrt-color-on-surface-variant);
   }
 
@@ -736,7 +736,7 @@ function handleDeleteContent(content: any) {
     border: 1px solid var(--smrt-color-outline-variant);
     background: transparent;
     color: var(--smrt-color-on-surface);
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     text-decoration: none;
     cursor: pointer;
   }
@@ -754,7 +754,7 @@ function handleDeleteContent(content: any) {
     gap: 0.9rem;
     flex-wrap: wrap;
     margin-top: 0.8rem;
-    font-size: 0.82rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.82rem);
     color: var(--smrt-color-on-surface-variant);
   }
 
@@ -764,7 +764,7 @@ function handleDeleteContent(content: any) {
   }
 
   .content-row__author {
-    font-size: 0.85rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.85rem);
     color: var(--smrt-color-on-surface-variant);
   }
 
@@ -786,8 +786,8 @@ function handleDeleteContent(content: any) {
   .content-table th {
     background: var(--smrt-color-surface-container-low);
     padding: 1rem;
-    font-size: 0.875rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-title-small-size, 0.875rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-on-surface-variant);
     border-bottom: 1px solid var(--smrt-color-outline-variant);
   }
@@ -796,7 +796,7 @@ function handleDeleteContent(content: any) {
     padding: 1rem;
     border-bottom: 1px solid var(--smrt-color-outline-variant);
     color: var(--smrt-color-on-surface);
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     vertical-align: middle;
   }
 
@@ -814,7 +814,7 @@ function handleDeleteContent(content: any) {
 
   .title-cell strong {
     color: var(--smrt-color-on-surface);
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .actions-col {
@@ -831,7 +831,7 @@ function handleDeleteContent(content: any) {
     background: transparent;
     border: none;
     cursor: pointer;
-    font-size: 1.1rem;
+    font-size: var(--smrt-typography-title-medium-size, 1.1rem);
     padding: 0.25rem;
     border-radius: 0.25rem;
     transition: background 0.2s;
@@ -854,7 +854,7 @@ function handleDeleteContent(content: any) {
     border-radius: 0.75rem;
     border: 1px dashed var(--smrt-color-outline);
     color: var(--smrt-color-on-surface-variant);
-    font-size: 1.1rem;
+    font-size: var(--smrt-typography-body-large-size, 1.1rem);
   }
 
   .source, .file {

--- a/packages/content/src/svelte/components/ContentMetadataFields.svelte
+++ b/packages/content/src/svelte/components/ContentMetadataFields.svelte
@@ -79,8 +79,8 @@ function updateTags(value: string) {
     display: grid;
     gap: 0.45rem;
     color: var(--smrt-color-on-surface-variant);
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
   input,

--- a/packages/content/src/svelte/components/ContentReferencesPanel.svelte
+++ b/packages/content/src/svelte/components/ContentReferencesPanel.svelte
@@ -139,7 +139,7 @@ function removeReference(id: string) {
   .empty-state {
     margin: 0;
     color: var(--smrt-color-on-surface-variant);
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     font-style: italic;
   }
 
@@ -174,12 +174,12 @@ function removeReference(id: string) {
 
   .reference-copy strong {
     color: var(--smrt-color-on-surface);
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-title-small-size, 0.875rem);
   }
 
   .reference-copy a {
     color: var(--smrt-color-primary);
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
     text-decoration: none;
   }
 
@@ -208,7 +208,7 @@ function removeReference(id: string) {
   button {
     background: var(--smrt-color-surface-container);
     cursor: pointer;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   button:hover {

--- a/packages/content/src/svelte/components/ContentStatusFields.svelte
+++ b/packages/content/src/svelte/components/ContentStatusFields.svelte
@@ -61,8 +61,8 @@ function updateField(key: string, value: unknown) {
     gap: 0.35rem;
     min-width: 8.5rem;
     color: var(--smrt-color-on-surface-variant);
-    font-size: 0.75rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   select,
@@ -73,8 +73,8 @@ function updateField(key: string, value: unknown) {
     background: var(--smrt-color-surface-container-low);
     color: var(--smrt-color-on-surface);
     font: inherit;
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
     padding: 0.55rem 0.75rem;
   }
 </style>

--- a/packages/content/src/svelte/components/ContentTitleField.svelte
+++ b/packages/content/src/svelte/components/ContentTitleField.svelte
@@ -32,9 +32,9 @@ let {
     background: transparent;
     color: var(--smrt-color-on-surface);
     font: inherit;
-    font-size: clamp(1.45rem, 1.1rem + 1vw, 2rem);
-    font-weight: 720;
-    line-height: 1.12;
+    font-size: var(--smrt-typography-headline-small-size, clamp(1.45rem, 1.1rem + 1vw, 2rem));
+    font-weight: var(--smrt-typography-weight-bold, 720);
+    line-height: var(--smrt-typography-headline-small-line-height, 1.12);
     letter-spacing: 0;
     padding: 0;
   }

--- a/packages/content/src/svelte/components/ContentTitleField.svelte
+++ b/packages/content/src/svelte/components/ContentTitleField.svelte
@@ -32,9 +32,9 @@ let {
     background: transparent;
     color: var(--smrt-color-on-surface);
     font: inherit;
-    font-size: var(--smrt-typography-headline-small-size, clamp(1.45rem, 1.1rem + 1vw, 2rem));
+    font-size: clamp(1.45rem, 1.1rem + 1vw, 2rem);
     font-weight: var(--smrt-typography-weight-bold, 720);
-    line-height: var(--smrt-typography-headline-small-line-height, 1.12);
+    line-height: 1.12;
     letter-spacing: 0;
     padding: 0;
   }

--- a/packages/content/src/svelte/components/ContentTransparencyReport.svelte
+++ b/packages/content/src/svelte/components/ContentTransparencyReport.svelte
@@ -246,7 +246,7 @@ function getFactLabel(fact: {
     background: var(--smrt-color-surface-container-high);
     color: var(--smrt-color-on-surface);
     padding: 0.25rem 0.65rem;
-    font-size: 0.8rem;
+    font-size: var(--smrt-typography-label-medium-size, 0.8rem);
   }
 
   .pill-list span.used {

--- a/packages/content/src/svelte/components/ContentTransparencyTool.svelte
+++ b/packages/content/src/svelte/components/ContentTransparencyTool.svelte
@@ -268,7 +268,7 @@ async function loadTransparency(contentIdToLoad = savedContentId) {
   .empty-copy,
   .section-caption {
     color: var(--smrt-color-on-surface-variant);
-    font-size: 0.85rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.85rem);
   }
 
   .transparency-card-prompt,
@@ -284,8 +284,8 @@ async function loadTransparency(contentIdToLoad = savedContentId) {
   .pill {
     border-radius: var(--smrt-radius-full, 9999px);
     padding: 0.2rem 0.55rem;
-    font-size: 0.75rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
     text-transform: capitalize;
   }
 
@@ -305,6 +305,6 @@ async function loadTransparency(contentIdToLoad = savedContentId) {
     padding: 0.75rem 0.9rem;
     background: color-mix(in srgb, var(--smrt-color-error) 10%, transparent);
     color: var(--smrt-color-on-error-container);
-    font-size: 0.9rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.9rem);
   }
 </style>

--- a/packages/content/src/svelte/components/ContentVersionsTool.svelte
+++ b/packages/content/src/svelte/components/ContentVersionsTool.svelte
@@ -236,7 +236,7 @@ async function restoreVersion(versionNumber: number) {
   .tool-card span,
   .empty-copy {
     color: var(--smrt-color-on-surface-variant);
-    font-size: 0.85rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.85rem);
   }
 
   .secondary-button {
@@ -246,7 +246,7 @@ async function restoreVersion(versionNumber: number) {
     background: var(--smrt-color-surface);
     color: var(--smrt-color-on-surface);
     cursor: pointer;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .secondary-button:disabled {
@@ -257,8 +257,8 @@ async function restoreVersion(versionNumber: number) {
   .pill {
     border-radius: var(--smrt-radius-full, 9999px);
     padding: 0.2rem 0.55rem;
-    font-size: 0.75rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
     text-transform: capitalize;
   }
 
@@ -272,7 +272,7 @@ async function restoreVersion(versionNumber: number) {
     margin: 0;
     border-radius: 0.6rem;
     padding: 0.75rem 0.9rem;
-    font-size: 0.9rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.9rem);
   }
 
   .tool-error {

--- a/packages/content/src/svelte/components/GovernedContentEditor.svelte
+++ b/packages/content/src/svelte/components/GovernedContentEditor.svelte
@@ -390,10 +390,10 @@ function handleSave(data: ContentData) {
   }
 
   .publish-readiness-card__profile {
-    font-size: 0.8rem;
+    font-size: var(--smrt-typography-label-medium-size, 0.8rem);
     color: var(--smrt-color-on-surface-variant);
     text-transform: uppercase;
-    letter-spacing: 0.04em;
+    letter-spacing: var(--smrt-typography-label-medium-tracking, 0.04em);
   }
 
   .publish-readiness-card p {

--- a/packages/content/src/svelte/components/ImageThumbnail.svelte
+++ b/packages/content/src/svelte/components/ImageThumbnail.svelte
@@ -147,9 +147,9 @@ $effect(() => {
   }
 
   .smrt-thumbnail-missing span {
-    font-size: 0.75rem;
-    font-weight: 600;
-    letter-spacing: 0.04em;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
+    letter-spacing: var(--smrt-typography-label-medium-tracking, 0.04em);
     text-transform: uppercase;
   }
 </style>

--- a/packages/content/src/svelte/components/Markdown.svelte
+++ b/packages/content/src/svelte/components/Markdown.svelte
@@ -88,7 +88,7 @@ const rendered = $derived(renderMarkdownToHtml(content));
   }
 
   .markdown-content :global(code) {
-    font-family: var(--font-family-mono, ui-monospace, monospace);
+    font-family: var(--smrt-font-family-mono, ui-monospace, monospace);
     font-size: 0.875em;
     background: var(--smrt-color-surface-container-high);
     color: var(--smrt-color-on-surface-variant);

--- a/packages/content/src/svelte/routes/ContentContributionsRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentContributionsRoute.svelte
@@ -553,21 +553,21 @@ async function handleDeleteContributor(data: Record<string, any>) {
   .eyebrow {
     color: var(--smrt-color-on-surface-variant);
     text-transform: uppercase;
-    letter-spacing: 0.08em;
-    font-size: 0.78rem;
-    font-weight: 700;
+    letter-spacing: var(--smrt-typography-label-medium-tracking, 0.08em);
+    font-size: var(--smrt-typography-label-medium-size, 0.78rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
   }
 
   .page-header h1 {
     margin: 0.35rem 0 0.65rem;
-    font-size: clamp(2rem, 5vw, 3rem);
-    line-height: 1.05;
+    font-size: var(--smrt-typography-headline-large-size, clamp(2rem, 5vw, 3rem));
+    line-height: var(--smrt-typography-headline-large-line-height, 1.05);
   }
 
   .page-header p {
     margin: 0;
     color: var(--smrt-color-on-surface-variant);
-    font-size: 1rem;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
     max-width: 52rem;
   }
 
@@ -593,7 +593,7 @@ async function handleDeleteContributor(data: Record<string, any>) {
     );
     color: var(--smrt-color-on-surface);
     text-decoration: none;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .page-nav a[aria-current='page'] {
@@ -673,14 +673,16 @@ async function handleDeleteContributor(data: Record<string, any>) {
       transparent
     );
     color: var(--smrt-color-on-surface);
-    font-size: 0.83rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-large-size, 0.83rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .callout code {
-    font-family:
+    font-family: var(
+      --smrt-font-family-mono,
       'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-      'Liberation Mono', 'Courier New', monospace;
+      'Liberation Mono', 'Courier New', monospace
+    );
     font-size: 0.9em;
   }
 
@@ -733,7 +735,7 @@ async function handleDeleteContributor(data: Record<string, any>) {
     );
     background: transparent;
     color: var(--smrt-color-primary);
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     padding: 0.65rem 0.95rem;
     cursor: pointer;
   }
@@ -751,7 +753,7 @@ async function handleDeleteContributor(data: Record<string, any>) {
       transparent
     );
     color: var(--smrt-color-primary);
-    font-weight: 700;
+    font-weight: var(--smrt-typography-weight-bold, 700);
     padding: 0 0.8rem;
   }
 
@@ -772,7 +774,7 @@ async function handleDeleteContributor(data: Record<string, any>) {
 
     .page-header h1 {
       margin-top: 0.25rem;
-      font-size: clamp(1.6rem, 9vw, 2.2rem);
+      font-size: var(--smrt-typography-headline-small-size, clamp(1.6rem, 9vw, 2.2rem));
     }
 
     .callout,
@@ -792,15 +794,15 @@ async function handleDeleteContributor(data: Record<string, any>) {
 
     .callout__header p,
     .callout__note {
-      font-size: 0.82rem;
-      line-height: 1.5;
+      font-size: var(--smrt-typography-body-medium-size, 0.82rem);
+      line-height: var(--smrt-typography-body-medium-line-height, 1.5);
     }
 
     .pill {
       min-height: 1.7rem;
       min-width: 0;
       padding: 0 0.65rem;
-      font-size: 0.78rem;
+      font-size: var(--smrt-typography-label-medium-size, 0.78rem);
     }
 
     .section-heading {

--- a/packages/content/src/svelte/routes/ContentContributionsRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentContributionsRoute.svelte
@@ -560,8 +560,8 @@ async function handleDeleteContributor(data: Record<string, any>) {
 
   .page-header h1 {
     margin: 0.35rem 0 0.65rem;
-    font-size: var(--smrt-typography-headline-large-size, clamp(2rem, 5vw, 3rem));
-    line-height: var(--smrt-typography-headline-large-line-height, 1.05);
+    font-size: clamp(2rem, 5vw, 3rem);
+    line-height: 1.05;
   }
 
   .page-header p {
@@ -774,7 +774,7 @@ async function handleDeleteContributor(data: Record<string, any>) {
 
     .page-header h1 {
       margin-top: 0.25rem;
-      font-size: var(--smrt-typography-headline-small-size, clamp(1.6rem, 9vw, 2.2rem));
+      font-size: clamp(1.6rem, 9vw, 2.2rem);
     }
 
     .callout,

--- a/packages/content/src/svelte/routes/ContentFactsRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentFactsRoute.svelte
@@ -290,8 +290,8 @@ onMount(() => {
 
   .page-header h1 {
     margin: 0.35rem 0 0.65rem;
-    font-size: var(--smrt-typography-headline-large-size, clamp(2rem, 5vw, 3rem));
-    line-height: var(--smrt-typography-headline-large-line-height, 1.05);
+    font-size: clamp(2rem, 5vw, 3rem);
+    line-height: 1.05;
   }
 
   .page-header p {

--- a/packages/content/src/svelte/routes/ContentFactsRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentFactsRoute.svelte
@@ -283,21 +283,21 @@ onMount(() => {
   .eyebrow {
     color: var(--smrt-color-on-surface-variant);
     text-transform: uppercase;
-    letter-spacing: 0.08em;
-    font-size: 0.78rem;
-    font-weight: 700;
+    letter-spacing: var(--smrt-typography-label-medium-tracking, 0.08em);
+    font-size: var(--smrt-typography-label-medium-size, 0.78rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
   }
 
   .page-header h1 {
     margin: 0.35rem 0 0.65rem;
-    font-size: clamp(2rem, 5vw, 3rem);
-    line-height: 1.05;
+    font-size: var(--smrt-typography-headline-large-size, clamp(2rem, 5vw, 3rem));
+    line-height: var(--smrt-typography-headline-large-line-height, 1.05);
   }
 
   .page-header p {
     margin: 0;
     color: var(--smrt-color-on-surface-variant);
-    font-size: 1rem;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
     max-width: 44rem;
   }
 
@@ -325,7 +325,7 @@ onMount(() => {
     );
     color: var(--smrt-color-on-surface);
     text-decoration: none;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .page-nav a[aria-current='page'] {
@@ -390,8 +390,8 @@ onMount(() => {
   }
 
   .search-field span {
-    font-size: 0.82rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-label-large-size, 0.82rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
     color: var(--smrt-color-on-surface-variant);
   }
 
@@ -422,7 +422,7 @@ onMount(() => {
     background: var(--smrt-color-primary);
     color: var(--smrt-color-on-primary);
     padding: 0 1rem;
-    font-weight: 700;
+    font-weight: var(--smrt-typography-weight-bold, 700);
     cursor: pointer;
   }
 
@@ -442,7 +442,7 @@ onMount(() => {
   }
 
   .results-meta strong {
-    font-size: 1.2rem;
+    font-size: var(--smrt-typography-title-large-size, 1.2rem);
     margin-right: 0.5rem;
   }
 
@@ -463,7 +463,7 @@ onMount(() => {
     padding: 0 0.7rem;
     border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-surface-container-low);
-    font-size: 0.82rem;
+    font-size: var(--smrt-typography-label-large-size, 0.82rem);
   }
 
   .facts-list {
@@ -504,14 +504,14 @@ onMount(() => {
 
   .fact-row h2 {
     margin: 0;
-    font-size: 1.08rem;
-    line-height: 1.45;
+    font-size: var(--smrt-typography-title-medium-size, 1.08rem);
+    line-height: var(--smrt-typography-title-medium-line-height, 1.45);
     color: var(--smrt-color-on-surface);
   }
 
   .fact-row__stats span {
     color: var(--smrt-color-on-surface-variant);
-    font-size: 0.84rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.84rem);
   }
 
   .badge {
@@ -526,8 +526,8 @@ onMount(() => {
       transparent
     );
     color: var(--smrt-color-primary);
-    font-size: 0.75rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
     text-transform: capitalize;
   }
 
@@ -543,7 +543,7 @@ onMount(() => {
 
   details summary {
     cursor: pointer;
-    font-weight: 700;
+    font-weight: var(--smrt-typography-weight-bold, 700);
     color: var(--smrt-color-on-surface);
   }
 
@@ -568,11 +568,11 @@ onMount(() => {
   }
 
   .metadata-list dt {
-    font-size: 0.72rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-label-medium-size, 0.72rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
     color: var(--smrt-color-on-surface-variant);
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: var(--smrt-typography-label-medium-tracking, 0.05em);
   }
 
   .metadata-list dd {

--- a/packages/content/src/svelte/routes/ContentGovernanceRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentGovernanceRoute.svelte
@@ -128,8 +128,8 @@ const workspaceHref = $derived(
 
   .page-header h1 {
     margin: 0.35rem 0 0.65rem;
-    font-size: var(--smrt-typography-headline-large-size, clamp(2rem, 5vw, 3rem));
-    line-height: var(--smrt-typography-headline-large-line-height, 1.05);
+    font-size: clamp(2rem, 5vw, 3rem);
+    line-height: 1.05;
   }
 
   .page-header p {

--- a/packages/content/src/svelte/routes/ContentGovernanceRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentGovernanceRoute.svelte
@@ -121,21 +121,21 @@ const workspaceHref = $derived(
   .eyebrow {
     color: var(--smrt-color-on-surface-variant);
     text-transform: uppercase;
-    letter-spacing: 0.08em;
-    font-size: 0.78rem;
-    font-weight: 700;
+    letter-spacing: var(--smrt-typography-label-medium-tracking, 0.08em);
+    font-size: var(--smrt-typography-label-medium-size, 0.78rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
   }
 
   .page-header h1 {
     margin: 0.35rem 0 0.65rem;
-    font-size: clamp(2rem, 5vw, 3rem);
-    line-height: 1.05;
+    font-size: var(--smrt-typography-headline-large-size, clamp(2rem, 5vw, 3rem));
+    line-height: var(--smrt-typography-headline-large-line-height, 1.05);
   }
 
   .page-header p {
     margin: 0;
     color: var(--smrt-color-on-surface-variant);
-    font-size: 1rem;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
     max-width: 42rem;
   }
 
@@ -161,7 +161,7 @@ const workspaceHref = $derived(
     );
     color: var(--smrt-color-on-surface);
     text-decoration: none;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .page-nav a[aria-current='page'] {

--- a/packages/content/src/svelte/routes/ContentWorkspaceRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentWorkspaceRoute.svelte
@@ -301,8 +301,8 @@ function closeForms() {
 
   .workspace-header h1 {
     margin: 0.35rem 0 0.65rem;
-    font-size: var(--smrt-typography-headline-large-size, clamp(2rem, 5vw, 3rem));
-    line-height: var(--smrt-typography-headline-large-line-height, 1.05);
+    font-size: clamp(2rem, 5vw, 3rem);
+    line-height: 1.05;
   }
 
   .workspace-header p {

--- a/packages/content/src/svelte/routes/ContentWorkspaceRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentWorkspaceRoute.svelte
@@ -294,15 +294,15 @@ function closeForms() {
   .eyebrow {
     color: var(--smrt-color-on-surface-variant);
     text-transform: uppercase;
-    letter-spacing: 0.08em;
-    font-size: 0.78rem;
-    font-weight: 700;
+    letter-spacing: var(--smrt-typography-label-medium-tracking, 0.08em);
+    font-size: var(--smrt-typography-label-medium-size, 0.78rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
   }
 
   .workspace-header h1 {
     margin: 0.35rem 0 0.65rem;
-    font-size: clamp(2rem, 5vw, 3rem);
-    line-height: 1.05;
+    font-size: var(--smrt-typography-headline-large-size, clamp(2rem, 5vw, 3rem));
+    line-height: var(--smrt-typography-headline-large-line-height, 1.05);
   }
 
   .workspace-header p {
@@ -333,7 +333,7 @@ function closeForms() {
     );
     color: var(--smrt-color-on-surface);
     text-decoration: none;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .workspace-nav a[aria-current='page'] {
@@ -380,7 +380,7 @@ function closeForms() {
   }
 
   .callout-card strong {
-    font-size: 1.8rem;
+    font-size: var(--smrt-typography-headline-medium-size, 1.8rem);
   }
 
   .callout-card span {
@@ -413,14 +413,14 @@ function closeForms() {
     color: var(--smrt-color-primary);
     padding: 0.65rem 0.95rem;
     border-radius: var(--smrt-radius-full, 9999px);
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     cursor: pointer;
   }
 
   .inline-link {
     color: var(--smrt-color-primary);
     text-decoration: none;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .inline-link:hover,

--- a/packages/content/src/svelte/routes/PublishedArticleRoute.svelte
+++ b/packages/content/src/svelte/routes/PublishedArticleRoute.svelte
@@ -134,8 +134,8 @@ function formatTimestamp(value: string | null | undefined) {
 
   .article-hero h1 {
     margin: 0;
-    font-size: var(--smrt-typography-display-small-size, clamp(2.2rem, 5vw, 4rem));
-    line-height: var(--smrt-typography-display-small-line-height, 1.05);
+    font-size: clamp(2.2rem, 5vw, 4rem);
+    line-height: 1.05;
     color: var(--smrt-color-on-surface);
   }
 

--- a/packages/content/src/svelte/routes/PublishedArticleRoute.svelte
+++ b/packages/content/src/svelte/routes/PublishedArticleRoute.svelte
@@ -116,7 +116,7 @@ function formatTimestamp(value: string | null | undefined) {
   .back-link {
     color: var(--smrt-color-primary);
     text-decoration: none;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     width: fit-content;
   }
 
@@ -127,21 +127,21 @@ function formatTimestamp(value: string | null | undefined) {
   .eyebrow {
     color: var(--smrt-color-on-surface-variant);
     text-transform: uppercase;
-    letter-spacing: 0.08em;
-    font-size: 0.8rem;
-    font-weight: 700;
+    letter-spacing: var(--smrt-typography-label-medium-tracking, 0.08em);
+    font-size: var(--smrt-typography-label-medium-size, 0.8rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
   }
 
   .article-hero h1 {
     margin: 0;
-    font-size: clamp(2.2rem, 5vw, 4rem);
-    line-height: 1.05;
+    font-size: var(--smrt-typography-display-small-size, clamp(2.2rem, 5vw, 4rem));
+    line-height: var(--smrt-typography-display-small-line-height, 1.05);
     color: var(--smrt-color-on-surface);
   }
 
   .article-dek {
     margin: 0;
-    font-size: 1.15rem;
+    font-size: var(--smrt-typography-body-large-size, 1.15rem);
     color: var(--smrt-color-on-surface-variant);
     max-width: 55rem;
   }
@@ -151,7 +151,7 @@ function formatTimestamp(value: string | null | undefined) {
     flex-wrap: wrap;
     gap: 0.85rem;
     color: var(--smrt-color-on-surface-variant);
-    font-size: 0.92rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.92rem);
   }
 
   .article-layout {

--- a/scripts/check-typography.mjs
+++ b/scripts/check-typography.mjs
@@ -36,6 +36,7 @@ const PACKAGES = join(ROOT, 'packages');
 /** Packages held to ERROR. Everything else is report-only for now (#1373). */
 const STRICT_PACKAGES = new Set([
   'smrt-svelte',
+  'content',
 ]);
 
 /** Dev/playground hosts skipped entirely (matches the other token ratchets). */

--- a/scripts/check-typography.mjs
+++ b/scripts/check-typography.mjs
@@ -252,9 +252,13 @@ function findViolations(file, source) {
     if (!value || KEYWORD_VALUES.has(value.toLowerCase())) continue;
     let suggestion = null;
     if (prop === 'font-size') {
+      // Fluid sizes (clamp/min/max) are intentionally responsive — they don't
+      // map to a fixed role token, so tokenizing them would freeze the scaling.
+      // Leave them raw (same spirit as directional shadows in the elevation check).
+      if (/\b(?:clamp|min|max)\(/i.test(value)) continue;
       // Flag iff a hard-coded absolute length remains (after token-stripping):
       // catches bare `0.875rem`, wrapped `var(--x, 16px)`, and `calc(... + 2px)`.
-      // Pure relative/keyword sizes (em/%/0/inherit) are allowed.
+      // Pure relative/keyword/viewport sizes (em/%/0/vw/inherit) are allowed.
       if (firstAbsoluteRem(value) === null) continue;
       suggestion = suggestSize(value);
     } else if (prop === 'font-weight') {


### PR DESCRIPTION
## What

S1 **typography** Phase 2 — migrates `content` (the largest consumer, 203 raw declarations) to the Material-3 `--smrt-typography-*` role scale, and flips `content` to strict in `scripts/check-typography.mjs`.

Follows the [Phase 1 ratchet + smrt-svelte migration](https://github.com/happyvertical/smrt/pull/1462).

## Approach

Every text element mapped to its proper M3 role (full semantic pass), original value preserved as the `var()` fallback:
- article/hero titles → `display-*` / `headline-*`
- card/section/list titles, table headers → `title-*`
- article/body/description copy → `body-*`
- buttons/chips/badges/captions/metadata/timestamps → `label-*`
- legacy `var(--font-size-*, <rem>)` and `var(--font-family-mono, …)` refs repointed to smrt tokens
- `line-height`/`letter-spacing` tokenized to each element's assigned role (`-line-height`/`-tracking`)

## Verification

- `node scripts/check-typography.mjs` → smrt-svelte + content both clean
- **Deterministic scope-check**: every added/removed line under `packages/content` is a `font-size`/`font-weight`/`font-family`/`line-height`/`letter-spacing`/`font` value — no JS/markup/TS touched, no `console.*` removed
- `turbo build --filter=@happyvertical/smrt-content` → 21/21 (no codegen route churn)
- `node scripts/check-svelte-tokens.mjs` → all consumed `--smrt-*` tokens emitted
- `pnpm knowledge:check --strict` → fresh
- `biome check` (read-only) on all 30 changed files → clean

## Remaining

After this: messages (100), products (71), assets (64), chat (62), images (43), analytics (28), commerce (20), + a single-digit tail. The final batch flips every package strict and closes #1373.