### PR TITLE
ci: gitleaks secret scanning — pre-commit + PR gate (S7, #1412)

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -144,6 +144,39 @@ jobs:
       - name: Verify SDK packages use same version
         run: bash scripts/check-sdk-versions.sh
 
+  secret-scan:
+    name: Secret Scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      # fetch-depth: 0 gives us the base branch history needed for merge-base.
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        env:
+          # Pin for deterministic results; bump deliberately.
+          GITLEAKS_VERSION: 8.30.1
+        run: |
+          url="https://github.com/gitleaks/gitleaks/releases/download"
+          url="$url/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL "$url" | tar -xz gitleaks
+          sudo mv gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      # Scan only the commits introduced by this PR. --redact keeps any matched
+      # secret out of the workflow logs. Allowlist: .gitleaks.toml.
+      - name: Scan PR commits for secrets
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch origin "$BASE_REF" --depth=200
+          FROM_SHA=$(git merge-base "origin/$BASE_REF" HEAD)
+          echo "Scanning commits $FROM_SHA..HEAD for secrets"
+          gitleaks git --redact --no-banner -c .gitleaks.toml \
+            --log-opts="$FROM_SHA..HEAD"
+
   check-standards:
     name: Check Monorepo Standards
     runs-on: ubuntu-latest

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,46 @@
+# Gitleaks configuration — SMRT monorepo secret scanning (Sweep S7, #1412).
+#
+# Secret scanning runs in two deterministic, tool-only places (no model-assisted
+# checks per AGENTS.md):
+#   - lefthook pre-commit  → `gitleaks git --staged`        (blocks secrets before commit)
+#   - CI (on-pull-request) → `gitleaks git --log-opts=…`    (scans the PR commit range)
+# Both invoke gitleaks with `--redact` so any matched secret is never printed to
+# logs (org secret-handling policy).
+#
+# We extend gitleaks' built-in rule set and add repo-specific allowlisting for
+# known, justified false positives. Keep this file the single source of truth —
+# expand the allowlist (with a justification comment) as new patterns appear.
+
+title = "SMRT gitleaks config"
+
+[extend]
+# Start from gitleaks' maintained default rules, then layer the allowlist below.
+useDefault = true
+
+[allowlist]
+description = "SMRT repo-specific false-positive exclusions"
+# Treat allowlist regexes as a global OR: a finding is ignored if its file path
+# (paths) or owning commit (commits) matches any entry.
+paths = [
+  # Build artifacts are generated, never hand-authored. Example/placeholder keys
+  # baked into bundles are not real credentials, and dist is not committed in the
+  # live tree anyway.
+  '''(^|/)dist/''',
+  # Lockfile entries are integrity hashes that can trip entropy heuristics.
+  '''(^|/)pnpm-lock\.yaml$''',
+  # Test & spec fixtures intentionally embed FAKE api keys / tokens to exercise
+  # sanitizers and auth flows (e.g. the legacy signals/sanitizer.test.ts). Real
+  # secrets must never live in tests, so excluding fixtures keeps the gate
+  # signal-rich without flagging deliberate dummies.
+  '''\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$''',
+  # This config documents example patterns; don't scan it.
+  '''(^|/)\.gitleaks\.toml$''',
+]
+commits = [
+  # Initial monorepo import (feat: initialize SMRT framework monorepo). Contains
+  # 4 generic-api-key matches in the now-removed legacy packages/smrt/ tree
+  # (a dist chunk, sanitizer.test.ts fixtures, and a placeholder in utils.ts).
+  # All are example/test values in deleted files; baselined so a full-history
+  # `gitleaks git` stays clean. PR-range and staged scans never see these.
+  "4d8980588ff0952a60caa22ccf08465c4d3a7f0d",
+]

--- a/docs/content/standards.md
+++ b/docs/content/standards.md
@@ -332,6 +332,28 @@ the design-token sweeps (S1). The raw `console.*` count overstates the work:
 most of it is the keep-console contexts above; the real target is runtime
 library logging, concentrated in `core`.
 
+### Secret scanning (S7)
+
+Committed credentials are blocked by [gitleaks](https://github.com/gitleaks/gitleaks),
+run deterministically (tool-only, no model-assisted checks) in two places:
+
+- **lefthook pre-commit** — `gitleaks git --staged` scans the staged diff before
+  the commit lands. Local-only and best-effort: if gitleaks isn't installed it
+  warns and skips (CI is the hard gate). Install with `brew install gitleaks`.
+- **CI (`on-pull-request`)** — the `Secret Scan (gitleaks)` job installs a pinned
+  gitleaks and scans the PR commit range (`merge-base..HEAD`). A finding fails
+  the PR.
+
+Both runs pass `--redact`, so a matched secret is never printed to logs (org
+secret-handling policy). Real secrets belong in Warden, never in the repo.
+
+**Config + allowlist.** `.gitleaks.toml` at the repo root is the single source of
+truth: it extends gitleaks' default rules (`useDefault = true`) and allowlists
+justified false positives (build artifacts under `dist/`, the lockfile, `*.test.`
+/`*.spec.` fixtures that embed deliberate dummy keys, and the legacy
+initial-import commit). Add new exclusions there with a justification comment —
+never disable the scan.
+
 ---
 
 ## 8. UI packaging (Svelte)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -93,6 +93,25 @@ pre-commit:
         Fix the issues above, or run:
           pnpm knowledge:check --changed --strict --format markdown
 
+    secret-scan:
+      # Block committed secrets (Sweep S7, #1412). Scans only the staged diff via
+      # gitleaks; --redact keeps any match out of the terminal. Best-effort
+      # locally: if gitleaks isn't installed we warn and continue (CI is the hard
+      # gate). Install: brew install gitleaks. Allowlist lives in .gitleaks.toml.
+      run: |
+        if command -v gitleaks >/dev/null 2>&1; then
+          gitleaks git --staged --redact --no-banner -c .gitleaks.toml
+        else
+          echo "⚠️  gitleaks not installed — skipping local secret scan (CI still enforces)."
+          echo "    Install: brew install gitleaks  (https://github.com/gitleaks/gitleaks)"
+        fi
+      fail_text: |
+        ❌ Potential secret detected in staged changes!
+
+        gitleaks flagged a possible credential. Remove it and store the value in
+        Warden instead. If it is a genuine false positive, add a justified
+        allowlist entry to .gitleaks.toml.
+
 # Check formatting before push
 pre-push:
   commands:


### PR DESCRIPTION
## Sweep S7 — secret scanning (gitleaks)

Closes #1412. Adds deterministic, tool-only secret scanning (no model-assisted checks per AGENTS.md) in two places.

### What changed
- **`.gitleaks.toml`** — root config. Extends gitleaks' default rules (`useDefault = true`) and allowlists justified false positives:
  - `dist/` build artifacts, `pnpm-lock.yaml`, and `*.test.`/`*.spec.` fixtures (which deliberately embed dummy keys);
  - the initial-import commit `4d8980588f`, whose 4 `generic-api-key` matches live in the now-removed legacy `packages/smrt/` tree (a dist chunk, `sanitizer.test.ts` fixtures, a placeholder in `utils.ts`).
- **lefthook pre-commit** (`secret-scan`) — `gitleaks git --staged --redact`. Best-effort locally: warns + skips if gitleaks isn't installed (CI is the hard gate).
- **CI** (`on-pull-request` → `Secret Scan (gitleaks)`) — installs a pinned gitleaks (8.30.1) and scans the PR commit range `merge-base..HEAD`. A finding fails the PR.
- **docs/content/standards.md §7** — documents the policy + allowlist mechanism.

Both runs pass `--redact`, so any matched secret never reaches the logs (org secret-handling policy).

### Acceptance criteria (#1412)
- [x] gitleaks runs in lefthook pre-commit
- [x] gitleaks runs as a CI gate on PRs
- [x] Config + allowlist committed; known false positives baselined
- [x] Proven to catch a planted test secret

### Verification
- Full-history scan with config → **0 leaks** (baseline clean).
- High-entropy planted secret in a normal `.ts` → caught (**exit 1**) via both the staged path and the CI `--log-opts` PR-range path.
- Example keys (`AKIA…EXAMPLE`), low-entropy tokens, and `.test.ts` fixtures correctly allowlisted.
- `yamllint` + `actionlint` pass on the workflow; all pre-push gates green.

Next: S8 (#1413) dependency-vuln gate — note `pnpm audit` currently reports 25 high + 2 critical (all transitive), so that one needs triage/baselining rather than a clean flip.