### PR TITLE
fix(products): typecheck clean + make repo typecheck gate unfiltered (S3, #1375)

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -90,15 +90,12 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Blocking gate. Every package ships a `typecheck` script and the whole
-      # repo is green EXCEPT smrt-products, which has pre-existing type errors
-      # in its standalone/federation app-mode entry files (Vite virtual
-      # modules, Bun globals, untyped store callbacks). It still ships a
-      # `typecheck` script so the standards check passes; it is filtered out of
-      # the blocking gate until remediated. TODO(#1370): drop this filter once
-      # smrt-products typechecks clean.
+      # Blocking gate (Sweep S3, #1375). Every package ships a `typecheck` script
+      # and the whole repo — products included — typechecks clean under root
+      # `strict: true`. No package is filtered out; a type error anywhere fails
+      # the PR.
       - name: Run typecheck
-        run: pnpm turbo run typecheck --filter='!@happyvertical/smrt-products'
+        run: pnpm turbo run typecheck
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/packages/products/ambient.d.ts
+++ b/packages/products/ambient.d.ts
@@ -1,0 +1,46 @@
+/**
+ * Ambient declarations for the SMRT Vite plugin's virtual modules.
+ *
+ * The plugin serves these under the `@happyvertical/smrt-virt-*` names at build
+ * time, so plain `tsc` can't resolve them and the standalone/federation
+ * entrypoints (`main.ts`, `client.ts`) fail to typecheck. Alias each to the
+ * generated `@smrt/*` declarations (`src/lib/types/smrt-generated/`, produced by
+ * `npm run generate`) so the demo entrypoints stay type-checked against the real
+ * shapes.
+ */
+declare module '@happyvertical/smrt-virt-client' {
+  export * from '@smrt/client';
+  export { default } from '@smrt/client';
+}
+
+declare module '@happyvertical/smrt-virt-types' {
+  export * from '@smrt/types';
+}
+
+declare module '@happyvertical/smrt-virt-manifest' {
+  export * from '@smrt/manifest';
+  export { default } from '@smrt/manifest';
+}
+
+declare module '@happyvertical/smrt-virt-mcp' {
+  export * from '@smrt/mcp';
+  export { default } from '@smrt/mcp';
+}
+
+declare module '@happyvertical/smrt-virt-routes' {
+  export * from '@smrt/routes';
+}
+
+/**
+ * Minimal `Bun` global for the standalone Bun demo server (`simple-server.ts`).
+ * Declared narrowly here rather than via `@types/bun` so Bun's global overrides
+ * (fetch/Response/etc.) don't pollute the browser/DOM (`main.ts`) and Node
+ * (`simple-api-server.ts`) entrypoints that share this package's single tsconfig.
+ */
+declare const Bun: {
+  serve(options: {
+    port?: number;
+    hostname?: string;
+    fetch(request: Request): Response | Promise<Response>;
+  }): { port: number };
+};

--- a/packages/products/package.json
+++ b/packages/products/package.json
@@ -52,9 +52,12 @@
     "@happyvertical/logger": "catalog:",
     "@happyvertical/smrt-assets": "workspace:*",
     "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-scanner": "workspace:*",
     "@happyvertical/smrt-tenancy": "workspace:*",
     "@happyvertical/sql": "catalog:",
-    "@happyvertical/utils": "catalog:"
+    "@happyvertical/utils": "catalog:",
+    "cors": "^2.8.5",
+    "express": "^5.2.1"
   },
   "peerDependencies": {
     "svelte": "^5.46.4"
@@ -69,6 +72,7 @@
     "@sveltejs/package": "^2.5.7",
     "@sveltejs/vite-plugin-svelte": "^6.2.4",
     "@types/cors": "2.8.19",
+    "@types/express": "^5.0.0",
     "@types/node": "25.0.9",
     "@happyvertical/smrt-vitest": "workspace:*",
     "concurrently": "^9.2.1",
@@ -85,6 +89,7 @@
     "dev:federation": "vite dev --mode federation --port 3002",
     "dev:library": "vite build --mode library --watch",
     "generate": "node scripts/generate-smrt-types.js",
+    "typecheck": "npm run generate && tsc --noEmit -p tsconfig.json",
     "build": "npm run build:lib",
     "build:all": "npm run clean && npm run generate && npm run build:lib && npm run build:app && npm run build:federation",
     "build:lib": "vite build --mode library && svelte-package -i src/lib/components -o dist/lib/lib/components --tsconfig tsconfig.svelte.json && svelte-package -i src/lib/features -o dist/lib/lib/features --tsconfig tsconfig.svelte.json && svelte-package -i src/lib/stores -o dist/lib/lib/stores --tsconfig tsconfig.svelte.json",

--- a/packages/products/src/mcp.ts
+++ b/packages/products/src/mcp.ts
@@ -30,7 +30,7 @@ async function generateMCPServer() {
   );
 
   // Generate tools to preview what will be available
-  const tools = generator.generateTools();
+  const tools = await generator.generateTools();
   console.log(`📝 Discovered ${tools.length} tools from SMRT objects:`);
   tools.forEach((tool) => {
     console.log(`   - ${tool.name}: ${tool.description}`);

--- a/packages/products/src/simple-server.ts
+++ b/packages/products/src/simple-server.ts
@@ -35,7 +35,7 @@ const server = Bun.serve({
         exclude: [],
       });
       const { resolved } = await scanner.scanAndResolve();
-      const manifest = ManifestAdapter.toManifest(resolved);
+      const manifest = new ManifestAdapter().toManifest(resolved);
       const generator = new ManifestGenerator();
 
       // Root - show discovered objects

--- a/packages/products/tsconfig.json
+++ b/packages/products/tsconfig.json
@@ -11,6 +11,10 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true
   },
-  "include": ["src/**/*", "src/lib/types/smrt-generated/**/*.d.ts"],
+  "include": [
+    "src/**/*",
+    "ambient.d.ts",
+    "src/lib/types/smrt-generated/**/*.d.ts"
+  ],
   "exclude": ["**/*.test.ts", "**/*.spec.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1476,6 +1476,9 @@ importers:
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
+      '@happyvertical/smrt-scanner':
+        specifier: workspace:*
+        version: link:../scanner
       '@happyvertical/smrt-tenancy':
         specifier: workspace:*
         version: link:../tenancy
@@ -1485,6 +1488,12 @@ importers:
       '@happyvertical/utils':
         specifier: ^0.74.4
         version: 0.74.4
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.6
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
     devDependencies:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
@@ -1501,6 +1510,9 @@ importers:
       '@types/cors':
         specifier: 2.8.19
         version: 2.8.19
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
       '@types/node':
         specifier: 24.10.9
         version: 24.10.9
@@ -5451,6 +5463,9 @@ packages:
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -5472,11 +5487,20 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
   '@types/http-cache-semantics@4.2.0':
     resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/jsdom@21.1.7':
     resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
@@ -5499,11 +5523,23 @@ packages:
   '@types/pluralize@0.0.33':
     resolution: {integrity: sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==}
 
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
@@ -13266,6 +13302,11 @@ snapshots:
 
   '@types/argparse@1.0.38': {}
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 24.10.9
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -13287,11 +13328,26 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 24.10.9
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
 
   '@types/http-cache-semantics@4.2.0': {}
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/jsdom@21.1.7':
     dependencies:
@@ -13321,10 +13377,23 @@ snapshots:
 
   '@types/pluralize@0.0.33': {}
 
+  '@types/qs@6.15.1': {}
+
+  '@types/range-parser@1.2.7': {}
+
   '@types/retry@0.12.0': {}
 
   '@types/sax@1.2.7':
     dependencies:
+      '@types/node': 24.10.9
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 24.10.9
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
       '@types/node': 24.10.9
 
   '@types/tedious@4.0.14':

--- a/scripts/check-standards.mjs
+++ b/scripts/check-standards.mjs
@@ -72,10 +72,6 @@ const EXEMPTIONS = {
   noTypecheckScript: new Set([
     'template-sveltekit',
     'template-site-static-json',
-    // TODO(#1370): products is the triple-consumption reference; its app-mode
-    // entry files (Vite virtual modules, Bun globals, runes) don't resolve under
-    // plain tsc. Re-add a typecheck script once #1370 makes it green.
-    'products',
   ]),
 };
 


### PR DESCRIPTION
## Sweep S3 — typecheck gate (now truly repo-wide)

Closes #1375.

### Reframing
The issue's premise (24 packages missing a `typecheck` script) was **stale** — the rollout already happened incrementally. A survey found only 3 packages without one: `template-sveltekit` and `template-site-static-json` (documented carve-outs in standards.md §2 — their typecheck obligation lives in the scaffolded `template/package.json`), and **`products`**. So the real remaining work was the one blocker that's kept the CI gate non-comprehensive: `products`' pre-existing type errors (the typecheck half of #1370), which were filtered out via `--filter='!@happyvertical/smrt-products'`.

### What changed — products typechecks clean (62 → 0 errors)
All errors were in the standalone/federation/Bun **app-mode entrypoints**, not the library surface:
- **Virtual modules** — app code imports the canonical `@happyvertical/smrt-virt-*` modules the Vite plugin serves at build time; plain `tsc` can't resolve them. Added a committed `ambient.d.ts` aliasing them to the generated `@smrt/*` declarations (real type safety, not `any`).
- **Two real bugs fixed:** `mcp.ts` called `generator.generateTools()` without `await` (`.length`/`.forEach` on a `Promise`); `simple-server.ts` called `ManifestAdapter.toManifest()` **statically** on an instance method (would throw at runtime). Fixing the latter cascaded away 18 `unknown` errors once `manifest` got its real type.
- **Missing deps declared:** `@happyvertical/smrt-scanner` (workspace), `express` + `@types/express`, `cors` — previously phantom/untyped.
- **Bun** scoped via a narrow ambient `declare const Bun` (not global `@types/bun`, which would pollute the DOM/Node entrypoints sharing products' single tsconfig).
- `ambient.d.ts` lives at package root (matching every other package's convention — `src/**/*.d.ts` is gitignored for generated output).

### Gate hardening
- Removed `products` from the `noTypecheckScript` allowlist in `scripts/check-standards.mjs`.
- Removed the `--filter='!@happyvertical/smrt-products'` from the CI typecheck job — it now runs `pnpm turbo run typecheck` across **all** packages.

### Acceptance criteria (#1375)
- [x] Every package has a `typecheck` script (49 pkgs; 2 documented template carve-outs)
- [x] `turbo typecheck` runs in CI as a blocking gate (now unfiltered)
- [x] `check-standards.mjs` asserts the `typecheck` script exists
- [x] Repo typechecks clean under root `strict: true`

### Verification
- `pnpm turbo run typecheck` (unfiltered): **78/78 tasks green** (tsc + svelte-check, products included).
- `node scripts/check-standards.mjs`: 49 packages, 0 violations.

Note: this completes the typecheck portion of #1370 (products rubric audit); other #1370 items remain.