### PR TITLE
feat(smrt-svelte): aria on multi-field composite inputs (L1 #1420)

### DIFF
--- a/packages/smrt-svelte/src/components/forms/AddressInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/AddressInput.svelte
@@ -288,6 +288,8 @@ function handleCountryChange(e: Event) {
           required={required && fields.includes('street')}
           class="smrt-input"
           class:invalid={!!error}
+          aria-invalid={error ? 'true' : undefined}
+          aria-describedby={error ? `${name}-error` : undefined}
           oninput={handleStreetInput}
         />
       </div>
@@ -307,6 +309,8 @@ function handleCountryChange(e: Event) {
             required={required && fields.includes('city')}
             class="smrt-input"
             class:invalid={!!error}
+            aria-invalid={error ? 'true' : undefined}
+            aria-describedby={error ? `${name}-error` : undefined}
             oninput={handleCityInput}
           />
         </div>
@@ -323,6 +327,8 @@ function handleCountryChange(e: Event) {
             required={required && fields.includes('province')}
             class="smrt-input smrt-select"
             class:invalid={!!error}
+            aria-invalid={error ? 'true' : undefined}
+            aria-describedby={error ? `${name}-error` : undefined}
             onchange={handleProvinceChange}
           >
             <option value="">Select...</option>
@@ -348,6 +354,8 @@ function handleCountryChange(e: Event) {
             required={required && fields.includes('postalCode')}
             class="smrt-input"
             class:invalid={!!error}
+            aria-invalid={error ? 'true' : undefined}
+            aria-describedby={error ? `${name}-error` : undefined}
             oninput={handlePostalInput}
           />
         </div>
@@ -364,6 +372,8 @@ function handleCountryChange(e: Event) {
             required={required && fields.includes('country')}
             class="smrt-input smrt-select"
             class:invalid={!!error}
+            aria-invalid={error ? 'true' : undefined}
+            aria-describedby={error ? `${name}-error` : undefined}
             onchange={handleCountryChange}
           >
             {#each countries as c (c.value)}
@@ -376,7 +386,7 @@ function handleCountryChange(e: Event) {
   </div>
 
   {#if error}
-    <div class="validation-error">{error}</div>
+    <div id={`${name}-error`} class="validation-error" role="alert">{error}</div>
   {/if}
 </div>
 

--- a/packages/smrt-svelte/src/components/forms/DateRangeInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/DateRangeInput.svelte
@@ -373,6 +373,8 @@ const primaryControlId = $derived(isSmrt ? `${name}_voice` : `${name}_start`);
             {disabled}
             required={required}
             class="smrt-input"
+            aria-invalid={showInvalid ? 'true' : undefined}
+            aria-describedby={showInvalid ? `${name}-error` : undefined}
             onchange={handleStartChange}
           />
         </div>
@@ -391,6 +393,8 @@ const primaryControlId = $derived(isSmrt ? `${name}_voice` : `${name}_start`);
             {disabled}
             required={required}
             class="smrt-input"
+            aria-invalid={showInvalid ? 'true' : undefined}
+            aria-describedby={showInvalid ? `${name}-error` : undefined}
             onchange={handleEndChange}
           />
         </div>
@@ -407,11 +411,13 @@ const primaryControlId = $derived(isSmrt ? `${name}_voice` : `${name}_start`);
   {:else if isParsing}
     <div class="parsing-indicator">Parsing dates...</div>
   {:else if parseError}
-    <div class="error-indicator">{parseError}</div>
+    <div id={`${name}-error`} class="error-indicator" role="alert">{parseError}</div>
   {:else if error}
-    <div class="error-indicator">{error}</div>
+    <div id={`${name}-error`} class="error-indicator" role="alert">{error}</div>
   {:else if !isValidRange}
-    <div class="error-indicator">End date must be after start date</div>
+    <div id={`${name}-error`} class="error-indicator" role="alert">
+      End date must be after start date
+    </div>
   {/if}
 </div>
 

--- a/packages/smrt-svelte/src/components/forms/DateTimeInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/DateTimeInput.svelte
@@ -299,6 +299,8 @@ function handleNativeChange(e: Event) {
         disabled={disabled || isParsing}
         {required}
         class="smrt-input smrt-mode"
+        aria-invalid={parseError ? 'true' : undefined}
+        aria-describedby={parseError ? `${name}-error` : undefined}
         readonly
         onmousedown={handleMouseDown}
         onmouseup={handleMouseUp}
@@ -360,6 +362,8 @@ function handleNativeChange(e: Event) {
         {disabled}
         {required}
         class="smrt-input"
+        aria-invalid={parseError ? 'true' : undefined}
+        aria-describedby={parseError ? `${name}-error` : undefined}
         onchange={handleNativeChange}
       />
     {/if}
@@ -370,7 +374,7 @@ function handleNativeChange(e: Event) {
   {:else if isParsing}
     <div class="parsing-indicator">Parsing date...</div>
   {:else if parseError}
-    <div class="error-indicator">{parseError}</div>
+    <div id={`${name}-error`} class="error-indicator" role="alert">{parseError}</div>
   {/if}
 </div>
 

--- a/packages/smrt-svelte/src/components/forms/MeasurementInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/MeasurementInput.svelte
@@ -349,6 +349,8 @@ function handleUnitChange(e: Event) {
       {required}
       class="smrt-input"
       class:invalid={showInvalid}
+      aria-invalid={showInvalid ? 'true' : undefined}
+      aria-describedby={showInvalid ? `${name}-error` : undefined}
       oninput={handleInput}
     />
 
@@ -358,6 +360,7 @@ function handleUnitChange(e: Event) {
       {disabled}
       class="unit-select"
       class:smrt-mode={isSmrt}
+      aria-label={label ? `${label} unit` : 'Unit'}
       onchange={handleUnitChange}
     >
       {#each units as u (u)}
@@ -370,9 +373,9 @@ function handleUnitChange(e: Event) {
   <input type="hidden" name="{name}_combined" value={value !== null ? `${value} ${unit}` : ''} />
 
   {#if error}
-    <div class="validation-error">{error}</div>
+    <div id={`${name}-error`} class="validation-error" role="alert">{error}</div>
   {:else if showInvalid && !isInRange}
-    <div class="validation-error">
+    <div id={`${name}-error`} class="validation-error" role="alert">
       {#if min !== undefined && value !== null && value < min}
         Value must be at least {min} {unitAbbreviations[unit]}
       {:else if max !== undefined && value !== null && value > max}

--- a/packages/smrt-svelte/src/components/forms/MoneyInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/MoneyInput.svelte
@@ -299,6 +299,8 @@ function handleBlur() {
       class="smrt-input"
       class:smrt-mode={isSmrt}
       class:invalid={showInvalid}
+      aria-invalid={showInvalid ? 'true' : undefined}
+      aria-describedby={showInvalid ? `${name}-error` : undefined}
       oninput={handleInput}
       onfocus={handleFocus}
       onblur={handleBlur}
@@ -310,9 +312,9 @@ function handleBlur() {
   <input type="hidden" name="{name}_cents" value={value ?? ''} />
 
   {#if error}
-    <div class="validation-error">{error}</div>
+    <div id={`${name}-error`} class="validation-error" role="alert">{error}</div>
   {:else if showInvalid && !isInRange}
-    <div class="validation-error">
+    <div id={`${name}-error`} class="validation-error" role="alert">
       {#if min !== undefined && value !== null && value < min}
         Value must be at least ${(min / 100).toFixed(2)}
       {:else if max !== undefined && value !== null && value > max}

--- a/packages/smrt-svelte/src/components/forms/__tests__/composite-inputs-a11y.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/composite-inputs-a11y.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Accessibility golden tests for the multi-field composite form inputs
+ * (Sweep L1, #1420). Each sub-field is programmatically labelled and the
+ * shared/validation error is associated via aria-describedby + role="alert".
+ * Hooks are mocked (Provider-backed, throw otherwise).
+ */
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+
+vi.mock('../../../hooks/useAppState.svelte.js', () => ({
+  useAppState: () => ({ state: { mode: 'default' }, setMode: vi.fn() }),
+}));
+vi.mock('../../../hooks/useSTT.svelte.js', () => ({
+  useSTT: () => ({
+    isListening: false,
+    isInitializing: false,
+    isReady: false,
+    adapterType: null,
+    downloadProgress: 0,
+    lastResult: '',
+    initialize: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+import AddressInput from '../AddressInput.svelte';
+import DateRangeInput from '../DateRangeInput.svelte';
+import DateTimeInput from '../DateTimeInput.svelte';
+import MeasurementInput from '../MeasurementInput.svelte';
+import MoneyInput from '../MoneyInput.svelte';
+
+describe('composite form inputs — accessibility', () => {
+  it('MoneyInput: labelled amount + axe-clean', async () => {
+    const { container } = render(MoneyInput, {
+      props: { name: 'price', label: 'Price' },
+    });
+    expect(screen.getByLabelText('Price')).toBeInTheDocument();
+    await expectNoA11yViolations(container);
+  });
+
+  it('MeasurementInput: labelled value + labelled unit select + axe-clean', async () => {
+    const { container } = render(MeasurementInput, {
+      props: { name: 'weight', label: 'Weight' },
+    });
+    expect(screen.getByLabelText('Weight')).toBeInTheDocument();
+    expect(screen.getByLabelText('Weight unit')).toBeInTheDocument();
+    await expectNoA11yViolations(container);
+  });
+
+  it('DateRangeInput: labelled start/end + axe-clean', async () => {
+    const { container } = render(DateRangeInput, {
+      props: { name: 'range', label: 'Dates' },
+    });
+    expect(screen.getByLabelText('Start')).toBeInTheDocument();
+    expect(screen.getByLabelText('End')).toBeInTheDocument();
+    await expectNoA11yViolations(container);
+  });
+
+  it('AddressInput: all fields labelled + axe-clean', async () => {
+    const { container } = render(AddressInput, {
+      props: { name: 'addr', label: 'Address' },
+    });
+    expect(screen.getAllByRole('textbox').length).toBeGreaterThan(0);
+    await expectNoA11yViolations(container);
+  });
+
+  it('DateTimeInput: labelled + axe-clean', async () => {
+    const { container } = render(DateTimeInput, {
+      props: { name: 'when', label: 'When' },
+    });
+    expect(screen.getByLabelText('When')).toBeInTheDocument();
+    await expectNoA11yViolations(container);
+  });
+});


### PR DESCRIPTION
## L1 (Phase 0) — form a11y: multi-field composite inputs (final batch)

Closes #1420. Completes the form-input accessibility pass: foundation (#1487) → single-field rich inputs (#1488) → these multi-field composites.

### What changed
- **AddressInput**: `aria-invalid` + `aria-describedby` → the shared validation error (now `id`'d, `role="alert"`) on all five fields (street/city/province/postal/country — each already had an associated `<label for>`).
- **MoneyInput**: `aria-invalid` + `aria-describedby` → the range/format error (`id`'d, `role="alert"`). Hidden cents field needs no label.
- **MeasurementInput**: same on the value input; **gave the unit `<select>` an `aria-label`** (it had none); error `id`'d + `role="alert"`.
- **DateRangeInput**: `aria-invalid` + `aria-describedby` on both the start and end date inputs; the parse/validation/range errors `id`'d + `role="alert"`.
- **DateTimeInput**: `aria-invalid` + `aria-describedby` on the input (both SMRT and native branches) tied to the parse error (`id`'d + `role="alert"`).

### Acceptance criteria (#1420)
- [x] Every form input has a programmatic label (label / aria-label) + error association — base primitives (#1487) + all rich/composite inputs (#1488 + this)
- [x] FormGroup associates hint/error via `aria-describedby` (#1487)
- [x] Form async status/errors announced via `aria-live` (#1487)
- [x] axe-clean for the form primitives (with L4)

### Verification
- New `composite-inputs-a11y.test.ts` (5): label associations (incl. the new MeasurementInput unit-select label, DateRange start/end) + axe-clean for each.
- Full smrt-svelte suite: **33 files / 340 tests green**; `tsc + svelte-check` 0 errors; `biome ci` clean.

The coverage gate skips smrt-svelte (exempt per #1488 → S11 #1416 owns component coverage).