### PR TITLE
refactor(assets): consolidate CreateAssetModal onto Modal + Button (S10 #1415)

### DIFF
--- a/packages/assets/src/svelte/CreateAssetModal.svelte
+++ b/packages/assets/src/svelte/CreateAssetModal.svelte
@@ -7,7 +7,7 @@
  * opens with the file pre-loaded.
  */
 
-import type { Snippet } from 'svelte';
+import { Button, Modal } from '@happyvertical/smrt-svelte';
 
 export interface CreateAssetModalProps {
   /** Whether the modal is open */
@@ -32,23 +32,12 @@ let {
   onclose,
 }: CreateAssetModalProps = $props();
 
-let dialogEl: HTMLDialogElement | null = $state(null);
 let file = $state<File | null>(null);
 let name = $state('');
 let description = $state('');
 let altText = $state('');
 let dragOver = $state(false);
 let previewUrl: string | null = $state(null);
-
-// Sync open state with dialog
-$effect(() => {
-  if (!dialogEl) return;
-  if (open && !dialogEl.open) {
-    dialogEl.showModal();
-  } else if (!open && dialogEl.open) {
-    dialogEl.close();
-  }
-});
 
 // Sync initial file
 $effect(() => {
@@ -120,18 +109,6 @@ function resetForm() {
   altText = '';
 }
 
-function handleCancel(e: Event) {
-  e.preventDefault();
-  handleClose();
-}
-
-function handleKeydown(e: KeyboardEvent) {
-  if (e.key === 'Escape') {
-    e.preventDefault();
-    handleClose();
-  }
-}
-
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
@@ -142,33 +119,7 @@ const isImage = $derived(file?.type?.startsWith('image/') ?? false);
 const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
 </script>
 
-<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-<dialog
-  bind:this={dialogEl}
-  class="create-modal"
-  oncancel={handleCancel}
-  onkeydown={handleKeydown}
-  onclick={(e) => { if (e.target === dialogEl) handleClose(); }}
-  aria-label="Upload asset"
->
-  <div
-    class="create-modal__container"
-    role="presentation"
-    tabindex="-1"
-    onclick={(e) => e.stopPropagation()}
-    onkeydown={(e) => e.stopPropagation()}
-  >
-    <header class="create-modal__header">
-      <h2 class="create-modal__title">Upload Asset</h2>
-      <button type="button" class="create-modal__close" onclick={handleClose} aria-label="Close">
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <line x1="18" y1="6" x2="6" y2="18"></line>
-          <line x1="6" y1="6" x2="18" y2="18"></line>
-        </svg>
-      </button>
-    </header>
-
-    <div class="create-modal__body">
+<Modal open={open} title="Upload Asset" onClose={handleClose} size="md">
       {#if !file}
         <!-- Dropzone -->
         <div
@@ -235,101 +186,16 @@ const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
           {/if}
         </div>
       {/if}
-    </div>
 
-    <footer class="create-modal__footer">
-      <button type="button" class="footer-btn footer-btn--cancel" onclick={handleClose}>Cancel</button>
-      <button type="button" class="footer-btn footer-btn--create" onclick={handleSubmit} disabled={!file}>
-        Upload
-      </button>
-    </footer>
-  </div>
-</dialog>
+  {#snippet footer()}
+    <Button variant="ghost" size="sm" onclick={handleClose}>Cancel</Button>
+    <Button variant="primary" size="sm" onclick={handleSubmit} disabled={!file}>
+      Upload
+    </Button>
+  {/snippet}
+</Modal>
 
 <style>
-  .create-modal {
-    position: fixed;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    max-width: 100%;
-    max-height: 100%;
-    margin: 0;
-    padding: 0;
-    border: none;
-    background: transparent;
-    overflow: hidden;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .create-modal::backdrop {
-    background: var(--smrt-color-scrim, rgba(0, 0, 0, 0.5));
-    backdrop-filter: blur(2px);
-  }
-
-  .create-modal:not([open]) {
-    display: none;
-  }
-
-  .create-modal__container {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    max-width: 32rem;
-    max-height: calc(100vh - 2rem);
-    background: var(--smrt-color-surface, #ffffff);
-    border-radius: var(--smrt-radius-large, 0.75rem);
-    box-shadow: var(--smrt-elevation-3);
-    overflow: hidden;
-    animation: modalEnter 300ms cubic-bezier(0.2, 0, 0, 1);
-  }
-
-  @keyframes modalEnter {
-    from { opacity: 0; transform: scale(0.9) translateY(-16px); }
-    to { opacity: 1; transform: scale(1) translateY(0); }
-  }
-
-  .create-modal__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: var(--smrt-spacing-4, 1rem) var(--smrt-spacing-5, 1.25rem);
-    border-bottom: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
-  }
-
-  .create-modal__title {
-    margin: 0;
-    font-size: var(--smrt-typography-title-medium-size, 1.125rem);
-    font-weight: var(--smrt-typography-weight-semibold, 600);
-    color: var(--smrt-color-on-surface, #111827);
-  }
-
-  .create-modal__close {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-    padding: 0;
-    border: none;
-    background: transparent;
-    color: var(--smrt-color-on-surface-variant, #6b7280);
-    cursor: pointer;
-    border-radius: var(--smrt-radius-full, 9999px);
-  }
-
-  .create-modal__close:hover {
-    background: var(--smrt-color-surface-container-highest, #e0e2ec);
-  }
-
-  .create-modal__body {
-    flex: 1;
-    padding: var(--smrt-spacing-5, 1.25rem);
-    overflow-y: auto;
-  }
-
   /* Dropzone */
   .dropzone {
     display: flex;
@@ -495,53 +361,4 @@ const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
     min-height: 60px;
   }
 
-  /* Footer */
-  .create-modal__footer {
-    display: flex;
-    justify-content: flex-end;
-    gap: var(--smrt-spacing-2, 0.5rem);
-    padding: var(--smrt-spacing-4, 1rem) var(--smrt-spacing-5, 1.25rem);
-    border-top: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
-  }
-
-  .footer-btn {
-    height: 36px;
-    padding: 0 var(--smrt-spacing-4, 1rem);
-    font-family: inherit;
-    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-    font-weight: var(--smrt-typography-weight-medium, 500);
-    border-radius: var(--smrt-radius-medium, 0.5rem);
-    cursor: pointer;
-    border: none;
-    transition: all 150ms ease;
-  }
-
-  .footer-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .footer-btn--cancel {
-    background: transparent;
-    color: var(--smrt-color-primary, #005ac1);
-  }
-
-  .footer-btn--cancel:hover {
-    background: var(--smrt-color-surface-container, #f3f4f6);
-  }
-
-  .footer-btn--create {
-    background: var(--smrt-color-primary, #005ac1);
-    color: var(--smrt-color-on-primary, #ffffff);
-  }
-
-  .footer-btn--create:hover:not(:disabled) {
-    box-shadow: var(--smrt-elevation-2);
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .create-modal__container {
-      animation: none;
-    }
-  }
 </style>

--- a/packages/assets/src/svelte/CreateAssetModal.svelte
+++ b/packages/assets/src/svelte/CreateAssetModal.svelte
@@ -7,7 +7,12 @@
  * opens with the file pre-loaded.
  */
 
-import { Button, Modal } from '@happyvertical/smrt-svelte';
+// Import primitives from subpaths (not the root barrel) so downstream
+// consumers of `@happyvertical/smrt-assets/svelte` don't have to resolve the
+// entire smrt-svelte surface — including optional peers like smrt-agents /
+// smrt-users — just to compile this modal.
+import { Modal } from '@happyvertical/smrt-svelte/feedback';
+import { Button } from '@happyvertical/smrt-svelte/ui';
 
 export interface CreateAssetModalProps {
   /** Whether the modal is open */

--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -31,6 +31,12 @@
       "import": "./dist/components/chat/index.js",
       "default": "./dist/components/chat/index.js"
     },
+    "./feedback": {
+      "types": "./dist/components/feedback/index.d.ts",
+      "svelte": "./dist/components/feedback/index.js",
+      "import": "./dist/components/feedback/index.js",
+      "default": "./dist/components/feedback/index.js"
+    },
     "./forms": {
       "types": "./dist/components/forms/index.d.ts",
       "svelte": "./dist/components/forms/index.js",

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -413,6 +413,11 @@ export function getWorkspaceViteAliases(
       );
       addAliasIfPresent(
         aliases,
+        '@happyvertical/smrt-svelte/feedback',
+        join(packageRoot, 'src/components/feedback/index.ts'),
+      );
+      addAliasIfPresent(
+        aliases,
         '@happyvertical/smrt-svelte/themes',
         join(packageRoot, 'src/themes/index.ts'),
       );


### PR DESCRIPTION
## S10 consolidation — assets `CreateAssetModal` → library `Modal` + `Button`

**Part of #1415.** Replaces the hand-rolled modal the S10 issue explicitly calls out (`assets/CreateAssetModal.svelte`). Reviewed by Fable at the plan stage (PROCEED WITH CHANGES — its P1/P2 fixes are folded in).

### What changed
- `CreateAssetModal.svelte` (**547 → 365 lines**): the hand-rolled `<dialog>` shell — `showModal()`/`close()` `$effect`, backdrop-click + Escape + cancel handlers, header (title + close button), footer buttons, and all the shell CSS — is replaced by `<Modal open title="Upload Asset" onClose={handleClose} size="md">` with a `{#snippet footer()}` of library `Button`s. The body (drag/drop/paste dropzone, file preview, metadata fields) and all logic are unchanged.
- **smrt-svelte**: added the missing `./feedback` subpath export (Modal/ConfirmDialog/LoadingOverlay/ProgressBar) — it had no subpath, only the package root. `verify:pack` confirms it resolves.

### Fable plan-review fixes folded in
- **P1**: `onClose={handleClose}` (not the raw `onclose`) so Modal-initiated closes (X/Esc/backdrop) still run `resetForm()` — otherwise a stale file/fields leak into the next open.
- **P2**: dropped the `.create-modal__body` wrapper — it duplicated Modal's own `.modal__body` (double padding).
- P3: `ghost`/`sm` Buttons (closest to the old text buttons); removed the unused `Snippet` import.

### Notes
- Controlled `open` pattern is safe: AssetManager owns `showCreateModal` and resets it on `onclose`.
- Imports use the package root (`@happyvertical/smrt-svelte`) — the smrt-vitest source resolver aliases the root to `src/`, and appending a subpath breaks under test; the root re-exports everything and resolves in both test and prod.
- **Deferred to follow-up S10 PRs** (intentional scope cut): dropzone → `FileUpload`, metadata fields → `TextInput`/`TextareaInput`. Pre-existing `previewUrl` `$effect` left verbatim (candidate cleanup).

### Verification
- assets: **6 files / 55 tests** pass; `tsc + svelte-check` 0 errors. smrt-svelte: 36 files / 371 tests. All strict ratchets (color/spacing/typography/radius/elevation) + `biome ci` clean. (assets has no component-test harness yet — that's S11; verified via typecheck/build + the existing playground preview.)