### PR TITLE
fix(a11y): repair UserMenu duplicate id + ReactionPicker grid role (S12 #1417)

### DIFF
--- a/packages/chat/src/svelte/components/shared/ReactionPicker.svelte
+++ b/packages/chat/src/svelte/components/shared/ReactionPicker.svelte
@@ -45,7 +45,7 @@ function handleKeydown(event: KeyboardEvent, emoji: string) {
 </script>
 
 {#if isOpen}
-  <div class="reaction-picker" role="grid" aria-label="Emoji reactions">
+  <div class="reaction-picker" role="group" aria-label="Emoji reactions">
     {#each emojis as emoji}
       <button
         class="reaction-picker__item"

--- a/packages/chat/src/svelte/components/shared/__tests__/ReactionPicker.test.ts
+++ b/packages/chat/src/svelte/components/shared/__tests__/ReactionPicker.test.ts
@@ -3,6 +3,7 @@
  * Component coverage for ReactionPicker via the shared S11 harness (#1416).
  */
 import {
+  expectNoA11yViolations,
   render,
   screen,
   userEvent,
@@ -11,23 +12,22 @@ import {
 import { describe, expect, it, vi } from 'vitest';
 import ReactionPicker from '../ReactionPicker.svelte';
 
-// NOTE: axe is intentionally not asserted here. ReactionPicker uses `role="grid"`
-// with buttons as direct children, which trips axe's `aria-required-children`
-// (a grid must contain `role="row"` → gridcells). Pre-existing a11y bug to fix
-// under S12 (#1417) — masking it with a passing axe test would hide it.
+// S12 a11y remediation (#1417): the picker is now a labelled `role="group"` of
+// buttons (was an invalid `role="grid"` with button children, which tripped axe's
+// `aria-required-children`), so axe is asserted on the open state.
 
 describe('ReactionPicker', () => {
-  it('renders a grid of emoji buttons when open', () => {
+  it('renders a labelled group of emoji buttons when open', () => {
     render(ReactionPicker, { props: { onreact: vi.fn(), isOpen: true } });
-    const grid = screen.getByRole('grid', { name: 'Emoji reactions' });
-    expect(within(grid).getAllByRole('button').length).toBeGreaterThan(0);
+    const group = screen.getByRole('group', { name: 'Emoji reactions' });
+    expect(within(group).getAllByRole('button').length).toBeGreaterThan(0);
   });
 
   it('reports the chosen emoji through onreact', async () => {
     const onreact = vi.fn();
     render(ReactionPicker, { props: { onreact, isOpen: true } });
     const [first] = within(
-      screen.getByRole('grid', { name: 'Emoji reactions' }),
+      screen.getByRole('group', { name: 'Emoji reactions' }),
     ).getAllByRole('button');
     await userEvent.click(first);
     expect(onreact).toHaveBeenCalledTimes(1);
@@ -36,6 +36,13 @@ describe('ReactionPicker', () => {
 
   it('renders nothing when closed', () => {
     render(ReactionPicker, { props: { onreact: vi.fn(), isOpen: false } });
-    expect(screen.queryByRole('grid')).toBeNull();
+    expect(screen.queryByRole('group')).toBeNull();
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(ReactionPicker, {
+      props: { onreact: vi.fn(), isOpen: true },
+    });
+    await expectNoA11yViolations(container);
   });
 });

--- a/packages/users/src/svelte/components/UserMenu.svelte
+++ b/packages/users/src/svelte/components/UserMenu.svelte
@@ -98,15 +98,16 @@ function getInitials(name: string): string {
 <svelte:window onclick={handleClickOutside} onkeydown={handleKeydown} />
 
 <div class="user-menu" id={menuId}>
-  <button 
+  <button
     bind:this={triggerButton}
-    class="user-menu-trigger" 
-    onclick={toggle} 
+    id="{menuId}-trigger"
+    class="user-menu-trigger"
+    onclick={toggle}
     type="button"
     use:ripple
     aria-haspopup="menu"
     aria-expanded={open}
-    aria-controls={open ? menuId : undefined}
+    aria-controls={open ? `${menuId}-dropdown` : undefined}
     aria-label={ariaLabel}
   >
     <span class="avatar" aria-hidden="true">
@@ -119,8 +120,8 @@ function getInitials(name: string): string {
   </button>
 
   {#if open}
-    <div 
-      id={menuId}
+    <div
+      id="{menuId}-dropdown"
       class="dropdown"
       role="menu"
       aria-orientation="vertical"

--- a/packages/users/src/svelte/components/__tests__/UserMenu.test.ts
+++ b/packages/users/src/svelte/components/__tests__/UserMenu.test.ts
@@ -1,10 +1,9 @@
 // @vitest-environment jsdom
 /**
- * Component coverage for UserMenu via the shared S11 harness (#1416).
- *
- * NOTE: axe is asserted on the closed state only. When open, the dropdown reuses
- * the wrapper's `id` (duplicate id) and points `aria-labelledby` at a
- * non-existent trigger id — pre-existing a11y bugs to fix under S12 (#1417).
+ * Component coverage for UserMenu via the shared S11 harness (#1416), plus the
+ * S12 a11y remediation (#1417): the open dropdown now has its own id (no longer
+ * duplicating the wrapper) and `aria-labelledby` resolves to the trigger, so axe
+ * is asserted on both the collapsed and open states.
  */
 import {
   expectNoA11yViolations,
@@ -41,10 +40,13 @@ describe('UserMenu', () => {
     ).toBeInTheDocument();
   });
 
-  it('is axe-clean while collapsed', async () => {
+  it('is axe-clean while collapsed and when open', async () => {
     const { container } = render(UserMenu, {
-      props: { user: { name: 'Ada Lovelace' } },
+      props: { user: { name: 'Ada Lovelace', email: 'ada@example.com' } },
     });
+    await expectNoA11yViolations(container);
+    await userEvent.click(screen.getByRole('button', { name: 'User menu' }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
     await expectNoA11yViolations(container);
   });
 });


### PR DESCRIPTION
## Summary
S12 accessibility remediation (#1417) — fixes two real a11y bugs the S11 axe harness surfaced (and which were documented in the component tests pending this sweep).

**`UserMenu` (users):** the open dropdown reused the wrapper's `id` (duplicate id), its `aria-labelledby` pointed at a non-existent trigger id, and `aria-controls` referenced the wrapper. Now:
- trigger gets `id="<menu>-trigger"` → `aria-labelledby` resolves
- dropdown gets a distinct `id="<menu>-dropdown"` → no duplicate id
- `aria-controls` points at the dropdown

**`ReactionPicker` (chat):** `role="grid"` with `<button>` children tripped axe's `aria-required-children` (a grid needs `role="row"` → gridcells). It's a labelled set of action buttons → **`role="group"`**.

## Verification
Both component tests now assert **axe-clean on the affected state** (UserMenu *open*, ReactionPicker *open*) — previously omitted with a `NOTE` pending this fix. Full **users (192)** + **chat (110)** suites green; typecheck/svelte-check clean.

## Remaining S12 (separate PR)
`AssetGrid`/`AssetList` nested-interactive (a clickable card nesting a checkbox) — needs an interaction-model change, so it's a follow-up.

Part of #1417