### PR TITLE
ci: add per-tier coverage gate on touched packages (S6, #1411)

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -166,6 +166,44 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  coverage-gate:
+    name: Coverage Gate
+    needs: build
+    runs-on: arc-happyvertical
+    timeout-minutes: 25
+
+    steps:
+      # fetch-depth: 0 so the gate can diff against the PR base to find the
+      # packages this PR touches.
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+        with:
+          node-version: '24'
+          install-deps: 'true'
+          setup-playwright: 'false'
+          registry-url: 'https://npm.pkg.github.com'
+          auth-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Restore build from cache
+        run: pnpm run build
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Sweep S6 (#1411): per-tier line-coverage floors (T1 80 / T2 70 / T3 50)
+      # on the packages this PR touches. Blocks regressions below the floor
+      # without forcing repo-wide uplift (that uplift is Wave 3). Floors + tier
+      # assignments mirror docs/content/PRODUCTION_READINESS.md.
+      - name: Per-tier coverage gate (touched packages)
+        run: node scripts/check-coverage.mjs
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   test-core:
     name: Test Core (${{ matrix.shard }})
     needs: build

--- a/docs/content/PRODUCTION_READINESS.md
+++ b/docs/content/PRODUCTION_READINESS.md
@@ -63,8 +63,10 @@ one tier; the dimension table states what each tier must satisfy.
 A PR that touches a package must bring that package to **at or above its tier floor**
 to merge — existing debt is not grandfathered. This is intentionally strict: the
 point of the stabilize phase is that you cannot add to a package without leaving it at
-standard. Enforcement lands with the coverage gate (sweep S6, #1411); until S6 ships,
-under-floor packages get a remediation runway via Wave 3.
+standard. Enforced by the coverage gate (sweep S6, #1411): the `Coverage Gate` CI job
+runs `scripts/check-coverage.mjs`, which measures per-package line coverage for the
+packages a PR touches and fails any below its tier floor. Under-floor packages a PR
+does not touch are not blocked; bringing them to floor is Wave 3 remediation.
 
 ## Dimensions
 
@@ -199,7 +201,7 @@ checks in hooks/CI — see AGENTS.md):
   off → warn → error, package by package, until the blanket override is deleted.
 - **Design tokens** → add a Biome (root) lint rule banning raw color literals in
   `.svelte`/`.css`, wired into root Biome + lefthook + CI (#1373).
-- **Coverage** → HARD floor: any package touched by a PR must be ≥ its tier floor (T1 80 / T2 70 / T3 50) to merge — no grandfathering. Enforced once the coverage gate (S6) lands.
+- **Coverage** → HARD floor: any package touched by a PR must be ≥ its tier floor (T1 80 / T2 70 / T3 50) to merge — no grandfathering. Enforced by the `Coverage Gate` CI job (`scripts/check-coverage.mjs`, S6 #1411).
 - **Secret scanning** → gitleaks in lefthook pre-commit + CI; blocks committed credentials.
 - **Dependency risk** → `pnpm audit` / osv-scanner as a CI check for known-vuln deps.
 - **Security/correctness lint** → promote Biome security rules to errors (ban `eval`, unsafe patterns) within the strictness ratchet.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "check:radius": "node scripts/check-radius.mjs",
     "check:elevation": "node scripts/check-elevation.mjs",
     "check:typography": "node scripts/check-typography.mjs",
+    "check:coverage": "node scripts/check-coverage.mjs",
     "knowledge:check": "tsx scripts/check-knowledge.ts",
     "changeset": "changeset",
     "changeset:auto": "npx tsx scripts/auto-changeset.ts",

--- a/scripts/check-coverage.mjs
+++ b/scripts/check-coverage.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+/**
+ * Per-tier test coverage gate (Sweep S6, #1411).
+ *
+ * Enforces the Production Readiness Rubric's per-tier line-coverage floors on the
+ * packages a PR *touches* — so it blocks regressions below the floor without
+ * forcing a repo-wide uplift (that uplift is Wave 3, off each package audit's
+ * dim-4 finding). The floor is a HARD floor: a touched package must measure at or
+ * above its tier floor to pass, no grandfathering.
+ *
+ * Floors + tier assignments are the machine-readable mirror of
+ * docs/content/PRODUCTION_READINESS.md §Tiers — keep the two in sync.
+ *
+ * Usage:
+ *   node scripts/check-coverage.mjs                 # touched packages vs BASE_REF (CI)
+ *   node scripts/check-coverage.mjs --packages a,b  # explicit list (local / manual)
+ *   BASE_REF=main node scripts/check-coverage.mjs   # override the diff base
+ *
+ * Measurement: per-package `vitest run --coverage` (v8) with the json-summary
+ * reporter; the gate reads total line coverage from coverage/coverage-summary.json.
+ *
+ * All subprocess calls use execFileSync with array args (no shell) so the
+ * branch-name base ref can't be interpreted as a shell command.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const PKGS = join(ROOT, 'packages');
+
+const FLOORS = { T1: 80, T2: 70, T3: 50 };
+
+// Tier assignments — mirror of docs/content/PRODUCTION_READINESS.md §Tiers.
+// Package directory name → tier. `types` is coverage-waived (zero-runtime).
+// Packages absent from this map are "untiered": skipped with a warning until a
+// tier is ratified for them (gnode/subscriptions/templates/etc.).
+const TIERS = {
+  // T1 Foundation (80%)
+  cli: 'T1',
+  config: 'T1',
+  core: 'T1',
+  scanner: 'T1',
+  tenancy: 'T1',
+  vitest: 'T1',
+  // T2 Mature domain (70%)
+  agents: 'T2',
+  assets: 'T2',
+  chat: 'T2',
+  commerce: 'T2',
+  content: 'T2',
+  jobs: 'T2',
+  ledgers: 'T2',
+  messages: 'T2',
+  profiles: 'T2',
+  secrets: 'T2',
+  'smrt-svelte': 'T2',
+  users: 'T2',
+  // T3 Light domain (50%)
+  ads: 'T3',
+  affiliates: 'T3',
+  analytics: 'T3',
+  'app-cli': 'T3',
+  'assets-ergot': 'T3',
+  'assets-local': 'T3',
+  events: 'T3',
+  facts: 'T3',
+  features: 'T3',
+  images: 'T3',
+  inventory: 'T3',
+  languages: 'T3',
+  manufacturing: 'T3',
+  places: 'T3',
+  products: 'T3',
+  projects: 'T3',
+  prompts: 'T3',
+  properties: 'T3',
+  sites: 'T3',
+  'smrt-dev-mcp': 'T3',
+  social: 'T3',
+  tags: 'T3',
+  video: 'T3',
+  voice: 'T3',
+};
+// Coverage-waived packages (zero-runtime). See rubric footnote †.
+const WAIVED = new Set(['types']);
+
+function flagValue(name) {
+  const i = process.argv.indexOf(name);
+  return i !== -1 ? process.argv[i + 1] : undefined;
+}
+
+function git(args, opts = {}) {
+  return execFileSync('git', args, { cwd: ROOT, encoding: 'utf8', ...opts });
+}
+
+/** Packages whose files changed vs the PR base, via `git diff`. */
+function touchedPackagesFromGit() {
+  const baseRef = process.env.BASE_REF || 'main';
+  let range;
+  try {
+    // Ensure the base is present (CI checkouts can be shallow), then diff.
+    try {
+      git(['fetch', 'origin', baseRef, '--depth=200'], { stdio: 'ignore' });
+    } catch {
+      // best-effort; the ref may already be local
+    }
+    const base = git(['merge-base', `origin/${baseRef}`, 'HEAD']).trim();
+    range = `${base}...HEAD`;
+  } catch {
+    range = `origin/${baseRef}...HEAD`;
+  }
+  const out = git(['diff', '--name-only', range]);
+  const pkgs = new Set();
+  for (const line of out.split('\n')) {
+    const m = line.match(/^packages\/([^/]+)\//);
+    if (m) pkgs.add(m[1]);
+  }
+  return [...pkgs];
+}
+
+/** Run vitest coverage for one package and return total line coverage %, or null. */
+function measureLineCoverage(pkg) {
+  const cwd = join(PKGS, pkg);
+  try {
+    execFileSync(
+      'pnpm',
+      [
+        'exec',
+        'vitest',
+        'run',
+        '--coverage',
+        '--coverage.reporter=json-summary',
+        '--coverage.reporter=text',
+      ],
+      { cwd, stdio: 'inherit', env: { ...process.env, NODE_ENV: 'test' } },
+    );
+  } catch {
+    // Non-zero exit (failing/zero tests). Fall through to read any summary; if
+    // none exists the package is treated as uncovered (gate fails).
+  }
+  const summaryPath = join(cwd, 'coverage', 'coverage-summary.json');
+  if (!existsSync(summaryPath)) return null;
+  try {
+    const summary = JSON.parse(readFileSync(summaryPath, 'utf8'));
+    return summary.total?.lines?.pct ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function main() {
+  const explicit = flagValue('--packages');
+  const touched = explicit
+    ? explicit
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : touchedPackagesFromGit();
+
+  if (touched.length === 0) {
+    console.log('✓ coverage-gate: no packages touched — nothing to check.');
+    return;
+  }
+
+  const checked = [];
+  const skipped = [];
+  for (const pkg of touched.sort()) {
+    if (!existsSync(join(PKGS, pkg))) continue; // deleted dir
+    if (WAIVED.has(pkg)) {
+      skipped.push(`${pkg} (coverage waived)`);
+      continue;
+    }
+    const tier = TIERS[pkg];
+    if (!tier) {
+      skipped.push(`${pkg} (untiered — no ratified floor)`);
+      continue;
+    }
+    checked.push({ pkg, tier, floor: FLOORS[tier] });
+  }
+
+  for (const line of skipped) console.log(`• skipped: ${line}`);
+  if (checked.length === 0) {
+    console.log('✓ coverage-gate: no tiered packages to check.');
+    return;
+  }
+
+  const failures = [];
+  const results = [];
+  for (const { pkg, tier, floor } of checked) {
+    console.log(`\n── measuring coverage: ${pkg} (${tier}, floor ${floor}%) ──`);
+    const pct = measureLineCoverage(pkg);
+    if (pct === null) {
+      failures.push({ pkg, tier, floor, pct: 'no coverage summary' });
+      results.push(`✗ ${pkg} (${tier}): no coverage produced (floor ${floor}%)`);
+      continue;
+    }
+    const ok = pct >= floor;
+    results.push(
+      `${ok ? '✓' : '✗'} ${pkg} (${tier}): ${pct.toFixed(2)}% (floor ${floor}%)`,
+    );
+    if (!ok) failures.push({ pkg, tier, floor, pct });
+  }
+
+  console.log('\n=== Per-tier coverage gate ===');
+  for (const r of results) console.log(`  ${r}`);
+
+  if (failures.length > 0) {
+    console.error(
+      `\n✗ coverage-gate: ${failures.length} package(s) below tier floor.\n` +
+        'A PR that touches a package must bring it to >= its tier floor\n' +
+        '(T1 80% / T2 70% / T3 50%). Add tests to the touched package(s).\n' +
+        'See docs/content/PRODUCTION_READINESS.md §Tiers.',
+    );
+    process.exit(1);
+  }
+  console.log(
+    `\n✓ coverage-gate: ${checked.length} package(s) at or above tier floor.`,
+  );
+}
+
+main();


### PR DESCRIPTION
## Sweep S6 — per-tier test coverage gate

Closes #1411. (Unblocked: #1355 — rubric/floors ratified — is closed.)

Enforces the Production Readiness Rubric's per-tier line-coverage floors (**T1 80% / T2 70% / T3 50%**) on the packages a PR **touches** — blocking regressions below the floor without forcing a repo-wide uplift (that uplift is Wave 3, off each package audit's dim-4 finding).

### What changed
- **`scripts/check-coverage.mjs`** — the gate. Detects touched packages from the PR diff (`BASE_REF`), runs `vitest run --coverage` (v8, json-summary) per touched tiered package, and fails any whose total line coverage is below its tier floor. `types` is coverage-waived; untiered packages (gnode/subscriptions/templates/…) are skipped with a warning. Supports `--packages a,b` for local/manual runs. All subprocess calls use `execFileSync` (no shell).
- **`test-suite.yml`** — new `Coverage Gate` job (`needs: build`, full checkout for diffing, build, then the script).
- **`docs/content/PRODUCTION_READINESS.md`** — flipped the coverage-floor policy from "enforced once S6 lands" to "enforced by the `Coverage Gate` job." Tier→floor mapping was already documented; the script mirrors it.
- **`package.json`** — `check:coverage` script.

### Tier source of truth
The script's `TIERS` map mirrors PRODUCTION_READINESS.md §Tiers (T1×6 runtime + waived `types`, T2×12, T3×24). Kept in sync via a comment on both sides.

### Acceptance criteria (#1411)
- [x] Per-tier thresholds configured (CI script)
- [x] Touched-package coverage gate runs in CI and blocks regressions below floor
- [x] Tier→floor mapping documented in PRODUCTION_READINESS.md
- [x] Gate proven to fail on a deliberately-undercovered sample, then pass clean

### Verification (local, via `--packages`)
- **Fails** below floor: `events` (T3) → **22.24%** < 50% → exit 1. (Untested files like `index.ts`/`utils.ts` correctly counted at 0%, so the measure is meaningful.)
- **Passes** at/above floor: `tags` (T3) 58.57%, `config` (T1) 89.47% → exit 0.
- Skips: `types` (waived) + `gnode` (untiered) → exit 0.
- This PR touches no `packages/*` files, so the gate finds 0 touched packages and passes trivially here.
- `yamllint` + `actionlint` pass on the workflow.

Note: per-package coverage-config tuning (e.g. `all`/include globs for `.svelte`-heavy packages) rides along with each package's Wave 3 uplift; the default v8 measure already counts untested source files.