### PR TITLE
fix(vitest): retry flaky tests in CI to stabilize the Test Packages job

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -14,6 +14,18 @@ export default defineConfig({
     // CI-safe timeouts. hookTimeout too, since beforeEach/afterAll can be slow.
     testTimeout: 30000,
     hookTimeout: 30000,
+    // Re-run a failed test in CI before failing the run (same policy as
+    // smrt-vitest's resolveCiRetry). cli does not use smrtVitestPlugin, so the
+    // retry is set inline here. Some cli tests (e.g. db:migrate atomic rollback)
+    // have rare CI-only timing flakes that pass on re-run; retry keeps the
+    // shared "Test Packages" job reliable without masking real failures (a
+    // deterministic failure still fails all attempts). Local runs keep retry at
+    // 0 so flakes stay visible; override with SMRT_VITEST_RETRY=<n>.
+    retry: process.env.SMRT_VITEST_RETRY
+      ? Number.parseInt(process.env.SMRT_VITEST_RETRY, 10)
+      : process.env.CI
+        ? 2
+        : 0,
   },
   resolve: {
     alias: [

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -21,8 +21,8 @@ export default defineConfig({
     // shared "Test Packages" job reliable without masking real failures (a
     // deterministic failure still fails all attempts). Local runs keep retry at
     // 0 so flakes stay visible; override with SMRT_VITEST_RETRY=<n>.
-    retry: process.env.SMRT_VITEST_RETRY
-      ? Number.parseInt(process.env.SMRT_VITEST_RETRY, 10)
+    retry: /^\d+$/.test(process.env.SMRT_VITEST_RETRY ?? '')
+      ? Number.parseInt(process.env.SMRT_VITEST_RETRY as string, 10)
       : process.env.CI
         ? 2
         : 0,

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -37,6 +37,16 @@ export default defineConfig({
     testTimeout: 60000, // 60 seconds for slow CI
     hookTimeout: 120000, // Hooks can include module setup in constrained CI
     teardownTimeout: 60000, // Allow time for cleanup
+    // Re-run a failed test in CI before failing the run (same policy as
+    // smrt-vitest's resolveCiRetry). core does not use smrtVitestPlugin, so the
+    // retry is set inline. Keeps the sharded Test Core job resilient to rare
+    // CI-only timing flakes that pass on re-run; local runs keep retry at 0.
+    // Override with SMRT_VITEST_RETRY=<n>.
+    retry: process.env.SMRT_VITEST_RETRY
+      ? Number.parseInt(process.env.SMRT_VITEST_RETRY, 10)
+      : process.env.CI
+        ? 2
+        : 0,
 
     // Reporter configuration
     reporters: ['default'],

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -42,8 +42,8 @@ export default defineConfig({
     // retry is set inline. Keeps the sharded Test Core job resilient to rare
     // CI-only timing flakes that pass on re-run; local runs keep retry at 0.
     // Override with SMRT_VITEST_RETRY=<n>.
-    retry: process.env.SMRT_VITEST_RETRY
-      ? Number.parseInt(process.env.SMRT_VITEST_RETRY, 10)
+    retry: /^\d+$/.test(process.env.SMRT_VITEST_RETRY ?? '')
+      ? Number.parseInt(process.env.SMRT_VITEST_RETRY as string, 10)
       : process.env.CI
         ? 2
         : 0,

--- a/packages/vitest/AGENTS.md
+++ b/packages/vitest/AGENTS.md
@@ -24,6 +24,19 @@ Without the plugin → "unregistered class" / "No field metadata found" errors.
 4. Registers all classes in ObjectRegistry
 5. Watch mode caveat: manifest only generated at startup — restart vitest after adding new classes/fields
 
+## CI retry (flaky-test resilience)
+
+The plugin injects `test.retry` into every consuming package's config: **2 in CI
+(`process.env.CI`), 0 locally** (`resolveCiRetry`). Several packages have rare,
+CI-environment-specific timing flakes that pass on re-run (none reproducible
+locally); retry keeps the shared cross-package "Test Packages" job reliable
+without masking real failures — a deterministic failure still fails all attempts,
+and vitest flags retried tests as `flaky`. Local runs keep retry at 0 so flakes
+surface during development. Override with `SMRT_VITEST_RETRY=<n>`.
+
+Packages that don't use `smrtVitestPlugin` (notably `cli`, plus `core`) set the
+same `retry` policy inline in their own `vitest.config.ts`.
+
 ## Test Database Utilities
 
 | Function | Use Case |

--- a/packages/vitest/src/__tests__/plugin-config.test.ts
+++ b/packages/vitest/src/__tests__/plugin-config.test.ts
@@ -126,6 +126,25 @@ describe('smrtVitestPlugin config', () => {
     vi.unstubAllEnvs();
   });
 
+  it('lets a project inherit the root retry and preserves object retry', () => {
+    vi.stubEnv('SMRT_VITEST_RETRY', '');
+    vi.stubEnv('CI', '1');
+    // Root retry 0 + a project with none: the project inherits the root's 0
+    // (Vitest would otherwise default the project to the CI value).
+    const rootZero = {
+      test: { retry: 0, projects: [{ test: { name: 'sqlite' } }] },
+    };
+    smrtVitestPlugin().config?.(rootZero as any);
+    expect((rootZero.test.projects[0] as any).test.retry).toBe(0);
+
+    // Object retry config is preserved as-is, not coerced to a number.
+    const objectRetry = { test: { retry: { count: 3, delay: 50 } } };
+    expect(
+      (smrtVitestPlugin().config?.(objectRetry as any) as any)?.test?.retry,
+    ).toEqual({ count: 3, delay: 50 });
+    vi.unstubAllEnvs();
+  });
+
   it('preserves an explicit retry and honours SMRT_VITEST_RETRY', () => {
     vi.stubEnv('CI', '1');
     vi.stubEnv('SMRT_VITEST_RETRY', '');

--- a/packages/vitest/src/__tests__/plugin-config.test.ts
+++ b/packages/vitest/src/__tests__/plugin-config.test.ts
@@ -109,6 +109,40 @@ describe('smrtVitestPlugin config', () => {
     });
   });
 
+  it('injects CI-aware retry into root and project configs', () => {
+    vi.stubEnv('SMRT_VITEST_RETRY', '');
+    vi.stubEnv('CI', '1');
+    const userConfig = {
+      test: { projects: [{ test: { name: 'sqlite' } }] },
+    };
+    const config = smrtVitestPlugin().config?.(userConfig as any);
+    expect((config as any)?.test?.retry).toBe(2);
+    expect((userConfig.test.projects[0] as any).test.retry).toBe(2);
+
+    vi.stubEnv('CI', '');
+    expect(
+      (smrtVitestPlugin().config?.({ test: {} } as any) as any)?.test?.retry,
+    ).toBe(0);
+    vi.unstubAllEnvs();
+  });
+
+  it('preserves an explicit retry and honours SMRT_VITEST_RETRY', () => {
+    vi.stubEnv('CI', '1');
+    vi.stubEnv('SMRT_VITEST_RETRY', '');
+    const retryFor = (userConfig: unknown) =>
+      (smrtVitestPlugin().config?.(userConfig as any) as any)?.test?.retry;
+
+    // explicit root retry preserved over the CI default
+    expect(retryFor({ test: { retry: 5 } })).toBe(5);
+    // valid env override wins over everything
+    vi.stubEnv('SMRT_VITEST_RETRY', '3');
+    expect(retryFor({ test: { retry: 5 } })).toBe(3);
+    // non-digit override is ignored, falling back to the explicit value
+    vi.stubEnv('SMRT_VITEST_RETRY', '2x');
+    expect(retryFor({ test: { retry: 5 } })).toBe(5);
+    vi.unstubAllEnvs();
+  });
+
   it('does not duplicate the setup file when already configured', () => {
     const plugin = smrtVitestPlugin();
     const userConfig = {

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -807,22 +807,29 @@ async function generateLocalManifest(
 }
 
 /**
- * Resolve the per-test retry count injected into the vitest config.
+ * Vitest's `test.retry` accepts a plain count or an object form
+ * (`{ count, delay }`). Mirror that so explicit object configs survive.
+ */
+type RetryConfig = number | { count?: number; delay?: number };
+
+/**
+ * Resolve the per-test `retry` injected into the vitest config.
  *
  * Precedence: `SMRT_VITEST_RETRY` (a digits-only, non-negative integer) wins;
- * otherwise an explicit `test.retry` already set by the consumer is preserved;
- * otherwise the default is 2 retries in CI (`process.env.CI`) and 0 everywhere
- * else, so local runs surface flaky tests immediately while the shared
- * cross-package CI job tolerates rare transient timing flakes.
+ * otherwise an explicit consumer value is preserved as-is — including the object
+ * form (`{ count, delay }`) — so options aren't dropped; otherwise the default is
+ * 2 retries in CI (`process.env.CI`) and 0 everywhere else, so local runs surface
+ * flaky tests immediately while the shared cross-package CI job tolerates rare
+ * transient timing flakes.
  */
-function resolveRetry(explicitRetry?: number): number {
+function resolveRetry(explicitRetry?: RetryConfig): RetryConfig {
   const override = process.env.SMRT_VITEST_RETRY;
   // Digits-only so "2x"/"2.5"/"-1" fall through to the explicit/default value
   // rather than being silently coerced by parseInt.
   if (override != null && /^\d+$/.test(override)) {
     return Number.parseInt(override, 10);
   }
-  if (typeof explicitRetry === 'number' && explicitRetry >= 0) {
+  if (explicitRetry != null) {
     return explicitRetry;
   }
   return process.env.CI ? 2 : 0;
@@ -900,6 +907,7 @@ export function smrtVitestPlugin(
 
   const applyTestDefaultsToProjects = (
     projects: unknown[] | undefined,
+    rootRetry: RetryConfig | undefined,
   ): void => {
     projects?.forEach((project) => {
       if (!project || typeof project !== 'object' || !('test' in project)) {
@@ -907,15 +915,16 @@ export function smrtVitestPlugin(
       }
 
       const projectConfig = project as Record<string, unknown> & {
-        test?: { setupFiles?: string | string[]; retry?: number };
+        test?: { setupFiles?: string | string[]; retry?: RetryConfig };
       };
 
       projectConfig.test = {
         ...projectConfig.test,
         // Vitest does NOT inherit the root `test.retry` into per-project configs,
-        // so apply it here. resolveRetry (set after the spread) preserves any
-        // explicit per-project retry unless SMRT_VITEST_RETRY forces a value.
-        retry: resolveRetry(projectConfig.test?.retry),
+        // so apply it here, falling back to the root retry (then the CI default)
+        // when the project has none. resolveRetry preserves an explicit
+        // per-project value unless SMRT_VITEST_RETRY forces one.
+        retry: resolveRetry(projectConfig.test?.retry ?? rootRetry),
         setupFiles: ensureSetupFiles(projectConfig.test?.setupFiles),
       };
     });
@@ -925,7 +934,8 @@ export function smrtVitestPlugin(
     name: 'smrt-vitest',
 
     config(userConfig) {
-      applyTestDefaultsToProjects(userConfig.test?.projects);
+      const rootRetry = userConfig.test?.retry as RetryConfig | undefined;
+      applyTestDefaultsToProjects(userConfig.test?.projects, rootRetry);
       const setupFiles = ensureSetupFiles(userConfig.test?.setupFiles);
       const resolveConfig =
         userConfig.resolve && typeof userConfig.resolve === 'object'
@@ -947,8 +957,9 @@ export function smrtVitestPlugin(
           // WITHOUT masking real failures — a deterministic failure still fails
           // all attempts, and vitest reports retried tests as "flaky" so they
           // stay visible. An explicit `test.retry` in the consumer config is
-          // preserved; override with SMRT_VITEST_RETRY=<n>.
-          retry: resolveRetry(userConfig.test?.retry as number | undefined),
+          // preserved (including the object form); override with
+          // SMRT_VITEST_RETRY=<n>.
+          retry: resolveRetry(rootRetry),
         },
       };
     },

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -895,17 +895,23 @@ export function smrtVitestPlugin(
     return setupFiles;
   };
 
-  const applySetupFilesToProjects = (projects: unknown[] | undefined): void => {
+  const applyTestDefaultsToProjects = (
+    projects: unknown[] | undefined,
+  ): void => {
     projects?.forEach((project) => {
       if (!project || typeof project !== 'object' || !('test' in project)) {
         return;
       }
 
       const projectConfig = project as Record<string, unknown> & {
-        test?: { setupFiles?: string | string[] };
+        test?: { setupFiles?: string | string[]; retry?: number };
       };
 
       projectConfig.test = {
+        // Vitest does NOT inherit the root `test.retry` into per-project configs,
+        // so apply the CI retry default here too — `...projectConfig.test` after
+        // it preserves any explicit per-project override.
+        retry: resolveCiRetry(),
         ...projectConfig.test,
         setupFiles: ensureSetupFiles(projectConfig.test?.setupFiles),
       };
@@ -916,7 +922,7 @@ export function smrtVitestPlugin(
     name: 'smrt-vitest',
 
     config(userConfig) {
-      applySetupFilesToProjects(userConfig.test?.projects);
+      applyTestDefaultsToProjects(userConfig.test?.projects);
       const setupFiles = ensureSetupFiles(userConfig.test?.setupFiles);
       const resolveConfig =
         userConfig.resolve && typeof userConfig.resolve === 'object'

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -851,6 +851,25 @@ async function generateLocalManifest(
  * });
  * ```
  */
+/**
+ * Resolve the per-test retry count injected into the vitest config.
+ *
+ * `SMRT_VITEST_RETRY` (when set to a non-negative integer) wins; otherwise the
+ * default is 2 retries in CI (`process.env.CI`) and 0 everywhere else, so local
+ * runs surface flaky tests immediately while the shared cross-package CI job
+ * tolerates rare transient timing flakes.
+ */
+function resolveCiRetry(): number {
+  const override = process.env.SMRT_VITEST_RETRY;
+  if (override != null && override !== '') {
+    const parsed = Number.parseInt(override, 10);
+    if (Number.isInteger(parsed) && parsed >= 0) {
+      return parsed;
+    }
+  }
+  return process.env.CI ? 2 : 0;
+}
+
 export function smrtVitestPlugin(
   options: SmrtVitestPluginOptions = {},
 ): Plugin {
@@ -911,6 +930,16 @@ export function smrtVitestPlugin(
         },
         test: {
           setupFiles,
+          // Re-run a failed test before failing the run, in CI only. Several
+          // packages have rare, CI-environment-specific timing flakes that pass
+          // on re-run (observed: every flaky "Test Packages" failure went green
+          // on rerun, on a different package each time, none reproducible
+          // locally). Retry keeps the shared cross-package CI job reliable
+          // WITHOUT masking real failures — a deterministic failure still fails
+          // all attempts, and vitest reports retried tests as "flaky" so they
+          // stay visible. Local runs keep retry at 0 so flakes surface during
+          // development. Override with SMRT_VITEST_RETRY=<n>.
+          retry: resolveCiRetry(),
         },
       };
     },

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -807,6 +807,28 @@ async function generateLocalManifest(
 }
 
 /**
+ * Resolve the per-test retry count injected into the vitest config.
+ *
+ * Precedence: `SMRT_VITEST_RETRY` (a digits-only, non-negative integer) wins;
+ * otherwise an explicit `test.retry` already set by the consumer is preserved;
+ * otherwise the default is 2 retries in CI (`process.env.CI`) and 0 everywhere
+ * else, so local runs surface flaky tests immediately while the shared
+ * cross-package CI job tolerates rare transient timing flakes.
+ */
+function resolveRetry(explicitRetry?: number): number {
+  const override = process.env.SMRT_VITEST_RETRY;
+  // Digits-only so "2x"/"2.5"/"-1" fall through to the explicit/default value
+  // rather than being silently coerced by parseInt.
+  if (override != null && /^\d+$/.test(override)) {
+    return Number.parseInt(override, 10);
+  }
+  if (typeof explicitRetry === 'number' && explicitRetry >= 0) {
+    return explicitRetry;
+  }
+  return process.env.CI ? 2 : 0;
+}
+
+/**
  * Create the SMRT Vitest plugin
  *
  * This plugin automatically generates and loads manifests before tests run,
@@ -851,25 +873,6 @@ async function generateLocalManifest(
  * });
  * ```
  */
-/**
- * Resolve the per-test retry count injected into the vitest config.
- *
- * `SMRT_VITEST_RETRY` (when set to a non-negative integer) wins; otherwise the
- * default is 2 retries in CI (`process.env.CI`) and 0 everywhere else, so local
- * runs surface flaky tests immediately while the shared cross-package CI job
- * tolerates rare transient timing flakes.
- */
-function resolveCiRetry(): number {
-  const override = process.env.SMRT_VITEST_RETRY;
-  if (override != null && override !== '') {
-    const parsed = Number.parseInt(override, 10);
-    if (Number.isInteger(parsed) && parsed >= 0) {
-      return parsed;
-    }
-  }
-  return process.env.CI ? 2 : 0;
-}
-
 export function smrtVitestPlugin(
   options: SmrtVitestPluginOptions = {},
 ): Plugin {
@@ -908,11 +911,11 @@ export function smrtVitestPlugin(
       };
 
       projectConfig.test = {
-        // Vitest does NOT inherit the root `test.retry` into per-project configs,
-        // so apply the CI retry default here too — `...projectConfig.test` after
-        // it preserves any explicit per-project override.
-        retry: resolveCiRetry(),
         ...projectConfig.test,
+        // Vitest does NOT inherit the root `test.retry` into per-project configs,
+        // so apply it here. resolveRetry (set after the spread) preserves any
+        // explicit per-project retry unless SMRT_VITEST_RETRY forces a value.
+        retry: resolveRetry(projectConfig.test?.retry),
         setupFiles: ensureSetupFiles(projectConfig.test?.setupFiles),
       };
     });
@@ -943,9 +946,9 @@ export function smrtVitestPlugin(
           // locally). Retry keeps the shared cross-package CI job reliable
           // WITHOUT masking real failures — a deterministic failure still fails
           // all attempts, and vitest reports retried tests as "flaky" so they
-          // stay visible. Local runs keep retry at 0 so flakes surface during
-          // development. Override with SMRT_VITEST_RETRY=<n>.
-          retry: resolveCiRetry(),
+          // stay visible. An explicit `test.retry` in the consumer config is
+          // preserved; override with SMRT_VITEST_RETRY=<n>.
+          retry: resolveRetry(userConfig.test?.retry as number | undefined),
         },
       };
     },


### PR DESCRIPTION
## Problem
The shared **Test Packages** CI job runs all ~48 non-core packages together and has been intermittently failing on a *different unrelated package each run* — `cli` `db-migrate-atomic` (assertion), then `content`, etc. This repeatedly blocked unrelated PRs (e.g. it forced serial retries while merging the S11 harness PRs #1516/#1517/#1518).

## Diagnosis
- Every such failure **passed on re-run**, on a different package each time.
- **None reproduce locally** — `db-migrate-atomic` passed 15/15 in isolation and 24/24 under heavy concurrent CPU load (16 cores).
- Job completes well under its 15-min timeout, failing with assertion errors, not timeouts.

That's the signature of **rare, CI-environment-specific timing flakes** (latent async races exposed only under the CI runner's conditions), not real regressions — and chasing each across 48 packages is impractical and unverifiable.

## Fix
Inject `test.retry` = **2 in CI, 0 locally** via smrt-vitest's `config()` hook (`resolveCiRetry`). A transient flake re-runs and passes; the job stays reliable. This **does not mask real failures** — a deterministic failure still fails all attempts, and vitest reports retried tests as `flaky`. Local runs keep `retry: 0` so flakes stay visible in development; override with `SMRT_VITEST_RETRY=<n>`.

- Covers the **43 packages** that use `smrtVitestPlugin` (one central change).
- Plugin-less packages set the same policy inline: **`cli`** (Test Packages job) and **`core`** (sharded Test Core job).

## Verification
End-to-end with a throwaway flaky probe (fails on attempt 1, passes on attempt 2):
- plugin package (assets) and inline package (cli): `CI=1` → **passes** (retried); `CI` unset → **fails** (visible locally); `SMRT_VITEST_RETRY=0` → disables.
- Full suites unaffected: cli 350 passed, assets 103 passed under `CI=1`. smrt-vitest 38 passed, typecheck clean.

Follow-up (not in this PR): the underlying latent races (e.g. `db-migrate-atomic`'s cross-test `migrationAttempts` accumulation) are worth hardening individually; retry makes the job reliable in the meantime.