### PR TITLE
feat(smrt-svelte): form a11y foundation — FormGroup wiring + Form live region (L1 #1420)

### DIFF
--- a/packages/smrt-svelte/src/components/forms/Form.svelte
+++ b/packages/smrt-svelte/src/components/forms/Form.svelte
@@ -489,6 +489,20 @@ function getFormData(): Record<string, unknown> {
 </script>
 
 <form class="smrt-form" onsubmit={handleSubmit} {method} {action}>
+  <!--
+    Screen-reader status region (L1 #1420): announces async STT / field-
+    extraction state politely, since the visible cues live on a button whose
+    label change isn't reliably announced. Visually hidden — the button still
+    shows the same state to sighted users.
+  -->
+  <div class="smrt-form__status" role="status" aria-live="polite">
+    {#if isExtracting}
+      Extracting form fields…
+    {:else if isFormListening}
+      Listening. Say "done" to finish.
+    {/if}
+  </div>
+
   {#if showModeToggle || showFormListen}
     <div class="form-controls">
       {#if showModeToggle}
@@ -571,7 +585,7 @@ function getFormData(): Record<string, unknown> {
   {/if}
 
   {#if extractError}
-    <div class="extract-error">{extractError}</div>
+    <div class="extract-error" role="alert">{extractError}</div>
   {/if}
 
   <div class="form-fields">
@@ -590,6 +604,19 @@ function getFormData(): Record<string, unknown> {
     display: flex;
     flex-direction: column;
     gap: var(--smrt-spacing-4, 16px);
+  }
+
+  /* Visually-hidden live region (L1 #1420) — announced to screen readers only. */
+  .smrt-form__status {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .form-controls {

--- a/packages/smrt-svelte/src/components/forms/FormGroup.svelte
+++ b/packages/smrt-svelte/src/components/forms/FormGroup.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
 import type { Snippet } from 'svelte';
+import {
+  type FormGroupContextValue,
+  nextFieldId,
+  setFormGroupContext,
+} from '../../state/form-group-context.js';
 
 export interface Props {
   label: string;
@@ -11,21 +16,41 @@ export interface Props {
 }
 
 const { label, id, error, hint, required = false, children }: Props = $props();
+
+// Stable id so the label's `for` and the wrapped input's `id` agree even when
+// the consumer doesn't pass one.
+const fallbackId = nextFieldId();
+const fieldId = $derived(id ?? fallbackId);
+const hintId = $derived(hint && !error ? `${fieldId}-hint` : undefined);
+const errorId = $derived(error ? `${fieldId}-error` : undefined);
+const describedBy = $derived(
+  [hintId, errorId].filter(Boolean).join(' ') || undefined,
+);
+
+// Publish the wiring a base input auto-applies (getter stays reactive as
+// hint/error change).
+setFormGroupContext(
+  (): FormGroupContextValue => ({
+    inputId: fieldId,
+    describedBy,
+    invalid: !!error,
+  }),
+);
 </script>
 
 <div class="form-group">
-	<label for={id} class="form-label">
+	<label for={fieldId} class="form-label">
 		{label}
 		{#if required}
-			<span class="required">*</span>
+			<span class="required" aria-hidden="true">*</span>
 		{/if}
 	</label>
 	{@render children()}
-	{#if hint && !error}
-		<p class="form-hint">{hint}</p>
+	{#if hintId}
+		<p id={hintId} class="form-hint">{hint}</p>
 	{/if}
-	{#if error}
-		<p class="form-error">{error}</p>
+	{#if errorId}
+		<p id={errorId} class="form-error" role="alert">{error}</p>
 	{/if}
 </div>
 

--- a/packages/smrt-svelte/src/components/forms/Input.svelte
+++ b/packages/smrt-svelte/src/components/forms/Input.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
-export interface Props {
-  id?: string;
-  type?: 'text' | 'email' | 'password' | 'number' | 'url' | 'tel' | 'search';
+import type { HTMLInputAttributes } from 'svelte/elements';
+import { tryGetFormGroupContext } from '../../state/form-group-context.js';
+
+export interface Props extends Omit<HTMLInputAttributes, 'class' | 'value'> {
   value?: string | number;
-  placeholder?: string;
-  disabled?: boolean;
-  readonly?: boolean;
-  required?: boolean;
-  name?: string;
   class?: string;
 }
 
@@ -21,19 +17,36 @@ let {
   required = false,
   name,
   class: className = '',
+  'aria-describedby': ariaDescribedby,
+  'aria-invalid': ariaInvalid,
+  ...rest
 }: Props = $props();
+
+// When wrapped in a <FormGroup>, inherit the id (so its <label for> resolves),
+// the hint/error association, and the error state — unless set explicitly.
+const formGroup = tryGetFormGroupContext();
+const resolvedId = $derived(id ?? formGroup?.().inputId);
+const resolvedDescribedBy = $derived(
+  ariaDescribedby ?? formGroup?.().describedBy,
+);
+const resolvedInvalid = $derived(
+  ariaInvalid ?? (formGroup?.().invalid ? 'true' : undefined),
+);
 </script>
 
 <input
-	{id}
+	id={resolvedId}
 	{type}
 	bind:value
 	{placeholder}
 	{disabled}
-	readonly={readonly}
+	{readonly}
 	{required}
 	{name}
+	aria-describedby={resolvedDescribedBy}
+	aria-invalid={resolvedInvalid}
 	class="input {className}"
+	{...rest}
 />
 
 <style>

--- a/packages/smrt-svelte/src/components/forms/Select.svelte
+++ b/packages/smrt-svelte/src/components/forms/Select.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
 import type { Snippet } from 'svelte';
+import type { HTMLSelectAttributes } from 'svelte/elements';
+import { tryGetFormGroupContext } from '../../state/form-group-context.js';
 
-export interface Props {
-  id?: string;
+export interface Props extends Omit<HTMLSelectAttributes, 'class' | 'value'> {
   value?: string;
-  disabled?: boolean;
-  required?: boolean;
-  name?: string;
   class?: string;
   children: Snippet;
 }
@@ -19,16 +17,32 @@ let {
   name,
   class: className = '',
   children,
+  'aria-describedby': ariaDescribedby,
+  'aria-invalid': ariaInvalid,
+  ...rest
 }: Props = $props();
+
+// Inherit id / hint+error association / error state from a wrapping FormGroup.
+const formGroup = tryGetFormGroupContext();
+const resolvedId = $derived(id ?? formGroup?.().inputId);
+const resolvedDescribedBy = $derived(
+  ariaDescribedby ?? formGroup?.().describedBy,
+);
+const resolvedInvalid = $derived(
+  ariaInvalid ?? (formGroup?.().invalid ? 'true' : undefined),
+);
 </script>
 
 <select
-	{id}
+	id={resolvedId}
 	bind:value
 	{disabled}
 	{required}
 	{name}
+	aria-describedby={resolvedDescribedBy}
+	aria-invalid={resolvedInvalid}
 	class="select {className}"
+	{...rest}
 >
 	{@render children()}
 </select>

--- a/packages/smrt-svelte/src/components/forms/Textarea.svelte
+++ b/packages/smrt-svelte/src/components/forms/Textarea.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
-export interface Props {
-  id?: string;
+import type { HTMLTextareaAttributes } from 'svelte/elements';
+import { tryGetFormGroupContext } from '../../state/form-group-context.js';
+
+export interface Props extends Omit<HTMLTextareaAttributes, 'class' | 'value'> {
   value?: string;
-  placeholder?: string;
-  disabled?: boolean;
-  readonly?: boolean;
-  required?: boolean;
-  name?: string;
   rows?: number;
   class?: string;
 }
@@ -21,19 +18,35 @@ let {
   name,
   rows = 4,
   class: className = '',
+  'aria-describedby': ariaDescribedby,
+  'aria-invalid': ariaInvalid,
+  ...rest
 }: Props = $props();
+
+// Inherit id / hint+error association / error state from a wrapping FormGroup.
+const formGroup = tryGetFormGroupContext();
+const resolvedId = $derived(id ?? formGroup?.().inputId);
+const resolvedDescribedBy = $derived(
+  ariaDescribedby ?? formGroup?.().describedBy,
+);
+const resolvedInvalid = $derived(
+  ariaInvalid ?? (formGroup?.().invalid ? 'true' : undefined),
+);
 </script>
 
 <textarea
-	{id}
+	id={resolvedId}
 	bind:value
 	{placeholder}
 	{disabled}
-	readonly={readonly}
+	{readonly}
 	{required}
 	{name}
 	{rows}
+	aria-describedby={resolvedDescribedBy}
+	aria-invalid={resolvedInvalid}
 	class="textarea {className}"
+	{...rest}
 ></textarea>
 
 <style>

--- a/packages/smrt-svelte/src/components/forms/__tests__/Form.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/Form.test.ts
@@ -52,6 +52,12 @@ describe('Form', () => {
     expect(onsubmit).toHaveBeenCalledTimes(1);
   });
 
+  it('exposes a polite aria-live status region for async state (L1)', () => {
+    render(Form, { props: { children: submitButton() } });
+    const status = screen.getByRole('status');
+    expect(status).toHaveAttribute('aria-live', 'polite');
+  });
+
   it('is axe-clean', async () => {
     const { container } = render(Form, { props: { children: submitButton() } });
     await expectNoA11yViolations(container);

--- a/packages/smrt-svelte/src/components/forms/__tests__/FormGroup.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/FormGroup.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Golden test for FormGroup accessibility wiring (Sweep L1, #1420).
+ *
+ * FormGroup must make a wrapped base input programmatically accessible with no
+ * extra wiring: a real <label> association, hint/error linked via
+ * aria-describedby, and aria-invalid in the error state.
+ */
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import Fixture from './form-group-input.fixture.svelte';
+
+describe('FormGroup a11y wiring', () => {
+  it('associates its label with the wrapped input', () => {
+    render(Fixture, {});
+    // getByLabelText only resolves if the label is programmatically associated.
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+  });
+
+  it('links a hint via aria-describedby', () => {
+    render(Fixture, { props: { hint: 'Work address preferred' } });
+    const input = screen.getByLabelText('Email');
+    const describedBy = input.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    const hint = document.getElementById(describedBy as string);
+    expect(hint).toHaveTextContent('Work address preferred');
+  });
+
+  it('sets aria-invalid and links the error in the error state', () => {
+    render(Fixture, { props: { error: 'Email is required' } });
+    const input = screen.getByLabelText('Email');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    const describedBy = input.getAttribute('aria-describedby');
+    const error = document.getElementById(describedBy as string);
+    expect(error).toHaveTextContent('Email is required');
+    // error is announced
+    expect(error).toHaveAttribute('role', 'alert');
+  });
+
+  it('is axe-clean (labelled control, associated hint)', async () => {
+    const { container } = render(Fixture, {
+      props: { hint: 'Work address preferred' },
+    });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean in the error state', async () => {
+    const { container } = render(Fixture, {
+      props: { error: 'Email is required' },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/Select.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/Select.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Golden test for Select (Sweep L1, #1420).
+ *
+ * Select forwards aria attributes (so it can be labelled / error-associated)
+ * and inherits id / describedby / invalid from a wrapping FormGroup via context.
+ */
+import { render, screen } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import Select from '../Select.svelte';
+
+function options() {
+  return createRawSnippet(() => ({
+    render: () => `<option value="a">A</option><option value="b">B</option>`,
+  }));
+}
+
+describe('Select', () => {
+  it('forwards aria-label / aria-describedby / aria-invalid', () => {
+    render(Select, {
+      props: {
+        'aria-label': 'Country',
+        'aria-describedby': 'country-hint',
+        'aria-invalid': 'true',
+        children: options(),
+      },
+    });
+    const select = screen.getByRole('combobox', { name: 'Country' });
+    expect(select).toHaveAttribute('aria-describedby', 'country-hint');
+    expect(select).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('is axe-clean when labelled', async () => {
+    const { container } = render(Select, {
+      props: { 'aria-label': 'Country', children: options() },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/Textarea.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/Textarea.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Golden test for Textarea (Sweep L1, #1420).
+ *
+ * Textarea forwards aria attributes and inherits id / describedby / invalid from
+ * a wrapping FormGroup via context.
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import Textarea from '../Textarea.svelte';
+
+describe('Textarea', () => {
+  it('forwards aria-label / aria-describedby / aria-invalid', () => {
+    render(Textarea, {
+      props: {
+        'aria-label': 'Notes',
+        'aria-describedby': 'notes-hint',
+        'aria-invalid': 'true',
+      },
+    });
+    const textarea = screen.getByRole('textbox', { name: 'Notes' });
+    expect(textarea).toHaveAttribute('aria-describedby', 'notes-hint');
+    expect(textarea).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('accepts typed input', async () => {
+    render(Textarea, { props: { 'aria-label': 'Notes' } });
+    const textarea = screen.getByRole<HTMLTextAreaElement>('textbox', {
+      name: 'Notes',
+    });
+    await userEvent.type(textarea, 'hello');
+    expect(textarea).toHaveValue('hello');
+  });
+
+  it('is axe-clean when labelled', async () => {
+    const { container } = render(Textarea, {
+      props: { 'aria-label': 'Notes' },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/form-group-input.fixture.svelte
+++ b/packages/smrt-svelte/src/components/forms/__tests__/form-group-input.fixture.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+/** Test fixture (L1 #1420): an Input wrapped in a FormGroup, to exercise the
+ *  FormGroup → base-input accessibility auto-wiring. */
+import FormGroup from '../FormGroup.svelte';
+import Input from '../Input.svelte';
+
+let {
+  error = undefined,
+  hint = undefined,
+  required = false,
+}: { error?: string; hint?: string; required?: boolean } = $props();
+</script>
+
+<FormGroup label="Email" {error} {hint} {required}>
+	<Input type="email" name="email" />
+</FormGroup>

--- a/packages/smrt-svelte/src/state/form-group-context.ts
+++ b/packages/smrt-svelte/src/state/form-group-context.ts
@@ -1,0 +1,44 @@
+/**
+ * FormGroup accessibility context (Sweep L1, #1420).
+ *
+ * `FormGroup` publishes the wiring a wrapped input needs to be programmatically
+ * accessible — the input's `id` (so the `<label for>` resolves), the
+ * space-joined ids of the hint/error text (for `aria-describedby`), and whether
+ * the field is currently in an error state (`aria-invalid`). The base form
+ * primitives (`Input`, `Select`, `Textarea`) read this and auto-apply those
+ * attributes when the consumer hasn't set them explicitly, so an input dropped
+ * inside a `<FormGroup>` is accessible with no extra wiring.
+ *
+ * The value is a getter so the consuming input always reads the *current*
+ * reactive state (id is stable; describedBy/invalid change as hint/error do).
+ */
+import { getContext, setContext } from 'svelte';
+
+export interface FormGroupContextValue {
+  /** Stable id for the field control; matches the FormGroup label's `for`. */
+  inputId: string;
+  /** Space-joined ids of the visible hint/error text, or undefined if none. */
+  describedBy: string | undefined;
+  /** Whether the field is currently showing an error. */
+  invalid: boolean;
+}
+
+const FORM_GROUP_KEY = Symbol('smrt-form-group');
+
+export function setFormGroupContext(get: () => FormGroupContextValue): void {
+  setContext(FORM_GROUP_KEY, get);
+}
+
+export function tryGetFormGroupContext():
+  | (() => FormGroupContextValue)
+  | undefined {
+  return getContext<(() => FormGroupContextValue) | undefined>(FORM_GROUP_KEY);
+}
+
+let autoIdCounter = 0;
+
+/** Deterministic, collision-resistant id for a FormGroup that wasn't given one. */
+export function nextFieldId(): string {
+  autoIdCounter += 1;
+  return `smrt-field-${autoIdCounter}`;
+}


### PR DESCRIPTION
## L1 (Phase 0) — form-input accessibility: foundation

**Part of #1420** (the foundation — base primitives + FormGroup + Form; the rich-input variants are the remaining pass, see below). Builds on L4's axe harness.

### What changed
- **FormGroup → input auto-wiring** (`src/state/form-group-context.ts` + `FormGroup.svelte`): FormGroup now generates a stable field id (so its `<label for>` resolves), gives the hint/error text ids, marks the error `role="alert"`, and publishes a context with `{ inputId, describedBy, invalid }`. A base input dropped inside a `<FormGroup>` is now accessible with zero extra wiring.
- **Accessible base primitives** (`Input`, `Select`, `Textarea`): now extend the native element attribute types and forward `...rest` (so `aria-label`/`aria-describedby`/`aria-invalid`/etc. pass through), and auto-apply `id` + `aria-describedby` + `aria-invalid` from FormGroup context when not set explicitly.
- **Form live region** (`Form.svelte`): added a visually-hidden `role="status" aria-live="polite"` region that announces async STT/extraction state, and `role="alert"` on the extraction-error banner.

### Acceptance criteria (#1420)
- [x] FormGroup associates hint/error via `aria-describedby`
- [x] Form async status/errors announced via `aria-live`
- [x] Programmatic label + error association — **for the base primitives** (Input/Select/Textarea via FormGroup); the standalone rich inputs are the remaining pass
- [x] axe-clean for the covered primitives (with L4 harness)

### Verification
- New a11y tests (20): `FormGroup` (label association, `aria-describedby` for hint+error, `aria-invalid`, `role=alert`, axe-clean in both states), `Select`/`Textarea` (aria forwarding + axe), `Input` (L4 behavior), `Form` (live region + axe). `getByLabelText('Email')` resolving proves real label association.
- Full smrt-svelte suite: **25 files / 301 tests green** (+11), `tsc + svelte-check` 0 errors, `biome ci` clean.

### Remaining (follow-up to fully close #1420)
The standalone rich inputs each carry their own `<label>` + supporting-text and need the same `aria-describedby` → supporting-text + `aria-invalid`-on-error pass, following this foundation's pattern: `TextInput`, `MoneyInput`, `NumberInput`, `PhoneInput`, `DateRangeInput`, `DateTimeInput`, `AddressInput`, `MeasurementInput` (+ `SelectInput`/`TextareaInput`/`SearchInput`/`CheckboxInput`). Done as the L1 rich-input sweep next.