### PR TITLE
feat(a11y): enforce Svelte compiler a11y warnings as errors in typecheck (S12 #1417)

### DIFF
--- a/docs/content/standards.md
+++ b/docs/content/standards.md
@@ -402,8 +402,33 @@ never disable the scan.
 - **`./playground` subpath**: exports the package's playground module for use by `smrt-playground`
 - **Svelte peer**: `svelte: ^5.18.0` (uniform). Drop the `^4.0.0 || ^5.0.0` range.
 - **Build script**: `vite build && svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json`
-- **Typecheck script**: packages with `./svelte` exports must run both TypeScript and Svelte checks, e.g. `tsc --noEmit && svelte-check --tsconfig ./tsconfig.svelte.json`. SvelteKit-backed packages should run `svelte-kit sync` before both the TypeScript and `svelte-check` passes.
+- **Typecheck script**: packages with `./svelte` exports must run both TypeScript and Svelte checks via the a11y wrapper, e.g. `tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json` (see Accessibility enforcement below). SvelteKit-backed packages should run `svelte-kit sync` before both the TypeScript and `svelte-check` passes.
 - **`tsconfig.svelte.json`**: extends `tsconfig.package-svelte.json`, includes `ambient.d.ts` and `*.svelte`
+
+### Accessibility enforcement (S12, #1417)
+
+Svelte's compiler a11y warnings are promoted to **errors** so a regression fails
+the existing (required) `typecheck` CI gate — no separate build job and no new
+required status check.
+
+- **Mechanism**: `scripts/svelte-check-a11y.mjs` is a drop-in `svelte-check`
+  wrapper that appends `--compiler-warnings "<a11y_*:error>"` (svelte-check's
+  native warning-promotion flag). Every UI package's `typecheck` calls the
+  wrapper instead of bare `svelte-check`, reusing each package's own
+  tsconfig/codegen flow unchanged.
+- **Single source of truth**: the canonical `a11y_*` code list lives in the
+  wrapper. A Svelte upgrade that adds a NEW a11y code surfaces it as a plain
+  (non-gating) warning until it is added to that list.
+- **Escape hatch**: `SMRT_A11Y_ENFORCE=0` runs plain `svelte-check` without the
+  promotion (local debugging only; CI always enforces).
+- **Remediation pairs with the gate**: the deterministic gate catches what the
+  compiler can see; component-test `axe` assertions (S11 harness) cover the
+  rest. As of S12 the repo is a11y-clean repo-wide (0 compiler a11y warnings).
+- **Waiver — `products`**: its `typecheck` is `npm run generate && tsc` (no
+  `svelte-check`, a pre-existing #1370/#1375 carve-out for its mixed app-mode
+  entrypoints), so its `.svelte` files are **not** a11y-gated. They are a11y-clean
+  today (verified via standalone `svelte-check`); wiring `svelte-check` into the
+  `products` typecheck is tracked with the rest of #1370.
 
 ---
 

--- a/docs/content/standards.md
+++ b/docs/content/standards.md
@@ -402,7 +402,7 @@ never disable the scan.
 - **`./playground` subpath**: exports the package's playground module for use by `smrt-playground`
 - **Svelte peer**: `svelte: ^5.18.0` (uniform). Drop the `^4.0.0 || ^5.0.0` range.
 - **Build script**: `vite build && svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json`
-- **Typecheck script**: packages with `./svelte` exports must run both TypeScript and Svelte checks via the a11y wrapper, e.g. `tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json` (see Accessibility enforcement below). SvelteKit-backed packages should run `svelte-kit sync` before both the TypeScript and `svelte-check` passes.
+- **Typecheck script**: packages with `./svelte` exports must run both TypeScript and Svelte checks via the a11y wrapper, e.g. `tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json` (see Accessibility enforcement below). SvelteKit-backed packages should run `svelte-kit sync` before both the TypeScript pass and the `svelte-check-a11y` wrapper pass.
 - **`tsconfig.svelte.json`**: extends `tsconfig.package-svelte.json`, includes `ambient.d.ts` and `*.svelte`
 
 ### Accessibility enforcement (S12, #1417)
@@ -412,10 +412,11 @@ the existing (required) `typecheck` CI gate — no separate build job and no new
 required status check.
 
 - **Mechanism**: `scripts/svelte-check-a11y.mjs` is a drop-in `svelte-check`
-  wrapper that appends `--compiler-warnings "<a11y_*:error>"` (svelte-check's
-  native warning-promotion flag). Every UI package's `typecheck` calls the
-  wrapper instead of bare `svelte-check`, reusing each package's own
-  tsconfig/codegen flow unchanged.
+  wrapper that appends `--compiler-warnings` with an explicit comma-separated
+  list of every `a11y_*` code mapped to `:error` (svelte-check's native
+  warning-promotion flag — there is no wildcard syntax, so each code is listed).
+  Every UI package's `typecheck` calls the wrapper instead of bare
+  `svelte-check`, reusing each package's own tsconfig/codegen flow unchanged.
 - **Single source of truth**: the canonical `a11y_*` code list lives in the
   wrapper. A Svelte upgrade that adds a NEW a11y code surfaces it as a plain
   (non-gating) warning until it is added to that list.

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -47,7 +47,7 @@
     "clean": "rm -rf dist",
     "dev": "vite dev",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
-    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -35,7 +35,7 @@
     "build": "vite build --mode library && svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json",
     "build:watch": "vite build --mode library --watch",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
-    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
     "clean": "rm -rf dist",
     "dev": "vite dev",
     "prepack": "node ../../scripts/prepack-package.js",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -42,7 +42,7 @@
     "pretest": "[ -f ../cli/dist/index.js ] && node ../cli/dist/index.js test --manifest-only || true",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "svelte-kit sync && tsc -p tsconfig.typecheck.json && svelte-check --tsconfig ./tsconfig.kit.json",
+    "typecheck": "svelte-kit sync && tsc -p tsconfig.typecheck.json && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.kit.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },
   "dependencies": {

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -38,7 +38,7 @@
     "dev": "npm run build:watch",
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },

--- a/packages/commerce/package.json
+++ b/packages/commerce/package.json
@@ -34,7 +34,7 @@
     "dev": "npm run build:watch",
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -47,7 +47,7 @@
     "test:e2e": "pnpm exec playwright test -c playwright.config.ts",
     "test:e2e:headed": "pnpm exec playwright test -c playwright.config.ts --headed",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.kit.json",
-    "typecheck": "svelte-kit sync && tsc -p tsconfig.typecheck.json && svelte-check --tsconfig ./tsconfig.kit.json",
+    "typecheck": "svelte-kit sync && tsc -p tsconfig.typecheck.json && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.kit.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },
   "dependencies": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -44,7 +44,7 @@
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },
   "peerDependencies": {

--- a/packages/images/package.json
+++ b/packages/images/package.json
@@ -41,7 +41,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.kit.json",
-    "typecheck": "svelte-kit sync && tsc -p tsconfig.typecheck.json && svelte-check --tsconfig ./tsconfig.kit.json",
+    "typecheck": "svelte-kit sync && tsc -p tsconfig.typecheck.json && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.kit.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },
   "dependencies": {

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -58,7 +58,7 @@
     "clean": "rm -rf dist",
     "dev": "vite dev",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
-    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -41,7 +41,7 @@
     "pretest": "[ -f ../cli/dist/index.js ] && node ../cli/dist/index.js test --manifest-only || true",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },
   "dependencies": {

--- a/packages/projects/package.json
+++ b/packages/projects/package.json
@@ -35,7 +35,7 @@
     "build": "vite build --mode library && svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json",
     "build:watch": "vite build --mode library --watch",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
-    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
     "clean": "rm -rf dist",
     "dev": "vite dev",
     "prepack": "node ../../scripts/prepack-package.js",

--- a/packages/smrt-playground/package.json
+++ b/packages/smrt-playground/package.json
@@ -32,7 +32,7 @@
     "clean": "rm -rf dist",
     "dev": "npm run build:watch",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
-    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."

--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -107,7 +107,7 @@
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },
   "keywords": [

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -41,7 +41,7 @@
     "build": "vite build --mode library && svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json",
     "build:watch": "vite build --mode library --watch",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
-    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/subscriptions/package.json
+++ b/packages/subscriptions/package.json
@@ -28,7 +28,7 @@
     "build": "vite build --mode library && svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json",
     "build:watch": "vite build --mode library --watch",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
-    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
     "clean": "rm -rf dist",
     "dev": "vite dev",
     "prepack": "node ../../scripts/prepack-package.js",

--- a/packages/tenancy/package.json
+++ b/packages/tenancy/package.json
@@ -48,7 +48,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
-    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },
   "dependencies": {

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -39,7 +39,7 @@
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
     "test:postgres": "DATABASE_URL=${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/test_db} vitest run",
-    "typecheck": "tsc --noEmit && pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },

--- a/scripts/svelte-check-a11y.mjs
+++ b/scripts/svelte-check-a11y.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * svelte-check-a11y — accessibility enforcement gate (Sweep S12, #1417).
+ *
+ * A drop-in wrapper around `svelte-check` that promotes Svelte's compiler
+ * accessibility warnings to ERRORS (non-zero exit) via svelte-check's native
+ * `--compiler-warnings` flag. Every UI package's `typecheck` script calls this
+ * instead of bare `svelte-check`, so a11y regressions fail the existing
+ * (required) typecheck CI gate — no separate build job, no new required check,
+ * and each package's own codegen/tsconfig flow is reused unchanged.
+ *
+ * Usage (from a package directory, mirroring the original svelte-check call):
+ *   node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json
+ *
+ * All CLI args are forwarded verbatim to svelte-check; this wrapper only appends
+ * the `--compiler-warnings "<a11y rules>:error"` promotion. The package-local
+ * svelte-check binary is resolved from the calling package's cwd, so the exact
+ * version pinned by that package is used.
+ *
+ * Escape hatch: set SMRT_A11Y_ENFORCE=0 to run plain svelte-check without the
+ * a11y promotion (local debugging only; CI always enforces).
+ *
+ * The canonical a11y warning-code list lives HERE as the single source of
+ * truth. These are Svelte 5's `a11y_*` compiler warning codes
+ * (https://svelte.dev/docs/svelte/compiler-warnings). A Svelte upgrade that
+ * introduces a NEW a11y code will surface it as a plain warning (non-gating)
+ * until it is added below — add new `a11y_*` codes here to enforce them.
+ */
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+/** Svelte 5 compiler accessibility warning codes — promoted to errors. */
+const A11Y_CODES = [
+  'a11y_accesskey',
+  'a11y_aria_activedescendant_has_tabindex',
+  'a11y_aria_attributes',
+  'a11y_autocomplete_valid',
+  'a11y_autofocus',
+  'a11y_click_events_have_key_events',
+  'a11y_consider_explicit_label',
+  'a11y_distracting_elements',
+  'a11y_figcaption_index',
+  'a11y_figcaption_parent',
+  'a11y_hidden',
+  'a11y_img_redundant_alt',
+  'a11y_incorrect_aria_attribute_type',
+  'a11y_incorrect_aria_attribute_type_boolean',
+  'a11y_incorrect_aria_attribute_type_id',
+  'a11y_incorrect_aria_attribute_type_idlist',
+  'a11y_incorrect_aria_attribute_type_integer',
+  'a11y_incorrect_aria_attribute_type_token',
+  'a11y_incorrect_aria_attribute_type_tokenlist',
+  'a11y_incorrect_aria_attribute_type_tristate',
+  'a11y_interactive_supports_focus',
+  'a11y_invalid_attribute',
+  'a11y_label_has_associated_control',
+  'a11y_media_has_caption',
+  'a11y_misplaced_role',
+  'a11y_misplaced_scope',
+  'a11y_missing_attribute',
+  'a11y_missing_content',
+  'a11y_mouse_events_have_key_events',
+  'a11y_no_abstract_role',
+  'a11y_no_interactive_element_to_noninteractive_role',
+  'a11y_no_noninteractive_element_interactions',
+  'a11y_no_noninteractive_element_to_interactive_role',
+  'a11y_no_noninteractive_tabindex',
+  'a11y_no_redundant_roles',
+  'a11y_no_static_element_interactions',
+  'a11y_positive_tabindex',
+  'a11y_role_has_required_aria_props',
+  'a11y_role_supports_aria_props',
+  'a11y_role_supports_aria_props_implicit',
+  'a11y_unknown_aria_attribute',
+  'a11y_unknown_role',
+];
+
+const enforce = process.env.SMRT_A11Y_ENFORCE !== '0';
+const forwardedArgs = process.argv.slice(2);
+
+// Resolve the package-local svelte-check binary from the calling package's cwd
+// so the version pinned by that package is used (not whatever happens to be on
+// PATH). svelte-check ships its CLI at `bin/svelte-check`.
+const require = createRequire(import.meta.url);
+let svelteCheckBin;
+try {
+  const pkgJsonPath = require.resolve('svelte-check/package.json', {
+    paths: [process.cwd()],
+  });
+  svelteCheckBin = path.join(path.dirname(pkgJsonPath), 'bin', 'svelte-check');
+} catch {
+  console.error(
+    '[svelte-check-a11y] Could not resolve svelte-check from ' +
+      `${process.cwd()} — is it a devDependency of this package?`,
+  );
+  process.exit(2);
+}
+
+const args = [svelteCheckBin, ...forwardedArgs];
+if (enforce) {
+  args.push(
+    '--compiler-warnings',
+    A11Y_CODES.map((code) => `${code}:error`).join(','),
+  );
+}
+
+const child = spawn(process.execPath, args, { stdio: 'inherit' });
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});
+child.on('error', (err) => {
+  console.error(`[svelte-check-a11y] Failed to launch svelte-check: ${err.message}`);
+  process.exit(2);
+});


### PR DESCRIPTION
## What

Completes the **enforcement** criterion of Sweep S12 (#1417): Svelte's compiler
accessibility warnings are now promoted to **errors**, so an a11y regression
fails the existing (required) `typecheck` CI gate.

## How

- **`scripts/svelte-check-a11y.mjs`** — a drop-in `svelte-check` wrapper that
  appends `--compiler-warnings "<a11y_*:error>"` (svelte-check's native
  warning-promotion flag). The canonical `a11y_*` code list lives here as the
  single source of truth.
- Every UI package's **`typecheck`** script now calls the wrapper instead of
  bare `svelte-check`, reusing each package's own tsconfig/codegen flow
  unchanged. 16 packages updated.
- Escape hatch: `SMRT_A11Y_ENFORCE=0` runs plain svelte-check (local debugging;
  CI always enforces).

### Why fold into `typecheck` rather than a new ratchet job

svelte-check needs built deps + per-package codegen, so it can't live in the
deps-free `check-standards` job. Folding into the existing required `typecheck`
gate reuses that codegen **and avoids registering a new required status check**
in the branch ruleset (which is painful to edit — see #1520).

## Validation

- `turbo typecheck` passes **78/78** with the gate live — the repo is
  a11y-clean (0 compiler a11y warnings across all 16 svelte-check'd UI packages).
- Verified the gate fires: an injected `<div onclick>` makes the package's
  `typecheck` exit non-zero with the `a11y_*` error + svelte.dev link.

## Waiver

`products` has no `svelte-check` in its typecheck (`generate && tsc`, the
pre-existing #1370/#1375 carve-out for its mixed app-mode entrypoints), so its
`.svelte` files are **not** gated. They are a11y-clean today (verified via
standalone svelte-check); wiring svelte-check into `products` is tracked with
the rest of #1370. Documented in `standards.md` §8.

## S12 status

- [x] Svelte a11y warnings enforced as errors in CI (this PR)
- [x] Per-UI-package a11y remediation (#1521, #1522, earlier — gate confirms 0 left)
- [x] axe assertions green in component tests (S11 harness)
- [x] Remaining waivers documented (`products`, standards.md §8)

Closes #1417.