### PR TITLE
feat(smrt-svelte): Avatar, Chip, Skeleton gap primitives (L3 #1422)

### DIFF
--- a/packages/smrt-svelte/playground/src/routes/primitives/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/primitives/+page.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+import { Avatar, Chip, Skeleton } from '@happyvertical/smrt-svelte';
+
+let selected = $state<Record<string, boolean>>({ ts: true, svelte: false });
+let chips = $state(['Design', 'A11y', 'Tokens']);
+
+function toggle(key: string) {
+  selected[key] = !selected[key];
+}
+function removeChip(name: string) {
+  chips = chips.filter((c) => c !== name);
+}
+</script>
+
+<h1>Gap Primitives</h1>
+<p class="description">
+  Generic library primitives (L3 #1422) — Avatar, Chip, Skeleton.
+</p>
+
+<section>
+  <h2>Avatar</h2>
+  <p class="section-desc">Image with initials fallback + optional presence dot.</p>
+  <div class="demo-row">
+    <Avatar name="Ada Lovelace" size="sm" />
+    <Avatar name="Grace Hopper" size="md" status="online" />
+    <Avatar name="Linus Torvalds" size="lg" status="busy" />
+    <Avatar name="Margaret Hamilton" size="xl" status="away" />
+  </div>
+</section>
+
+<section>
+  <h2>Chip</h2>
+  <p class="section-desc">Selectable toggles and closeable tokens.</p>
+  <div class="demo-row">
+    <Chip
+      label="TypeScript"
+      selectable
+      selected={selected.ts}
+      onselect={() => toggle('ts')}
+    />
+    <Chip
+      label="Svelte"
+      selectable
+      selected={selected.svelte}
+      onselect={() => toggle('svelte')}
+    />
+  </div>
+  <div class="demo-row">
+    {#each chips as chip (chip)}
+      <Chip label={chip} closeable onclose={() => removeChip(chip)} />
+    {/each}
+  </div>
+</section>
+
+<section>
+  <h2>Skeleton</h2>
+  <p class="section-desc">Shape-matching loading placeholders.</p>
+  <div class="demo-row" style="align-items: center; gap: 16px;">
+    <Skeleton variant="circle" />
+    <div style="flex: 1;">
+      <Skeleton variant="text" lines={3} />
+    </div>
+  </div>
+  <div class="demo-row">
+    <Skeleton variant="rect" width="240px" height="120px" />
+  </div>
+</section>
+
+<style>
+  .description {
+    color: var(--smrt-color-on-surface-variant, #6b7280);
+    margin-bottom: 2rem;
+  }
+  section {
+    margin-bottom: 2.5rem;
+  }
+  .section-desc {
+    color: var(--smrt-color-on-surface-variant, #6b7280);
+    font-size: 0.875rem;
+    margin-bottom: 0.75rem;
+  }
+  .demo-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 0.75rem;
+  }
+</style>

--- a/packages/smrt-svelte/src/components/ui/Avatar.svelte
+++ b/packages/smrt-svelte/src/components/ui/Avatar.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+/**
+ * Avatar — user/entity image with initials fallback and optional presence dot.
+ *
+ * Renders the image when `src` is set, otherwise initials derived from `name`.
+ * `name` is always the accessible label (image alt / initials aria-label), so an
+ * Avatar is never an unlabelled graphic.
+ */
+import type { HTMLAttributes } from 'svelte/elements';
+
+export type AvatarSize = 'sm' | 'md' | 'lg' | 'xl';
+export type AvatarStatus = 'online' | 'offline' | 'away' | 'busy';
+
+export interface Props extends Omit<HTMLAttributes<HTMLSpanElement>, 'class'> {
+  /** Image URL. When absent, initials from `name` are shown. */
+  src?: string;
+  /** Accessible name; also the image alt and initials fallback source. */
+  name: string;
+  /** Size variant. */
+  size?: AvatarSize;
+  /** Optional presence indicator. */
+  status?: AvatarStatus;
+  /** Extra class on the root. */
+  class?: string;
+}
+
+const {
+  src,
+  name,
+  size = 'md',
+  status,
+  class: className = '',
+  ...rest
+}: Props = $props();
+
+/** First+last initial (or first two letters of a single word). */
+function initialsOf(value: string): string {
+  const parts = value.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+const statusLabels: Record<AvatarStatus, string> = {
+  online: 'Online',
+  offline: 'Offline',
+  away: 'Away',
+  busy: 'Busy',
+};
+</script>
+
+<span class="avatar {size} {className}" {...rest}>
+  {#if src}
+    <img class="avatar__img" {src} alt={name} />
+  {:else}
+    <span class="avatar__initials" role="img" aria-label={name}>
+      {initialsOf(name)}
+    </span>
+  {/if}
+  {#if status}
+    <span class="avatar__status {status}">
+      <span class="avatar__sr-only">{statusLabels[status]}</span>
+    </span>
+  {/if}
+</span>
+
+<style>
+  .avatar {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    border-radius: var(--smrt-radius-full, 9999px);
+    background: var(--smrt-color-surface-container-high);
+    color: var(--smrt-color-on-surface-variant);
+    font-weight: var(--smrt-typography-weight-medium, 500);
+    overflow: visible;
+    user-select: none;
+  }
+
+  .avatar__img {
+    width: 100%;
+    height: 100%;
+    border-radius: inherit;
+    object-fit: cover;
+  }
+
+  .avatar__initials {
+    line-height: 1;
+  }
+
+  /* Sizes */
+  .sm {
+    width: 24px;
+    height: 24px;
+    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
+  }
+  .md {
+    width: 36px;
+    height: 36px;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
+  }
+  .lg {
+    width: 48px;
+    height: 48px;
+    font-size: var(--smrt-typography-title-medium-size, 1rem);
+  }
+  .xl {
+    width: 64px;
+    height: 64px;
+    font-size: var(--smrt-typography-title-large-size, 1.375rem);
+  }
+
+  /* Presence dot */
+  .avatar__status {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    width: 28%;
+    height: 28%;
+    min-width: 8px;
+    min-height: 8px;
+    border-radius: var(--smrt-radius-full, 9999px);
+    border: 2px solid var(--smrt-color-surface);
+    box-sizing: border-box;
+  }
+  .avatar__status.online {
+    background: var(--smrt-color-success, #2e7d32);
+  }
+  .avatar__status.offline {
+    background: var(--smrt-color-outline, #79747e);
+  }
+  .avatar__status.away {
+    background: var(--smrt-color-warning, #ed6c02);
+  }
+  .avatar__status.busy {
+    background: var(--smrt-color-error, #ba1a1a);
+  }
+
+  .avatar__sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+</style>

--- a/packages/smrt-svelte/src/components/ui/Chip.svelte
+++ b/packages/smrt-svelte/src/components/ui/Chip.svelte
@@ -1,0 +1,167 @@
+<script lang="ts">
+/**
+ * Chip — compact token, optionally selectable (toggle) and/or closeable.
+ *
+ * When `selectable`, the body is a `<button>` reflecting `selected` via
+ * `aria-pressed`. When `closeable`, a labelled remove `<button>` is appended.
+ * Both are native buttons, so keyboard activation is built in.
+ */
+import type { Snippet } from 'svelte';
+
+export type ChipSize = 'sm' | 'md';
+
+export interface Props {
+  /** Text label; also the close button's accessible name (`Remove <label>`). */
+  label?: string;
+  /** Chip content; falls back to `label`. */
+  children?: Snippet;
+  /** Render the body as a toggle button reflecting `selected`. */
+  selectable?: boolean;
+  /** Selected state (only meaningful with `selectable`). */
+  selected?: boolean;
+  /** Append a remove (×) button. */
+  closeable?: boolean;
+  /** Disable both buttons. */
+  disabled?: boolean;
+  /** Size variant. */
+  size?: ChipSize;
+  /** Fired when a selectable chip body is activated. */
+  onselect?: () => void;
+  /** Fired when the remove button is activated. */
+  onclose?: () => void;
+}
+
+const {
+  label,
+  children,
+  selectable = false,
+  selected = false,
+  closeable = false,
+  disabled = false,
+  size = 'md',
+  onselect,
+  onclose,
+}: Props = $props();
+</script>
+
+<span
+  class="chip {size}"
+  class:selected
+  class:disabled
+  class:selectable
+  class:closeable
+>
+  {#if selectable}
+    <button
+      type="button"
+      class="chip__body"
+      aria-pressed={selected}
+      {disabled}
+      onclick={() => onselect?.()}
+    >
+      {#if children}{@render children()}{:else}{label}{/if}
+    </button>
+  {:else}
+    <span class="chip__body">
+      {#if children}{@render children()}{:else}{label}{/if}
+    </span>
+  {/if}
+
+  {#if closeable}
+    <button
+      type="button"
+      class="chip__close"
+      aria-label={label ? `Remove ${label}` : 'Remove'}
+      {disabled}
+      onclick={() => onclose?.()}
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        aria-hidden="true"
+      >
+        <line x1="18" y1="6" x2="6" y2="18" />
+        <line x1="6" y1="6" x2="18" y2="18" />
+      </svg>
+    </button>
+  {/if}
+</span>
+
+<style>
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--smrt-spacing-1, 4px);
+    border-radius: var(--smrt-radius-full, 9999px);
+    background: var(--smrt-color-surface-container-high);
+    color: var(--smrt-color-on-surface);
+    border: 1px solid var(--smrt-color-outline-variant, #cac4d0);
+    max-width: 100%;
+  }
+
+  .chip.sm {
+    padding: 0 var(--smrt-spacing-1, 4px);
+    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
+  }
+  .chip.md {
+    padding: 0 var(--smrt-spacing-2, 8px);
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
+  }
+
+  .chip.selected {
+    background: var(--smrt-color-primary-container);
+    color: var(--smrt-color-on-primary-container);
+    border-color: var(--smrt-color-primary);
+  }
+
+  .chip.disabled {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+
+  .chip__body {
+    appearance: none;
+    background: none;
+    border: none;
+    color: inherit;
+    font: inherit;
+    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-1, 4px);
+    cursor: default;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .chip.selectable .chip__body {
+    cursor: pointer;
+  }
+
+  .chip__close {
+    appearance: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    padding: var(--smrt-spacing-1, 4px);
+    border-radius: var(--smrt-radius-full, 9999px);
+    opacity: 0.7;
+  }
+  .chip__close:hover {
+    opacity: 1;
+    background: color-mix(in srgb, currentColor 12%, transparent);
+  }
+
+  .chip__body:focus-visible,
+  .chip__close:focus-visible {
+    outline: 2px solid var(--smrt-color-primary);
+    outline-offset: 1px;
+  }
+</style>

--- a/packages/smrt-svelte/src/components/ui/Skeleton.svelte
+++ b/packages/smrt-svelte/src/components/ui/Skeleton.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+/**
+ * Skeleton — shape-matching loading placeholder.
+ *
+ * Variants: `text` (one or more lines), `circle`, `rect`. The wrapper is a
+ * polite `role="status"` region with an sr-only label so assistive tech
+ * announces that content is loading; the shimmer honors `prefers-reduced-motion`.
+ */
+export type SkeletonVariant = 'text' | 'circle' | 'rect';
+
+export interface Props {
+  /** Placeholder shape. */
+  variant?: SkeletonVariant;
+  /** CSS width (e.g. '100%', '8rem'). */
+  width?: string;
+  /** CSS height (e.g. '1rem', '48px'). */
+  height?: string;
+  /** Number of lines for the `text` variant. */
+  lines?: number;
+  /** Accessible loading label. */
+  label?: string;
+}
+
+const {
+  variant = 'text',
+  width,
+  height,
+  lines = 1,
+  label = 'Loading…',
+}: Props = $props();
+
+const lineIndexes = $derived(
+  variant === 'text'
+    ? Array.from({ length: Math.max(1, lines) }, (_, i) => i)
+    : [0],
+);
+</script>
+
+<span class="skeleton-wrap" role="status" aria-label={label}>
+  {#if variant === 'text'}
+    {#each lineIndexes as i (i)}
+      <span
+        class="skeleton skeleton--text"
+        style:width={width}
+        style:height={height}
+        aria-hidden="true"
+      ></span>
+    {/each}
+  {:else}
+    <span
+      class="skeleton skeleton--{variant}"
+      style:width={width}
+      style:height={height}
+      aria-hidden="true"
+    ></span>
+  {/if}
+</span>
+
+<style>
+  .skeleton-wrap {
+    display: inline-flex;
+    flex-direction: column;
+    gap: var(--smrt-spacing-2, 8px);
+    width: 100%;
+  }
+
+  .skeleton {
+    display: block;
+    background: var(--smrt-color-surface-container-highest, #e7e0ec);
+    background-image: linear-gradient(
+      90deg,
+      transparent 0%,
+      color-mix(in srgb, var(--smrt-color-surface) 60%, transparent) 50%,
+      transparent 100%
+    );
+    background-size: 200% 100%;
+    animation: smrt-skeleton-shimmer 1.4s ease-in-out infinite;
+    border-radius: var(--smrt-radius-small, 4px);
+  }
+
+  .skeleton--text {
+    width: 100%;
+    height: var(--smrt-typography-body-medium-size, 1rem);
+    border-radius: var(--smrt-radius-extra-small, 4px);
+  }
+
+  .skeleton--circle {
+    width: 48px;
+    height: 48px;
+    border-radius: var(--smrt-radius-full, 9999px);
+  }
+
+  .skeleton--rect {
+    width: 100%;
+    height: 96px;
+    border-radius: var(--smrt-radius-medium, 8px);
+  }
+
+  @keyframes smrt-skeleton-shimmer {
+    from {
+      background-position: 200% 0;
+    }
+    to {
+      background-position: -200% 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .skeleton {
+      animation: none;
+    }
+  }
+</style>

--- a/packages/smrt-svelte/src/components/ui/__tests__/gap-primitives.test.ts
+++ b/packages/smrt-svelte/src/components/ui/__tests__/gap-primitives.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Golden tests for the L3 gap primitives — batch 1 (Avatar, Chip, Skeleton).
+ * Render + interaction + a11y, per the L4 harness pattern (#1422 / #1423).
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import Avatar from '../Avatar.svelte';
+import Chip from '../Chip.svelte';
+import Skeleton from '../Skeleton.svelte';
+
+describe('Avatar', () => {
+  it('shows initials + accessible name when no src', () => {
+    render(Avatar, { props: { name: 'Ada Lovelace' } });
+    const img = screen.getByRole('img', { name: 'Ada Lovelace' });
+    expect(img).toHaveTextContent('AL');
+  });
+
+  it('renders an <img> with alt when src is set', () => {
+    render(Avatar, { props: { name: 'Ada', src: 'https://x/a.png' } });
+    expect(screen.getByRole('img', { name: 'Ada' }).tagName).toBe('IMG');
+  });
+
+  it('announces presence status', () => {
+    render(Avatar, { props: { name: 'Ada', status: 'online' } });
+    expect(screen.getByText('Online')).toBeInTheDocument();
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(Avatar, {
+      props: { name: 'Ada Lovelace', status: 'away' },
+    });
+    await expectNoA11yViolations(container);
+  });
+});
+
+describe('Chip', () => {
+  it('renders its label', () => {
+    render(Chip, { props: { label: 'TypeScript' } });
+    expect(screen.getByText('TypeScript')).toBeInTheDocument();
+  });
+
+  it('selectable: toggle button exposes aria-pressed and fires onselect', async () => {
+    const onselect = vi.fn();
+    render(Chip, {
+      props: { label: 'Tag', selectable: true, selected: true, onselect },
+    });
+    const btn = screen.getByRole('button', { name: 'Tag', pressed: true });
+    await userEvent.click(btn);
+    expect(onselect).toHaveBeenCalledTimes(1);
+  });
+
+  it('closeable: labelled remove button fires onclose', async () => {
+    const onclose = vi.fn();
+    render(Chip, { props: { label: 'Tag', closeable: true, onclose } });
+    await userEvent.click(screen.getByRole('button', { name: 'Remove Tag' }));
+    expect(onclose).toHaveBeenCalledTimes(1);
+  });
+
+  it('is axe-clean (selectable + closeable)', async () => {
+    const { container } = render(Chip, {
+      props: { label: 'Tag', selectable: true, closeable: true },
+    });
+    await expectNoA11yViolations(container);
+  });
+});
+
+describe('Skeleton', () => {
+  it('is a labelled status region', () => {
+    render(Skeleton, { props: { label: 'Loading profile' } });
+    expect(
+      screen.getByRole('status', { name: 'Loading profile' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders one placeholder per text line', () => {
+    const { container } = render(Skeleton, {
+      props: { variant: 'text', lines: 3 },
+    });
+    expect(container.querySelectorAll('.skeleton')).toHaveLength(3);
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(Skeleton, { props: { variant: 'circle' } });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/ui/index.ts
+++ b/packages/smrt-svelte/src/components/ui/index.ts
@@ -3,10 +3,13 @@
  */
 
 // Export components
+export { default as Avatar } from './Avatar.svelte';
 export { default as Badge } from './Badge.svelte';
 export { default as Button } from './Button.svelte';
 export { default as Card } from './Card.svelte';
+export { default as Chip } from './Chip.svelte';
 export { default as Pagination } from './Pagination.svelte';
+export { default as Skeleton } from './Skeleton.svelte';
 
 // Note: Component prop types (BadgeProps, ButtonProps, etc.) are available
 // via svelte-package build output but cannot be re-exported here because


### PR DESCRIPTION
## L3 (Phase 0) — gap primitives, batch 1

**Part of #1422** (display primitives; interactive Dropdown/Tooltip/Tree and the `/chat` set follow in subsequent batches). Adds library primitives domain packages currently re-roll, so S10 has something to consolidate onto.

### Added (each meets the bar: tokens + a11y + JSDoc + golden test + playground)
- **Avatar** — image with initials fallback + optional presence dot. `name` is always the accessible label (img alt / initials `role=img` aria-label).
- **Chip** — selectable (toggle `<button>` + `aria-pressed`) and/or closeable (labelled `Remove <label>` button); native buttons → keyboard built in.
- **Skeleton** — text/circle/rect loading placeholder; polite `role=status` + sr-only label; honors `prefers-reduced-motion`.

Exported via `./ui` (and the package root). Playground showcase at `playground/.../primitives`.

### Verification
- `gap-primitives.test.ts` (11): render, Chip select/close interaction, label/role assertions, axe-clean each.
- Full smrt-svelte suite: **34 files / 351 tests**; `tsc + svelte-check` 0 errors.
- Strict token gates pass: `check-svelte-tokens` / `check-color-literals` / `check-spacing` / `check-elevation`; `biome ci` clean.

### Next (keep #1422 open)
Dropdown/Menu, Tooltip, generic Tree → then `/chat` (MessageBubble, ReactionPicker, TypingIndicator) → then doc S10 adoption-only items.