### PR TITLE
ci: forbid per-package lint/format scripts in check-standards (S2, #1374)

### DIFF
--- a/docs/content/standards.md
+++ b/docs/content/standards.md
@@ -123,7 +123,7 @@ See [§11](#11-forbidden-artifacts) for the full list.
   - `@types/node` always `catalog:`
   - `vite`, `vitest`, `vite-plugin-dts`, `typescript` come from root devDependencies — do not redeclare per-package unless overriding
   - Pinning style: prefer caret (`^X.Y.Z`) for third-party deps; exact pins (`X.Y.Z`) only for tools where minor bumps cause breakage (document why)
-- **Scripts**: every package has `build`, `build:watch`, `dev`, `clean`, `test`, `test:watch`, `typecheck`, `prepack`, `verify:pack`. No `lint` or `format` scripts — those are root-level via Biome. The presence of `typecheck` is enforced by `scripts/check-standards.mjs`; the only carve-outs are the plain-JS template wrappers (`template-sveltekit`, `template-site-static-json`), whose typecheck obligation lives in their scaffolded `template/package.json` (see §10).
+- **Scripts**: every package has `build`, `build:watch`, `dev`, `clean`, `test`, `test:watch`, `typecheck`, `prepack`, `verify:pack`. **No `lint` or `format` scripts** — those are root-level Biome tasks only (`turbo lint` / `biome ci` / `npm run format-check`), which already gate every package on PRs; `scripts/check-standards.mjs` **forbids** per-package `lint`/`lint:fix`/`format`/`format-check` scripts so drift back to them is caught (S2, #1374). The presence of `typecheck` is likewise enforced by `scripts/check-standards.mjs`; the only carve-outs are the plain-JS template wrappers (`template-sveltekit`, `template-site-static-json`), whose typecheck obligation lives in their scaffolded `template/package.json` (see §10).
 - **`peerDependencies`**:
   - Svelte peer always `svelte: ^5.18.0` for packages shipping UI
   - Optional peers explicitly marked in `peerDependenciesMeta`

--- a/scripts/check-standards.mjs
+++ b/scripts/check-standards.mjs
@@ -296,6 +296,24 @@ function checkPackage(name) {
     }
   }
 
+  // 9. No per-package lint/format scripts (Sweep S2, #1374). Lint and format
+  //    are root-level Biome tasks (`turbo lint`, `biome ci`, `npm run
+  //    format-check`) that already gate every package on PRs. Per-package
+  //    `lint`/`format` scripts are anti-standard — they drift from the single
+  //    Biome config and create inconsistent local behavior. See
+  //    docs/content/standards.md §7.
+  if (json.scripts) {
+    for (const key of ['lint', 'lint:fix', 'format', 'format-check']) {
+      if (typeof json.scripts[key] === 'string') {
+        violations.push(
+          `scripts.${key} is forbidden — lint/format are root-level Biome ` +
+            'tasks only (turbo lint / biome ci / npm run format-check). ' +
+            'Remove the per-package script.',
+        );
+      }
+    }
+  }
+
   return violations;
 }
 


### PR DESCRIPTION
## Sweep S2 — enforce root-level Biome lint/format

Closes #1374.

Per the issue's reframing (after PR #1419): the original "add a lint script to every package" premise was wrong — lint and format are **root-level Biome tasks** (`turbo lint`, `biome ci`, `npm run format-check`) that already gate every package on PRs. Per-package `lint`/`format` scripts are anti-standard. So the real work is enforcement completeness.

### What changed
- **`scripts/check-standards.mjs`** — new check #9: fails any package declaring a `lint`, `lint:fix`, `format`, or `format-check` script, so drift back to per-package tooling is caught.
- **docs/content/standards.md §2** — strengthened the existing note: lint/format are root-level only, and the prohibition is now *enforced* (not just stated).

### Acceptance criteria (#1374)
- [x] Root Biome lint/format confirmed to cover every package as a blocking PR gate — `biome.json` `files.includes` globs `packages/*/src/**` etc., and the CI `Lint` job runs `turbo lint` + `npm run format-check` (test-suite.yml).
- [x] `check-standards.mjs` fails any package declaring a `lint`/`format` script
- [x] Rubric/standards note: lint+format are root-level only

### Verification
- `node scripts/check-standards.mjs`: **49 packages, 0 violations** (no package currently declares lint/format — pure drift-prevention).
- Drift test: temporarily adding `scripts.lint` to a package is correctly flagged (`scripts.lint is forbidden …`), then clean again on revert.