### PR TITLE
fix(tenancy): handle array tenant filters in beforeList/beforeGet

### DIFF
--- a/packages/tenancy/src/__tests__/tenancy.test.ts
+++ b/packages/tenancy/src/__tests__/tenancy.test.ts
@@ -515,6 +515,209 @@ describe('TenantInterceptor', () => {
         ).toThrow(TenantIsolationError);
       });
     });
+
+    it('should pass through scalar filter matching context tenant', async () => {
+      registerTenantScopedClass('Document');
+      const interceptor = createTenantInterceptor();
+
+      await withTenant({ tenantId: 'tenant-123' }, async () => {
+        const result = interceptor.beforeList?.(
+          'Document',
+          { where: { tenantId: 'tenant-123' } },
+          {
+            className: 'Document',
+            operation: 'list',
+            timestamp: new Date(),
+          },
+        );
+
+        // Filter already correct - pass through unchanged
+        expect(result).toBeUndefined();
+      });
+    });
+
+    // Array (IN-style) tenant filters - issue #1495
+    it('should allow array filter containing only the context tenant (issue #1495)', async () => {
+      registerTenantScopedClass('Document');
+      const interceptor = createTenantInterceptor();
+
+      await withTenant({ tenantId: 'tenant-123' }, async () => {
+        const result = interceptor.beforeList?.(
+          'Document',
+          { where: { tenantId: ['tenant-123'] } },
+          {
+            className: 'Document',
+            operation: 'list',
+            timestamp: new Date(),
+          },
+        );
+
+        // Filter already correct - pass through unchanged
+        expect(result).toBeUndefined();
+      });
+    });
+
+    it('should throw on array filter containing only a foreign tenant', async () => {
+      registerTenantScopedClass('Document');
+      const onIsolationViolation = vi.fn();
+      const interceptor = createTenantInterceptor({ onIsolationViolation });
+
+      await withTenant({ tenantId: 'tenant-123' }, async () => {
+        expect(() =>
+          interceptor.beforeList?.(
+            'Document',
+            { where: { tenantId: ['different-tenant'] } },
+            {
+              className: 'Document',
+              operation: 'list',
+              timestamp: new Date(),
+            },
+          ),
+        ).toThrow(TenantIsolationError);
+
+        // Violation callback reports the offending foreign tenant,
+        // not an Array.prototype.toString() of the whole filter
+        expect(onIsolationViolation).toHaveBeenCalledWith(
+          'Document',
+          'tenant-123',
+          'different-tenant',
+          expect.anything(),
+        );
+      });
+    });
+
+    it('should throw on array filter mixing context and foreign tenants', async () => {
+      registerTenantScopedClass('Document');
+      const interceptor = createTenantInterceptor();
+
+      await withTenant({ tenantId: 'tenant-123' }, async () => {
+        expect(() =>
+          interceptor.beforeList?.(
+            'Document',
+            { where: { tenantId: ['tenant-123', 'different-tenant'] } },
+            {
+              className: 'Document',
+              operation: 'list',
+              timestamp: new Date(),
+            },
+          ),
+        ).toThrow(TenantIsolationError);
+      });
+    });
+  });
+
+  describe('beforeGet', () => {
+    it('should convert string ID filter to object with tenant filter', async () => {
+      registerTenantScopedClass('Document');
+      const interceptor = createTenantInterceptor();
+
+      await withTenant({ tenantId: 'tenant-123' }, async () => {
+        const result = interceptor.beforeGet?.('Document', 'doc-1', {
+          className: 'Document',
+          operation: 'get',
+          timestamp: new Date(),
+        });
+
+        expect(result).toEqual({ id: 'doc-1', tenantId: 'tenant-123' });
+      });
+    });
+
+    it('should pass through scalar filter matching context tenant', async () => {
+      registerTenantScopedClass('Document');
+      const interceptor = createTenantInterceptor();
+
+      await withTenant({ tenantId: 'tenant-123' }, async () => {
+        const result = interceptor.beforeGet?.(
+          'Document',
+          { id: 'doc-1', tenantId: 'tenant-123' },
+          {
+            className: 'Document',
+            operation: 'get',
+            timestamp: new Date(),
+          },
+        );
+
+        expect(result).toBeUndefined();
+      });
+    });
+
+    it('should throw on scalar foreign tenant filter', async () => {
+      registerTenantScopedClass('Document');
+      const interceptor = createTenantInterceptor();
+
+      await withTenant({ tenantId: 'tenant-123' }, async () => {
+        expect(() =>
+          interceptor.beforeGet?.(
+            'Document',
+            { id: 'doc-1', tenantId: 'different-tenant' },
+            {
+              className: 'Document',
+              operation: 'get',
+              timestamp: new Date(),
+            },
+          ),
+        ).toThrow(TenantIsolationError);
+      });
+    });
+
+    // Array (IN-style) tenant filters - issue #1495
+    it('should allow array filter containing only the context tenant (issue #1495)', async () => {
+      registerTenantScopedClass('Document');
+      const interceptor = createTenantInterceptor();
+
+      await withTenant({ tenantId: 'tenant-123' }, async () => {
+        const result = interceptor.beforeGet?.(
+          'Document',
+          { id: 'doc-1', tenantId: ['tenant-123'] },
+          {
+            className: 'Document',
+            operation: 'get',
+            timestamp: new Date(),
+          },
+        );
+
+        expect(result).toBeUndefined();
+      });
+    });
+
+    it('should throw on array filter containing a foreign tenant', async () => {
+      registerTenantScopedClass('Document');
+      const onIsolationViolation = vi.fn();
+      const interceptor = createTenantInterceptor({ onIsolationViolation });
+
+      await withTenant({ tenantId: 'tenant-123' }, async () => {
+        expect(() =>
+          interceptor.beforeGet?.(
+            'Document',
+            { id: 'doc-1', tenantId: ['different-tenant'] },
+            {
+              className: 'Document',
+              operation: 'get',
+              timestamp: new Date(),
+            },
+          ),
+        ).toThrow(TenantIsolationError);
+
+        expect(onIsolationViolation).toHaveBeenCalledWith(
+          'Document',
+          'tenant-123',
+          'different-tenant',
+          expect.anything(),
+        );
+
+        expect(() =>
+          interceptor.beforeGet?.(
+            'Document',
+            { id: 'doc-1', tenantId: ['tenant-123', 'different-tenant'] },
+            {
+              className: 'Document',
+              operation: 'get',
+              timestamp: new Date(),
+            },
+          ),
+        ).toThrow(TenantIsolationError);
+      });
+    });
   });
 
   describe('beforeSave', () => {

--- a/packages/tenancy/src/interceptor.ts
+++ b/packages/tenancy/src/interceptor.ts
@@ -242,21 +242,34 @@ export function createTenantInterceptor(
 
       // Check if tenant filter is already present
       if (tenantField in where) {
-        // Validate it matches context
+        // Validate it matches context. The filter may be a scalar
+        // (`tenantId: 'x'`) or an IN-style array (`tenantId: ['x']`) —
+        // smrt-core auto-converts array values to SQL IN clauses, so an
+        // array containing only the context tenant is a valid filter.
+        // See https://github.com/happyvertical/smrt/issues/1495
         const existingFilter = where[tenantField];
-        if (existingFilter !== tenantContext.tenantId) {
+        const filterValues = Array.isArray(existingFilter)
+          ? existingFilter
+          : [existingFilter];
+        // findIndex (not find) so a literal null/undefined filter value is
+        // still flagged as a violation rather than mistaken for "not found"
+        const offendingIndex = filterValues.findIndex(
+          (value) => value !== tenantContext.tenantId,
+        );
+        if (offendingIndex !== -1) {
+          const offending = filterValues[offendingIndex];
           opts.onIsolationViolation?.(
             className,
             tenantContext.tenantId,
-            String(existingFilter),
+            String(offending),
             context,
           );
           throw new TenantIsolationError(
             `Tenant isolation violation in ${className} query: ` +
-              `context tenant is '${tenantContext.tenantId}' but query filters by '${existingFilter}'`,
+              `context tenant is '${tenantContext.tenantId}' but query filters by '${String(offending)}'`,
             {
               tenantId: tenantContext.tenantId,
-              attemptedTenantId: String(existingFilter),
+              attemptedTenantId: String(offending),
             },
           );
         }
@@ -326,20 +339,32 @@ export function createTenantInterceptor(
         };
       }
 
-      // Validate existing filter
-      if (filter[tenantField] !== tenantContext.tenantId) {
+      // Validate existing filter. Like beforeList, accept scalar or
+      // IN-style array filters (smrt-core auto-converts arrays to SQL IN).
+      // See https://github.com/happyvertical/smrt/issues/1495
+      const existingFilter = filter[tenantField];
+      const filterValues = Array.isArray(existingFilter)
+        ? existingFilter
+        : [existingFilter];
+      // findIndex (not find) so a literal null/undefined filter value is
+      // still flagged as a violation rather than mistaken for "not found"
+      const offendingIndex = filterValues.findIndex(
+        (value) => value !== tenantContext.tenantId,
+      );
+      if (offendingIndex !== -1) {
+        const offending = filterValues[offendingIndex];
         opts.onIsolationViolation?.(
           className,
           tenantContext.tenantId,
-          String(filter[tenantField]),
+          String(offending),
           context,
         );
         throw new TenantIsolationError(
           `Tenant isolation violation in ${className} get: ` +
-            `context tenant is '${tenantContext.tenantId}' but query filters by '${filter[tenantField]}'`,
+            `context tenant is '${tenantContext.tenantId}' but query filters by '${String(offending)}'`,
           {
             tenantId: tenantContext.tenantId,
-            attemptedTenantId: String(filter[tenantField]),
+            attemptedTenantId: String(offending),
           },
         );
       }


### PR DESCRIPTION
Fixes #1495.

## Problem
`beforeList`/`beforeGet` validated an already-present tenant filter with a scalar strict compare: `existingFilter !== tenantContext.tenantId`. When a caller uses the valid IN-style array filter `where: { tenantId: [ctxTenant] }` — which `smrt-users` `TenantPermissionOverrideCollection.getOverridesByEffectBatch` does (`this.list({ where: { tenantId: tenantIds } })`) — `existingFilter` is an array, so `["x"] !== "x"` is always true and the interceptor false-fires an isolation violation. (`String(["x"])` joins to `"x"`, which is why the error read the nonsensical "expected x but got x".) This broke all permission resolution that batches overrides by tenant.

## Fix
Normalize the existing filter to a value list (`Array.isArray(f) ? f : [f]`) and use `findIndex(v => v !== ctx.tenantId)` to locate a foreign value; fire the violation only when one exists, reporting the actual offending value. Applied symmetrically to `beforeList` and `beforeGet`. `findIndex` (not `find`) is used so a literal `null`/`undefined` filter value is still flagged (fail-closed), matching the prior scalar behavior.

Edge cases: empty array passes the interceptor and is rejected downstream by smrt-core's non-empty-IN guard (`collection.ts`); operator objects aren't a thing for the bare key in smrt (operators live in the where key), so scalar+array is the complete surface. `beforeSave`/`beforeDelete` (which compare a single instance's `tenantId`) are unchanged.

## Tests
9 new tests in `packages/tenancy/src/__tests__/tenancy.test.ts` covering list + get: array-ctx passes, array-foreign throws (+ offending value reported), mixed throws, scalar passes, scalar-foreign throws. `pnpm --filter @happyvertical/smrt-tenancy test`: 63/63 passed. Typecheck + build clean.

Found in anytown.ai prod via an integration-health doctor sweep.