### PR TITLE
test(users): roll in S11 component-test harness + cover all 6 components (#1416)

### DIFF
--- a/packages/users/src/svelte/components/__tests__/InviteUserModal.test.ts
+++ b/packages/users/src/svelte/components/__tests__/InviteUserModal.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for InviteUserModal via the shared S11 harness (#1416).
+ */
+import {
+  fireEvent,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import InviteUserModal from '../InviteUserModal.svelte';
+
+const baseProps = (over = {}) => ({
+  open: true,
+  tenant: { name: 'Acme' } as any,
+  roles: [{ id: 'r1', slug: 'member', name: 'Member' }] as any,
+  onsubmit: vi.fn(),
+  onclose: vi.fn(),
+  ...over,
+});
+
+describe('InviteUserModal', () => {
+  it('renders the invite dialog scoped to the tenant when open', () => {
+    render(InviteUserModal, { props: baseProps() });
+    expect(
+      screen.getByRole('heading', { name: 'Invite User to Acme' }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Email address')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Send Invite' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders nothing when closed', () => {
+    render(InviteUserModal, { props: baseProps({ open: false }) });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('shows the JS validation error when submitted with no email', async () => {
+    const onsubmit = vi.fn();
+    const { container } = render(InviteUserModal, {
+      props: baseProps({ onsubmit }),
+    });
+    // Submit the form directly to exercise the component's own guard — a button
+    // click would be pre-empted by the input's native `required` constraint.
+    const form = container.querySelector('form');
+    if (!form) throw new Error('form not found');
+    await fireEvent.submit(form);
+    expect(screen.getByText('Email is required')).toBeInTheDocument();
+    expect(onsubmit).not.toHaveBeenCalled();
+  });
+
+  it('submits the email and default role', async () => {
+    const onsubmit = vi.fn();
+    render(InviteUserModal, { props: baseProps({ onsubmit }) });
+    await userEvent.type(
+      screen.getByLabelText('Email address'),
+      'ada@example.com',
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Send Invite' }));
+    expect(onsubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'ada@example.com', roleId: 'r1' }),
+    );
+  });
+
+  it('closes via the Cancel button', async () => {
+    const onclose = vi.fn();
+    render(InviteUserModal, { props: baseProps({ onclose }) });
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onclose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/users/src/svelte/components/__tests__/UserAvatar.test.ts
+++ b/packages/users/src/svelte/components/__tests__/UserAvatar.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+/**
+ * First component test in smrt-users via the shared S11 harness (#1416): the
+ * Testing-Library + axe surface comes from `@happyvertical/smrt-vitest` and the
+ * jsdom + jest-dom setup from the shared `svelte-setup` wired in vitest.config.
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it } from 'vitest';
+import UserAvatar from '../UserAvatar.svelte';
+
+// UserAvatar only reads `profile.name`, so a minimal stub is enough to drive it.
+const profile = { name: 'Ada Lovelace' } as any;
+
+describe('UserAvatar', () => {
+  it('renders the initials derived from the profile name', () => {
+    render(UserAvatar, { props: { profile } });
+    expect(screen.getByText('AL')).toBeInTheDocument();
+  });
+
+  it('renders the full name when showName is set', () => {
+    render(UserAvatar, { props: { profile, showName: true } });
+    expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+  });
+
+  it('falls back to "U" initials for a profile with no name', () => {
+    render(UserAvatar, { props: { profile: {} as any } });
+    expect(screen.getByText('U')).toBeInTheDocument();
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(UserAvatar, {
+      props: { profile, showName: true },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/users/src/svelte/components/__tests__/UserCard.test.ts
+++ b/packages/users/src/svelte/components/__tests__/UserCard.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for UserCard via the shared S11 harness (#1416).
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import UserCard from '../UserCard.svelte';
+
+const baseProps = (over = {}) => ({
+  user: { id: 'u1', email: 'ada@example.com', status: 'active' } as any,
+  profile: { name: 'Ada Lovelace' } as any,
+  role: 'admin',
+  status: 'active',
+  ...over,
+});
+
+describe('UserCard', () => {
+  it('renders the name, email, role, and status', () => {
+    render(UserCard, { props: baseProps() });
+    expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+    expect(screen.getByText('ada@example.com')).toBeInTheDocument();
+    expect(screen.getByText('admin')).toBeInTheDocument();
+    expect(screen.getByText('active')).toBeInTheDocument();
+  });
+
+  it('invokes onclick when the card is activated', async () => {
+    const onclick = vi.fn();
+    render(UserCard, { props: baseProps({ onclick }) });
+    await userEvent.click(screen.getByRole('button'));
+    expect(onclick).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a disabled, non-interactive card without an onclick', () => {
+    render(UserCard, { props: baseProps() });
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(UserCard, {
+      props: baseProps({ onclick: vi.fn() }),
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/users/src/svelte/components/__tests__/UserForm.test.ts
+++ b/packages/users/src/svelte/components/__tests__/UserForm.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for UserForm via the shared S11 harness (#1416).
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import UserForm from '../UserForm.svelte';
+
+describe('UserForm', () => {
+  it('renders create-mode fields and a Create button', () => {
+    render(UserForm, { props: { onsubmit: vi.fn() } });
+    expect(screen.getByLabelText('Name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    expect(screen.getByLabelText('Status')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Create User' }),
+    ).toBeInTheDocument();
+  });
+
+  it('submits the entered name and email', async () => {
+    const onsubmit = vi.fn();
+    render(UserForm, { props: { onsubmit } });
+    await userEvent.type(screen.getByLabelText('Name'), 'Ada Lovelace');
+    await userEvent.type(screen.getByLabelText('Email'), 'ada@example.com');
+    await userEvent.click(screen.getByRole('button', { name: 'Create User' }));
+    expect(onsubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Ada Lovelace',
+        email: 'ada@example.com',
+      }),
+    );
+  });
+
+  it('locks the email and switches to update mode for an existing user', () => {
+    render(UserForm, {
+      props: {
+        onsubmit: vi.fn(),
+        user: { email: 'ada@example.com', status: 'active' } as any,
+        profile: { name: 'Ada Lovelace' } as any,
+      },
+    });
+    expect(screen.getByLabelText('Email')).toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: 'Update User' }),
+    ).toBeInTheDocument();
+  });
+
+  it('invokes oncancel from the Cancel button', async () => {
+    const oncancel = vi.fn();
+    render(UserForm, { props: { onsubmit: vi.fn(), oncancel } });
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(oncancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(UserForm, {
+      props: { onsubmit: vi.fn(), oncancel: vi.fn() },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/users/src/svelte/components/__tests__/UserList.test.ts
+++ b/packages/users/src/svelte/components/__tests__/UserList.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for UserList via the shared S11 harness (#1416).
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import UserList from '../UserList.svelte';
+
+const users = [
+  {
+    user: { id: 'u1', email: 'ada@example.com', status: 'active' } as any,
+    profile: { name: 'Ada Lovelace' } as any,
+    role: 'admin',
+  },
+  {
+    user: { id: 'u2', email: 'alan@example.com', status: 'pending' } as any,
+    profile: { name: 'Alan Turing' } as any,
+    role: 'member',
+  },
+];
+
+describe('UserList', () => {
+  it('renders a card per user', () => {
+    render(UserList, { props: { users } });
+    expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+    expect(screen.getByText('Alan Turing')).toBeInTheDocument();
+  });
+
+  it('forwards the selected user through onselect', async () => {
+    const onselect = vi.fn();
+    render(UserList, { props: { users, onselect } });
+    await userEvent.click(screen.getByText('Alan Turing'));
+    expect(onselect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'u2' }),
+    );
+  });
+
+  it('shows the empty message when there are no users', () => {
+    render(UserList, {
+      props: { users: [], emptyMessage: 'Nobody here' },
+    });
+    expect(screen.getByText('Nobody here')).toBeInTheDocument();
+  });
+
+  it('shows a loading state', () => {
+    render(UserList, { props: { users: [], loading: true } });
+    expect(screen.getByText('Loading users...')).toBeInTheDocument();
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(UserList, {
+      props: { users, onselect: vi.fn() },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/users/src/svelte/components/__tests__/UserMenu.test.ts
+++ b/packages/users/src/svelte/components/__tests__/UserMenu.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for UserMenu via the shared S11 harness (#1416).
+ *
+ * NOTE: axe is asserted on the closed state only. When open, the dropdown reuses
+ * the wrapper's `id` (duplicate id) and points `aria-labelledby` at a
+ * non-existent trigger id — pre-existing a11y bugs to fix under S12 (#1417).
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it } from 'vitest';
+import UserMenu from '../UserMenu.svelte';
+
+describe('UserMenu', () => {
+  it('renders a collapsed trigger labelled with the display name', () => {
+    render(UserMenu, { props: { user: { name: 'Ada Lovelace' } } });
+    const trigger = screen.getByRole('button', { name: 'User menu' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+
+  it('opens the menu with profile/settings/sign-out items on click', async () => {
+    render(UserMenu, {
+      props: { user: { name: 'Ada Lovelace', email: 'ada@example.com' } },
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'User menu' }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Profile' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Settings' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Sign out' }),
+    ).toBeInTheDocument();
+  });
+
+  it('is axe-clean while collapsed', async () => {
+    const { container } = render(UserMenu, {
+      props: { user: { name: 'Ada Lovelace' } },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/users/vitest.config.ts
+++ b/packages/users/vitest.config.ts
@@ -1,13 +1,28 @@
+import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { defineConfig } from 'vitest/config';
-import { smrtVitestPlugin } from '../vitest/src/index.ts';
+import {
+  smrtVitestPlugin,
+  smrtVitestSetupPath,
+} from '../../vitest.workspace.js';
 
 export default defineConfig({
-  plugins: [smrtVitestPlugin({ verbose: true })],
+  plugins: [svelte(), smrtVitestPlugin({ setupFile: smrtVitestSetupPath })],
+  // The smrt-vitest plugin auto-applies the workspace package→src aliases
+  // (including smrt-svelte subpaths) in its config() hook, so no manual alias
+  // list is needed here — only the browser resolve conditions for Svelte.
+  resolve: {
+    conditions: ['browser'],
+  },
   test: {
     globals: true,
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.{test,spec}.ts'],
+    // Manifest setup + the shared Svelte component-test harness (S11 #1416). The
+    // harness only activates under a DOM, so node-environment tests are
+    // unaffected; component tests opt in with `// @vitest-environment jsdom`.
+    setupFiles: [smrtVitestSetupPath, '@happyvertical/smrt-vitest/svelte-setup'],
     testTimeout: 60000,
+    hookTimeout: 30000,
     // Run test files sequentially to avoid SQLite locking issues
     fileParallelism: false,
     // Use single-threaded pool to avoid database contention


### PR DESCRIPTION
## Summary
S11 harness rollout (#1416) — first of three (users → projects → chat). Wires the shared component-test harness into **smrt-users** and adds component tests for all 6 Svelte components.

**Wiring** (`vitest.config.ts`): adds the `svelte()` plugin, `browser` resolve conditions, the `@happyvertical/smrt-vitest/svelte-setup` setupFile, and `.spec.ts` discovery. The smrt-vitest plugin already auto-applies the workspace package→src aliases (incl. smrt-svelte subpaths) in its `config()` hook, so **no per-package `workspace-aliases.js` is needed** (simpler than the assets/content wiring).

**Tests** (26 cases, pattern: render → assert role/name/state → drive with user-event → axe-clean): `UserAvatar`, `UserCard`, `UserList`, `UserForm`, `UserMenu`, `InviteUserModal`.

## Coverage
79.16% → **79.85%** lines — stays above the 70% T2 floor with the `.svelte` now in the denominator (the components are well-covered, so adding them didn't drag it down). Full suite 192 passed, typecheck 0 errors.

## Surfaced for S12 (#1417), not fixed here
`UserMenu`'s open dropdown reuses the wrapper's `id` (duplicate id) and points `aria-labelledby` at a non-existent trigger id — pre-existing a11y bugs. axe is asserted on the collapsed state only; these belong to the a11y sweep.

Part of #1416