### PR TITLE
feat(messages,products): typography → M3 role tokens (#1373 Phase 3)

### DIFF
--- a/packages/messages/src/svelte/components/AccountAvatar.svelte
+++ b/packages/messages/src/svelte/components/AccountAvatar.svelte
@@ -59,26 +59,26 @@ const _icon = $derived.by(() => {
     border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-secondary-container, #d7e3f7);
     color: var(--smrt-color-on-secondary-container, #101c2b);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     flex-shrink: 0;
   }
 
   .avatar--sm {
     width: 1.5rem;
     height: 1.5rem;
-    font-size: 0.625rem;
+    font-size: var(--smrt-typography-label-small-size, 0.625rem);
   }
 
   .avatar--md {
     width: 2rem;
     height: 2rem;
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
   }
 
   .avatar--lg {
     width: 2.5rem;
     height: 2.5rem;
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
   }
 
   .avatar--email {

--- a/packages/messages/src/svelte/components/AccountCard.svelte
+++ b/packages/messages/src/svelte/components/AccountCard.svelte
@@ -125,7 +125,7 @@ const _lastSyncFormatted = $derived.by(() => {
   .status {
     padding: 0.125rem 0.375rem;
     border-radius: var(--smrt-radius-small, 0.25rem);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
   .status--active {
@@ -143,7 +143,7 @@ const _lastSyncFormatted = $derived.by(() => {
   }
 
   .unread-count {
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-primary, #005ac1);
   }
 

--- a/packages/messages/src/svelte/components/AttachmentChip.svelte
+++ b/packages/messages/src/svelte/components/AttachmentChip.svelte
@@ -82,7 +82,7 @@ const _formattedSize = $derived.by(() => {
 
   .icon {
     flex-shrink: 0;
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
   }
 
   .name {
@@ -94,6 +94,6 @@ const _formattedSize = $derived.by(() => {
   .size {
     flex-shrink: 0;
     opacity: 0.7;
-    font-size: 0.6875rem;
+    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
   }
 </style>

--- a/packages/messages/src/svelte/components/AttachmentUpload.svelte
+++ b/packages/messages/src/svelte/components/AttachmentUpload.svelte
@@ -104,8 +104,8 @@ export interface Props {
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border-radius: var(--smrt-radius-sm, 8px);
     background: var(--smrt-color-surface-variant, #e7e0ec);
-    font-size: 13px;
-    font-family: var(--smrt-typography-body, system-ui);
+    font-size: var(--smrt-typography-body-medium-size, 13px);
+    font-family: var(--smrt-font-family, system-ui);
   }
 
   .filename {
@@ -114,7 +114,7 @@ export interface Props {
 
   .size {
     color: var(--smrt-color-outline, #79747e);
-    font-size: 11px;
+    font-size: var(--smrt-typography-label-small-size, 11px);
   }
 
   .remove {
@@ -123,7 +123,7 @@ export interface Props {
     cursor: pointer;
     padding: 0 var(--smrt-spacing-1, 4px);
     color: var(--smrt-color-error, #ba1a1a);
-    font-size: 14px;
+    font-size: var(--smrt-typography-label-large-size, 14px);
   }
 
   .drop-zone {
@@ -149,7 +149,7 @@ export interface Props {
 
   .upload-text {
     color: var(--smrt-color-outline, #79747e);
-    font-size: 13px;
-    font-family: var(--smrt-typography-body, system-ui);
+    font-size: var(--smrt-typography-body-medium-size, 13px);
+    font-family: var(--smrt-font-family, system-ui);
   }
 </style>

--- a/packages/messages/src/svelte/components/ComposeForm.svelte
+++ b/packages/messages/src/svelte/components/ComposeForm.svelte
@@ -260,7 +260,7 @@ export interface Props {
     flex-direction: column;
     gap: var(--smrt-spacing-2, 8px);
     padding: var(--smrt-spacing-4, 16px);
-    font-family: var(--smrt-typography-body, system-ui);
+    font-family: var(--smrt-font-family, system-ui);
   }
 
   .field {
@@ -272,7 +272,7 @@ export interface Props {
   }
 
   .field-label {
-    font-size: 14px;
+    font-size: var(--smrt-typography-label-large-size, 14px);
     color: var(--smrt-color-on-surface-variant, #49454f);
     min-width: 56px;
   }
@@ -283,7 +283,7 @@ export interface Props {
     border: none;
     outline: none;
     font-family: inherit;
-    font-size: 14px;
+    font-size: var(--smrt-typography-body-medium-size, 14px);
     padding: var(--smrt-spacing-2, 8px) 0;
     background: transparent;
     color: var(--smrt-color-on-surface, #1c1b1f);
@@ -300,7 +300,7 @@ export interface Props {
     border: none;
     cursor: pointer;
     color: var(--smrt-color-primary, #6750a4);
-    font-size: 13px;
+    font-size: var(--smrt-typography-label-large-size, 13px);
     text-decoration: underline;
   }
 
@@ -313,8 +313,8 @@ export interface Props {
     border: 1px solid var(--smrt-color-outline-variant, #cac4d0);
     border-radius: var(--smrt-radius-md, 12px);
     padding: var(--smrt-spacing-3, 12px);
-    font-family: var(--smrt-typography-body, system-ui);
-    font-size: 14px;
+    font-family: var(--smrt-font-family, system-ui);
+    font-size: var(--smrt-typography-body-medium-size, 14px);
     resize: vertical;
     background: var(--smrt-color-surface, #fffbfe);
     color: var(--smrt-color-on-surface, #1c1b1f);
@@ -328,14 +328,14 @@ export interface Props {
 
   .char-count {
     text-align: right;
-    font-size: 12px;
+    font-size: var(--smrt-typography-label-medium-size, 12px);
     color: var(--smrt-color-outline, #79747e);
     padding-top: var(--smrt-spacing-1, 4px);
   }
 
   .char-count.over-limit {
     color: var(--smrt-color-error, #ba1a1a);
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .actions {
@@ -350,8 +350,8 @@ export interface Props {
     border: none;
     background: var(--smrt-color-primary, #6750a4);
     color: var(--smrt-color-on-primary, #fff);
-    font-family: var(--smrt-typography-label, system-ui);
-    font-size: 14px;
+    font-family: var(--smrt-font-family, system-ui);
+    font-size: var(--smrt-typography-label-large-size, 14px);
     cursor: pointer;
   }
 
@@ -366,8 +366,8 @@ export interface Props {
     border: 1px solid var(--smrt-color-outline, #79747e);
     background: transparent;
     color: var(--smrt-color-primary, #6750a4);
-    font-family: var(--smrt-typography-label, system-ui);
-    font-size: 14px;
+    font-family: var(--smrt-font-family, system-ui);
+    font-size: var(--smrt-typography-label-large-size, 14px);
     cursor: pointer;
   }
 
@@ -376,8 +376,8 @@ export interface Props {
     border: none;
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #49454f);
-    font-family: var(--smrt-typography-label, system-ui);
-    font-size: 14px;
+    font-family: var(--smrt-font-family, system-ui);
+    font-size: var(--smrt-typography-label-large-size, 14px);
     cursor: pointer;
   }
 </style>

--- a/packages/messages/src/svelte/components/EmailAccountManager.svelte
+++ b/packages/messages/src/svelte/components/EmailAccountManager.svelte
@@ -342,7 +342,7 @@ function getProviderLabel(type: string): string {
   }
 
   .section-description {
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
@@ -353,9 +353,9 @@ function getProviderLabel(type: string): string {
     background: transparent;
     color: var(--smrt-color-primary, #005ac1);
     cursor: pointer;
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-label-large-size, 0.8125rem);
     font-family: inherit;
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     transition: all 150ms ease;
     flex-shrink: 0;
   }
@@ -376,17 +376,17 @@ function getProviderLabel(type: string): string {
   }
 
   .form-title {
-    font-size: 0.875rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-title-small-size, 0.875rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-primary, #005ac1);
   }
 
   .form-section-label {
-    font-size: 0.75rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-on-surface-variant, #43474e);
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: var(--smrt-typography-label-medium-tracking, 0.05em);
     padding-top: 0.25rem;
   }
 
@@ -403,8 +403,8 @@ function getProviderLabel(type: string): string {
   }
 
   .form-label {
-    font-size: 0.75rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
@@ -415,7 +415,7 @@ function getProviderLabel(type: string): string {
     border: 1px solid var(--smrt-color-outline-variant, #c2c7cf);
     background: var(--smrt-color-surface, #fefbff);
     color: var(--smrt-color-on-surface, #1a1c1e);
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
     font-family: inherit;
     transition: border-color 150ms ease;
   }
@@ -441,7 +441,7 @@ function getProviderLabel(type: string): string {
     align-items: center;
     gap: 0.5rem;
     cursor: pointer;
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
     color: var(--smrt-color-on-surface, #1a1c1e);
     white-space: nowrap;
   }
@@ -464,7 +464,7 @@ function getProviderLabel(type: string): string {
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #43474e);
     cursor: pointer;
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-label-large-size, 0.8125rem);
     font-family: inherit;
     transition: all 150ms ease;
   }
@@ -480,9 +480,9 @@ function getProviderLabel(type: string): string {
     background: var(--smrt-color-primary, #005ac1);
     color: var(--smrt-color-on-primary, #fff);
     cursor: pointer;
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-label-large-size, 0.8125rem);
     font-family: inherit;
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     transition: all 150ms ease;
   }
 
@@ -498,7 +498,7 @@ function getProviderLabel(type: string): string {
   .test-result {
     padding: 0.5rem 0.75rem;
     border-radius: var(--smrt-radius-md, 8px);
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -517,7 +517,7 @@ function getProviderLabel(type: string): string {
   .dismiss-btn {
     background: transparent;
     border: none;
-    font-size: 1rem;
+    font-size: var(--smrt-typography-label-large-size, 1rem);
     cursor: pointer;
     color: inherit;
     padding: 0 0.25rem;
@@ -574,9 +574,9 @@ function getProviderLabel(type: string): string {
   }
 
   .type-badge {
-    font-size: 0.6875rem;
-    font-weight: 600;
-    font-family: monospace;
+    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
+    font-family: var(--smrt-font-family-mono, monospace);
     background: var(--smrt-color-surface, #fefbff);
     border: 1px solid var(--smrt-color-outline-variant, #c2c7cf);
     padding: 0.25rem 0.5rem;
@@ -588,9 +588,9 @@ function getProviderLabel(type: string): string {
 
   .type-badge.provider {
     font-family: inherit;
-    font-size: 0.625rem;
+    font-size: var(--smrt-typography-label-small-size, 0.625rem);
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: var(--smrt-typography-label-small-tracking, 0.05em);
     background: var(--smrt-color-primary-container, #d8e2ff);
     color: var(--smrt-color-primary, #005ac1);
     border-color: transparent;
@@ -606,21 +606,21 @@ function getProviderLabel(type: string): string {
   }
 
   .entry-pattern {
-    font-weight: 500;
-    font-size: 0.875rem;
+    font-weight: var(--smrt-typography-weight-medium, 500);
+    font-size: var(--smrt-typography-title-small-size, 0.875rem);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
   .entry-description {
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
   .host-tag {
-    font-size: 0.6875rem;
-    font-family: monospace;
+    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
+    font-family: var(--smrt-font-family-mono, monospace);
     color: var(--smrt-color-on-surface-variant, #43474e);
     background: var(--smrt-color-surface, #fefbff);
     padding: 0.125rem 0.5rem;
@@ -629,7 +629,7 @@ function getProviderLabel(type: string): string {
   }
 
   .inactive-tag {
-    font-size: 0.6875rem;
+    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
     color: var(--smrt-color-on-surface-variant, #43474e);
     background: var(--smrt-color-surface-container-high, #e6e7ef);
     padding: 0.125rem 0.5rem;
@@ -644,7 +644,7 @@ function getProviderLabel(type: string): string {
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #43474e);
     cursor: pointer;
-    font-size: 0.6875rem;
+    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
     font-family: inherit;
     transition: all 150ms ease;
   }
@@ -660,7 +660,7 @@ function getProviderLabel(type: string): string {
   }
 
   .delete-btn {
-    font-size: 1rem;
+    font-size: var(--smrt-typography-label-large-size, 1rem);
     line-height: 1;
     padding: 0.125rem 0.5rem;
     border-radius: var(--smrt-radius-full, 9999px);

--- a/packages/messages/src/svelte/components/EmailAccountManager.svelte
+++ b/packages/messages/src/svelte/components/EmailAccountManager.svelte
@@ -517,7 +517,7 @@ function getProviderLabel(type: string): string {
   .dismiss-btn {
     background: transparent;
     border: none;
-    font-size: var(--smrt-typography-label-large-size, 1rem);
+    font-size: var(--smrt-typography-body-large-size, 1rem);
     cursor: pointer;
     color: inherit;
     padding: 0 0.25rem;
@@ -660,7 +660,7 @@ function getProviderLabel(type: string): string {
   }
 
   .delete-btn {
-    font-size: var(--smrt-typography-label-large-size, 1rem);
+    font-size: var(--smrt-typography-body-large-size, 1rem);
     line-height: 1;
     padding: 0.125rem 0.5rem;
     border-radius: var(--smrt-radius-full, 9999px);

--- a/packages/messages/src/svelte/components/EmailFilterManager.svelte
+++ b/packages/messages/src/svelte/components/EmailFilterManager.svelte
@@ -385,7 +385,7 @@ function getPatternPlaceholder(type: string): string {
     border-radius: var(--smrt-radius-md, 8px);
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #43474e);
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-label-large-size, 0.8125rem);
     font-family: inherit;
     cursor: pointer;
     transition: all 150ms ease;
@@ -401,7 +401,7 @@ function getPatternPlaceholder(type: string): string {
   }
 
   .count {
-    font-size: 0.6875rem;
+    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
     background: var(--smrt-color-outline-variant, #c2c7cf);
     padding: 0.0625rem 0.375rem;
     border-radius: var(--smrt-radius-full, 9999px);
@@ -421,7 +421,7 @@ function getPatternPlaceholder(type: string): string {
   }
 
   .section-description {
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
@@ -432,9 +432,9 @@ function getPatternPlaceholder(type: string): string {
     background: transparent;
     color: var(--smrt-color-primary, #005ac1);
     cursor: pointer;
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-label-large-size, 0.8125rem);
     font-family: inherit;
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     transition: all 150ms ease;
     flex-shrink: 0;
   }
@@ -455,8 +455,8 @@ function getPatternPlaceholder(type: string): string {
   }
 
   .form-title {
-    font-size: 0.875rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-title-small-size, 0.875rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-primary, #005ac1);
   }
 
@@ -473,13 +473,13 @@ function getPatternPlaceholder(type: string): string {
   }
 
   .form-label {
-    font-size: 0.75rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
   .optional {
-    font-weight: 400;
+    font-weight: var(--smrt-typography-weight-normal, 400);
     opacity: 0.7;
   }
 
@@ -490,7 +490,7 @@ function getPatternPlaceholder(type: string): string {
     border: 1px solid var(--smrt-color-outline-variant, #c2c7cf);
     background: var(--smrt-color-surface, #fefbff);
     color: var(--smrt-color-on-surface, #1a1c1e);
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
     font-family: inherit;
     transition: border-color 150ms ease;
   }
@@ -516,7 +516,7 @@ function getPatternPlaceholder(type: string): string {
     align-items: center;
     gap: 0.5rem;
     cursor: pointer;
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
     color: var(--smrt-color-on-surface, #1a1c1e);
     white-space: nowrap;
   }
@@ -539,7 +539,7 @@ function getPatternPlaceholder(type: string): string {
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #43474e);
     cursor: pointer;
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-label-large-size, 0.8125rem);
     font-family: inherit;
     transition: all 150ms ease;
   }
@@ -555,9 +555,9 @@ function getPatternPlaceholder(type: string): string {
     background: var(--smrt-color-primary, #005ac1);
     color: var(--smrt-color-on-primary, #fff);
     cursor: pointer;
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-label-large-size, 0.8125rem);
     font-family: inherit;
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     transition: all 150ms ease;
   }
 
@@ -608,9 +608,9 @@ function getPatternPlaceholder(type: string): string {
   }
 
   .type-badge {
-    font-size: 0.6875rem;
-    font-weight: 600;
-    font-family: monospace;
+    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
+    font-family: var(--smrt-font-family-mono, monospace);
     background: var(--smrt-color-surface, #fefbff);
     border: 1px solid var(--smrt-color-outline-variant, #c2c7cf);
     padding: 0.25rem 0.5rem;
@@ -629,20 +629,20 @@ function getPatternPlaceholder(type: string): string {
   }
 
   .entry-pattern {
-    font-weight: 500;
-    font-size: 0.875rem;
+    font-weight: var(--smrt-typography-weight-medium, 500);
+    font-size: var(--smrt-typography-title-small-size, 0.875rem);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
   .entry-description {
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
   .category-tag {
-    font-size: 0.6875rem;
+    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
     color: var(--smrt-color-tertiary, #6b5778);
     background: var(--smrt-color-tertiary-container, #f2daff);
     padding: 0.125rem 0.5rem;
@@ -651,7 +651,7 @@ function getPatternPlaceholder(type: string): string {
   }
 
   .auto-archive-tag {
-    font-size: 0.6875rem;
+    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
     color: var(--smrt-color-warning, #ca8a04);
     background: var(--smrt-color-warning-container, #fef9c3);
     padding: 0.125rem 0.5rem;
@@ -660,7 +660,7 @@ function getPatternPlaceholder(type: string): string {
   }
 
   .delete-btn {
-    font-size: 1rem;
+    font-size: var(--smrt-typography-label-large-size, 1rem);
     line-height: 1;
     padding: 0.125rem 0.5rem;
     border-radius: var(--smrt-radius-full, 9999px);

--- a/packages/messages/src/svelte/components/EmailFilterManager.svelte
+++ b/packages/messages/src/svelte/components/EmailFilterManager.svelte
@@ -660,7 +660,7 @@ function getPatternPlaceholder(type: string): string {
   }
 
   .delete-btn {
-    font-size: var(--smrt-typography-label-large-size, 1rem);
+    font-size: var(--smrt-typography-body-large-size, 1rem);
     line-height: 1;
     padding: 0.125rem 0.5rem;
     border-radius: var(--smrt-radius-full, 9999px);

--- a/packages/messages/src/svelte/components/FolderNav.svelte
+++ b/packages/messages/src/svelte/components/FolderNav.svelte
@@ -125,7 +125,7 @@ function getFolderIcon(specialUse?: string): string {
 
   .folder-item--active {
     background: var(--smrt-color-secondary-container, #d7e3f7);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
   .folder-item:focus-visible {
@@ -135,7 +135,7 @@ function getFolderIcon(specialUse?: string): string {
 
   .folder-icon {
     flex-shrink: 0;
-    font-size: 1rem;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
   }
 
   .folder-name {

--- a/packages/messages/src/svelte/components/ForwardForm.svelte
+++ b/packages/messages/src/svelte/components/ForwardForm.svelte
@@ -88,13 +88,13 @@ export interface Props {
     border: 1px solid var(--smrt-color-outline-variant, #cac4d0);
     border-radius: var(--smrt-radius-md, 12px);
     background: var(--smrt-color-surface, #fffbfe);
-    font-family: var(--smrt-typography-body, system-ui);
+    font-family: var(--smrt-font-family, system-ui);
   }
 
   .forward-header {
-    font-size: 13px;
+    font-size: var(--smrt-typography-title-small-size, 13px);
     color: var(--smrt-color-on-surface-variant, #49454f);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
   .forward-body {
@@ -102,8 +102,8 @@ export interface Props {
     border: 1px solid var(--smrt-color-outline-variant, #cac4d0);
     border-radius: var(--smrt-radius-sm, 8px);
     padding: var(--smrt-spacing-2, 8px);
-    font-family: var(--smrt-typography-body, system-ui);
-    font-size: 14px;
+    font-family: var(--smrt-font-family, system-ui);
+    font-size: var(--smrt-typography-body-medium-size, 14px);
     resize: vertical;
     box-sizing: border-box;
   }
@@ -123,10 +123,10 @@ export interface Props {
 
   .forwarded-text {
     margin: 0;
-    font-size: 12px;
+    font-size: var(--smrt-typography-body-small-size, 12px);
     color: var(--smrt-color-on-surface-variant, #49454f);
     white-space: pre-wrap;
-    font-family: var(--smrt-typography-body, system-ui);
+    font-family: var(--smrt-font-family, system-ui);
   }
 
   .actions {
@@ -140,8 +140,8 @@ export interface Props {
     border: none;
     background: var(--smrt-color-primary, #6750a4);
     color: var(--smrt-color-on-primary, #fff);
-    font-family: var(--smrt-typography-label, system-ui);
-    font-size: 14px;
+    font-family: var(--smrt-font-family, system-ui);
+    font-size: var(--smrt-typography-label-large-size, 14px);
     cursor: pointer;
   }
 
@@ -155,8 +155,8 @@ export interface Props {
     border: none;
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #49454f);
-    font-family: var(--smrt-typography-label, system-ui);
-    font-size: 14px;
+    font-family: var(--smrt-font-family, system-ui);
+    font-size: var(--smrt-typography-label-large-size, 14px);
     cursor: pointer;
   }
 </style>

--- a/packages/messages/src/svelte/components/MessageCard.svelte
+++ b/packages/messages/src/svelte/components/MessageCard.svelte
@@ -239,7 +239,7 @@ const _slackMeta = $derived.by(() => {
   }
 
   .sender-name--unread {
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .account-label {
@@ -280,7 +280,7 @@ const _slackMeta = $derived.by(() => {
   }
 
   .subject--unread {
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .preview-row {
@@ -312,7 +312,7 @@ const _slackMeta = $derived.by(() => {
     border: none;
     background: none;
     cursor: pointer;
-    font-size: 1rem;
+    font-size: var(--smrt-typography-label-large-size, 1rem);
     color: var(--smrt-color-on-surface-variant, #43474e);
     opacity: 0.5;
     transition: opacity var(--smrt-duration-short2, 150ms);

--- a/packages/messages/src/svelte/components/MessageCard.svelte
+++ b/packages/messages/src/svelte/components/MessageCard.svelte
@@ -312,7 +312,7 @@ const _slackMeta = $derived.by(() => {
     border: none;
     background: none;
     cursor: pointer;
-    font-size: var(--smrt-typography-label-large-size, 1rem);
+    font-size: var(--smrt-typography-body-large-size, 1rem);
     color: var(--smrt-color-on-surface-variant, #43474e);
     opacity: 0.5;
     transition: opacity var(--smrt-duration-short2, 150ms);

--- a/packages/messages/src/svelte/components/MessageDetail.svelte
+++ b/packages/messages/src/svelte/components/MessageDetail.svelte
@@ -225,7 +225,7 @@ const _sanitizedHtml = $derived.by(() => {
     flex-shrink: 0;
     width: 4rem;
     color: var(--smrt-color-on-surface-variant, #43474e);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
   .meta-value {

--- a/packages/messages/src/svelte/components/MessageStatusIndicator.svelte
+++ b/packages/messages/src/svelte/components/MessageStatusIndicator.svelte
@@ -45,7 +45,7 @@ const {
     display: inline-flex;
     align-items: center;
     gap: 0.375rem;
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
   }
 
   .indicator {

--- a/packages/messages/src/svelte/components/RecipientInput.svelte
+++ b/packages/messages/src/svelte/components/RecipientInput.svelte
@@ -90,8 +90,8 @@ export interface Props {
   }
 
   .label {
-    font-family: var(--smrt-typography-label, system-ui);
-    font-size: 14px;
+    font-family: var(--smrt-font-family, system-ui);
+    font-size: var(--smrt-typography-label-large-size, 14px);
     color: var(--smrt-color-on-surface-variant, #49454f);
     padding-top: var(--smrt-spacing-2, 8px);
     min-width: 32px;
@@ -113,8 +113,8 @@ export interface Props {
     border-radius: var(--smrt-radius-sm, 8px);
     background: var(--smrt-color-secondary-container, #e8def8);
     color: var(--smrt-color-on-secondary-container, #1d192b);
-    font-size: 13px;
-    font-family: var(--smrt-typography-body, system-ui);
+    font-size: var(--smrt-typography-label-large-size, 13px);
+    font-family: var(--smrt-font-family, system-ui);
   }
 
   .chip.invalid {
@@ -127,7 +127,7 @@ export interface Props {
     border: none;
     cursor: pointer;
     padding: 0 var(--smrt-spacing-1, 4px);
-    font-size: 14px;
+    font-size: var(--smrt-typography-label-large-size, 14px);
     color: inherit;
     opacity: 0.7;
   }
@@ -141,8 +141,8 @@ export interface Props {
     min-width: 120px;
     border: none;
     outline: none;
-    font-family: var(--smrt-typography-body, system-ui);
-    font-size: 14px;
+    font-family: var(--smrt-font-family, system-ui);
+    font-size: var(--smrt-typography-body-medium-size, 14px);
     padding: var(--smrt-spacing-1, 4px) 0;
     background: transparent;
     color: var(--smrt-color-on-surface, #1c1b1f);

--- a/packages/messages/src/svelte/components/ReplyForm.svelte
+++ b/packages/messages/src/svelte/components/ReplyForm.svelte
@@ -79,13 +79,13 @@ export interface Props {
     border: 1px solid var(--smrt-color-outline-variant, #cac4d0);
     border-radius: var(--smrt-radius-md, 12px);
     background: var(--smrt-color-surface, #fffbfe);
-    font-family: var(--smrt-typography-body, system-ui);
+    font-family: var(--smrt-font-family, system-ui);
   }
 
   .reply-header {
-    font-size: 13px;
+    font-size: var(--smrt-typography-title-small-size, 13px);
     color: var(--smrt-color-on-surface-variant, #49454f);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
   .reply-body {
@@ -93,8 +93,8 @@ export interface Props {
     border: 1px solid var(--smrt-color-outline-variant, #cac4d0);
     border-radius: var(--smrt-radius-sm, 8px);
     padding: var(--smrt-spacing-2, 8px);
-    font-family: var(--smrt-typography-body, system-ui);
-    font-size: 14px;
+    font-family: var(--smrt-font-family, system-ui);
+    font-size: var(--smrt-typography-body-medium-size, 14px);
     resize: vertical;
     box-sizing: border-box;
   }
@@ -115,10 +115,10 @@ export interface Props {
 
   .quoted-text {
     margin: 0;
-    font-size: 12px;
+    font-size: var(--smrt-typography-body-small-size, 12px);
     color: var(--smrt-color-on-surface-variant, #49454f);
     white-space: pre-wrap;
-    font-family: var(--smrt-typography-body, system-ui);
+    font-family: var(--smrt-font-family, system-ui);
   }
 
   .actions {
@@ -132,8 +132,8 @@ export interface Props {
     border: none;
     background: var(--smrt-color-primary, #6750a4);
     color: var(--smrt-color-on-primary, #fff);
-    font-family: var(--smrt-typography-label, system-ui);
-    font-size: 14px;
+    font-family: var(--smrt-font-family, system-ui);
+    font-size: var(--smrt-typography-label-large-size, 14px);
     cursor: pointer;
   }
 
@@ -147,8 +147,8 @@ export interface Props {
     border: none;
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #49454f);
-    font-family: var(--smrt-typography-label, system-ui);
-    font-size: 14px;
+    font-family: var(--smrt-font-family, system-ui);
+    font-size: var(--smrt-typography-label-large-size, 14px);
     cursor: pointer;
   }
 </style>

--- a/packages/messages/src/svelte/components/SendStatusBadge.svelte
+++ b/packages/messages/src/svelte/components/SendStatusBadge.svelte
@@ -44,18 +44,18 @@ export interface Props {
     border-radius: var(--smrt-radius-sm, 8px);
     border: 1px solid var(--badge-color);
     color: var(--badge-color);
-    font-family: var(--smrt-typography-label, system-ui);
+    font-family: var(--smrt-font-family, system-ui);
     white-space: nowrap;
   }
 
   .sm {
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
-    font-size: 11px;
+    font-size: var(--smrt-typography-label-small-size, 11px);
   }
 
   .md {
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-3, 12px);
-    font-size: 13px;
+    font-size: var(--smrt-typography-label-large-size, 13px);
   }
 
   .icon {

--- a/packages/messages/src/svelte/components/ThreadView.svelte
+++ b/packages/messages/src/svelte/components/ThreadView.svelte
@@ -183,7 +183,7 @@ const _sortedMessages = $derived(
     border: none;
     background: none;
     cursor: pointer;
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
     color: var(--smrt-color-on-surface-variant, #43474e);
     z-index: 1;
     padding: 0.25rem;
@@ -215,7 +215,7 @@ const _sortedMessages = $derived(
 
   .collapsed-sender {
     font: var(--smrt-typography-body-medium-font, 0.875rem / 1.25 sans-serif);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     flex-shrink: 0;
   }
 

--- a/packages/products/src/app/App.svelte
+++ b/packages/products/src/app/App.svelte
@@ -55,13 +55,13 @@ onMount(() => {
   
   .placeholder-page h2 {
     margin: 0 0 1rem 0;
-    font-size: 2rem;
+    font-size: var(--smrt-typography-headline-large-size, 2rem);
     color: var(--smrt-color-on-surface, #1f2937);
   }
 
   .placeholder-page p {
     margin: 0;
     color: var(--smrt-color-on-surface-variant, #6b7280);
-    font-size: 1.125rem;
+    font-size: var(--smrt-typography-body-large-size, 1.125rem);
   }
 </style>

--- a/packages/products/src/app/app.css
+++ b/packages/products/src/app/app.css
@@ -20,10 +20,12 @@ html {
 body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
-  font-family:
+  font-family: var(
+    --smrt-font-family,
     "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
     "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
+    sans-serif
+  );
   background-color: var(--smrt-color-surface-container-low, #f9fafb);
   color: var(--smrt-color-on-surface, #1f2937);
 }
@@ -56,21 +58,21 @@ h6 {
 
 /* Typography scale */
 h1 {
-  font-size: 2.25rem;
-  font-weight: 800;
-  line-height: 1.2;
+  font-size: var(--smrt-typography-display-small-size, 2.25rem);
+  font-weight: var(--smrt-typography-weight-bold, 800);
+  line-height: var(--smrt-typography-display-small-line-height, 1.2);
 }
 
 h2 {
-  font-size: 1.875rem;
-  font-weight: 700;
-  line-height: 1.3;
+  font-size: var(--smrt-typography-headline-large-size, 1.875rem);
+  font-weight: var(--smrt-typography-weight-bold, 700);
+  line-height: var(--smrt-typography-headline-large-line-height, 1.3);
 }
 
 h3 {
-  font-size: 1.5rem;
-  font-weight: 600;
-  line-height: 1.4;
+  font-size: var(--smrt-typography-headline-small-size, 1.5rem);
+  font-weight: var(--smrt-typography-weight-semibold, 600);
+  line-height: var(--smrt-typography-headline-small-line-height, 1.4);
 }
 
 /* Utility classes */

--- a/packages/products/src/app/layouts/AppLayout.svelte
+++ b/packages/products/src/app/layouts/AppLayout.svelte
@@ -76,13 +76,13 @@ const { children }: Props = $props();
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    font-size: 1.5rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-headline-small-size, 1.5rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
     color: var(--smrt-color-on-surface, #1f2937);
   }
   
   .logo {
-    font-size: 1.75rem;
+    font-size: var(--smrt-typography-headline-medium-size, 1.75rem);
   }
   
   .main-nav {
@@ -93,7 +93,7 @@ const { children }: Props = $props();
   .nav-link {
     color: var(--smrt-color-on-surface-variant, #6b7280);
     text-decoration: none;
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     padding: 0.5rem 1rem;
     border-radius: var(--smrt-radius-sm, 4px);
     transition: all 0.2s;
@@ -114,7 +114,7 @@ const { children }: Props = $props();
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
     color: var(--smrt-color-on-surface-variant, #6b7280);
   }
   
@@ -157,7 +157,7 @@ const { children }: Props = $props();
   .footer-content p {
     margin: 0;
     color: var(--smrt-color-on-surface-variant, #6b7280);
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
   }
   
   .footer-links {
@@ -168,7 +168,7 @@ const { children }: Props = $props();
   .footer-links a {
     color: var(--smrt-color-on-surface-variant, #6b7280);
     text-decoration: none;
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
     transition: color 0.2s;
   }
 

--- a/packages/products/src/app/pages/DemoPage.svelte
+++ b/packages/products/src/app/pages/DemoPage.svelte
@@ -201,14 +201,14 @@ function _handleCustomSubmit(data: ProductData) {
   }
 
   .demo-header h1 {
-    font-size: 2.5rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-display-medium-size, 2.5rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
     color: var(--smrt-color-on-surface, #1f2937);
     margin: 0 0 0.5rem 0;
   }
 
   .demo-subtitle {
-    font-size: 1.125rem;
+    font-size: var(--smrt-typography-body-large-size, 1.125rem);
     color: var(--smrt-color-on-surface-variant, #6b7280);
     margin: 0;
   }
@@ -226,7 +226,7 @@ function _handleCustomSubmit(data: ProductData) {
     background: color-mix(in srgb, var(--smrt-color-surface, #fff) 90%, transparent);
     border: 2px solid transparent;
     border-radius: 0.5rem;
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     cursor: pointer;
     transition: all 0.2s;
   }
@@ -256,7 +256,7 @@ function _handleCustomSubmit(data: ProductData) {
   }
 
   .section-description {
-    font-size: 1rem;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
     color: var(--smrt-color-on-surface-variant, #6b7280);
     margin-bottom: 2rem;
     text-align: center;
@@ -290,7 +290,7 @@ function _handleCustomSubmit(data: ProductData) {
   .comparison-column h3 {
     text-align: center;
     margin-bottom: 1rem;
-    font-size: 1.25rem;
+    font-size: var(--smrt-typography-title-large-size, 1.25rem);
   }
 
   .feature-list {
@@ -301,7 +301,7 @@ function _handleCustomSubmit(data: ProductData) {
   }
 
   .feature {
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     color: var(--smrt-color-on-surface, #374151);
   }
 
@@ -318,8 +318,8 @@ function _handleCustomSubmit(data: ProductData) {
   }
 
   .framework-info h4 {
-    font-size: 1.25rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-title-large-size, 1.25rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     margin-bottom: 1rem;
     color: var(--smrt-color-on-surface, #1f2937);
   }
@@ -336,7 +336,7 @@ function _handleCustomSubmit(data: ProductData) {
     padding: 0.75rem;
     background: var(--smrt-color-surface-container, #f3f4f6);
     border-radius: 0.375rem;
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
   }
 
   @media (max-width: 768px) {
@@ -351,7 +351,7 @@ function _handleCustomSubmit(data: ProductData) {
     }
 
     .demo-header h1 {
-      font-size: 2rem;
+      font-size: var(--smrt-typography-headline-large-size, 2rem);
     }
   }
 </style>

--- a/packages/products/src/app/pages/ProductsPage.svelte
+++ b/packages/products/src/app/pages/ProductsPage.svelte
@@ -57,18 +57,18 @@
   
   .page-header h1 {
     margin: 0 0 0.5rem 0;
-    font-size: 2.25rem;
-    font-weight: 800;
+    font-size: var(--smrt-typography-display-small-size, 2.25rem);
+    font-weight: var(--smrt-typography-weight-bold, 800);
     color: var(--smrt-color-on-surface, #1f2937);
   }
 
   .page-description {
     margin: 0;
-    font-size: 1.125rem;
+    font-size: var(--smrt-typography-body-large-size, 1.125rem);
     color: var(--smrt-color-on-surface-variant, #6b7280);
     max-width: 600px;
     margin: 0 auto;
-    line-height: 1.6;
+    line-height: var(--smrt-typography-body-large-line-height, 1.6);
   }
 
   .page-content {
@@ -97,15 +97,15 @@
 
   .info-card h3 {
     margin: 0 0 0.5rem 0;
-    font-size: 1.125rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-title-medium-size, 1.125rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-on-surface, #1f2937);
   }
 
   .info-card p {
     margin: 0;
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     color: var(--smrt-color-on-surface-variant, #6b7280);
-    line-height: 1.5;
+    line-height: var(--smrt-typography-body-medium-line-height, 1.5);
   }
 </style>

--- a/packages/products/src/lib/components/ProductCard.svelte
+++ b/packages/products/src/lib/components/ProductCard.svelte
@@ -78,26 +78,26 @@ const { product, onEdit, onDelete }: Props = $props();
   
   .product-name {
     margin: 0;
-    font-size: 1.125rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-title-medium-size, 1.125rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-on-surface, #1f2937);
   }
 
   .product-manufacturer {
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-title-small-size, 0.875rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-surface-variant, #6b7280);
   }
 
   .product-model {
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     color: var(--smrt-color-on-surface-variant, #6b7280);
     margin-bottom: 0.5rem;
   }
 
   .product-category {
-    font-size: 0.75rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-surface, #374151);
     background: var(--smrt-color-surface-container, #f3f4f6);
     padding: 0.25rem 0.5rem;
@@ -109,8 +109,8 @@ const { product, onEdit, onDelete }: Props = $props();
   .product-description {
     margin: 0.5rem 0;
     color: var(--smrt-color-on-surface-variant, #6b7280);
-    font-size: 0.875rem;
-    line-height: 1.4;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
+    line-height: var(--smrt-typography-body-medium-line-height, 1.4);
   }
   
   .product-meta {
@@ -130,7 +130,7 @@ const { product, onEdit, onDelete }: Props = $props();
     color: var(--smrt-color-on-surface, #374151);
     padding: 0.125rem 0.5rem;
     border-radius: var(--smrt-radius-full, 9999px);
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
   }
 
   .product-actions {
@@ -144,8 +144,8 @@ const { product, onEdit, onDelete }: Props = $props();
   .edit-btn, .delete-btn {
     padding: 0.375rem 0.75rem;
     border-radius: var(--smrt-radius-sm, 4px);
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
     border: 1px solid;
     cursor: pointer;
     transition: all 0.2s;

--- a/packages/products/src/lib/components/ProductForm.svelte
+++ b/packages/products/src/lib/components/ProductForm.svelte
@@ -186,9 +186,9 @@ function _handleSubmit(event: Event) {
   label {
     display: block;
     margin-bottom: 0.25rem;
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-surface, #374151);
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
   }
 
   .form-input, .form-textarea {
@@ -196,7 +196,7 @@ function _handleSubmit(event: Event) {
     padding: 0.5rem;
     border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
     border-radius: var(--smrt-radius-sm, 4px);
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     transition: border-color 0.2s;
   }
 
@@ -228,13 +228,13 @@ function _handleSubmit(event: Event) {
   
   .form-hint {
     color: var(--smrt-color-on-surface-variant, #6b7280);
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
     margin-top: 0.25rem;
   }
 
   .error-message {
     color: var(--smrt-color-error, #dc2626);
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
     margin-top: 0.25rem;
     display: block;
   }
@@ -251,8 +251,8 @@ function _handleSubmit(event: Event) {
   .cancel-btn, .submit-btn {
     padding: 0.5rem 1rem;
     border-radius: var(--smrt-radius-sm, 4px);
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
     cursor: pointer;
     border: 1px solid;
     transition: all 0.2s;

--- a/packages/products/src/lib/components/auto-generated/AutoForm.svelte
+++ b/packages/products/src/lib/components/auto-generated/AutoForm.svelte
@@ -156,14 +156,14 @@ function _getFieldType(
   }
 
   .form-title {
-    font-size: 1.5rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-headline-small-size, 1.5rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-on-surface, #1f2937);
     margin: 0 0 0.5rem 0;
   }
 
   .form-subtitle {
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     color: var(--smrt-color-on-surface-variant, #6b7280);
     font-style: italic;
   }
@@ -188,7 +188,7 @@ function _getFieldType(
     border: none;
     padding: 0.75rem 1.5rem;
     border-radius: 0.375rem;
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     cursor: pointer;
     transition: background-color 0.2s;
   }
@@ -203,7 +203,7 @@ function _getFieldType(
     border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
     padding: 0.75rem 1.5rem;
     border-radius: 0.375rem;
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     cursor: pointer;
     transition: background-color 0.2s;
   }
@@ -222,13 +222,13 @@ function _getFieldType(
 
   .form-debug summary {
     cursor: pointer;
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-surface, #374151);
   }
 
   .form-debug pre {
     margin-top: 0.5rem;
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
     color: var(--smrt-color-on-surface-variant, #6b7280);
     white-space: pre-wrap;
     word-break: break-word;

--- a/packages/products/src/lib/components/auto-generated/FieldRenderer.svelte
+++ b/packages/products/src/lib/components/auto-generated/FieldRenderer.svelte
@@ -151,9 +151,9 @@ function _handleObjectInput(event: Event) {
   }
 
   .field-label {
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-surface, #374151);
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
   }
 
   .required {
@@ -165,7 +165,7 @@ function _handleObjectInput(event: Event) {
     padding: 0.5rem 0.75rem;
     border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
     border-radius: 0.375rem;
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     transition: border-color 0.2s, box-shadow 0.2s;
   }
 
@@ -187,7 +187,7 @@ function _handleObjectInput(event: Event) {
   }
 
   .field-hint {
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
     color: var(--smrt-color-on-surface-variant, #6b7280);
     font-style: italic;
   }

--- a/packages/products/src/lib/features/CategoryManager.svelte
+++ b/packages/products/src/lib/features/CategoryManager.svelte
@@ -45,8 +45,8 @@ const _loading = $state(false);
   .manager-header h2 {
     margin: 0 0 0.5rem 0;
     color: var(--smrt-color-on-surface, #1f2937);
-    font-size: 1.5rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-headline-small-size, 1.5rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .manager-header p {

--- a/packages/products/src/lib/features/ProductCatalog.svelte
+++ b/packages/products/src/lib/features/ProductCatalog.svelte
@@ -189,14 +189,14 @@ function _handleCancelForm() {
   .catalog-header h2 {
     margin: 0;
     color: var(--smrt-color-on-surface, #1f2937);
-    font-size: 1.875rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-headline-large-size, 1.875rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
   }
 
   .catalog-stats {
     display: flex;
     gap: 1.5rem;
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
     color: var(--smrt-color-on-surface-variant, #6b7280);
   }
   
@@ -218,7 +218,7 @@ function _handleCancelForm() {
     padding: 0.5rem;
     border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
     border-radius: var(--smrt-radius-sm, 4px);
-    font-size: 0.875rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
   }
   
   .search-input {
@@ -236,7 +236,7 @@ function _handleCancelForm() {
     border: none;
     padding: 0.5rem 1rem;
     border-radius: var(--smrt-radius-sm, 4px);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     cursor: pointer;
     transition: background-color 0.2s;
   }
@@ -293,7 +293,7 @@ function _handleCancelForm() {
     margin: 0 0 1rem 0;
     padding: 1.5rem 1.5rem 0 1.5rem;
     color: var(--smrt-color-on-surface, #1f2937);
-    font-size: 1.25rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-title-large-size, 1.25rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 </style>

--- a/scripts/check-typography.mjs
+++ b/scripts/check-typography.mjs
@@ -37,6 +37,8 @@ const PACKAGES = join(ROOT, 'packages');
 const STRICT_PACKAGES = new Set([
   'smrt-svelte',
   'content',
+  'messages',
+  'products',
 ]);
 
 /** Dev/playground hosts skipped entirely (matches the other token ratchets). */


### PR DESCRIPTION
## What

S1 **typography** Phase 3 — migrates `messages` (~100) and `products` (~71) to the Material-3 `--smrt-typography-*` role scale, and flips both to strict in `scripts/check-typography.mjs`.

Continues [#1462 (Phase 1: ratchet + smrt-svelte)](https://github.com/happyvertical/smrt/pull/1462) and [#1463 (Phase 2: content)](https://github.com/happyvertical/smrt/pull/1463).

## Approach

Full semantic pass — each text element mapped to its M3 role, original value kept as `var()` fallback:
- card/panel/list titles, table headers → `title-*`
- message/email body text, input values, descriptions → `body-*`
- buttons/badges/chips/captions/field-labels/status pills → `label-*`
- hero/demo headings → `display-*` / `headline-*`
- `line-height`/`letter-spacing` tokenized to each element's assigned role
- weight `800` → `weight-bold`, monospace stacks → `--smrt-font-family-mono`

## Bonus: fixes 21 dangling font-family refs

messages had 21 pre-existing `font-family: var(--smrt-typography-body|label, system-ui)` declarations referencing **token names that are never emitted** (the real tokens are `--smrt-typography-<role>-<size>-font-family`), so they always fell back. These slipped past both the svelte-token guard (scoped to smrt-svelte) and the ratchet's var-strip (exempts any `--smrt-typography-*`). Repointed all 21 to the valid `var(--smrt-font-family, system-ui)` — in-scope for the font-family migration, and avoids shipping phantom refs in a now-strict package.

## Verification

- `node scripts/check-typography.mjs` → smrt-svelte + content + messages + products all clean
- **Deterministic scope-check**: every added/removed line under both packages is a typography value (no JS/markup/TS; no `console.*` removed)
- `npm run build` → 50/50
- `node scripts/check-svelte-tokens.mjs` → all consumed `--smrt-*` tokens emitted
- `biome check` (read-only) on all 26 changed files → clean

## Remaining

assets (64), chat (62), images (43), analytics (28), commerce (20), + a single-digit tail. The final batch flips every remaining package strict and closes #1373.