### PR TITLE
feat(i18n): extract UI strings in assets + chat, flip to lint-strict (S13 #1418 wave 2)

### DIFF
--- a/packages/assets/src/svelte/ActionBar.svelte
+++ b/packages/assets/src/svelte/ActionBar.svelte
@@ -7,7 +7,11 @@
  */
 
 import { ConfirmDialog } from '@happyvertical/smrt-svelte/feedback';
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from './i18n.js';
 import type { ActionBarProps } from './types';
+
+const { t } = useI18n();
 
 let {
   selectedAssets,
@@ -95,7 +99,10 @@ const count = $derived(selectedAssets.length);
   <!-- Delete confirmation — library ConfirmDialog (S10 #1415) -->
   <ConfirmDialog
     open={showDeleteConfirm}
-    title="Delete {count} asset{count > 1 ? 's' : ''}?"
+    title={t(M['assets.action_bar.delete_confirm_title'], {
+      count,
+      plural: count > 1 ? 's' : '',
+    })}
     message="This action cannot be undone. The asset{count > 1 ? 's' : ''} and {count > 1 ? 'their' : 'its'} file data will be permanently removed."
     confirmLabel="Delete"
     cancelLabel="Cancel"

--- a/packages/assets/src/svelte/ActionBar.svelte
+++ b/packages/assets/src/svelte/ActionBar.svelte
@@ -103,9 +103,11 @@ const count = $derived(selectedAssets.length);
       count,
       plural: count > 1 ? 's' : '',
     })}
-    message="This action cannot be undone. The asset{count > 1 ? 's' : ''} and {count > 1 ? 'their' : 'its'} file data will be permanently removed."
-    confirmLabel="Delete"
-    cancelLabel="Cancel"
+    message={count > 1
+      ? t(M['assets.action_bar.delete_confirm_message_other'])
+      : t(M['assets.action_bar.delete_confirm_message_one'])}
+    confirmLabel={t(M['assets.action_bar.delete'])}
+    cancelLabel={t(M['assets.action_bar.cancel'])}
     destructive
     loading={isDeleting}
     onconfirm={confirmDelete}

--- a/packages/assets/src/svelte/AssetDetail.svelte
+++ b/packages/assets/src/svelte/AssetDetail.svelte
@@ -7,9 +7,13 @@
  */
 
 import { Modal } from '@happyvertical/smrt-svelte/feedback';
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import { Button } from '@happyvertical/smrt-svelte/ui';
 import type { Snippet } from 'svelte';
+import { M } from './i18n.js';
 import type { PersistedAsset } from './types';
+
+const { t } = useI18n();
 
 export interface AssetDetailProps {
   /** The asset to display */
@@ -180,7 +184,7 @@ function formatDate(date: Date | string | undefined): string {
             {:else if isPdf && asset.sourceUri}
               <div class="preview-document">
                 <span class="preview-document__icon">📄</span>
-                <a href={asset.sourceUri} target="_blank" rel="noopener noreferrer" class="preview-document__link">Open PDF in new tab</a>
+                <a href={asset.sourceUri} target="_blank" rel="noopener noreferrer" class="preview-document__link">{t(M['assets.asset_detail.open_pdf_in_new_tab'])}</a>
               </div>
             {:else}
               <div class="preview-generic">
@@ -204,18 +208,18 @@ function formatDate(date: Date | string | undefined): string {
             {#if isImage}
               <div class="form-field">
                 <label for="detail-alt" class="form-label">
-                  Alt Text
+                  {t(M['assets.asset_detail.alt_text'])}
                   {#if missingAlt}
-                    <span class="label-warning">⚠️ Missing — required for accessibility</span>
+                    <span class="label-warning">{t(M['assets.asset_detail.alt_text_missing_warning'])}</span>
                   {/if}
                 </label>
-                <input id="detail-alt" type="text" class="form-input" bind:value={editAlt} placeholder="Describe this image for screen readers" />
+                <input id="detail-alt" type="text" class="form-input" bind:value={editAlt} placeholder={t(M['assets.asset_detail.alt_text_placeholder'])} />
               </div>
             {/if}
 
             <div class="form-field">
               <label for="detail-desc" class="form-label">Description</label>
-              <textarea id="detail-desc" class="form-textarea" bind:value={editDescription} rows="3" placeholder="Optional description"></textarea>
+              <textarea id="detail-desc" class="form-textarea" bind:value={editDescription} rows="3" placeholder={t(M['assets.asset_detail.description_placeholder'])}></textarea>
             </div>
           </div>
         </section>
@@ -255,19 +259,19 @@ function formatDate(date: Date | string | undefined): string {
 
         <!-- Quick Actions -->
         <section class="detail__section">
-          <h3 class="section-heading">Quick Actions</h3>
+          <h3 class="section-heading">{t(M['assets.asset_detail.quick_actions'])}</h3>
           <div class="quick-actions">
             <button type="button" class="quick-btn" onclick={copyUrl} disabled={!asset.sourceUri}>
-              📋 Copy URL
+              {t(M['assets.asset_detail.copy_url'])}
             </button>
             {#if isImage}
               <button type="button" class="quick-btn" onclick={copyMarkdown} disabled={!asset.sourceUri}>
-                📝 Copy Markdown
+                {t(M['assets.asset_detail.copy_markdown'])}
               </button>
             {/if}
             {#if onedit && isImage}
               <button type="button" class="quick-btn" onclick={handleEdit}>
-                ✏️ Edit Image
+                {t(M['assets.asset_detail.edit_image'])}
               </button>
             {/if}
           </div>
@@ -279,7 +283,7 @@ function formatDate(date: Date | string | undefined): string {
         <!-- Content References (injected) -->
         {#if contentReferences && asset.id}
           <section class="detail__section">
-            <h3 class="section-heading">Used In</h3>
+            <h3 class="section-heading">{t(M['assets.asset_detail.used_in'])}</h3>
             {@render contentReferences({ assetId: asset.id })}
           </section>
         {/if}

--- a/packages/assets/src/svelte/AssetGrid.svelte
+++ b/packages/assets/src/svelte/AssetGrid.svelte
@@ -6,7 +6,11 @@
  * type-based thumbnails, and missing alt-text warnings for images.
  */
 
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from './i18n.js';
 import type { AssetGridProps, PersistedAsset } from './types';
+
+const { t } = useI18n();
 
 let {
   assets,
@@ -20,7 +24,11 @@ let {
 
 // A card click opens the detail view in manage mode, or toggles selection in
 // pick mode — label the action accordingly.
-const actionVerb = $derived(mode === 'pick' ? 'Select' : 'Open');
+function openCardLabel(name: string): string {
+  return mode === 'pick'
+    ? t(M['assets.asset_grid.select_named'], { name })
+    : t(M['assets.asset_grid.open_named'], { name });
+}
 
 function toggleSelection(asset: PersistedAsset, event: Event) {
   event.stopPropagation();
@@ -75,7 +83,7 @@ function getAltText(asset: PersistedAsset): string {
   {#if loading}
     <div class="asset-grid__loading">
       <span class="spinner"></span>
-      <span>Loading assets...</span>
+      <span>{t(M['assets.asset_grid.loading'])}</span>
     </div>
   {:else if assets.length === 0}
     <div class="empty-state">
@@ -86,8 +94,8 @@ function getAltText(asset: PersistedAsset): string {
           <polyline points="21 15 16 10 5 21"></polyline>
         </svg>
       </div>
-      <p class="empty-state__title">No assets found</p>
-      <p class="empty-state__desc">Upload an asset or change your search filters to see results.</p>
+      <p class="empty-state__title">{t(M['assets.asset_grid.no_assets_found'])}</p>
+      <p class="empty-state__desc">{t(M['assets.asset_grid.empty_hint'])}</p>
     </div>
   {:else}
     <div class="grid">
@@ -102,7 +110,7 @@ function getAltText(asset: PersistedAsset): string {
           <button
             type="button"
             class="asset-card__open"
-            aria-label="{actionVerb} {asset.name || 'Untitled'}"
+            aria-label={openCardLabel(asset.name || 'Untitled')}
             title={asset.name || 'Untitled'}
             onclick={() => handleClick(asset)}
             ondblclick={() => handleDblClick(asset)}
@@ -115,7 +123,7 @@ function getAltText(asset: PersistedAsset): string {
               checked={selected}
               onchange={(e) => toggleSelection(asset, e)}
               onclick={(e) => e.stopPropagation()}
-              aria-label="Select {asset.name}"
+              aria-label={t(M['assets.asset_grid.select_named_checkbox'], { name: asset.name })}
             />
           </div>
 
@@ -146,7 +154,7 @@ function getAltText(asset: PersistedAsset): string {
 
           <!-- Badges / warnings -->
           {#if isMissingAlt(asset)}
-            <span class="asset-card__badge asset-card__badge--warning" title="Missing alt text">⚠️ No alt</span>
+            <span class="asset-card__badge asset-card__badge--warning" title={t(M['assets.asset_grid.missing_alt_text'])}>{t(M['assets.asset_grid.no_alt'])}</span>
           {/if}
         </div>
       {/each}

--- a/packages/assets/src/svelte/AssetList.svelte
+++ b/packages/assets/src/svelte/AssetList.svelte
@@ -6,12 +6,16 @@
  * type badges, and metadata columns.
  */
 
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from './i18n.js';
 import type {
   AssetListProps,
   AssetSort,
   AssetSortField,
   PersistedAsset,
 } from './types';
+
+const { t } = useI18n();
 
 interface ListAsset extends PersistedAsset {
   alt?: string;
@@ -111,7 +115,7 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
             checked={allSelected}
             use:setIndeterminate={someSelected}
             onchange={toggleSelectAll}
-            aria-label="Select all"
+            aria-label={t(M['assets.asset_list.select_all'])}
           />
         </th>
         <th class="col-thumb">Preview</th>
@@ -135,7 +139,7 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
           <td colspan="6" class="cell-empty">
             <div class="asset-list__loading">
               <span class="spinner"></span>
-              <span>Loading assets...</span>
+              <span>{t(M['assets.asset_list.loading'])}</span>
             </div>
           </td>
         </tr>
@@ -153,8 +157,8 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
                   <line x1="3" y1="18" x2="3.01" y2="18"></line>
                 </svg>
               </div>
-              <p class="empty-state__title">No assets found</p>
-              <p class="empty-state__desc">Upload an asset or change your search filters to see results.</p>
+              <p class="empty-state__title">{t(M['assets.asset_list.no_assets_found'])}</p>
+              <p class="empty-state__desc">{t(M['assets.asset_list.empty_hint'])}</p>
             </div>
           </td>
         </tr>
@@ -171,7 +175,7 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
                 checked={selected}
                 onchange={(e) => toggleSelection(asset, e)}
                 onclick={(e) => e.stopPropagation()}
-                aria-label="Select {asset.name}"
+                aria-label={t(M['assets.asset_list.select_named'], { name: asset.name })}
               />
             </td>
             <td class="col-thumb">

--- a/packages/assets/src/svelte/AssetManager.svelte
+++ b/packages/assets/src/svelte/AssetManager.svelte
@@ -19,12 +19,14 @@
  * ```
  */
 
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import ActionBar from './ActionBar.svelte';
 import AssetDetail from './AssetDetail.svelte';
 import AssetGrid from './AssetGrid.svelte';
 import AssetList from './AssetList.svelte';
 import AssetToolbar from './AssetToolbar.svelte';
 import CreateAssetModal from './CreateAssetModal.svelte';
+import { M } from './i18n.js';
 import type {
   AssetFilters,
   AssetManagerProps,
@@ -32,6 +34,8 @@ import type {
   AssetViewMode,
   PersistedAsset,
 } from './types';
+
+const { t } = useI18n();
 
 let {
   tenantId,
@@ -299,7 +303,7 @@ function handleManagerDrop(event: DragEvent) {
           <polyline points="17 8 12 3 7 8"></polyline>
           <line x1="12" y1="3" x2="12" y2="15"></line>
         </svg>
-        <p>Drop file to upload</p>
+        <p>{t(M['assets.asset_manager.drop_file_to_upload'])}</p>
       </div>
     </div>
   {/if}

--- a/packages/assets/src/svelte/AssetToolbar.svelte
+++ b/packages/assets/src/svelte/AssetToolbar.svelte
@@ -7,6 +7,8 @@ import { onDestroy } from 'svelte';
  * and an upload button.
  */
 
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from './i18n.js';
 import type {
   AssetFilters,
   AssetSort,
@@ -14,6 +16,8 @@ import type {
   AssetToolbarProps,
   AssetViewMode,
 } from './types';
+
+const { t } = useI18n();
 
 let {
   view,
@@ -106,13 +110,13 @@ const views: { key: AssetViewMode; label: string; icon: string }[] = [
       <input
         type="search"
         class="search-field"
-        placeholder="Search assets..."
+        placeholder={t(M['assets.asset_toolbar.search_placeholder'])}
         value={searchValue}
         oninput={handleSearch}
-        aria-label="Search assets"
+        aria-label={t(M['assets.asset_toolbar.search_assets'])}
       />
       {#if searchValue}
-        <button type="button" class="search-clear" onclick={handleClearSearch} aria-label="Clear search">
+        <button type="button" class="search-clear" onclick={handleClearSearch} aria-label={t(M['assets.asset_toolbar.clear_search'])}>
           <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <line x1="18" y1="6" x2="6" y2="18"></line>
             <line x1="6" y1="6" x2="18" y2="18"></line>
@@ -122,8 +126,8 @@ const views: { key: AssetViewMode; label: string; icon: string }[] = [
     </div>
 
     <!-- Type Filter -->
-    <select class="asset-toolbar__select" value={typeValue} onchange={handleTypeFilter} aria-label="Filter by type">
-      <option value="">All types</option>
+    <select class="asset-toolbar__select" value={typeValue} onchange={handleTypeFilter} aria-label={t(M['assets.asset_toolbar.filter_by_type'])}>
+      <option value="">{t(M['assets.asset_toolbar.all_types'])}</option>
       <option value="image">Images</option>
       <option value="video">Videos</option>
       <option value="document">Documents</option>
@@ -131,25 +135,25 @@ const views: { key: AssetViewMode; label: string; icon: string }[] = [
     </select>
 
     <!-- Sort -->
-    <select class="asset-toolbar__select" value={sortValue} onchange={handleSortChange} aria-label="Sort assets">
-      <option value="createdAt:desc">Newest first</option>
-      <option value="createdAt:asc">Oldest first</option>
-      <option value="name:asc">Name A–Z</option>
-      <option value="name:desc">Name Z–A</option>
-      <option value="updatedAt:desc">Recently updated</option>
+    <select class="asset-toolbar__select" value={sortValue} onchange={handleSortChange} aria-label={t(M['assets.asset_toolbar.sort_assets'])}>
+      <option value="createdAt:desc">{t(M['assets.asset_toolbar.newest_first'])}</option>
+      <option value="createdAt:asc">{t(M['assets.asset_toolbar.oldest_first'])}</option>
+      <option value="name:asc">{t(M['assets.asset_toolbar.name_a_z'])}</option>
+      <option value="name:desc">{t(M['assets.asset_toolbar.name_z_a'])}</option>
+      <option value="updatedAt:desc">{t(M['assets.asset_toolbar.recently_updated'])}</option>
     </select>
   </div>
 
   <div class="asset-toolbar__right">
     <!-- View Toggle -->
-    <div class="view-toggle" role="group" aria-label="View mode">
+    <div class="view-toggle" role="group" aria-label={t(M['assets.asset_toolbar.view_mode'])}>
       {#each views as v (v.key)}
         <button
           type="button"
           class="view-toggle__btn"
           class:view-toggle__btn--active={view === v.key}
           onclick={() => (onviewchange ?? onViewChange)(v.key)}
-          aria-label="{v.label} view"
+          aria-label={t(M['assets.asset_toolbar.view_label'], { label: v.label })}
           aria-pressed={view === v.key}
         >
           {#if v.icon === 'grid'}

--- a/packages/assets/src/svelte/CreateAssetModal.svelte
+++ b/packages/assets/src/svelte/CreateAssetModal.svelte
@@ -12,7 +12,11 @@
 // entire smrt-svelte surface — including optional peers like smrt-agents /
 // smrt-users — just to compile this modal.
 import { Modal } from '@happyvertical/smrt-svelte/feedback';
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import { Button } from '@happyvertical/smrt-svelte/ui';
+import { M } from './i18n.js';
+
+const { t } = useI18n();
 
 export interface CreateAssetModalProps {
   /** Whether the modal is open */
@@ -124,7 +128,7 @@ const isImage = $derived(file?.type?.startsWith('image/') ?? false);
 const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
 </script>
 
-<Modal open={open} title="Upload Asset" onClose={handleClose} size="md">
+<Modal open={open} title={t(M['assets.create_asset_modal.upload_asset'])} onClose={handleClose} size="md">
       {#if !file}
         <!-- Dropzone -->
         <div
@@ -143,15 +147,15 @@ const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
             <polyline points="17 8 12 3 7 8"></polyline>
             <line x1="12" y1="3" x2="12" y2="15"></line>
           </svg>
-          <p class="dropzone__text">Drag & drop a file here, or click to browse</p>
-          <p class="dropzone__hint">You can also paste an image from your clipboard</p>
+          <p class="dropzone__text">{t(M['assets.create_asset_modal.dropzone_text'])}</p>
+          <p class="dropzone__hint">{t(M['assets.create_asset_modal.dropzone_hint'])}</p>
           <input id="file-input" type="file" class="dropzone__input" onchange={handleFileSelect} />
         </div>
       {:else}
         <!-- File preview + metadata form -->
         <div class="file-preview">
           {#if previewUrl}
-            <img src={previewUrl} alt="Preview" class="file-preview__image" />
+            <img src={previewUrl} alt={t(M['assets.create_asset_modal.preview_alt'])} class="file-preview__image" />
           {:else}
             <div class="file-preview__icon">📎</div>
           {/if}
@@ -159,10 +163,10 @@ const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
             <span class="file-preview__filename">{file.name}</span>
             <span class="file-preview__size">{formatSize(file.size)}</span>
             {#if isLargeFile}
-              <span class="file-preview__warning">⚠️ Large file — may slow page loads</span>
+              <span class="file-preview__warning">{t(M['assets.create_asset_modal.large_file_warning'])}</span>
             {/if}
           </div>
-          <button type="button" class="file-preview__remove" onclick={() => { file = null; }} aria-label="Remove file">
+          <button type="button" class="file-preview__remove" onclick={() => { file = null; }} aria-label={t(M['assets.create_asset_modal.remove_file'])}>
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
           </button>
         </div>
@@ -170,23 +174,23 @@ const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
         <div class="form-fields">
           <div class="form-field">
             <label for="asset-name" class="form-label">Name</label>
-            <input id="asset-name" type="text" class="form-input" bind:value={name} placeholder="Asset name" />
+            <input id="asset-name" type="text" class="form-input" bind:value={name} placeholder={t(M['assets.create_asset_modal.name_placeholder'])} />
           </div>
 
           <div class="form-field">
             <label for="asset-desc" class="form-label">Description</label>
-            <textarea id="asset-desc" class="form-textarea" bind:value={description} placeholder="Optional description" rows="2"></textarea>
+            <textarea id="asset-desc" class="form-textarea" bind:value={description} placeholder={t(M['assets.create_asset_modal.description_placeholder'])} rows="2"></textarea>
           </div>
 
           {#if isImage}
             <div class="form-field">
               <label for="asset-alt" class="form-label">
-                Alt Text
+                {t(M['assets.create_asset_modal.alt_text'])}
                 {#if !altText}
-                  <span class="form-label__warning">⚠️ Recommended for accessibility</span>
+                  <span class="form-label__warning">{t(M['assets.create_asset_modal.alt_text_recommended_warning'])}</span>
                 {/if}
               </label>
-              <input id="asset-alt" type="text" class="form-input" bind:value={altText} placeholder="Describe this image for screen readers" />
+              <input id="asset-alt" type="text" class="form-input" bind:value={altText} placeholder={t(M['assets.create_asset_modal.alt_text_placeholder'])} />
             </div>
           {/if}
         </div>

--- a/packages/assets/src/svelte/i18n.ts
+++ b/packages/assets/src/svelte/i18n.ts
@@ -3,6 +3,13 @@ import { defineMessages } from '@happyvertical/smrt-svelte/i18n';
 export const M = defineMessages({
   // ActionBar
   'assets.action_bar.delete_confirm_title': 'Delete {count} asset{plural}?',
+  // Separate singular/plural messages (an English `{plural}` suffix doesn't translate).
+  'assets.action_bar.delete_confirm_message_one':
+    'This action cannot be undone. The asset and its file data will be permanently removed.',
+  'assets.action_bar.delete_confirm_message_other':
+    'This action cannot be undone. The assets and their file data will be permanently removed.',
+  'assets.action_bar.delete': 'Delete',
+  'assets.action_bar.cancel': 'Cancel',
 
   // AssetDetail
   'assets.asset_detail.open_pdf_in_new_tab': 'Open PDF in new tab',

--- a/packages/assets/src/svelte/i18n.ts
+++ b/packages/assets/src/svelte/i18n.ts
@@ -1,0 +1,106 @@
+import { defineMessages } from '@happyvertical/smrt-svelte/i18n';
+
+export const M = defineMessages({
+  // ActionBar
+  'assets.action_bar.delete_confirm_title': 'Delete {count} asset{plural}?',
+
+  // AssetDetail
+  'assets.asset_detail.open_pdf_in_new_tab': 'Open PDF in new tab',
+  'assets.asset_detail.alt_text': 'Alt Text',
+  'assets.asset_detail.alt_text_missing_warning':
+    '⚠️ Missing — required for accessibility',
+  'assets.asset_detail.quick_actions': 'Quick Actions',
+  'assets.asset_detail.copy_url': '📋 Copy URL',
+  'assets.asset_detail.copy_markdown': '📝 Copy Markdown',
+  'assets.asset_detail.edit_image': '✏️ Edit Image',
+  'assets.asset_detail.used_in': 'Used In',
+  'assets.asset_detail.alt_text_placeholder':
+    'Describe this image for screen readers',
+  'assets.asset_detail.description_placeholder': 'Optional description',
+
+  // AssetGrid
+  'assets.asset_grid.loading': 'Loading assets...',
+  'assets.asset_grid.no_assets_found': 'No assets found',
+  'assets.asset_grid.empty_hint':
+    'Upload an asset or change your search filters to see results.',
+  'assets.asset_grid.no_alt': '⚠️ No alt',
+  'assets.asset_grid.missing_alt_text': 'Missing alt text',
+  'assets.asset_grid.open_named': 'Open {name}',
+  'assets.asset_grid.select_named': 'Select {name}',
+  'assets.asset_grid.select_named_checkbox': 'Select {name}',
+
+  // AssetList
+  'assets.asset_list.loading': 'Loading assets...',
+  'assets.asset_list.no_assets_found': 'No assets found',
+  'assets.asset_list.empty_hint':
+    'Upload an asset or change your search filters to see results.',
+  'assets.asset_list.select_all': 'Select all',
+  'assets.asset_list.select_named': 'Select {name}',
+
+  // AssetManager
+  'assets.asset_manager.drop_file_to_upload': 'Drop file to upload',
+
+  // AssetToolbar
+  'assets.asset_toolbar.all_types': 'All types',
+  'assets.asset_toolbar.newest_first': 'Newest first',
+  'assets.asset_toolbar.oldest_first': 'Oldest first',
+  'assets.asset_toolbar.name_a_z': 'Name A–Z',
+  'assets.asset_toolbar.name_z_a': 'Name Z–A',
+  'assets.asset_toolbar.recently_updated': 'Recently updated',
+  'assets.asset_toolbar.search_placeholder': 'Search assets...',
+  'assets.asset_toolbar.search_assets': 'Search assets',
+  'assets.asset_toolbar.clear_search': 'Clear search',
+  'assets.asset_toolbar.filter_by_type': 'Filter by type',
+  'assets.asset_toolbar.sort_assets': 'Sort assets',
+  'assets.asset_toolbar.view_mode': 'View mode',
+  'assets.asset_toolbar.view_label': '{label} view',
+
+  // CreateAssetModal
+  'assets.create_asset_modal.dropzone_text':
+    'Drag & drop a file here, or click to browse',
+  'assets.create_asset_modal.dropzone_hint':
+    'You can also paste an image from your clipboard',
+  'assets.create_asset_modal.large_file_warning':
+    '⚠️ Large file — may slow page loads',
+  'assets.create_asset_modal.alt_text': 'Alt Text',
+  'assets.create_asset_modal.alt_text_recommended_warning':
+    '⚠️ Recommended for accessibility',
+  'assets.create_asset_modal.name_placeholder': 'Asset name',
+  'assets.create_asset_modal.description_placeholder': 'Optional description',
+  'assets.create_asset_modal.alt_text_placeholder':
+    'Describe this image for screen readers',
+  'assets.create_asset_modal.upload_asset': 'Upload Asset',
+  'assets.create_asset_modal.preview_alt': 'Preview',
+  'assets.create_asset_modal.remove_file': 'Remove file',
+
+  // AssetDetailPreview (playground)
+  'assets.asset_detail_preview.modal_preview': 'Modal Preview',
+  'assets.asset_detail_preview.description':
+    'Launch the asset detail dialog from inside the preview stage so the shared\n      playground stays navigable.',
+  'assets.asset_detail_preview.open_asset_detail': 'Open Asset Detail',
+
+  // CreateAssetModalPreview (playground)
+  'assets.create_asset_modal_preview.modal_preview': 'Modal Preview',
+  'assets.create_asset_modal_preview.title': 'Create Asset Modal',
+  'assets.create_asset_modal_preview.description':
+    'Open the upload dialog from inside the preview stage to exercise the real\n      modal flow without covering the host navigation.',
+  'assets.create_asset_modal_preview.open_upload_modal': 'Open Upload Modal',
+  'assets.create_asset_modal_preview.alt_text': 'Alt Text',
+
+  // AssetManagerRoute (route)
+  'assets.asset_manager_route.eyebrow': 'Package Route Surface',
+  'assets.asset_manager_route.title': 'Asset Manager',
+  'assets.asset_manager_route.lede':
+    'The reference route for browsing, selecting, and reviewing uploaded\n        assets with the package-owned asset manager UI.',
+  'assets.asset_manager_route.selection_state': 'Selection State',
+  'assets.asset_manager_route.no_assets_selected': 'No assets selected.',
+  'assets.asset_manager_route.assets_selected': 'asset{plural} selected.',
+  'assets.asset_manager_route.custom_action_example': 'Custom Action Example',
+  'assets.asset_manager_route.custom_action_description':
+    'This route keeps package-owned defaults while leaving room for app\n          specific actions.',
+  'assets.asset_manager_route.queue_review': 'Queue Review',
+  'assets.asset_manager_route.queue_review_hint':
+    'from the selection action bar to see\n            the package route feedback.',
+  'assets.asset_manager_route.surface_label': 'Asset manager surface',
+  'assets.asset_manager_route.route_state_label': 'Asset route state',
+});

--- a/packages/assets/src/svelte/playground/AssetDetailPreview.svelte
+++ b/packages/assets/src/svelte/playground/AssetDetailPreview.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type { AssetDetailUpdates } from '../AssetDetail.svelte';
 import AssetDetail from '../AssetDetail.svelte';
+import { M } from '../i18n.js';
 import type { PersistedAsset } from '../types';
+
+const { t } = useI18n();
 
 let { asset }: { asset: PersistedAsset } = $props();
 
@@ -60,13 +64,10 @@ function handleEdit() {
 
 <div class="preview-shell">
   <div class="preview-card">
-    <p class="eyebrow">Modal Preview</p>
+    <p class="eyebrow">{t(M['assets.asset_detail_preview.modal_preview'])}</p>
     <h4>{previewAsset?.name ?? asset.name}</h4>
-    <p>
-      Launch the asset detail dialog from inside the preview stage so the shared
-      playground stays navigable.
-    </p>
-    <button type="button" onclick={openPreview}>Open Asset Detail</button>
+    <p>{t(M['assets.asset_detail_preview.description'])}</p>
+    <button type="button" onclick={openPreview}>{t(M['assets.asset_detail_preview.open_asset_detail'])}</button>
     {#if statusMessage}
       <p class="status">{statusMessage}</p>
     {/if}

--- a/packages/assets/src/svelte/playground/CreateAssetModalPreview.svelte
+++ b/packages/assets/src/svelte/playground/CreateAssetModalPreview.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import CreateAssetModal from '../CreateAssetModal.svelte';
+import { M } from '../i18n.js';
+
+const { t } = useI18n();
 
 interface CreatedAssetSummary {
   name: string;
@@ -40,13 +44,10 @@ function handleCreate(data: {
 
 <div class="preview-shell">
   <div class="preview-card">
-    <p class="eyebrow">Modal Preview</p>
-    <h4>Create Asset Modal</h4>
-    <p>
-      Open the upload dialog from inside the preview stage to exercise the real
-      modal flow without covering the host navigation.
-    </p>
-    <button type="button" onclick={openPreview}>Open Upload Modal</button>
+    <p class="eyebrow">{t(M['assets.create_asset_modal_preview.modal_preview'])}</p>
+    <h4>{t(M['assets.create_asset_modal_preview.title'])}</h4>
+    <p>{t(M['assets.create_asset_modal_preview.description'])}</p>
+    <button type="button" onclick={openPreview}>{t(M['assets.create_asset_modal_preview.open_upload_modal'])}</button>
 
     {#if statusMessage}
       <p class="status">{statusMessage}</p>
@@ -67,7 +68,7 @@ function handleCreate(data: {
           <dd>{lastCreated.description || '—'}</dd>
         </div>
         <div>
-          <dt>Alt Text</dt>
+          <dt>{t(M['assets.create_asset_modal_preview.alt_text'])}</dt>
           <dd>{lastCreated.altText || '—'}</dd>
         </div>
       </dl>

--- a/packages/assets/src/svelte/routes/AssetManagerRoute.svelte
+++ b/packages/assets/src/svelte/routes/AssetManagerRoute.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../i18n.js';
 import { AssetManager } from '../index.js';
 import type { PersistedAsset } from '../types.js';
+
+const { t } = useI18n();
 
 let selectedAssets = $state<PersistedAsset[]>([]);
 let lastActionMessage = $state<string | null>(null);
@@ -31,17 +35,14 @@ const customActions = [
 <div class="assets-route">
   <header class="assets-route__header">
     <div>
-      <p class="assets-route__eyebrow">Package Route Surface</p>
-      <h1>Asset Manager</h1>
-      <p class="assets-route__lede">
-        The reference route for browsing, selecting, and reviewing uploaded
-        assets with the package-owned asset manager UI.
-      </p>
+      <p class="assets-route__eyebrow">{t(M['assets.asset_manager_route.eyebrow'])}</p>
+      <h1>{t(M['assets.asset_manager_route.title'])}</h1>
+      <p class="assets-route__lede">{t(M['assets.asset_manager_route.lede'])}</p>
     </div>
   </header>
 
   <div class="assets-route__body">
-    <section class="assets-route__manager" aria-label="Asset manager surface">
+    <section class="assets-route__manager" aria-label={t(M['assets.asset_manager_route.surface_label'])}>
       <AssetManager
         mode="manage"
         accept="image/*"
@@ -50,17 +51,17 @@ const customActions = [
       />
     </section>
 
-    <aside class="assets-route__sidebar" aria-label="Asset route state">
+    <aside class="assets-route__sidebar" aria-label={t(M['assets.asset_manager_route.route_state_label'])}>
       <div class="assets-route__panel">
-        <h2>Selection State</h2>
+        <h2>{t(M['assets.asset_manager_route.selection_state'])}</h2>
         {#if selectedAssets.length === 0}
-          <p class="assets-route__empty">No assets selected.</p>
+          <p class="assets-route__empty">{t(M['assets.asset_manager_route.no_assets_selected'])}</p>
         {:else}
           <p>
-            <strong>{selectedAssets.length}</strong> asset{selectedAssets.length ===
-            1
-              ? ''
-              : 's'} selected.
+            <strong>{selectedAssets.length}</strong> {t(
+              M['assets.asset_manager_route.assets_selected'],
+              { plural: selectedAssets.length === 1 ? '' : 's' },
+            )}
           </p>
           <ul class="assets-route__selection-list">
             {#each selectedAssets as asset}
@@ -74,17 +75,13 @@ const customActions = [
       </div>
 
       <div class="assets-route__panel">
-        <h2>Custom Action Example</h2>
-        <p>
-          This route keeps package-owned defaults while leaving room for app
-          specific actions.
-        </p>
+        <h2>{t(M['assets.asset_manager_route.custom_action_example'])}</h2>
+        <p>{t(M['assets.asset_manager_route.custom_action_description'])}</p>
         {#if lastActionMessage}
           <p class="assets-route__message">{lastActionMessage}</p>
         {:else}
           <p class="assets-route__empty">
-            Trigger <em>Queue Review</em> from the selection action bar to see
-            the package route feedback.
+            Trigger <em>{t(M['assets.asset_manager_route.queue_review'])}</em> {t(M['assets.asset_manager_route.queue_review_hint'])}
           </p>
         {/if}
       </div>

--- a/packages/chat/src/svelte/components/agent/AgentChat.svelte
+++ b/packages/chat/src/svelte/components/agent/AgentChat.svelte
@@ -4,6 +4,9 @@
  * Shows agent info header, message list with tool call displays, and input bar.
  * Agent messages are styled differently from user messages.
  */
+
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.js';
 import type {
   AgentSessionData,
   ChatMessageData,
@@ -12,6 +15,8 @@ import type {
 import Avatar from '../shared/Avatar.svelte';
 import { parseAgentMessageBlocks } from './message-blocks.js';
 import ToolCallDisplay from './ToolCallDisplay.svelte';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Agent session data */
@@ -85,27 +90,27 @@ $effect(() => {
 });
 </script>
 
-<div class="agent-chat" aria-label="Agent conversation">
+<div class="agent-chat" aria-label={t(M['chat.agent_chat.conversation'])}>
   <form class="agent-chat__input-bar" onsubmit={(e) => handleSubmit(e)}>
     {#if !isActive}
       <div class="agent-chat__inactive-notice">
-        Session {session.status}. Cannot send messages.
+        {t(M['chat.agent_chat.inactive_notice'], { status: session.status })}
       </div>
     {:else}
       <textarea
         class="agent-chat__input"
-        placeholder="Ask the AI to write or edit content..."
+        placeholder={t(M['chat.agent_chat.input_placeholder'])}
         bind:value={inputValue}
         onkeydown={handleKeydown}
         rows={1}
         disabled={!isActive}
-        aria-label="Message input"
+        aria-label={t(M['chat.agent_chat.message_input'])}
       ></textarea>
       <button
         class="agent-chat__send-btn"
         type="submit"
         disabled={!inputValue.trim() || !isActive}
-        aria-label="Send message"
+        aria-label={t(M['chat.agent_chat.send_message'])}
       >
         <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />
@@ -118,7 +123,7 @@ $effect(() => {
     class="agent-chat__messages"
     bind:this={messageContainer}
     role="log"
-    aria-label="Conversation messages"
+    aria-label={t(M['chat.agent_chat.messages'])}
   >
     {#each messages as msg (msg.id)}
       {@const isUser = msg.role === 'user'}
@@ -145,7 +150,7 @@ $effect(() => {
                     <span class="text-block">{block.content}</span>
                   {:else if block.type === 'fields'}
                     <div class="field-update-block">
-                      <span class="applied-badge">✓ Updated {Object.keys(block.fields).length} field{Object.keys(block.fields).length !== 1 ? 's' : ''}</span>
+                      <span class="applied-badge">{t(M['chat.agent_chat.updated_fields'], { count: Object.keys(block.fields).length, plural: Object.keys(block.fields).length !== 1 ? 's' : '' })}</span>
                       <button class="diff-btn" type="button" onclick={() => showDiff(block.fields)}>Diff</button>
                     </div>
                   {:else if block.type === 'markdown'}
@@ -183,7 +188,7 @@ $effect(() => {
 
     {#if messages.length === 0 && !loading}
       <div class="agent-chat__empty">
-        <span class="agent-chat__empty-text">Ask the AI to write or edit your content</span>
+        <span class="agent-chat__empty-text">{t(M['chat.agent_chat.empty'])}</span>
       </div>
     {/if}
   </div>
@@ -192,7 +197,7 @@ $effect(() => {
 <!-- Diff Modal -->
 <dialog bind:this={diffDialog} class="diff-dialog">
   <div class="diff-dialog__header">
-    <h4>Field Changes</h4>
+    <h4>{t(M['chat.agent_chat.field_changes'])}</h4>
     <button class="diff-dialog__close" type="button" onclick={closeDiff}>✕</button>
   </div>
   {#if diffDialogFields}

--- a/packages/chat/src/svelte/components/agent/AgentSelector.svelte
+++ b/packages/chat/src/svelte/components/agent/AgentSelector.svelte
@@ -4,6 +4,8 @@
  * Grid/list of available agents with avatars, names, and descriptions.
  * Disabled state for unavailable agents.
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.js';
 import type { AgentDescriptor } from '../../types.js';
 import Avatar from '../shared/Avatar.svelte';
 
@@ -15,12 +17,14 @@ export interface Props {
 }
 
 const { agents, onselect }: Props = $props();
+
+const { t } = useI18n();
 </script>
 
-<div class="agent-selector" aria-label="Select an agent">
-  <h3 class="agent-selector__title">Choose an Agent</h3>
+<div class="agent-selector" aria-label={t(M['chat.agent_selector.select_an_agent'])}>
+  <h3 class="agent-selector__title">{t(M['chat.agent_selector.title'])}</h3>
 
-  <div class="agent-selector__grid" role="listbox" aria-label="Available agents">
+  <div class="agent-selector__grid" role="listbox" aria-label={t(M['chat.agent_selector.available_agents'])}>
     {#each agents as agent (agent.id)}
       <button
         class="agent-selector__card"
@@ -52,7 +56,7 @@ const { agents, onselect }: Props = $props();
 
   {#if agents.length === 0}
     <div class="agent-selector__empty">
-      <span class="agent-selector__empty-text">No agents available</span>
+      <span class="agent-selector__empty-text">{t(M['chat.agent_selector.empty'])}</span>
     </div>
   {/if}
 </div>

--- a/packages/chat/src/svelte/components/agent/AgentSessionPanel.svelte
+++ b/packages/chat/src/svelte/components/agent/AgentSessionPanel.svelte
@@ -4,8 +4,12 @@
  * Lists past agent sessions with status, message count, and allowed tools.
  * Allows selecting an existing session or creating a new one.
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.js';
 import type { AgentSessionData } from '../../types.js';
 import Avatar from '../shared/Avatar.svelte';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Available sessions */
@@ -41,7 +45,7 @@ const statusLabel: Record<string, string> = {
 };
 </script>
 
-<aside class="session-panel" aria-label="Agent sessions">
+<aside class="session-panel" aria-label={t(M['chat.agent_session_panel.sessions'])}>
   <div class="session-panel__header">
     <h2 class="session-panel__title">Sessions</h2>
     {#if onnewsession}
@@ -49,8 +53,8 @@ const statusLabel: Record<string, string> = {
         class="session-panel__new-btn"
         type="button"
         onclick={onnewsession}
-        aria-label="New session"
-        title="New session"
+        aria-label={t(M['chat.agent_session_panel.new_session'])}
+        title={t(M['chat.agent_session_panel.new_session'])}
       >
         <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
@@ -59,7 +63,7 @@ const statusLabel: Record<string, string> = {
     {/if}
   </div>
 
-  <div class="session-panel__list" role="listbox" aria-label="Session list">
+  <div class="session-panel__list" role="listbox" aria-label={t(M['chat.agent_session_panel.session_list'])}>
     {#each sessions as session (session.id)}
       {@const isCurrent = session.id === currentSessionId}
       <button
@@ -116,7 +120,7 @@ const statusLabel: Record<string, string> = {
 
     {#if sessions.length === 0}
       <div class="session-panel__empty">
-        <span class="session-panel__empty-text">No sessions yet</span>
+        <span class="session-panel__empty-text">{t(M['chat.agent_session_panel.empty'])}</span>
       </div>
     {/if}
   </div>

--- a/packages/chat/src/svelte/components/agent/ToolCallDisplay.svelte
+++ b/packages/chat/src/svelte/components/agent/ToolCallDisplay.svelte
@@ -4,6 +4,8 @@
  * Collapsible card showing tool name, arguments (as JSON), status indicator,
  * and result/error. Color-coded by status (pending, running, success, error).
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.js';
 import type { ToolCallDisplayData } from '../../types.js';
 
 export interface Props {
@@ -12,6 +14,8 @@ export interface Props {
 }
 
 const { toolCall }: Props = $props();
+
+const { t } = useI18n();
 
 let isExpanded = $state(false);
 
@@ -60,7 +64,7 @@ function formatDuration(ms: number | undefined): string {
 }
 </script>
 
-<div class="tool-call tool-call--{toolCall.status}" aria-label="Tool call: {toolCall.toolName}">
+<div class="tool-call tool-call--{toolCall.status}" aria-label={t(M['chat.tool_call_display.tool_call'], { toolName: toolCall.toolName })}>
   <button
     class="tool-call__header"
     type="button"
@@ -116,7 +120,7 @@ function formatDuration(ms: number | undefined): string {
 
       {#if toolCall.status === 'running'}
         <div class="tool-call__running">
-          <div class="tool-call__spinner" aria-label="Running"></div>
+          <div class="tool-call__spinner" aria-label={t(M['chat.tool_call_display.running'])}></div>
           <span>Executing...</span>
         </div>
       {/if}

--- a/packages/chat/src/svelte/components/dialogs/RoomCreateDialog.svelte
+++ b/packages/chat/src/svelte/components/dialogs/RoomCreateDialog.svelte
@@ -3,6 +3,10 @@
  * RoomCreateDialog - Modal dialog for creating a new chat room
  * Provides name, type selector, and description fields
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.js';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Whether the dialog is open */
@@ -104,7 +108,7 @@ $effect(() => {
       type="button"
       class="dialog-backdrop__dismiss"
       tabindex="-1"
-      aria-label="Close room creation dialog"
+      aria-label={t(M['chat.room_create_dialog.close'])}
       onclick={handleClose}
     ></button>
     <div
@@ -114,7 +118,7 @@ $effect(() => {
       aria-labelledby="create-room-title"
       tabindex="-1"
     >
-      <h2 id="create-room-title" class="dialog__title">Create a Room</h2>
+      <h2 id="create-room-title" class="dialog__title">{t(M['chat.room_create_dialog.title'])}</h2>
 
       <form
         class="dialog__form"
@@ -122,7 +126,7 @@ $effect(() => {
       >
         <div class="field">
           <label class="field__label" for="room-name">
-            Room Name <span class="field__required" aria-label="required">*</span>
+            {t(M['chat.room_create_dialog.room_name'])} <span class="field__required" aria-label={t(M['chat.room_create_dialog.required'])}>*</span>
           </label>
           <input
             bind:this={nameInput}
@@ -130,14 +134,14 @@ $effect(() => {
             id="room-name"
             type="text"
             class="field__input"
-            placeholder="e.g. general, project-updates"
+            placeholder={t(M['chat.room_create_dialog.name_placeholder'])}
             maxlength="100"
             autocomplete="off"
           />
         </div>
 
         <fieldset class="field">
-          <legend class="field__label">Room Type</legend>
+          <legend class="field__label">{t(M['chat.room_create_dialog.room_type'])}</legend>
           <div class="type-options">
             {#each roomTypes as option (option.value)}
               <label
@@ -166,7 +170,7 @@ $effect(() => {
             bind:value={description}
             id="room-description"
             class="field__textarea"
-            placeholder="What is this room about?"
+            placeholder={t(M['chat.room_create_dialog.description_placeholder'])}
             rows="3"
             maxlength="500"
           ></textarea>
@@ -186,7 +190,7 @@ $effect(() => {
             class="btn btn--primary"
             disabled={!canCreate}
           >
-            Create Room
+            {t(M['chat.room_create_dialog.create_room'])}
           </button>
         </div>
       </form>

--- a/packages/chat/src/svelte/components/dialogs/SearchMessages.svelte
+++ b/packages/chat/src/svelte/components/dialogs/SearchMessages.svelte
@@ -3,7 +3,11 @@
  * SearchMessages - Message search interface with results list
  * Provides a search input and displays matching messages
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.js';
 import type { ChatMessageData } from '../../types.js';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Whether the search panel is open */
@@ -100,15 +104,15 @@ $effect(() => {
   <div
     class="search-panel"
     role="search"
-    aria-label="Search messages"
+    aria-label={t(M['chat.search_messages.search'])}
   >
     <div class="search-panel__header">
-      <h2 class="search-panel__title">Search Messages</h2>
+      <h2 class="search-panel__title">{t(M['chat.search_messages.title'])}</h2>
       <button
         class="close-btn"
         type="button"
         onclick={handleClose}
-        aria-label="Close search"
+        aria-label={t(M['chat.search_messages.close'])}
       >
         <svg class="close-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <path d="M18 6 6 18" />
@@ -131,16 +135,16 @@ $effect(() => {
           bind:value={query}
           type="search"
           class="search-input"
-          placeholder="Search messages..."
+          placeholder={t(M['chat.search_messages.input_placeholder'])}
           autocomplete="off"
-          aria-label="Search query"
+          aria-label={t(M['chat.search_messages.query'])}
         />
         {#if hasQuery}
           <button
             class="clear-btn"
             type="button"
             onclick={() => { query = ''; searchInput?.focus(); }}
-            aria-label="Clear search"
+            aria-label={t(M['chat.search_messages.clear'])}
           >
             <svg class="clear-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="M18 6 6 18" />
@@ -151,12 +155,12 @@ $effect(() => {
       </div>
     </form>
 
-    <div class="search-results" aria-label="Search results">
+    <div class="search-results" aria-label={t(M['chat.search_messages.results'])}>
       {#if hasResults}
         <p class="results-count">
-          {results.length} result{results.length !== 1 ? 's' : ''} found
+          {t(M['chat.search_messages.results_count'], { count: results.length, plural: results.length !== 1 ? 's' : '' })}
         </p>
-        <ul class="results-list" aria-label="Search results">
+        <ul class="results-list" aria-label={t(M['chat.search_messages.results'])}>
           {#each results as message (message.id)}
             <li class="results-list__item">
               <button
@@ -190,12 +194,12 @@ $effect(() => {
         </ul>
       {:else if hasQuery}
         <div class="search-empty" role="status">
-          <p class="search-empty__text">No messages found for "{query}"</p>
-          <p class="search-empty__hint">Try different keywords or check your spelling</p>
+          <p class="search-empty__text">{t(M['chat.search_messages.no_results'], { query })}</p>
+          <p class="search-empty__hint">{t(M['chat.search_messages.no_results_hint'])}</p>
         </div>
       {:else}
         <div class="search-empty" role="status">
-          <p class="search-empty__text">Enter a search term to find messages</p>
+          <p class="search-empty__text">{t(M['chat.search_messages.empty'])}</p>
         </div>
       {/if}
     </div>

--- a/packages/chat/src/svelte/components/layout/ChatLayout.svelte
+++ b/packages/chat/src/svelte/components/layout/ChatLayout.svelte
@@ -3,9 +3,13 @@
  * ChatLayout - Main chat container with sidebar and content area
  * Discord/Slack-style layout with resizable room list sidebar
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type { Snippet } from 'svelte';
+import { M } from '../../i18n.messages.js';
 import type { ChatRoomData } from '../../types.js';
 import RoomList from './RoomList.svelte';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Available chat rooms */
@@ -50,7 +54,7 @@ function handlePointerUp() {
   <aside
     class="chat-layout__sidebar"
     style:width="{sidebarWidth}px"
-    aria-label="Chat rooms"
+    aria-label={t(M['chat.chat_layout.rooms_label'])}
   >
     <RoomList
       {rooms}
@@ -62,7 +66,7 @@ function handlePointerUp() {
   <button
     type="button"
     class="chat-layout__resize-handle"
-    aria-label="Resize sidebar"
+    aria-label={t(M['chat.chat_layout.resize_sidebar'])}
     onpointerdown={handlePointerDown}
     onpointermove={handlePointerMove}
     onpointerup={handlePointerUp}

--- a/packages/chat/src/svelte/components/layout/MemberList.svelte
+++ b/packages/chat/src/svelte/components/layout/MemberList.svelte
@@ -3,7 +3,11 @@
  * MemberList - Room member sidebar panel
  * Lists participants grouped by online status with role badges
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.messages.js';
 import type { ChatParticipantData } from '../../types.js';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Room participants */
@@ -64,7 +68,7 @@ function getRoleBadgeLabel(role: string): string {
 }
 </script>
 
-<aside class="member-list" aria-label="Room members">
+<aside class="member-list" aria-label={t(M['chat.member_list.room_members'])}>
   <div class="member-list__header">
     <h2 class="member-list__title">Members</h2>
     <span class="member-list__count">{participants.length}</span>
@@ -72,7 +76,7 @@ function getRoleBadgeLabel(role: string): string {
       class="close-btn"
       type="button"
       onclick={onclose}
-      aria-label="Close member list"
+      aria-label={t(M['chat.member_list.close'])}
     >
       <svg class="close-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <path d="M18 6 6 18" />
@@ -194,7 +198,7 @@ function getRoleBadgeLabel(role: string): string {
     {/if}
 
     {#if participants.length === 0}
-      <p class="member-list__empty">No members</p>
+      <p class="member-list__empty">{t(M['chat.member_list.empty'])}</p>
     {/if}
   </div>
 </aside>

--- a/packages/chat/src/svelte/components/layout/RoomHeader.svelte
+++ b/packages/chat/src/svelte/components/layout/RoomHeader.svelte
@@ -3,7 +3,11 @@
  * RoomHeader - Room header bar with name, topic, and action buttons
  * Displays room info and provides access to members and search
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.messages.js';
 import type { ChatRoomData } from '../../types.js';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Current room data */
@@ -49,7 +53,7 @@ const roomTypeLabel = $derived.by(() => {
 });
 </script>
 
-<header class="room-header" aria-label="Room: {room.name}">
+<header class="room-header" aria-label={t(M['chat.room_header.room_label'], { name: room.name })}>
   <div class="room-header__info">
     <div class="room-header__title-row">
       {#if room.roomType !== 'dm'}
@@ -78,8 +82,8 @@ const roomTypeLabel = $derived.by(() => {
         class="header-btn"
         type="button"
         onclick={onshowmembers}
-        aria-label="Show members ({participantCount})"
-        title="Members"
+        aria-label={t(M['chat.room_header.show_members'], { count: participantCount })}
+        title={t(M['chat.room_header.members'])}
       >
         <svg class="header-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
@@ -96,8 +100,8 @@ const roomTypeLabel = $derived.by(() => {
         class="header-btn"
         type="button"
         onclick={onshowsearch}
-        aria-label="Search messages"
-        title="Search"
+        aria-label={t(M['chat.room_header.search_messages'])}
+        title={t(M['chat.room_header.search'])}
       >
         <svg class="header-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <circle cx="11" cy="11" r="8" />

--- a/packages/chat/src/svelte/components/layout/RoomList.svelte
+++ b/packages/chat/src/svelte/components/layout/RoomList.svelte
@@ -3,7 +3,11 @@
  * RoomList - Sidebar room navigation with grouping and unread badges
  * Groups rooms by type: channels, DMs, and agent conversations
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.messages.js';
 import type { ChatRoomData } from '../../types.js';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Available chat rooms */
@@ -64,16 +68,16 @@ function formatTimestamp(date?: string | Date | null): string {
 }
 </script>
 
-<nav class="room-list" aria-label="Chat rooms">
+<nav class="room-list" aria-label={t(M['chat.room_list.rooms_label'])}>
   {#if oncreateroom}
     <div class="room-list__header">
       <button
         class="create-room-btn"
         type="button"
         onclick={oncreateroom}
-        aria-label="Create new room"
+        aria-label={t(M['chat.room_list.create_new_room'])}
       >
-        + New Room
+        {t(M['chat.room_list.new_room'])}
       </button>
     </div>
   {/if}
@@ -108,7 +112,7 @@ function formatTimestamp(date?: string | Date | null): string {
                 <span class="room-item__icon">{getRoomIcon(room)}</span>
                 <span class="room-item__name">{room.name}</span>
                 {#if room.unreadCount > 0}
-                  <span class="unread-badge" aria-label="{room.unreadCount} unread messages">
+                  <span class="unread-badge" aria-label={t(M['chat.room_list.unread_messages'], { count: room.unreadCount })}>
                     {room.unreadCount > 99 ? '99+' : room.unreadCount}
                   </span>
                 {/if}
@@ -131,7 +135,7 @@ function formatTimestamp(date?: string | Date | null): string {
         <span class="room-group__chevron" class:room-group__chevron--collapsed={collapsedGroups['dms']}>
           &#9662;
         </span>
-        <span class="room-group__label">Direct Messages</span>
+        <span class="room-group__label">{t(M['chat.room_list.direct_messages'])}</span>
         <span class="room-group__count">{directMessages.length}</span>
       </button>
 
@@ -165,7 +169,7 @@ function formatTimestamp(date?: string | Date | null): string {
                     <span class="room-item__time">{formatTimestamp(room.lastMessageAt)}</span>
                   {/if}
                   {#if room.unreadCount > 0}
-                    <span class="unread-badge" aria-label="{room.unreadCount} unread messages">
+                    <span class="unread-badge" aria-label={t(M['chat.room_list.unread_messages'], { count: room.unreadCount })}>
                       {room.unreadCount > 99 ? '99+' : room.unreadCount}
                     </span>
                   {/if}
@@ -207,7 +211,7 @@ function formatTimestamp(date?: string | Date | null): string {
                 <span class="room-item__agent-icon" aria-hidden="true">&#9881;</span>
                 <span class="room-item__name">{room.name}</span>
                 {#if room.unreadCount > 0}
-                  <span class="unread-badge" aria-label="{room.unreadCount} unread messages">
+                  <span class="unread-badge" aria-label={t(M['chat.room_list.unread_messages'], { count: room.unreadCount })}>
                     {room.unreadCount > 99 ? '99+' : room.unreadCount}
                   </span>
                 {/if}
@@ -221,10 +225,10 @@ function formatTimestamp(date?: string | Date | null): string {
 
   {#if rooms.length === 0}
     <div class="room-list__empty">
-      <p>No rooms yet</p>
+      <p>{t(M['chat.room_list.no_rooms'])}</p>
       {#if oncreateroom}
         <button class="create-link" type="button" onclick={oncreateroom}>
-          Create your first room
+          {t(M['chat.room_list.create_first_room'])}
         </button>
       {/if}
     </div>

--- a/packages/chat/src/svelte/components/messages/MessageInput.svelte
+++ b/packages/chat/src/svelte/components/messages/MessageInput.svelte
@@ -3,6 +3,10 @@
  * MessageInput - Chat message input bar
  * Text area with send button. Shows reply preview when replying.
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.messages.js';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Callback when a message is sent */
@@ -64,7 +68,7 @@ function handleInput() {
           class="message-input__reply-close"
           type="button"
           onclick={oncancelreply}
-          aria-label="Cancel reply"
+          aria-label={t(M['chat.message_input.cancel_reply'])}
         >
           <svg viewBox="0 0 16 16" width="14" height="14"><path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" /></svg>
         </button>
@@ -82,14 +86,14 @@ function handleInput() {
       rows="1"
       onkeydown={handleKeydown}
       oninput={handleInput}
-      aria-label="Message input"
+      aria-label={t(M['chat.message_input.input_label'])}
     ></textarea>
     <button
       class="message-input__send"
       type="button"
       onclick={handleSend}
       disabled={disabled || content.trim().length === 0}
-      aria-label="Send message"
+      aria-label={t(M['chat.message_input.send'])}
     >
       <svg viewBox="0 0 20 20" width="18" height="18">
         <path

--- a/packages/chat/src/svelte/components/messages/MessageItem.svelte
+++ b/packages/chat/src/svelte/components/messages/MessageItem.svelte
@@ -4,10 +4,14 @@
  * Displays avatar, message bubble, reactions, reply preview, and tool call data.
  */
 
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.messages.js';
 import type { ChatMessageData } from '../../types.js';
 import Avatar from '../shared/Avatar.svelte';
 import MessageBubble from '../shared/MessageBubble.svelte';
 import ReactionPicker from '../shared/ReactionPicker.svelte';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Message data to render */
@@ -71,7 +75,7 @@ function toggleReactionPicker() {
     class="message-item"
     class:message-item--own={isOwn}
     role="article"
-    aria-label="Message from {message.senderName}"
+    aria-label={t(M['chat.message_item.message_from'], { name: message.senderName })}
     onmouseenter={() => showActions = true}
     onmouseleave={() => { showActions = false; showReactionPicker = false; }}
   >
@@ -154,7 +158,7 @@ function toggleReactionPicker() {
             class="message-item__action-btn"
             type="button"
             onclick={toggleReactionPicker}
-            aria-label="Add reaction"
+            aria-label={t(M['chat.message_item.add_reaction'])}
           >
             <svg viewBox="0 0 16 16" width="14" height="14"><circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" stroke-width="1.2" /><circle cx="5.5" cy="6.5" r="0.8" fill="currentColor" /><circle cx="10.5" cy="6.5" r="0.8" fill="currentColor" /><path d="M5.5 9.5c.5 1.2 1.5 1.8 2.5 1.8s2-.6 2.5-1.8" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round" /></svg>
           </button>
@@ -164,7 +168,7 @@ function toggleReactionPicker() {
             class="message-item__action-btn"
             type="button"
             onclick={() => onreply?.(message.id)}
-            aria-label="Reply"
+            aria-label={t(M['chat.message_item.reply'])}
           >
             <svg viewBox="0 0 16 16" width="14" height="14"><path d="M6 3L2 7l4 4" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" /><path d="M2 7h8c2.2 0 4 1.8 4 4v1" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" /></svg>
           </button>
@@ -174,7 +178,7 @@ function toggleReactionPicker() {
             class="message-item__action-btn"
             type="button"
             onclick={() => onedit?.(message.id)}
-            aria-label="Edit"
+            aria-label={t(M['chat.message_item.edit'])}
           >
             <svg viewBox="0 0 16 16" width="14" height="14"><path d="M11.5 1.5l3 3L5 14H2v-3z" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" /></svg>
           </button>
@@ -184,7 +188,7 @@ function toggleReactionPicker() {
             class="message-item__action-btn"
             type="button"
             onclick={() => ondelete?.(message.id)}
-            aria-label="Delete"
+            aria-label={t(M['chat.message_item.delete'])}
           >
             <svg viewBox="0 0 16 16" width="14" height="14"><path d="M2 4h12M5.3 4V2.7A.7.7 0 016 2h4a.7.7 0 01.7.7V4m1.6 0v9.3a1.4 1.4 0 01-1.4 1.4H5.1a1.4 1.4 0 01-1.4-1.4V4" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" /></svg>
           </button>

--- a/packages/chat/src/svelte/components/messages/MessageList.svelte
+++ b/packages/chat/src/svelte/components/messages/MessageList.svelte
@@ -5,8 +5,12 @@
  * Supports infinite scroll via onloadmore callback.
  */
 
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.messages.js';
 import type { ChatMessageData } from '../../types.js';
 import MessageItem from './MessageItem.svelte';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Messages to display */
@@ -64,11 +68,11 @@ function handleScroll(event: Event) {
   bind:this={scrollContainer}
   onscroll={handleScroll}
   role="log"
-  aria-label="Messages"
+  aria-label={t(M['chat.message_list.messages_label'])}
 >
   {#if messages.length === 0}
     <div class="message-list__empty">
-      <span>No messages yet</span>
+      <span>{t(M['chat.message_list.no_messages'])}</span>
     </div>
   {:else}
     {#each groupedMessages as group}

--- a/packages/chat/src/svelte/components/messages/ThreadPanel.svelte
+++ b/packages/chat/src/svelte/components/messages/ThreadPanel.svelte
@@ -4,9 +4,13 @@
  * Shows the root message, thread replies, and an input for new replies.
  */
 
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.messages.js';
 import type { ChatMessageData, ChatThreadData } from '../../types.js';
 import MessageInput from './MessageInput.svelte';
 import MessageList from './MessageList.svelte';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Thread metadata */
@@ -29,7 +33,7 @@ const replyCount = $derived(
 );
 </script>
 
-<aside class="thread-panel" aria-label="Thread: {threadTitle}">
+<aside class="thread-panel" aria-label={t(M['chat.thread_panel.thread_label'], { title: threadTitle })}>
   <header class="thread-panel__header">
     <div class="thread-panel__header-text">
       <h3 class="thread-panel__title">{threadTitle}</h3>
@@ -47,7 +51,7 @@ const replyCount = $derived(
       class="thread-panel__close"
       type="button"
       onclick={onclose}
-      aria-label="Close thread"
+      aria-label={t(M['chat.thread_panel.close'])}
     >
       <svg viewBox="0 0 16 16" width="16" height="16">
         <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
@@ -65,7 +69,7 @@ const replyCount = $derived(
   <div class="thread-panel__input">
     <MessageInput
       {onsend}
-      placeholder="Reply in thread..."
+      placeholder={t(M['chat.thread_panel.reply_placeholder'])}
     />
   </div>
 </aside>

--- a/packages/chat/src/svelte/components/shared/FileUpload.svelte
+++ b/packages/chat/src/svelte/components/shared/FileUpload.svelte
@@ -4,6 +4,10 @@
  * Button with drag-and-drop zone. Shows file preview before upload.
  * Supports file type filtering and max size constraints.
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.js';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Callback when files are selected */
@@ -104,7 +108,7 @@ function getFileIcon(type: string): string {
 
 <div class="file-upload" class:file-upload--disabled={disabled}>
   {#if pendingFiles.length > 0}
-    <div class="file-upload__preview" aria-label="Files to upload">
+    <div class="file-upload__preview" aria-label={t(M['chat.file_upload.preview'])}>
       {#each pendingFiles as file, i (file.name + i)}
         <div class="file-upload__file">
           <span class="file-upload__file-icon">{getFileIcon(file.type)}</span>
@@ -116,7 +120,7 @@ function getFileIcon(type: string): string {
             class="file-upload__file-remove"
             type="button"
             onclick={() => removePending(i)}
-            aria-label="Remove {file.name}"
+            aria-label={t(M['chat.file_upload.remove'], { name: file.name })}
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
@@ -131,7 +135,7 @@ function getFileIcon(type: string): string {
           type="button"
           onclick={confirmUpload}
         >
-          Upload {pendingFiles.length} file{pendingFiles.length !== 1 ? 's' : ''}
+          {t(M['chat.file_upload.upload_files'], { count: pendingFiles.length, plural: pendingFiles.length !== 1 ? 's' : '' })}
         </button>
         <button
           class="file-upload__clear-btn"
@@ -173,12 +177,12 @@ function getFileIcon(type: string): string {
       </svg>
       <span class="file-upload__text">
         {#if disabled}
-          Upload disabled
+          {t(M['chat.file_upload.disabled'])}
         {:else}
-          Drop files here or click to browse
+          {t(M['chat.file_upload.drop_files'])}
         {/if}
       </span>
-      <span class="file-upload__hint">Max {formatSize(maxSize)} per file</span>
+      <span class="file-upload__hint">{t(M['chat.file_upload.max_size'], { size: formatSize(maxSize) })}</span>
     </label>
   </div>
 </div>

--- a/packages/chat/src/svelte/components/shared/MentionAutocomplete.svelte
+++ b/packages/chat/src/svelte/components/shared/MentionAutocomplete.svelte
@@ -4,7 +4,11 @@
  * Floating dropdown positioned near cursor. Shows matching profile names
  * with optional avatars. Keyboard navigable.
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.js';
 import Avatar from './Avatar.svelte';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Current search query (text after @) */
@@ -72,7 +76,7 @@ function highlightMatch(
   <div
     class="mention-autocomplete"
     role="listbox"
-    aria-label="Mention suggestions"
+    aria-label={t(M['chat.mention_autocomplete.suggestions'])}
   >
     {#each suggestions as suggestion, i (suggestion.id)}
       {@const parts = highlightMatch(suggestion.name, query)}

--- a/packages/chat/src/svelte/components/shared/ReactionPicker.svelte
+++ b/packages/chat/src/svelte/components/shared/ReactionPicker.svelte
@@ -3,6 +3,10 @@
  * ReactionPicker - Emoji reaction selector
  * Compact popup grid of common emojis.
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.js';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Callback when an emoji is selected */
@@ -45,13 +49,13 @@ function handleKeydown(event: KeyboardEvent, emoji: string) {
 </script>
 
 {#if isOpen}
-  <div class="reaction-picker" role="group" aria-label="Emoji reactions">
+  <div class="reaction-picker" role="group" aria-label={t(M['chat.reaction_picker.reactions'])}>
     {#each emojis as emoji}
       <button
         class="reaction-picker__item"
         type="button"
         onclick={() => handleSelect(emoji)}
-        aria-label="React with {emoji}"
+        aria-label={t(M['chat.reaction_picker.react_with'], { emoji })}
       >
         {emoji}
       </button>

--- a/packages/chat/src/svelte/components/shared/ReadReceipts.svelte
+++ b/packages/chat/src/svelte/components/shared/ReadReceipts.svelte
@@ -3,6 +3,10 @@
  * ReadReceipts - Message read status display
  * Shows checkmarks or small avatars indicating who has read a message.
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.js';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Users who have read the message */
@@ -21,7 +25,7 @@ function getInitial(name: string): string {
 }
 </script>
 
-<span class="read-receipts" aria-label="{readBy.length} of {totalParticipants} read">
+<span class="read-receipts" aria-label={t(M['chat.read_receipts.read_status'], { readCount: readBy.length, total: totalParticipants })}>
   {#if readBy.length === 0}
     <!-- Single check: sent -->
     <svg class="read-receipts__icon" viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">

--- a/packages/chat/src/svelte/components/tabs/ChatTab.svelte
+++ b/packages/chat/src/svelte/components/tabs/ChatTab.svelte
@@ -4,9 +4,13 @@
  * Compact header with title, collapse/close buttons. Contains message list and input.
  * Expands upward from the bottom tab bar.
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.messages.js';
 import type { ChatMessageData, ChatTabState } from '../../types.js';
 import Avatar from '../shared/Avatar.svelte';
 import MiniChat from './MiniChat.svelte';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Tab state */
@@ -37,13 +41,13 @@ const {
 </script>
 
 {#if tab.isExpanded}
-  <div class="chat-tab chat-tab--expanded" aria-label="Chat with {tab.room.name}">
+  <div class="chat-tab chat-tab--expanded" aria-label={t(M['chat.chat_tab.chat_with'], { name: tab.room.name })}>
     <div class="chat-tab__header">
       <button
         class="chat-tab__header-btn"
         type="button"
         onclick={oncollapse}
-        aria-label="Collapse chat"
+        aria-label={t(M['chat.chat_tab.collapse'])}
       >
         <Avatar
           name={tab.room.name}
@@ -58,8 +62,8 @@ const {
           class="chat-tab__icon-btn"
           type="button"
           onclick={oncollapse}
-          aria-label="Minimize"
-          title="Minimize"
+          aria-label={t(M['chat.chat_tab.minimize'])}
+          title={t(M['chat.chat_tab.minimize'])}
         >
           <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
             <rect x="3" y="12" width="10" height="2" rx="1" />
@@ -69,8 +73,8 @@ const {
           class="chat-tab__icon-btn"
           type="button"
           onclick={onclose}
-          aria-label="Close"
-          title="Close"
+          aria-label={t(M['chat.chat_tab.close'])}
+          title={t(M['chat.chat_tab.close'])}
         >
           <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
             <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z" />
@@ -93,7 +97,7 @@ const {
     class="chat-tab chat-tab--collapsed"
     type="button"
     onclick={onexpand}
-    aria-label="Open chat with {tab.room.name}"
+    aria-label={t(M['chat.chat_tab.open_chat_with'], { name: tab.room.name })}
   >
     <Avatar
       name={tab.room.name}
@@ -102,7 +106,7 @@ const {
     />
     <span class="chat-tab__name">{tab.room.name}</span>
     {#if tab.unreadCount > 0}
-      <span class="chat-tab__badge" aria-label="{tab.unreadCount} unread">{tab.unreadCount}</span>
+      <span class="chat-tab__badge" aria-label={t(M['chat.chat_tab.unread'], { count: tab.unreadCount })}>{tab.unreadCount}</span>
     {/if}
   </button>
 {/if}

--- a/packages/chat/src/svelte/components/tabs/ChatTabList.svelte
+++ b/packages/chat/src/svelte/components/tabs/ChatTabList.svelte
@@ -3,8 +3,12 @@
  * ChatTabList - Minimized tab overview bar
  * Horizontal bar of small avatars/names at bottom. Shows unread badges.
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.messages.js';
 import type { ChatTabState } from '../../types.js';
 import Avatar from '../shared/Avatar.svelte';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Collapsed/minimized tabs */
@@ -19,14 +23,14 @@ const { tabs, onselect, onclose }: Props = $props();
 </script>
 
 {#if tabs.length > 0}
-  <nav class="tab-list" aria-label="Minimized chats">
+  <nav class="tab-list" aria-label={t(M['chat.chat_tab_list.minimized_chats'])}>
     {#each tabs as tab (tab.roomId)}
       <div class="tab-list__item">
         <button
           class="tab-list__btn"
           type="button"
           onclick={() => onselect(tab.roomId)}
-          aria-label="Open chat with {tab.room.name}"
+          aria-label={t(M['chat.chat_tab_list.open_chat_with'], { name: tab.room.name })}
           title={tab.room.name}
         >
           <Avatar
@@ -35,7 +39,7 @@ const { tabs, onselect, onclose }: Props = $props();
             size="sm"
           />
           {#if tab.unreadCount > 0}
-            <span class="tab-list__badge" aria-label="{tab.unreadCount} unread">
+            <span class="tab-list__badge" aria-label={t(M['chat.chat_tab_list.unread'], { count: tab.unreadCount })}>
               {tab.unreadCount > 99 ? '99+' : tab.unreadCount}
             </span>
           {/if}
@@ -44,8 +48,8 @@ const { tabs, onselect, onclose }: Props = $props();
           class="tab-list__close"
           type="button"
           onclick={(e) => { e.stopPropagation(); onclose(tab.roomId); }}
-          aria-label="Close chat with {tab.room.name}"
-          title="Close"
+          aria-label={t(M['chat.chat_tab_list.close_chat_with'], { name: tab.room.name })}
+          title={t(M['chat.chat_tab_list.close'])}
         >
           <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
             <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z" />

--- a/packages/chat/src/svelte/components/tabs/ChatTabs.svelte
+++ b/packages/chat/src/svelte/components/tabs/ChatTabs.svelte
@@ -3,9 +3,13 @@
  * ChatTabs - Bottom bar with expandable chat tabs (Facebook Messenger style)
  * Fixed to viewport bottom. Shows collapsed tab headers that expand upward on click.
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.messages.js';
 import type { ChatMessageData, ChatTabState } from '../../types.js';
 import ChatTab from './ChatTab.svelte';
 import ChatTabList from './ChatTabList.svelte';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Active chat tabs */
@@ -38,7 +42,7 @@ const expandedTabs = $derived(tabs.filter((t) => t.isExpanded));
 const collapsedTabs = $derived(tabs.filter((t) => !t.isExpanded));
 </script>
 
-<div class="chat-tabs" aria-label="Chat tabs">
+<div class="chat-tabs" aria-label={t(M['chat.chat_tabs.tabs_label'])}>
   <div class="chat-tabs__expanded">
     {#each expandedTabs as tab (tab.roomId)}
       <ChatTab

--- a/packages/chat/src/svelte/components/tabs/MiniChat.svelte
+++ b/packages/chat/src/svelte/components/tabs/MiniChat.svelte
@@ -4,8 +4,12 @@
  * Simplified message list + input in minimal space.
  * No thread panel, no reactions. Just messages and a send box.
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../../i18n.messages.js';
 import type { ChatMessageData } from '../../types.js';
 import Avatar from '../shared/Avatar.svelte';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Messages to display */
@@ -56,7 +60,7 @@ $effect(() => {
     style:max-height="{maxHeight}px"
     bind:this={messageContainer}
     role="log"
-    aria-label="Chat messages"
+    aria-label={t(M['chat.mini_chat.messages_label'])}
   >
     {#each messages as msg (msg.id)}
       {@const isOwn = msg.senderProfileId === currentProfileId}
@@ -76,7 +80,7 @@ $effect(() => {
 
     {#if messages.length === 0}
       <div class="mini-chat__empty">
-        <span class="mini-chat__empty-text">No messages yet</span>
+        <span class="mini-chat__empty-text">{t(M['chat.mini_chat.no_messages'])}</span>
       </div>
     {/if}
   </div>
@@ -85,16 +89,16 @@ $effect(() => {
     <input
       class="mini-chat__input"
       type="text"
-      placeholder="Type a message..."
+      placeholder={t(M['chat.mini_chat.placeholder'])}
       bind:value={inputValue}
       onkeydown={handleKeydown}
-      aria-label="Message input"
+      aria-label={t(M['chat.mini_chat.input_label'])}
     />
     <button
       class="mini-chat__send-btn"
       type="submit"
       disabled={!inputValue.trim()}
-      aria-label="Send message"
+      aria-label={t(M['chat.mini_chat.send'])}
     >
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
         <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />

--- a/packages/chat/src/svelte/i18n.messages.ts
+++ b/packages/chat/src/svelte/i18n.messages.ts
@@ -1,0 +1,81 @@
+/**
+ * Chat component message catalog (i18n, Sweep S13 #1418).
+ *
+ * English code defaults for user-facing strings in the chat Svelte components
+ * under `tabs/`, `messages/`, and `layout/`. Keys follow
+ * `chat.<component>.<descriptor>`.
+ */
+import { defineMessages } from '@happyvertical/smrt-svelte/i18n';
+
+export const M = defineMessages({
+  // ChatLayout
+  'chat.chat_layout.rooms_label': 'Chat rooms',
+  'chat.chat_layout.resize_sidebar': 'Resize sidebar',
+
+  // MemberList
+  'chat.member_list.room_members': 'Room members',
+  'chat.member_list.close': 'Close member list',
+  'chat.member_list.empty': 'No members',
+
+  // RoomHeader
+  'chat.room_header.room_label': 'Room: {name}',
+  'chat.room_header.show_members': 'Show members ({count})',
+  'chat.room_header.members': 'Members',
+  'chat.room_header.search_messages': 'Search messages',
+  'chat.room_header.search': 'Search',
+
+  // RoomList
+  'chat.room_list.rooms_label': 'Chat rooms',
+  'chat.room_list.create_new_room': 'Create new room',
+  'chat.room_list.new_room': '+ New Room',
+  'chat.room_list.direct_messages': 'Direct Messages',
+  'chat.room_list.unread_messages': '{count} unread messages',
+  'chat.room_list.no_rooms': 'No rooms yet',
+  'chat.room_list.create_first_room': 'Create your first room',
+
+  // MessageInput
+  'chat.message_input.cancel_reply': 'Cancel reply',
+  'chat.message_input.input_label': 'Message input',
+  'chat.message_input.send': 'Send message',
+
+  // MessageItem
+  'chat.message_item.message_from': 'Message from {name}',
+  'chat.message_item.add_reaction': 'Add reaction',
+  'chat.message_item.reply': 'Reply',
+  'chat.message_item.edit': 'Edit',
+  'chat.message_item.delete': 'Delete',
+
+  // MessageList
+  'chat.message_list.messages_label': 'Messages',
+  'chat.message_list.no_messages': 'No messages yet',
+
+  // ThreadPanel
+  'chat.thread_panel.thread_label': 'Thread: {title}',
+  'chat.thread_panel.close': 'Close thread',
+  'chat.thread_panel.reply_placeholder': 'Reply in thread...',
+
+  // ChatTab
+  'chat.chat_tab.chat_with': 'Chat with {name}',
+  'chat.chat_tab.collapse': 'Collapse chat',
+  'chat.chat_tab.minimize': 'Minimize',
+  'chat.chat_tab.close': 'Close',
+  'chat.chat_tab.open_chat_with': 'Open chat with {name}',
+  'chat.chat_tab.unread': '{count} unread',
+
+  // ChatTabList
+  'chat.chat_tab_list.minimized_chats': 'Minimized chats',
+  'chat.chat_tab_list.open_chat_with': 'Open chat with {name}',
+  'chat.chat_tab_list.unread': '{count} unread',
+  'chat.chat_tab_list.close_chat_with': 'Close chat with {name}',
+  'chat.chat_tab_list.close': 'Close',
+
+  // ChatTabs
+  'chat.chat_tabs.tabs_label': 'Chat tabs',
+
+  // MiniChat
+  'chat.mini_chat.messages_label': 'Chat messages',
+  'chat.mini_chat.no_messages': 'No messages yet',
+  'chat.mini_chat.placeholder': 'Type a message...',
+  'chat.mini_chat.input_label': 'Message input',
+  'chat.mini_chat.send': 'Send message',
+});

--- a/packages/chat/src/svelte/i18n.ts
+++ b/packages/chat/src/svelte/i18n.ts
@@ -1,0 +1,83 @@
+/**
+ * smrt-chat Svelte component message catalog (Sweep S13 #1418).
+ *
+ * English code defaults for user-facing strings in the chat components under
+ * `src/svelte/components/`. Keys use the `chat.` namespace
+ * (`chat.<component>.<descriptor>`). Importing this module registers the
+ * defaults so `useI18n().t` renders correctly even without a server snapshot.
+ *
+ * `M` is a typed key map — `M['chat.agent_chat.empty']` is the key literal — so
+ * component call sites stay typo-safe.
+ */
+import { defineMessages } from '@happyvertical/smrt-svelte/i18n';
+
+export const M = defineMessages({
+  // AgentChat
+  'chat.agent_chat.conversation': 'Agent conversation',
+  'chat.agent_chat.inactive_notice': 'Session {status}. Cannot send messages.',
+  'chat.agent_chat.input_placeholder': 'Ask the AI to write or edit content...',
+  'chat.agent_chat.message_input': 'Message input',
+  'chat.agent_chat.send_message': 'Send message',
+  'chat.agent_chat.messages': 'Conversation messages',
+  'chat.agent_chat.updated_fields': '✓ Updated {count} field{plural}',
+  'chat.agent_chat.empty': 'Ask the AI to write or edit your content',
+  'chat.agent_chat.field_changes': 'Field Changes',
+
+  // AgentSelector
+  'chat.agent_selector.select_an_agent': 'Select an agent',
+  'chat.agent_selector.title': 'Choose an Agent',
+  'chat.agent_selector.available_agents': 'Available agents',
+  'chat.agent_selector.empty': 'No agents available',
+
+  // AgentSessionPanel
+  'chat.agent_session_panel.sessions': 'Agent sessions',
+  'chat.agent_session_panel.new_session': 'New session',
+  'chat.agent_session_panel.session_list': 'Session list',
+  'chat.agent_session_panel.empty': 'No sessions yet',
+
+  // ToolCallDisplay
+  'chat.tool_call_display.tool_call': 'Tool call: {toolName}',
+  'chat.tool_call_display.running': 'Running',
+
+  // RoomCreateDialog
+  'chat.room_create_dialog.close': 'Close room creation dialog',
+  'chat.room_create_dialog.title': 'Create a Room',
+  'chat.room_create_dialog.room_name': 'Room Name',
+  'chat.room_create_dialog.required': 'required',
+  'chat.room_create_dialog.name_placeholder': 'e.g. general, project-updates',
+  'chat.room_create_dialog.room_type': 'Room Type',
+  'chat.room_create_dialog.description_placeholder': 'What is this room about?',
+  'chat.room_create_dialog.create_room': 'Create Room',
+
+  // SearchMessages
+  'chat.search_messages.search': 'Search messages',
+  'chat.search_messages.title': 'Search Messages',
+  'chat.search_messages.close': 'Close search',
+  'chat.search_messages.input_placeholder': 'Search messages...',
+  'chat.search_messages.query': 'Search query',
+  'chat.search_messages.clear': 'Clear search',
+  'chat.search_messages.results': 'Search results',
+  'chat.search_messages.results_count': '{count} result{plural} found',
+  'chat.search_messages.no_results': 'No messages found for "{query}"',
+  'chat.search_messages.no_results_hint':
+    'Try different keywords or check your spelling',
+  'chat.search_messages.empty': 'Enter a search term to find messages',
+
+  // FileUpload
+  'chat.file_upload.preview': 'Files to upload',
+  'chat.file_upload.remove': 'Remove {name}',
+  'chat.file_upload.upload_files': 'Upload {count} file{plural}',
+  'chat.file_upload.disabled': 'Upload disabled',
+  'chat.file_upload.drop_files': 'Drop files here or click to browse',
+  'chat.file_upload.max_size': 'Max {size} per file',
+
+  // MentionAutocomplete
+  'chat.mention_autocomplete.suggestions': 'Mention suggestions',
+
+  // ReactionPicker
+  'chat.reaction_picker.reactions': 'Emoji reactions',
+  'chat.reaction_picker.react_with': 'React with {emoji}',
+
+  // ReadReceipts
+  'chat.read_receipts.read_status': '{readCount} of {total} read',
+});

--- a/scripts/check-hardcoded-strings.mjs
+++ b/scripts/check-hardcoded-strings.mjs
@@ -40,6 +40,8 @@ const STRICT_PACKAGES = new Set([
   'social',
   'tenancy',
   'subscriptions',
+  'assets',
+  'chat',
 ]);
 
 // Dev/playground host, not a shippable library (consistent with the other ratchets).


### PR DESCRIPTION
## What

Phase-2 **wave 2** of the i18n rollout (#1418): route hardcoded user-facing
strings in **assets** and **chat** through the smrt-svelte i18n layer
(`useI18n().t`) and add both to the ratchet's `STRICT_PACKAGES`.

## How

- Extraction ran as **3 parallel subagents** — one for assets, and chat split
  across two (`agent/dialogs/shared` and `tabs/messages/layout`), each writing a
  **separate catalog file** so the two chat agents never collide.
- Every edit is a string→`t()` swap plus per-package `defineMessages` catalogs in
  `src/svelte/` — no logic / `console.*` / markup changes (diff scope-checked).
- **assets**: 69 keys (`src/svelte/i18n.ts`), 10 components.
- **chat**: 96 keys across `src/svelte/i18n.ts` (agent/dialogs/shared) and
  `src/svelte/i18n.messages.ts` (tabs/messages/layout), 22 components.

Report-only backlog **761 → 594** across 6 packages.

## Validation

- `turbo typecheck` **78/78** (a11y gate clean; validates every new import/path).
- **Coverage gate green** — assets **71.2%** (≥70 T2), chat **90.8%** (≥70 T2);
  extraction is coverage-neutral (catalogs are covered on import).
- Both test suites green — `t()` falls back to registered English defaults, so
  existing string assertions hold.
- Full build **50/50**; ratchet green with 11 strict packages.

## S13 progress

Waves so far: phase 1 (#1527 foundation+pilot), wave 1 (#1528, 9 packages).
This is wave 2. Remaining gate-clear: **content** (split across ~5 agents next),
**smrt-svelte** (coverage-exempt). Deferred — coverage-blocked (need a separate
test investment, not i18n): messages (54%), products (17%), images (13%),
events (22%).