### PR TITLE
fix(deps): override @grpc/grpc-js to 1.14.4 (S8 audit gate)

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
       "@happyvertical/spider": "^1.0.0",
       "@happyvertical/sql": "^0.74.5",
       "@happyvertical/utils": "^0.74.5",
+      "@grpc/grpc-js@>=1.14.0 <1.14.4": "1.14.4",
       "minimatch@>=10.0.0 <10.2.3": "10.2.3",
       "undici@>=7.0.0 <7.24.0": "7.24.0",
       "tar@>=7.0.0 <7.5.11": "7.5.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,7 @@ overrides:
   '@happyvertical/spider': ^1.0.0
   '@happyvertical/sql': ^0.74.5
   '@happyvertical/utils': ^0.74.5
+  '@grpc/grpc-js@>=1.14.0 <1.14.4': 1.14.4
   minimatch@>=10.0.0 <10.2.3: 10.2.3
   undici@>=7.0.0 <7.24.0: 7.24.0
   tar@>=7.0.0 <7.5.11: 7.5.11
@@ -3446,8 +3447,8 @@ packages:
   '@googlemaps/url-signature@1.0.40':
     resolution: {integrity: sha512-Gme3JxGZWQ4NVpATajSpS2/inQzhUxRvr/FK6IFpcC7AHOAmx8blI0y1/Qi2jqil+WoQ3TkEqq/MaKVtuV68RQ==}
 
-  '@grpc/grpc-js@1.14.3':
-    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+  '@grpc/grpc-js@1.14.4':
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
 
   '@grpc/proto-loader@0.8.0':
@@ -11482,7 +11483,7 @@ snapshots:
     dependencies:
       crypto-js: 4.2.0
 
-  '@grpc/grpc-js@1.14.3':
+  '@grpc/grpc-js@1.14.4':
     dependencies:
       '@grpc/proto-loader': 0.8.0
       '@js-sdsl/ordered-map': 4.4.2
@@ -15490,7 +15491,7 @@ snapshots:
 
   google-gax@5.0.6:
     dependencies:
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.8.0
       duplexify: 4.1.3
       google-auth-library: 10.6.2


### PR DESCRIPTION
## Unblock the S8 dependency-audit gate (main-wide)

Two newly-published **high** advisories against `@grpc/grpc-js` (transitive) started failing the `Dependency Vulnerability Audit` gate on every open PR:

- [GHSA-5375-pq7m-f5r2](https://github.com/advisories/GHSA-5375-pq7m-f5r2) — malformed request can crash a server
- [GHSA-99f4-grh7-6pcq](https://github.com/advisories/GHSA-99f4-grh7-6pcq) — malformed compressed message

Both affect `>=1.14.0 <1.14.4`, fixed in **1.14.4**.

### Fix
Added a version-range-scoped `pnpm.override` (same pattern as the existing S8 overrides) bumping only the vulnerable range to `1.14.4` — a patch bump, no API change. Lockfile delta is grpc-js only.

### Verification
- `pnpm audit --audit-level=high` → **exit 0** (was exit 1): 4 high / 4 ignored, 1 critical / 1 ignored — zero un-ignored high+crit.
- Lockfile change scoped to `@grpc/grpc-js@1.14.4`.