### PR TITLE
feat(i18n): extract UI strings in content, flip to lint-strict (S13 #1418 wave 3)

### DIFF
--- a/packages/content/src/svelte/components/ArticleList.svelte
+++ b/packages/content/src/svelte/components/ArticleList.svelte
@@ -4,9 +4,14 @@
  *
  * Renders articles in a responsive grid layout with configurable columns.
  */
+
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import { Grid } from '@happyvertical/smrt-svelte/layout';
+import { M } from '../i18n.contribution.js';
 import type { Article } from '../types.js';
 import ArticleCard from './ArticleCard.svelte';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Array of articles to display */
@@ -42,7 +47,7 @@ const {
     <p>{emptyMessage}</p>
   </div>
 {:else}
-  <Grid {columns} role="list" aria-label="Articles">
+  <Grid {columns} role="list" aria-label={t(M['content.article_list.aria_label'])}>
     {#each articles as article (article.id)}
       <div role="listitem">
         <ArticleCard

--- a/packages/content/src/svelte/components/ContentAgentChat.svelte
+++ b/packages/content/src/svelte/components/ContentAgentChat.svelte
@@ -6,6 +6,7 @@
  */
 
 import { AgentChat } from '@happyvertical/smrt-chat/svelte';
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type {
   ContentEditorAssistantContext,
   ContentEditorAssistantFieldUpdateAllowList,
@@ -15,6 +16,7 @@ import {
   sanitizeContentEditorAssistantFieldUpdates,
 } from '../../content-editor-assistant';
 import { joinApiUrl } from '../api';
+import { M } from '../i18n.editor.js';
 
 const AI_MODELS = [
   { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
@@ -25,6 +27,8 @@ const AI_MODELS = [
   { id: 'gpt-4o-mini', label: 'GPT-4o Mini' },
 ];
 const DEFAULT_MODEL_ID = AI_MODELS[0].id;
+
+const { t } = useI18n();
 
 export interface Props {
   apiBaseUrl?: string;
@@ -417,7 +421,7 @@ async function handleSendMessage(content: string) {
 
 <div class="content-agent-chat-container">
   {#if loadingSession && !threads.length}
-    <div class="loading-state">Loading AI Assistant...</div>
+    <div class="loading-state">{t(M['content.content_agent_chat.loading_ai_assistant'])}</div>
   {:else if error && !session}
     <div class="error-state">
       <p>{error}</p>
@@ -438,11 +442,11 @@ async function handleSendMessage(content: string) {
       <div class="agent-chat-host">
         {#if loadingMessages || isCreatingTopic}
            <div class="loading-state">
-             <span class="spinner"></span> Loading topic...
+             <span class="spinner"></span> {t(M['content.content_agent_chat.loading_topic'])}
            </div>
         {:else}
           {#if !resolvedCurrentProfileId}
-            <div class="loading-state">Loading participant...</div>
+            <div class="loading-state">{t(M['content.content_agent_chat.loading_participant'])}</div>
           {:else}
           <AgentChat 
             session={session} 
@@ -463,7 +467,7 @@ async function handleSendMessage(content: string) {
           <input 
             class="new-topic-input" 
             type="text" 
-            placeholder="Topic name..." 
+            placeholder={t(M['content.content_agent_chat.topic_name_placeholder'])}
             bind:value={newTopicTitle}
             onkeydown={(e: KeyboardEvent) => { if (e.key === 'Enter') { createNewTopic(); showNewTopicInput = false; } }}
           />
@@ -480,13 +484,13 @@ async function handleSendMessage(content: string) {
           disabled={!threads.length}
         >
           {#if !threads.length}
-            <option value="" disabled>No topics...</option>
+            <option value="" disabled>{t(M['content.content_agent_chat.no_topics'])}</option>
           {/if}
           {#each threads as thread}
             <option value={thread.id}>{thread.title || 'Untitled Topic'}</option>
           {/each}
         </select>
-        <button class="topic-action-btn" onclick={() => { showNewTopicInput = true; newTopicTitle = ''; }} title="New Topic">
+        <button class="topic-action-btn" onclick={() => { showNewTopicInput = true; newTopicTitle = ''; }} title={t(M['content.content_agent_chat.new_topic'])}>
           <svg viewBox="0 0 24 24" width="14" height="14" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
           New
         </button>

--- a/packages/content/src/svelte/components/ContentAgentChat.svelte
+++ b/packages/content/src/svelte/components/ContentAgentChat.svelte
@@ -487,12 +487,12 @@ async function handleSendMessage(content: string) {
             <option value="" disabled>{t(M['content.content_agent_chat.no_topics'])}</option>
           {/if}
           {#each threads as thread}
-            <option value={thread.id}>{thread.title || 'Untitled Topic'}</option>
+            <option value={thread.id}>{thread.title || t(M['content.content_agent_chat.untitled_topic'])}</option>
           {/each}
         </select>
         <button class="topic-action-btn" onclick={() => { showNewTopicInput = true; newTopicTitle = ''; }} title={t(M['content.content_agent_chat.new_topic'])}>
           <svg viewBox="0 0 24 24" width="14" height="14" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
-          New
+          {t(M['content.content_agent_chat.new'])}
         </button>
       {/if}
     </div>

--- a/packages/content/src/svelte/components/ContentBodyEditor.svelte
+++ b/packages/content/src/svelte/components/ContentBodyEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { ImageLike } from '@happyvertical/smrt-images/svelte';
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import {
   bodyToEditorHtml,
   type ContentBodyFormat,
@@ -11,6 +12,9 @@ import {
   normalizeEditorHtml,
   resolveBodyFormat,
 } from '../../body-format';
+import { M } from '../i18n.editor.js';
+
+const { t } = useI18n();
 
 export interface ContentBodyEditorChange {
   body: string;
@@ -991,17 +995,17 @@ function handleEditorDragEnd() {
 </script>
 
 <div bind:this={rootElement} class="content-body-editor">
-  <div class="body-editor-toolbar" aria-label="Body editor toolbar">
-    <button type="button" title="Bold" aria-label="Bold" onclick={() => runCommand('bold')}>
+  <div class="body-editor-toolbar" aria-label={t(M['content.content_body_editor.toolbar'])}>
+    <button type="button" title={t(M['content.content_body_editor.bold'])} aria-label={t(M['content.content_body_editor.bold'])} onclick={() => runCommand('bold')}>
       <strong>B</strong>
     </button>
-    <button type="button" title="Italic" aria-label="Italic" onclick={() => runCommand('italic')}>
+    <button type="button" title={t(M['content.content_body_editor.italic'])} aria-label={t(M['content.content_body_editor.italic'])} onclick={() => runCommand('italic')}>
       <em>I</em>
     </button>
-    <button type="button" title="Heading" aria-label="Heading" onclick={() => runCommand('formatBlock', 'h2')}>
+    <button type="button" title={t(M['content.content_body_editor.heading'])} aria-label={t(M['content.content_body_editor.heading'])} onclick={() => runCommand('formatBlock', 'h2')}>
       H2
     </button>
-    <button type="button" title="Bulleted list" aria-label="Bulleted list" onclick={() => runCommand('insertUnorderedList')}>
+    <button type="button" title={t(M['content.content_body_editor.bulleted_list'])} aria-label={t(M['content.content_body_editor.bulleted_list'])} onclick={() => runCommand('insertUnorderedList')}>
       <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
         <line x1="9" y1="6" x2="21" y2="6"></line>
         <line x1="9" y1="12" x2="21" y2="12"></line>
@@ -1011,7 +1015,7 @@ function handleEditorDragEnd() {
         <circle cx="4" cy="18" r="1"></circle>
       </svg>
     </button>
-    <button type="button" title="Insert image" aria-label="Insert image" onclick={() => onOpenImageChooser?.()}>
+    <button type="button" title={t(M['content.content_body_editor.insert_image'])} aria-label={t(M['content.content_body_editor.insert_image'])} onclick={() => onOpenImageChooser?.()}>
       <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <rect x="3" y="3" width="18" height="18" rx="2"></rect>
         <circle cx="8.5" cy="8.5" r="1.5"></circle>
@@ -1020,7 +1024,7 @@ function handleEditorDragEnd() {
     </button>
 
     <label class="format-select">
-      <span>Save as</span>
+      <span>{t(M['content.content_body_editor.save_as'])}</span>
       <select
         value={currentFormat}
         onchange={(event) => setBodyFormat((event.currentTarget as HTMLSelectElement).value as ContentBodyFormat)}
@@ -1035,9 +1039,9 @@ function handleEditorDragEnd() {
     <div
       class="image-control-popover"
       style={`top: ${Math.max(44, selectedImageBox.top + 8)}px; left: ${selectedImageBox.left + selectedImageBox.width / 2}px;`}
-      aria-label="Selected image controls"
+      aria-label={t(M['content.content_body_editor.selected_image_controls'])}
     >
-      <button type="button" title="Move image" aria-label="Move image" onpointerdown={startImageMove}>
+      <button type="button" title={t(M['content.content_body_editor.move_image'])} aria-label={t(M['content.content_body_editor.move_image'])} onpointerdown={startImageMove}>
         <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M12 2v20"></path>
           <path d="M2 12h20"></path>
@@ -1050,8 +1054,8 @@ function handleEditorDragEnd() {
       <span class="image-control-divider"></span>
       <button
         type="button"
-        title="Wrap text on right"
-        aria-label="Wrap text on right"
+        title={t(M['content.content_body_editor.wrap_text_on_right'])}
+        aria-label={t(M['content.content_body_editor.wrap_text_on_right'])}
         class:active={selectedImagePlacement === 'left'}
         onclick={() => applyImagePlacement('left')}
       >
@@ -1065,8 +1069,8 @@ function handleEditorDragEnd() {
       </button>
       <button
         type="button"
-        title="Center image"
-        aria-label="Center image"
+        title={t(M['content.content_body_editor.center_image'])}
+        aria-label={t(M['content.content_body_editor.center_image'])}
         class:active={selectedImagePlacement === 'center' || selectedImagePlacement === 'block'}
         onclick={() => applyImagePlacement('center')}
       >
@@ -1078,8 +1082,8 @@ function handleEditorDragEnd() {
       </button>
       <button
         type="button"
-        title="Wrap text on left"
-        aria-label="Wrap text on left"
+        title={t(M['content.content_body_editor.wrap_text_on_left'])}
+        aria-label={t(M['content.content_body_editor.wrap_text_on_left'])}
         class:active={selectedImagePlacement === 'right'}
         onclick={() => applyImagePlacement('right')}
       >
@@ -1093,8 +1097,8 @@ function handleEditorDragEnd() {
       </button>
       <button
         type="button"
-        title="Full width"
-        aria-label="Full width"
+        title={t(M['content.content_body_editor.full_width'])}
+        aria-label={t(M['content.content_body_editor.full_width'])}
         class:active={selectedImagePlacement === 'full'}
         onclick={() => applyImagePlacement('full')}
       >
@@ -1105,14 +1109,14 @@ function handleEditorDragEnd() {
         </svg>
       </button>
       <span class="image-control-divider"></span>
-      <button type="button" title="Make smaller" aria-label="Make image smaller" onclick={() => resizeSelectedImage(-IMAGE_WIDTH_STEP)}>
+      <button type="button" title={t(M['content.content_body_editor.make_smaller'])} aria-label={t(M['content.content_body_editor.make_image_smaller'])} onclick={() => resizeSelectedImage(-IMAGE_WIDTH_STEP)}>
         <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
           <path d="M5 12h14"></path>
           <path d="M9 8 5 12l4 4"></path>
           <path d="m15 8 4 4-4 4"></path>
         </svg>
       </button>
-      <button type="button" title="Make larger" aria-label="Make image larger" onclick={() => resizeSelectedImage(IMAGE_WIDTH_STEP)}>
+      <button type="button" title={t(M['content.content_body_editor.make_larger'])} aria-label={t(M['content.content_body_editor.make_image_larger'])} onclick={() => resizeSelectedImage(IMAGE_WIDTH_STEP)}>
         <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
           <path d="M3 12h18"></path>
           <path d="m7 8-4 4 4 4"></path>
@@ -1120,13 +1124,13 @@ function handleEditorDragEnd() {
         </svg>
       </button>
       {#if selectedImageAssetId && onUseImageAsThumbnail}
-        <button type="button" title="Use as primary image" aria-label="Use as primary image" onclick={useSelectedImageAsThumbnail}>
+        <button type="button" title={t(M['content.content_body_editor.use_as_primary_image'])} aria-label={t(M['content.content_body_editor.use_as_primary_image'])} onclick={useSelectedImageAsThumbnail}>
           <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round">
             <path d="m12 3 2.8 5.7 6.2.9-4.5 4.4 1.1 6.2L12 17.3 6.4 20.2 7.5 14 3 9.6l6.2-.9L12 3Z"></path>
           </svg>
         </button>
       {/if}
-      <button type="button" title="Remove image" aria-label="Remove image" onclick={removeSelectedImage}>
+      <button type="button" title={t(M['content.content_body_editor.remove_image'])} aria-label={t(M['content.content_body_editor.remove_image'])} onclick={removeSelectedImage}>
         <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M3 6h18"></path>
           <path d="M8 6V4h8v2"></path>
@@ -1138,8 +1142,8 @@ function handleEditorDragEnd() {
     <button
       type="button"
       class="image-resize-handle"
-      title="Resize image"
-      aria-label="Resize selected image"
+      title={t(M['content.content_body_editor.resize_image'])}
+      aria-label={t(M['content.content_body_editor.resize_selected_image'])}
       style={`top: ${selectedImageBox.top + selectedImageBox.height - 12}px; left: ${selectedImageBox.left + selectedImageBox.width - 12}px;`}
       onpointerdown={startImageResize}
     >

--- a/packages/content/src/svelte/components/ContentClaimAuditTool.svelte
+++ b/packages/content/src/svelte/components/ContentClaimAuditTool.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type {
   FactAuditClaimData,
   FactAuditStateData,
 } from '../../mock-smrt-client';
 import { createClient } from '../../mock-smrt-client';
 import { normalizeApiBaseUrl } from '../api';
+import { M } from '../i18n.tools.js';
+
+const { t } = useI18n();
 
 export interface Props {
   apiBaseUrl?: string;
@@ -183,11 +187,11 @@ async function recheckFactClaims(claimIds: string[]) {
   {/if}
 
   {#if !savedContentId}
-    <p class="empty-copy">Save this content to audit article claims against evidence.</p>
+    <p class="empty-copy">{t(M['content.claim_audit_tool.save_to_audit_claims'])}</p>
   {:else}
     <div class="claim-audit-toolbar">
       <div class="claim-audit-counts">
-        <span><strong>{factAudit?.counts.total ?? 0}</strong> article claims</span>
+        <span><strong>{factAudit?.counts.total ?? 0}</strong> {t(M['content.claim_audit_tool.article_claims'])}</span>
         <span><strong>{factAudit?.counts.supported ?? 0}</strong> supported</span>
         <span><strong>{factAudit?.counts.unsupported ?? 0}</strong> unsupported</span>
         <span><strong>{factAudit?.counts.contradicted ?? 0}</strong> contradicted</span>
@@ -211,7 +215,7 @@ async function recheckFactClaims(claimIds: string[]) {
       </button>
     </div>
     <p class="empty-copy">
-      Article claims are statements made by this draft. A supported claim has linked source evidence from the references; unsupported means the audit has not found that supporting evidence yet.
+      {t(M['content.claim_audit_tool.article_claims_help'])}
     </p>
 
     {#if actionableWarnings.length}
@@ -223,7 +227,7 @@ async function recheckFactClaims(claimIds: string[]) {
     {/if}
 
     {#if !factAudit || factAudit.counts.total === 0}
-      <p class="empty-copy">No article claim audit has been generated yet.</p>
+      <p class="empty-copy">{t(M['content.claim_audit_tool.no_claim_audit_generated'])}</p>
     {:else}
       {#each [
         ['contradicted', 'Contradicted'],
@@ -235,7 +239,7 @@ async function recheckFactClaims(claimIds: string[]) {
         {@const groupClaims = factAuditGroups[groupKey]}
         {#if groupClaims.length > 0}
           <div class="tool-list">
-            <div class="section-caption">{group[1]} article claims</div>
+            <div class="section-caption">{t(M['content.claim_audit_tool.group_article_claims'], { group: group[1] })}</div>
             {#each groupClaims as claim (claim.id ?? claim.claimQuote ?? claim.fact.textRefined)}
               <details class="tool-card">
                 <summary>
@@ -263,21 +267,21 @@ async function recheckFactClaims(claimIds: string[]) {
                         if (claimId) void recheckFactClaims([claimId]);
                       }}
                     >
-                      Recheck support
+                      {t(M['content.claim_audit_tool.recheck_support'])}
                     </button>
                   </div>
                   {#if claim.claimQuote}
-                    <p><strong>Article claim:</strong> {claim.claimQuote}</p>
+                    <p><strong>{t(M['content.claim_audit_tool.article_claim_label'])}</strong> {claim.claimQuote}</p>
                   {/if}
                   {#if claim.rationale}
-                    <p><strong>Support assessment:</strong> {claim.rationale}</p>
+                    <p><strong>{t(M['content.claim_audit_tool.support_assessment_label'])}</strong> {claim.rationale}</p>
                   {/if}
                   {#if claim.matchedFacts?.length}
                     <div class="tool-list">
-                      <div class="section-caption">Based on source evidence</div>
+                      <div class="section-caption">{t(M['content.claim_audit_tool.based_on_source_evidence'])}</div>
                       {#each claim.matchedFacts as matched (matched.fact.id ?? matched.fact.textRefined)}
                         <div class="tool-card nested">
-                          <strong>Source claim: {matched.fact.textRefined || matched.fact.textRaw || matched.fact.id}</strong>
+                          <strong>{t(M['content.claim_audit_tool.source_claim_label'])} {matched.fact.textRefined || matched.fact.textRaw || matched.fact.id}</strong>
                           {#each matched.evidence ?? [] as evidence (evidence.id ?? evidence.evidenceKey)}
                             <span>
                               {evidence.sourceTitle || 'Source'}
@@ -293,7 +297,7 @@ async function recheckFactClaims(claimIds: string[]) {
                       {/each}
                     </div>
                   {:else}
-                    <p><strong>Based on:</strong> No supporting source evidence linked.</p>
+                    <p><strong>{t(M['content.claim_audit_tool.based_on_label'])}</strong> {t(M['content.claim_audit_tool.no_supporting_source_evidence'])}</p>
                   {/if}
                 </div>
               </details>

--- a/packages/content/src/svelte/components/ContentContributionForm.svelte
+++ b/packages/content/src/svelte/components/ContentContributionForm.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type {
   ContentContributionData,
   ContentContributionTypeData,
 } from '../../mock-smrt-client';
+import { M } from '../i18n.contribution.js';
+
+const { t } = useI18n();
 
 export interface ContentContributionFormSubmitData {
   typeKey: string;
@@ -121,10 +125,10 @@ function handleSubmit(event: SubmitEvent) {
   {action}
   onsubmit={handleSubmit}
 >
-  <h3>Submit a contribution</h3>
+  <h3>{t(M['content.contribution_form.heading'])}</h3>
 
   <label>
-    Contribution type
+    {t(M['content.contribution_form.contribution_type'])}
     <select name="typeKey" bind:value={draft.typeKey} required>
       {#each types.filter((type) => type.enabled !== false) as type (type.key)}
         <option value={type.key}>{type.label}</option>
@@ -162,7 +166,7 @@ function handleSubmit(event: SubmitEvent) {
 
   {#if activeType?.allowFiles !== false}
     <label>
-      Attach files
+      {t(M['content.contribution_form.attach_files'])}
       <input
         name="files"
         type="file"

--- a/packages/content/src/svelte/components/ContentContributionInbox.svelte
+++ b/packages/content/src/svelte/components/ContentContributionInbox.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type { ContentContributionData } from '../../mock-smrt-client';
+import { M } from '../i18n.contribution.js';
+
+const { t } = useI18n();
 
 export interface Props {
   contributions?: ContentContributionData[];
@@ -116,8 +120,8 @@ $effect(() => {
 <section class="inbox">
   <header class="inbox__header">
     <div>
-      <h3>Contribution inbox</h3>
-      <p>Review held submissions, request changes, or promote them into editorial content.</p>
+      <h3>{t(M['content.contribution_inbox.heading'])}</h3>
+      <p>{t(M['content.contribution_inbox.intro'])}</p>
     </div>
     <span class="pill">{contributions.length}</span>
   </header>
@@ -166,12 +170,12 @@ $effect(() => {
               <dd>{selectedContribution.revisionCount || 0}</dd>
             </div>
             <div>
-              <dt>Promoted content</dt>
+              <dt>{t(M['content.contribution_inbox.promoted_content'])}</dt>
               <dd>{selectedContribution.promotedContentId || 'Not promoted yet'}</dd>
             </div>
             {#if selectedContribution.intakeDecision}
               <div>
-                <dt>Intake decision</dt>
+                <dt>{t(M['content.contribution_inbox.intake_decision'])}</dt>
                 <dd>{selectedContribution.intakeDecision}</dd>
               </div>
             {/if}
@@ -187,14 +191,14 @@ $effect(() => {
             {/if}
 
             <label>
-              Editorial note
+              {t(M['content.contribution_inbox.editorial_note'])}
               <textarea name="editorNote" bind:value={note} rows="4"></textarea>
             </label>
 
             <div class="actions">
               {#if onApprove || workflowFormAction}
                 <label class="inline">
-                  Promote to
+                  {t(M['content.contribution_inbox.promote_to'])}
                   <select name="targetStatus" bind:value={targetStatus}>
                     <option value="draft">draft</option>
                     <option value="review">review</option>
@@ -218,7 +222,7 @@ $effect(() => {
                   class="secondary"
                   disabled={!canSubmitWorkflow}
                 >
-                  Request changes
+                  {t(M['content.contribution_inbox.request_changes'])}
                 </button>
               {/if}
 

--- a/packages/content/src/svelte/components/ContentContributionPortal.svelte
+++ b/packages/content/src/svelte/components/ContentContributionPortal.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type { ContentContributionData } from '../../mock-smrt-client';
+import { M } from '../i18n.contribution.js';
+
+const { t } = useI18n();
 
 export interface Props {
   contributions?: ContentContributionData[];
@@ -33,8 +37,8 @@ function canWithdraw(contribution: ContentContributionData) {
 <section class="portal">
   <header class="portal__header">
     <div>
-      <h3>Your contributions</h3>
-      <p>Track the status of your submissions and follow up when editors request changes.</p>
+      <h3>{t(M['content.contribution_portal.heading'])}</h3>
+      <p>{t(M['content.contribution_portal.intro'])}</p>
     </div>
     <span class="pill">{contributions.length}</span>
   </header>
@@ -67,7 +71,7 @@ function canWithdraw(contribution: ContentContributionData) {
           {/if}
           {#if selectedContribution.editorNotes}
             <div class="callout">
-              <strong>Editor notes</strong>
+              <strong>{t(M['content.contribution_portal.editor_notes'])}</strong>
               <p>{selectedContribution.editorNotes}</p>
             </div>
           {/if}
@@ -88,7 +92,7 @@ function canWithdraw(contribution: ContentContributionData) {
 
           {#if onWithdraw && canWithdraw(selectedContribution)}
             <button type="button" class="secondary" onclick={() => onWithdraw?.(selectedContribution)}>
-              Withdraw submission
+              {t(M['content.contribution_portal.withdraw_submission'])}
             </button>
           {/if}
         </article>

--- a/packages/content/src/svelte/components/ContentContributionTypeManager.svelte
+++ b/packages/content/src/svelte/components/ContentContributionTypeManager.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type { ContentContributionTypeData } from '../../mock-smrt-client';
+import { M } from '../i18n.contribution.js';
+
+const { t } = useI18n();
 
 export interface Props {
   types?: ContentContributionTypeData[];
@@ -109,10 +113,10 @@ function handleSubmit() {
 <section class="manager">
   <header>
     <div>
-      <h3>Contribution types</h3>
-      <p>Configure what contributors can send, where it promotes, and which intake rules apply.</p>
+      <h3>{t(M['content.contribution_type_manager.heading'])}</h3>
+      <p>{t(M['content.contribution_type_manager.intro'])}</p>
     </div>
-    <button type="button" onclick={() => (editing = {})}>Add type</button>
+    <button type="button" onclick={() => (editing = {})}>{t(M['content.contribution_type_manager.add_type'])}</button>
   </header>
 
   <div class="layout">
@@ -151,9 +155,9 @@ function handleSubmit() {
 
       <div class="checkbox-grid">
         <label><input type="checkbox" bind:checked={draft.enabled} /> Enabled</label>
-        <label><input type="checkbox" bind:checked={draft.allowText} /> Allow text</label>
-        <label><input type="checkbox" bind:checked={draft.allowFiles} /> Allow files</label>
-        <label><input type="checkbox" bind:checked={draft.allowEmptyText} /> Allow empty text</label>
+        <label><input type="checkbox" bind:checked={draft.allowText} /> {t(M['content.contribution_type_manager.allow_text'])}</label>
+        <label><input type="checkbox" bind:checked={draft.allowFiles} /> {t(M['content.contribution_type_manager.allow_files'])}</label>
+        <label><input type="checkbox" bind:checked={draft.allowEmptyText} /> {t(M['content.contribution_type_manager.allow_empty_text'])}</label>
       </div>
 
       <div class="checkbox-grid">
@@ -176,15 +180,15 @@ function handleSubmit() {
       </div>
 
       <label>
-        Promotion content type
+        {t(M['content.contribution_type_manager.promotion_content_type'])}
         <input type="text" bind:value={draft.promotion.targetContentType} required />
       </label>
       <label>
-        Promotion variant
+        {t(M['content.contribution_type_manager.promotion_variant'])}
         <input type="text" bind:value={draft.promotion.targetContentVariant} />
       </label>
       <label>
-        Promotion status
+        {t(M['content.contribution_type_manager.promotion_status'])}
         <select bind:value={draft.promotion.targetContentStatus}>
           <option value="draft">draft</option>
           <option value="review">review</option>
@@ -192,42 +196,42 @@ function handleSubmit() {
       </label>
 
       <div class="checkbox-grid">
-        <label><input type="checkbox" bind:checked={draft.promotion.autoPromoteTrusted} /> Auto-promote trusted</label>
-        <label><input type="checkbox" bind:checked={draft.promotion.createAssets} /> Create assets on promotion</label>
-        <label><input type="checkbox" bind:checked={draft.intakeRules.trustedOnly} /> Trusted contributors only</label>
+        <label><input type="checkbox" bind:checked={draft.promotion.autoPromoteTrusted} /> {t(M['content.contribution_type_manager.auto_promote_trusted'])}</label>
+        <label><input type="checkbox" bind:checked={draft.promotion.createAssets} /> {t(M['content.contribution_type_manager.create_assets_on_promotion'])}</label>
+        <label><input type="checkbox" bind:checked={draft.intakeRules.trustedOnly} /> {t(M['content.contribution_type_manager.trusted_contributors_only'])}</label>
       </div>
 
       <label>
-        Max files
+        {t(M['content.contribution_type_manager.max_files'])}
         <input type="number" min="0" bind:value={draft.intakeRules.maxFiles} />
       </label>
       <label>
-        Max total bytes
+        {t(M['content.contribution_type_manager.max_total_bytes'])}
         <input type="number" min="0" bind:value={draft.intakeRules.maxTotalBytes} />
       </label>
       <label>
-        Allowed MIME patterns
-        <input type="text" bind:value={draft.intakeRules.allowedMimePatterns} placeholder="image/*, video/mp4" />
+        {t(M['content.contribution_type_manager.allowed_mime_patterns'])}
+        <input type="text" bind:value={draft.intakeRules.allowedMimePatterns} placeholder={t(M['content.contribution_type_manager.allowed_mime_patterns_placeholder'])} />
       </label>
       <label>
-        Blocked MIME patterns
+        {t(M['content.contribution_type_manager.blocked_mime_patterns'])}
         <input type="text" bind:value={draft.intakeRules.blockedMimePatterns} />
       </label>
       <label>
-        Quarantine MIME patterns
+        {t(M['content.contribution_type_manager.quarantine_mime_patterns'])}
         <input type="text" bind:value={draft.intakeRules.quarantineMimePatterns} />
       </label>
       <label>
-        Blocked text patterns
+        {t(M['content.contribution_type_manager.blocked_text_patterns'])}
         <textarea bind:value={draft.intakeRules.blockedTextPatterns} rows="2"></textarea>
       </label>
       <label>
-        Quarantine text patterns
+        {t(M['content.contribution_type_manager.quarantine_text_patterns'])}
         <textarea bind:value={draft.intakeRules.quarantineTextPatterns} rows="2"></textarea>
       </label>
 
       <div class="actions">
-        <button type="submit">Save type</button>
+        <button type="submit">{t(M['content.contribution_type_manager.save_type'])}</button>
       </div>
     </form>
   </div>

--- a/packages/content/src/svelte/components/ContentContributorManager.svelte
+++ b/packages/content/src/svelte/components/ContentContributorManager.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type { ContentContributorData } from '../../mock-smrt-client';
+import { M } from '../i18n.contribution.js';
+
+const { t } = useI18n();
 
 export interface Props {
   contributors?: ContentContributorData[];
@@ -39,9 +43,9 @@ function handleSubmit() {
   <header>
     <div>
       <h3>Contributors</h3>
-      <p>Manage contributor trust levels for intake queue bypass and moderation.</p>
+      <p>{t(M['content.contributor_manager.intro'])}</p>
     </div>
-    <button type="button" onclick={() => (editing = {})}>Add contributor</button>
+    <button type="button" onclick={() => (editing = {})}>{t(M['content.contributor_manager.add_contributor'])}</button>
   </header>
 
   <div class="layout">
@@ -78,7 +82,7 @@ function handleSubmit() {
         <input type="text" bind:value={draft.name} />
       </label>
       <label>
-        Trust level
+        {t(M['content.contributor_manager.trust_level'])}
         <select bind:value={draft.trustLevel}>
           <option value="standard">standard</option>
           <option value="trusted">trusted</option>
@@ -87,7 +91,7 @@ function handleSubmit() {
       </label>
 
       <div class="actions">
-        <button type="submit">Save contributor</button>
+        <button type="submit">{t(M['content.contributor_manager.save_contributor'])}</button>
       </div>
     </form>
   </div>

--- a/packages/content/src/svelte/components/ContentCorrectionsTool.svelte
+++ b/packages/content/src/svelte/components/ContentCorrectionsTool.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type { ContentCorrectionData, FactData } from '../../mock-smrt-client';
 import { createClient } from '../../mock-smrt-client';
 import { normalizeApiBaseUrl } from '../api';
+import { M } from '../i18n.tools.js';
+
+const { t } = useI18n();
 
 export interface Props {
   apiBaseUrl?: string;
@@ -164,21 +168,21 @@ async function issueCorrection() {
   {/if}
 
   {#if !savedContentId}
-    <p class="empty-copy">Save this content to issue corrections.</p>
+    <p class="empty-copy">{t(M['content.corrections_tool.save_to_issue_corrections'])}</p>
   {:else}
     <label class="workflow-field">
       Summary
       <input
         type="text"
         bind:value={correctionSummary}
-        placeholder="What was wrong?"
+        placeholder={t(M['content.corrections_tool.what_was_wrong'])}
       />
     </label>
 
     <label class="workflow-field">
-      Related fact
+      {t(M['content.corrections_tool.related_fact'])}
       <select bind:value={correctionFactId}>
-        <option value="">General correction</option>
+        <option value="">{t(M['content.corrections_tool.general_correction'])}</option>
         {#each facts as fact (fact.id)}
           <option value={fact.id ?? ''}>{fact.textRefined}</option>
         {/each}
@@ -186,26 +190,26 @@ async function issueCorrection() {
     </label>
 
     <label class="workflow-field">
-      Corrected fact text
+      {t(M['content.corrections_tool.corrected_fact_text'])}
       <textarea
         rows="4"
         bind:value={correctedFactText}
-        placeholder="Provide the corrected claim or wording"
+        placeholder={t(M['content.corrections_tool.provide_corrected_wording'])}
       ></textarea>
     </label>
 
     <label class="workflow-field">
-      Public note
+      {t(M['content.corrections_tool.public_note'])}
       <textarea
         rows="3"
         bind:value={correctionPublicNote}
-        placeholder="Optional public-facing correction note"
+        placeholder={t(M['content.corrections_tool.optional_public_correction_note'])}
       ></textarea>
     </label>
 
     <label class="checkbox-row">
       <input type="checkbox" bind:checked={publishCorrection} />
-      Publish immediately
+      {t(M['content.corrections_tool.publish_immediately'])}
     </label>
 
     <button
@@ -217,9 +221,9 @@ async function issueCorrection() {
     </button>
 
     <div class="tool-list">
-      <div class="section-caption">Published history</div>
+      <div class="section-caption">{t(M['content.corrections_tool.published_history'])}</div>
       {#if corrections.length === 0}
-        <p class="empty-copy">No corrections issued.</p>
+        <p class="empty-copy">{t(M['content.corrections_tool.no_corrections_issued'])}</p>
       {:else}
         {#each corrections as correction (correction.id ?? `${correction.correctionType}-${correction.createdAt}`)}
           <div class="tool-card">

--- a/packages/content/src/svelte/components/ContentEditor.svelte
+++ b/packages/content/src/svelte/components/ContentEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { ImageLike } from '@happyvertical/smrt-images/svelte';
 import { ImageUploader } from '@happyvertical/smrt-images/svelte';
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import { untrack } from 'svelte';
 import { extractBodyImages, resolveBodyFormat } from '../../body-format';
 import type {
@@ -26,11 +27,14 @@ import {
   getContentEditorSnapshot,
   normalizePublishDate,
 } from '../content-editor-form';
+import { M } from '../i18n.editor.js';
 import ContentAgentChat from './ContentAgentChat.svelte';
 import ContentBodyEditor, {
   type ContentBodyEditorChange,
 } from './ContentBodyEditor.svelte';
 import ContentImageChooser from './ContentImageChooser.svelte';
+
+const { t } = useI18n();
 
 export interface Props {
   apiBaseUrl?: string;
@@ -940,7 +944,7 @@ function removeAsset(id: string) {
           </div>
           <div class="mui-field">
             <input id="publish-date-input" type="datetime-local" bind:value={formData.publish_date} class="mui-input" />
-            <label for="publish-date-input">Publish Date</label>
+            <label for="publish-date-input">{t(M['content.content_editor.publish_date'])}</label>
           </div>
         </div>
         {#if showActions}
@@ -960,8 +964,8 @@ function removeAsset(id: string) {
       <input 
          type="text" 
          class="document-title-input" 
-         bind:value={formData.title} 
-         placeholder="Document title..."
+         bind:value={formData.title}
+         placeholder={t(M['content.content_editor.document_title_placeholder'])}
          required 
       />
 
@@ -969,7 +973,15 @@ function removeAsset(id: string) {
         <div class="undo-banner">
           <span class="undo-banner__text">
             <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 14l-4-4 4-4"/><path d="M5 10h11a4 4 0 0 1 0 8h-1"/></svg>
-            AI updated {lastAppliedFields.length} field{lastAppliedFields.length !== 1 ? 's' : ''}: {lastAppliedFields.join(', ')}
+            {t(M['content.content_editor.ai_updated_fields'], {
+              count: lastAppliedFields.length,
+              fieldLabel: t(
+                lastAppliedFields.length !== 1
+                  ? M['content.content_editor.field_plural']
+                  : M['content.content_editor.field_singular'],
+              ),
+              fields: lastAppliedFields.join(', '),
+            })}
           </span>
           <button type="button" class="undo-banner__btn" onclick={undoLastApply}>
             Undo{fieldUndoStack.length > 1 ? ` (${fieldUndoStack.length})` : ''}
@@ -1040,18 +1052,18 @@ function removeAsset(id: string) {
                         class="media-item"
                         class:is-thumbnail={assetId === formData.thumbnailAssetId}
                         draggable="true"
-                        title="Drag into the body"
+                        title={t(M['content.content_editor.drag_into_body'])}
                         ondragstart={(event) => handleAttachedImageDragStart(event, asset)}
                       >
                         <img class="media-item-image" src={getAssetImageSource(asset)} alt={asset.name || 'Asset image'} />
                         <div class="media-item-overlay">
                            {#if assetId && assetId !== formData.thumbnailAssetId}
-                             <button type="button" class="btn-make-thumbnail" title="Make Thumbnail" onclick={() => setThumbnail(assetId)}>
+                             <button type="button" class="btn-make-thumbnail" title={t(M['content.content_editor.make_thumbnail'])} onclick={() => setThumbnail(assetId)}>
                                <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
                              </button>
                            {/if}
                            {#if assetId}
-                             <button type="button" class="btn-remove-asset" title="Remove" onclick={() => removeAsset(assetId)}>
+                             <button type="button" class="btn-remove-asset" title={t(M['content.content_editor.remove'])} onclick={() => removeAsset(assetId)}>
                                <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
                              </button>
                            {/if}
@@ -1063,7 +1075,7 @@ function removeAsset(id: string) {
                     {/each}
                   </div>
                 {:else}
-                  <p class="no-media-text">No images attached.</p>
+                  <p class="no-media-text">{t(M['content.content_editor.no_images_attached'])}</p>
                 {/if}
                 {#if !showImageUploader}
                   <button type="button" class="add-image-btn" onclick={() => showImageUploader = true} style="margin-top: 1rem;">
@@ -1072,7 +1084,7 @@ function removeAsset(id: string) {
                       <circle cx="8.5" cy="8.5" r="1.5"></circle>
                       <polyline points="21 15 16 10 5 21"></polyline>
                     </svg>
-                    Add Image
+                    {t(M['content.content_editor.add_image'])}
                   </button>
                 {/if}
 
@@ -1099,18 +1111,18 @@ function removeAsset(id: string) {
         <div class="editor-drawer-content">
           <label>
             Author:
-            <input type="text" bind:value={formData.author} placeholder="Author name" />
+            <input type="text" bind:value={formData.author} placeholder={t(M['content.content_editor.author_name_placeholder'])} />
           </label>
           <label>
             Description:
-            <textarea bind:value={formData.description} rows="2" placeholder="Brief summary..."></textarea>
+            <textarea bind:value={formData.description} rows="2" placeholder={t(M['content.content_editor.brief_summary_placeholder'])}></textarea>
           </label>
           <label>
-            Tags (Comma separated):
+            {t(M['content.content_editor.tags_comma_separated'])}
             <input
               type="text"
               value={(formData.tags || []).join(', ')}
-              placeholder="e.g. news, tech"
+              placeholder={t(M['content.content_editor.tags_placeholder'])}
               oninput={(event) => parseTagsInput((event.currentTarget as HTMLInputElement).value)}
             />
           </label>
@@ -1145,7 +1157,7 @@ function removeAsset(id: string) {
                     </div>
                   {/each}
                   {#if formData.referenceIds.length === 0 && auditReferences.length === 0}
-                    <span class="no-refs">No references.</span>
+                    <span class="no-refs">{t(M['content.content_editor.no_references'])}</span>
                   {/if}
                </div>
                {#if auditReferences.length > 0}
@@ -1157,7 +1169,14 @@ function removeAsset(id: string) {
                      <p class="evidence-message evidence-message--notice">{evidenceNotice}</p>
                    {/if}
                    <div class="evidence-bulk-toolbar">
-                     <span>{selectedEvidenceCount} evidence item{selectedEvidenceCount === 1 ? '' : 's'} selected</span>
+                     <span>{t(M['content.content_editor.evidence_items_selected'], {
+                       count: selectedEvidenceCount,
+                       itemLabel: t(
+                         selectedEvidenceCount === 1
+                           ? M['content.content_editor.evidence_item_singular']
+                           : M['content.content_editor.evidence_item_plural'],
+                       ),
+                     })}</span>
                      <select bind:value={bulkEvidenceStatus} disabled={selectedEvidenceCount === 0 || Boolean(evidenceBusy)}>
                        {#each evidenceStatuses as status}
                          <option value={status}>{status}</option>
@@ -1175,7 +1194,7 @@ function removeAsset(id: string) {
                        disabled={selectedEvidenceCount === 0 || Boolean(evidenceBusy)}
                        onclick={() => void repairSelectedReferenceEvidence()}
                      >
-                       Repair resources
+                       {t(M['content.content_editor.repair_resources'])}
                      </button>
                    </div>
                    {#each auditReferences as reference, referenceIndex (reference._auditSourceId ?? reference.id ?? reference.url ?? reference.title)}
@@ -1193,7 +1212,14 @@ function removeAsset(id: string) {
                            {/if}
                          </div>
                          <div class="reference-detail-actions">
-                           <span>{resourceClaims.length} evidence claim{resourceClaims.length === 1 ? '' : 's'}</span>
+                           <span>{t(M['content.content_editor.evidence_claims'], {
+                             count: resourceClaims.length,
+                             claimLabel: t(
+                               resourceClaims.length === 1
+                                 ? M['content.content_editor.evidence_claim_singular']
+                                 : M['content.content_editor.evidence_claim_plural'],
+                             ),
+                           })}</span>
                            <button
                              type="button"
                              disabled={Boolean(evidenceBusy)}
@@ -1288,7 +1314,7 @@ function removeAsset(id: string) {
                  </div>
                {/if}
                <div class="add-reference-row">
-                  <input type="text" bind:value={newReferenceId} placeholder="Reference ID or URL" />
+                  <input type="text" bind:value={newReferenceId} placeholder={t(M['content.content_editor.reference_id_or_url_placeholder'])} />
                   <button type="button" onclick={addReference}>Add</button>
                </div>
             </div>
@@ -1298,7 +1324,7 @@ function removeAsset(id: string) {
               <input type="url" bind:value={formData.url} />
             </label>
             <label>
-              File Key:
+              {t(M['content.content_editor.file_key'])}
               <input type="text" bind:value={formData.fileKey} />
             </label>
           </div>
@@ -1325,7 +1351,7 @@ function removeAsset(id: string) {
               class="chat-sidebar-empty-state"
               data-testid="content-editor-agent-chat-disabled"
             >
-              <h3>Agent chat unavailable</h3>
+              <h3>{t(M['content.content_editor.agent_chat_unavailable'])}</h3>
               <p>
                 {agentChatNotice ||
                   'Run the content package dev server to use the agent chat sidebar for this editor.'}

--- a/packages/content/src/svelte/components/ContentGovernanceAssignmentEditor.svelte
+++ b/packages/content/src/svelte/components/ContentGovernanceAssignmentEditor.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type {
   ContentGovernanceAssignmentData,
   ContentGovernanceProfileData,
 } from '../../mock-smrt-client';
+import { M } from '../i18n.tools.js';
+
+const { t } = useI18n();
 
 export interface Props {
   assignment?: Partial<ContentGovernanceAssignmentData>;
@@ -99,33 +103,33 @@ function handleSubmit() {
     <input type="text" bind:value={draft.label} />
   </label>
   <label>
-    Content type
+    {t(M['content.governance_assignment_editor.content_type'])}
     <input type="text" bind:value={draft.contentType} required />
   </label>
   <label>
-    Content variant
+    {t(M['content.governance_assignment_editor.content_variant'])}
     <input type="text" bind:value={draft.contentVariant} />
   </label>
   <label>
-    Publication profile
+    {t(M['content.governance_assignment_editor.publication_profile'])}
     <select bind:value={draft.publicationProfileKey}>
-      <option value="" disabled={profiles.length > 0}>Select a profile</option>
+      <option value="" disabled={profiles.length > 0}>{t(M['content.governance_assignment_editor.select_a_profile'])}</option>
       {#each profiles as profile (profile.key)}
         <option value={profile.key}>{profile.label}</option>
       {/each}
     </select>
   </label>
   <label>
-    Correction profile
+    {t(M['content.governance_assignment_editor.correction_profile'])}
     <select bind:value={draft.correctionProfileKey}>
-      <option value="" disabled={profiles.length > 0}>Select a profile</option>
+      <option value="" disabled={profiles.length > 0}>{t(M['content.governance_assignment_editor.select_a_profile'])}</option>
       {#each profiles as profile (profile.key)}
         <option value={profile.key}>{profile.label}</option>
       {/each}
     </select>
   </label>
   <label>
-    Default fact relationship
+    {t(M['content.governance_assignment_editor.default_fact_relationship'])}
     <select bind:value={draft.defaultFactRelationship}>
       <option value="supports">supports</option>
       <option value="referenced_in">referenced_in</option>
@@ -141,7 +145,7 @@ function handleSubmit() {
     </label>
     <label class="checkbox">
       <input type="checkbox" bind:checked={draft.factLinkingEnabled} />
-      Fact linking
+      {t(M['content.governance_assignment_editor.fact_linking'])}
     </label>
     <label class="checkbox">
       <input type="checkbox" bind:checked={draft.transparencyEnabled} />
@@ -149,12 +153,12 @@ function handleSubmit() {
     </label>
     <label class="checkbox">
       <input type="checkbox" bind:checked={draft.enforcePublishReadiness} />
-      Enforce publish readiness
+      {t(M['content.governance_assignment_editor.enforce_publish_readiness'])}
     </label>
   </div>
 
   <div class="actions">
-    <button type="submit">Save assignment</button>
+    <button type="submit">{t(M['content.governance_assignment_editor.save_assignment'])}</button>
     {#if onCancel}
       <button type="button" class="secondary" onclick={() => onCancel?.()}>
         Cancel

--- a/packages/content/src/svelte/components/ContentGovernanceManager.svelte
+++ b/packages/content/src/svelte/components/ContentGovernanceManager.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import { onMount } from 'svelte';
 import {
   type ContentGovernanceAssignmentData,
@@ -9,6 +10,7 @@ import {
 } from '../../mock-smrt-client';
 import { normalizeApiBaseUrl } from '../api';
 import type { ContentGovernanceManagerClient } from '../governance-manager-client';
+import { M } from '../i18n.tools.js';
 import ContentGovernanceAssignmentEditor from './ContentGovernanceAssignmentEditor.svelte';
 import ContentGovernancePolicyEditor from './ContentGovernancePolicyEditor.svelte';
 import ContentGovernanceProfileEditor from './ContentGovernanceProfileEditor.svelte';
@@ -26,6 +28,8 @@ let {
   client = undefined,
   onChange = undefined,
 }: Props = $props();
+
+const { t } = useI18n();
 
 const governanceClient = $derived(
   client ?? createClient(normalizeApiBaseUrl(apiBaseUrl)),
@@ -134,8 +138,8 @@ function cancelEditing() {
 <div class="governance-manager">
   <div class="governance-manager__header">
     <div>
-      <h3>Content Governance</h3>
-      <p>Manage effective policies, profiles, and type assignments for governed content.</p>
+      <h3>{t(M['content.governance_manager.content_governance'])}</h3>
+      <p>{t(M['content.governance_manager.manage_governed_content'])}</p>
     </div>
     <button type="button" class="secondary" onclick={() => void loadDefinitions()}>
       Refresh
@@ -143,7 +147,7 @@ function cancelEditing() {
   </div>
 
   {#if loading}
-    <p>Loading governance definitions...</p>
+    <p>{t(M['content.governance_manager.loading_governance_definitions'])}</p>
   {:else if error}
     <p class="error">{error}</p>
   {:else if definitions}
@@ -155,7 +159,7 @@ function cancelEditing() {
             editMode = 'policy';
             editingPolicy = null;
           }}>
-            Add policy
+            {t(M['content.governance_manager.add_policy'])}
           </button>
         </div>
         {#if editMode === 'policy'}
@@ -183,7 +187,7 @@ function cancelEditing() {
                 </button>
                 {#if definitions.persisted.policies.some((item) => item.key === policy.key)}
                   <button type="button" class="secondary" onclick={() => void deletePolicy(policy.id)}>
-                    Delete override
+                    {t(M['content.governance_manager.delete_override'])}
                   </button>
                 {/if}
               </div>
@@ -199,7 +203,7 @@ function cancelEditing() {
             editMode = 'profile';
             editingProfile = null;
           }}>
-            Add profile
+            {t(M['content.governance_manager.add_profile'])}
           </button>
         </div>
         {#if editMode === 'profile'}
@@ -228,7 +232,7 @@ function cancelEditing() {
                 </button>
                 {#if definitions.persisted.profiles.some((item) => item.key === profile.key)}
                   <button type="button" class="secondary" onclick={() => void deleteProfile(profile.id)}>
-                    Delete override
+                    {t(M['content.governance_manager.delete_override'])}
                   </button>
                 {/if}
               </div>
@@ -244,7 +248,7 @@ function cancelEditing() {
             editMode = 'assignment';
             editingAssignment = null;
           }}>
-            Add assignment
+            {t(M['content.governance_manager.add_assignment'])}
           </button>
         </div>
         {#if editMode === 'assignment'}

--- a/packages/content/src/svelte/components/ContentGovernancePanel.svelte
+++ b/packages/content/src/svelte/components/ContentGovernancePanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import {
   type ContentCorrectionData,
   type ContentGovernanceDefinitionsData,
@@ -16,6 +17,9 @@ import {
   type ResolvedContentGovernanceData,
 } from '../../mock-smrt-client';
 import { normalizeApiBaseUrl } from '../api';
+import { M } from '../i18n.governance.js';
+
+const { t } = useI18n();
 
 export interface Props {
   apiBaseUrl?: string;
@@ -1038,7 +1042,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
     <details class="editor-drawer" open={(factAudit?.counts.total ?? 0) > 0}>
     <summary class="editor-drawer-header">
       <div style="display: flex; align-items: center; gap: 0.5rem;">
-        Article claim audit
+        {t(M['content.governance_panel.article_claim_audit'])}
         {#if factAuditBusy}
           <span class="section-status" style="font-size: 0.875rem; font-weight: 400; color: var(--smrt-color-outline);">Repairing...</span>
         {/if}
@@ -1047,11 +1051,11 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
     </summary>
     <div class="editor-drawer-content">
       {#if !savedContentId}
-        <p class="empty-copy">Save this content to audit article claims against evidence.</p>
+        <p class="empty-copy">{t(M['content.governance_panel.save_to_audit_claims'])}</p>
       {:else}
         <div class="claim-audit-toolbar">
           <div class="claim-audit-counts">
-            <span><strong>{factAudit?.counts.total ?? 0}</strong> article claims</span>
+            <span><strong>{factAudit?.counts.total ?? 0}</strong> {t(M['content.governance_panel.article_claims'])}</span>
             <span><strong>{factAudit?.counts.supported ?? 0}</strong> supported</span>
             <span><strong>{factAudit?.counts.unsupported ?? 0}</strong> unsupported</span>
             <span><strong>{factAudit?.counts.contradicted ?? 0}</strong> contradicted</span>
@@ -1075,7 +1079,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
           </button>
         </div>
         <p class="claim-audit-help">
-          Article claims are statements made by this draft. A supported claim has linked source evidence from the references; unsupported means the audit has not found that supporting evidence yet.
+          {t(M['content.governance_panel.article_claims_help'])}
         </p>
 
         {#if actionableFactAuditWarnings.length}
@@ -1088,7 +1092,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
 
         {#if !factAudit || factAudit.counts.total === 0}
           <p class="empty-copy">
-            No article claim audit has been generated yet.
+            {t(M['content.governance_panel.no_claim_audit_generated'])}
           </p>
         {:else}
           {#each [
@@ -1101,7 +1105,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
             {@const groupClaims = factAuditGroups[groupKey]}
             {#if groupClaims.length > 0}
               <div class="claim-audit-group">
-                <div class="section-caption">{group[1]} article claims</div>
+                <div class="section-caption">{t(M['content.governance_panel.group_article_claims'], { group: group[1] })}</div>
                 {#each groupClaims as claim (claim.id ?? claim.claimQuote ?? claim.fact.textRefined)}
                   <details class="claim-audit-item">
                     <summary>
@@ -1129,18 +1133,18 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
                             if (claimId) void recheckFactClaims([claimId]);
                           }}
                         >
-                          Recheck support
+                          {t(M['content.governance_panel.recheck_support'])}
                         </button>
                       </div>
                       {#if claim.claimQuote}
-                        <p><strong>Article claim:</strong> {claim.claimQuote}</p>
+                        <p><strong>{t(M['content.governance_panel.article_claim_label'])}</strong> {claim.claimQuote}</p>
                       {/if}
                       {#if claim.rationale}
-                        <p><strong>Support assessment:</strong> {claim.rationale}</p>
+                        <p><strong>{t(M['content.governance_panel.support_assessment_label'])}</strong> {claim.rationale}</p>
                       {/if}
                       {#if claim.evidence?.length}
                         <div class="claim-audit-evidence">
-                          <div class="section-caption">Claim excerpt</div>
+                          <div class="section-caption">{t(M['content.governance_panel.claim_excerpt'])}</div>
                           {#each claim.evidence as evidence (evidence.id ?? evidence.evidenceKey)}
                             <p>{evidence.quote || evidence.locator || evidence.sourceTitle}</p>
                           {/each}
@@ -1148,10 +1152,10 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
                       {/if}
                       {#if claim.matchedFacts?.length}
                         <div class="claim-audit-evidence">
-                          <div class="section-caption">Based on source evidence</div>
+                          <div class="section-caption">{t(M['content.governance_panel.based_on_source_evidence'])}</div>
                           {#each claim.matchedFacts as matched (matched.fact.id ?? matched.fact.textRefined)}
                             <div class="claim-audit-match">
-                              <strong>Source claim: {matched.fact.textRefined || matched.fact.textRaw || matched.fact.id}</strong>
+                              <strong>{t(M['content.governance_panel.source_claim_label'])} {matched.fact.textRefined || matched.fact.textRaw || matched.fact.id}</strong>
                               {#each matched.evidence ?? [] as evidence (evidence.id ?? evidence.evidenceKey)}
                                 <span>
                                   {evidence.sourceTitle || 'Source'}
@@ -1167,7 +1171,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
                           {/each}
                         </div>
                       {:else}
-                        <p><strong>Based on:</strong> No supporting source evidence linked.</p>
+                        <p><strong>{t(M['content.governance_panel.based_on_label'])}</strong> {t(M['content.governance_panel.no_supporting_source_evidence'])}</p>
                       {/if}
                     </div>
                   </details>
@@ -1185,9 +1189,9 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
     <details class="editor-drawer" open={selectedFactsResolved.length > 0}>
       <summary class="editor-drawer-header">
         <div style="display: flex; align-items: center; gap: 0.5rem;">
-          Manual fact links
+          {t(M['content.governance_panel.manual_fact_links'])}
           {#if syncingFacts}
-            <span class="section-status" style="font-size: 0.875rem; font-weight: 400; color: var(--smrt-color-outline);">Saving links...</span>
+            <span class="section-status" style="font-size: 0.875rem; font-weight: 400; color: var(--smrt-color-outline);">{t(M['content.governance_panel.saving_links'])}</span>
           {/if}
         </div>
         <svg class="drawer-icon" viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
@@ -1195,13 +1199,13 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
       <div class="editor-drawer-content">
         {#if governanceState && !governanceState.factLinkingEnabled}
           <p class="empty-copy">
-            Fact linking is not enabled for this governed content type.
+            {t(M['content.governance_panel.fact_linking_not_enabled'])}
           </p>
         {:else}
           <div class="selected-facts">
-            <div class="section-caption">Manually linked facts</div>
+            <div class="section-caption">{t(M['content.governance_panel.manually_linked_facts'])}</div>
             {#if selectedFactsResolved.length === 0}
-              <p class="empty-copy">No manually linked facts yet.</p>
+              <p class="empty-copy">{t(M['content.governance_panel.no_manually_linked_facts'])}</p>
             {:else}
               <div class="fact-chip-list">
                 {#each selectedFactsResolved as fact (fact.id ?? fact.textRefined)}
@@ -1230,7 +1234,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
               <input
                 type="text"
                 bind:value={factQuery}
-                placeholder="Search fact catalog"
+                placeholder={t(M['content.governance_panel.search_fact_catalog'])}
               />
               <button type="button" onclick={searchFactsFirstPage}>
                 Search
@@ -1242,11 +1246,11 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
             {/if}
 
             <div class="fact-catalog">
-              <div class="section-caption">Fact catalog</div>
+              <div class="section-caption">{t(M['content.governance_panel.fact_catalog'])}</div>
               {#if catalogLoading}
-                <p class="empty-copy">Loading facts...</p>
+                <p class="empty-copy">{t(M['content.governance_panel.loading_facts'])}</p>
               {:else if catalogFacts.length === 0}
-                <p class="empty-copy">No facts matched this search.</p>
+                <p class="empty-copy">{t(M['content.governance_panel.no_facts_matched'])}</p>
               {:else}
                 <div class="fact-catalog__list">
                   {#each catalogFacts as fact (fact.id ?? fact.textRefined)}
@@ -1270,7 +1274,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
               {/if}
 
               {#if catalogFacts.length > 0 || catalogPage > 1}
-                <div class="fact-pagination" aria-label="Fact catalog pagination">
+                <div class="fact-pagination" aria-label={t(M['content.governance_panel.fact_catalog_pagination'])}>
                   <span>
                     Page {catalogPage}
                     {#if catalogFacts.length > 0}
@@ -1327,12 +1331,12 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
 
     {#if !savedContentId}
       <p class="empty-copy">
-        Save this content to run governance reviews, corrections, and version management.
+        {t(M['content.governance_panel.save_to_run_governance'])}
       </p>
     {:else}
       {#if reviewProfiles.length > 0}
         <label class="workflow-field">
-          Review profile
+          {t(M['content.governance_panel.review_profile'])}
           <select bind:value={activeReviewProfileKey}>
             {#each reviewProfiles as profile (profile.profileKey)}
               <option value={profile.profileKey}>
@@ -1359,15 +1363,15 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
 
           {#if activeUnsatisfiedRequirements.length > 0}
             <div class="review-profile-callout">
-              <strong>Needs attention</strong>
+              <strong>{t(M['content.governance_panel.needs_attention'])}</strong>
               <span>
-                {activeUnsatisfiedRequirements.length} review requirement(s) still need attention before this profile is fully ready.
+                {t(M['content.governance_panel.requirements_need_attention'], { count: activeUnsatisfiedRequirements.length })}
               </span>
             </div>
           {/if}
 
           {#if activeReviewProfile.requirements?.length === 0}
-            <p class="empty-copy">No review requirements are configured for this profile.</p>
+            <p class="empty-copy">{t(M['content.governance_panel.no_review_requirements'])}</p>
           {:else}
             <div class="review-profile-list">
               {#each activeReviewProfile.requirements as requirement (requirement.policyKey)}
@@ -1410,7 +1414,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
       <div class="workflow-field-group">
         {#if availableCustomPolicies.length > 0}
           <label class="workflow-field">
-            App review policy
+            {t(M['content.governance_panel.app_review_policy'])}
             <select bind:value={activeCustomPolicyKey}>
               {#each availableCustomPolicies as policy (policy.key)}
                 <option value={policy.key}>
@@ -1426,7 +1430,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
           <textarea
             rows="3"
             bind:value={customReviewText}
-            placeholder="Optional additional review instructions"
+            placeholder={t(M['content.governance_panel.optional_review_instructions'])}
           ></textarea>
         </label>
         <button
@@ -1451,9 +1455,9 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
       </div>
 
       <div class="review-list">
-        <div class="section-caption">Recent reviews</div>
+        <div class="section-caption">{t(M['content.governance_panel.recent_reviews'])}</div>
         {#if reviews.length === 0}
-          <p class="empty-copy">No reviews have been run yet.</p>
+          <p class="empty-copy">{t(M['content.governance_panel.no_reviews_run'])}</p>
         {:else}
           {#each reviews as review (review.id ?? `${review.kind}-${review.createdAt}`)}
             <div class="review-card">
@@ -1478,7 +1482,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
                     </div>
                   {/each}
                   {#if review.findings.length > 2}
-                    <span>+ {review.findings.length - 2} more finding(s)</span>
+                    <span>{t(M['content.governance_panel.more_findings'], { count: review.findings.length - 2 })}</span>
                   {/if}
                 </div>
               {:else}
@@ -1508,23 +1512,23 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
 
     {#if !savedContentId}
       <p class="empty-copy">
-        Save this content to preview the public transparency breakdown.
+        {t(M['content.governance_panel.save_to_preview_transparency'])}
       </p>
     {:else if governanceState && !governanceState.transparencyEnabled}
       <p class="empty-copy">
-        Public transparency snapshots are not enabled for this governed content type.
+        {t(M['content.governance_panel.transparency_snapshots_not_enabled'])}
       </p>
     {:else if !transparencyPreview}
-      <p class="empty-copy">No transparency preview is available yet.</p>
+      <p class="empty-copy">{t(M['content.governance_panel.no_transparency_preview'])}</p>
     {:else}
       <p class="section-caption">
-        The preview below reflects the latest saved article state. The published snapshot stays frozen until the next successful publication.
+        {t(M['content.governance_panel.transparency_preview_explainer'])}
       </p>
 
       <div class="transparency-stats">
         <div class="transparency-stat">
           <strong>{transparencyPreview.factsUsed.length}</strong>
-          <span>Facts used</span>
+          <span>{t(M['content.governance_panel.facts_used'])}</span>
         </div>
         <div class="transparency-stat">
           <strong>{transparencyPreview.references.length}</strong>
@@ -1532,25 +1536,25 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
         </div>
         <div class="transparency-stat">
           <strong>{transparencyPreview.otherExtractedFacts.length}</strong>
-          <span>Other extracted facts</span>
+          <span>{t(M['content.governance_panel.other_extracted_facts'])}</span>
         </div>
         <div class="transparency-stat">
           <strong>{transparencyPreview.corrections.length}</strong>
-          <span>Public corrections</span>
+          <span>{t(M['content.governance_panel.public_corrections'])}</span>
         </div>
       </div>
 
       <div class="transparency-grid">
         <div class="transparency-card">
           <div class="transparency-card__header">
-            <strong>Current preview</strong>
+            <strong>{t(M['content.governance_panel.current_preview'])}</strong>
             <span class="pill pill--neutral">{transparencyPreview.snapshotKind}</span>
           </div>
           <span>
             {#if transparencyPreview.generation.publicPrompt}
-              Public prompt is set for publication.
+              {t(M['content.governance_panel.public_prompt_set'])}
             {:else}
-              No public prompt is exposed yet.
+              {t(M['content.governance_panel.no_public_prompt_exposed'])}
             {/if}
           </span>
           {#if transparencyPreview.generation.publicPrompt}
@@ -1561,9 +1565,9 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
 
           <div class="transparency-list">
             <div class="transparency-list__section">
-              <div class="section-caption">Facts used in the article</div>
+              <div class="section-caption">{t(M['content.governance_panel.facts_used_in_article'])}</div>
               {#if transparencyPreview.factsUsed.length === 0}
-                <p class="empty-copy">No used facts will be shown publicly yet.</p>
+                <p class="empty-copy">{t(M['content.governance_panel.no_used_facts_public'])}</p>
               {:else}
                 {#each transparencyPreview.factsUsed.slice(0, 3) as fact (fact.id ?? fact.textRefined ?? fact.textRaw)}
                   <div class="transparency-list__item">
@@ -1580,15 +1584,15 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
             </div>
 
             <div class="transparency-list__section">
-              <div class="section-caption">Source material</div>
+              <div class="section-caption">{t(M['content.governance_panel.source_material'])}</div>
               {#if transparencyPreview.references.length === 0}
-                <p class="empty-copy">No references will be shown publicly yet.</p>
+                <p class="empty-copy">{t(M['content.governance_panel.no_references_public'])}</p>
               {:else}
                 {#each transparencyPreview.references.slice(0, 3) as reference (reference.id ?? reference.url ?? reference.title)}
                   <div class="transparency-list__item">
                     <strong>{getTransparencyReferenceLabel(reference)}</strong>
                     <span>
-                      {reference.usedFactIds.length} used fact(s) · {reference.extractedFacts.length} extracted fact(s)
+                      {t(M['content.governance_panel.reference_fact_counts'], { used: reference.usedFactIds.length, extracted: reference.extractedFacts.length })}
                     </span>
                   </div>
                 {/each}
@@ -1599,7 +1603,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
 
         <div class="transparency-card">
           <div class="transparency-card__header">
-            <strong>Latest published snapshot</strong>
+            <strong>{t(M['content.governance_panel.latest_published_snapshot'])}</strong>
             {#if publishedTransparency?.publicationVersion?.version !== null && publishedTransparency?.publicationVersion?.version !== undefined}
               <span class="pill pill--passed">v{publishedTransparency.publicationVersion.version}</span>
             {/if}
@@ -1610,11 +1614,11 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
               Published {formatTimestamp(publishedTransparency.publicationVersion?.createdAt || publishedTransparency.generatedAt)}
             </span>
             <span>
-              {publishedTransparency.versionHistory.length} timeline event(s) and {publishedTransparency.corrections.length} public correction(s)
+              {t(M['content.governance_panel.timeline_and_corrections'], { events: publishedTransparency.versionHistory.length, corrections: publishedTransparency.corrections.length })}
             </span>
           {:else}
             <p class="empty-copy">
-              No published transparency snapshot yet. Publish this article to freeze one for the built site.
+              {t(M['content.governance_panel.no_published_snapshot'])}
             </p>
           {/if}
         </div>
@@ -1639,14 +1643,14 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
           <input
             type="text"
             bind:value={correctionSummary}
-            placeholder="What was wrong?"
+            placeholder={t(M['content.governance_panel.what_was_wrong'])}
           />
         </label>
 
         <label class="workflow-field">
-          Related fact
+          {t(M['content.governance_panel.related_fact'])}
           <select bind:value={correctionFactId}>
-            <option value="">General correction</option>
+            <option value="">{t(M['content.governance_panel.general_correction'])}</option>
             {#each selectedFactsResolved as fact (fact.id)}
               <option value={fact.id ?? ''}>{fact.textRefined}</option>
             {/each}
@@ -1654,26 +1658,26 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
         </label>
 
         <label class="workflow-field">
-          Corrected fact text
+          {t(M['content.governance_panel.corrected_fact_text'])}
           <textarea
             rows="4"
             bind:value={correctedFactText}
-            placeholder="Provide the corrected claim or wording"
+            placeholder={t(M['content.governance_panel.provide_corrected_wording'])}
           ></textarea>
         </label>
 
         <label class="workflow-field">
-          Public note
+          {t(M['content.governance_panel.public_note'])}
           <textarea
             rows="3"
             bind:value={correctionPublicNote}
-            placeholder="Optional public-facing correction note"
+            placeholder={t(M['content.governance_panel.optional_public_correction_note'])}
           ></textarea>
         </label>
 
         <label class="checkbox-row">
           <input type="checkbox" bind:checked={publishCorrection} />
-          Publish immediately
+          {t(M['content.governance_panel.publish_immediately'])}
         </label>
 
         <button
@@ -1685,9 +1689,9 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
         </button>
 
         <div class="review-list">
-          <div class="section-caption">Published history</div>
+          <div class="section-caption">{t(M['content.governance_panel.published_history'])}</div>
           {#if corrections.length === 0}
-            <p class="empty-copy">No corrections issued.</p>
+            <p class="empty-copy">{t(M['content.governance_panel.no_corrections_issued'])}</p>
           {:else}
             {#each corrections as correction (correction.id ?? `${correction.correctionType}-${correction.createdAt}`)}
               <div class="review-card">
@@ -1729,7 +1733,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
         <div class="editor-drawer-content">
 
         {#if versions.length === 0}
-          <p class="empty-copy">No versions saved yet.</p>
+          <p class="empty-copy">{t(M['content.governance_panel.no_versions_saved'])}</p>
         {:else}
           <div class="review-list">
             {#each versions as version (version.id ?? `version-${version.version ?? 0}`)}

--- a/packages/content/src/svelte/components/ContentGovernancePolicyEditor.svelte
+++ b/packages/content/src/svelte/components/ContentGovernancePolicyEditor.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type { ContentReviewPolicyData } from '../../mock-smrt-client';
+import { M } from '../i18n.tools.js';
+
+const { t } = useI18n();
 
 export interface Props {
   policy?: Partial<ContentReviewPolicyData>;
@@ -66,7 +70,7 @@ function handleSubmit() {
     Enabled
   </label>
   <div class="actions">
-    <button type="submit">Save policy</button>
+    <button type="submit">{t(M['content.governance_policy_editor.save_policy'])}</button>
     {#if onCancel}
       <button type="button" class="secondary" onclick={() => onCancel?.()}>
         Cancel

--- a/packages/content/src/svelte/components/ContentGovernanceProfileEditor.svelte
+++ b/packages/content/src/svelte/components/ContentGovernanceProfileEditor.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type {
   ContentGovernanceProfileData,
   ContentReviewPolicyData,
 } from '../../mock-smrt-client';
+import { M } from '../i18n.tools.js';
+
+const { t } = useI18n();
 
 export interface Props {
   profile?: Partial<ContentGovernanceProfileData>;
@@ -102,7 +106,7 @@ function handleSubmit() {
     <div class="requirements__header">
       <strong>Requirements</strong>
       <button type="button" class="secondary" onclick={addRequirement}>
-        Add requirement
+        {t(M['content.governance_profile_editor.add_requirement'])}
       </button>
     </div>
 
@@ -132,7 +136,7 @@ function handleSubmit() {
   </div>
 
   <div class="actions">
-    <button type="submit">Save profile</button>
+    <button type="submit">{t(M['content.governance_profile_editor.save_profile'])}</button>
     {#if onCancel}
       <button type="button" class="secondary" onclick={() => onCancel?.()}>
         Cancel

--- a/packages/content/src/svelte/components/ContentImageBrowser.svelte
+++ b/packages/content/src/svelte/components/ContentImageBrowser.svelte
@@ -3,7 +3,11 @@ import {
   type ImageLike,
   ImageUploader,
 } from '@happyvertical/smrt-images/svelte';
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type { ContentEditorAsset } from '../content-editor-form';
+import { M } from '../i18n.editor.js';
+
+const { t } = useI18n();
 
 export interface Props {
   apiBaseUrl?: string;
@@ -96,7 +100,7 @@ function handleSelect(selected: ImageLike | File | string) {
       {/each}
     </div>
   {:else}
-    <p class="empty-state">No images attached.</p>
+    <p class="empty-state">{t(M['content.content_image_browser.no_images_attached'])}</p>
   {/if}
 
   {#if showUploader}

--- a/packages/content/src/svelte/components/ContentImageChooser.svelte
+++ b/packages/content/src/svelte/components/ContentImageChooser.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import {
   type ContentBodyFormat,
   extractBodyImages,
   resolveBodyFormat,
 } from '../../body-format';
+import { M } from '../i18n.editor.js';
+
+const { t } = useI18n();
 
 export interface Props {
   body: string;
@@ -42,12 +46,12 @@ function cycle(delta: number) {
 </script>
 
 {#if activeImage}
-  <div class="content-image-chooser" aria-label="Body images">
+  <div class="content-image-chooser" aria-label={t(M['content.content_image_chooser.body_images'])}>
     {#if hasMultiple}
       <button
         type="button"
         class="chooser-arrow"
-        aria-label="Previous body image"
+        aria-label={t(M['content.content_image_chooser.previous_body_image'])}
         onclick={() => cycle(-1)}
       >
         <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -59,7 +63,7 @@ function cycle(delta: number) {
     <button
       type="button"
       class="chooser-preview"
-      aria-label="Focus selected body image"
+      aria-label={t(M['content.content_image_chooser.focus_selected_body_image'])}
       onclick={() => onSelect?.(normalizedIndex)}
     >
       <img src={activeImage.src} alt={activeImage.alt || 'Body image'} />
@@ -70,7 +74,7 @@ function cycle(delta: number) {
       <button
         type="button"
         class="chooser-arrow"
-        aria-label="Next body image"
+        aria-label={t(M['content.content_image_chooser.next_body_image'])}
         onclick={() => cycle(1)}
       >
         <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/packages/content/src/svelte/components/ContentList.svelte
+++ b/packages/content/src/svelte/components/ContentList.svelte
@@ -145,17 +145,17 @@ function handleDeleteContent(content: any) {
       {#if !type}
         <select bind:value={selectedType}>
           <option value="All Types">{t(M['content.content_list.all_types'])}</option>
-          <option>Articles</option>
-          <option>Documents</option>
-          <option>Mirrors</option>
+          <option value="Articles">Articles</option>
+          <option value="Documents">Documents</option>
+          <option value="Mirrors">Mirrors</option>
         </select>
       {/if}
       
       <select bind:value={selectedStatus}>
         <option value="All Statuses">{t(M['content.content_list.all_statuses'])}</option>
-        <option>Published</option>
-        <option>Draft</option>
-        <option>Archived</option>
+        <option value="Published">Published</option>
+        <option value="Draft">Draft</option>
+        <option value="Archived">Archived</option>
       </select>
       
       {#if controls}
@@ -303,13 +303,13 @@ function handleDeleteContent(content: any) {
             {#if getViewHref?.(content)}
               <a href={getViewHref(content) || '#'} class="quiet-action">{t(M['content.content_list.view_article'])}</a>
             {/if}
-            <button type="button" class="quiet-action" onclick={() => onEdit(content)}>Edit</button>
+            <button type="button" class="quiet-action" onclick={() => onEdit(content)}>{t(M['content.content_list.edit'])}</button>
             <button
               type="button"
               class="quiet-action quiet-action--danger"
               onclick={() => handleDeleteContent(content)}
             >
-              Delete
+              {t(M['content.content_list.delete'])}
             </button>
           </div>
         </article>
@@ -363,8 +363,8 @@ function handleDeleteContent(content: any) {
               {#if getViewHref?.(content)}
                 <a href={getViewHref(content) || '#'} class="view-btn">{t(M['content.content_list.view_article_button'])}</a>
               {/if}
-              <button onclick={() => onEdit(content)}>Edit</button>
-              <button onclick={() => handleDeleteContent(content)} class="delete-btn">Delete</button>
+              <button onclick={() => onEdit(content)}>{t(M['content.content_list.edit'])}</button>
+              <button onclick={() => handleDeleteContent(content)} class="delete-btn">{t(M['content.content_list.delete'])}</button>
             </div>
           </div>
         </div>

--- a/packages/content/src/svelte/components/ContentList.svelte
+++ b/packages/content/src/svelte/components/ContentList.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type { Snippet } from 'svelte';
 import { untrack } from 'svelte';
+import { M } from '../i18n.contribution.js';
 import ImageThumbnail from './ImageThumbnail.svelte';
+
+const { t } = useI18n();
 
 let {
   apiBaseUrl = '/api/v1',
@@ -136,11 +140,11 @@ function handleDeleteContent(content: any) {
   
   <div class="content-controls">
     <div class="search-filters">
-      <input type="text" placeholder="Search contents..." bind:value={searchTerm} />
+      <input type="text" placeholder={t(M['content.content_list.search_placeholder'])} bind:value={searchTerm} />
       
       {#if !type}
         <select bind:value={selectedType}>
-          <option>All Types</option>
+          <option value="All Types">{t(M['content.content_list.all_types'])}</option>
           <option>Articles</option>
           <option>Documents</option>
           <option>Mirrors</option>
@@ -148,7 +152,7 @@ function handleDeleteContent(content: any) {
       {/if}
       
       <select bind:value={selectedStatus}>
-        <option>All Statuses</option>
+        <option value="All Statuses">{t(M['content.content_list.all_statuses'])}</option>
         <option>Published</option>
         <option>Draft</option>
         <option>Archived</option>
@@ -165,7 +169,7 @@ function handleDeleteContent(content: any) {
           type="button"
           class:active={viewMode === 'grid'} 
           onclick={() => viewMode = 'grid'}
-          title="Grid View"
+          title={t(M['content.content_list.grid_view'])}
         >
           <svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none">
             <rect x="3" y="3" width="7" height="7"></rect>
@@ -178,7 +182,7 @@ function handleDeleteContent(content: any) {
           type="button"
           class:active={viewMode === 'detailed'} 
           onclick={() => viewMode = 'detailed'}
-          title="Detailed List"
+          title={t(M['content.content_list.detailed_list'])}
         >
           <svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none">
             <line x1="8" y1="6" x2="21" y2="6"></line>
@@ -193,7 +197,7 @@ function handleDeleteContent(content: any) {
           type="button"
           class:active={viewMode === 'compact'} 
           onclick={() => viewMode = 'compact'}
-          title="Compact List"
+          title={t(M['content.content_list.compact_list'])}
         >
           <svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none">
             <line x1="3" y1="6" x2="21" y2="6"></line>
@@ -208,14 +212,14 @@ function handleDeleteContent(content: any) {
           <line x1="12" y1="5" x2="12" y2="19"></line>
           <line x1="5" y1="12" x2="19" y2="12"></line>
         </svg>
-        Add Content
+        {t(M['content.content_list.add_content'])}
       </button>
     </div>
   </div>
 
   {#if filteredContents.length === 0}
     <div class="empty-state">
-      No contents match your filters.
+      {t(M['content.content_list.empty'])}
     </div>
   {:else if viewMode === 'compact'}
     <div class="content-table-wrapper">
@@ -244,10 +248,10 @@ function handleDeleteContent(content: any) {
               <td><span class="badge state-{getStateBadge(content.state)}">{content.state}</span></td>
               <td class="actions-cell">
                 {#if getViewHref?.(content)}
-                  <a class="icon-btn" href={getViewHref(content) || '#'} title="View published article">🔎</a>
+                  <a class="icon-btn" href={getViewHref(content) || '#'} title={t(M['content.content_list.view_published_article'])}>🔎</a>
                 {/if}
-                <button class="icon-btn" type="button" onclick={() => onEdit(content)} title="Edit">✏️</button>
-                <button class="icon-btn delete-icon" type="button" onclick={() => handleDeleteContent(content)} title="Delete">🗑️</button>
+                <button class="icon-btn" type="button" onclick={() => onEdit(content)} title={t(M['content.content_list.edit'])}>✏️</button>
+                <button class="icon-btn delete-icon" type="button" onclick={() => handleDeleteContent(content)} title={t(M['content.content_list.delete'])}>🗑️</button>
               </td>
             </tr>
           {/each}
@@ -278,7 +282,7 @@ function handleDeleteContent(content: any) {
               <div class="content-row__links">
                 {#if content.url}
                   <a href={content.url} target="_blank" rel="noreferrer">
-                    Source material
+                    {t(M['content.content_list.source_material'])}
                   </a>
                 {/if}
                 {#if content.fileKey}
@@ -297,7 +301,7 @@ function handleDeleteContent(content: any) {
 
           <div class="content-row__actions">
             {#if getViewHref?.(content)}
-              <a href={getViewHref(content) || '#'} class="quiet-action">View article</a>
+              <a href={getViewHref(content) || '#'} class="quiet-action">{t(M['content.content_list.view_article'])}</a>
             {/if}
             <button type="button" class="quiet-action" onclick={() => onEdit(content)}>Edit</button>
             <button
@@ -357,7 +361,7 @@ function handleDeleteContent(content: any) {
             
             <div class="content-actions">
               {#if getViewHref?.(content)}
-                <a href={getViewHref(content) || '#'} class="view-btn">View Article</a>
+                <a href={getViewHref(content) || '#'} class="view-btn">{t(M['content.content_list.view_article_button'])}</a>
               {/if}
               <button onclick={() => onEdit(content)}>Edit</button>
               <button onclick={() => handleDeleteContent(content)} class="delete-btn">Delete</button>

--- a/packages/content/src/svelte/components/ContentMetadataFields.svelte
+++ b/packages/content/src/svelte/components/ContentMetadataFields.svelte
@@ -1,4 +1,9 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../i18n.editor.js';
+
+const { t } = useI18n();
+
 export interface Props {
   data: Record<string, any>;
   onChange?: (change: Record<string, unknown>) => void;
@@ -47,7 +52,7 @@ function updateTags(value: string) {
     <input
       type="text"
       value={tagsValue}
-      placeholder="e.g. news, tech"
+      placeholder={t(M['content.content_metadata_fields.tags_placeholder'])}
       oninput={(event) => updateTags(event.currentTarget.value)}
     />
   </label>
@@ -60,7 +65,7 @@ function updateTags(value: string) {
     />
   </label>
   <label>
-    <span>File Key</span>
+    <span>{t(M['content.content_metadata_fields.file_key'])}</span>
     <input
       type="text"
       value={data.fileKey || ''}

--- a/packages/content/src/svelte/components/ContentReferencesPanel.svelte
+++ b/packages/content/src/svelte/components/ContentReferencesPanel.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type { Snippet } from 'svelte';
 import type { ContentEditorReference } from '../content-editor-form';
+import { M } from '../i18n.editor.js';
+
+const { t } = useI18n();
 
 export interface Props {
   referenceIds?: string[];
@@ -101,14 +105,14 @@ function removeReference(id: string) {
       {/each}
     </div>
   {:else}
-    <p class="empty-state">No references.</p>
+    <p class="empty-state">{t(M['content.content_references_panel.no_references'])}</p>
   {/if}
 
   <div class="reference-input-row">
     <input
       type="text"
-      aria-label="Add reference by ID or URL"
-      placeholder="Reference ID or URL"
+      aria-label={t(M['content.content_references_panel.add_reference_by_id_or_url'])}
+      placeholder={t(M['content.content_references_panel.reference_id_or_url_placeholder'])}
       bind:value={newReferenceId}
       onkeydown={(event) => {
         if (event.key === 'Enter') {

--- a/packages/content/src/svelte/components/ContentStatusFields.svelte
+++ b/packages/content/src/svelte/components/ContentStatusFields.svelte
@@ -1,4 +1,9 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../i18n.editor.js';
+
+const { t } = useI18n();
+
 export interface Props {
   data: Record<string, any>;
   onChange?: (change: Record<string, unknown>) => void;
@@ -18,7 +23,7 @@ function updateField(key: string, value: unknown) {
       <option value="article">Article</option>
       <option value="document">Document</option>
       <option value="mirror">Mirror</option>
-      <option value="video-segment">Video Segment</option>
+      <option value="video-segment">{t(M['content.content_status_fields.video_segment'])}</option>
     </select>
   </label>
   <label>

--- a/packages/content/src/svelte/components/ContentTransparencyReport.svelte
+++ b/packages/content/src/svelte/components/ContentTransparencyReport.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type { ContentTransparencyData } from '../../mock-smrt-client';
+import { M } from '../i18n.tools.js';
+
+const { t } = useI18n();
 
 export interface Props {
   transparency?: ContentTransparencyData | null;
@@ -53,7 +57,7 @@ function getFactLabel(fact: {
     </div>
     {#if transparency}
       <div class="transparency-report__badges">
-        <span class="badge">{transparency.factsUsed.length} facts used</span>
+        <span class="badge">{transparency.factsUsed.length} {t(M['content.transparency_report.facts_used'])}</span>
         <span class="badge">{transparency.references.length} references</span>
         <span class="badge">{transparency.corrections.length} corrections</span>
       </div>
@@ -68,9 +72,9 @@ function getFactLabel(fact: {
         <h4>Generation</h4>
         <p>
           {#if transparency.generation.aiAssisted}
-            AI-assisted
+            {t(M['content.transparency_report.ai_assisted'])}
           {:else}
-            Authored without public AI disclosure
+            {t(M['content.transparency_report.authored_without_disclosure'])}
           {/if}
           {#if transparency.generation.model}
             · {transparency.generation.model}
@@ -79,14 +83,14 @@ function getFactLabel(fact: {
         {#if transparency.generation.publicPrompt}
           <pre class="prompt">{transparency.generation.publicPrompt}</pre>
         {:else}
-          <p class="empty-copy">No public prompt was attached to this publication.</p>
+          <p class="empty-copy">{t(M['content.transparency_report.no_public_prompt_attached'])}</p>
         {/if}
       </article>
 
       <article class="panel">
-        <h4>Facts Used</h4>
+        <h4>{t(M['content.transparency_report.facts_used_heading'])}</h4>
         {#if transparency.factsUsed.length === 0}
-          <p class="empty-copy">No explicit facts were marked as used in the article.</p>
+          <p class="empty-copy">{t(M['content.transparency_report.no_explicit_facts'])}</p>
         {:else}
           <div class="item-list">
             {#each transparency.factsUsed as fact (fact.id ?? fact.textRefined ?? fact.textRaw)}
@@ -106,9 +110,9 @@ function getFactLabel(fact: {
     </div>
 
     <article class="panel">
-      <h4>Source Material</h4>
+      <h4>{t(M['content.transparency_report.source_material'])}</h4>
       {#if transparency.references.length === 0}
-        <p class="empty-copy">No public references are attached to this snapshot.</p>
+        <p class="empty-copy">{t(M['content.transparency_report.no_public_references'])}</p>
       {:else}
         <div class="item-list">
           {#each transparency.references as reference (reference.id ?? reference.url ?? reference.title)}
@@ -135,7 +139,7 @@ function getFactLabel(fact: {
 
     {#if transparency.otherExtractedFacts.length > 0}
       <article class="panel">
-        <h4>Other Extracted Facts</h4>
+        <h4>{t(M['content.transparency_report.other_extracted_facts'])}</h4>
         <div class="pill-list">
           {#each transparency.otherExtractedFacts as fact (fact.id ?? fact.textRefined ?? fact.textRaw)}
             <span>{getFactLabel(fact)}</span>
@@ -148,7 +152,7 @@ function getFactLabel(fact: {
       <article class="panel">
         <h4>Reviews</h4>
         {#if transparency.reviews.length === 0}
-          <p class="empty-copy">No reviews were captured in this snapshot.</p>
+          <p class="empty-copy">{t(M['content.transparency_report.no_reviews_captured'])}</p>
         {:else}
           <div class="item-list">
             {#each transparency.reviews as review (`${review.id ?? review.policyKey}-${review.createdAt ?? ''}`)}
@@ -167,7 +171,7 @@ function getFactLabel(fact: {
       <article class="panel">
         <h4>Corrections</h4>
         {#if transparency.corrections.length === 0}
-          <p class="empty-copy">No public corrections have been issued.</p>
+          <p class="empty-copy">{t(M['content.transparency_report.no_public_corrections'])}</p>
         {:else}
           <div class="item-list">
             {#each transparency.corrections as correction (`${correction.id ?? correction.summary}-${correction.publishedAt ?? ''}`)}
@@ -187,9 +191,9 @@ function getFactLabel(fact: {
     </div>
 
     <article class="panel">
-      <h4>Version History</h4>
+      <h4>{t(M['content.transparency_report.version_history'])}</h4>
       {#if transparency.versionHistory.length === 0}
-        <p class="empty-copy">No version history is attached to this snapshot.</p>
+        <p class="empty-copy">{t(M['content.transparency_report.no_version_history'])}</p>
       {:else}
         <div class="item-list">
           {#each transparency.versionHistory as version (`${version.id ?? version.version}-${version.createdAt ?? ''}`)}

--- a/packages/content/src/svelte/components/ContentTransparencyReport.svelte
+++ b/packages/content/src/svelte/components/ContentTransparencyReport.svelte
@@ -58,8 +58,8 @@ function getFactLabel(fact: {
     {#if transparency}
       <div class="transparency-report__badges">
         <span class="badge">{transparency.factsUsed.length} {t(M['content.transparency_report.facts_used'])}</span>
-        <span class="badge">{transparency.references.length} references</span>
-        <span class="badge">{transparency.corrections.length} corrections</span>
+        <span class="badge">{transparency.references.length} {t(M['content.transparency_report.references'])}</span>
+        <span class="badge">{transparency.corrections.length} {t(M['content.transparency_report.corrections'])}</span>
       </div>
     {/if}
   </div>

--- a/packages/content/src/svelte/components/ContentTransparencyTool.svelte
+++ b/packages/content/src/svelte/components/ContentTransparencyTool.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type {
   ContentGovernanceStateData,
   ContentTransparencyData,
 } from '../../mock-smrt-client';
 import { createClient } from '../../mock-smrt-client';
 import { normalizeApiBaseUrl } from '../api';
+import { M } from '../i18n.tools.js';
+
+const { t } = useI18n();
 
 export interface Props {
   apiBaseUrl?: string;
@@ -102,22 +106,22 @@ async function loadTransparency(contentIdToLoad = savedContentId) {
   {/if}
 
   {#if !savedContentId}
-    <p class="empty-copy">Save this content to preview the public transparency breakdown.</p>
+    <p class="empty-copy">{t(M['content.transparency_tool.save_to_preview_transparency'])}</p>
   {:else if busy && !transparencyPreview}
-    <p class="empty-copy">Loading transparency...</p>
+    <p class="empty-copy">{t(M['content.transparency_tool.loading_transparency'])}</p>
   {:else if governanceState && !governanceState.transparencyEnabled}
-    <p class="empty-copy">Public transparency snapshots are not enabled for this governed content type.</p>
+    <p class="empty-copy">{t(M['content.transparency_tool.transparency_snapshots_not_enabled'])}</p>
   {:else if !transparencyPreview}
-    <p class="empty-copy">No transparency preview is available yet.</p>
+    <p class="empty-copy">{t(M['content.transparency_tool.no_transparency_preview'])}</p>
   {:else}
     <p class="section-caption">
-      The preview below reflects the latest saved article state. The published snapshot stays frozen until the next successful publication.
+      {t(M['content.transparency_tool.transparency_preview_explainer'])}
     </p>
 
     <div class="transparency-stats">
       <div class="transparency-stat">
         <strong>{transparencyPreview.factsUsed.length}</strong>
-        <span>Facts used</span>
+        <span>{t(M['content.transparency_tool.facts_used'])}</span>
       </div>
       <div class="transparency-stat">
         <strong>{transparencyPreview.references.length}</strong>
@@ -125,24 +129,24 @@ async function loadTransparency(contentIdToLoad = savedContentId) {
       </div>
       <div class="transparency-stat">
         <strong>{transparencyPreview.otherExtractedFacts.length}</strong>
-        <span>Other extracted facts</span>
+        <span>{t(M['content.transparency_tool.other_extracted_facts'])}</span>
       </div>
       <div class="transparency-stat">
         <strong>{transparencyPreview.corrections.length}</strong>
-        <span>Public corrections</span>
+        <span>{t(M['content.transparency_tool.public_corrections'])}</span>
       </div>
     </div>
 
     <div class="transparency-card">
       <div class="tool-card-header">
-        <strong>Current preview</strong>
+        <strong>{t(M['content.transparency_tool.current_preview'])}</strong>
         <span class="pill pill--neutral">{transparencyPreview.snapshotKind}</span>
       </div>
       <span>
         {#if transparencyPreview.generation.publicPrompt}
-          Public prompt is set for publication.
+          {t(M['content.transparency_tool.public_prompt_set'])}
         {:else}
-          No public prompt is exposed yet.
+          {t(M['content.transparency_tool.no_public_prompt_exposed'])}
         {/if}
       </span>
       {#if transparencyPreview.generation.publicPrompt}
@@ -153,9 +157,9 @@ async function loadTransparency(contentIdToLoad = savedContentId) {
 
       <div class="tool-list">
         <div class="tool-list-section">
-          <div class="section-caption">Facts used in the article</div>
+          <div class="section-caption">{t(M['content.transparency_tool.facts_used_in_article'])}</div>
           {#if transparencyPreview.factsUsed.length === 0}
-            <p class="empty-copy">No used facts will be shown publicly yet.</p>
+            <p class="empty-copy">{t(M['content.transparency_tool.no_used_facts_public'])}</p>
           {:else}
             {#each transparencyPreview.factsUsed.slice(0, 3) as fact (fact.id ?? fact.textRefined ?? fact.textRaw)}
               <div class="transparency-list-item">
@@ -172,15 +176,15 @@ async function loadTransparency(contentIdToLoad = savedContentId) {
         </div>
 
         <div class="tool-list-section">
-          <div class="section-caption">Source material</div>
+          <div class="section-caption">{t(M['content.transparency_tool.source_material'])}</div>
           {#if transparencyPreview.references.length === 0}
-            <p class="empty-copy">No references will be shown publicly yet.</p>
+            <p class="empty-copy">{t(M['content.transparency_tool.no_references_public'])}</p>
           {:else}
             {#each transparencyPreview.references.slice(0, 3) as reference (reference.id ?? reference.url ?? reference.title)}
               <div class="transparency-list-item">
                 <strong>{getReferenceLabel(reference)}</strong>
                 <span>
-                  {reference.usedFactIds.length} used fact(s) · {reference.extractedFacts.length} extracted fact(s)
+                  {t(M['content.transparency_tool.reference_fact_counts'], { used: reference.usedFactIds.length, extracted: reference.extractedFacts.length })}
                 </span>
               </div>
             {/each}
@@ -191,7 +195,7 @@ async function loadTransparency(contentIdToLoad = savedContentId) {
 
     <div class="transparency-card">
       <div class="tool-card-header">
-        <strong>Latest published snapshot</strong>
+        <strong>{t(M['content.transparency_tool.latest_published_snapshot'])}</strong>
         {#if publishedTransparency?.publicationVersion?.version !== null && publishedTransparency?.publicationVersion?.version !== undefined}
           <span class="pill pill--passed">v{publishedTransparency.publicationVersion.version}</span>
         {/if}
@@ -202,11 +206,11 @@ async function loadTransparency(contentIdToLoad = savedContentId) {
           Published {formatTimestamp(publishedTransparency.publicationVersion?.createdAt || publishedTransparency.generatedAt)}
         </span>
         <span>
-          {publishedTransparency.versionHistory.length} timeline event(s) and {publishedTransparency.corrections.length} public correction(s)
+          {t(M['content.transparency_tool.timeline_and_corrections'], { events: publishedTransparency.versionHistory.length, corrections: publishedTransparency.corrections.length })}
         </span>
       {:else}
         <p class="empty-copy">
-          No published transparency snapshot yet. Publish this article to freeze one for the built site.
+          {t(M['content.transparency_tool.no_published_snapshot'])}
         </p>
       {/if}
     </div>

--- a/packages/content/src/svelte/components/ContentVersionsTool.svelte
+++ b/packages/content/src/svelte/components/ContentVersionsTool.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type { ContentVersionData } from '../../mock-smrt-client';
 import { createClient } from '../../mock-smrt-client';
 import { normalizeApiBaseUrl } from '../api';
+import { M } from '../i18n.tools.js';
+
+const { t } = useI18n();
 
 export interface Props {
   apiBaseUrl?: string;
@@ -164,9 +168,9 @@ async function restoreVersion(versionNumber: number) {
   {/if}
 
   {#if !savedContentId}
-    <p class="empty-copy">Save this content to manage versions.</p>
+    <p class="empty-copy">{t(M['content.versions_tool.save_to_manage_versions'])}</p>
   {:else if versions.length === 0}
-    <p class="empty-copy">No versions saved yet.</p>
+    <p class="empty-copy">{t(M['content.versions_tool.no_versions_saved'])}</p>
   {:else}
     <div class="tool-list">
       {#each versions as version (version.id ?? `version-${version.version ?? 0}`)}

--- a/packages/content/src/svelte/components/ImageThumbnail.svelte
+++ b/packages/content/src/svelte/components/ImageThumbnail.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import { joinApiUrl } from '../api';
+import { M } from '../i18n.editor.js';
 import {
   getCachedThumbnail,
   setCachedThumbnail,
   THUMBNAIL_FAILURE_TTL_MS,
   type ThumbnailState,
 } from './ImageThumbnail.cache';
+
+const { t } = useI18n();
 
 interface ImageThumbnailProps {
   assetId: string;
@@ -95,7 +99,7 @@ $effect(() => {
 {#if thumbnailState === 'ready' && imageUrl}
   <img
     src={imageUrl}
-    alt="Thumbnail preview"
+    alt={t(M['content.image_thumbnail.thumbnail_preview'])}
     class="smrt-thumbnail-img"
     loading="lazy"
     onerror={() => {
@@ -113,8 +117,8 @@ $effect(() => {
 {:else if thumbnailState === 'loading'}
   <div class="smrt-thumbnail-skeleton" aria-hidden="true"></div>
 {:else}
-  <div class="smrt-thumbnail-missing" aria-label="Thumbnail unavailable">
-    <span>Preview unavailable</span>
+  <div class="smrt-thumbnail-missing" aria-label={t(M['content.image_thumbnail.thumbnail_unavailable'])}>
+    <span>{t(M['content.image_thumbnail.preview_unavailable'])}</span>
   </div>
 {/if}
 

--- a/packages/content/src/svelte/i18n.contribution.ts
+++ b/packages/content/src/svelte/i18n.contribution.ts
@@ -1,0 +1,85 @@
+import { defineMessages } from '@happyvertical/smrt-svelte/i18n';
+
+export const M = defineMessages({
+  // ArticleList
+  'content.article_list.aria_label': 'Articles',
+
+  // ContentContributionForm
+  'content.contribution_form.heading': 'Submit a contribution',
+  'content.contribution_form.contribution_type': 'Contribution type',
+  'content.contribution_form.attach_files': 'Attach files',
+
+  // ContentContributionInbox
+  'content.contribution_inbox.heading': 'Contribution inbox',
+  'content.contribution_inbox.intro':
+    'Review held submissions, request changes, or promote them into editorial content.',
+  'content.contribution_inbox.promoted_content': 'Promoted content',
+  'content.contribution_inbox.intake_decision': 'Intake decision',
+  'content.contribution_inbox.editorial_note': 'Editorial note',
+  'content.contribution_inbox.promote_to': 'Promote to',
+  'content.contribution_inbox.request_changes': 'Request changes',
+
+  // ContentContributionPortal
+  'content.contribution_portal.heading': 'Your contributions',
+  'content.contribution_portal.intro':
+    'Track the status of your submissions and follow up when editors request changes.',
+  'content.contribution_portal.editor_notes': 'Editor notes',
+  'content.contribution_portal.withdraw_submission': 'Withdraw submission',
+
+  // ContentContributionTypeManager
+  'content.contribution_type_manager.heading': 'Contribution types',
+  'content.contribution_type_manager.intro':
+    'Configure what contributors can send, where it promotes, and which intake rules apply.',
+  'content.contribution_type_manager.add_type': 'Add type',
+  'content.contribution_type_manager.allow_text': 'Allow text',
+  'content.contribution_type_manager.allow_files': 'Allow files',
+  'content.contribution_type_manager.allow_empty_text': 'Allow empty text',
+  'content.contribution_type_manager.promotion_content_type':
+    'Promotion content type',
+  'content.contribution_type_manager.promotion_variant': 'Promotion variant',
+  'content.contribution_type_manager.promotion_status': 'Promotion status',
+  'content.contribution_type_manager.auto_promote_trusted':
+    'Auto-promote trusted',
+  'content.contribution_type_manager.create_assets_on_promotion':
+    'Create assets on promotion',
+  'content.contribution_type_manager.trusted_contributors_only':
+    'Trusted contributors only',
+  'content.contribution_type_manager.max_files': 'Max files',
+  'content.contribution_type_manager.max_total_bytes': 'Max total bytes',
+  'content.contribution_type_manager.allowed_mime_patterns':
+    'Allowed MIME patterns',
+  'content.contribution_type_manager.allowed_mime_patterns_placeholder':
+    'image/*, video/mp4',
+  'content.contribution_type_manager.blocked_mime_patterns':
+    'Blocked MIME patterns',
+  'content.contribution_type_manager.quarantine_mime_patterns':
+    'Quarantine MIME patterns',
+  'content.contribution_type_manager.blocked_text_patterns':
+    'Blocked text patterns',
+  'content.contribution_type_manager.quarantine_text_patterns':
+    'Quarantine text patterns',
+  'content.contribution_type_manager.save_type': 'Save type',
+
+  // ContentContributorManager
+  'content.contributor_manager.intro':
+    'Manage contributor trust levels for intake queue bypass and moderation.',
+  'content.contributor_manager.add_contributor': 'Add contributor',
+  'content.contributor_manager.trust_level': 'Trust level',
+  'content.contributor_manager.save_contributor': 'Save contributor',
+
+  // ContentList
+  'content.content_list.search_placeholder': 'Search contents...',
+  'content.content_list.all_types': 'All Types',
+  'content.content_list.all_statuses': 'All Statuses',
+  'content.content_list.grid_view': 'Grid View',
+  'content.content_list.detailed_list': 'Detailed List',
+  'content.content_list.compact_list': 'Compact List',
+  'content.content_list.add_content': 'Add Content',
+  'content.content_list.empty': 'No contents match your filters.',
+  'content.content_list.view_published_article': 'View published article',
+  'content.content_list.edit': 'Edit',
+  'content.content_list.delete': 'Delete',
+  'content.content_list.source_material': 'Source material',
+  'content.content_list.view_article': 'View article',
+  'content.content_list.view_article_button': 'View Article',
+});

--- a/packages/content/src/svelte/i18n.editor.ts
+++ b/packages/content/src/svelte/i18n.editor.ts
@@ -1,0 +1,101 @@
+/**
+ * Content editor component message catalog (i18n, Sweep S13 #1418).
+ *
+ * English code defaults for user-facing strings in the EDITOR component group
+ * of the content Svelte components under `components/`. Keys follow
+ * `content.<component>.<descriptor>`.
+ */
+import { defineMessages } from '@happyvertical/smrt-svelte/i18n';
+
+export const M = defineMessages({
+  // ContentAgentChat
+  'content.content_agent_chat.loading_ai_assistant': 'Loading AI Assistant...',
+  'content.content_agent_chat.loading_topic': 'Loading topic...',
+  'content.content_agent_chat.loading_participant': 'Loading participant...',
+  'content.content_agent_chat.no_topics': 'No topics...',
+  'content.content_agent_chat.topic_name_placeholder': 'Topic name...',
+  'content.content_agent_chat.new_topic': 'New Topic',
+
+  // ContentBodyEditor
+  'content.content_body_editor.toolbar': 'Body editor toolbar',
+  'content.content_body_editor.bold': 'Bold',
+  'content.content_body_editor.italic': 'Italic',
+  'content.content_body_editor.heading': 'Heading',
+  'content.content_body_editor.bulleted_list': 'Bulleted list',
+  'content.content_body_editor.insert_image': 'Insert image',
+  'content.content_body_editor.save_as': 'Save as',
+  'content.content_body_editor.selected_image_controls':
+    'Selected image controls',
+  'content.content_body_editor.move_image': 'Move image',
+  'content.content_body_editor.wrap_text_on_right': 'Wrap text on right',
+  'content.content_body_editor.center_image': 'Center image',
+  'content.content_body_editor.wrap_text_on_left': 'Wrap text on left',
+  'content.content_body_editor.full_width': 'Full width',
+  'content.content_body_editor.make_smaller': 'Make smaller',
+  'content.content_body_editor.make_image_smaller': 'Make image smaller',
+  'content.content_body_editor.make_larger': 'Make larger',
+  'content.content_body_editor.make_image_larger': 'Make image larger',
+  'content.content_body_editor.use_as_primary_image': 'Use as primary image',
+  'content.content_body_editor.remove_image': 'Remove image',
+  'content.content_body_editor.resize_image': 'Resize image',
+  'content.content_body_editor.resize_selected_image': 'Resize selected image',
+
+  // ContentEditor
+  'content.content_editor.publish_date': 'Publish Date',
+  'content.content_editor.document_title_placeholder': 'Document title...',
+  'content.content_editor.ai_updated_fields':
+    'AI updated {count} {fieldLabel}: {fields}',
+  'content.content_editor.field_singular': 'field',
+  'content.content_editor.field_plural': 'fields',
+  'content.content_editor.drag_into_body': 'Drag into the body',
+  'content.content_editor.make_thumbnail': 'Make Thumbnail',
+  'content.content_editor.remove': 'Remove',
+  'content.content_editor.no_images_attached': 'No images attached.',
+  'content.content_editor.add_image': 'Add Image',
+  'content.content_editor.author_name_placeholder': 'Author name',
+  'content.content_editor.brief_summary_placeholder': 'Brief summary...',
+  'content.content_editor.tags_comma_separated': 'Tags (Comma separated):',
+  'content.content_editor.tags_placeholder': 'e.g. news, tech',
+  'content.content_editor.no_references': 'No references.',
+  'content.content_editor.evidence_items_selected':
+    '{count} evidence {itemLabel} selected',
+  'content.content_editor.evidence_item_singular': 'item',
+  'content.content_editor.evidence_item_plural': 'items',
+  'content.content_editor.repair_resources': 'Repair resources',
+  'content.content_editor.evidence_claims': '{count} evidence {claimLabel}',
+  'content.content_editor.evidence_claim_singular': 'claim',
+  'content.content_editor.evidence_claim_plural': 'claims',
+  'content.content_editor.reference_id_or_url_placeholder':
+    'Reference ID or URL',
+  'content.content_editor.file_key': 'File Key:',
+  'content.content_editor.agent_chat_unavailable': 'Agent chat unavailable',
+
+  // ContentImageBrowser
+  'content.content_image_browser.no_images_attached': 'No images attached.',
+
+  // ContentImageChooser
+  'content.content_image_chooser.body_images': 'Body images',
+  'content.content_image_chooser.previous_body_image': 'Previous body image',
+  'content.content_image_chooser.focus_selected_body_image':
+    'Focus selected body image',
+  'content.content_image_chooser.next_body_image': 'Next body image',
+
+  // ContentMetadataFields
+  'content.content_metadata_fields.file_key': 'File Key',
+  'content.content_metadata_fields.tags_placeholder': 'e.g. news, tech',
+
+  // ContentReferencesPanel
+  'content.content_references_panel.no_references': 'No references.',
+  'content.content_references_panel.reference_id_or_url_placeholder':
+    'Reference ID or URL',
+  'content.content_references_panel.add_reference_by_id_or_url':
+    'Add reference by ID or URL',
+
+  // ContentStatusFields
+  'content.content_status_fields.video_segment': 'Video Segment',
+
+  // ImageThumbnail
+  'content.image_thumbnail.preview_unavailable': 'Preview unavailable',
+  'content.image_thumbnail.thumbnail_preview': 'Thumbnail preview',
+  'content.image_thumbnail.thumbnail_unavailable': 'Thumbnail unavailable',
+});

--- a/packages/content/src/svelte/i18n.editor.ts
+++ b/packages/content/src/svelte/i18n.editor.ts
@@ -15,6 +15,8 @@ export const M = defineMessages({
   'content.content_agent_chat.no_topics': 'No topics...',
   'content.content_agent_chat.topic_name_placeholder': 'Topic name...',
   'content.content_agent_chat.new_topic': 'New Topic',
+  'content.content_agent_chat.new': 'New',
+  'content.content_agent_chat.untitled_topic': 'Untitled Topic',
 
   // ContentBodyEditor
   'content.content_body_editor.toolbar': 'Body editor toolbar',

--- a/packages/content/src/svelte/i18n.governance.ts
+++ b/packages/content/src/svelte/i18n.governance.ts
@@ -1,0 +1,92 @@
+import { defineMessages } from '@happyvertical/smrt-svelte/i18n';
+
+export const M = defineMessages({
+  'content.governance_panel.article_claim_audit': 'Article claim audit',
+  'content.governance_panel.save_to_audit_claims':
+    'Save this content to audit article claims against evidence.',
+  'content.governance_panel.article_claims': 'article claims',
+  'content.governance_panel.article_claims_help':
+    'Article claims are statements made by this draft. A supported claim has linked source evidence from the references; unsupported means the audit has not found that supporting evidence yet.',
+  'content.governance_panel.no_claim_audit_generated':
+    'No article claim audit has been generated yet.',
+  'content.governance_panel.group_article_claims': '{group} article claims',
+  'content.governance_panel.recheck_support': 'Recheck support',
+  'content.governance_panel.article_claim_label': 'Article claim:',
+  'content.governance_panel.support_assessment_label': 'Support assessment:',
+  'content.governance_panel.claim_excerpt': 'Claim excerpt',
+  'content.governance_panel.based_on_source_evidence':
+    'Based on source evidence',
+  'content.governance_panel.source_claim_label': 'Source claim:',
+  'content.governance_panel.based_on_label': 'Based on:',
+  'content.governance_panel.no_supporting_source_evidence':
+    'No supporting source evidence linked.',
+  'content.governance_panel.manual_fact_links': 'Manual fact links',
+  'content.governance_panel.saving_links': 'Saving links...',
+  'content.governance_panel.fact_linking_not_enabled':
+    'Fact linking is not enabled for this governed content type.',
+  'content.governance_panel.manually_linked_facts': 'Manually linked facts',
+  'content.governance_panel.no_manually_linked_facts':
+    'No manually linked facts yet.',
+  'content.governance_panel.search_fact_catalog': 'Search fact catalog',
+  'content.governance_panel.fact_catalog': 'Fact catalog',
+  'content.governance_panel.loading_facts': 'Loading facts...',
+  'content.governance_panel.no_facts_matched': 'No facts matched this search.',
+  'content.governance_panel.fact_catalog_pagination': 'Fact catalog pagination',
+  'content.governance_panel.save_to_run_governance':
+    'Save this content to run governance reviews, corrections, and version management.',
+  'content.governance_panel.review_profile': 'Review profile',
+  'content.governance_panel.needs_attention': 'Needs attention',
+  'content.governance_panel.requirements_need_attention':
+    '{count} review requirement(s) still need attention before this profile is fully ready.',
+  'content.governance_panel.no_review_requirements':
+    'No review requirements are configured for this profile.',
+  'content.governance_panel.app_review_policy': 'App review policy',
+  'content.governance_panel.optional_review_instructions':
+    'Optional additional review instructions',
+  'content.governance_panel.recent_reviews': 'Recent reviews',
+  'content.governance_panel.no_reviews_run': 'No reviews have been run yet.',
+  'content.governance_panel.more_findings': '+ {count} more finding(s)',
+  'content.governance_panel.save_to_preview_transparency':
+    'Save this content to preview the public transparency breakdown.',
+  'content.governance_panel.transparency_snapshots_not_enabled':
+    'Public transparency snapshots are not enabled for this governed content type.',
+  'content.governance_panel.no_transparency_preview':
+    'No transparency preview is available yet.',
+  'content.governance_panel.transparency_preview_explainer':
+    'The preview below reflects the latest saved article state. The published snapshot stays frozen until the next successful publication.',
+  'content.governance_panel.facts_used': 'Facts used',
+  'content.governance_panel.other_extracted_facts': 'Other extracted facts',
+  'content.governance_panel.public_corrections': 'Public corrections',
+  'content.governance_panel.current_preview': 'Current preview',
+  'content.governance_panel.public_prompt_set':
+    'Public prompt is set for publication.',
+  'content.governance_panel.no_public_prompt_exposed':
+    'No public prompt is exposed yet.',
+  'content.governance_panel.facts_used_in_article': 'Facts used in the article',
+  'content.governance_panel.no_used_facts_public':
+    'No used facts will be shown publicly yet.',
+  'content.governance_panel.source_material': 'Source material',
+  'content.governance_panel.no_references_public':
+    'No references will be shown publicly yet.',
+  'content.governance_panel.reference_fact_counts':
+    '{used} used fact(s) · {extracted} extracted fact(s)',
+  'content.governance_panel.latest_published_snapshot':
+    'Latest published snapshot',
+  'content.governance_panel.timeline_and_corrections':
+    '{events} timeline event(s) and {corrections} public correction(s)',
+  'content.governance_panel.no_published_snapshot':
+    'No published transparency snapshot yet. Publish this article to freeze one for the built site.',
+  'content.governance_panel.related_fact': 'Related fact',
+  'content.governance_panel.general_correction': 'General correction',
+  'content.governance_panel.corrected_fact_text': 'Corrected fact text',
+  'content.governance_panel.public_note': 'Public note',
+  'content.governance_panel.publish_immediately': 'Publish immediately',
+  'content.governance_panel.published_history': 'Published history',
+  'content.governance_panel.no_corrections_issued': 'No corrections issued.',
+  'content.governance_panel.no_versions_saved': 'No versions saved yet.',
+  'content.governance_panel.what_was_wrong': 'What was wrong?',
+  'content.governance_panel.provide_corrected_wording':
+    'Provide the corrected claim or wording',
+  'content.governance_panel.optional_public_correction_note':
+    'Optional public-facing correction note',
+});

--- a/packages/content/src/svelte/i18n.routes.ts
+++ b/packages/content/src/svelte/i18n.routes.ts
@@ -89,5 +89,9 @@ export const M = defineMessages({
 
   // PublishedArticleRoute.svelte
   'content.published_article.eyebrow': 'Published article',
+  'content.published_article.untitled': 'Untitled article',
+  'content.published_article.unknown_author': 'Unknown author',
+  'content.published_article.empty_copy':
+    'This published article does not have a public transparency snapshot yet.',
   'content.published_article.transparency_title': 'How this article was made',
 });

--- a/packages/content/src/svelte/i18n.routes.ts
+++ b/packages/content/src/svelte/i18n.routes.ts
@@ -1,0 +1,93 @@
+/**
+ * smrt-content route UI message catalog (S13 #1418).
+ * Keys: `content.<route_snake>.<descriptor_snake>`, grouped by route file.
+ */
+import { defineMessages } from '@happyvertical/smrt-svelte/i18n';
+
+export const M = defineMessages({
+  // ContentContributionsRoute.svelte
+  'content.contributions.eyebrow': 'Content contributions',
+  'content.contributions.heading': 'Contribution operations',
+  'content.contributions.intro':
+    'Manage public intake, contributor records, moderation decisions, and\n          promotion into draft or review-ready content.',
+  'content.contributions.nav_aria': 'Content navigation',
+  'content.contributions.callout_title': 'Live contribution stack',
+  'content.contributions.callout_body':
+    'Intake, moderation, and contributor controls against the generated\n            content APIs.',
+  'content.contributions.chips_aria': 'Workspace scope',
+  'content.contributions.chip_held_intake': 'Held web intake',
+  'content.contributions.chip_portal_actions': 'Contributor portal actions',
+  'content.contributions.chip_inbox_decisions': 'Editorial inbox decisions',
+  'content.contributions.chip_type_trust': 'Type and trust overrides',
+  'content.contributions.email_note_prefix':
+    'Email ingestion remains available at',
+  'content.contributions.email_note_suffix':
+    'when message\n        records exist.',
+  'content.contributions.loading': 'Loading contribution operations...',
+  'content.contributions.latest_action': 'Latest action',
+  'content.contributions.submission_title': 'Contributor submission',
+  'content.contributions.submission_body':
+    'Submit a held contribution through the same generated action\n                your app would call.',
+  'content.contributions.portal_title': 'Contributor portal',
+  'content.contributions.portal_body':
+    'Load a contributor by email to inspect their submissions and\n                withdraw eligible items.',
+  'content.contributions.portal_email_placeholder': 'contributor@example.com',
+  'content.contributions.inbox_title': 'Editorial inbox',
+  'content.contributions.inbox_body':
+    'Review held or quarantined submissions and promote them into\n              draft or review content.',
+  'content.contributions.types_title': 'Contribution types',
+  'content.contributions.types_body':
+    'Adjust intake rules, allowed channels, and promotion behavior.',
+  'content.contributions.trust_title': 'Contributor trust',
+  'content.contributions.trust_body':
+    'Set contributor trust levels for moderation and auto-promotion\n                paths.',
+
+  // ContentFactsRoute.svelte
+  'content.facts.eyebrow': 'Content facts',
+  'content.facts.heading': 'Fact catalog',
+  'content.facts.intro':
+    'Search the tenant fact index, inspect confidence and domains, and\n          verify what governed content can cite or review against.',
+  'content.facts.nav_aria': 'Content navigation',
+  'content.facts.create_cta': 'Create Content',
+  'content.facts.search_placeholder': 'Search fact text or domain',
+  'content.facts.latest_only': 'Latest only',
+  'content.facts.include_superseded': 'Include superseded',
+  'content.facts.loading': 'Loading facts…',
+  'content.facts.empty_title': 'No facts yet',
+  'content.facts.empty_body':
+    'Once Praeco or other content workflows record facts for this tenant,\n          they will appear here for linking and review.',
+  'content.facts.raw_input': 'Raw input',
+
+  // ContentGovernanceRoute.svelte
+  'content.governance.eyebrow': 'Content governance',
+  'content.governance.heading': 'Governance rules',
+  'content.governance.intro':
+    'Manage the policies, review profiles, fact-linking settings, and\n          publication rules the workspace applies during authoring.',
+  'content.governance.nav_aria': 'Content navigation',
+  'content.governance.controls_title': 'What you control here',
+  'content.governance.controls_policies':
+    'Create and edit review policies, profiles, and type assignments.',
+  'content.governance.controls_types':
+    'Control which content types require facts, reviews, and transparency.',
+  'content.governance.controls_return_prefix': 'Return to the',
+  'content.governance.controls_workspace_link': 'content workspace',
+  'content.governance.controls_return_suffix':
+    'to verify\n          how the current rules affect live authoring and publication.',
+
+  // ContentWorkspaceRoute.svelte
+  'content.workspace.eyebrow': 'Content operations',
+  'content.workspace.heading': 'Content workspace',
+  'content.workspace.intro':
+    "Search, edit, and publish the tenant's articles, agendas, documents,\n        and mirrored records from one workspace.",
+  'content.workspace.nav_aria': 'Content navigation',
+  'content.workspace.stat_total': 'Records in the library',
+  'content.workspace.stat_published': 'Published right now',
+  'content.workspace.loading': 'Loading contents...',
+  'content.workspace.try_again': 'Try again',
+  'content.workspace.create_governed': 'Create governed article',
+  'content.workspace.review_governance': 'Review governance settings',
+
+  // PublishedArticleRoute.svelte
+  'content.published_article.eyebrow': 'Published article',
+  'content.published_article.transparency_title': 'How this article was made',
+});

--- a/packages/content/src/svelte/i18n.tools.ts
+++ b/packages/content/src/svelte/i18n.tools.ts
@@ -1,0 +1,132 @@
+import { defineMessages } from '@happyvertical/smrt-svelte/i18n';
+
+export const M = defineMessages({
+  // ContentClaimAuditTool
+  'content.claim_audit_tool.save_to_audit_claims':
+    'Save this content to audit article claims against evidence.',
+  'content.claim_audit_tool.article_claims': 'article claims',
+  'content.claim_audit_tool.article_claims_help':
+    'Article claims are statements made by this draft. A supported claim has linked source evidence from the references; unsupported means the audit has not found that supporting evidence yet.',
+  'content.claim_audit_tool.no_claim_audit_generated':
+    'No article claim audit has been generated yet.',
+  'content.claim_audit_tool.group_article_claims': '{group} article claims',
+  'content.claim_audit_tool.recheck_support': 'Recheck support',
+  'content.claim_audit_tool.article_claim_label': 'Article claim:',
+  'content.claim_audit_tool.support_assessment_label': 'Support assessment:',
+  'content.claim_audit_tool.based_on_source_evidence':
+    'Based on source evidence',
+  'content.claim_audit_tool.source_claim_label': 'Source claim:',
+  'content.claim_audit_tool.based_on_label': 'Based on:',
+  'content.claim_audit_tool.no_supporting_source_evidence':
+    'No supporting source evidence linked.',
+
+  // ContentCorrectionsTool
+  'content.corrections_tool.save_to_issue_corrections':
+    'Save this content to issue corrections.',
+  'content.corrections_tool.related_fact': 'Related fact',
+  'content.corrections_tool.general_correction': 'General correction',
+  'content.corrections_tool.corrected_fact_text': 'Corrected fact text',
+  'content.corrections_tool.public_note': 'Public note',
+  'content.corrections_tool.publish_immediately': 'Publish immediately',
+  'content.corrections_tool.published_history': 'Published history',
+  'content.corrections_tool.no_corrections_issued': 'No corrections issued.',
+  'content.corrections_tool.what_was_wrong': 'What was wrong?',
+  'content.corrections_tool.provide_corrected_wording':
+    'Provide the corrected claim or wording',
+  'content.corrections_tool.optional_public_correction_note':
+    'Optional public-facing correction note',
+
+  // ContentGovernanceAssignmentEditor
+  'content.governance_assignment_editor.content_type': 'Content type',
+  'content.governance_assignment_editor.content_variant': 'Content variant',
+  'content.governance_assignment_editor.publication_profile':
+    'Publication profile',
+  'content.governance_assignment_editor.select_a_profile': 'Select a profile',
+  'content.governance_assignment_editor.correction_profile':
+    'Correction profile',
+  'content.governance_assignment_editor.default_fact_relationship':
+    'Default fact relationship',
+  'content.governance_assignment_editor.fact_linking': 'Fact linking',
+  'content.governance_assignment_editor.enforce_publish_readiness':
+    'Enforce publish readiness',
+  'content.governance_assignment_editor.save_assignment': 'Save assignment',
+
+  // ContentGovernanceManager
+  'content.governance_manager.content_governance': 'Content Governance',
+  'content.governance_manager.manage_governed_content':
+    'Manage effective policies, profiles, and type assignments for governed content.',
+  'content.governance_manager.loading_governance_definitions':
+    'Loading governance definitions...',
+  'content.governance_manager.add_policy': 'Add policy',
+  'content.governance_manager.delete_override': 'Delete override',
+  'content.governance_manager.add_profile': 'Add profile',
+  'content.governance_manager.add_assignment': 'Add assignment',
+
+  // ContentGovernancePolicyEditor
+  'content.governance_policy_editor.save_policy': 'Save policy',
+
+  // ContentGovernanceProfileEditor
+  'content.governance_profile_editor.add_requirement': 'Add requirement',
+  'content.governance_profile_editor.save_profile': 'Save profile',
+
+  // ContentTransparencyReport
+  'content.transparency_report.facts_used': 'facts used',
+  'content.transparency_report.ai_assisted': 'AI-assisted',
+  'content.transparency_report.authored_without_disclosure':
+    'Authored without public AI disclosure',
+  'content.transparency_report.no_public_prompt_attached':
+    'No public prompt was attached to this publication.',
+  'content.transparency_report.facts_used_heading': 'Facts Used',
+  'content.transparency_report.no_explicit_facts':
+    'No explicit facts were marked as used in the article.',
+  'content.transparency_report.source_material': 'Source Material',
+  'content.transparency_report.no_public_references':
+    'No public references are attached to this snapshot.',
+  'content.transparency_report.other_extracted_facts': 'Other Extracted Facts',
+  'content.transparency_report.no_reviews_captured':
+    'No reviews were captured in this snapshot.',
+  'content.transparency_report.no_public_corrections':
+    'No public corrections have been issued.',
+  'content.transparency_report.version_history': 'Version History',
+  'content.transparency_report.no_version_history':
+    'No version history is attached to this snapshot.',
+
+  // ContentTransparencyTool
+  'content.transparency_tool.save_to_preview_transparency':
+    'Save this content to preview the public transparency breakdown.',
+  'content.transparency_tool.loading_transparency': 'Loading transparency...',
+  'content.transparency_tool.transparency_snapshots_not_enabled':
+    'Public transparency snapshots are not enabled for this governed content type.',
+  'content.transparency_tool.no_transparency_preview':
+    'No transparency preview is available yet.',
+  'content.transparency_tool.transparency_preview_explainer':
+    'The preview below reflects the latest saved article state. The published snapshot stays frozen until the next successful publication.',
+  'content.transparency_tool.facts_used': 'Facts used',
+  'content.transparency_tool.other_extracted_facts': 'Other extracted facts',
+  'content.transparency_tool.public_corrections': 'Public corrections',
+  'content.transparency_tool.current_preview': 'Current preview',
+  'content.transparency_tool.public_prompt_set':
+    'Public prompt is set for publication.',
+  'content.transparency_tool.no_public_prompt_exposed':
+    'No public prompt is exposed yet.',
+  'content.transparency_tool.facts_used_in_article':
+    'Facts used in the article',
+  'content.transparency_tool.no_used_facts_public':
+    'No used facts will be shown publicly yet.',
+  'content.transparency_tool.source_material': 'Source material',
+  'content.transparency_tool.no_references_public':
+    'No references will be shown publicly yet.',
+  'content.transparency_tool.reference_fact_counts':
+    '{used} used fact(s) · {extracted} extracted fact(s)',
+  'content.transparency_tool.latest_published_snapshot':
+    'Latest published snapshot',
+  'content.transparency_tool.timeline_and_corrections':
+    '{events} timeline event(s) and {corrections} public correction(s)',
+  'content.transparency_tool.no_published_snapshot':
+    'No published transparency snapshot yet. Publish this article to freeze one for the built site.',
+
+  // ContentVersionsTool
+  'content.versions_tool.save_to_manage_versions':
+    'Save this content to manage versions.',
+  'content.versions_tool.no_versions_saved': 'No versions saved yet.',
+});

--- a/packages/content/src/svelte/i18n.tools.ts
+++ b/packages/content/src/svelte/i18n.tools.ts
@@ -71,6 +71,8 @@ export const M = defineMessages({
 
   // ContentTransparencyReport
   'content.transparency_report.facts_used': 'facts used',
+  'content.transparency_report.references': 'references',
+  'content.transparency_report.corrections': 'corrections',
   'content.transparency_report.ai_assisted': 'AI-assisted',
   'content.transparency_report.authored_without_disclosure':
     'Authored without public AI disclosure',

--- a/packages/content/src/svelte/routes/ContentContributionsRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentContributionsRoute.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import { onMount } from 'svelte';
 import {
   type ContentContributionData,
@@ -13,6 +14,7 @@ import ContentContributionInbox from '../components/ContentContributionInbox.sve
 import ContentContributionPortal from '../components/ContentContributionPortal.svelte';
 import ContentContributionTypeManager from '../components/ContentContributionTypeManager.svelte';
 import ContentContributorManager from '../components/ContentContributorManager.svelte';
+import { M } from '../i18n.routes.js';
 import {
   CONTENT_DEFAULT_ROUTE_NAVIGATION,
   CONTENT_ROUTE_IDS,
@@ -32,6 +34,7 @@ let {
 }: ContentContributionsRouteProps = $props();
 
 const client = $derived(createClient(apiBaseUrl));
+const { t } = useI18n();
 
 let contributionTypes = $state<ContentContributionTypeConfigStateData | null>(
   null,
@@ -300,15 +303,14 @@ async function handleDeleteContributor(data: Record<string, any>) {
   <header class="page-header">
     <div class="container">
       <div class="page-header__copy">
-        <div class="eyebrow">Content contributions</div>
-        <h1>Contribution operations</h1>
+        <div class="eyebrow">{t(M['content.contributions.eyebrow'])}</div>
+        <h1>{t(M['content.contributions.heading'])}</h1>
         <p>
-          Manage public intake, contributor records, moderation decisions, and
-          promotion into draft or review-ready content.
+          {t(M['content.contributions.intro'])}
         </p>
       </div>
 
-      <nav class="page-nav" aria-label="Content navigation">
+      <nav class="page-nav" aria-label={t(M['content.contributions.nav_aria'])}>
         {#each navigation as item (item.routeId)}
           <a
             href={item.href}
@@ -327,32 +329,30 @@ async function handleDeleteContributor(data: Record<string, any>) {
     <section class="callout">
       <div class="callout__header">
         <div>
-          <strong>Live contribution stack</strong>
+          <strong>{t(M['content.contributions.callout_title'])}</strong>
           <p>
-            Intake, moderation, and contributor controls against the generated
-            content APIs.
+            {t(M['content.contributions.callout_body'])}
           </p>
         </div>
         <span class="pill">Live</span>
       </div>
 
-      <div class="callout__chips" aria-label="Workspace scope">
-        <span>Held web intake</span>
-        <span>Contributor portal actions</span>
-        <span>Editorial inbox decisions</span>
-        <span>Type and trust overrides</span>
+      <div class="callout__chips" aria-label={t(M['content.contributions.chips_aria'])}>
+        <span>{t(M['content.contributions.chip_held_intake'])}</span>
+        <span>{t(M['content.contributions.chip_portal_actions'])}</span>
+        <span>{t(M['content.contributions.chip_inbox_decisions'])}</span>
+        <span>{t(M['content.contributions.chip_type_trust'])}</span>
       </div>
 
       <p class="callout__note">
-        Email ingestion remains available at
-        <code>/api/v1/contentcontributions/ingest-email</code> when message
-        records exist.
+        {t(M['content.contributions.email_note_prefix'])}
+        <code>/api/v1/contentcontributions/ingest-email</code> {t(M['content.contributions.email_note_suffix'])}
       </p>
     </section>
 
     {#if loading}
       <section class="panel">
-        <p>Loading contribution operations...</p>
+        <p>{t(M['content.contributions.loading'])}</p>
       </section>
     {:else}
       {#if error}
@@ -364,7 +364,7 @@ async function handleDeleteContributor(data: Record<string, any>) {
 
       {#if notice}
         <section class="panel panel--notice">
-          <strong>Latest action</strong>
+          <strong>{t(M['content.contributions.latest_action'])}</strong>
           <p>{notice}</p>
         </section>
       {/if}
@@ -379,10 +379,9 @@ async function handleDeleteContributor(data: Record<string, any>) {
         <section class="panel">
           <div class="section-heading">
             <div>
-              <h2>Contributor submission</h2>
+              <h2>{t(M['content.contributions.submission_title'])}</h2>
               <p>
-                Submit a held contribution through the same generated action
-                your app would call.
+                {t(M['content.contributions.submission_body'])}
               </p>
             </div>
           </div>
@@ -397,10 +396,9 @@ async function handleDeleteContributor(data: Record<string, any>) {
         <section class="panel">
           <div class="section-heading">
             <div>
-              <h2>Contributor portal</h2>
+              <h2>{t(M['content.contributions.portal_title'])}</h2>
               <p>
-                Load a contributor by email to inspect their submissions and
-                withdraw eligible items.
+                {t(M['content.contributions.portal_body'])}
               </p>
             </div>
             <form
@@ -413,7 +411,7 @@ async function handleDeleteContributor(data: Record<string, any>) {
               <input
                 type="email"
                 bind:value={portalEmail}
-                placeholder="contributor@example.com"
+                placeholder={t(M['content.contributions.portal_email_placeholder'])}
               />
               <button
                 type="submit"
@@ -440,10 +438,9 @@ async function handleDeleteContributor(data: Record<string, any>) {
       <section class="panel">
         <div class="section-heading">
           <div>
-            <h2>Editorial inbox</h2>
+            <h2>{t(M['content.contributions.inbox_title'])}</h2>
             <p>
-              Review held or quarantined submissions and promote them into
-              draft or review content.
+              {t(M['content.contributions.inbox_body'])}
             </p>
           </div>
         </div>
@@ -464,9 +461,9 @@ async function handleDeleteContributor(data: Record<string, any>) {
         <section class="panel">
           <div class="section-heading">
             <div>
-              <h2>Contribution types</h2>
+              <h2>{t(M['content.contributions.types_title'])}</h2>
               <p>
-                Adjust intake rules, allowed channels, and promotion behavior.
+                {t(M['content.contributions.types_body'])}
               </p>
             </div>
             <span class="pill">{contributionTypes?.effective.length || 0}</span>
@@ -482,10 +479,9 @@ async function handleDeleteContributor(data: Record<string, any>) {
         <section class="panel">
           <div class="section-heading">
             <div>
-              <h2>Contributor trust</h2>
+              <h2>{t(M['content.contributions.trust_title'])}</h2>
               <p>
-                Set contributor trust levels for moderation and auto-promotion
-                paths.
+                {t(M['content.contributions.trust_body'])}
               </p>
             </div>
             <span class="pill">{contributors.length}</span>

--- a/packages/content/src/svelte/routes/ContentFactsRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentFactsRoute.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import { onMount } from 'svelte';
 import { createClient, type FactData } from '../../mock-smrt-client.js';
+import { M } from '../i18n.routes.js';
 import {
   CONTENT_DEFAULT_ROUTE_NAVIGATION,
   CONTENT_ROUTE_IDS,
@@ -22,6 +24,7 @@ let {
 }: ContentFactsRouteProps = $props();
 
 const client = $derived(createClient(apiBaseUrl));
+const { t } = useI18n();
 
 let query = $state('');
 let latestOnly = $state(true);
@@ -84,16 +87,15 @@ onMount(() => {
   <header class="page-header">
     <div class="container">
       <div class="page-header__copy">
-        <div class="eyebrow">Content facts</div>
-        <h1>Fact catalog</h1>
+        <div class="eyebrow">{t(M['content.facts.eyebrow'])}</div>
+        <h1>{t(M['content.facts.heading'])}</h1>
         <p>
-          Search the tenant fact index, inspect confidence and domains, and
-          verify what governed content can cite or review against.
+          {t(M['content.facts.intro'])}
         </p>
       </div>
 
       <div class="page-header__actions">
-        <nav class="page-nav" aria-label="Content navigation">
+        <nav class="page-nav" aria-label={t(M['content.facts.nav_aria'])}>
           {#each navigation as item (item.routeId)}
             <a
               href={item.href}
@@ -107,7 +109,7 @@ onMount(() => {
         </nav>
 
         {#if createHref}
-          <a class="page-cta" href={createHref}>Create Content</a>
+          <a class="page-cta" href={createHref}>{t(M['content.facts.create_cta'])}</a>
         {/if}
       </div>
     </div>
@@ -121,7 +123,7 @@ onMount(() => {
           <input
             type="search"
             bind:value={query}
-            placeholder="Search fact text or domain"
+            placeholder={t(M['content.facts.search_placeholder'])}
           />
         </label>
 
@@ -131,7 +133,7 @@ onMount(() => {
             bind:checked={latestOnly}
             onchange={() => void loadFacts()}
           />
-          <span>Latest only</span>
+          <span>{t(M['content.facts.latest_only'])}</span>
         </label>
 
         <label class="toggle">
@@ -140,7 +142,7 @@ onMount(() => {
             bind:checked={includeSuperseded}
             onchange={() => void loadFacts()}
           />
-          <span>Include superseded</span>
+          <span>{t(M['content.facts.include_superseded'])}</span>
         </label>
 
         <button class="refresh-button" type="submit" disabled={refreshing}>
@@ -156,14 +158,13 @@ onMount(() => {
       </section>
     {:else if loading}
       <section class="panel empty-state">
-        <p>Loading facts…</p>
+        <p>{t(M['content.facts.loading'])}</p>
       </section>
     {:else if facts.length === 0}
       <section class="panel empty-state">
-        <h2>No facts yet</h2>
+        <h2>{t(M['content.facts.empty_title'])}</h2>
         <p>
-          Once Praeco or other content workflows record facts for this tenant,
-          they will appear here for linking and review.
+          {t(M['content.facts.empty_body'])}
         </p>
       </section>
     {:else}
@@ -203,7 +204,7 @@ onMount(() => {
 
               {#if fact.textRaw && fact.textRefined && fact.textRaw !== fact.textRefined}
                 <details>
-                  <summary>Raw input</summary>
+                  <summary>{t(M['content.facts.raw_input'])}</summary>
                   <p>{fact.textRaw}</p>
                 </details>
               {/if}

--- a/packages/content/src/svelte/routes/ContentGovernanceRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentGovernanceRoute.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import ContentGovernanceManager from '../components/ContentGovernanceManager.svelte';
+import { M } from '../i18n.routes.js';
 import {
   CONTENT_DEFAULT_ROUTE_NAVIGATION,
   CONTENT_ROUTE_IDS,
@@ -22,21 +24,21 @@ let {
 const workspaceHref = $derived(
   getContentRouteHref(navigation, CONTENT_ROUTE_IDS.workspace),
 );
+const { t } = useI18n();
 </script>
 
 <div class:page={true} class:page--embedded={embedded}>
   <header class="page-header">
     <div class="container">
       <div class="page-header__copy">
-        <div class="eyebrow">Content governance</div>
-        <h1>Governance rules</h1>
+        <div class="eyebrow">{t(M['content.governance.eyebrow'])}</div>
+        <h1>{t(M['content.governance.heading'])}</h1>
         <p>
-          Manage the policies, review profiles, fact-linking settings, and
-          publication rules the workspace applies during authoring.
+          {t(M['content.governance.intro'])}
         </p>
       </div>
 
-      <nav class="page-nav" aria-label="Content navigation">
+      <nav class="page-nav" aria-label={t(M['content.governance.nav_aria'])}>
         {#each navigation as item (item.routeId)}
           <a
             href={item.href}
@@ -53,13 +55,12 @@ const workspaceHref = $derived(
 
   <main class="container page-main">
     <section class="callout">
-      <strong>What you control here</strong>
+      <strong>{t(M['content.governance.controls_title'])}</strong>
       <ul>
-        <li>Create and edit review policies, profiles, and type assignments.</li>
-        <li>Control which content types require facts, reviews, and transparency.</li>
+        <li>{t(M['content.governance.controls_policies'])}</li>
+        <li>{t(M['content.governance.controls_types'])}</li>
         <li>
-          Return to the <a href={workspaceHref}>content workspace</a> to verify
-          how the current rules affect live authoring and publication.
+          {t(M['content.governance.controls_return_prefix'])} <a href={workspaceHref}>{t(M['content.governance.controls_workspace_link'])}</a> {t(M['content.governance.controls_return_suffix'])}
         </li>
       </ul>
     </section>

--- a/packages/content/src/svelte/routes/ContentWorkspaceRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentWorkspaceRoute.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import { onMount } from 'svelte';
 import type { ContentData } from '../../mock-smrt-client.js';
 import { createClient } from '../../mock-smrt-client.js';
 import ContentEditor from '../components/ContentEditor.svelte';
 import ContentList from '../components/ContentList.svelte';
 import GovernedContentEditor from '../components/GovernedContentEditor.svelte';
+import { M } from '../i18n.routes.js';
 import {
   buildPublishedArticlePath,
   CONTENT_DEFAULT_ROUTE_NAVIGATION,
@@ -39,6 +41,7 @@ const client = $derived(createClient(apiBaseUrl));
 const governanceHref = $derived(
   getContentRouteHref(navigation, CONTENT_ROUTE_IDS.governance),
 );
+const { t } = useI18n();
 
 let contents = $state<ContentData[]>([]);
 let loading = $state(true);
@@ -152,15 +155,14 @@ function closeForms() {
 <div class:workspace-shell={true} class:workspace-shell--embedded={embedded}>
   <header class="workspace-header">
     <div class="workspace-header__copy">
-      <div class="eyebrow">Content operations</div>
-      <h1>Content workspace</h1>
+      <div class="eyebrow">{t(M['content.workspace.eyebrow'])}</div>
+      <h1>{t(M['content.workspace.heading'])}</h1>
       <p>
-        Search, edit, and publish the tenant's articles, agendas, documents,
-        and mirrored records from one workspace.
+        {t(M['content.workspace.intro'])}
       </p>
     </div>
 
-    <nav class="workspace-nav" aria-label="Content navigation">
+    <nav class="workspace-nav" aria-label={t(M['content.workspace.nav_aria'])}>
       {#each navigation as item (item.routeId)}
         <a
           href={item.href}
@@ -178,22 +180,22 @@ function closeForms() {
     <section class="callout-grid">
       <article class="callout-card">
         <strong>{stats.total}</strong>
-        <span>Records in the library</span>
+        <span>{t(M['content.workspace.stat_total'])}</span>
       </article>
       <article class="callout-card">
         <strong>{stats.published}</strong>
-        <span>Published right now</span>
+        <span>{t(M['content.workspace.stat_published'])}</span>
       </article>
     </section>
 
     {#if loading}
       <section class="panel">
-        <p>Loading contents...</p>
+        <p>{t(M['content.workspace.loading'])}</p>
       </section>
     {:else if error}
       <section class="panel panel--error">
         <p><strong>Error:</strong> {error}</p>
-        <button type="button" onclick={loadContents}>Try again</button>
+        <button type="button" onclick={loadContents}>{t(M['content.workspace.try_again'])}</button>
       </section>
     {:else if showAddForm || editingContent}
       <section class="panel">
@@ -233,10 +235,10 @@ function closeForms() {
                 class="secondary-action"
                 onclick={handleAddGovernedContent}
               >
-                Create governed article
+                {t(M['content.workspace.create_governed'])}
               </button>
               <a class="inline-link" href={governanceHref}>
-                Review governance settings
+                {t(M['content.workspace.review_governance'])}
               </a>
             </div>
           {/snippet}

--- a/packages/content/src/svelte/routes/PublishedArticleRoute.svelte
+++ b/packages/content/src/svelte/routes/PublishedArticleRoute.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import ContentBodyRenderer from '../components/ContentBodyRenderer.svelte';
 import ContentTransparencyReport from '../components/ContentTransparencyReport.svelte';
+import { M } from '../i18n.routes.js';
 import {
   CONTENT_ROUTE_IDS,
   getContentRouteDefaultPath,
@@ -19,6 +21,8 @@ let {
   backLabel = 'Back to content workspace',
 }: PublishedArticleRouteProps = $props();
 
+const { t } = useI18n();
+
 function formatTimestamp(value: string | null | undefined) {
   if (!value) {
     return 'Unscheduled';
@@ -32,7 +36,7 @@ function formatTimestamp(value: string | null | undefined) {
   <header class="article-hero">
     <div class="article-hero__inner">
       <a href={backHref} class="back-link">{backLabel}</a>
-      <div class="eyebrow">Published article</div>
+      <div class="eyebrow">{t(M['content.published_article.eyebrow'])}</div>
       <h1>{data.content.title || 'Untitled article'}</h1>
       {#if data.content.description}
         <p class="article-dek">{data.content.description}</p>
@@ -59,7 +63,7 @@ function formatTimestamp(value: string | null | undefined) {
     <aside class="article-sidebar">
       <ContentTransparencyReport
         transparency={data.transparency}
-        title="How this article was made"
+        title={t(M['content.published_article.transparency_title'])}
         emptyCopy="This published article does not have a public transparency snapshot yet."
       />
     </aside>

--- a/packages/content/src/svelte/routes/PublishedArticleRoute.svelte
+++ b/packages/content/src/svelte/routes/PublishedArticleRoute.svelte
@@ -37,13 +37,13 @@ function formatTimestamp(value: string | null | undefined) {
     <div class="article-hero__inner">
       <a href={backHref} class="back-link">{backLabel}</a>
       <div class="eyebrow">{t(M['content.published_article.eyebrow'])}</div>
-      <h1>{data.content.title || 'Untitled article'}</h1>
+      <h1>{data.content.title || t(M['content.published_article.untitled'])}</h1>
       {#if data.content.description}
         <p class="article-dek">{data.content.description}</p>
       {/if}
 
       <div class="article-meta">
-        <span>{data.content.author || 'Unknown author'}</span>
+        <span>{data.content.author || t(M['content.published_article.unknown_author'])}</span>
         <span>{formatTimestamp(data.content.publish_date)}</span>
         {#if data.content.slug}
           <span>/{data.content.slug}</span>
@@ -64,7 +64,7 @@ function formatTimestamp(value: string | null | undefined) {
       <ContentTransparencyReport
         transparency={data.transparency}
         title={t(M['content.published_article.transparency_title'])}
-        emptyCopy="This published article does not have a public transparency snapshot yet."
+        emptyCopy={t(M['content.published_article.empty_copy'])}
       />
     </aside>
   </main>

--- a/packages/content/vitest.config.ts
+++ b/packages/content/vitest.config.ts
@@ -25,6 +25,10 @@ export default defineConfig({
     include: ['src/**/*.{test,spec}.ts'],
     setupFiles: [smrtVitestSetupPath],
     testTimeout: 30000,
+    // The smrt-vitest setup's async afterAll dynamically loads smrt-core; under
+    // loaded CI runners that exceeds the default 10s hookTimeout and times out
+    // the suite even though all test bodies pass (the ContentEditor flake).
+    hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
     singleFork: true,

--- a/scripts/check-hardcoded-strings.mjs
+++ b/scripts/check-hardcoded-strings.mjs
@@ -42,6 +42,7 @@ const STRICT_PACKAGES = new Set([
   'subscriptions',
   'assets',
   'chat',
+  'content',
 ]);
 
 // Dev/playground host, not a shippable library (consistent with the other ratchets).
@@ -69,7 +70,11 @@ function listSvelteFiles(dir) {
         continue;
       }
       out.push(...listSvelteFiles(full));
-    } else if (entry.name.endsWith('.svelte')) {
+    } else if (entry.name.endsWith('.svelte') && !entry.name.startsWith('+')) {
+      // Skip SvelteKit route files (`+page`/`+layout`/`+error`/`+server`.svelte):
+      // those are a package's dev-server/demo app surface, not the shippable
+      // library components (which live under src/svelte/). Same rationale as the
+      // smrt-playground exclusion.
       out.push(full);
     }
   }

--- a/scripts/check-hardcoded-strings.mjs
+++ b/scripts/check-hardcoded-strings.mjs
@@ -71,10 +71,11 @@ function listSvelteFiles(dir) {
       }
       out.push(...listSvelteFiles(full));
     } else if (entry.name.endsWith('.svelte') && !entry.name.startsWith('+')) {
-      // Skip SvelteKit route files (`+page`/`+layout`/`+error`/`+server`.svelte):
+      // Skip SvelteKit route components (`+page`/`+layout`/`+error`.svelte):
       // those are a package's dev-server/demo app surface, not the shippable
       // library components (which live under src/svelte/). Same rationale as the
-      // smrt-playground exclusion.
+      // smrt-playground exclusion. (`+server` files are `.ts`/`.js`, already
+      // out of scope.)
       out.push(full);
     }
   }


### PR DESCRIPTION
## What

Phase-2 **wave 3** of the i18n rollout (#1418): route hardcoded user-facing
strings in **content** — the largest UI package (329 across 45 files) — through
the smrt-svelte i18n layer and add it to `STRICT_PACKAGES`.

## How

- Extraction ran as **5 parallel subagents** by feature group (governance panel /
  editor / contribution+list / tools+governance / routes), each writing a
  **separate catalog** under `src/svelte/` (`i18n.governance.ts`, `i18n.editor.ts`,
  `i18n.contribution.ts`, `i18n.tools.ts`, `i18n.routes.ts`; **~311 keys**).
- All edits are string→`t()` swaps — no logic/`console.*`/markup changes
  (diff scope-checked). One deliberate logic touch: `ContentList`'s filter
  `<option>`s gained explicit `value="…"` so translating the label can't break
  the value comparison.

## Also in this PR

- **content `hookTimeout: 30000`** — fixes the recurring `ContentEditor.test.ts`
  *"Hook timed out in 10000ms"* CI flake (the smrt-vitest `afterAll` teardown
  exceeds the default 10s under loaded runners; 264 test bodies pass).
- **ratchet**: exclude SvelteKit route files (`+page`/`+layout`/`+server`/
  `+error`.svelte) — a package's dev-server app surface, not shippable library
  components (same rationale as the smrt-playground exclusion).

Report-only backlog **594 → 265** across 5 packages.

## Validation

- `turbo typecheck` **78/78** (a11y gate clean; validates all 5 catalogs + every import).
- **Coverage gate green** — content **72.2%** (≥70 T2; coverage-neutral).
- **264 content tests pass** (incl. ContentEditor with the hookTimeout fix).
- Full build **50/50**; ratchet green with **12 strict packages**.

## S13 progress

Remaining gate-clear: **smrt-svelte** (coverage-exempt) — wave 4. Deferred
(coverage-blocked, need a test investment, not i18n): messages (54%), products
(17%), images (13%), events (22%).