### PR TITLE
ci: shared turbo build cache across jobs + Test Packages shard headroom

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -157,17 +157,21 @@ runs:
           ${{ runner.os }}-pnpm-store-
 
     # Turbo build/test/typecheck cache shared across CI jobs. turbo.json pins the
-    # cache to .turbo/cache; the build job populates it and every dependent job
-    # restores it, so their `pnpm run build` is a turbo cache hit instead of a
-    # cold full rebuild (was ~11 redundant builds per run). Key is per-commit with
-    # progressively looser restore-keys (same manifests, then any) for warm starts.
+    # cache to .turbo/cache. This RESTORES only — the build job alone saves the
+    # populated cache (a dedicated actions/cache/save step) so that parallel jobs
+    # which don't run a build (e.g. dependency-audit, install-deps:false) can't
+    # claim the immutable per-SHA key with an empty cache. Dependent jobs restore
+    # the build job's cache, so their `pnpm run build` is a turbo cache hit instead
+    # of a cold full rebuild (was ~11 redundant builds per run). Key is per-commit
+    # with progressively looser restore-keys (same manifests, then any) for warm
+    # starts across runs.
     - name: Ensure Turbo cache directory exists
       shell: bash
       run: mkdir -p .turbo/cache
 
-    - name: Setup Turbo cache
+    - name: Restore Turbo cache
       id: turbo-cache
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: .turbo/cache
         key: ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml', 'package.json', 'turbo.json', 'packages/*/package.json') }}-${{ github.sha }}

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -156,6 +156,25 @@ runs:
         restore-keys: |
           ${{ runner.os }}-pnpm-store-
 
+    # Turbo build/test/typecheck cache shared across CI jobs. turbo.json pins the
+    # cache to .turbo/cache; the build job populates it and every dependent job
+    # restores it, so their `pnpm run build` is a turbo cache hit instead of a
+    # cold full rebuild (was ~11 redundant builds per run). Key is per-commit with
+    # progressively looser restore-keys (same manifests, then any) for warm starts.
+    - name: Ensure Turbo cache directory exists
+      shell: bash
+      run: mkdir -p .turbo/cache
+
+    - name: Setup Turbo cache
+      id: turbo-cache
+      uses: actions/cache@v4
+      with:
+        path: .turbo/cache
+        key: ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml', 'package.json', 'turbo.json', 'packages/*/package.json') }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml', 'package.json', 'turbo.json', 'packages/*/package.json') }}-
+          ${{ runner.os }}-turbo-
+
     - name: Cache Playwright browsers
       if: inputs.setup-playwright == 'true'
       uses: actions/cache@v4

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -285,10 +285,12 @@ jobs:
     name: Test Packages (${{ matrix.shard }})
     needs: build
     runs-on: arc-happyvertical
-    timeout-minutes: 15
+    # Each shard does a full build + ~1/3 of the package tests; 15m was too tight
+    # under self-hosted runner-pool contention (shards timed out at ~15m20s).
+    timeout-minutes: 25
     strategy:
       fail-fast: false
-      max-parallel: 3
+      max-parallel: 2
       matrix:
         shard: ['1/3', '2/3', '3/3']
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -30,10 +30,15 @@ jobs:
       # Build BEFORE the version-bump preview so the populated turbo cache reflects
       # the committed tree that dependent jobs check out (the preview rewrites
       # package.json versions, which would otherwise change turbo's task hashes).
+      # TURBO_FORCE: the SEED build never trusts a restored cache, so it always
+      # exercises the current commit even for inputs Turbo doesn't hash (e.g.
+      # per-package build helper scripts). It then saves a correct cache that the
+      # dependent jobs restore — they get the speed-up without the staleness risk.
       - name: Build packages
         run: pnpm run build
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TURBO_FORCE: 'true'
 
       # Only the build job saves the turbo cache (setup-environment restores only),
       # under the same per-SHA key, computed from the still-committed package.json.

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -27,6 +27,22 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           auth-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Build BEFORE the version-bump preview so the populated turbo cache reflects
+      # the committed tree that dependent jobs check out (the preview rewrites
+      # package.json versions, which would otherwise change turbo's task hashes).
+      - name: Build packages
+        run: pnpm run build
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Only the build job saves the turbo cache (setup-environment restores only),
+      # under the same per-SHA key, computed from the still-committed package.json.
+      - name: Save Turbo cache
+        uses: actions/cache/save@v4
+        with:
+          path: .turbo/cache
+          key: ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml', 'package.json', 'turbo.json', 'packages/*/package.json') }}-${{ github.sha }}
+
       - name: Preview changeset version bump
         run: |
           echo "🔍 Simulating changeset version bump..."
@@ -60,11 +76,6 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build packages
-        run: pnpm run build
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   typecheck:
     name: Typecheck

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,11 @@
   "$schema": "https://turbo.build/schema.json",
   "cacheDir": ".turbo/cache",
   "globalDependencies": [
-    "pnpm-lock.yaml"
+    "pnpm-lock.yaml",
+    "tsconfig*.json",
+    "vite.config.base.ts",
+    "vitest.workspace.ts",
+    "biome.json"
   ],
   "tasks": {
     "generate": {

--- a/turbo.json
+++ b/turbo.json
@@ -1,9 +1,14 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": ["pnpm-lock.yaml"],
+  "cacheDir": ".turbo/cache",
+  "globalDependencies": [
+    "pnpm-lock.yaml"
+  ],
   "tasks": {
     "generate": {
-      "dependsOn": ["^build"],
+      "dependsOn": [
+        "^build"
+      ],
       "inputs": [
         "src/**/*.ts",
         "!src/**/*.test.ts",
@@ -28,7 +33,9 @@
       "cache": true
     },
     "generate:test": {
-      "dependsOn": ["^build"],
+      "dependsOn": [
+        "^build"
+      ],
       "inputs": [
         "src/**/__tests__/**/*.ts",
         "src/**/*.test.ts",
@@ -45,20 +52,54 @@
       "cache": true
     },
     "build": {
-      "dependsOn": ["^build", "generate"],
-      "inputs": ["src/**", "package.json", "tsconfig*.json", "vite.config.ts", "vite.config.js"],
-      "outputs": ["dist/**", ".next/**", "docs/**", "tsconfig.*.tsbuildinfo"],
+      "dependsOn": [
+        "^build",
+        "generate"
+      ],
+      "inputs": [
+        "src/**",
+        "package.json",
+        "tsconfig*.json",
+        "vite.config.ts",
+        "vite.config.js"
+      ],
+      "outputs": [
+        "dist/**",
+        ".next/**",
+        "docs/**",
+        "tsconfig.*.tsbuildinfo"
+      ],
       "cache": true
     },
     "prebuild": {
-      "inputs": ["src/**", "package.json", "tsconfig*.json"],
-      "outputs": ["src/runtime/**"],
+      "inputs": [
+        "src/**",
+        "package.json",
+        "tsconfig*.json"
+      ],
+      "outputs": [
+        "src/runtime/**"
+      ],
       "cache": true
     },
     "test": {
-      "dependsOn": ["^build", "build", "generate:test"],
-      "inputs": ["src/**", "test/**", "**/*.test.ts", "**/*.spec.ts", "package.json", "vitest.config.ts", "vitest.config.js"],
-      "outputs": ["coverage/**"],
+      "dependsOn": [
+        "^build",
+        "build",
+        "generate:test"
+      ],
+      "inputs": [
+        "src/**",
+        "test/**",
+        "**/*.test.ts",
+        "**/*.spec.ts",
+        "package.json",
+        "vitest.config.ts",
+        "vitest.config.js"
+      ],
+      "outputs": [
+        "coverage/**"
+      ],
       "cache": true
     },
     "test:watch": {
@@ -66,24 +107,60 @@
       "persistent": true
     },
     "lint": {
-      "inputs": ["src/**", "test/**", "**/*.ts", "**/*.js", "biome.json"],
+      "inputs": [
+        "src/**",
+        "test/**",
+        "**/*.ts",
+        "**/*.js",
+        "biome.json"
+      ],
       "cache": true
     },
     "lint:fix": {
-      "inputs": ["src/**", "test/**", "**/*.ts", "**/*.js", "biome.json"],
+      "inputs": [
+        "src/**",
+        "test/**",
+        "**/*.ts",
+        "**/*.js",
+        "biome.json"
+      ],
       "cache": false
     },
     "format": {
-      "inputs": ["src/**", "test/**", "**/*.ts", "**/*.js", "**/*.json", "**/*.md", "biome.json"],
+      "inputs": [
+        "src/**",
+        "test/**",
+        "**/*.ts",
+        "**/*.js",
+        "**/*.json",
+        "**/*.md",
+        "biome.json"
+      ],
       "cache": false
     },
     "format-check": {
-      "inputs": ["src/**", "test/**", "**/*.ts", "**/*.js", "**/*.json", "**/*.md", "biome.json"],
+      "inputs": [
+        "src/**",
+        "test/**",
+        "**/*.ts",
+        "**/*.js",
+        "**/*.json",
+        "**/*.md",
+        "biome.json"
+      ],
       "cache": true
     },
     "typecheck": {
-      "dependsOn": ["^build", "generate:test"],
-      "inputs": ["src/**", "test/**", "**/*.ts", "tsconfig*.json"],
+      "dependsOn": [
+        "^build",
+        "generate:test"
+      ],
+      "inputs": [
+        "src/**",
+        "test/**",
+        "**/*.ts",
+        "tsconfig*.json"
+      ],
       "cache": true
     },
     "dev": {
@@ -94,9 +171,19 @@
       "cache": false
     },
     "docs": {
-      "dependsOn": ["build"],
-      "inputs": ["src/**", "README.md", "CLAUDE.md", "package.json"],
-      "outputs": ["docs/**", "manual/**"],
+      "dependsOn": [
+        "build"
+      ],
+      "inputs": [
+        "src/**",
+        "README.md",
+        "CLAUDE.md",
+        "package.json"
+      ],
+      "outputs": [
+        "docs/**",
+        "manual/**"
+      ],
       "cache": true
     }
   }


### PR DESCRIPTION
## Problem
There was **no shared turbo cache** in CI at all — no `TURBO_TOKEN`/remote cache, and nothing persisting `.turbo`. So **every job** (build, the 3 Test Core shards, the 3 Test Packages shards, test-integration, typecheck, lint, knowledge, coverage) ran its own **cold `pnpm run build`** — ~11 redundant full builds per run. That redundancy is what made the newly-sharded Test Packages job slow enough to **time out at ~15m20s**.

## Fix (mirrors anytown.ai's pattern — GitHub Actions cache, no external service/secrets)
1. **Pin the turbo cache to `.turbo/cache`** (`turbo.json` `cacheDir`). turbo 2.7's default location wasn't being cached; pinning it makes the path deterministic for both CI and local.
2. **Cache `.turbo/cache` via `actions/cache`** in the shared `setup-environment` action, keyed per-commit (`<os>-turbo-<manifests-hash>-<sha>`) with progressively looser restore-keys. The `build` job populates it; every dependent job restores it → their `pnpm run build` is a **turbo cache hit** instead of a cold rebuild.
3. **Shard headroom:** Test Packages shard `timeout-minutes: 15 → 25` and `max-parallel: 3 → 2` (matches Test Core), so shards don't starve each other on the self-hosted pool while the cache warms.

## Verification
Full build populates `.turbo/cache` (100 entries) and the build still passes. In CI, each job is a clean checkout, so downstream jobs hit the build job's cache (the watch is the Test Packages shards now finishing well under 25m). Unblocks the a11y PR (#1522) whose shards timed out.

## Follow-up (noted, not in this PR)
The build writes generated `.d.ts` into `src/**` (a turbo input), which busts the cache on warm *local* trees; CI's clean per-job checkouts are unaffected, but separating generated outputs from inputs would raise the hit-rate further.