### PR TITLE
fix(core): save() on a loaded object with a changed slug violates *_pkey (#1472)

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -17,7 +17,7 @@ ORM, code generation, AI integration, and the DispatchBus. Everything else build
 `constructor(options)` → `initialize()` → ready for `save()`/`delete()`/`loadFromId()`
 
 - `initialize()`: loads field initializers, applies option values (options override initializers), loads from DB if id/slug provided
-- `save()`: upsert with STI validation, interceptor execution, auto-embeddings
+- `save()`: upsert with STI validation, interceptor execution, auto-embeddings. Persisted objects (`isPersisted` — set by DB hydration and successful saves) upsert on `['id']` so natural-key edits (e.g. slug renames) update in place; new objects upsert on the natural-key conflict columns for ingestion-style dedup (#1472)
 - `is(criteria)` / `do(instructions)`: AI operations via function calling
 - `getSlug()`: auto-generates from name → title → label → id
 - `loadRelated(fieldName)`: lazy-loads relationships (cached in `_loadedRelationships` Map)

--- a/packages/core/src/__tests__/issue-1472-natural-key-rename-save.test.ts
+++ b/packages/core/src/__tests__/issue-1472-natural-key-rename-save.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Issue #1472: save() on a loaded object with a changed slug must not
+ * violate the `*_pkey` primary-key constraint.
+ *
+ * Background
+ * ----------
+ * `save()` persists via upsert against the registry's natural-key conflict
+ * columns (default `['slug', 'context']`, plus `'_meta_type'` for STI).
+ * When the slug of an **existing** row changes, the conflict target no
+ * longer matches any row, so the upsert takes the INSERT path with the
+ * object's existing `id` and collides on the primary key:
+ *
+ *     duplicate key value violates unique constraint "contents_pkey"
+ *
+ * Net effect before the fix: natural-key fields were effectively immutable
+ * for any persisted SmrtObject.
+ *
+ * Resolution
+ * ----------
+ * SmrtObject now tracks whether it is backed by an existing database row
+ * (`isPersisted`), set during hydration (collection get/list/query,
+ * `loadFromId()`, `loadFromSlug()`) and after a successful `save()`.
+ * Persisted objects upsert with `['id']` as the conflict target, so
+ * natural-key edits update the existing row in place. New objects keep the
+ * natural-key conflict columns so ingestion-style dedup (create /
+ * getOrUpsert against a known slug) still updates matching rows instead of
+ * inserting duplicates.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SmrtCollection } from '../collection';
+import { field } from '../decorators';
+import { SmrtObject } from '../object';
+import { ObjectRegistry, smrt } from '../registry';
+import { getTestDatabase } from '../testing/database';
+
+@smrt({ tableName: 'issue_1472_contents' })
+class Issue1472Content extends SmrtObject {
+  @field()
+  title: string = '';
+
+  @field()
+  status: string = 'draft';
+
+  constructor(options: Record<string, any> = {}) {
+    super(options as any);
+    if (options.title !== undefined) this.title = options.title;
+    if (options.status !== undefined) this.status = options.status;
+  }
+}
+
+class Issue1472ContentCollection extends SmrtCollection<Issue1472Content> {
+  static readonly _itemClass = Issue1472Content;
+}
+
+// STI hierarchy mirroring the `contents` table from the original report.
+@smrt({ tableName: 'issue_1472_sti_contents', tableStrategy: 'sti' })
+class Issue1472StiContent extends SmrtObject {
+  @field()
+  title: string = '';
+
+  constructor(options: Record<string, any> = {}) {
+    super(options as any);
+    if (options.title !== undefined) this.title = options.title;
+  }
+}
+
+@smrt()
+class Issue1472StiArticle extends Issue1472StiContent {}
+
+class Issue1472StiContentCollection extends SmrtCollection<Issue1472StiContent> {
+  static readonly _itemClass = Issue1472StiContent;
+}
+
+function requireFound<T>(value: T | null | undefined): T {
+  if (!value) throw new Error('expected a loaded instance');
+  return value;
+}
+
+describe('Issue #1472: save() after renaming a natural-key field', () => {
+  let db: Awaited<ReturnType<typeof getTestDatabase>>;
+  let contents: Issue1472ContentCollection;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({
+      classes: [
+        'Issue1472Content',
+        'Issue1472StiContent',
+        'Issue1472StiArticle',
+      ],
+    });
+    ObjectRegistry.registerCollection(
+      'Issue1472Content',
+      Issue1472ContentCollection,
+    );
+    contents = (await Issue1472ContentCollection.create({
+      db,
+    })) as Issue1472ContentCollection;
+  });
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') {
+      await db.close();
+    }
+  });
+
+  it('renames the slug of an object loaded via collection.get() (issue repro)', async () => {
+    const item = await contents.create({
+      title: 'A',
+      slug: 'old-slug',
+      status: 'draft',
+    });
+
+    const loaded = requireFound(await contents.get(String(item.id)));
+    expect(loaded.isPersisted).toBe(true);
+
+    loaded.slug = 'new-slug';
+    await loaded.save();
+
+    const all = await db.list('issue_1472_contents', {});
+    expect(all).toHaveLength(1);
+    expect((all[0] as Record<string, unknown>).slug).toBe('new-slug');
+    expect((all[0] as Record<string, unknown>).id).toBe(item.id);
+  });
+
+  it('renames the slug of an object hydrated via list()', async () => {
+    await contents.create({ title: 'B', slug: 'list-slug', status: 'draft' });
+
+    const [loaded] = await contents.list({ where: { slug: 'list-slug' } });
+    expect(loaded.isPersisted).toBe(true);
+
+    loaded.slug = 'list-slug-renamed';
+    await loaded.save();
+
+    const all = await db.list('issue_1472_contents', {});
+    expect(all).toHaveLength(1);
+    expect((all[0] as Record<string, unknown>).slug).toBe('list-slug-renamed');
+  });
+
+  it('renames the slug of an object hydrated via loadFromSlug()', async () => {
+    const item = await contents.create({
+      title: 'C',
+      slug: 'slug-load',
+      status: 'draft',
+    });
+
+    const loaded = new Issue1472Content({ db, slug: 'slug-load' });
+    await loaded.initialize();
+    expect(loaded.id).toBe(item.id);
+    expect(loaded.isPersisted).toBe(true);
+
+    loaded.slug = 'slug-load-renamed';
+    await loaded.save();
+
+    const all = await db.list('issue_1472_contents', {});
+    expect(all).toHaveLength(1);
+    expect((all[0] as Record<string, unknown>).slug).toBe('slug-load-renamed');
+  });
+
+  it('renames the slug on the same in-memory instance returned by create()', async () => {
+    const item = await contents.create({
+      title: 'D',
+      slug: 'create-slug',
+      status: 'draft',
+    });
+    // A successful save() marks the object as persisted.
+    expect(item.isPersisted).toBe(true);
+
+    item.slug = 'create-slug-renamed';
+    await item.save();
+
+    const all = await db.list('issue_1472_contents', {});
+    expect(all).toHaveLength(1);
+    expect((all[0] as Record<string, unknown>).slug).toBe(
+      'create-slug-renamed',
+    );
+    expect((all[0] as Record<string, unknown>).id).toBe(item.id);
+  });
+
+  it('still updates status (non-natural-key field) on a loaded object', async () => {
+    const item = await contents.create({
+      title: 'E',
+      slug: 'status-slug',
+      status: 'draft',
+    });
+
+    const loaded = requireFound(await contents.get(String(item.id)));
+    loaded.status = 'published';
+    await loaded.save();
+
+    const all = await db.list('issue_1472_contents', {});
+    expect(all).toHaveLength(1);
+    expect((all[0] as Record<string, unknown>).status).toBe('published');
+  });
+
+  it('keeps natural-key dedup for new (non-persisted) objects', async () => {
+    // Ingestion-style flows (e.g. re-scrapes) rely on saving a brand-new
+    // object with a known slug to update the existing row instead of
+    // inserting a duplicate. That behavior must survive the #1472 fix.
+    await contents.create({ title: 'F', slug: 'dedup-slug', status: 'draft' });
+
+    const rescraped = new Issue1472Content({
+      db,
+      slug: 'dedup-slug',
+      title: 'F (rescraped)',
+      _skipLoad: true,
+    });
+    await rescraped.initialize();
+    expect(rescraped.isPersisted).toBe(false);
+    (rescraped as any)._id = crypto.randomUUID();
+    await rescraped.save();
+
+    const all = await db.list('issue_1472_contents', {});
+    expect(all).toHaveLength(1);
+    expect((all[0] as Record<string, unknown>).title).toBe('F (rescraped)');
+  });
+
+  it('resets persistence on delete() so a re-save inserts a fresh row', async () => {
+    const item = await contents.create({
+      title: 'G',
+      slug: 'delete-slug',
+      status: 'draft',
+    });
+    expect(item.isPersisted).toBe(true);
+
+    await item.delete();
+    expect(item.isPersisted).toBe(false);
+
+    await item.save();
+    const all = await db.list('issue_1472_contents', {});
+    expect(all).toHaveLength(1);
+    expect((all[0] as Record<string, unknown>).slug).toBe('delete-slug');
+  });
+
+  it('renames the slug of a loaded STI child without violating the PK', async () => {
+    ObjectRegistry.registerCollection(
+      'Issue1472StiContent',
+      Issue1472StiContentCollection,
+    );
+    const stiContents = await Issue1472StiContentCollection.create({ db });
+
+    const article = await stiContents.create({
+      _meta_type: 'Issue1472StiArticle',
+      title: 'STI Article',
+      slug: 'sti-old-slug',
+    });
+
+    const loaded = requireFound(await stiContents.get(String(article.id)));
+    expect(loaded.isPersisted).toBe(true);
+    expect(loaded).toBeInstanceOf(Issue1472StiArticle);
+
+    loaded.slug = 'sti-new-slug';
+    await loaded.save();
+
+    const all = await db.list('issue_1472_sti_contents', {});
+    expect(all).toHaveLength(1);
+    expect((all[0] as Record<string, unknown>).slug).toBe('sti-new-slug');
+    expect((all[0] as Record<string, unknown>).id).toBe(article.id);
+  });
+});

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -2020,11 +2020,15 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     );
 
     if (isSTI && formattedData._meta_type) {
-      return await this.createPolymorphic(
+      const polymorphicInstance = await this.createPolymorphic(
         formattedData._meta_type,
         formattedData,
         { hydrateOnly: true },
       );
+      // Hydrated from an existing row — save() must update by primary key
+      // even if natural-key fields change (issue #1472).
+      polymorphicInstance.markAsPersisted();
+      return polymorphicInstance;
     }
 
     const instanceParams = {
@@ -2045,6 +2049,9 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
         registeredClass?.qualifiedName || this._itemClass.name;
     }
 
+    // Hydrated from an existing row — save() must update by primary key
+    // even if natural-key fields change (issue #1472).
+    instance.markAsPersisted();
     return instance;
   }
 

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -239,6 +239,18 @@ export class SmrtObject extends SmrtClass {
   private _loadedRelationships: Map<string, any> = new Map();
 
   /**
+   * Whether this object is backed by an existing database row.
+   *
+   * Set when the object is hydrated from the database (collection
+   * get/list/query, `loadFromId()`, `loadFromSlug()`) and after a successful
+   * `save()`. `save()` uses it to target the primary key on upsert instead
+   * of the natural-key conflict columns, so natural-key edits (e.g. renaming
+   * a slug) update the existing row rather than colliding on `*_pkey`
+   * (issue #1472).
+   */
+  private _persisted = false;
+
+  /**
    * Override options with SmrtObjectOptions type for proper type narrowing.
    * Initialized by parent constructor via super() call.
    */
@@ -441,6 +453,26 @@ export class SmrtObject extends SmrtClass {
    */
   protected setId(id: string): void {
     this._id = id;
+  }
+
+  /**
+   * Whether this object is backed by an existing database row.
+   *
+   * True after hydration from the database (collection get/list/query,
+   * `loadFromId()`, `loadFromSlug()`) or after a successful `save()`.
+   */
+  public get isPersisted(): boolean {
+    return this._persisted;
+  }
+
+  /**
+   * Marks this object as backed by an existing database row, so `save()`
+   * targets the primary key instead of the natural-key conflict columns.
+   * Called by framework hydration paths (issue #1472).
+   * @internal
+   */
+  public markAsPersisted(): void {
+    this._persisted = true;
   }
 
   protected async verifyStorageReady(): Promise<void> {
@@ -819,6 +851,10 @@ export class SmrtObject extends SmrtClass {
         totalFields: Object.keys(fields).length,
       });
     }
+
+    // The data came from an existing row, so subsequent saves must update
+    // that row by primary key even if natural-key fields change (issue #1472).
+    this._persisted = true;
   }
 
   /**
@@ -1523,6 +1559,17 @@ export class SmrtObject extends SmrtClass {
         conflictColumns,
       );
 
+      // Issue #1472: objects backed by an existing row must conflict on the
+      // primary key. With natural-key conflict columns, editing a natural-key
+      // field (e.g. slug) makes the conflict target match no row, so the
+      // upsert takes the INSERT path with the existing id and violates
+      // `*_pkey`. New objects keep natural-key conflict so ingestion-style
+      // dedup (create/getOrUpsert against a known slug) still updates in
+      // place. planPersistenceWrite() intentionally still receives the
+      // natural-key columns — its legacy-STI probe semantics are unchanged.
+      const upsertConflictColumns =
+        this._persisted && data.id ? ['id'] : conflictColumns;
+
       await ErrorUtils.withRetry(
         async () => {
           try {
@@ -1531,11 +1578,7 @@ export class SmrtObject extends SmrtClass {
               await this.db.update(this.tableName, { id: data.id }, updateData);
               this.setMetaType(writePlan.qualifiedMetaType);
             } else {
-              await this.db.upsert(
-                this.tableName,
-                writePlan.conflictColumns,
-                data,
-              );
+              await this.db.upsert(this.tableName, upsertConflictColumns, data);
             }
           } catch (error) {
             // Detect specific database error types
@@ -1563,6 +1606,10 @@ export class SmrtObject extends SmrtClass {
         3,
         500,
       );
+
+      // The row now exists, so any further save() must update it by primary
+      // key even if natural-key fields change afterwards (issue #1472).
+      this._persisted = true;
 
       // Execute afterSave interceptors (e.g., tenant audit logging)
       await GlobalInterceptors.executeAfterSave(this, interceptorContext);
@@ -2061,6 +2108,10 @@ export class SmrtObject extends SmrtClass {
 
     await this.verifyStorageReady();
     await this.db.delete(this.tableName, { id: this.id });
+
+    // The backing row is gone — a later save() should go through the
+    // natural-key insert path again rather than targeting a deleted id.
+    this._persisted = false;
 
     await this.runHook('afterDelete');
 


### PR DESCRIPTION
## Summary

Fixes #1472. Calling `save()` on a SmrtObject **loaded from the database** after changing a natural-key field (e.g. `slug`) failed with a primary-key violation:

```
DatabaseError: UPSERT INTO contents — duplicate key value violates unique constraint "contents_pkey" (23505)
```

`save()` persists via `db.upsert(table, conflictColumns, data)` using the registry's natural-key conflict columns (`['slug', 'context']`, plus `'_meta_type'` for STI). When the slug of an existing row changes, the `ON CONFLICT (slug, context, …)` target matches no row, so the upsert takes the INSERT path with the object's existing `id` → `*_pkey` violation. Net effect: **slug (and any natural-key field) was effectively immutable for any persisted object.** Status-only edits succeeded because they don't move the conflict target.

## Fix

`SmrtObject` now tracks whether it's backed by an existing DB row via an `isPersisted` flag:

- **Set on hydration** — `loadDataFromDb()` (covers `loadFromId()` / `loadFromSlug()`) and `SmrtCollection.hydrateResultRow()` (covers `get` / `list` / `query` / eager `include`, both STI and non-STI branches).
- **Set after a successful `save()`**, and **reset on `delete()`**.

In `save()`, persisted objects upsert with `['id']` as the conflict target (natural-key edits update the row in place); **new objects keep the natural-key conflict columns**, so ingestion-style dedup — praeco re-scrape flows, `getOrUpsert()` against a known slug — still updates matching rows instead of inserting duplicates. `planPersistenceWrite()`'s legacy-STI probe continues to receive the natural-key columns, so its semantics are unchanged (per the issue's design note).

## Tests

New `packages/core/src/__tests__/issue-1472-natural-key-rename-save.test.ts` (8 cases):

- The exact repro (rename slug on a `collection.get()` object)
- Rename via `list()` / `loadFromSlug()` / same `create()` instance hydration paths
- Status-only update still works on a loaded object
- **Natural-key dedup preserved** for new (non-persisted) objects
- `delete()` resets persistence so a re-save inserts fresh
- STI child rename without PK violation

Verified the suite fails with the reported `UNIQUE constraint failed: …id` error when the fix is disabled.

## Verification

- `@happyvertical/smrt-core`: full suite green (1886 passing)
- Repo-wide `turbo typecheck`: green
- Full monorepo `turbo test`: green
- `pnpm knowledge:check --strict`: fresh