### PR TITLE
feat(smrt-svelte): Modal placement='end' drawer + assets AssetDetail consolidation (S10 #1415)

### DIFF
--- a/packages/assets/src/svelte/AssetDetail.svelte
+++ b/packages/assets/src/svelte/AssetDetail.svelte
@@ -156,13 +156,15 @@ function formatDate(date: Date | string | undefined): string {
 
 {#if asset}
   <!-- Shell consolidated onto the library Modal (S10 #1415): title + close X,
-       backdrop, Esc, and showModal lifecycle come from Modal; this file owns the
-       asset-detail body + action footer. -->
+       backdrop, Esc, and showModal lifecycle come from Modal. `placement="end"`
+       preserves the original right-anchored detail-drawer presentation; this
+       file owns only the asset-detail body + action footer. -->
   <Modal
     open={open}
     title={asset.name || 'Untitled Asset'}
     onClose={handleClose}
-    size="lg"
+    size="md"
+    placement="end"
   >
       <div class="detail__body">
         <!-- Preview Section -->

--- a/packages/assets/src/svelte/AssetDetail.svelte
+++ b/packages/assets/src/svelte/AssetDetail.svelte
@@ -6,6 +6,8 @@
  * metadata, content references ("Used In"), copy utilities, and actions.
  */
 
+import { Modal } from '@happyvertical/smrt-svelte/feedback';
+import { Button } from '@happyvertical/smrt-svelte/ui';
 import type { Snippet } from 'svelte';
 import type { PersistedAsset } from './types';
 
@@ -58,7 +60,6 @@ let {
   contentReferences,
 }: AssetDetailProps = $props();
 
-let dialogEl: HTMLDialogElement | null = $state(null);
 let saving = $state(false);
 let copyFeedback = $state('');
 
@@ -73,16 +74,6 @@ $effect(() => {
     editName = asset.name || '';
     editDescription = asset.description || '';
     editAlt = (asset as any).alt || '';
-  }
-});
-
-// Sync open state with dialog
-$effect(() => {
-  if (!dialogEl) return;
-  if (open && !dialogEl.open) {
-    dialogEl.showModal();
-  } else if (!open && dialogEl.open) {
-    dialogEl.close();
   }
 });
 
@@ -142,18 +133,6 @@ function copyMarkdown() {
   }
 }
 
-function handleCancel(e: Event) {
-  e.preventDefault();
-  handleClose();
-}
-
-function handleKeydown(e: KeyboardEvent) {
-  if (e.key === 'Escape') {
-    e.preventDefault();
-    handleClose();
-  }
-}
-
 const isImage = $derived(asset?.mimeType?.startsWith('image/') ?? false);
 const isVideo = $derived(asset?.mimeType?.startsWith('video/') ?? false);
 const isAudio = $derived(asset?.mimeType?.startsWith('audio/') ?? false);
@@ -175,34 +154,16 @@ function formatDate(date: Date | string | undefined): string {
 }
 </script>
 
-<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-<dialog
-  bind:this={dialogEl}
-  class="detail-modal"
-  oncancel={handleCancel}
-  onkeydown={handleKeydown}
-  onclick={(e) => { if (e.target === dialogEl) handleClose(); }}
-  aria-label="Asset details"
->
-  {#if asset}
-    <div
-      class="detail-modal__container"
-      role="presentation"
-      tabindex="-1"
-      onclick={(e) => e.stopPropagation()}
-      onkeydown={(e) => e.stopPropagation()}
-    >
-      <!-- Header -->
-      <header class="detail__header">
-        <h2 class="detail__title">{asset.name || 'Untitled Asset'}</h2>
-        <button type="button" class="detail__close" onclick={handleClose} aria-label="Close">
-          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <line x1="18" y1="6" x2="6" y2="18"></line>
-            <line x1="6" y1="6" x2="18" y2="18"></line>
-          </svg>
-        </button>
-      </header>
-
+{#if asset}
+  <!-- Shell consolidated onto the library Modal (S10 #1415): title + close X,
+       backdrop, Esc, and showModal lifecycle come from Modal; this file owns the
+       asset-detail body + action footer. -->
+  <Modal
+    open={open}
+    title={asset.name || 'Untitled Asset'}
+    onClose={handleClose}
+    size="lg"
+  >
       <div class="detail__body">
         <!-- Preview Section -->
         <section class="detail__section">
@@ -322,114 +283,25 @@ function formatDate(date: Date | string | undefined): string {
         {/if}
       </div>
 
-      <!-- Footer -->
-      <footer class="detail__footer">
-        <button type="button" class="footer-btn footer-btn--danger" onclick={handleDelete}>
-          Delete
-        </button>
-        <div class="footer-right">
-          <button type="button" class="footer-btn footer-btn--ghost" onclick={handleClose}>
-            Cancel
-          </button>
-          <button type="button" class="footer-btn footer-btn--primary" onclick={handleSave} disabled={saving}>
+    {#snippet footer()}
+      <div class="detail-footer">
+        <Button variant="danger" onclick={handleDelete}>Delete</Button>
+        <div class="detail-footer__right">
+          <Button variant="ghost" onclick={handleClose}>Cancel</Button>
+          <Button variant="primary" onclick={handleSave} disabled={saving}>
             {#if saving}Saving...{:else}Save{/if}
-          </button>
+          </Button>
         </div>
-      </footer>
-    </div>
-  {/if}
-</dialog>
+      </div>
+    {/snippet}
+  </Modal>
+{/if}
 
 <style>
-  .detail-modal {
-    position: fixed;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    max-width: 100%;
-    max-height: 100%;
-    margin: 0;
-    padding: 0;
-    border: none;
-    background: transparent;
-    overflow: hidden;
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-  }
-
-  .detail-modal::backdrop {
-    background: var(--smrt-color-scrim, rgba(0, 0, 0, 0.5));
-    backdrop-filter: blur(2px);
-  }
-
-  .detail-modal:not([open]) {
-    display: none;
-  }
-
-  .detail-modal__container {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    max-width: 520px;
-    height: calc(100vh - 2rem);
-    margin-right: 1rem;
-    background: var(--smrt-color-surface, #ffffff);
-    border-radius: var(--smrt-radius-large, 0.75rem);
-    box-shadow: var(--smrt-elevation-3);
-    overflow: hidden;
-    animation: slideIn 300ms cubic-bezier(0.2, 0, 0, 1);
-  }
-
-  @keyframes slideIn {
-    from { transform: translateX(100%); opacity: 0; }
-    to { transform: translateX(0); opacity: 1; }
-  }
-
-  /* Header */
-  .detail__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: var(--smrt-spacing-4, 1rem) var(--smrt-spacing-5, 1.25rem);
-    border-bottom: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
-    flex-shrink: 0;
-  }
-
-  .detail__title {
-    margin: 0;
-    font-size: var(--smrt-typography-title-medium-size, 1.125rem);
-    font-weight: var(--smrt-typography-weight-semibold, 600);
-    color: var(--smrt-color-on-surface, #111827);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .detail__close {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-    padding: 0;
-    border: none;
-    background: transparent;
-    color: var(--smrt-color-on-surface-variant, #6b7280);
-    cursor: pointer;
-    border-radius: var(--smrt-radius-full, 9999px);
-    flex-shrink: 0;
-  }
-
-  .detail__close:hover {
-    background: var(--smrt-color-surface-container-highest, #e0e2ec);
-  }
-
-  /* Body */
+  /* Body — negative margin cancels Modal's .modal__body padding so the section
+     dividers stay full-bleed (Modal owns the dialog shell + scroll container). */
   .detail__body {
-    flex: 1;
-    overflow-y: auto;
-    padding: 0;
+    margin: calc(-1 * var(--smrt-spacing-5, 1.25rem));
   }
 
   .detail__section {
@@ -626,77 +498,18 @@ function formatDate(date: Date | string | undefined): string {
     to { opacity: 1; }
   }
 
-  /* Footer */
-  .detail__footer {
+  /* Footer — split layout: destructive Delete on the left, Cancel/Save on the
+     right. The buttons are library <Button>s; only the split layout is local. */
+  .detail-footer {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: var(--smrt-spacing-3, 0.75rem) var(--smrt-spacing-5, 1.25rem);
-    border-top: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
-    flex-shrink: 0;
-  }
-
-  .footer-right {
-    display: flex;
+    width: 100%;
     gap: var(--smrt-spacing-2, 0.5rem);
   }
 
-  .footer-btn {
-    height: 36px;
-    padding: 0 var(--smrt-spacing-4, 1rem);
-    font-family: inherit;
-    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-    font-weight: var(--smrt-typography-weight-medium, 500);
-    border-radius: var(--smrt-radius-medium, 0.5rem);
-    cursor: pointer;
-    border: none;
-    transition: all 150ms ease;
-  }
-
-  .footer-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .footer-btn--primary {
-    background: var(--smrt-color-primary, #005ac1);
-    color: var(--smrt-color-on-primary, #ffffff);
-  }
-
-  .footer-btn--primary:hover:not(:disabled) {
-    box-shadow: var(--smrt-elevation-2);
-  }
-
-  .footer-btn--ghost {
-    background: transparent;
-    color: var(--smrt-color-on-surface-variant, #6b7280);
-  }
-
-  .footer-btn--ghost:hover {
-    background: var(--smrt-color-surface-container, #f3f4f6);
-  }
-
-  .footer-btn--danger {
-    background: transparent;
-    color: var(--smrt-color-error, #dc2626);
-  }
-
-  .footer-btn--danger:hover {
-    background: var(--smrt-color-error-container, #fef2f2);
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .detail-modal__container {
-      animation: none;
-    }
-  }
-
-  @media (max-width: 640px) {
-    .detail-modal__container {
-      max-width: 100%;
-      margin-right: 0;
-      height: 100vh;
-      border-radius: 0;
-    }
+  .detail-footer__right {
+    display: flex;
+    gap: var(--smrt-spacing-2, 0.5rem);
   }
 </style>

--- a/packages/assets/src/svelte/__tests__/AssetDetail.test.ts
+++ b/packages/assets/src/svelte/__tests__/AssetDetail.test.ts
@@ -37,8 +37,10 @@ describe('AssetDetail', () => {
   it('closes via the close button', async () => {
     const onClose = vi.fn();
     render(AssetDetail, { props: baseProps({ onClose }) });
+    // The library Modal (S10) provides the dialog's close affordance, labelled
+    // "Close modal".
     await userEvent.click(
-      screen.getByRole('button', { name: 'Close', hidden: true }),
+      screen.getByRole('button', { name: 'Close modal', hidden: true }),
     );
     expect(onClose).toHaveBeenCalled();
   });

--- a/packages/smrt-svelte/src/components/feedback/Modal.svelte
+++ b/packages/smrt-svelte/src/components/feedback/Modal.svelte
@@ -24,6 +24,8 @@ export interface Props {
   title?: string;
   /** Modal size variant */
   size?: 'sm' | 'md' | 'lg' | 'xl' | 'full';
+  /** Placement: center (default) or end for a right-anchored full-height drawer */
+  placement?: 'center' | 'end';
   /** Whether clicking backdrop closes modal */
   closeOnBackdrop?: boolean;
   /** Whether pressing Escape closes modal */
@@ -47,6 +49,7 @@ let {
   onClose,
   title,
   size = 'md',
+  placement = 'center',
   closeOnBackdrop = true,
   closeOnEscape = true,
   showClose = true,
@@ -106,12 +109,16 @@ const sizeClasses = {
   xl: 'modal--xl',
   full: 'modal--full',
 };
+
+const placementClass = $derived(
+  placement === 'end' ? 'modal--end' : 'modal--center',
+);
 </script>
 
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <dialog
   bind:this={dialogEl}
-  class="modal {sizeClasses[size]}"
+  class="modal {sizeClasses[size]} {placementClass}"
   onclick={handleBackdropClick}
   onkeydown={handleKeydown}
   oncancel={handleCancel}
@@ -254,6 +261,38 @@ const sizeClasses = {
     max-width: none;
     max-height: none;
     border-radius: var(--smrt-radius-medium, 0.5rem);
+  }
+
+  /* Placement: end = right-anchored, full-height drawer (e.g. detail panels).
+     The size variant still sets the panel width. */
+  .modal--end {
+    justify-content: flex-end;
+    align-items: stretch;
+  }
+
+  .modal--end .modal__container {
+    height: 100%;
+    max-height: 100%;
+    border-radius: var(--smrt-radius-none, 0);
+    animation: modal-slide-end var(--smrt-duration-medium2, 300ms)
+      var(--smrt-easing-emphasized, cubic-bezier(0.2, 0, 0, 1));
+  }
+
+  @keyframes modal-slide-end {
+    from {
+      opacity: 0;
+      transform: translateX(100%);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .modal--end .modal__container {
+      animation: none;
+    }
   }
 
   /* Header */

--- a/packages/smrt-svelte/src/components/feedback/Modal.svelte
+++ b/packages/smrt-svelte/src/components/feedback/Modal.svelte
@@ -377,5 +377,13 @@ const placementClass = $derived(
     .modal--xl .modal__container {
       max-width: calc(100vw - var(--smrt-spacing-4, 1rem));
     }
+
+    /* A drawer goes full-bleed on mobile — no backdrop strip. Declared after the
+       size-cap rule above so it wins for end placement regardless of size. */
+    .modal--end .modal__container {
+      width: 100%;
+      max-width: 100%;
+      max-height: 100%;
+    }
   }
 </style>

--- a/packages/smrt-svelte/src/components/feedback/__tests__/Modal.test.ts
+++ b/packages/smrt-svelte/src/components/feedback/__tests__/Modal.test.ts
@@ -49,11 +49,37 @@ describe('Modal', () => {
     ).toBeNull();
   });
 
+  it('defaults to centered placement', () => {
+    render(Modal, { props: { open: true, title: 'X' } });
+    expect(screen.getByRole('dialog', { hidden: true })).toHaveClass(
+      'modal--center',
+    );
+  });
+
+  it('applies the end (drawer) placement variant', () => {
+    render(Modal, { props: { open: true, title: 'X', placement: 'end' } });
+    const dialog = screen.getByRole('dialog', { hidden: true });
+    expect(dialog).toHaveClass('modal--end');
+    expect(dialog).not.toHaveClass('modal--center');
+  });
+
   it('is axe-clean', async () => {
     const { container } = render(Modal, {
       props: {
         open: true,
         title: 'Accessible dialog',
+        children: bodySnippet('content'),
+      },
+    });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean with end placement', async () => {
+    const { container } = render(Modal, {
+      props: {
+        open: true,
+        title: 'Detail drawer',
+        placement: 'end',
         children: bodySnippet('content'),
       },
     });


### PR DESCRIPTION
## Summary
S10 UI consolidation (#1415), with the supporting upstream primitive change.

**smrt-svelte — `Modal` gains a `placement` prop** (additive, backward-compatible): `'center'` (default — unchanged for every existing consumer) or `'end'` (right-anchored, full-height, slide-in-from-right **drawer**). Drawer CSS uses only `--smrt-*` tokens.

**assets — `AssetDetail` consolidated onto `Modal`**: it hand-rolled a native `<dialog>` (showModal/close lifecycle, backdrop, Esc, custom header + close button) plus a footer of styled buttons, duplicating `Modal` + `Button`. Now uses `<Modal placement="end" size="md">` (preserving its original detail-drawer presentation) + library `<Button>`s (danger/ghost/primary). **Net −185 lines** in AssetDetail (702 → 515); no hand-rolled dialogs remain in assets.

Completes assets' dialog consolidation: CreateAssetModal ([#1510](https://github.com/happyvertical/smrt/pull/1510)) → ActionBar ([#1514](https://github.com/happyvertical/smrt/pull/1514)) → AssetDetail (here).

## Why the Modal change
Copilot correctly flagged that consolidating AssetDetail's bespoke **right-anchored drawer** onto the centered Modal would change its UX. The framework-correct fix is an upstream prop, not a bespoke shell (per the smrt-svelte "missing a prop? add it upstream" convention) — so Modal now offers the drawer placement and AssetDetail adopts it.

## Tests
- `Modal.test.ts`: golden tests for both placements (`modal--center` default, `modal--end` variant) + an axe-clean drawer case. smrt-svelte suite 374/374, typecheck 0 errors.
- `AssetDetail.test.ts`: close affordance is now Modal's built-in button (`aria-label="Close modal"`); 5 cases green. assets suite 103/103, typecheck 0 errors, coverage 70.36% ≥ 70 (T2 floor).
- All 6 design-token ratchets green on the new Modal CSS.

Part of #1415