### PR TITLE
feat(smrt-svelte,chat): S10 kickoff — import convention + first Avatar consolidation (#1415)

### DIFF
--- a/packages/chat/src/svelte/components/shared/Avatar.svelte
+++ b/packages/chat/src/svelte/components/shared/Avatar.svelte
@@ -1,138 +1,30 @@
 <script lang="ts">
 /**
- * Avatar - Profile avatar with online presence indicator
- * Shows initials fallback when no image URL is provided.
+ * Avatar — chat profile avatar with online-presence indicator.
+ *
+ * Thin adapter over the shared `@happyvertical/smrt-svelte` `Avatar` primitive
+ * (S10 consolidation, #1415): it keeps chat's prop vocabulary
+ * (`avatarUrl` / `onlineStatus`) but delegates rendering, the initials +
+ * image-error fallback, presence dot, tokens, and a11y to the library so that
+ * logic lives in exactly one place.
  */
+import { Avatar as UiAvatar } from '@happyvertical/smrt-svelte';
 
 export interface Props {
-  /** Display name used for initials fallback */
+  /** Display name used for initials fallback. */
   name: string;
-  /** URL for the avatar image */
+  /** URL for the avatar image. */
   avatarUrl?: string;
-  /** Online presence status */
+  /** Online presence status. */
   onlineStatus?: 'online' | 'away' | 'dnd' | 'offline';
-  /** Avatar size */
+  /** Avatar size. */
   size?: 'sm' | 'md' | 'lg';
 }
 
 const { name, avatarUrl, onlineStatus, size = 'md' }: Props = $props();
-const safeName = $derived(name?.trim() || '');
-const avatarAlt = $derived(safeName || 'Avatar');
-const avatarLabel = $derived(safeName ? `${safeName}'s avatar` : 'Avatar');
 
-const initials = $derived.by(() => {
-  const parts = safeName.split(/\s+/);
-  if (!parts[0]) return '?';
-  if (parts.length >= 2) {
-    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-  }
-  return (parts[0]?.[0] ?? '?').toUpperCase();
-});
-
-let imgError = $state(false);
-
-function handleImgError() {
-  imgError = true;
-}
+// chat's "dnd" maps to the library's "busy" presence value.
+const status = $derived(onlineStatus === 'dnd' ? 'busy' : onlineStatus);
 </script>
 
-<div class="avatar {size}" aria-label={avatarLabel}>
-  {#if avatarUrl && !imgError}
-    <img
-      class="avatar__img"
-      src={avatarUrl}
-      alt={avatarAlt}
-      onerror={handleImgError}
-    />
-  {:else}
-    <span class="avatar__initials">{initials}</span>
-  {/if}
-
-  {#if onlineStatus}
-    <span class="avatar__presence {onlineStatus}" aria-label="{onlineStatus}"></span>
-  {/if}
-</div>
-
-<style>
-  .avatar {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: var(--smrt-radius-full, 9999px);
-    background: var(--smrt-color-primary-container, #d6e3ff);
-    color: var(--smrt-color-on-primary-container, #001a41);
-    font-weight: var(--smrt-typography-weight-medium, 500);
-    flex-shrink: 0;
-    overflow: hidden;
-  }
-
-  .sm {
-    width: 28px;
-    height: 28px;
-    font-size: var(--smrt-typography-label-small-size, 0.6875rem);
-  }
-
-  .md {
-    width: 36px;
-    height: 36px;
-    font-size: var(--smrt-typography-label-large-size, 0.8125rem);
-  }
-
-  .lg {
-    width: 48px;
-    height: 48px;
-    font-size: var(--smrt-typography-body-large-size, 1rem);
-  }
-
-  .avatar__img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    border-radius: var(--smrt-radius-full, 9999px);
-  }
-
-  .avatar__initials {
-    user-select: none;
-    line-height: 1;
-  }
-
-  .avatar__presence {
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    border-radius: var(--smrt-radius-full, 9999px);
-    border: 2px solid var(--smrt-color-surface, #ffffff);
-  }
-
-  .sm .avatar__presence {
-    width: 8px;
-    height: 8px;
-  }
-
-  .md .avatar__presence {
-    width: 10px;
-    height: 10px;
-  }
-
-  .lg .avatar__presence {
-    width: 12px;
-    height: 12px;
-  }
-
-  .avatar__presence.online {
-    background: var(--smrt-color-success, #4caf50);
-  }
-
-  .avatar__presence.away {
-    background: var(--smrt-color-warning, #ff9800);
-  }
-
-  .avatar__presence.dnd {
-    background: var(--smrt-color-error, #f44336);
-  }
-
-  .avatar__presence.offline {
-    background: var(--smrt-color-outline, #74777f);
-  }
-</style>
+<UiAvatar {name} src={avatarUrl} {size} {status} />

--- a/packages/smrt-svelte/AGENTS.md
+++ b/packages/smrt-svelte/AGENTS.md
@@ -72,6 +72,41 @@ migrate domain re-rolls *onto* them rather than build new primitives:
   flow.
 - **`Card`** (`./ui`) — the standard surface/container; retire local card CSS.
 
+### Import convention (S10 #1415)
+
+Domain packages **consume** these primitives; they do not re-roll them. The
+duplication of Modal/Form/Button/Avatar across packages is the root cause of
+inconsistent a11y, tokens, and states downstream — fix it by importing from the
+library. Which barrel for what:
+
+| Need | Import from |
+|------|-------------|
+| Buttons, cards, badges, avatars, chips, skeletons, tooltips, dropdowns, trees, pagination | `@happyvertical/smrt-svelte/ui` (or the package root) |
+| Text/select/number/date/money/address inputs, toggles, file upload, `Form`, `FormGroup` | `@happyvertical/smrt-svelte/forms` |
+| `Modal`, `ConfirmDialog`, `LoadingOverlay`, `ProgressBar` | `@happyvertical/smrt-svelte/feedback` |
+| `Container`, `Grid`, `Header`, `Footer`, `PageHeader`, `EmptyState` | `@happyvertical/smrt-svelte/layout` |
+| Chat message bubble, reaction picker, typing indicator | `@happyvertical/smrt-svelte/chat` |
+| Admin shell, nav tree, breadcrumbs, tools dock | `@happyvertical/smrt-svelte/workspace` |
+
+The package root re-exports `./ui`, `./forms`, etc., so `from
+'@happyvertical/smrt-svelte'` also works; prefer the specific subpath in domain
+code for tree-shaking and clarity.
+
+**Consolidating an existing re-roll** — two patterns:
+
+1. **Direct use** (preferred for new code and when the local API already matches):
+   delete the local component, import the library primitive at each call site.
+2. **Thin adapter** (when a package has an established, differing prop vocabulary
+   or a `ModuleUIRegistry` registration to preserve): keep the local file but
+   reduce it to a wrapper that maps the package's props onto the library
+   component — no duplicated markup/styles/logic. Example:
+   `chat/.../shared/Avatar.svelte` maps `avatarUrl`→`src` and `onlineStatus`'s
+   `dnd`→the library's `busy`, delegating everything else.
+
+**Missing a primitive or prop?** Add it upstream in `smrt-svelte`, don't re-roll
+downstream (e.g. the library `Avatar` gained an image-error→initials fallback
+while consolidating chat's avatar).
+
 ## Permission Action
 
 ```svelte

--- a/packages/smrt-svelte/src/components/ui/Avatar.svelte
+++ b/packages/smrt-svelte/src/components/ui/Avatar.svelte
@@ -33,6 +33,14 @@ const {
   ...rest
 }: Props = $props();
 
+// Fall back to initials if the image fails to load (e.g. a dead avatar URL).
+let imgFailed = $state(false);
+// Reset the failure flag whenever the source changes.
+$effect(() => {
+  src;
+  imgFailed = false;
+});
+
 /** First+last initial (or first two letters of a single word). */
 function initialsOf(value: string): string {
   const parts = value.trim().split(/\s+/).filter(Boolean);
@@ -50,8 +58,15 @@ const statusLabels: Record<AvatarStatus, string> = {
 </script>
 
 <span class="avatar {size} {className}" {...rest}>
-  {#if src}
-    <img class="avatar__img" {src} alt={name} />
+  {#if src && !imgFailed}
+    <img
+      class="avatar__img"
+      {src}
+      alt={name}
+      onerror={() => {
+        imgFailed = true;
+      }}
+    />
   {:else}
     <span class="avatar__initials" role="img" aria-label={name}>
       {initialsOf(name)}

--- a/packages/smrt-svelte/src/components/ui/__tests__/gap-primitives.test.ts
+++ b/packages/smrt-svelte/src/components/ui/__tests__/gap-primitives.test.ts
@@ -2,7 +2,7 @@
  * Golden tests for the L3 gap primitives — batch 1 (Avatar, Chip, Skeleton).
  * Render + interaction + a11y, per the L4 harness pattern (#1422 / #1423).
  */
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { expectNoA11yViolations } from '../../../test-support/a11y';
@@ -25,6 +25,18 @@ describe('Avatar', () => {
   it('announces presence status', () => {
     render(Avatar, { props: { name: 'Ada', status: 'online' } });
     expect(screen.getByText('Online')).toBeInTheDocument();
+  });
+
+  it('falls back to initials when the image fails to load', async () => {
+    render(Avatar, {
+      props: { name: 'Ada Lovelace', src: 'https://x/broken.png' },
+    });
+    const img = screen.getByRole('img', { name: 'Ada Lovelace' });
+    expect(img.tagName).toBe('IMG');
+    await fireEvent.error(img);
+    expect(screen.getByRole('img', { name: 'Ada Lovelace' })).toHaveTextContent(
+      'AL',
+    );
   });
 
   it('is axe-clean', async () => {


### PR DESCRIPTION
## S10 kickoff — component consolidation

**Part of #1415.** Establishes the import convention and lands the first per-package consolidation, exercising the full pattern end-to-end on the `Avatar` primitive shipped in L3.

### 1. Import convention documented (acceptance #1)
`smrt-svelte/AGENTS.md` now has an **Import convention (S10)** section: a barrel→primitive table (which of `./ui` / `./forms` / `./feedback` / `./layout` / `./chat` / `./workspace` to import from) and the two consolidation patterns — **direct use** vs **thin adapter** (for packages with an established differing API or a `ModuleUIRegistry` registration to preserve).

### 2. First consolidation: chat `Avatar` → library `Avatar` (acceptance #2)
chat had its own 130-line `Avatar.svelte` (markup + styles + initials logic) duplicating the library `Avatar`. It's now a **thin adapter** (~12 lines) that maps chat's vocabulary (`avatarUrl`→`src`, `onlineStatus`'s `dnd`→the library's `busy`) and delegates everything else. chat's public API, barrel export, and `ModuleUIRegistry` registration are unchanged — **non-breaking**. The 8 internal call sites are untouched (they only pass `name`/`avatarUrl`/`size`).

### 3. Filled a real library gap (acceptance #3)
Consolidation surfaced that the library `Avatar` lacked chat's image-error fallback. Added: a failed `src` now falls back to initials (resets on `src` change) — a generally useful robustness fix, not a chat-specific re-roll.

### Verification
- New test: `Avatar falls back to initials when the image fails to load`.
- smrt-svelte: **36 files / 371 tests**; chat: **8 files / 86 tests**; both `tsc + svelte-check` 0 errors.
- `check-svelte-tokens` clean; `biome ci` clean. (The chat adapter has no styles — all tokens/a11y now live once in the library.)

### Next S10 steps (tracked, not in this PR)
Inventory from this sweep's recon — packages with hand-rolled primitives / low library adoption: **content** (45 svelte / 4 import), **chat** dialogs, **products** (11/0), **assets** (`CreateAssetModal`/`AssetDetail` hand-rolled modals), **users** (`InviteUserModal`), **projects** (`RejectDialog`). Plus the acceptance #4 report-only duplication ratchet. Each becomes its own consolidation PR.