### PR TITLE
ci: add knowledge-freshness PR gate (S5, #1376)

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -131,6 +131,41 @@ jobs:
       - name: Format check
         run: pnpm run format-check
 
+  knowledge:
+    name: Knowledge Freshness
+    needs: build
+    runs-on: arc-happyvertical
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+        with:
+          node-version: '24'
+          install-deps: 'true'
+          setup-playwright: 'false'
+          registry-url: 'https://npm.pkg.github.com'
+          auth-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build first so the per-package domain-knowledge artifacts
+      # (.smrt/ or dist/smrt-knowledge.json) exist with source hashes matching
+      # this commit; the freshness check compares those hashes against the
+      # current package.json / AGENTS.md / manifest.
+      - name: Restore build from cache
+        run: pnpm run build
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Sweep S5 (#1376): blocking gate. Fails on stale agent docs, dangling
+      # references, missing package docs, or drifted domain-knowledge artifacts.
+      - name: Check SMRT knowledge freshness
+        run: pnpm knowledge:check --strict --format markdown
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   test-core:
     name: Test Core (${{ matrix.shard }})
     needs: build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ From [@happyvertical/sdk](https://github.com/happyvertical/sdk): `@happyvertical
 - `smrt knowledge:review-context` and `smrt knowledge:architecture-context`
   build domain-scoped prompt bundles. Use `--scope project|local|package|sdk`
   and `--package <name>` to narrow context.
-- Lefthook runs deterministic knowledge freshness locally: changed-file strict checks on pre-commit and full strict checks on pre-push. Model-assisted audits are never required in hooks or CI.
+- Lefthook runs deterministic knowledge freshness locally: changed-file strict checks on pre-commit and full strict checks on pre-push. CI runs the full strict check as a blocking PR gate (the `Knowledge Freshness` job, sweep S5 #1376). Model-assisted audits are never required in hooks or CI.
 - `smrt-dev-mcp` exposes the same knowledge through `reflect-knowledge`, `reflect-domain-knowledge`, `check-knowledge-freshness`, `check-domain-knowledge`, `build-review-context`, `build-domain-review-context`, `smrt-review`, `build-architecture-context`, `build-domain-architecture-context`, and `smrt-architecture`.
 - `smrt-dev-mcp` also ships harness-agnostic skills. Downstream agents can call `get-agent-skill` with `name: "smrt-code-review"` to fetch the portable review procedure before using `smrt-review` on a project diff.
 


### PR DESCRIPTION
## Sweep S5 — AGENTS.md/CLAUDE.md enforcement + knowledge-check gate

Closes #1376.

Per the issue's reframing, the per-package docs convention is **already satisfied** (all packages ship `AGENTS.md` + a one-line `CLAUDE.md` shim), and the assertion **already exists** in `scripts/check-standards.mjs` (AGENTS.md presence + `CLAUDE.md` must equal `@AGENTS.md`, lines 240–253). The only missing piece was making knowledge-check a CI gate — it ran only in lefthook (pre-commit `--changed`, pre-push full) but not in CI.

### What changed
- **`test-suite.yml`** — new `Knowledge Freshness` job (mirrors the `lint` job): `needs: build`, restores the build, then runs `pnpm knowledge:check --strict --format markdown` as a blocking gate. Fails on stale agent docs, dangling references, missing package docs, or drifted domain-knowledge artifacts.
- **`AGENTS.md`** — updated the knowledge-freshness note to mention the new CI gate (it previously implied local-only).

### Why build-then-check
Staleness is **hash-based**: each package's domain-knowledge artifact (`.smrt/` preferred, else the turbo-cached `dist/smrt-knowledge.json`) records source hashes of `package.json`/`AGENTS.md`/`manifest`. Building in the same CI run produces artifacts whose hashes match the checked-out commit, so the gate is meaningful rather than trivially stale.

### Acceptance criteria (#1376)
- [x] check-standards asserts AGENTS.md present + CLAUDE.md is the one-line shim (pre-existing, verified)
- [x] `smrt dev:knowledge-check` runs as a blocking PR gate (new `Knowledge Freshness` job)
- [x] Any package failing the assertion is fixed (all 49 packages already pass)

### Verification
- Survey: all packages have `AGENTS.md` + exact `@AGENTS.md` `CLAUDE.md` shim; `check-standards` → 0 violations.
- `pnpm knowledge:check --strict` (the exact gate command) after a clean build → **0 errors, 0 warnings**.
- `yamllint` + `actionlint` pass on the workflow.