### PR TITLE
test(smrt-svelte): component golden-test harness — testing-library + axe (L4, #1423)

### DIFF
--- a/packages/smrt-svelte/AGENTS.md
+++ b/packages/smrt-svelte/AGENTS.md
@@ -84,6 +84,30 @@ Single source of truth: `src/themes/shared.ts` (alias maps) → emitted by `src/
 - `src/browser-ai/` -- STT/TTS/LLM adapters, capability detection (bundled, not external)
 - `src/registry/` -- ModuleUIRegistry for cross-package component discovery
 
+## Component testing (golden tests)
+
+Component test harness (sweep L4, #1423): `@testing-library/svelte` + `@testing-library/jest-dom` + `@testing-library/user-event` + `axe-core`, wired through `src/test-support/setup.ts` (jest-dom matchers, Testing Library auto-cleanup, a jsdom `<dialog>` `showModal`/`close` polyfill). The smrt-vitest plugin appends its own setup to `setupFiles` — it merges, so don't remove the entry.
+
+**Golden test pattern** — render → assert role/name/state → drive with `user-event` → prove axe-clean. `src/components/ui/__tests__/Button.test.ts` is the reference:
+
+```ts
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+
+render(Component, { props: { /* … */ } });
+const el = screen.getByRole('button', { name: 'Save' });
+await userEvent.click(el);
+expect(el).toHaveAttribute('aria-busy', 'true');
+const { container } = render(Component, { props });
+await expectNoA11yViolations(container); // axe; color-contrast off (jsdom has no paint)
+```
+
+- **Snippet props** (`children`, cell/header renderers): build with `createRawSnippet(() => ({ render: () => '<span>…</span>' }))`.
+- **Hook-dependent components** (anything calling `useAppState`/`useSTT`/`useAuth` — they throw outside `<Provider>`): `vi.mock` the hook module with stub defaults. See `src/components/forms/__tests__/Form.test.ts`.
+- **Form-input a11y** (programmatic labels, `aria-describedby`, axe-clean for `Input`/`TextInput`/etc.) is L1's deliverable (#1420) on top of this harness — bare primitives like `Input` get behavior tests here, labelled axe coverage there.
+- Existing reference suites: Button, Input, Modal, DataTable, Form. The pattern is what sweep S11 (#1416) rolls out repo-wide.
+
 ## Dependencies
 
 - `@happyvertical/smrt-types` (shared types)

--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -168,7 +168,11 @@
   "devDependencies": {
     "@sveltejs/package": "^2.5.7",
     "@sveltejs/vite-plugin-svelte": "^6.2.4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/svelte": "^5.3.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "25.0.9",
+    "axe-core": "^4.12.1",
     "svelte": "^5.46.4",
     "svelte-check": "^4.3.5",
     "typescript": "^5.9.3",

--- a/packages/smrt-svelte/src/components/data/__tests__/DataTable.test.ts
+++ b/packages/smrt-svelte/src/components/data/__tests__/DataTable.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Golden test for DataTable (Sweep L4, #1423).
+ *
+ * Covers the semantic table structure (caption → accessible name, column
+ * headers, cells, row count), the empty state, sortable-header interaction
+ * (aria-sort transition), and axe-cleanliness.
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import DataTable from '../DataTable.svelte';
+
+interface Person {
+  name: string;
+  age: number;
+}
+
+const columns = [
+  { id: 'name', label: 'Name', accessor: 'name', sortable: true },
+  { id: 'age', label: 'Age', accessor: 'age' },
+];
+const data: Person[] = [
+  { name: 'Ada', age: 36 },
+  { name: 'Linus', age: 54 },
+];
+
+describe('DataTable', () => {
+  it('renders caption, headers, cells, and a row per datum', () => {
+    render(DataTable, { props: { data, columns, caption: 'People' } });
+    expect(screen.getByRole('table', { name: 'People' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', { name: 'Name' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Ada' })).toBeInTheDocument();
+    // header row + one row per datum
+    expect(screen.getAllByRole('row')).toHaveLength(data.length + 1);
+  });
+
+  it('renders the empty state when there is no data', () => {
+    render(DataTable, { props: { data: [], columns } });
+    expect(screen.getByText('No data available')).toBeInTheDocument();
+  });
+
+  it('toggles aria-sort when a sortable header is activated', async () => {
+    render(DataTable, { props: { data, columns, sortable: true } });
+    const nameHeader = screen.getByRole('columnheader', { name: 'Name' });
+    // aria-sort is only present on the actively-sorted column.
+    expect(nameHeader).not.toHaveAttribute('aria-sort');
+    await userEvent.click(screen.getByRole('button', { name: 'Name' }));
+    expect(nameHeader).toHaveAttribute('aria-sort', 'ascending');
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(DataTable, {
+      props: { data, columns, caption: 'People' },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/feedback/__tests__/Modal.test.ts
+++ b/packages/smrt-svelte/src/components/feedback/__tests__/Modal.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Golden test for Modal (Sweep L4, #1423).
+ *
+ * Modal wraps a native <dialog>; jsdom implements showModal()/close(), so the
+ * open/close effect runs. Content is always in the DOM — visibility is driven
+ * by the dialog's modal state.
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import Modal from '../Modal.svelte';
+
+function bodySnippet(text: string) {
+  return createRawSnippet(() => ({ render: () => `<p>${text}</p>` }));
+}
+
+describe('Modal', () => {
+  it('exposes a dialog labelled by its title, with content', () => {
+    render(Modal, {
+      props: {
+        open: true,
+        title: 'Settings',
+        children: bodySnippet('Body copy'),
+      },
+    });
+    const dialog = screen.getByRole('dialog', { hidden: true });
+    expect(dialog).toHaveAttribute('aria-label', 'Settings');
+    expect(
+      screen.getByRole('heading', { name: 'Settings', hidden: true }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Body copy')).toBeInTheDocument();
+  });
+
+  it('invokes onClose from the close button', async () => {
+    const onClose = vi.fn();
+    render(Modal, { props: { open: true, title: 'X', onClose } });
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Close modal', hidden: true }),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the close button when showClose is false', () => {
+    render(Modal, { props: { open: true, title: 'X', showClose: false } });
+    expect(
+      screen.queryByRole('button', { name: 'Close modal', hidden: true }),
+    ).toBeNull();
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(Modal, {
+      props: {
+        open: true,
+        title: 'Accessible dialog',
+        children: bodySnippet('content'),
+      },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/Form.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/Form.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Golden test for Form (Sweep L4, #1423).
+ *
+ * Form depends on the Provider-backed `useAppState`/`useSTT` hooks (they throw
+ * outside a <Provider>), so we mock them to stub, non-listening defaults — this
+ * is the reference pattern for testing hook-dependent components in isolation.
+ * The aria-live status region is L1's deliverable (#1420); here we cover the
+ * form element, children rendering, the onsubmit contract, and axe.
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+
+vi.mock('../../../hooks/useAppState.svelte.js', () => ({
+  useAppState: () => ({ state: { mode: 'default' }, setMode: vi.fn() }),
+}));
+vi.mock('../../../hooks/useSTT.svelte.js', () => ({
+  useSTT: () => ({
+    isListening: false,
+    lastResult: '',
+    isReady: false,
+    adapterType: null,
+    isInitializing: false,
+    downloadProgress: 0,
+    initialize: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+import Form from '../Form.svelte';
+
+function submitButton() {
+  return createRawSnippet(() => ({
+    render: () => `<button type="submit">Submit</button>`,
+  }));
+}
+
+describe('Form', () => {
+  it('renders a <form> with its children', () => {
+    const { container } = render(Form, { props: { children: submitButton() } });
+    expect(container.querySelector('form')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument();
+  });
+
+  it('calls onsubmit (preventing native submission) when submitted', async () => {
+    const onsubmit = vi.fn();
+    render(Form, { props: { children: submitButton(), onsubmit } });
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(onsubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(Form, { props: { children: submitButton() } });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/Input.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/Input.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Golden test for Input (Sweep L4, #1423).
+ *
+ * Input is the low-level form primitive: a bare <input> whose accessible name
+ * comes from a wrapping label/FormGroup, not from itself. Programmatic-label +
+ * axe-clean coverage for the form primitives is L1's deliverable (#1420, "with
+ * L4"); here we cover render + interaction + state behavior.
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import Input from '../Input.svelte';
+
+describe('Input', () => {
+  it('renders an <input> with the given id/name/type', () => {
+    render(Input, { props: { id: 'first', name: 'first', type: 'text' } });
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('id', 'first');
+    expect(input).toHaveAttribute('name', 'first');
+    expect(input).toHaveAttribute('type', 'text');
+  });
+
+  it('accepts typed input', async () => {
+    render(Input, { props: { id: 'q', name: 'q' } });
+    const input = screen.getByRole<HTMLInputElement>('textbox');
+    await userEvent.type(input, 'hello');
+    expect(input).toHaveValue('hello');
+  });
+
+  it('renders the placeholder', () => {
+    render(Input, { props: { id: 'q', placeholder: 'Search…' } });
+    expect(screen.getByPlaceholderText('Search…')).toBeInTheDocument();
+  });
+
+  it('does not accept input when disabled', async () => {
+    render(Input, { props: { id: 'q', disabled: true } });
+    const input = screen.getByRole<HTMLInputElement>('textbox');
+    expect(input).toBeDisabled();
+    await userEvent.type(input, 'nope');
+    expect(input).toHaveValue('');
+  });
+
+  it('is read-only when readonly is set', async () => {
+    render(Input, { props: { id: 'q', readonly: true, value: 'fixed' } });
+    const input = screen.getByRole<HTMLInputElement>('textbox');
+    expect(input).toHaveAttribute('readonly');
+    await userEvent.type(input, 'x');
+    expect(input).toHaveValue('fixed');
+  });
+
+  it('marks required inputs', () => {
+    render(Input, { props: { id: 'q', required: true } });
+    expect(screen.getByRole('textbox')).toBeRequired();
+  });
+});

--- a/packages/smrt-svelte/src/components/ui/__tests__/Button.test.ts
+++ b/packages/smrt-svelte/src/components/ui/__tests__/Button.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Golden test for Button (Sweep L4, #1423).
+ *
+ * The reference pattern for component tests in this package: render via Testing
+ * Library, assert role/name/state, drive interaction with user-event, and prove
+ * the rendered output is axe-clean. New primitive tests should mirror this shape.
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import Button from '../Button.svelte';
+
+/** Build a text Snippet for the Button's `children` prop. */
+function textSnippet(text: string) {
+  return createRawSnippet(() => ({ render: () => `<span>${text}</span>` }));
+}
+
+describe('Button', () => {
+  it('renders children as a <button> with type=button by default', () => {
+    render(Button, { props: { children: textSnippet('Save') } });
+    const button = screen.getByRole('button', { name: 'Save' });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute('type', 'button');
+  });
+
+  it('fires onclick when clicked', async () => {
+    const onclick = vi.fn();
+    render(Button, { props: { children: textSnippet('Go'), onclick } });
+    await userEvent.click(screen.getByRole('button', { name: 'Go' }));
+    expect(onclick).toHaveBeenCalledTimes(1);
+  });
+
+  it('is keyboard-activatable when focused', async () => {
+    const onclick = vi.fn();
+    render(Button, { props: { children: textSnippet('Go'), onclick } });
+    const button = screen.getByRole('button', { name: 'Go' });
+    button.focus();
+    expect(button).toHaveFocus();
+    await userEvent.keyboard('{Enter}');
+    expect(onclick).toHaveBeenCalled();
+  });
+
+  it('does not fire onclick when disabled', async () => {
+    const onclick = vi.fn();
+    render(Button, {
+      props: { children: textSnippet('Go'), disabled: true, onclick },
+    });
+    const button = screen.getByRole('button', { name: 'Go' });
+    expect(button).toBeDisabled();
+    await userEvent.click(button);
+    expect(onclick).not.toHaveBeenCalled();
+  });
+
+  it('reflects loading as aria-busy and disables interaction', () => {
+    render(Button, { props: { children: textSnippet('Go'), loading: true } });
+    const button = screen.getByRole('button', { name: 'Go' });
+    expect(button).toHaveAttribute('aria-busy', 'true');
+    expect(button).toBeDisabled();
+  });
+
+  it('renders as a link (role=link) when href is provided', () => {
+    render(Button, {
+      props: { children: textSnippet('Home'), href: '/home' },
+    });
+    const link = screen.getByRole('link', { name: 'Home' });
+    expect(link).toHaveAttribute('href', '/home');
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(Button, {
+      props: { children: textSnippet('Accessible') },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/test-support/a11y.ts
+++ b/packages/smrt-svelte/src/test-support/a11y.ts
@@ -1,0 +1,39 @@
+/**
+ * Accessibility assertion helper for component golden tests (Sweep L4, #1423).
+ *
+ * Runs axe-core against a rendered container and fails the test with a readable
+ * report if any violations are found. Use after a Testing Library `render()`:
+ *
+ *   const { container } = render(MyComponent, { props });
+ *   await expectNoA11yViolations(container);
+ *
+ * `color-contrast` is disabled by default: jsdom has no layout/paint engine, so
+ * contrast can't be computed and the rule produces non-deterministic noise.
+ * Pass `{ rules: { 'color-contrast': { enabled: true } } }` to override.
+ */
+import axe from 'axe-core';
+import { expect } from 'vitest';
+
+export async function expectNoA11yViolations(
+  container: HTMLElement,
+  options: axe.RunOptions = {},
+): Promise<void> {
+  const results = await axe.run(container, {
+    rules: { 'color-contrast': { enabled: false } },
+    ...options,
+  });
+
+  if (results.violations.length > 0) {
+    const report = results.violations
+      .map((v) => {
+        const targets = v.nodes
+          .map((n) => `      - ${n.target.join(' ')}`)
+          .join('\n');
+        return `  [${v.id}] ${v.help}\n    ${v.helpUrl}\n${targets}`;
+      })
+      .join('\n');
+    expect.fail(
+      `axe found ${results.violations.length} accessibility violation(s):\n${report}`,
+    );
+  }
+}

--- a/packages/smrt-svelte/src/test-support/setup.ts
+++ b/packages/smrt-svelte/src/test-support/setup.ts
@@ -1,0 +1,39 @@
+/**
+ * Vitest setup for smrt-svelte component tests (Sweep L4, #1423).
+ *
+ * Registered via `setupFiles` in vitest.config.ts (the smrt-vitest plugin
+ * appends its own setup alongside this one). Provides:
+ *   - jest-dom matchers (`toBeInTheDocument`, `toHaveAttribute`, `toBeDisabled`, …)
+ *   - Testing Library auto-cleanup after each test (unmounts mounted components
+ *     so the jsdom document doesn't leak between tests).
+ */
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/svelte';
+import { afterEach } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});
+
+// jsdom does not implement the native <dialog> modal methods, so components
+// that drive a dialog via showModal()/close() (e.g. Modal, ConfirmDialog) throw
+// on mount. Polyfill the minimum: toggle the `open` property (which jsdom
+// reflects to the attribute, giving the element its `dialog` role) and emit the
+// matching events.
+if (typeof HTMLDialogElement !== 'undefined') {
+  if (!HTMLDialogElement.prototype.showModal) {
+    HTMLDialogElement.prototype.showModal = function showModal(
+      this: HTMLDialogElement,
+    ) {
+      this.open = true;
+    };
+  }
+  if (!HTMLDialogElement.prototype.close) {
+    HTMLDialogElement.prototype.close = function close(
+      this: HTMLDialogElement,
+    ) {
+      this.open = false;
+      this.dispatchEvent(new Event('close'));
+    };
+  }
+}

--- a/packages/smrt-svelte/vitest.config.ts
+++ b/packages/smrt-svelte/vitest.config.ts
@@ -24,6 +24,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    // Component golden-test harness (L4 #1423): jest-dom matchers + Testing
+    // Library auto-cleanup. The smrt-vitest plugin appends its own setup file
+    // to this list (it merges rather than overrides).
+    setupFiles: ['./src/test-support/setup.ts'],
     include: ['src/**/*.{test,spec}.ts'],
     testTimeout: 30000,
     // Match testTimeout. The smrt-vitest setup file

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1998,9 +1998,21 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.4
         version: 6.2.4(svelte@5.53.5)(vite@7.3.2(@types/node@24.10.9)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/svelte':
+        specifier: ^5.3.1
+        version: 5.3.1(svelte@5.53.5)(vite@7.3.2(@types/node@24.10.9)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.10.9)(happy-dom@20.10.2)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@7.3.2(@types/node@24.10.9)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)))
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: 24.10.9
         version: 24.10.9
+      axe-core:
+        specifier: ^4.12.1
+        version: 4.12.1
       svelte:
         specifier: ^5.46.4
         version: 5.53.5
@@ -2420,6 +2432,9 @@ packages:
 
   '@acemir/cssom@0.9.31':
     resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
   '@anthropic-ai/sdk@0.90.0':
     resolution: {integrity: sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==}
@@ -3487,6 +3502,11 @@ packages:
     peerDependencies:
       jimp: '>=1.6.1'
       sharp: '>=0.34.5'
+    peerDependenciesMeta:
+      jimp:
+        optional: true
+      sharp:
+        optional: true
 
   '@happyvertical/jobs@0.74.5':
     resolution: {integrity: sha512-gAXE4t+uDICJsFgvpSW6IhMsuMejlEKGPZuuyZ0RX7LNqtxZXj/0RsE2JMDVMOmC11aTPtaJ9jbUzOhrocI8zg==, tarball: https://npm.pkg.github.com/download/@happyvertical/jobs/0.74.5/307a48e4b6bde5640574b4c09001744aeea5dcf1}
@@ -3496,6 +3516,15 @@ packages:
       '@google-cloud/tasks': '>=4.1.0'
       bull: '>=4.16.5'
       bullmq: '>=5.76.0'
+    peerDependenciesMeta:
+      '@aws-sdk/client-sqs':
+        optional: true
+      '@google-cloud/tasks':
+        optional: true
+      bull:
+        optional: true
+      bullmq:
+        optional: true
 
   '@happyvertical/json@0.74.5':
     resolution: {integrity: sha512-cJLwW+WLB3VZv8szyk+FY7fVk85cSW7G+u4MP/ohx/4zmQWveqXOjlDivJ6cFHRvclZ0SEhLpJfc5ccEW24Zeg==, tarball: https://npm.pkg.github.com/download/@happyvertical/json/0.74.5/425c002020a930a5f736b275107c38c50be6ca88}
@@ -3505,6 +3534,9 @@ packages:
     hasBin: true
     peerDependencies:
       '@sentry/node': '>=10.49.0'
+    peerDependenciesMeta:
+      '@sentry/node':
+        optional: true
 
   '@happyvertical/messages@0.74.5':
     resolution: {integrity: sha512-mbEAjhazBb47NL/+Hqp3+CH2sT/wWwIe1NMfjRqX79ENcm7mPToA8r0/6t5OytTfnAi0sZpTKdLilnY0Av0HGQ==, tarball: https://npm.pkg.github.com/download/@happyvertical/messages/0.74.5/27289b162efd577fb8491443198d884f1b51f632}
@@ -3534,6 +3566,9 @@ packages:
     engines: {node: '>=24', pnpm: '>=9'}
     peerDependencies:
       cloakbrowser: ^0.3.28
+    peerDependenciesMeta:
+      cloakbrowser:
+        optional: true
 
   '@happyvertical/sql@0.74.5':
     resolution: {integrity: sha512-ioBdYfjo2+wlamMxC51dsylWz00fe4twpw3sFHkERS7UcOQq28kLLlIcYfC26ZxwfIm5m4d2VQw/QMqbYuGXNQ==, tarball: https://npm.pkg.github.com/download/@happyvertical/sql/0.74.5/df89334ad8dd4d4b5300006d7a3c0530b2cd20ef}
@@ -3541,6 +3576,11 @@ packages:
     peerDependencies:
       '@russellthehippo/honker-node': ^0.3.3
       '@sqliteai/sqlite-vector': ^1.0.0
+    peerDependenciesMeta:
+      '@russellthehippo/honker-node':
+        optional: true
+      '@sqliteai/sqlite-vector':
+        optional: true
 
   '@happyvertical/utils@0.74.5':
     resolution: {integrity: sha512-U2HZRK6TyzTNgDpDw4SyGvXn9OueE+gqJzuczr2Y488nho+h9WrhRrwCpFqg/06+K24qtWe7/xHN2TvSz9FupQ==, tarball: https://npm.pkg.github.com/download/@happyvertical/utils/0.74.5/eeaff4565d92fad58a25dc18e6af99eb42f13815}
@@ -5621,6 +5661,39 @@ packages:
   '@techstark/opencv-js@4.9.0-release.3':
     resolution: {integrity: sha512-y+KoLLlkXVUHWozYlN1vmMD9TQMPJObqml5nPA5vPWgHtOgm8q5O74UtzM23eayidvmeFX6tF5e2gDdyxcpy3Q==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/svelte-core@1.0.0':
+    resolution: {integrity: sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+
+  '@testing-library/svelte@5.3.1':
+    resolution: {integrity: sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+      vite: 7.3.2
+      vitest: 4.1.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+      vitest:
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
@@ -5633,6 +5706,9 @@ packages:
 
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
@@ -5914,6 +5990,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -5929,6 +6009,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.1:
     resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
@@ -5958,6 +6041,10 @@ packages:
   await-to-js@3.0.0:
     resolution: {integrity: sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==}
     engines: {node: '>=6.0.0'}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
 
   axios@1.17.0:
     resolution: {integrity: sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==}
@@ -6396,6 +6483,9 @@ packages:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssom@0.5.0:
     resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
 
@@ -6499,6 +6589,10 @@ packages:
     engines: {node: ^20.12||^22||>=24}
     hasBin: true
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -6527,6 +6621,12 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -7234,6 +7334,10 @@ packages:
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -7674,6 +7778,10 @@ packages:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.27.0:
     resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
     engines: {node: '>=12'}
@@ -7772,6 +7880,10 @@ packages:
   mimic-response@4.0.0:
     resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.3:
     resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
@@ -8327,6 +8439,10 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
@@ -8416,6 +8532,9 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
@@ -8442,6 +8561,10 @@ packages:
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
     engines: {node: '>= 10.13.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
@@ -8858,6 +8981,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -9534,6 +9661,8 @@ snapshots:
 
   '@acemir/cssom@0.9.31':
     optional: true
+
+  '@adobe/css-tools@4.5.0': {}
 
   '@anthropic-ai/sdk@0.90.0(zod@4.3.6)':
     dependencies:
@@ -11482,16 +11611,18 @@ snapshots:
   '@happyvertical/images@0.74.5(jimp@1.6.1)(sharp@0.34.5)':
     dependencies:
       '@resvg/resvg-js': 2.6.2
-      jimp: 1.6.1
       satori: 0.26.0
+    optionalDependencies:
+      jimp: 1.6.1
       sharp: 0.34.5
 
   '@happyvertical/jobs@0.74.5(@aws-sdk/client-sqs@3.1038.0)(@google-cloud/tasks@6.2.1)(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)(bull@4.16.5)(bullmq@5.76.4)':
     dependencies:
-      '@aws-sdk/client-sqs': 3.1038.0
-      '@google-cloud/tasks': 6.2.1
       '@happyvertical/sql': 0.74.5(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@happyvertical/utils': 0.74.5
+    optionalDependencies:
+      '@aws-sdk/client-sqs': 3.1038.0
+      '@google-cloud/tasks': 6.2.1
       bull: 4.16.5
       bullmq: 5.76.4
     transitivePeerDependencies:
@@ -11507,6 +11638,7 @@ snapshots:
   '@happyvertical/logger@0.74.5(@sentry/node@10.51.0)':
     dependencies:
       '@happyvertical/utils': 0.74.5
+    optionalDependencies:
       '@sentry/node': 10.51.0
 
   '@happyvertical/messages@0.74.5(@sentry/node@10.51.0)':
@@ -11582,11 +11714,12 @@ snapshots:
       '@happyvertical/cache': 0.74.5(@opentelemetry/api@1.9.1)
       '@happyvertical/utils': 0.74.5
       cheerio: 1.2.0
-      cloakbrowser: 0.3.31(playwright-core@1.60.0)
       crawlee: 3.17.0(@types/node@24.10.9)(playwright@1.60.0)
       happy-dom: 20.10.2
       playwright: 1.60.0
       undici: 7.24.0
+    optionalDependencies:
+      cloakbrowser: 0.3.31(playwright-core@1.60.0)
     transitivePeerDependencies:
       - '@node-rs/xxhash'
       - '@opentelemetry/api'
@@ -11603,10 +11736,11 @@ snapshots:
       '@duckdb/node-api': 1.4.3-r.3
       '@happyvertical/utils': 0.74.5
       '@libsql/client': 0.17.2
-      '@russellthehippo/honker-node': 0.3.3
-      '@sqliteai/sqlite-vector': 1.0.0
       pg: 8.21.0
       sqlite-vss: 0.1.2
+    optionalDependencies:
+      '@russellthehippo/honker-node': 0.3.3
+      '@sqliteai/sqlite-vector': 1.0.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -12993,6 +13127,7 @@ snapshots:
       '@russellthehippo/honker-node-darwin-x64': 0.3.3
       '@russellthehippo/honker-node-linux-arm64-gnu': 0.3.3
       '@russellthehippo/honker-node-linux-x64-gnu': 0.3.3
+    optional: true
 
   '@sapphire/async-queue@1.5.5': {}
 
@@ -13625,6 +13760,7 @@ snapshots:
       '@sqliteai/sqlite-vector-linux-x86_64': 1.0.0
       '@sqliteai/sqlite-vector-linux-x86_64-musl': 1.0.0
       '@sqliteai/sqlite-vector-win32-x86_64': 1.0.0
+    optional: true
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -13740,6 +13876,43 @@ snapshots:
 
   '@techstark/opencv-js@4.9.0-release.3': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      aria-query: 5.3.1
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/svelte-core@1.0.0(svelte@5.53.5)':
+    dependencies:
+      svelte: 5.53.5
+
+  '@testing-library/svelte@5.3.1(svelte@5.53.5)(vite@7.3.2(@types/node@24.10.9)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.10.9)(happy-dom@20.10.2)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@7.3.2(@types/node@24.10.9)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)))':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+      '@testing-library/svelte-core': 1.0.0(svelte@5.53.5)
+      svelte: 5.53.5
+    optionalDependencies:
+      vite: 7.3.2(@types/node@24.10.9)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.10.9)(happy-dom@20.10.2)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@7.3.2(@types/node@24.10.9)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3
@@ -13755,6 +13928,8 @@ snapshots:
     optional: true
 
   '@types/argparse@1.0.38': {}
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -14071,6 +14246,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   any-base@1.1.0: {}
@@ -14082,6 +14259,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.1: {}
 
@@ -14102,6 +14283,8 @@ snapshots:
   atomic-sleep@1.0.0: {}
 
   await-to-js@3.0.0: {}
+
+  axe-core@4.12.1: {}
 
   axios@1.17.0:
     dependencies:
@@ -14385,6 +14568,7 @@ snapshots:
       tar: 7.5.11
     optionalDependencies:
       playwright-core: 1.60.0
+    optional: true
 
   clone@1.0.4: {}
 
@@ -14552,6 +14736,8 @@ snapshots:
 
   css-what@6.2.2: {}
 
+  css.escape@1.5.1: {}
+
   cssom@0.5.0: {}
 
   cssstyle@4.6.0:
@@ -14655,6 +14841,8 @@ snapshots:
       tsconfig-paths-webpack-plugin: 4.2.0
       watskeburt: 5.0.2
 
+  dequal@2.0.3: {}
+
   detect-indent@6.1.0: {}
 
   detect-libc@2.0.2: {}
@@ -14672,6 +14860,10 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -15596,6 +15788,8 @@ snapshots:
 
   import-meta-resolve@4.2.0: {}
 
+  indent-string@4.0.0: {}
+
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
@@ -16083,6 +16277,8 @@ snapshots:
 
   luxon@3.7.2: {}
 
+  lz-string@1.5.0: {}
+
   magic-string@0.27.0:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -16174,6 +16370,8 @@ snapshots:
   mimic-response@3.1.0: {}
 
   mimic-response@4.0.0: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@10.2.3:
     dependencies:
@@ -16747,6 +16945,12 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   process-warning@5.0.0: {}
 
   promise-limit@2.7.0: {}
@@ -16862,6 +17066,8 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  react-is@17.0.2: {}
+
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -16886,6 +17092,11 @@ snapshots:
   rechoir@0.8.0:
     dependencies:
       resolve: 1.22.11
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   redis-errors@1.2.0: {}
 
@@ -17398,6 +17609,10 @@ snapshots:
       ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@2.0.1: {}
 


### PR DESCRIPTION
## L4 (Phase 0) — smrt-svelte component test harness

Closes #1423. Stands up component testing for the library — the highest-leverage place to test, since everything depends on it — and establishes the render/interaction/a11y pattern that S11 (#1416) rolls out repo-wide and L1 (#1420) builds on for form a11y.

### Harness
- Added `@testing-library/svelte` + `@testing-library/jest-dom` + `@testing-library/user-event` + `axe-core` (devDeps).
- `src/test-support/setup.ts` — jest-dom matchers, Testing Library auto-cleanup, and a jsdom `<dialog>` `showModal`/`close` polyfill (this jsdom build lacks them, so any dialog-driven component would otherwise throw on mount). Wired via `vitest.config.ts` `setupFiles` (the smrt-vitest plugin *merges* its own setup, so both run).
- `src/test-support/a11y.ts` — `expectNoA11yViolations(container)` axe helper (color-contrast disabled: jsdom has no paint engine).

### Golden tests (the named primitives)
`Button`, `Input`, `Modal`, `DataTable`, `Form` — render + role/name/state assertions + user-event interaction + axe-clean. `Button.test.ts` is the documented reference.
- **Hook-dependent components** (`Form` calls `useAppState`/`useSTT`, which throw outside `<Provider>`): the pattern is to `vi.mock` the hook modules — see `Form.test.ts`.
- **Form-input a11y** (programmatic labels, `aria-describedby`, axe-clean for `Input`/`TextInput`/…) is **L1's** deliverable (#1420) on this harness; bare `Input` gets behavior tests here, labelled axe coverage there.

### Docs
- `AGENTS.md` → new "Component testing (golden tests)" section documenting the pattern, snippet props, hook-mocking, and the L1 boundary.

### Acceptance criteria (#1423)
- [x] `@testing-library/svelte` + axe wired into the package's vitest setup
- [x] Documented golden test pattern (render / interaction / a11y)
- [x] Button / Input / Modal / DataTable / Form covered with interaction + axe tests
- [x] Pattern reused by S11 (#1416); seeds smrt-svelte coverage growth (S6 #1411)

### Verification
- Full smrt-svelte suite: **22 files / 290 tests green** (was 17 files; +5 golden suites / 24 tests), no regressions.
- `tsc --noEmit && svelte-check`: **0 errors** (jest-dom matcher augmentation resolves via the setup import).
- `biome check`: clean.

Note: this is the harness + named-primitive golden suites. Extending toward the full T2 coverage floor is the ongoing tail that S11 carries repo-wide; the v8 line-coverage gate (S6) doesn't instrument `.svelte` files, so component coverage is tracked by suite growth rather than the gate number.