### PR TITLE
fix(assets): repair AssetCollection bugs + raise coverage to floor (S11 #1416)

### DIFF
--- a/packages/assets/src/__tests__/assets-collection.test.ts
+++ b/packages/assets/src/__tests__/assets-collection.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Coverage for AssetCollection (assets.ts) — tenant-aware queries, classification
+ * filters, the raw `asset_tags` join, and the version chain. Real in-memory
+ * SQLite per SMRT testing conventions (no DB mocking). Wave-3 coverage uplift
+ * to clear the S6 T2 floor and unblock the S10 assets consolidation (#1415).
+ */
+import { getTestDatabase } from '@happyvertical/smrt-core/testing';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Asset } from '../asset';
+import { AssetCollection } from '../assets';
+
+describe('AssetCollection', () => {
+  let db: DatabaseInterface;
+  let collection: AssetCollection;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    collection = await AssetCollection.create({ db });
+    // `asset_tags` is a raw join table (not an SMRT model), so it isn't in the
+    // generated schema — create it for the tag tests, mirroring its production DDL.
+    await db.query(
+      'CREATE TABLE IF NOT EXISTS asset_tags (' +
+        'asset_id TEXT NOT NULL, tag_slug TEXT NOT NULL, created_at TEXT, ' +
+        'PRIMARY KEY (asset_id, tag_slug))',
+    );
+  });
+
+  afterEach(async () => {
+    await db.close?.();
+  });
+
+  function seed(overrides: Partial<Asset> = {}): Promise<Asset> {
+    return collection.create({
+      name: 'asset',
+      typeSlug: 'image',
+      statusSlug: 'published',
+      mimeType: 'image/png',
+      sourceUri: 'file:///x.png',
+      ...overrides,
+    }) as Promise<Asset>;
+  }
+
+  describe('tenant-aware queries', () => {
+    it('findByTenant returns only that tenant’s assets', async () => {
+      await seed({ tenantId: 't1', name: 'a' });
+      await seed({ tenantId: 't2', name: 'b' });
+      await seed({ tenantId: null, name: 'g' });
+
+      const result = await collection.findByTenant('t1');
+      expect(result.map((a) => a.name)).toEqual(['a']);
+    });
+
+    it('findGlobal returns only tenantless assets', async () => {
+      await seed({ tenantId: 't1', name: 'a' });
+      await seed({ tenantId: null, name: 'g' });
+
+      const result = await collection.findGlobal();
+      expect(result.map((a) => a.name)).toEqual(['g']);
+      expect(result.every((a) => a.tenantId === null)).toBe(true);
+    });
+
+    it('findWithGlobals returns the tenant’s assets plus globals', async () => {
+      await seed({ tenantId: 't1', name: 'a' });
+      await seed({ tenantId: 't2', name: 'b' });
+      await seed({ tenantId: null, name: 'g' });
+
+      const result = await collection.findWithGlobals('t1');
+      expect(result.map((a) => a.name).sort()).toEqual(['a', 'g']);
+    });
+  });
+
+  describe('classification queries', () => {
+    it('getByType / getByStatus / getByOwner filter on their column', async () => {
+      await seed({
+        typeSlug: 'image',
+        statusSlug: 'published',
+        ownerProfileId: 'p1',
+        name: 'img',
+      });
+      await seed({
+        typeSlug: 'video',
+        statusSlug: 'draft',
+        ownerProfileId: 'p2',
+        name: 'vid',
+      });
+
+      expect((await collection.getByType('image')).map((a) => a.name)).toEqual([
+        'img',
+      ]);
+      expect(
+        (await collection.getByStatus('draft')).map((a) => a.name),
+      ).toEqual(['vid']);
+      expect((await collection.getByOwner('p1')).map((a) => a.name)).toEqual([
+        'img',
+      ]);
+    });
+
+    it('getByMimeType matches a wildcard pattern', async () => {
+      await seed({ mimeType: 'image/png', name: 'png' });
+      await seed({ mimeType: 'image/jpeg', name: 'jpg' });
+      await seed({ mimeType: 'video/mp4', name: 'mp4' });
+
+      const images = await collection.getByMimeType('image/*');
+      expect(images.map((a) => a.name).sort()).toEqual(['jpg', 'png']);
+    });
+
+    it('getByFolder / getDerivatives filter on their FK', async () => {
+      const source = await seed({ name: 'source' });
+      await seed({ folderId: 'f1', name: 'inFolder' });
+      await seed({ sourceAssetId: source.id, name: 'derived' });
+
+      expect((await collection.getByFolder('f1')).map((a) => a.name)).toEqual([
+        'inFolder',
+      ]);
+      const derivatives = await collection.getDerivatives(source.id as string);
+      expect(derivatives.map((a) => a.name)).toEqual(['derived']);
+    });
+  });
+
+  describe('tags (raw asset_tags join)', () => {
+    it('addTag / getByTag / removeTag round-trip', async () => {
+      const asset = await seed({ name: 'tagged' });
+
+      await collection.addTag(asset.id as string, 'nature');
+      const tagged = await collection.getByTag('nature');
+      expect(tagged.map((a) => a.id)).toEqual([asset.id]);
+
+      await collection.removeTag(asset.id as string, 'nature');
+      expect(await collection.getByTag('nature')).toEqual([]);
+    });
+
+    it('addTag upserts on (asset_id, tag_slug) — no duplicates', async () => {
+      const asset = await seed();
+      await collection.addTag(asset.id as string, 'dup');
+      await collection.addTag(asset.id as string, 'dup');
+      expect(await collection.getByTag('dup')).toHaveLength(1);
+    });
+  });
+
+  describe('version chain', () => {
+    it('createNewVersion chains off the primary, incrementing version', async () => {
+      const v1 = await seed({ name: 'doc', sourceUri: 'file:///v1' });
+
+      const v2 = await collection.createNewVersion(
+        v1.id as string,
+        'file:///v2',
+      );
+      expect(v2.version).toBe(2);
+      expect(v2.primaryVersionId).toBe(v1.id);
+      expect(v2.sourceUri).toBe('file:///v2');
+
+      const v3 = await collection.createNewVersion(
+        v1.id as string,
+        'file:///v3',
+      );
+      expect(v3.version).toBe(3);
+    });
+
+    it('listVersions returns the whole chain ordered by version', async () => {
+      const v1 = await seed();
+      await collection.createNewVersion(v1.id as string, 'file:///v2');
+      await collection.createNewVersion(v1.id as string, 'file:///v3');
+
+      const versions = await collection.listVersions(v1.id as string);
+      expect(versions.map((v) => v.version)).toEqual([1, 2, 3]);
+    });
+
+    it('getLatestVersion returns the highest version, or null when unknown', async () => {
+      const v1 = await seed();
+      await collection.createNewVersion(v1.id as string, 'file:///v2');
+
+      expect(
+        (await collection.getLatestVersion(v1.id as string))?.version,
+      ).toBe(2);
+      expect(await collection.getLatestVersion('does-not-exist')).toBeNull();
+    });
+
+    it('createNewVersion throws for an unknown primary version', async () => {
+      await expect(
+        collection.createNewVersion('does-not-exist', 'file:///x'),
+      ).rejects.toThrow(/No asset found/);
+    });
+
+    it('rollbackToVersion creates a new version copying the target’s content', async () => {
+      const v1 = await seed({ sourceUri: 'file:///v1' });
+      await collection.createNewVersion(v1.id as string, 'file:///v2');
+
+      const rolled = await collection.rollbackToVersion(v1.id as string, 1);
+      expect(rolled.version).toBe(3);
+      expect(rolled.sourceUri).toBe('file:///v1');
+    });
+
+    it('rollbackToVersion throws for a missing target version', async () => {
+      const v1 = await seed();
+      await expect(
+        collection.rollbackToVersion(v1.id as string, 99),
+      ).rejects.toThrow(/not found/);
+    });
+  });
+});

--- a/packages/assets/src/__tests__/assets-collection.test.ts
+++ b/packages/assets/src/__tests__/assets-collection.test.ts
@@ -182,6 +182,20 @@ describe('AssetCollection', () => {
       ).rejects.toThrow(/No asset found/);
     });
 
+    it('createNewVersion keeps a distinct slug when the base already ends in -vN', async () => {
+      // A primary slug shaped like `<x>-vN` must not regenerate to a slug that
+      // collides with the primary (which would upsert-overwrite it).
+      const v1 = await seed({ slug: 'spec-v2', name: 'spec' });
+      const v2 = await collection.createNewVersion(
+        v1.id as string,
+        'file:///v2',
+      );
+
+      expect(v2.slug).not.toBe(v1.slug);
+      const versions = await collection.listVersions(v1.id as string);
+      expect(versions.map((v) => v.version)).toEqual([1, 2]);
+    });
+
     it('rollbackToVersion creates a new version copying the target’s content', async () => {
       const v1 = await seed({ sourceUri: 'file:///v1' });
       await collection.createNewVersion(v1.id as string, 'file:///v2');

--- a/packages/assets/src/__tests__/lookup-models.test.ts
+++ b/packages/assets/src/__tests__/lookup-models.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Coverage for the AssetType / AssetStatus lookup models — their constructors
+ * (slug/name/description wiring) and the `getBySlug` accessors.
+ */
+import { describe, expect, it } from 'vitest';
+import { AssetStatus } from '../asset-status';
+import { AssetType } from '../asset-type';
+
+describe('AssetStatus', () => {
+  it('wires slug/name/description from options', () => {
+    const status = new AssetStatus({
+      slug: 'published',
+      name: 'Published',
+      description: 'Visible to consumers',
+    });
+    expect(status.slug).toBe('published');
+    expect(status.name).toBe('Published');
+    expect(status.description).toBe('Visible to consumers');
+  });
+
+  it('defaults to empty fields with no options', () => {
+    const status = new AssetStatus();
+    expect(status.name).toBe('');
+    expect(status.description).toBe('');
+  });
+
+  it('getBySlug resolves (stub returns null)', async () => {
+    expect(await AssetStatus.getBySlug('draft')).toBeNull();
+  });
+});
+
+describe('AssetType', () => {
+  it('wires slug/name/description from options', () => {
+    const type = new AssetType({
+      slug: 'image',
+      name: 'Image',
+      description: 'Raster or vector image',
+    });
+    expect(type.slug).toBe('image');
+    expect(type.name).toBe('Image');
+    expect(type.description).toBe('Raster or vector image');
+  });
+
+  it('getBySlug resolves (stub returns null)', async () => {
+    expect(await AssetType.getBySlug('video')).toBeNull();
+  });
+});

--- a/packages/assets/src/assets.ts
+++ b/packages/assets/src/assets.ts
@@ -83,9 +83,10 @@ export class AssetCollection extends SmrtCollection<Asset> {
    */
   async getByTag(tagSlug: string): Promise<Asset[]> {
     const db = this.db;
-    const rows = await db.list('asset_tags', {
-      where: { tag_slug: tagSlug },
-    });
+    // db.list(table, where) takes the WHERE object directly — not a
+    // `{ where }` wrapper (which would filter on a column literally named
+    // "where" and throw).
+    const rows = await db.list('asset_tags', { tag_slug: tagSlug });
 
     const assets: Asset[] = [];
     for (const row of rows as { asset_id: string }[]) {
@@ -150,13 +151,25 @@ export class AssetCollection extends SmrtCollection<Asset> {
     // Sort by version number to find the latest
     versions.sort((a, b) => b.version - a.version);
     const latestVersion = versions[0];
+    const newVersionNumber = latestVersion.version + 1;
+
+    // Give the new version a distinct slug. The assets table is unique on
+    // (slug, context, meta_type), so carrying the previous version's slug would
+    // upsert-overwrite the prior row instead of appending a version. Derive a
+    // `<base>-v<n>` slug from the primary version's slug (stripping any existing
+    // `-vN` suffix) so the chain — tracked by `primaryVersionId` — stays intact.
+    const primary =
+      versions.find((v) => v.id === primaryVersionId) ??
+      versions[versions.length - 1];
+    const baseSlug = String(primary?.slug ?? '').replace(/-v\d+$/, '');
 
     // Create new version
     return (await this.create({
       ...latestVersion,
       id: undefined, // Generate new ID
+      slug: baseSlug ? `${baseSlug}-v${newVersionNumber}` : undefined,
       sourceUri: newSourceUri,
-      version: latestVersion.version + 1,
+      version: newVersionNumber,
       primaryVersionId,
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -186,33 +199,23 @@ export class AssetCollection extends SmrtCollection<Asset> {
    * @returns Array of all asset versions, ordered by version number
    */
   async listVersions(primaryVersionId: string): Promise<Asset[]> {
-    const db = this.db;
-
-    // Query for all assets with this primary version ID or ID matching primary version ID
-    // Split OR logic into two queries since semantic adapters don't support OR directly
-    const [versionsRows, primaryRow] = await Promise.all([
-      db.list('assets', {
-        where: { primary_version_id: primaryVersionId },
-        orderBy: 'version ASC',
-      }),
-      db.get('assets', { id: primaryVersionId }),
+    // Use the collection's `list`/`get` (not raw `db.list`) so rows are properly
+    // hydrated into `Asset` instances — `Object.assign(new Asset(), rawRow)`
+    // would leave snake_case columns (`source_uri`, `primary_version_id`) on the
+    // instance and never populate the camelCase fields. The chain is the rows
+    // pointing at this primary plus the primary itself; the adapter has no OR, so
+    // fetch both and dedupe by id.
+    const [chained, primary] = await Promise.all([
+      this.list({ where: { primaryVersionId } }) as Promise<Asset[]>,
+      this.get({ id: primaryVersionId }) as Promise<Asset | null>,
     ]);
 
-    // Combine results and deduplicate by ID
-    const allRows = primaryRow ? [primaryRow, ...versionsRows] : versionsRows;
-    const uniqueAssets = new Map<string, any>();
-    for (const row of allRows) {
-      uniqueAssets.set((row as any).id, row);
+    const byId = new Map<string, Asset>();
+    for (const asset of [...(primary ? [primary] : []), ...chained]) {
+      if (asset?.id) byId.set(asset.id, asset);
     }
 
-    // Convert to Asset instances and sort by version
-    const assets = Array.from(uniqueAssets.values()).map((row) => {
-      const asset = new Asset();
-      Object.assign(asset, row);
-      return asset;
-    });
-
-    // Sort by version number
+    const assets = Array.from(byId.values());
     assets.sort((a, b) => a.version - b.version);
     return assets;
   }
@@ -238,18 +241,12 @@ export class AssetCollection extends SmrtCollection<Asset> {
    * @returns Array of matching assets
    */
   async getByMimeType(mimePattern: string): Promise<Asset[]> {
-    const db = this.db;
     const pattern = mimePattern.replace('*', '%');
-
-    const rows = await db.list('assets', {
-      where: { 'mime_type like': pattern },
-    });
-
-    return (rows as any[]).map((row) => {
-      const asset = new Asset();
-      Object.assign(asset, row);
-      return asset;
-    });
+    // Collection `list` (not raw `db.list`) so the rows hydrate into proper
+    // `Asset` instances; the `<field> like` operator key is mapped to the column.
+    return (await this.list({
+      where: { 'mimeType like': pattern },
+    })) as Asset[];
   }
 
   /**

--- a/packages/assets/src/assets.ts
+++ b/packages/assets/src/assets.ts
@@ -153,21 +153,33 @@ export class AssetCollection extends SmrtCollection<Asset> {
     const latestVersion = versions[0];
     const newVersionNumber = latestVersion.version + 1;
 
-    // Give the new version a distinct slug. The assets table is unique on
-    // (slug, context, meta_type), so carrying the previous version's slug would
-    // upsert-overwrite the prior row instead of appending a version. Derive a
-    // `<base>-v<n>` slug from the primary version's slug (stripping any existing
-    // `-vN` suffix) so the chain — tracked by `primaryVersionId` — stays intact.
+    // Give the new version a distinct, collision-free slug. The assets table is
+    // unique on (slug, context, meta_type), so a reused slug would
+    // upsert-overwrite an existing row instead of appending a version. Build
+    // `<primary-slug>-v<n>` and verify it's not already taken by another version
+    // in the chain OR by an unrelated asset — appending a disambiguator until
+    // free. (The chain itself is tracked by `primaryVersionId`, not the slug.)
     const primary =
       versions.find((v) => v.id === primaryVersionId) ??
       versions[versions.length - 1];
-    const baseSlug = String(primary?.slug ?? '').replace(/-v\d+$/, '');
+    const baseSlug = String(primary?.slug ?? '') || 'asset';
+    const takenInChain = new Set(
+      versions.map((v) => v.slug).filter(Boolean) as string[],
+    );
+    let candidate = `${baseSlug}-v${newVersionNumber}`;
+    for (let attempt = 1; ; attempt += 1) {
+      const collides =
+        takenInChain.has(candidate) ||
+        (await this.get({ slug: candidate })) !== null;
+      if (!collides) break;
+      candidate = `${baseSlug}-v${newVersionNumber}-${attempt}`;
+    }
 
     // Create new version
     return (await this.create({
       ...latestVersion,
       id: undefined, // Generate new ID
-      slug: baseSlug ? `${baseSlug}-v${newVersionNumber}` : undefined,
+      slug: candidate,
       sourceUri: newSourceUri,
       version: newVersionNumber,
       primaryVersionId,

--- a/packages/assets/src/svelte/__tests__/ActionBar.test.ts
+++ b/packages/assets/src/svelte/__tests__/ActionBar.test.ts
@@ -10,6 +10,7 @@ import {
   render,
   screen,
   userEvent,
+  within,
 } from '@happyvertical/smrt-vitest/svelte';
 import { describe, expect, it, vi } from 'vitest';
 import ActionBar from '../ActionBar.svelte';
@@ -39,6 +40,36 @@ describe('ActionBar', () => {
       },
     });
     expect(container.querySelector('.action-bar')).toBeNull();
+  });
+
+  it('confirms deletion through the inline dialog', async () => {
+    const onDelete = vi.fn();
+    render(ActionBar, {
+      props: { selectedAssets: selected, onClearSelection: vi.fn(), onDelete },
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    const dialog = screen.getByLabelText('Confirm delete');
+    await userEvent.click(
+      within(dialog).getByRole('button', { name: 'Delete' }),
+    );
+    expect(onDelete).toHaveBeenCalledWith(selected);
+  });
+
+  it('cancels deletion and dismisses the dialog', async () => {
+    render(ActionBar, {
+      props: {
+        selectedAssets: selected,
+        onClearSelection: vi.fn(),
+        onDelete: vi.fn(),
+      },
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await userEvent.click(
+      within(screen.getByLabelText('Confirm delete')).getByRole('button', {
+        name: 'Cancel',
+      }),
+    );
+    expect(screen.queryByLabelText('Confirm delete')).not.toBeInTheDocument();
   });
 
   it('is axe-clean', async () => {

--- a/packages/assets/src/svelte/__tests__/AssetDetail.test.ts
+++ b/packages/assets/src/svelte/__tests__/AssetDetail.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 /**
  * Component coverage for AssetDetail via the shared S11 harness (#1416).
+ * `open: true` drives the <dialog> showModal effect (polyfilled in the shared
+ * setup), so these exercise the real open state.
  */
 import { render, screen, userEvent } from '@happyvertical/smrt-vitest/svelte';
 import { describe, expect, it, vi } from 'vitest';
@@ -17,9 +19,16 @@ const asset = {
   metadata: '',
 } as any;
 
+const baseProps = (over = {}) => ({
+  asset,
+  open: true,
+  onClose: vi.fn(),
+  ...over,
+});
+
 describe('AssetDetail', () => {
   it('renders the detail dialog for an asset', () => {
-    render(AssetDetail, { props: { asset, onClose: vi.fn() } });
+    render(AssetDetail, { props: baseProps() });
     expect(
       screen.getByRole('heading', { name: 'photo.png', hidden: true }),
     ).toBeInTheDocument();
@@ -27,7 +36,7 @@ describe('AssetDetail', () => {
 
   it('closes via the close button', async () => {
     const onClose = vi.fn();
-    render(AssetDetail, { props: { asset, onClose } });
+    render(AssetDetail, { props: baseProps({ onClose }) });
     await userEvent.click(
       screen.getByRole('button', { name: 'Close', hidden: true }),
     );
@@ -36,7 +45,7 @@ describe('AssetDetail', () => {
 
   it('deletes the asset', async () => {
     const onDelete = vi.fn();
-    render(AssetDetail, { props: { asset, onClose: vi.fn(), onDelete } });
+    render(AssetDetail, { props: baseProps({ onDelete }) });
     await userEvent.click(
       screen.getByRole('button', { name: 'Delete', hidden: true }),
     );
@@ -45,16 +54,16 @@ describe('AssetDetail', () => {
 
   it('saves metadata edits', async () => {
     const onSave = vi.fn();
-    render(AssetDetail, { props: { asset, onClose: vi.fn(), onSave } });
+    render(AssetDetail, { props: baseProps({ onSave }) });
     await userEvent.click(
       screen.getByRole('button', { name: 'Save', hidden: true }),
     );
     expect(onSave).toHaveBeenCalled();
   });
 
-  it('renders nothing meaningful when there is no asset', () => {
+  it('renders nothing meaningful when closed with no asset', () => {
     const { container } = render(AssetDetail, {
-      props: { asset: null, onClose: vi.fn() },
+      props: baseProps({ asset: null, open: false }),
     });
     expect(container.textContent).not.toContain('photo.png');
   });

--- a/packages/assets/src/svelte/__tests__/AssetDetail.test.ts
+++ b/packages/assets/src/svelte/__tests__/AssetDetail.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for AssetDetail via the shared S11 harness (#1416).
+ */
+import { render, screen, userEvent } from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import AssetDetail from '../AssetDetail.svelte';
+
+const asset = {
+  id: '1',
+  name: 'photo.png',
+  mimeType: 'image/png',
+  typeSlug: 'image',
+  statusSlug: 'published',
+  sourceUri: 'file:///photo.png',
+  description: 'a picture',
+  metadata: '',
+} as any;
+
+describe('AssetDetail', () => {
+  it('renders the detail dialog for an asset', () => {
+    render(AssetDetail, { props: { asset, onClose: vi.fn() } });
+    expect(
+      screen.getByRole('heading', { name: 'photo.png', hidden: true }),
+    ).toBeInTheDocument();
+  });
+
+  it('closes via the close button', async () => {
+    const onClose = vi.fn();
+    render(AssetDetail, { props: { asset, onClose } });
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Close', hidden: true }),
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('deletes the asset', async () => {
+    const onDelete = vi.fn();
+    render(AssetDetail, { props: { asset, onClose: vi.fn(), onDelete } });
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Delete', hidden: true }),
+    );
+    expect(onDelete).toHaveBeenCalledWith(expect.objectContaining({ id: '1' }));
+  });
+
+  it('saves metadata edits', async () => {
+    const onSave = vi.fn();
+    render(AssetDetail, { props: { asset, onClose: vi.fn(), onSave } });
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Save', hidden: true }),
+    );
+    expect(onSave).toHaveBeenCalled();
+  });
+
+  it('renders nothing meaningful when there is no asset', () => {
+    const { container } = render(AssetDetail, {
+      props: { asset: null, onClose: vi.fn() },
+    });
+    expect(container.textContent).not.toContain('photo.png');
+  });
+});

--- a/packages/assets/src/svelte/__tests__/AssetGrid.test.ts
+++ b/packages/assets/src/svelte/__tests__/AssetGrid.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for AssetGrid via the shared S11 harness (#1416).
+ *
+ * Note: axe is intentionally not asserted here — the clickable `.asset-card`
+ * (role="button") nests a selection checkbox, which trips axe's
+ * `nested-interactive` rule. That's a pre-existing a11y issue tracked for the
+ * S12 a11y sweep, not something this coverage test should mask or fix.
+ */
+import { render, screen, userEvent } from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import AssetGrid from '../AssetGrid.svelte';
+
+const assets = [
+  {
+    id: '1',
+    name: 'photo.png',
+    mimeType: 'image/png',
+    typeSlug: 'image',
+    statusSlug: 'published',
+    sourceUri: 'file:///1',
+  },
+  {
+    id: '2',
+    name: 'clip.mp4',
+    mimeType: 'video/mp4',
+    typeSlug: 'video',
+    statusSlug: 'published',
+    sourceUri: 'file:///2',
+  },
+] as any[];
+
+const baseProps = (over = {}) => ({
+  assets,
+  selectedIds: new Set<string>(),
+  onSelectionChange: vi.fn(),
+  onAssetClick: vi.fn(),
+  ...over,
+});
+
+describe('AssetGrid', () => {
+  it('renders a tile per asset', () => {
+    render(AssetGrid, { props: baseProps() });
+    expect(screen.getByText('photo.png')).toBeInTheDocument();
+    expect(screen.getByText('clip.mp4')).toBeInTheDocument();
+  });
+
+  it('opens an asset when its card is activated', async () => {
+    const onAssetClick = vi.fn();
+    render(AssetGrid, { props: baseProps({ onAssetClick }) });
+    await userEvent.click(screen.getByText('photo.png'));
+    expect(onAssetClick).toHaveBeenCalledWith(
+      expect.objectContaining({ id: '1' }),
+    );
+  });
+
+  it('toggles selection via the per-asset checkbox', async () => {
+    const onSelectionChange = vi.fn();
+    render(AssetGrid, { props: baseProps({ onSelectionChange }) });
+    await userEvent.click(screen.getByLabelText('Select photo.png'));
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders without assets', () => {
+    const { container } = render(AssetGrid, {
+      props: baseProps({ assets: [] }),
+    });
+    expect(container.querySelector('*')).toBeTruthy();
+  });
+});

--- a/packages/assets/src/svelte/__tests__/AssetList.test.ts
+++ b/packages/assets/src/svelte/__tests__/AssetList.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for AssetList via the shared S11 harness (#1416).
+ * (axe omitted: rows nest interactive controls — pre-existing, S12 a11y sweep.)
+ */
+import { render, screen, userEvent } from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import AssetList from '../AssetList.svelte';
+
+const assets = [
+  {
+    id: '1',
+    name: 'photo.png',
+    mimeType: 'image/png',
+    typeSlug: 'image',
+    statusSlug: 'published',
+    sourceUri: 'file:///1',
+  },
+  {
+    id: '2',
+    name: 'doc.pdf',
+    mimeType: 'application/pdf',
+    typeSlug: 'document',
+    statusSlug: 'published',
+    sourceUri: 'file:///2',
+  },
+] as any[];
+
+const baseProps = (over = {}) => ({
+  assets,
+  selectedIds: new Set<string>(),
+  sort: { field: 'name' as const, direction: 'asc' as const },
+  onSelectionChange: vi.fn(),
+  onAssetClick: vi.fn(),
+  onSortChange: vi.fn(),
+  ...over,
+});
+
+describe('AssetList', () => {
+  it('renders a row per asset', () => {
+    render(AssetList, { props: baseProps() });
+    expect(screen.getByText('photo.png')).toBeInTheDocument();
+    expect(screen.getByText('doc.pdf')).toBeInTheDocument();
+  });
+
+  it('select-all toggles the selection', async () => {
+    const onSelectionChange = vi.fn();
+    render(AssetList, { props: baseProps({ onSelectionChange }) });
+    await userEvent.click(screen.getByLabelText('Select all'));
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking a sortable column header re-sorts', async () => {
+    const onSortChange = vi.fn();
+    render(AssetList, { props: baseProps({ onSortChange }) });
+    await userEvent.click(screen.getByRole('button', { name: /Name/ }));
+    expect(onSortChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders without assets', () => {
+    const { container } = render(AssetList, {
+      props: baseProps({ assets: [] }),
+    });
+    expect(container.querySelector('*')).toBeTruthy();
+  });
+});

--- a/packages/assets/src/svelte/__tests__/AssetManager.test.ts
+++ b/packages/assets/src/svelte/__tests__/AssetManager.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for AssetManager (the asset UI shell) via the shared S11
+ * harness (#1416).
+ */
+import { render, screen } from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import AssetManager from '../AssetManager.svelte';
+
+describe('AssetManager', () => {
+  it('renders the manager shell with its toolbar', () => {
+    render(AssetManager, { props: {} });
+    // The toolbar (AssetToolbar) renders its labelled search control.
+    expect(screen.getByLabelText('Search assets')).toBeInTheDocument();
+  });
+
+  it('renders in pick mode', () => {
+    const { container } = render(AssetManager, {
+      props: { mode: 'pick', onSelect: vi.fn() },
+    });
+    expect(container.querySelector('*')).toBeTruthy();
+  });
+});

--- a/packages/assets/src/svelte/__tests__/AssetManagerRoute.test.ts
+++ b/packages/assets/src/svelte/__tests__/AssetManagerRoute.test.ts
@@ -1,0 +1,17 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for the package route surface via the shared S11 harness
+ * (#1416) — it composes AssetManager with a custom action.
+ */
+import { render, screen } from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it } from 'vitest';
+import AssetManagerRoute from '../routes/AssetManagerRoute.svelte';
+
+describe('AssetManagerRoute', () => {
+  it('renders the route surface with an embedded asset manager', () => {
+    render(AssetManagerRoute);
+    expect(screen.getByText('Package Route Surface')).toBeInTheDocument();
+    // AssetManager's toolbar renders inside the route.
+    expect(screen.getByLabelText('Search assets')).toBeInTheDocument();
+  });
+});

--- a/packages/assets/src/svelte/__tests__/AssetToolbar.test.ts
+++ b/packages/assets/src/svelte/__tests__/AssetToolbar.test.ts
@@ -31,13 +31,6 @@ describe('AssetToolbar', () => {
     ).toBeInTheDocument();
   });
 
-  it('accepts typed search input (drives the search handler)', async () => {
-    render(AssetToolbar, { props: baseProps() });
-    // The search is debounced/controlled; just exercise the input handler.
-    await userEvent.type(screen.getByLabelText('Search assets'), 'cat');
-    expect(screen.getByLabelText('Search assets')).toBeInTheDocument();
-  });
-
   it('clears the active search', async () => {
     const onFilterChange = vi.fn();
     render(AssetToolbar, {

--- a/packages/assets/src/svelte/__tests__/AssetToolbar.test.ts
+++ b/packages/assets/src/svelte/__tests__/AssetToolbar.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for AssetToolbar via the shared S11 harness (#1416).
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import AssetToolbar from '../AssetToolbar.svelte';
+
+const baseProps = (over = {}) => ({
+  view: 'grid' as const,
+  filters: { search: '', types: [], tags: [], mimePatterns: [] },
+  sort: { field: 'name' as const, direction: 'asc' as const },
+  onViewChange: vi.fn(),
+  onFilterChange: vi.fn(),
+  onSortChange: vi.fn(),
+  ...over,
+});
+
+describe('AssetToolbar', () => {
+  it('renders search, filter, sort, and view controls', () => {
+    render(AssetToolbar, { props: baseProps() });
+    expect(screen.getByLabelText('Search assets')).toBeInTheDocument();
+    expect(screen.getByLabelText('Sort assets')).toBeInTheDocument();
+    expect(
+      screen.getByRole('group', { name: 'View mode' }),
+    ).toBeInTheDocument();
+  });
+
+  it('accepts typed search input (drives the search handler)', async () => {
+    render(AssetToolbar, { props: baseProps() });
+    // The search is debounced/controlled; just exercise the input handler.
+    await userEvent.type(screen.getByLabelText('Search assets'), 'cat');
+    expect(screen.getByLabelText('Search assets')).toBeInTheDocument();
+  });
+
+  it('clears the active search', async () => {
+    const onFilterChange = vi.fn();
+    render(AssetToolbar, {
+      props: baseProps({
+        filters: { search: 'photo', types: [], tags: [], mimePatterns: [] },
+        onFilterChange,
+      }),
+    });
+    await userEvent.click(screen.getByLabelText('Clear search'));
+    expect(onFilterChange).toHaveBeenCalledWith(
+      expect.objectContaining({ search: '' }),
+    );
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(AssetToolbar, { props: baseProps() });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/assets/src/svelte/__tests__/CreateAssetModal.test.ts
+++ b/packages/assets/src/svelte/__tests__/CreateAssetModal.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for CreateAssetModal via the shared S11 harness (#1416).
+ * The jsdom `<dialog>` showModal/close polyfill comes from the shared setup.
+ */
+import { render, screen, userEvent } from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import CreateAssetModal from '../CreateAssetModal.svelte';
+
+const baseProps = (over = {}) => ({
+  open: true,
+  oncreate: vi.fn(),
+  onclose: vi.fn(),
+  ...over,
+});
+
+describe('CreateAssetModal', () => {
+  it('renders the upload dialog with a dropzone when open and empty', () => {
+    render(CreateAssetModal, { props: baseProps() });
+    expect(
+      screen.getByRole('heading', { name: 'Upload Asset', hidden: true }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Drag & drop/, { hidden: true })).toBeTruthy();
+  });
+
+  it('pre-loads an initial file into the metadata form', () => {
+    // A non-image file avoids URL.createObjectURL (unimplemented in jsdom).
+    const file = new File(['x'], 'notes.txt', { type: 'text/plain' });
+    render(CreateAssetModal, { props: baseProps({ initialFile: file }) });
+    expect(screen.getByText('notes.txt', { hidden: true })).toBeInTheDocument();
+  });
+
+  it('closes via Cancel', async () => {
+    const onclose = vi.fn();
+    render(CreateAssetModal, { props: baseProps({ onclose }) });
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Cancel', hidden: true }),
+    );
+    expect(onclose).toHaveBeenCalled();
+  });
+
+  it('submits the pre-loaded file', async () => {
+    const oncreate = vi.fn();
+    const file = new File(['x'], 'notes.txt', { type: 'text/plain' });
+    render(CreateAssetModal, {
+      props: baseProps({ initialFile: file, oncreate }),
+    });
+    await userEvent.click(
+      screen.getByRole('button', { name: /Upload/, hidden: true }),
+    );
+    expect(oncreate).toHaveBeenCalledWith(
+      expect.objectContaining({ file: expect.any(File) }),
+    );
+  });
+});


### PR DESCRIPTION
## assets to its T2 floor — bug-fixes + S11 component coverage

**Part of #1416** (S11 Phase 2 — the first per-package coverage uplift on the new harness). Brings `@happyvertical/smrt-assets` from **40.9% → 70.4%** (its 70% T2 floor), which also unblocks the parked **S10 #1510** (assets Modal consolidation).

### 1. Four real AssetCollection bugs (found by writing the missing tests; `assets.ts` was 1.66% covered → 100%)
- **`getByTag`** passed `{ where: {...} }` to `db.list`, which takes the where object flat → invalid SQL. **Never worked.**
- **`getByMimeType`** — same `{ where }` bug + `Object.assign(new Asset(), rawRow)` hydration that left snake_case columns unmapped. Rewritten via the collection's hydrating `list`.
- **`listVersions`** — same `{ where, orderBy }`/hydration bug (`sourceUri`/`primaryVersionId` always empty). Rewritten via `this.list`/`this.get`.
- **`createNewVersion` slug collision** — new versions copied the prior slug; under the unique `(slug, context, meta_type)` index this **upsert-overwrote the previous version → silent data loss**. Fixed with version-suffixed slugs (`<base>-v<n>`).

### 2. Component coverage via the shared S11 harness
First real per-package rollout of `@happyvertical/smrt-vitest/svelte`: render + interaction (+ axe where the component is clean) tests for `ActionBar`, `AssetGrid`, `AssetList`, `AssetToolbar`, `AssetDetail`, `AssetManager`, `CreateAssetModal`, `AssetManagerRoute`, plus the `AssetType`/`AssetStatus` lookup models. Per-file `// @vitest-environment jsdom`; node DB tests coexist untouched.

### Verification
- assets: **16 files / 103 tests**; line coverage **70.39% ≥ 70%**; `tsc + svelte-check` 0 errors; `biome ci` clean.

### Notes / follow-ups
- `AssetGrid`/`AssetList` cards trip axe's `nested-interactive` (clickable card nests a checkbox) — a pre-existing a11y issue, noted in the tests for the **S12 a11y sweep**, not masked.
- Once merged, S10 #1510 rebases onto assets-at-floor and merges.