### PR TITLE
fix(scanner)!: guard publish against manifests missing @smrt objects (#1483)

### DIFF
--- a/packages/scanner/AGENTS.md
+++ b/packages/scanner/AGENTS.md
@@ -7,6 +7,7 @@ AST-based scanner for discovering SMRT objects in TypeScript source. Uses oxc-pa
 - `ManifestBuilder` — scans source files, builds `SmartObjectManifest` (`.generate()`)
 - `discoverBaseClasses({ cwd })` — finds SMRT base classes in node_modules
 - `SmartObjectDefinition`, `FieldDefinition` — scanned class metadata types
+- `verifyManifestCompleteness({ packageDir })` — publish guard: re-scans `src/` and asserts every `@smrt()` object reached `dist/manifest.json` (issue #1483). Driven by `scripts/verify-manifest-completeness.mjs` from `prepack`.
 
 ## How It Works
 

--- a/packages/scanner/src/__tests__/manifest-adapter-conversion.test.ts
+++ b/packages/scanner/src/__tests__/manifest-adapter-conversion.test.ts
@@ -1,0 +1,384 @@
+import { describe, expect, it } from 'vitest';
+import { ManifestAdapter } from '../manifest-adapter.js';
+import type {
+  RawFieldDefinition,
+  RawMethodDefinition,
+  ResolvedClassDefinition,
+} from '../types.js';
+
+/**
+ * Field/method/collection conversion coverage for ManifestAdapter — the
+ * decorator-option, exclusion, and pluralization branches that the publish
+ * manifest depends on but the existing inferFieldType suite did not exercise.
+ */
+function field(
+  partial: Partial<RawFieldDefinition> & { name: string },
+): RawFieldDefinition {
+  return {
+    typeAnnotation: null,
+    initializer: null,
+    hasDecimalPoint: false,
+    numericValue: null,
+    decorators: [],
+    optional: false,
+    isStatic: false,
+    readonly: false,
+    accessibility: 'public',
+    line: 1,
+    ...partial,
+  };
+}
+
+function method(
+  partial: Partial<RawMethodDefinition> & { name: string },
+): RawMethodDefinition {
+  return {
+    async: false,
+    isStatic: false,
+    accessibility: 'public',
+    parameters: [],
+    returnType: null,
+    description: null,
+    line: 1,
+    ...partial,
+  };
+}
+
+function resolved(
+  partial: Partial<ResolvedClassDefinition> & { className: string },
+): ResolvedClassDefinition {
+  return {
+    filePath: '/fixture.ts',
+    extendsClause: 'SmrtObject',
+    extendsTypeArg: null,
+    decoratorConfig: {},
+    hasSmartDecorator: true,
+    fields: [],
+    methods: [],
+    startLine: 1,
+    endLine: 2,
+    inheritanceChain: [],
+    stiBase: null,
+    effectiveTableStrategy: 'cti',
+    isSTI: false,
+    isFrameworkBase: false,
+    allFields: [],
+    packageName: null,
+    ...partial,
+  };
+}
+
+describe('ManifestAdapter conversion', () => {
+  const adapter = new ManifestAdapter();
+
+  describe('convertField exclusions', () => {
+    it('drops non-public fields', () => {
+      expect(
+        adapter.convertField(
+          field({ name: 'secret', accessibility: 'private' }),
+        ),
+      ).toBeNull();
+      expect(
+        adapter.convertField(
+          field({ name: 'secret', accessibility: 'protected' }),
+        ),
+      ).toBeNull();
+    });
+
+    it('drops framework-internal fields', () => {
+      expect(adapter.convertField(field({ name: '_db' }))).toBeNull();
+      expect(adapter.convertField(field({ name: '_tableName' }))).toBeNull();
+    });
+
+    it('marks Function-typed fields as transient', () => {
+      const result = adapter.convertField(
+        field({ name: 'onSave', typeAnnotation: 'Function' }),
+      );
+      expect(result?.transient).toBe(true);
+    });
+
+    it('honours an explicit @field({ transient: true })', () => {
+      const result = adapter.convertField(
+        field({
+          name: 'computed',
+          typeAnnotation: 'string',
+          initializer: "''",
+          decorators: [{ name: 'field', arguments: ['{ transient: true }'] }],
+        }),
+      );
+      expect(result?.transient).toBe(true);
+    });
+  });
+
+  describe('@field numeric/string constraints', () => {
+    it('carries min/max/minLength/maxLength into the definition', () => {
+      const result = adapter.convertField(
+        field({
+          name: 'score',
+          typeAnnotation: 'number',
+          initializer: '0',
+          decorators: [
+            {
+              name: 'field',
+              arguments: ['{ min: 1, max: 10, minLength: 2, maxLength: 8 }'],
+            },
+          ],
+        }),
+      );
+      expect(result?.min).toBe(1);
+      expect(result?.max).toBe(10);
+      expect(result?.minLength).toBe(2);
+      expect(result?.maxLength).toBe(8);
+    });
+  });
+
+  describe('@field default/related/ignored-shape options', () => {
+    it('applies default and related from @field options', () => {
+      const result = adapter.convertField(
+        field({
+          name: 'parentId',
+          typeAnnotation: 'string',
+          decorators: [
+            {
+              name: 'field',
+              arguments: ['{ default: "root", related: "Node" }'],
+            },
+          ],
+        }),
+      );
+      expect(result?.default).toBe('root');
+      expect(result?.related).toBe('Node');
+    });
+
+    it('ignores a non-object @field argument', () => {
+      const result = adapter.convertField(
+        field({
+          name: 'label',
+          typeAnnotation: 'string',
+          initializer: "''",
+          decorators: [{ name: 'field', arguments: ['[1, 2, 3]'] }],
+        }),
+      );
+      // Array argument is not a valid options object → treated as plain text field.
+      expect(result?.type).toBe('text');
+    });
+  });
+
+  describe('@meta decorator', () => {
+    it('flags STI meta storage and preserves indexed/nullable options', () => {
+      const result = adapter.convertField(
+        field({
+          name: 'extra',
+          typeAnnotation: 'string',
+          decorators: [
+            { name: 'meta', arguments: ['{ indexed: true, nullable: true }'] },
+          ],
+        }),
+      );
+      expect(result?.type).toBe('meta');
+      expect(result?._meta?.indexed).toBe(true);
+      expect(result?._meta?.nullable).toBe(true);
+    });
+  });
+
+  describe('@crossPackageRef decorator', () => {
+    it('captures the qualified target and standard option metadata', () => {
+      const result = adapter.convertField(
+        field({
+          name: 'ownerId',
+          typeAnnotation: 'string',
+          decorators: [
+            {
+              name: 'crossPackageRef',
+              arguments: [
+                "'@happyvertical/smrt-profiles:Person'",
+                '{ nullable: true, unique: true, description: "owner" }',
+              ],
+            },
+          ],
+        }),
+      );
+      expect(result?.type).toBe('crossPackageRef');
+      expect(result?.related).toBe('@happyvertical/smrt-profiles:Person');
+      expect(result?._meta?.unique).toBe(true);
+      expect(result?._meta?.nullable).toBe(true);
+    });
+  });
+
+  describe('convertMethod', () => {
+    it('drops private/protected methods', () => {
+      expect(
+        adapter.convertMethod(
+          method({ name: 'helper', accessibility: 'private' }),
+        ),
+      ).toBeNull();
+      expect(
+        adapter.convertMethod(
+          method({ name: 'helper', accessibility: 'protected' }),
+        ),
+      ).toBeNull();
+    });
+
+    it('maps public methods with parameters, defaults, and return type', () => {
+      const result = adapter.convertMethod(
+        method({
+          name: 'rename',
+          async: true,
+          isStatic: true,
+          returnType: 'Promise<void>',
+          description: 'Rename the record',
+          parameters: [
+            {
+              name: 'next',
+              type: 'string',
+              optional: false,
+              defaultValue: "'x'",
+            },
+            {
+              name: 'force',
+              type: 'boolean',
+              optional: true,
+              defaultValue: null,
+            },
+          ],
+        }),
+      );
+      expect(result?.name).toBe('rename');
+      expect(result?.async).toBe(true);
+      expect(result?.isStatic).toBe(true);
+      expect(result?.returnType).toBe('Promise<void>');
+      expect(result?.parameters[0]).toMatchObject({
+        name: 'next',
+        default: 'x',
+      });
+      expect(result?.parameters[1]).toMatchObject({
+        name: 'force',
+        type: 'boolean',
+      });
+    });
+  });
+
+  describe('type inference heuristics without annotation', () => {
+    it('infers integer from a bare numeric literal', () => {
+      const result = adapter.convertField(
+        field({ name: 'count', initializer: '1', numericValue: 1 }),
+      );
+      expect(result?.type).toBe('integer');
+      expect(result?.default).toBe(1);
+    });
+
+    it('infers decimal from a bare decimal literal', () => {
+      const result = adapter.convertField(
+        field({
+          name: 'price',
+          initializer: '1.5',
+          numericValue: 1.5,
+          hasDecimalPoint: true,
+        }),
+      );
+      expect(result?.type).toBe('decimal');
+      expect(result?.default).toBe(1.5);
+    });
+
+    it('infers boolean from a bare boolean literal', () => {
+      const result = adapter.convertField(
+        field({ name: 'isRead', initializer: 'false' }),
+      );
+      expect(result?.type).toBe('boolean');
+      expect(result?.default).toBe(false);
+    });
+
+    it('unwraps Meta<T> annotations to a meta field with underlying type', () => {
+      const result = adapter.convertField(
+        field({ name: 'detail', typeAnnotation: 'Meta<number>' }),
+      );
+      expect(result?.type).toBe('meta');
+      expect(result?._meta?.underlyingType).toBe('integer');
+    });
+  });
+
+  describe('relationship decorators', () => {
+    it('captures @oneToMany related class and foreignKey', () => {
+      const result = adapter.convertField(
+        field({
+          name: 'items',
+          decorators: [
+            {
+              name: 'oneToMany',
+              arguments: ['Item', '{ foreignKey: "parent_id" }'],
+            },
+          ],
+        }),
+      );
+      expect(result?.type).toBe('oneToMany');
+      expect(result?.related).toBe('Item');
+      expect(result?._meta?.foreignKey).toBe('parent_id');
+    });
+
+    it('captures @manyToMany junction coordinates', () => {
+      const result = adapter.convertField(
+        field({
+          name: 'tags',
+          decorators: [
+            {
+              name: 'manyToMany',
+              arguments: [
+                'Tag',
+                '{ through: "widget_tags", sourceKey: "widget_id", targetKey: "tag_id" }',
+              ],
+            },
+          ],
+        }),
+      );
+      expect(result?.type).toBe('manyToMany');
+      expect(result?.related).toBe('Tag');
+      expect(result?._meta?.through).toBe('widget_tags');
+      expect(result?._meta?.sourceKey).toBe('widget_id');
+      expect(result?._meta?.targetKey).toBe('tag_id');
+    });
+  });
+
+  describe('static properties', () => {
+    const uiSlots = field({
+      name: 'uiSlots',
+      isStatic: true,
+      initializer: '{ main: ["card"] }',
+    });
+
+    it('captures own static uiSlots', () => {
+      const def = adapter.toSmartObjectDefinition(
+        resolved({
+          className: 'Widget',
+          fields: [uiSlots],
+          allFields: [uiSlots],
+        }),
+      );
+      expect(def.staticProperties?.uiSlots).toEqual({ main: ['card'] });
+    });
+
+    it('captures inherited static uiSlots not redeclared by the child', () => {
+      const def = adapter.toSmartObjectDefinition(
+        resolved({ className: 'Widget', fields: [], allFields: [uiSlots] }),
+      );
+      expect(def.staticProperties?.uiSlots).toEqual({ main: ['card'] });
+    });
+  });
+
+  describe('collection pluralization', () => {
+    const cases: Array<[string, string]> = [
+      ['City', 'cities'],
+      ['Box', 'boxes'],
+      ['Bus', 'buses'],
+      ['Dish', 'dishes'],
+      ['Watch', 'watches'],
+      ['Widget', 'widgets'],
+    ];
+
+    for (const [className, expected] of cases) {
+      it(`pluralizes ${className} -> ${expected}`, () => {
+        const def = adapter.toSmartObjectDefinition(resolved({ className }));
+        expect(def.collection).toBe(expected);
+      });
+    }
+  });
+});

--- a/packages/scanner/src/__tests__/scanner-api.test.ts
+++ b/packages/scanner/src/__tests__/scanner-api.test.ts
@@ -1,0 +1,129 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { OxcScanner, scanDirectory } from '../scanner.js';
+
+/**
+ * Public-API coverage for OxcScanner: the two-phase guards, cross-package import
+ * discovery, external-manifest registration, statistics, and the scanDirectory
+ * convenience wrapper.
+ */
+describe('OxcScanner API', () => {
+  let dir: string;
+
+  function write(rel: string, source: string): void {
+    const full = join(dir, rel);
+    mkdirSync(join(full, '..'), { recursive: true });
+    writeFileSync(full, source);
+  }
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'smrt-scanner-api-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('throws when resolve() runs before scan()', () => {
+    const scanner = new OxcScanner({ cwd: dir });
+    expect(() => scanner.resolve()).toThrow(/scan\(\) before resolve\(\)/);
+  });
+
+  it('throws when scanSmrtImports() runs before scan()', () => {
+    const scanner = new OxcScanner({ cwd: dir });
+    expect(() => scanner.scanSmrtImports()).toThrow(
+      /scan\(\) before scanSmrtImports\(\)/,
+    );
+  });
+
+  it('discovers and merges @happyvertical/smrt-* imports across files', async () => {
+    write(
+      'src/a.ts',
+      `import { Person } from '@happyvertical/smrt-profiles';\nexport const a = Person;\n`,
+    );
+    write(
+      'src/b.ts',
+      `import { Organization } from '@happyvertical/smrt-profiles';\nexport const b = Organization;\n`,
+    );
+    const scanner = new OxcScanner({ cwd: dir, include: ['src/**/*.ts'] });
+    await scanner.scan();
+
+    const imports = scanner.scanSmrtImports();
+    const profiles = imports.get('@happyvertical/smrt-profiles');
+    expect(profiles).toBeDefined();
+    expect(profiles?.has('Person')).toBe(true);
+    expect(profiles?.has('Organization')).toBe(true);
+  });
+
+  it('reports per-scan statistics', async () => {
+    write(
+      'src/widget.ts',
+      `import { smrt, SmrtObject } from '@happyvertical/smrt-core';\n@smrt()\nexport class Widget extends SmrtObject { name = ''; }\n`,
+    );
+    const scanner = new OxcScanner({ cwd: dir, include: ['src/**/*.ts'] });
+    await scanner.scan();
+
+    const stats = scanner.getStats();
+    expect(stats.fileCount).toBeGreaterThanOrEqual(1);
+    expect(stats.smrtClasses).toBeGreaterThanOrEqual(1);
+    expect(stats.parseTimeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('registers an external manifest for cross-package base resolution', async () => {
+    write(
+      'src/special.ts',
+      `@smrt()\nexport class Special extends BasePerson { nickname = ''; }\n`,
+    );
+    const scanner = new OxcScanner({ cwd: dir, include: ['src/**/*.ts'] });
+    scanner.addExternalManifest({
+      packageName: '@happyvertical/smrt-profiles',
+      packageVersion: '1.0.0',
+      classes: new Map([
+        [
+          'BasePerson',
+          {
+            className: 'BasePerson',
+            filePath: '',
+            extendsClause: null,
+            extendsTypeArg: null,
+            decoratorConfig: null,
+            hasSmartDecorator: true,
+            fields: [],
+            methods: [],
+            startLine: 0,
+            endLine: 0,
+          },
+        ],
+      ]),
+    });
+
+    const { resolved } = await scanner.scanAndResolve();
+    const special = resolved.find((c) => c.className === 'Special');
+    expect(special).toBeDefined();
+    expect(special?.inheritanceChain).toContain('BasePerson');
+  });
+
+  it('surfaces parse errors from scanned files', async () => {
+    write(
+      'src/broken.ts',
+      `@smrt()\nclass Broken extends SmrtObject {\n  name: string = // missing value\n}\n`,
+    );
+    const scanner = new OxcScanner({ cwd: dir, include: ['src/**/*.ts'] });
+    const results = await scanner.scan();
+    expect(results.errors.length).toBeGreaterThan(0);
+  });
+
+  it('scanDirectory() runs both phases against a directory', async () => {
+    write(
+      'src/widget.ts',
+      `import { smrt, SmrtObject } from '@happyvertical/smrt-core';\n@smrt()\nexport class Widget extends SmrtObject { name = ''; }\n`,
+    );
+    const { results, resolved } = await scanDirectory(dir, {
+      include: ['src/**/*.ts'],
+    });
+    expect(results.errors).toEqual([]);
+    expect(resolved.some((c) => c.className === 'Widget')).toBe(true);
+  });
+});

--- a/packages/scanner/src/__tests__/verify-completeness.test.ts
+++ b/packages/scanner/src/__tests__/verify-completeness.test.ts
@@ -112,6 +112,60 @@ export class Widget extends SmrtObject {
     expect(result.reason).toMatch(/does not publish a \.\/manifest/);
   });
 
+  it('skips when there is no package.json', async () => {
+    const result = await verifyManifestCompleteness({
+      packageDir: join(pkgDir, 'does-not-exist'),
+    });
+    expect(result.status).toBe('skipped');
+    expect(result.reason).toMatch(/no package.json/);
+  });
+
+  it('skips a manifest-publishing package with no @smrt objects in source', async () => {
+    // package.json declares ./manifest, but src has no @smrt() classes.
+    writeFileSync(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({
+        name: '@happyvertical/smrt-fixture',
+        version: '0.0.0',
+        exports: { './manifest': './dist/manifest.json' },
+      }),
+    );
+    mkdirSync(join(pkgDir, 'src'), { recursive: true });
+    writeFileSync(join(pkgDir, 'src', 'plain.ts'), 'export const x = 1;\n');
+
+    const result = await verifyManifestCompleteness({ packageDir: pkgDir });
+    expect(result.status).toBe('skipped');
+    expect(result.reason).toMatch(/no @smrt\(\) objects/);
+  });
+
+  it('resolves a conditional ./manifest export object', async () => {
+    writeFileSync(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({
+        name: '@happyvertical/smrt-fixture',
+        version: '0.0.0',
+        exports: { './manifest': { default: './dist/manifest.json' } },
+      }),
+    );
+    mkdirSync(join(pkgDir, 'src'), { recursive: true });
+    writeFileSync(join(pkgDir, 'src', 'widget.ts'), WIDGET_SOURCE);
+    // No dist manifest → must still resolve the conditional export and report it missing.
+
+    const result = await verifyManifestCompleteness({ packageDir: pkgDir });
+    expect(result.status).toBe('missing-manifest');
+    expect(result.manifestPath).toMatch(/dist\/manifest\.json$/);
+  });
+
+  it('treats an unparseable manifest as missing', async () => {
+    writePackage({ withManifestExport: true });
+    mkdirSync(join(pkgDir, 'dist'), { recursive: true });
+    writeFileSync(join(pkgDir, 'dist', 'manifest.json'), '{ not valid json');
+
+    const result = await verifyManifestCompleteness({ packageDir: pkgDir });
+    expect(result.status).toBe('missing-manifest');
+    expect(result.reason).toMatch(/not valid JSON/);
+  });
+
   it('skips framework-infrastructure packages by basename', async () => {
     const skipDir = join(pkgDir, 'core');
     mkdirSync(skipDir, { recursive: true });

--- a/packages/scanner/src/__tests__/verify-completeness.test.ts
+++ b/packages/scanner/src/__tests__/verify-completeness.test.ts
@@ -1,0 +1,131 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { verifyManifestCompleteness } from '../verify-completeness.js';
+
+/**
+ * Regression coverage for issue #1483: a published dist/manifest.json that omits
+ * an @smrt object (there, SmrtWorker) silently breaks downstream db:migrate.
+ * The guard re-scans source and asserts every object reaches the manifest.
+ */
+describe('verifyManifestCompleteness', () => {
+  let pkgDir: string;
+
+  const WIDGET_SOURCE = `
+import { smrt, SmrtObject } from '@happyvertical/smrt-core';
+
+@smrt({ tableName: 'widgets' })
+export class Widget extends SmrtObject {
+  label: string = '';
+}
+`;
+
+  function writePackage(options: { withManifestExport: boolean }): void {
+    const exportsMap: Record<string, unknown> = {
+      '.': { import: './dist/index.js' },
+    };
+    if (options.withManifestExport) {
+      exportsMap['./manifest'] = './dist/manifest.json';
+    }
+    writeFileSync(
+      join(pkgDir, 'package.json'),
+      JSON.stringify(
+        {
+          name: '@happyvertical/smrt-fixture',
+          version: '0.0.0',
+          exports: exportsMap,
+        },
+        null,
+        2,
+      ),
+    );
+    mkdirSync(join(pkgDir, 'src'), { recursive: true });
+    writeFileSync(join(pkgDir, 'src', 'widget.ts'), WIDGET_SOURCE);
+  }
+
+  function writeDistManifest(objectKeys: string[]): void {
+    mkdirSync(join(pkgDir, 'dist'), { recursive: true });
+    const objects: Record<string, unknown> = {};
+    for (const key of objectKeys) {
+      objects[key] = { name: key };
+    }
+    writeFileSync(
+      join(pkgDir, 'dist', 'manifest.json'),
+      JSON.stringify({ version: '1.0.0', objects }, null, 2),
+    );
+  }
+
+  beforeEach(() => {
+    pkgDir = mkdtempSync(join(tmpdir(), 'smrt-verify-manifest-'));
+  });
+
+  afterEach(() => {
+    rmSync(pkgDir, { recursive: true, force: true });
+  });
+
+  it('reports objects present in source but missing from the manifest', async () => {
+    writePackage({ withManifestExport: true });
+    // Empty manifest: every scanned object is missing.
+    writeDistManifest([]);
+
+    const result = await verifyManifestCompleteness({ packageDir: pkgDir });
+
+    expect(result.status).toBe('incomplete');
+    expect(result.expectedCount).toBeGreaterThan(0);
+    expect(result.missing).toContain('@happyvertical/smrt-fixture:Widget');
+    // An empty manifest is missing every scanned object.
+    expect(result.missing).toHaveLength(result.expectedCount);
+  });
+
+  it('passes when the manifest contains every scanned object', async () => {
+    writePackage({ withManifestExport: true });
+
+    // Discover the exact keys the scanner produces, then write a complete manifest.
+    writeDistManifest([]);
+    const discovery = await verifyManifestCompleteness({ packageDir: pkgDir });
+    writeDistManifest(discovery.missing);
+
+    const result = await verifyManifestCompleteness({ packageDir: pkgDir });
+
+    expect(result.status).toBe('ok');
+    expect(result.missing).toEqual([]);
+    expect(result.distCount).toBe(result.expectedCount);
+  });
+
+  it('flags a missing manifest file when source declares objects', async () => {
+    writePackage({ withManifestExport: true });
+    // No dist/manifest.json written.
+
+    const result = await verifyManifestCompleteness({ packageDir: pkgDir });
+
+    expect(result.status).toBe('missing-manifest');
+    expect(result.missing.length).toBeGreaterThan(0);
+  });
+
+  it('skips packages that do not publish a manifest export', async () => {
+    writePackage({ withManifestExport: false });
+
+    const result = await verifyManifestCompleteness({ packageDir: pkgDir });
+
+    expect(result.status).toBe('skipped');
+    expect(result.reason).toMatch(/does not publish a \.\/manifest/);
+  });
+
+  it('skips framework-infrastructure packages by basename', async () => {
+    const skipDir = join(pkgDir, 'core');
+    mkdirSync(skipDir, { recursive: true });
+    writeFileSync(
+      join(skipDir, 'package.json'),
+      JSON.stringify({
+        name: '@happyvertical/smrt-core',
+        exports: { './manifest': './dist/manifest.json' },
+      }),
+    );
+
+    const result = await verifyManifestCompleteness({ packageDir: skipDir });
+
+    expect(result.status).toBe('skipped');
+    expect(result.reason).toMatch(/framework infrastructure/);
+  });
+});

--- a/packages/scanner/src/index.ts
+++ b/packages/scanner/src/index.ts
@@ -23,3 +23,9 @@ export { ManifestAdapter } from './manifest-adapter.js';
 export { extractSmrtImports, parseFile, parseSource } from './oxc-parser.js';
 export { OxcScanner } from './scanner.js';
 export * from './types.js';
+export {
+  type VerifyManifestCompletenessOptions,
+  type VerifyManifestCompletenessResult,
+  type VerifyManifestStatus,
+  verifyManifestCompleteness,
+} from './verify-completeness.js';

--- a/packages/scanner/src/verify-completeness.ts
+++ b/packages/scanner/src/verify-completeness.ts
@@ -29,16 +29,21 @@ import { ManifestAdapter } from './manifest-adapter.js';
 import { OxcScanner } from './scanner.js';
 
 /**
- * Source globs that mirror what `vite.config.base.ts` passes to `smrtPlugin`
- * (`include: ['src/**\/*.ts']`, test/spec excluded) plus the scanner's own
- * exclusions. Test probe classes (`*.test.ts` / `*.spec.ts`) carry `@smrt()`
- * for fixtures and are intentionally absent from the published manifest, so
- * they must be excluded here to avoid false positives.
+ * Source globs for the completeness scan. The build (`vite.config.base.ts`)
+ * passes `include: ['src/**\/*.ts']` and excludes `*.test.ts` / `*.spec.ts` (the
+ * plugin also drops `*.svelte`); we reproduce that so the expected object set
+ * matches what the build would publish. We additionally exclude
+ * `**\/__tests__\/**` so any `@smrt()` fixtures in non-test helper modules under
+ * `src/__tests__/` (e.g. `src/__tests__/helpers/*.ts`) are never required in the
+ * published manifest. These extra exclusions can only shrink `expected` relative
+ * to the build, so they can never cause a false failure — the check is
+ * `expected ⊆ dist`.
  */
 const DEFAULT_INCLUDE = ['src/**/*.ts'];
 const DEFAULT_EXCLUDE = [
   '**/*.test.ts',
   '**/*.spec.ts',
+  '**/__tests__/**',
   '**/*.svelte',
   '**/node_modules/**',
   '**/dist/**',

--- a/packages/scanner/src/verify-completeness.ts
+++ b/packages/scanner/src/verify-completeness.ts
@@ -1,0 +1,250 @@
+/**
+ * Manifest completeness verification.
+ *
+ * Re-scans a package's `src/` with the same OXC scanner the build uses and
+ * asserts that every `@smrt()`-decorated object (and its collection) is present
+ * in the package's published `dist/manifest.json`. This is a publish-time guard:
+ * downstream schema migration is manifest-driven, so a stale manifest that omits
+ * an object means consumers can never create its table via `smrt db:migrate`.
+ *
+ * Root cause it guards against (issue #1483): `@happyvertical/smrt-jobs@0.27.41`
+ * shipped a `dist/manifest.json` generated before `SmrtWorker` existed. The
+ * source, exports, and `__smrt-register__` path were all correct, but the
+ * published manifest had only 4 of 6 objects, so `_smrt_workers` was never
+ * created and `TaskRunner.start()` threw on every consumer that upgraded.
+ *
+ * The check compares object-key SETS only. The downstream manifest-enrichment
+ * passes (schema/validation/agent generation) mutate object entries but never
+ * add or remove object keys, so the scanner + adapter object set is the source
+ * of truth for "which objects the published manifest must contain". The
+ * comparison is `expected ⊆ dist`: enrichment passes that add keys to `dist`
+ * (e.g. STI children) never trigger a false failure.
+ *
+ * @see https://github.com/happyvertical/smrt/issues/1483
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+import { ManifestAdapter } from './manifest-adapter.js';
+import { OxcScanner } from './scanner.js';
+
+/**
+ * Source globs that mirror what `vite.config.base.ts` passes to `smrtPlugin`
+ * (`include: ['src/**\/*.ts']`, test/spec excluded) plus the scanner's own
+ * exclusions. Test probe classes (`*.test.ts` / `*.spec.ts`) carry `@smrt()`
+ * for fixtures and are intentionally absent from the published manifest, so
+ * they must be excluded here to avoid false positives.
+ */
+const DEFAULT_INCLUDE = ['src/**/*.ts'];
+const DEFAULT_EXCLUDE = [
+  '**/*.test.ts',
+  '**/*.spec.ts',
+  '**/*.svelte',
+  '**/node_modules/**',
+  '**/dist/**',
+  '**/*.d.ts',
+];
+
+/**
+ * Framework-infrastructure packages whose published manifest is NOT produced by
+ * the OXC scanner path (e.g. `@happyvertical/smrt-core` ships a curated static
+ * manifest). Mirrors `skipSmrtPlugin` in `vite.config.base.ts`. Keyed by package
+ * directory basename.
+ */
+const DEFAULT_SKIP_PACKAGES = [
+  'core',
+  'types',
+  'config',
+  'scanner',
+  'vitest',
+  'smrt-playground',
+];
+
+export type VerifyManifestStatus =
+  | 'ok'
+  | 'incomplete'
+  | 'missing-manifest'
+  | 'skipped';
+
+export interface VerifyManifestCompletenessOptions {
+  /** Absolute or relative path to the package directory to verify. */
+  packageDir: string;
+  /** Source include globs (default mirrors the build). */
+  include?: string[];
+  /** Source exclude globs (default mirrors the build). */
+  exclude?: string[];
+  /** Package directory basenames to skip (default: framework infrastructure). */
+  skipPackages?: string[];
+}
+
+export interface VerifyManifestCompletenessResult {
+  status: VerifyManifestStatus;
+  packageName?: string;
+  manifestPath?: string;
+  /** Qualified object keys present in source but missing from the manifest. */
+  missing: string[];
+  /** Number of objects the source is expected to contribute. */
+  expectedCount: number;
+  /** Number of objects present in the published manifest. */
+  distCount: number;
+  /** Human-readable explanation for `skipped` / `missing-manifest`. */
+  reason?: string;
+}
+
+interface MinimalPackageJson {
+  name?: string;
+  version?: string;
+  exports?: Record<string, unknown>;
+}
+
+/**
+ * Resolve the `./manifest` (or `./manifest.json`) export target to an absolute
+ * path. Returns `null` when the package does not publish a manifest.
+ */
+function resolveManifestPath(
+  packageDir: string,
+  pkgJson: MinimalPackageJson,
+): string | null {
+  const exportsMap = pkgJson.exports ?? {};
+  const entry = exportsMap['./manifest'] ?? exportsMap['./manifest.json'];
+
+  let relativeTarget: string | undefined;
+  if (typeof entry === 'string') {
+    relativeTarget = entry;
+  } else if (entry && typeof entry === 'object') {
+    const conditional = entry as Record<string, unknown>;
+    const candidate =
+      conditional.default ?? conditional.import ?? conditional.types;
+    if (typeof candidate === 'string') {
+      relativeTarget = candidate;
+    }
+  }
+
+  if (!relativeTarget) {
+    return null;
+  }
+
+  return resolve(packageDir, relativeTarget);
+}
+
+/**
+ * Verify that `dist/manifest.json` contains every `@smrt()` object declared in
+ * the package source. See module docs for the rationale and guarantees.
+ */
+export async function verifyManifestCompleteness(
+  options: VerifyManifestCompletenessOptions,
+): Promise<VerifyManifestCompletenessResult> {
+  const packageDir = resolve(options.packageDir);
+  const include = options.include ?? DEFAULT_INCLUDE;
+  const exclude = options.exclude ?? DEFAULT_EXCLUDE;
+  const skipPackages = options.skipPackages ?? DEFAULT_SKIP_PACKAGES;
+
+  const packageJsonPath = resolve(packageDir, 'package.json');
+  if (!existsSync(packageJsonPath)) {
+    return {
+      status: 'skipped',
+      missing: [],
+      expectedCount: 0,
+      distCount: 0,
+      reason: `no package.json at ${packageDir}`,
+    };
+  }
+
+  const pkgJson: MinimalPackageJson = JSON.parse(
+    readFileSync(packageJsonPath, 'utf-8'),
+  );
+  const packageName = pkgJson.name;
+
+  if (skipPackages.includes(basename(packageDir))) {
+    return {
+      status: 'skipped',
+      packageName,
+      missing: [],
+      expectedCount: 0,
+      distCount: 0,
+      reason:
+        'framework infrastructure package (does not use scanner manifest)',
+    };
+  }
+
+  const manifestPath = resolveManifestPath(packageDir, pkgJson);
+  if (!manifestPath) {
+    return {
+      status: 'skipped',
+      packageName,
+      missing: [],
+      expectedCount: 0,
+      distCount: 0,
+      reason: 'package does not publish a ./manifest export',
+    };
+  }
+
+  // Derive the object set the source SHOULD produce, using the same scanner and
+  // adapter the build uses (vite-plugin scanWithOxc).
+  const scanner = new OxcScanner({ cwd: packageDir, include, exclude });
+  const { results, resolved } = await scanner.scanAndResolve();
+  const adapter = new ManifestAdapter();
+  const expected = adapter.toManifest(resolved, {
+    packageName,
+    packageVersion: pkgJson.version,
+    typeAliases: results.typeAliases,
+  });
+  const expectedKeys = Object.keys(expected.objects);
+
+  // Nothing to verify if the package declares no SMRT objects (e.g. a package
+  // that publishes ./manifest but only ships base classes).
+  if (expectedKeys.length === 0) {
+    return {
+      status: 'skipped',
+      packageName,
+      manifestPath,
+      missing: [],
+      expectedCount: 0,
+      distCount: 0,
+      reason: 'no @smrt() objects found in source',
+    };
+  }
+
+  if (!existsSync(manifestPath)) {
+    return {
+      status: 'missing-manifest',
+      packageName,
+      manifestPath,
+      missing: expectedKeys,
+      expectedCount: expectedKeys.length,
+      distCount: 0,
+      reason: `published manifest not found at ${manifestPath}`,
+    };
+  }
+
+  let distObjects: Record<string, unknown> = {};
+  try {
+    const distManifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+    distObjects =
+      distManifest && typeof distManifest.objects === 'object'
+        ? distManifest.objects
+        : {};
+  } catch (error) {
+    return {
+      status: 'missing-manifest',
+      packageName,
+      manifestPath,
+      missing: expectedKeys,
+      expectedCount: expectedKeys.length,
+      distCount: 0,
+      reason: `published manifest is not valid JSON: ${(error as Error).message}`,
+    };
+  }
+
+  const distKeys = new Set(Object.keys(distObjects));
+  const missing = expectedKeys.filter((key) => !distKeys.has(key));
+
+  return {
+    status: missing.length > 0 ? 'incomplete' : 'ok',
+    packageName,
+    manifestPath,
+    missing,
+    expectedCount: expectedKeys.length,
+    distCount: distKeys.size,
+  };
+}

--- a/scripts/prepack-package.js
+++ b/scripts/prepack-package.js
@@ -2,11 +2,36 @@
 
 import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const manifestVerifierPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  'verify-manifest-completeness.mjs',
+);
 
 function fail(message) {
   console.error(`❌ ${message}`);
   process.exit(1);
+}
+
+/**
+ * Run the manifest-completeness guard for the current package (issue #1483).
+ * Returns true when the published manifest includes every @smrt object in
+ * source (or the check does not apply); false when it is stale/incomplete.
+ */
+function manifestCheckPasses() {
+  const result = spawnSync(
+    process.execPath,
+    [manifestVerifierPath, process.cwd()],
+    { stdio: 'inherit', env: process.env },
+  );
+
+  if (result.error) {
+    fail(`Failed to run manifest verifier: ${result.error.message}`);
+  }
+
+  return result.status === 0;
 }
 
 function runScript(scriptName) {
@@ -60,7 +85,12 @@ if (runningInCi && hasDistArtifacts && verifyScripts.length > 0) {
     `[smrt-prepack] Reusing existing CI build artifacts for ${packageName} when verification succeeds.`,
   );
 
-  const reusable = verifyScripts.every((scriptName) => tryScript(scriptName));
+  // The manifest guard is part of the reuse gate: a reused dist whose
+  // manifest.json predates a new @smrt class (issue #1483) must NOT be
+  // republished. Failing here falls through to a clean rebuild below.
+  const reusable =
+    verifyScripts.every((scriptName) => tryScript(scriptName)) &&
+    manifestCheckPasses();
   if (reusable) {
     process.exit(0);
   }
@@ -77,4 +107,13 @@ for (const scriptName of verifyScripts) {
     continue;
   }
   runScript(scriptName);
+}
+
+// Final gate: even a fresh build must produce a manifest that includes every
+// @smrt object in source. Catches scanner/build regressions, not just stale
+// reused artifacts (issue #1483).
+if (!manifestCheckPasses()) {
+  fail(
+    `Published manifest for ${packageName} is incomplete after build. See the [verify-manifest] output above.`,
+  );
 }

--- a/scripts/verify-manifest-completeness.mjs
+++ b/scripts/verify-manifest-completeness.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+/**
+ * Publish-time guard: verify a package's `dist/manifest.json` includes every
+ * `@smrt()` object declared in its source. A stale manifest that omits an object
+ * silently breaks downstream `smrt db:migrate` (the object's table is never
+ * created), which is exactly how `@happyvertical/smrt-jobs@0.27.41` shipped a
+ * manifest missing `SmrtWorker` and broke every consumer's `TaskRunner.start()`.
+ *
+ * Usage: node scripts/verify-manifest-completeness.mjs [packageDir]
+ *   - packageDir defaults to the current working directory (so `prepack` can
+ *     invoke it without arguments from each package directory).
+ *
+ * Exit codes:
+ *   0 — manifest complete, or check not applicable (package publishes no
+ *       manifest / is framework infrastructure / scanner not built).
+ *   1 — manifest is stale/incomplete or missing while objects exist in source.
+ *
+ * @see https://github.com/happyvertical/smrt/issues/1483
+ */
+
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '..');
+const packageDir = resolve(process.argv[2] ?? process.cwd());
+
+// The scanner exposes verifyManifestCompleteness from its built output. The
+// publish pipeline builds every workspace package before per-package prepack
+// runs, so dist is present where this guard matters. When it is absent (e.g. a
+// single-package publish before a full build), skip rather than block — the
+// guard is a safety net, not a hard dependency of every publish path.
+const scannerDist = resolve(repoRoot, 'packages/scanner/dist/index.js');
+if (!existsSync(scannerDist)) {
+  console.warn(
+    `[verify-manifest] @happyvertical/smrt-scanner is not built at ${scannerDist}; skipping manifest completeness check.`,
+  );
+  process.exit(0);
+}
+
+let verifyManifestCompleteness;
+try {
+  ({ verifyManifestCompleteness } = await import(
+    pathToFileURL(scannerDist).href
+  ));
+} catch (error) {
+  console.warn(
+    `[verify-manifest] Could not load scanner module; skipping check: ${error.message}`,
+  );
+  process.exit(0);
+}
+
+const result = await verifyManifestCompleteness({ packageDir });
+const label = result.packageName ?? packageDir;
+
+if (result.status === 'ok') {
+  console.log(
+    `[verify-manifest] ✅ ${label}: dist/manifest.json includes all ${result.expectedCount} source object(s).`,
+  );
+  process.exit(0);
+}
+
+if (result.status === 'skipped') {
+  console.log(`[verify-manifest] ⏭️  ${label}: skipped (${result.reason}).`);
+  process.exit(0);
+}
+
+// status: 'incomplete' | 'missing-manifest'
+console.error(
+  `\n[verify-manifest] ❌ ${label}: published manifest is stale or incomplete.`,
+);
+console.error(
+  `[verify-manifest]    ${
+    result.reason ??
+    `${result.missing.length} object(s) declared in src/ are missing from ${result.manifestPath}`
+  }`,
+);
+if (result.missing.length > 0) {
+  console.error('[verify-manifest]    Missing objects:');
+  for (const missing of result.missing) {
+    console.error(`[verify-manifest]      - ${missing}`);
+  }
+}
+console.error(
+  '[verify-manifest]    Fix: rebuild the package so dist/manifest.json is regenerated from src/.',
+);
+console.error(
+  '[verify-manifest]    Guards issue #1483 (a stale manifest omitting @smrt classes breaks downstream db:migrate).',
+);
+process.exit(1);


### PR DESCRIPTION
Fixes #1483.

## Problem

`@happyvertical/smrt-jobs@0.27.41` shipped a `dist/manifest.json` generated before `SmrtWorker` existed — 4 of 6 objects. The source, `index.ts` exports, and `__smrt-register__` path were all correct, but the **stale published manifest** meant downstream `smrt db:migrate` never created `_smrt_workers`. `TaskRunner.start()` then threw on every consumer that upgraded, and `db:migrate` could not self-heal because the object wasn't in the published manifest.

A fresh build already produces the correct 6-object manifest (verified locally). The gap was a **stale artifact reaching publish** with nothing validating manifest contents.

## Fix — a publish-time completeness guard (issue point 3)

Re-scan `src/` with the same OXC scanner the build uses and fail if any `@smrt` object is absent from `dist/manifest.json`:

- **`packages/scanner`** — new exported `verifyManifestCompleteness({ packageDir })`. Compares the scanner+adapter object set against the published manifest (`expected ⊆ dist`, so STI enrichment passes that *add* keys never false-fail). Mirrors the build's `include`/`exclude` so test-probe `@smrt` classes in `*.test.ts` don't trip it.
- **`scripts/verify-manifest-completeness.mjs`** — thin CLI wrapper for `prepack`.
- **`scripts/prepack-package.js`** — runs the guard in **two** places:
  1. the CI artifact-reuse gate — a stale reused manifest now forces a clean rebuild instead of being republished;
  2. a hard **post-build** gate — catches scanner/build regressions, not just reused artifacts.
- Regression test + scanner `AGENTS.md` updated.

### Validation

- Reproduced the exact failure: deleting `SmrtWorker` from jobs' manifest → guard exits 1 listing the missing objects. Restored → exits 0.
- Ran the guard against **all 34 standard manifest packages**: **zero false positives**, exact object-set parity (incl. STI-heavy `content`=33, `commerce`=31, `profiles`=29).
- `scanner` typecheck + full suite (100 tests, incl. 5 new) green; `dev:knowledge-check` fresh.

### Republish

All `@happyvertical/smrt-*` packages are in the changeset `fixed` version-lock group, so this release republishes **smrt-jobs** with a freshly built, now-guarded manifest (issue point 1).

### On issue point 2 (`__smrt-register__`)

Does **not** apply: all 33 `__smrt-register__.ts` files are byte-identical and register the *whole* `manifest.json` URL — there is no per-module list, so a complete manifest already exposes `SmrtWorker`. The only real gap was manifest completeness, which this guards.

## Also requested: #1477 + spider deps

Verified against the GitHub Packages API — already current, no changes needed:
- SDK pins are `^0.74.5` across the catalog, `pnpm.overrides`, and the lockfile (latest release is `v0.74.5`; landed in `301ad0690`).
- `@happyvertical/spider` is `^1.0.0` everywhere (catalog + overrides + `content` via `catalog:`); `1.0.0` is the latest published version. Lockfile resolves `1.0.0`.

## Release impact (minor bump)

This release republishes `@happyvertical/smrt-jobs` with the worker-liveness code + manifest the stale 0.27.41 artifact dropped, so it is marked breaking to land as a coordinated **minor** (0.x.0) bump rather than a silent patch.

**BREAKING CHANGE:** `@happyvertical/smrt-jobs` now requires the `_smrt_workers` table at runtime. After upgrading, run `smrt db:migrate` to create it; `TaskRunner.start()` throws until the table exists. This restores the requirement that the stale 0.27.41 publish accidentally masked (see #1483).
