### PR TITLE
feat(assets,chat,images): typography → M3 role tokens (#1373 Phase 4)

### DIFF
--- a/packages/assets/src/svelte/ActionBar.svelte
+++ b/packages/assets/src/svelte/ActionBar.svelte
@@ -147,7 +147,7 @@ const count = $derived(selectedAssets.length);
 
   .action-bar__count {
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-on-primary-container, #002d6c);
   }
 
@@ -180,7 +180,7 @@ const count = $derived(selectedAssets.length);
     padding: 0 var(--smrt-spacing-3, 0.75rem);
     font-family: inherit;
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     border: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
     background: var(--smrt-color-surface, #ffffff);
     color: var(--smrt-color-on-surface, #111827);
@@ -232,8 +232,8 @@ const count = $derived(selectedAssets.length);
 
   .confirm-title {
     margin: 0 0 var(--smrt-spacing-4, 16px);
-    font-size: 1.125rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-title-medium-size, 1.125rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-on-surface, #111827);
   }
 
@@ -258,7 +258,7 @@ const count = $derived(selectedAssets.length);
     padding: 0 var(--smrt-spacing-6, 24px);
     font-family: inherit;
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     border-radius: var(--smrt-radius-2xl, 24px);
     cursor: pointer;
     border: none;

--- a/packages/assets/src/svelte/AssetDetail.svelte
+++ b/packages/assets/src/svelte/AssetDetail.svelte
@@ -398,8 +398,8 @@ function formatDate(date: Date | string | undefined): string {
 
   .detail__title {
     margin: 0;
-    font-size: 1.125rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-title-medium-size, 1.125rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-on-surface, #111827);
     white-space: nowrap;
     overflow: hidden;
@@ -443,12 +443,11 @@ function formatDate(date: Date | string | undefined): string {
 
   .section-heading {
     margin: 0 0 var(--smrt-spacing-3, 0.75rem);
-    font-size: var(--smrt-typography-title-small-size, 0.875rem);
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-on-surface, #111827);
     text-transform: uppercase;
-    letter-spacing: 0.05em;
-    font-size: 0.75rem;
+    letter-spacing: var(--smrt-typography-label-medium-tracking, 0.05em);
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
   }
 
   /* Preview */
@@ -486,12 +485,12 @@ function formatDate(date: Date | string | undefined): string {
   }
 
   .preview-document__icon, .preview-generic__icon {
-    font-size: 2.5rem;
+    font-size: var(--smrt-typography-display-medium-size, 2.5rem);
   }
 
   .preview-document__link {
     color: var(--smrt-color-primary, #005ac1);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     text-decoration: none;
   }
 
@@ -500,7 +499,7 @@ function formatDate(date: Date | string | undefined): string {
   }
 
   .preview-generic__mime {
-    font-size: 0.8rem;
+    font-size: var(--smrt-typography-body-small-size, 0.8rem);
     color: var(--smrt-color-on-surface-variant, #6b7280);
   }
 
@@ -518,14 +517,14 @@ function formatDate(date: Date | string | undefined): string {
   }
 
   .form-label {
-    font-size: 0.8rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-label-medium-size, 0.8rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-surface, #111827);
   }
 
   .label-warning {
-    font-weight: 400;
-    font-size: 0.7rem;
+    font-weight: var(--smrt-typography-weight-normal, 400);
+    font-size: var(--smrt-typography-label-small-size, 0.7rem);
     color: var(--smrt-color-error, #dc2626);
     margin-left: var(--smrt-spacing-1, 4px);
   }
@@ -567,10 +566,10 @@ function formatDate(date: Date | string | undefined): string {
   }
 
   .metadata-label {
-    font-size: 0.7rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-small-size, 0.7rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: var(--smrt-typography-label-small-tracking, 0.05em);
     color: var(--smrt-color-on-surface-variant, #6b7280);
   }
 
@@ -594,8 +593,8 @@ function formatDate(date: Date | string | undefined): string {
     height: 32px;
     padding: 0 var(--smrt-spacing-3, 0.75rem);
     font-family: inherit;
-    font-size: 0.8rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-label-medium-size, 0.8rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
     border: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
     background: var(--smrt-color-surface, #ffffff);
     color: var(--smrt-color-on-surface, #111827);
@@ -616,9 +615,9 @@ function formatDate(date: Date | string | undefined): string {
 
   .copy-feedback {
     margin-top: var(--smrt-spacing-2, 0.5rem);
-    font-size: 0.8rem;
+    font-size: var(--smrt-typography-label-medium-size, 0.8rem);
     color: var(--smrt-color-success, #22c55e);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     animation: fadeIn 150ms ease;
   }
 
@@ -647,7 +646,7 @@ function formatDate(date: Date | string | undefined): string {
     padding: 0 var(--smrt-spacing-4, 1rem);
     font-family: inherit;
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     border-radius: var(--smrt-radius-medium, 0.5rem);
     cursor: pointer;
     border: none;

--- a/packages/assets/src/svelte/AssetGrid.svelte
+++ b/packages/assets/src/svelte/AssetGrid.svelte
@@ -233,7 +233,7 @@ function getAltText(asset: PersistedAsset): string {
   }
 
   .asset-card__type-icon {
-    font-size: 2.5rem;
+    font-size: var(--smrt-typography-display-medium-size, 2.5rem);
   }
 
   /* Info */
@@ -244,7 +244,7 @@ function getAltText(asset: PersistedAsset): string {
   .asset-card__name {
     display: block;
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-surface, #111827);
     white-space: nowrap;
     overflow: hidden;
@@ -259,11 +259,11 @@ function getAltText(asset: PersistedAsset): string {
   }
 
   .asset-card__type {
-    font-size: 0.7rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-small-size, 0.7rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-on-surface-variant, #6b7280);
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: var(--smrt-typography-label-small-tracking, 0.05em);
   }
 
   /* Badge */
@@ -272,8 +272,8 @@ function getAltText(asset: PersistedAsset): string {
     top: var(--smrt-spacing-2, 0.5rem);
     right: var(--smrt-spacing-2, 0.5rem);
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
-    font-size: 0.65rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-small-size, 0.65rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     border-radius: var(--smrt-radius-small, 0.25rem);
     z-index: 2;
   }

--- a/packages/assets/src/svelte/AssetList.svelte
+++ b/packages/assets/src/svelte/AssetList.svelte
@@ -241,7 +241,7 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
   .list-table__head th {
     padding: var(--smrt-spacing-2, 0.5rem) var(--smrt-spacing-3, 0.75rem);
     text-align: left;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     white-space: nowrap;
     color: var(--smrt-color-on-surface, #111827);
   }
@@ -296,8 +296,8 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
     height: 40px;
     background: var(--smrt-color-surface-container, #f3f4f6);
     border-radius: var(--smrt-radius-small, 0.25rem);
-    font-size: 0.6rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-label-small-size, 0.6rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
     color: var(--smrt-color-on-surface-variant, #6b7280);
   }
 
@@ -307,7 +307,7 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
 
   .row-name {
     display: block;
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -316,7 +316,7 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
 
   .row-desc {
     display: block;
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
     color: var(--smrt-color-on-surface-variant, #6b7280);
     white-space: nowrap;
     overflow: hidden;
@@ -327,13 +327,13 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
   .type-badge {
     display: inline-block;
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
-    font-size: 0.65rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-label-small-size, 0.65rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
     text-transform: uppercase;
     background: var(--smrt-color-surface-container, #f3f4f6);
     color: var(--smrt-color-on-surface-variant, #6b7280);
     border-radius: var(--smrt-radius-small, 0.25rem);
-    letter-spacing: 0.05em;
+    letter-spacing: var(--smrt-typography-label-small-tracking, 0.05em);
   }
 
   .col-date {
@@ -369,7 +369,7 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
     border: none;
     background: transparent;
     font: inherit;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: inherit;
     cursor: pointer;
   }
@@ -379,7 +379,7 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
   }
 
   .sort-indicator {
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
     opacity: 0.5;
   }
 

--- a/packages/assets/src/svelte/AssetManager.svelte
+++ b/packages/assets/src/svelte/AssetManager.svelte
@@ -366,11 +366,11 @@ function handleManagerDrop(event: DragEvent) {
     align-items: center;
     gap: var(--smrt-spacing-2, 0.5rem);
     color: var(--smrt-color-primary, #005ac1);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
   .drag-overlay__content p {
     margin: 0;
-    font-size: 1.1rem;
+    font-size: var(--smrt-typography-body-large-size, 1.1rem);
   }
 </style>

--- a/packages/assets/src/svelte/AssetToolbar.svelte
+++ b/packages/assets/src/svelte/AssetToolbar.svelte
@@ -345,7 +345,7 @@ const views: { key: AssetViewMode; label: string; icon: string }[] = [
     padding: 0 var(--smrt-spacing-3, 0.75rem);
     font-family: inherit;
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-primary, #ffffff);
     background: var(--smrt-color-primary, #005ac1);
     border: none;

--- a/packages/assets/src/svelte/CreateAssetModal.svelte
+++ b/packages/assets/src/svelte/CreateAssetModal.svelte
@@ -301,8 +301,8 @@ const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
 
   .create-modal__title {
     margin: 0;
-    font-size: 1.125rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-title-medium-size, 1.125rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-on-surface, #111827);
   }
 
@@ -356,13 +356,13 @@ const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
 
   .dropzone__text {
     margin: 0;
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-surface, #111827);
   }
 
   .dropzone__hint {
     margin: var(--smrt-spacing-1, 0.25rem) 0 0;
-    font-size: 0.8rem;
+    font-size: var(--smrt-typography-body-small-size, 0.8rem);
     color: var(--smrt-color-on-surface-variant, #9ca3af);
   }
 
@@ -394,7 +394,7 @@ const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 1.5rem;
+    font-size: var(--smrt-typography-headline-small-size, 1.5rem);
     background: var(--smrt-color-surface-container, #f3f4f6);
     border-radius: var(--smrt-radius-small, 0.25rem);
   }
@@ -406,7 +406,7 @@ const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
 
   .file-preview__filename {
     display: block;
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     white-space: nowrap;
     overflow: hidden;
@@ -415,13 +415,13 @@ const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
 
   .file-preview__size {
     display: block;
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
     color: var(--smrt-color-on-surface-variant, #6b7280);
   }
 
   .file-preview__warning {
     display: block;
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
     color: var(--smrt-color-error, #dc2626);
     margin-top: var(--smrt-spacing-1, 4px);
   }
@@ -461,13 +461,13 @@ const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
 
   .form-label {
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-surface, #111827);
   }
 
   .form-label__warning {
-    font-weight: 400;
-    font-size: 0.75rem;
+    font-weight: var(--smrt-typography-weight-normal, 400);
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
     color: var(--smrt-color-error, #dc2626);
     margin-left: var(--smrt-spacing-1, 4px);
   }
@@ -509,7 +509,7 @@ const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
     padding: 0 var(--smrt-spacing-4, 1rem);
     font-family: inherit;
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     border-radius: var(--smrt-radius-medium, 0.5rem);
     cursor: pointer;
     border: none;

--- a/packages/assets/src/svelte/playground/AssetDetailPreview.svelte
+++ b/packages/assets/src/svelte/playground/AssetDetailPreview.svelte
@@ -105,8 +105,8 @@ function handleEdit() {
   }
 
   .eyebrow {
-    font-size: 0.75rem;
-    letter-spacing: 0.12em;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    letter-spacing: var(--smrt-typography-label-medium-tracking, 0.12em);
     text-transform: uppercase;
     color: var(--smrt-color-primary, #0f766e);
   }
@@ -117,7 +117,7 @@ function handleEdit() {
     border-radius: var(--smrt-radius-full, 9999px);
     padding: 0.75rem 1rem;
     font: inherit;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     background: var(--smrt-color-primary, #0f766e);
     color: var(--smrt-color-on-primary, white);
     cursor: pointer;
@@ -125,6 +125,6 @@ function handleEdit() {
 
   .status {
     color: var(--smrt-color-primary, #0f766e);
-    font-size: 0.95rem;
+    font-size: var(--smrt-typography-body-large-size, 0.95rem);
   }
 </style>

--- a/packages/assets/src/svelte/playground/CreateAssetModalPreview.svelte
+++ b/packages/assets/src/svelte/playground/CreateAssetModalPreview.svelte
@@ -103,8 +103,8 @@ function handleCreate(data: {
   }
 
   .eyebrow {
-    font-size: 0.75rem;
-    letter-spacing: 0.12em;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    letter-spacing: var(--smrt-typography-label-medium-tracking, 0.12em);
     text-transform: uppercase;
     color: var(--smrt-color-primary, #0f766e);
   }
@@ -115,7 +115,7 @@ function handleCreate(data: {
     border-radius: var(--smrt-radius-full, 9999px);
     padding: 0.75rem 1rem;
     font: inherit;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     background: var(--smrt-color-primary, #0f766e);
     color: var(--smrt-color-on-primary, white);
     cursor: pointer;
@@ -123,7 +123,7 @@ function handleCreate(data: {
 
   .status {
     color: var(--smrt-color-primary, #0f766e);
-    font-size: 0.95rem;
+    font-size: var(--smrt-typography-body-large-size, 0.95rem);
   }
 
   .summary {
@@ -138,8 +138,8 @@ function handleCreate(data: {
   }
 
   .summary dt {
-    font-size: 0.75rem;
-    letter-spacing: 0.08em;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    letter-spacing: var(--smrt-typography-label-medium-tracking, 0.08em);
     text-transform: uppercase;
     color: var(--smrt-color-on-surface-variant, #5b6574);
   }

--- a/packages/assets/src/svelte/routes/AssetManagerRoute.svelte
+++ b/packages/assets/src/svelte/routes/AssetManagerRoute.svelte
@@ -112,9 +112,9 @@ const customActions = [
   .assets-route__eyebrow {
     margin: 0 0 0.5rem;
     color: var(--smrt-color-primary, #0f766e);
-    font-size: 0.75rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
+    letter-spacing: var(--smrt-typography-label-medium-tracking, 0.08em);
     text-transform: uppercase;
   }
 
@@ -157,7 +157,7 @@ const customActions = [
 
   .assets-route__panel h2 {
     margin: 0 0 0.75rem;
-    font-size: 1rem;
+    font-size: var(--smrt-typography-title-medium-size, 1rem);
   }
 
   .assets-route__empty {
@@ -192,7 +192,7 @@ const customActions = [
   }
 
   .assets-route__selection-list code {
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
     color: var(--smrt-color-on-primary-container, #155e75);
   }
 

--- a/packages/chat/src/svelte/components/agent/AgentChat.svelte
+++ b/packages/chat/src/svelte/components/agent/AgentChat.svelte
@@ -255,8 +255,8 @@ $effect(() => {
     padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
     border-radius: var(--smrt-radius-lg, 12px);
     word-break: break-word;
-    font-size: 0.8125rem;
-    line-height: 1.45;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
+    line-height: var(--smrt-typography-body-medium-line-height, 1.45);
   }
 
   .agent-chat__bubble--user {
@@ -283,7 +283,7 @@ $effect(() => {
   }
 
   .agent-chat__msg-time {
-    font-size: 0.5625rem;
+    font-size: var(--smrt-typography-label-small-size, 0.5625rem);
     color: var(--smrt-color-outline, #74777f);
     align-self: flex-end;
     line-height: 1;
@@ -298,7 +298,7 @@ $effect(() => {
   }
 
   .agent-chat__empty-text {
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
     color: var(--smrt-color-outline, #74777f);
   }
 
@@ -315,7 +315,7 @@ $effect(() => {
     flex: 1;
     text-align: center;
     padding: var(--smrt-spacing-2, 8px);
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
     color: var(--smrt-color-outline, #74777f);
     font-style: italic;
   }
@@ -325,8 +325,8 @@ $effect(() => {
     border: none;
     border-radius: var(--smrt-radius-md, 8px);
     padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
-    font-size: 0.8125rem;
-    line-height: 1.4;
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
+    line-height: var(--smrt-typography-body-medium-line-height, 1.4);
     color: var(--smrt-color-on-surface, #1a1c1e);
     background: var(--smrt-color-surface-container-low, #f7f7fb);
     resize: none;
@@ -372,8 +372,8 @@ $effect(() => {
     display: inline-flex;
     align-items: center;
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
-    font-size: 0.6875rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-on-success-container, #16a34a);
     background: var(--smrt-color-success-container, #f0fdf4);
     border: 1px solid var(--smrt-color-success, #bbf7d0);
@@ -402,14 +402,14 @@ $effect(() => {
     overflow-x: auto;
     white-space: pre-wrap;
     word-break: break-word;
-    font-size: 0.875rem;
-    line-height: 1.45;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
+    line-height: var(--smrt-typography-body-medium-line-height, 1.45);
   }
 
   .diff-btn {
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
-    font-size: 0.625rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-small-size, 0.625rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     border: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
     border-radius: var(--smrt-radius-full, 9999px);
     background: none;
@@ -448,14 +448,14 @@ $effect(() => {
 
   .diff-dialog__header h4 {
     margin: 0;
-    font-size: 0.875rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-title-small-size, 0.875rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .diff-dialog__close {
     background: none;
     border: none;
-    font-size: 1rem;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
     cursor: pointer;
     color: var(--smrt-color-outline, #74777f);
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
@@ -482,10 +482,10 @@ $effect(() => {
 
   .diff-field__name {
     display: block;
-    font-size: 0.6875rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     text-transform: uppercase;
-    letter-spacing: 0.04em;
+    letter-spacing: var(--smrt-typography-label-small-tracking, 0.04em);
     color: var(--smrt-color-outline, #74777f);
     margin-bottom: var(--smrt-spacing-1, 4px);
   }
@@ -493,8 +493,8 @@ $effect(() => {
   .diff-field__value {
     margin: 0;
     padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
-    font-size: 0.75rem;
-    line-height: 1.5;
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
+    line-height: var(--smrt-typography-body-small-line-height, 1.5);
     background: var(--smrt-color-surface-container-low, #f7f7fb);
     border-radius: var(--smrt-radius-md, 8px);
     white-space: pre-wrap;

--- a/packages/chat/src/svelte/components/agent/AgentSessionPanel.svelte
+++ b/packages/chat/src/svelte/components/agent/AgentSessionPanel.svelte
@@ -282,8 +282,8 @@ const statusLabel: Record<string, string> = {
   }
 
   .session-panel__tool-chip {
-    font-size: 0.625rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-label-small-size, 0.625rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border-radius: var(--smrt-radius-small, 4px);
     background: var(--smrt-color-surface-container-highest, #dddde1);

--- a/packages/chat/src/svelte/components/agent/ToolCallDisplay.svelte
+++ b/packages/chat/src/svelte/components/agent/ToolCallDisplay.svelte
@@ -129,7 +129,7 @@ function formatDuration(ms: number | undefined): string {
     border: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
     border-radius: var(--smrt-radius-medium, 8px);
     overflow: hidden;
-    font-family: var(--smrt-typography-body, system-ui);
+    font-family: var(--smrt-font-family, system-ui);
   }
 
   .tool-call--pending {
@@ -198,7 +198,7 @@ function formatDuration(ms: number | undefined): string {
 
   .tool-call__name {
     font: var(--smrt-typography-label-large-font, 500 0.875rem/1.25 sans-serif);
-    font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+    font-family: var(--smrt-font-family-mono, 'SF Mono', 'Fira Code', 'Cascadia Code', monospace);
     flex: 1;
     min-width: 0;
     white-space: nowrap;
@@ -251,7 +251,7 @@ function formatDuration(ms: number | undefined): string {
     font: var(--smrt-typography-label-small-font, 500 0.6875rem/1 sans-serif);
     color: var(--smrt-color-on-surface-variant, #43474e);
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: var(--smrt-typography-label-small-tracking, 0.5px);
   }
 
   .tool-call__json {
@@ -260,9 +260,9 @@ function formatDuration(ms: number | undefined): string {
     border-radius: var(--smrt-radius-small, 4px);
     background: var(--smrt-color-surface-container-low, #f7f7fb);
     color: var(--smrt-color-on-surface, #1a1c1e);
-    font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
-    font-size: 0.75rem;
-    line-height: 1.5;
+    font-family: var(--smrt-font-family-mono, 'SF Mono', 'Fira Code', 'Cascadia Code', monospace);
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
+    line-height: var(--smrt-typography-body-small-line-height, 1.5);
     overflow-x: auto;
     white-space: pre-wrap;
     word-break: break-all;

--- a/packages/chat/src/svelte/components/dialogs/RoomCreateDialog.svelte
+++ b/packages/chat/src/svelte/components/dialogs/RoomCreateDialog.svelte
@@ -339,7 +339,7 @@ $effect(() => {
   .type-option__label {
     font: var(--smrt-typography-body-medium-font, 0.875rem / 1.25 sans-serif);
     color: var(--smrt-color-on-surface, #1a1c1e);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
   .type-option__description {

--- a/packages/chat/src/svelte/components/layout/RoomHeader.svelte
+++ b/packages/chat/src/svelte/components/layout/RoomHeader.svelte
@@ -136,8 +136,8 @@ const roomTypeLabel = $derived.by(() => {
 
   .room-header__icon {
     flex-shrink: 0;
-    font-size: 1.125rem;
-    font-weight: 700;
+    font-size: var(--smrt-typography-title-medium-size, 1.125rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 

--- a/packages/chat/src/svelte/components/layout/RoomList.svelte
+++ b/packages/chat/src/svelte/components/layout/RoomList.svelte
@@ -280,7 +280,7 @@ function formatTimestamp(date?: string | Date | null): string {
     font: var(--smrt-typography-label-small-font, 500 0.6875rem / 1 sans-serif);
     color: var(--smrt-color-on-surface-variant, #43474e);
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: var(--smrt-typography-label-small-tracking, 0.05em);
   }
 
   .room-group__header:hover {
@@ -288,7 +288,7 @@ function formatTimestamp(date?: string | Date | null): string {
   }
 
   .room-group__chevron {
-    font-size: 0.625rem;
+    font-size: var(--smrt-typography-label-small-size, 0.625rem);
     transition: transform var(--smrt-duration-short2, 150ms);
   }
 
@@ -303,7 +303,7 @@ function formatTimestamp(date?: string | Date | null): string {
 
   .room-group__count {
     color: var(--smrt-color-outline, #74777f);
-    font-size: 0.625rem;
+    font-size: var(--smrt-typography-label-small-size, 0.625rem);
   }
 
   .room-group__list {
@@ -334,7 +334,7 @@ function formatTimestamp(date?: string | Date | null): string {
 
   .room-item--active {
     background: var(--smrt-color-secondary-container, #d7e3f7);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
   .room-item--muted {
@@ -351,14 +351,14 @@ function formatTimestamp(date?: string | Date | null): string {
     width: 1.25rem;
     text-align: center;
     color: var(--smrt-color-on-surface-variant, #43474e);
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .room-item__agent-icon {
     flex-shrink: 0;
     width: 1.25rem;
     text-align: center;
-    font-size: 1rem;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
   }
 
   .room-item__avatar {

--- a/packages/chat/src/svelte/components/messages/MessageInput.svelte
+++ b/packages/chat/src/svelte/components/messages/MessageInput.svelte
@@ -139,7 +139,7 @@ function handleInput() {
 
   .message-input__reply-name {
     font-size: var(--smrt-typography-body-small-size, 0.75rem);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-primary, #005ac1);
   }
 

--- a/packages/chat/src/svelte/components/messages/MessageItem.svelte
+++ b/packages/chat/src/svelte/components/messages/MessageItem.svelte
@@ -237,7 +237,7 @@ function toggleReactionPicker() {
 
   .message-item__sender {
     font-size: var(--smrt-typography-body-small-size, 0.75rem);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-surface-variant, #43474e);
     padding-left: var(--smrt-spacing-1, 0.25rem);
   }
@@ -256,7 +256,7 @@ function toggleReactionPicker() {
   }
 
   .message-item__reply-name {
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-primary, #005ac1);
   }
 
@@ -279,16 +279,16 @@ function toggleReactionPicker() {
   }
 
   .message-item__tool-name {
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-surface, #1b1b1f);
   }
 
   .message-item__tool-status {
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border-radius: var(--smrt-radius-small, 0.25rem);
-    font-size: 0.625rem;
+    font-size: var(--smrt-typography-label-small-size, 0.625rem);
     text-transform: uppercase;
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   .message-item__tool-status.pending {
@@ -334,7 +334,7 @@ function toggleReactionPicker() {
     border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-surface, #ffffff);
     cursor: pointer;
-    font-size: 0.75rem;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
     transition: background var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
   }
 
@@ -348,12 +348,12 @@ function toggleReactionPicker() {
   }
 
   .message-item__reaction-emoji {
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-label-large-size, 0.8125rem);
     line-height: 1;
   }
 
   .message-item__reaction-count {
-    font-size: 0.6875rem;
+    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
@@ -365,12 +365,12 @@ function toggleReactionPicker() {
   }
 
   .message-item__time {
-    font-size: 0.625rem;
+    font-size: var(--smrt-typography-label-small-size, 0.625rem);
     color: var(--smrt-color-outline, #74777f);
   }
 
   .message-item__edited {
-    font-size: 0.625rem;
+    font-size: var(--smrt-typography-label-small-size, 0.625rem);
     color: var(--smrt-color-outline, #74777f);
     font-style: italic;
   }

--- a/packages/chat/src/svelte/components/messages/ThreadPanel.svelte
+++ b/packages/chat/src/svelte/components/messages/ThreadPanel.svelte
@@ -97,7 +97,7 @@ const replyCount = $derived(
   .thread-panel__title {
     margin: 0;
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-on-surface, #1b1b1f);
     white-space: nowrap;
     overflow: hidden;
@@ -112,7 +112,7 @@ const replyCount = $derived(
   .thread-panel__resolved {
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     font-size: var(--smrt-typography-body-small-size, 0.75rem);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-success-container, #2e7d32);
     background: var(--smrt-color-success-container, #e8f5e9);
     border-radius: var(--smrt-radius-full, 9999px);

--- a/packages/chat/src/svelte/components/shared/Avatar.svelte
+++ b/packages/chat/src/svelte/components/shared/Avatar.svelte
@@ -62,7 +62,7 @@ function handleImgError() {
     border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-primary-container, #d6e3ff);
     color: var(--smrt-color-on-primary-container, #001a41);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     flex-shrink: 0;
     overflow: hidden;
   }
@@ -70,19 +70,19 @@ function handleImgError() {
   .sm {
     width: 28px;
     height: 28px;
-    font-size: 0.6875rem;
+    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
   }
 
   .md {
     width: 36px;
     height: 36px;
-    font-size: 0.8125rem;
+    font-size: var(--smrt-typography-label-large-size, 0.8125rem);
   }
 
   .lg {
     width: 48px;
     height: 48px;
-    font-size: 1rem;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
   }
 
   .avatar__img {

--- a/packages/chat/src/svelte/components/shared/LinkPreview.svelte
+++ b/packages/chat/src/svelte/components/shared/LinkPreview.svelte
@@ -84,7 +84,7 @@ const hostname = $derived.by(() => {
 
   .link-preview__title {
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-surface, #1b1b1f);
     white-space: nowrap;
     overflow: hidden;
@@ -102,7 +102,7 @@ const hostname = $derived.by(() => {
   }
 
   .link-preview__domain {
-    font-size: 0.6875rem;
+    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
     color: var(--smrt-color-outline, #74777f);
   }
 </style>

--- a/packages/chat/src/svelte/components/shared/MentionAutocomplete.svelte
+++ b/packages/chat/src/svelte/components/shared/MentionAutocomplete.svelte
@@ -153,7 +153,7 @@ function highlightMatch(
   .mention-autocomplete__highlight {
     background: transparent;
     color: var(--smrt-color-primary, #005ac1);
-    font-weight: 600;
+    font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/packages/chat/src/svelte/components/shared/ReactionPicker.svelte
+++ b/packages/chat/src/svelte/components/shared/ReactionPicker.svelte
@@ -82,7 +82,7 @@ function handleKeydown(event: KeyboardEvent, emoji: string) {
     border-radius: var(--smrt-radius-small, 0.25rem);
     background: transparent;
     cursor: pointer;
-    font-size: 1.125rem;
+    font-size: var(--smrt-typography-body-large-size, 1.125rem);
     line-height: 1;
     padding: 0;
     transition: background var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);

--- a/packages/chat/src/svelte/components/shared/ReadReceipts.svelte
+++ b/packages/chat/src/svelte/components/shared/ReadReceipts.svelte
@@ -78,7 +78,7 @@ function getInitial(name: string): string {
   }
 
   .read-receipts__count {
-    font-size: 0.625rem;
+    font-size: var(--smrt-typography-label-small-size, 0.625rem);
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
@@ -107,8 +107,8 @@ function getInitial(name: string): string {
     justify-content: center;
     background: var(--smrt-color-surface-container-high, #e1e3e8);
     color: var(--smrt-color-on-surface-variant, #43474e);
-    font-size: 0.5rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-label-small-size, 0.5rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
   .read-receipts__mini-avatar--more {
@@ -117,7 +117,7 @@ function getInitial(name: string): string {
     justify-content: center;
     background: var(--smrt-color-surface-container, #f3f4f6);
     color: var(--smrt-color-on-surface-variant, #43474e);
-    font-size: 0.5rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-label-small-size, 0.5rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
   }
 </style>

--- a/packages/chat/src/svelte/components/tabs/ChatTab.svelte
+++ b/packages/chat/src/svelte/components/tabs/ChatTab.svelte
@@ -222,8 +222,8 @@ const {
     border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-error, #ba1a1a);
     color: var(--smrt-color-on-error, #ffffff);
-    font-size: 0.6875rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     line-height: 1;
   }
 

--- a/packages/chat/src/svelte/components/tabs/ChatTabList.svelte
+++ b/packages/chat/src/svelte/components/tabs/ChatTabList.svelte
@@ -109,8 +109,8 @@ const { tabs, onselect, onclose }: Props = $props();
     border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-error, #ba1a1a);
     color: var(--smrt-color-on-error, #ffffff);
-    font-size: 0.625rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-small-size, 0.625rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     line-height: 1;
     border: 2px solid var(--smrt-color-surface, #fefbff);
   }

--- a/packages/chat/src/svelte/components/tabs/MiniChat.svelte
+++ b/packages/chat/src/svelte/components/tabs/MiniChat.svelte
@@ -149,8 +149,8 @@ $effect(() => {
   }
 
   .mini-chat__sender {
-    font-size: 0.6875rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-primary, #005ac1);
     line-height: 1;
   }
@@ -160,7 +160,7 @@ $effect(() => {
   }
 
   .mini-chat__time {
-    font-size: 0.625rem;
+    font-size: var(--smrt-typography-label-small-size, 0.625rem);
     color: var(--smrt-color-outline, #74777f);
     align-self: flex-end;
     line-height: 1;

--- a/packages/images/src/svelte/components/AssetsGallery.svelte
+++ b/packages/images/src/svelte/components/AssetsGallery.svelte
@@ -256,7 +256,7 @@ function handleDragStart(event: DragEvent, image: ImageLike) {
 
   .gallery-header h3 {
     margin: 0;
-    font-size: 1.25rem;
+    font-size: var(--smrt-typography-title-large-size, 1.25rem);
   }
 
   .toolbar {
@@ -279,7 +279,7 @@ function handleDragStart(event: DragEvent, image: ImageLike) {
     border: 1px solid var(--smrt-color-outline-variant, #444);
     border-radius: var(--smrt-radius-full, 9999px);
     color: inherit;
-    font-size: 0.95rem;
+    font-size: var(--smrt-typography-body-large-size, 0.95rem);
     transition: box-shadow 0.2s, border-color 0.2s;
   }
 
@@ -381,16 +381,16 @@ function handleDragStart(event: DragEvent, image: ImageLike) {
   }
 
   .item-name {
-    font-weight: 500;
-    font-size: 1rem;
+    font-weight: var(--smrt-typography-weight-medium, 500);
+    font-size: var(--smrt-typography-title-medium-size, 1rem);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    letter-spacing: 0.1px;
+    letter-spacing: var(--smrt-typography-title-medium-tracking, 0.1px);
   }
 
   .item-meta {
-    font-size: 0.85rem;
+    font-size: var(--smrt-typography-label-large-size, 0.85rem);
     color: var(--smrt-color-outline, #888);
   }
 
@@ -416,7 +416,7 @@ function handleDragStart(event: DragEvent, image: ImageLike) {
     color: var(--smrt-color-primary, #3b82f6);
     border: 1px solid var(--smrt-color-outline-variant, #444);
     border-radius: var(--smrt-radius-full, 9999px);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     cursor: pointer;
     transition: background 0.2s;
   }

--- a/packages/images/src/svelte/components/ImageEditor.svelte
+++ b/packages/images/src/svelte/components/ImageEditor.svelte
@@ -289,15 +289,15 @@ async function handleAIEdit() {
   
   .header h3 {
     margin: 0;
-    font-size: 1.15rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-title-medium-size, 1.15rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
   .close-btn {
     background: transparent;
     border: none;
     color: inherit;
-    font-size: 1.5rem;
+    font-size: var(--smrt-typography-headline-small-size, 1.5rem);
     cursor: pointer;
   }
 
@@ -349,7 +349,7 @@ async function handleAIEdit() {
     padding: 0.6rem 1rem;
     color: var(--smrt-color-outline, #666);
     cursor: pointer;
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     border-radius: var(--smrt-radius-full, 9999px);
     transition: all 0.2s;
   }
@@ -362,8 +362,8 @@ async function handleAIEdit() {
 
   .tool-section h4 {
     margin: 0 0 1rem 0;
-    font-size: 0.95rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-title-medium-size, 0.95rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-on-surface-variant, #ccc);
   }
 
@@ -378,8 +378,8 @@ async function handleAIEdit() {
   .row label {
     display: flex;
     flex-direction: column;
-    font-size: 0.8rem;
-    font-weight: 500;
+    font-size: var(--smrt-typography-label-medium-size, 0.8rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
     color: var(--smrt-color-outline, #888);
     gap: 0.25rem;
   }
@@ -416,7 +416,7 @@ async function handleAIEdit() {
     border: 1px solid var(--smrt-color-outline-variant, #444);
     padding: 0.6rem 1.2rem;
     border-radius: var(--smrt-radius-full, 9999px);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     cursor: pointer;
     transition: background 0.2s;
     margin-top: 1.25rem;
@@ -443,7 +443,7 @@ async function handleAIEdit() {
     border: none;
     padding: 0.6rem 1.5rem;
     border-radius: var(--smrt-radius-full, 9999px);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     cursor: pointer;
     transition: background 0.2s, opacity 0.2s;
   }
@@ -458,7 +458,7 @@ async function handleAIEdit() {
   }
 
   .hint {
-    font-size: 0.8rem;
+    font-size: var(--smrt-typography-body-small-size, 0.8rem);
     color: var(--smrt-color-outline, #888);
     margin: 0 0 0.5rem 0;
   }
@@ -468,7 +468,7 @@ async function handleAIEdit() {
     background: color-mix(in srgb, var(--smrt-color-error) 10%, transparent);
     padding: 0.5rem;
     border-radius: var(--smrt-radius-sm, 4px);
-    font-size: 0.85rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.85rem);
   }
 
   .success-msg {
@@ -476,6 +476,6 @@ async function handleAIEdit() {
     background: color-mix(in srgb, var(--smrt-color-success) 10%, transparent);
     padding: 0.5rem;
     border-radius: var(--smrt-radius-sm, 4px);
-    font-size: 0.85rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.85rem);
   }
 </style>

--- a/packages/images/src/svelte/components/ImageUploader.svelte
+++ b/packages/images/src/svelte/components/ImageUploader.svelte
@@ -460,14 +460,14 @@ onDestroy(() => {
   
   .header h3 {
     margin: 0;
-    font-size: 1.15rem;
+    font-size: var(--smrt-typography-title-medium-size, 1.15rem);
   }
 
   .close-btn {
     background: transparent;
     border: none;
     color: var(--smrt-color-outline, #888);
-    font-size: 1.5rem;
+    font-size: var(--smrt-typography-headline-small-size, 1.5rem);
     line-height: 1;
     cursor: pointer;
   }
@@ -489,12 +489,12 @@ onDestroy(() => {
     border-bottom: 2px solid var(--smrt-color-outline-variant, #333);
     padding: 1rem;
     color: var(--smrt-color-outline, #888);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     cursor: pointer;
     transition: all 0.2s;
     text-transform: uppercase;
-    font-size: 0.85rem;
-    letter-spacing: 0.5px;
+    font-size: var(--smrt-typography-label-large-size, 0.85rem);
+    letter-spacing: var(--smrt-typography-label-large-tracking, 0.5px);
   }
 
   .tabs button:hover {
@@ -559,12 +559,12 @@ onDestroy(() => {
   }
 
   .upload-area p {
-    font-size: 1.1rem;
+    font-size: var(--smrt-typography-body-large-size, 1.1rem);
     margin: 0 0 0.5rem 0;
   }
 
   .divider {
-    font-size: 0.85rem;
+    font-size: var(--smrt-typography-label-large-size, 0.85rem);
     color: var(--smrt-color-outline, #666);
     margin-bottom: 1rem;
   }
@@ -575,14 +575,14 @@ onDestroy(() => {
     border: none;
     padding: 0.5rem 1.5rem;
     border-radius: var(--smrt-radius-full, 9999px);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     pointer-events: none; /* Let parent handle clicks */
   }
 
   .error {
     margin-top: 1rem;
     color: var(--smrt-color-error, #ef4444);
-    font-size: 0.9rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.9rem);
   }
 
   /* Camera Tab */
@@ -629,8 +629,8 @@ onDestroy(() => {
     border: none;
     padding: 1rem 3rem;
     border-radius: var(--smrt-radius-full, 9999px);
-    font-size: 1.1rem;
-    font-weight: 600;
+    font-size: var(--smrt-typography-body-large-size, 1.1rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
     cursor: pointer;
   }
 
@@ -690,7 +690,7 @@ onDestroy(() => {
     border: 1px solid var(--smrt-color-outline-variant, #444);
     border-radius: var(--smrt-radius-sm, 4px);
     color: var(--smrt-color-on-surface, #fff);
-    font-size: 1rem;
+    font-size: var(--smrt-typography-body-large-size, 1rem);
     transition: border-color 0.2s, box-shadow 0.2s;
   }
 
@@ -706,7 +706,7 @@ onDestroy(() => {
     border: none;
     padding: 0 1.5rem;
     border-radius: var(--smrt-radius-md, 6px);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     cursor: pointer;
   }
 
@@ -724,7 +724,7 @@ onDestroy(() => {
     background: transparent;
     border: none;
     color: var(--smrt-color-primary, #3b82f6);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     cursor: pointer;
     padding: 0.25rem 0.5rem;
     border-radius: var(--smrt-radius-sm, 4px);
@@ -771,12 +771,12 @@ onDestroy(() => {
   }
 
   .confirm-name {
-    font-weight: 500;
-    font-size: 1.05rem;
+    font-weight: var(--smrt-typography-weight-medium, 500);
+    font-size: var(--smrt-typography-title-medium-size, 1.05rem);
   }
 
   .confirm-meta {
-    font-size: 0.85rem;
+    font-size: var(--smrt-typography-label-large-size, 0.85rem);
     color: var(--smrt-color-outline, #888);
   }
 
@@ -795,7 +795,7 @@ onDestroy(() => {
     border: none;
     padding: 0.65rem 1.5rem;
     border-radius: var(--smrt-radius-full, 9999px);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     cursor: pointer;
     transition: filter 0.15s;
   }
@@ -813,7 +813,7 @@ onDestroy(() => {
     border: 1px solid var(--smrt-color-outline-variant, #444);
     padding: 0.65rem 1.25rem;
     border-radius: var(--smrt-radius-full, 9999px);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     cursor: pointer;
     transition: all 0.2s;
   }
@@ -841,7 +841,7 @@ onDestroy(() => {
   }
 
   .variation-hint {
-    font-size: 0.85rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.85rem);
     color: var(--smrt-color-outline, #888);
     margin: 0;
   }
@@ -854,7 +854,7 @@ onDestroy(() => {
     border-radius: var(--smrt-radius-sm, 4px);
     color: inherit;
     font-family: inherit;
-    font-size: 0.95rem;
+    font-size: var(--smrt-typography-body-large-size, 0.95rem);
     resize: vertical;
     transition: border-color 0.2s, box-shadow 0.2s;
   }
@@ -874,7 +874,7 @@ onDestroy(() => {
     background: color-mix(in srgb, var(--smrt-color-error) 10%, transparent);
     padding: 0.5rem 0.75rem;
     border-radius: var(--smrt-radius-sm, 4px);
-    font-size: 0.85rem;
+    font-size: var(--smrt-typography-body-medium-size, 0.85rem);
   }
 
   .generate-btn {
@@ -888,7 +888,7 @@ onDestroy(() => {
     border: none;
     padding: 0.65rem 1.5rem;
     border-radius: var(--smrt-radius-full, 9999px);
-    font-weight: 500;
+    font-weight: var(--smrt-typography-weight-medium, 500);
     cursor: pointer;
     transition: filter 0.15s, opacity 0.15s;
   }

--- a/packages/images/src/svelte/routes/ImageStudioRoute.svelte
+++ b/packages/images/src/svelte/routes/ImageStudioRoute.svelte
@@ -115,9 +115,9 @@ function handleEditorSave(image: StudioImage) {
   .images-route__eyebrow {
     margin: 0 0 0.5rem;
     color: var(--smrt-color-primary, #7dd3fc);
-    font-size: 0.75rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
+    letter-spacing: var(--smrt-typography-label-medium-tracking, 0.08em);
     text-transform: uppercase;
   }
 

--- a/scripts/check-typography.mjs
+++ b/scripts/check-typography.mjs
@@ -39,6 +39,9 @@ const STRICT_PACKAGES = new Set([
   'content',
   'messages',
   'products',
+  'assets',
+  'chat',
+  'images',
 ]);
 
 /** Dev/playground hosts skipped entirely (matches the other token ratchets). */


### PR DESCRIPTION
## What

S1 **typography** Phase 4 — migrates `assets` (~64), `chat` (~62), `images` (~43) to the Material-3 `--smrt-typography-*` role scale, and flips all three to strict.

Continues #1462 (Phase 1: smrt-svelte), #1463 (Phase 2: content), #1464 (Phase 3: messages+products).

## Approach

Full semantic pass — each text element mapped to its M3 role, original kept as `var()` fallback:
- card/panel/list titles, table headers → `title-*`
- chat/message body text, input values, descriptions → `body-*`
- buttons/badges/chips/captions/metadata/timestamps → `label-*`
- hero/empty-state glyphs → `display-*` / `headline-*`
- `line-height`/`letter-spacing` tokenized to each element's assigned role

Applies the lessons from earlier phases:
- **Exact-size rule** (from #1464): 1rem icon controls → `body-large` (1rem), never `label-large` (0.875rem) — so they don't shrink under the theme. Audited the full diff: 0 exact-match size mismatches.
- **Fluid `clamp()`** hero font-sizes left raw (responsive — would freeze if tokenized).
- Repointed a dangling `font-family: var(--smrt-typography-body, …)` ref (never-emitted name) → `var(--smrt-font-family, …)`, and removed a pre-existing dead-duplicate `font-size` on `AssetDetail .section-heading`.

## Verification

- `node scripts/check-typography.mjs` → 7 strict packages all clean
- **Deterministic scope-check**: every added/removed line under the 3 packages is a typography value (no JS/markup/TS; no `console.*` removed)
- **Size-mismatch audit**: 0 exact-match values mapped to a wrong-size tier
- `npm run build` → 50/50; `svelte-token` + `knowledge:check` fresh; `biome` clean (31 files)

## Remaining

analytics (28), commerce (20), + single-digit tail (events/social/agents/subscriptions/tenancy/users/jobs). The final batch flips every remaining package strict and **closes #1373**.