### PR TITLE
test(projects): roll in S11 component-test harness + cover all 7 components (#1416)

### DIFF
--- a/packages/projects/src/svelte/components/__tests__/ApprovalActions.test.ts
+++ b/packages/projects/src/svelte/components/__tests__/ApprovalActions.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for ApprovalActions via the shared S11 harness (#1416).
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import ApprovalActions from '../ApprovalActions.svelte';
+
+describe('ApprovalActions', () => {
+  it('offers Submit/Delete for a draft and submits on click', async () => {
+    const onsubmit = vi.fn();
+    render(ApprovalActions, {
+      props: { status: 'draft' as any, onsubmit, ondelete: vi.fn() },
+    });
+    expect(
+      screen.getByRole('button', { name: 'Submit for Approval' }),
+    ).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Submit for Approval' }),
+    );
+    expect(onsubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers Approve/Reject for a submitted entry', async () => {
+    const onapprove = vi.fn();
+    render(ApprovalActions, {
+      props: { status: 'submitted' as any, onapprove, onreject: vi.fn() },
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    expect(onapprove).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: 'Reject' })).toBeInTheDocument();
+  });
+
+  it('shows the approved status message', () => {
+    render(ApprovalActions, { props: { status: 'approved' as any } });
+    expect(
+      screen.getByText('This entry has been approved'),
+    ).toBeInTheDocument();
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(ApprovalActions, {
+      props: {
+        status: 'submitted' as any,
+        onapprove: vi.fn(),
+        onreject: vi.fn(),
+      },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/projects/src/svelte/components/__tests__/BulkActions.test.ts
+++ b/packages/projects/src/svelte/components/__tests__/BulkActions.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for BulkActions via the shared S11 harness (#1416).
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import BulkActions from '../BulkActions.svelte';
+
+const baseProps = (over = {}) => ({
+  selectedCount: 3,
+  onapprove: vi.fn(),
+  onreject: vi.fn(),
+  ondelete: vi.fn(),
+  onexport: vi.fn(),
+  onclear: vi.fn(),
+  ...over,
+});
+
+describe('BulkActions', () => {
+  it('shows the selection count and bulk action buttons', () => {
+    render(BulkActions, { props: baseProps() });
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('items selected')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Approve All' }),
+    ).toBeInTheDocument();
+  });
+
+  it('invokes onapprove when Approve All is clicked', async () => {
+    const onapprove = vi.fn();
+    render(BulkActions, { props: baseProps({ onapprove }) });
+    await userEvent.click(screen.getByRole('button', { name: 'Approve All' }));
+    expect(onapprove).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the selection', async () => {
+    const onclear = vi.fn();
+    render(BulkActions, { props: baseProps({ onclear }) });
+    await userEvent.click(screen.getByRole('button', { name: 'Clear' }));
+    expect(onclear).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders nothing when no items are selected', () => {
+    const { container } = render(BulkActions, {
+      props: baseProps({ selectedCount: 0 }),
+    });
+    expect(container.querySelector('.bulk-actions')).toBeNull();
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(BulkActions, { props: baseProps() });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/projects/src/svelte/components/__tests__/DurationDisplay.test.ts
+++ b/packages/projects/src/svelte/components/__tests__/DurationDisplay.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+/**
+ * First component test in smrt-projects via the shared S11 harness (#1416).
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it } from 'vitest';
+import DurationDisplay from '../DurationDisplay.svelte';
+
+describe('DurationDisplay', () => {
+  it('renders decimal hours to one decimal place', () => {
+    render(DurationDisplay, { props: { hours: 2.5 } });
+    expect(screen.getByText('2.5')).toBeInTheDocument();
+  });
+
+  it('renders an HH:MM value in hhmm format', () => {
+    render(DurationDisplay, { props: { hours: 1.5, format: 'hhmm' } });
+    expect(screen.getByText('1:30')).toBeInTheDocument();
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(DurationDisplay, {
+      props: { hours: 8, showLabel: true },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/projects/src/svelte/components/__tests__/RejectDialog.test.ts
+++ b/packages/projects/src/svelte/components/__tests__/RejectDialog.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for RejectDialog via the shared S11 harness (#1416).
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import RejectDialog from '../RejectDialog.svelte';
+
+const baseProps = (over = {}) => ({
+  open: true,
+  onconfirm: vi.fn(),
+  oncancel: vi.fn(),
+  ...over,
+});
+
+describe('RejectDialog', () => {
+  it('renders the dialog with a reason field when open', () => {
+    render(RejectDialog, { props: baseProps() });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reject' })).toBeInTheDocument();
+  });
+
+  it('renders nothing when closed', () => {
+    render(RejectDialog, { props: baseProps({ open: false }) });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('requires a reason before the confirm button is enabled', async () => {
+    const onconfirm = vi.fn();
+    render(RejectDialog, { props: baseProps({ onconfirm }) });
+    const confirm = screen.getByRole('button', { name: 'Reject' });
+    expect(confirm).toBeDisabled();
+    await userEvent.type(screen.getByRole('textbox'), 'Insufficient detail');
+    expect(confirm).toBeEnabled();
+    await userEvent.click(confirm);
+    expect(onconfirm).toHaveBeenCalledWith('Insufficient detail');
+  });
+
+  it('cancels via the cancel button', async () => {
+    const oncancel = vi.fn();
+    render(RejectDialog, { props: baseProps({ oncancel }) });
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(oncancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(RejectDialog, { props: baseProps() });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/projects/src/svelte/components/__tests__/TimeEntryCard.test.ts
+++ b/packages/projects/src/svelte/components/__tests__/TimeEntryCard.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for TimeEntryCard via the shared S11 harness (#1416).
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import TimeEntryCard from '../TimeEntryCard.svelte';
+
+const entry = {
+  id: 'e1',
+  date: '2026-06-01',
+  description: 'Implement feature',
+  status: 'draft',
+  hours: 3,
+  hourlyRate: 100,
+  amount: 300,
+  workerName: 'Ada Lovelace',
+} as any;
+
+describe('TimeEntryCard', () => {
+  it('renders the entry description, status, and worker', () => {
+    render(TimeEntryCard, { props: { entry } });
+    expect(screen.getByText('Implement feature')).toBeInTheDocument();
+    expect(screen.getByText('DRAFT')).toBeInTheDocument();
+    expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+  });
+
+  it('forwards checkbox selection through onselect', async () => {
+    const onselect = vi.fn();
+    render(TimeEntryCard, {
+      props: { entry, selectable: true, onselect },
+    });
+    await userEvent.click(
+      screen.getByLabelText('Select time entry for Implement feature'),
+    );
+    expect(onselect).toHaveBeenCalledWith('e1', true);
+  });
+
+  it('invokes onclick when the card is activated', async () => {
+    const onclick = vi.fn();
+    render(TimeEntryCard, { props: { entry, onclick } });
+    await userEvent.click(screen.getByText('Implement feature'));
+    expect(onclick).toHaveBeenCalledTimes(1);
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(TimeEntryCard, {
+      props: { entry, selectable: true, onselect: vi.fn() },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/projects/src/svelte/components/__tests__/TimeEntryList.test.ts
+++ b/packages/projects/src/svelte/components/__tests__/TimeEntryList.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for TimeEntryList via the shared S11 harness (#1416).
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import TimeEntryList from '../TimeEntryList.svelte';
+
+const entries = [
+  {
+    id: 'e1',
+    date: '2026-06-01',
+    description: 'First task',
+    status: 'draft',
+    hours: 2,
+  },
+  {
+    id: 'e2',
+    date: '2026-06-02',
+    description: 'Second task',
+    status: 'draft',
+    hours: 4,
+  },
+] as any[];
+
+describe('TimeEntryList', () => {
+  it('renders a card per entry', () => {
+    render(TimeEntryList, { props: { entries } });
+    expect(screen.getByText('First task')).toBeInTheDocument();
+    expect(screen.getByText('Second task')).toBeInTheDocument();
+  });
+
+  it('shows the empty message when there are no entries', () => {
+    render(TimeEntryList, {
+      props: { entries: [], emptyMessage: 'No time entries' },
+    });
+    expect(screen.getByText('No time entries')).toBeInTheDocument();
+  });
+
+  it('selects all entries via the header checkbox', async () => {
+    const onselectionchange = vi.fn();
+    render(TimeEntryList, {
+      props: { entries, selectable: true, onselectionchange },
+    });
+    await userEvent.click(screen.getByLabelText('Select all time entries'));
+    expect(onselectionchange).toHaveBeenCalledWith(['e1', 'e2']);
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(TimeEntryList, {
+      props: { entries, selectable: true, onselectionchange: vi.fn() },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/projects/src/svelte/components/__tests__/TimeSummary.test.ts
+++ b/packages/projects/src/svelte/components/__tests__/TimeSummary.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for TimeSummary via the shared S11 harness (#1416).
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it } from 'vitest';
+import TimeSummary from '../TimeSummary.svelte';
+
+describe('TimeSummary', () => {
+  it('renders the total hours and value cards', () => {
+    render(TimeSummary, {
+      props: { totalHours: 12, totalAmount: 600, entryCount: 3 },
+    });
+    expect(screen.getByText('Total Hours')).toBeInTheDocument();
+    expect(screen.getByText('Total Value')).toBeInTheDocument();
+    expect(screen.getByText('3 entries')).toBeInTheDocument();
+  });
+
+  it('shows pending and approved cards when enabled and non-zero', () => {
+    render(TimeSummary, {
+      props: {
+        totalHours: 12,
+        totalAmount: 600,
+        pendingHours: 4,
+        pendingAmount: 200,
+        approvedHours: 8,
+        approvedAmount: 400,
+        showPending: true,
+        showApproved: true,
+      },
+    });
+    expect(screen.getByText('Pending Approval')).toBeInTheDocument();
+    expect(screen.getByText('Approved')).toBeInTheDocument();
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(TimeSummary, {
+      props: { totalHours: 12, totalAmount: 600 },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/projects/vitest.config.ts
+++ b/packages/projects/vitest.config.ts
@@ -1,19 +1,39 @@
+import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { defineConfig } from 'vitest/config';
-import { smrtVitestPlugin } from '../vitest/src/index.ts';
+import {
+  smrtVitestPlugin,
+  smrtVitestSetupPath,
+} from '../../vitest.workspace.js';
 
 export default defineConfig({
-  plugins: [smrtVitestPlugin({ verbose: true })],
+  plugins: [svelte(), smrtVitestPlugin({ setupFile: smrtVitestSetupPath })],
+  // The smrt-vitest plugin auto-applies the workspace package→src aliases
+  // (including smrt-svelte subpaths) in its config() hook, so no manual alias
+  // list is needed here — only the browser resolve conditions for Svelte.
+  resolve: {
+    conditions: ['browser'],
+  },
   test: {
     globals: true,
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.{test,spec}.ts'],
+    // Manifest setup + the shared Svelte component-test harness (S11 #1416). The
+    // harness only activates under a DOM, so node-environment tests are
+    // unaffected; component tests opt in with `// @vitest-environment jsdom`.
+    setupFiles: [smrtVitestSetupPath, '@happyvertical/smrt-vitest/svelte-setup'],
     testTimeout: 30000,
+    hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
     poolOptions: {
       forks: {
         singleFork: true,
       },
+    },
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', '**/node_modules/**'],
     },
   },
 });


### PR DESCRIPTION
## Summary
S11 harness rollout (#1416) — second of three (users → **projects** → chat). Wires the shared component-test harness into **smrt-projects** and adds component tests for all 7 Svelte components.

**Wiring** (`vitest.config.ts`): same minimal recipe as the users rollout — `svelte()` plugin, `browser` resolve conditions, the `svelte-setup` setupFile, `.spec.ts` discovery. The smrt-vitest plugin auto-applies workspace aliases, so no per-package alias file is needed.

**Tests** (28 cases): `DurationDisplay`, `TimeSummary`, `ApprovalActions`, `BulkActions`, `TimeEntryCard`, `TimeEntryList`, `RejectDialog`.

## Coverage
35.6% → **65.3%** lines — **clears the 50% T3 floor** purely via the component tests. projects was previously *below* its floor (untested `.svelte` were a large fraction of the package); the harness rollout fixes that without any `.ts` test changes. Full suite 30 passed, typecheck 0 errors.

Note: `RejectDialog` is also an S10 Modal-consolidation candidate (hand-rolled reject-with-reason dialog) — left as a separate follow-up; this PR is harness-only.

Part of #1416