### PR TITLE
feat(i18n): extract UI strings in smrt-svelte, flip to lint-strict (S13 #1418 wave 4)

### DIFF
--- a/packages/smrt-svelte/src/browser-ai/svelte/components/STTTest.svelte
+++ b/packages/smrt-svelte/src/browser-ai/svelte/components/STTTest.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
 import { useAppState } from '../../../hooks/useAppState.svelte.js';
+import { M } from '../../../i18n/strings.workspace.js';
+import { useI18n } from '../../../i18n/use-i18n.js';
 import type { GetSTTOptions } from '../../index.js';
 import DownloadProgress from './DownloadProgress.svelte';
+
+const { t } = useI18n();
 
 /** Props for STTTest component */
 export interface Props {
@@ -101,15 +105,15 @@ function clearLogs() {
 </script>
 
 <div class="stt-test">
-  <h3>STT Adapter Test</h3>
+  <h3>{t(M['ui.stt_test.heading'])}</h3>
 
   <div class="controls">
     <div class="adapter-select">
       <label for="adapter">Adapter:</label>
       <select id="adapter" bind:value={selectedAdapter} disabled={isRecording}>
-        <option value="browser-speech">Browser (Web Speech API)</option>
-        <option value="whisper-wasm">Whisper WASM (v2)</option>
-        <option value="whisper-cpp">Whisper CPP</option>
+        <option value="browser-speech">{t(M['ui.stt_test.adapter_browser'])}</option>
+        <option value="whisper-wasm">{t(M['ui.stt_test.adapter_whisper_wasm'])}</option>
+        <option value="whisper-cpp">{t(M['ui.stt_test.adapter_whisper_cpp'])}</option>
       </select>
     </div>
 
@@ -126,11 +130,11 @@ function clearLogs() {
     <span class="status-item">
       <strong>Status:</strong>
       {#if isInitializing}
-        Initializing...
+        {t(M['ui.stt_test.status_initializing'])}
       {:else if isReady}
-        Ready
+        {t(M['ui.stt_test.status_ready'])}
       {:else}
-        Not initialized
+        {t(M['ui.stt_test.status_not_initialized'])}
       {/if}
     </span>
     <span class="status-item">

--- a/packages/smrt-svelte/src/components/admin/AgentAdminPanel.svelte
+++ b/packages/smrt-svelte/src/components/admin/AgentAdminPanel.svelte
@@ -4,6 +4,10 @@ import type {
   AgentUIComponentRegistry,
   AgentUISlot,
 } from '@happyvertical/smrt-agents/ui';
+import { M } from '../../i18n/strings.workspace.js';
+import { useI18n } from '../../i18n/use-i18n.js';
+
+const { t } = useI18n();
 
 export interface Props {
   /** The registry to look up components from */
@@ -57,10 +61,10 @@ async function handleSave(newConfig: unknown) {
 	<div class="no-panel">
 		<div class="no-panel-icon">⚙️</div>
 		<p class="no-panel-message">
-			No admin panel registered for <code>{agentClass}.{slotId}</code>
+			{t(M['ui.agent_admin_panel.no_panel_message'])} <code>{agentClass}.{slotId}</code>
 		</p>
 		<p class="no-panel-hint">
-			Import the agent's admin package to register its panels.
+			{t(M['ui.agent_admin_panel.no_panel_hint'])}
 		</p>
 	</div>
 {/if}

--- a/packages/smrt-svelte/src/components/admin/AgentAdminTabs.svelte
+++ b/packages/smrt-svelte/src/components/admin/AgentAdminTabs.svelte
@@ -3,7 +3,11 @@ import type {
   AgentUIComponentRegistry,
   AgentUISlots,
 } from '@happyvertical/smrt-agents/ui';
+import { M } from '../../i18n/strings.workspace.js';
+import { useI18n } from '../../i18n/use-i18n.js';
 import AgentAdminPanel from './AgentAdminPanel.svelte';
+
+const { t } = useI18n();
 
 export interface Props {
   /** The registry to look up components from */
@@ -111,7 +115,7 @@ async function handleSave(config: unknown) {
 </script>
 
 <div class="agent-admin-tabs">
-	<div class="tabs-nav" role="tablist" aria-label="Agent configuration tabs" bind:this={tablistEl}>
+	<div class="tabs-nav" role="tablist" aria-label={t(M['ui.agent_admin_tabs.tablist_label'])} bind:this={tablistEl}>
 		{#each sortedSlots as [slotId, slot]}
 			<button
 				class="tab-button"
@@ -160,7 +164,7 @@ async function handleSave(config: unknown) {
 			</div>
 		{:else}
 			<div class="no-slots">
-				<p>No configuration slots available for this agent.</p>
+				<p>{t(M['ui.agent_admin_tabs.no_slots'])}</p>
 			</div>
 		{/if}
 	</div>

--- a/packages/smrt-svelte/src/components/admin/AgentSettingsShell.svelte
+++ b/packages/smrt-svelte/src/components/admin/AgentSettingsShell.svelte
@@ -3,7 +3,11 @@ import type {
   AgentUIComponentRegistry,
   AgentUISlots,
 } from '@happyvertical/smrt-agents/ui';
+import { M } from '../../i18n/strings.workspace.js';
+import { useI18n } from '../../i18n/use-i18n.js';
 import AgentAdminTabs from './AgentAdminTabs.svelte';
+
+const { t } = useI18n();
 
 /**
  * Serialized agent data passed from server
@@ -110,10 +114,9 @@ async function handleSave(slotId: string, config: unknown) {
 		{:else if agents.length === 0}
 			<div class="no-agents">
 				<div class="no-agents-icon">🤖</div>
-				<p class="no-agents-message">No agents configured for this site.</p>
+				<p class="no-agents-message">{t(M['ui.agent_settings_shell.no_agents_message'])}</p>
 				<p class="no-agents-hint">
-					Agents are discovered by matching their context field to the site
-					domain.
+					{t(M['ui.agent_settings_shell.no_agents_hint'])}
 				</p>
 			</div>
 		{/if}

--- a/packages/smrt-svelte/src/components/calendar/Calendar.svelte
+++ b/packages/smrt-svelte/src/components/calendar/Calendar.svelte
@@ -4,7 +4,11 @@
  * Month view calendar with event indicators and day navigation
  */
 
+import { M } from '../../i18n/strings.ui.js';
+import { useI18n } from '../../i18n/use-i18n.js';
 import type { DayEventDetail, DayEventsData } from '../../types-generic';
+
+const { t } = useI18n();
 
 export interface Props {
   events?: DayEventsData[] | null;
@@ -209,13 +213,13 @@ const yearOptions = $derived(() => {
 <div class="calendar">
   <header class="calendar-header">
     <div class="nav-buttons">
-      <button class="nav-btn" onclick={prevMonth} aria-label="Previous month">
+      <button class="nav-btn" onclick={prevMonth} aria-label={t(M['ui.calendar.previous_month'])}>
         <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
           <path d="M12 15L7 10L12 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
       </button>
       <span class="current-month">{MONTHS[currentMonth]} {currentYear}</span>
-      <button class="nav-btn" onclick={nextMonth} aria-label="Next month">
+      <button class="nav-btn" onclick={nextMonth} aria-label={t(M['ui.calendar.next_month'])}>
         <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
           <path d="M8 5L13 10L8 15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
@@ -226,7 +230,7 @@ const yearOptions = $derived(() => {
       <select
         class="month-select"
         bind:value={currentMonth}
-        aria-label="Select month"
+        aria-label={t(M['ui.calendar.select_month'])}
       >
         {#each MONTHS as month, i}
           <option value={i}>{month}</option>
@@ -236,7 +240,7 @@ const yearOptions = $derived(() => {
       <select
         class="year-select"
         bind:value={currentYear}
-        aria-label="Select year"
+        aria-label={t(M['ui.calendar.select_year'])}
       >
         {#each yearOptions() as year}
           <option value={year}>{year}</option>

--- a/packages/smrt-svelte/src/components/calendar/DayView.svelte
+++ b/packages/smrt-svelte/src/components/calendar/DayView.svelte
@@ -4,7 +4,11 @@
  * Full event list for a specific day with optional weather
  */
 
+import { M } from '../../i18n/strings.ui.js';
+import { useI18n } from '../../i18n/use-i18n.js';
 import type { DayEventDetail, DayForecast } from '../../types-generic';
+
+const { t } = useI18n();
 
 export interface Props {
   date: Date;
@@ -94,7 +98,7 @@ function getTypeLabel(type: string): string {
       <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
         <path d="M10 12L6 8L10 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
-      Back to Calendar
+      {t(M['ui.day_view.back_to_calendar'])}
     </a>
     <h1 class="date-title">{formattedDate}</h1>
 
@@ -113,7 +117,7 @@ function getTypeLabel(type: string): string {
     {#if !events || events.length === 0}
       <div class="empty-state">
         <span class="empty-icon">{'\u{1F4C5}'}</span>
-        <p class="empty-text">No events scheduled for this day</p>
+        <p class="empty-text">{t(M['ui.day_view.no_events'])}</p>
       </div>
     {:else if groupedEvents()}
       {#each Object.entries(groupedEvents()!) as [type, typeEvents]}

--- a/packages/smrt-svelte/src/components/feedback/Modal.svelte
+++ b/packages/smrt-svelte/src/components/feedback/Modal.svelte
@@ -13,6 +13,10 @@
  */
 
 import type { Snippet } from 'svelte';
+import { M } from '../../i18n/strings.ui.js';
+import { useI18n } from '../../i18n/use-i18n.js';
+
+const { t } = useI18n();
 
 /** Props for Modal component */
 export interface Props {
@@ -142,7 +146,7 @@ const placementClass = $derived(
             type="button"
             class="modal__close"
             onclick={handleClose}
-            aria-label="Close modal"
+            aria-label={t(M['ui.modal.close'])}
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/packages/smrt-svelte/src/components/feedback/ProgressBar.svelte
+++ b/packages/smrt-svelte/src/components/feedback/ProgressBar.svelte
@@ -7,6 +7,11 @@
  * Useful for budget tracking, task completion, etc.
  */
 
+import { M } from '../../i18n/strings.ui.js';
+import { useI18n } from '../../i18n/use-i18n.js';
+
+const { t } = useI18n();
+
 /** Props for ProgressBar component */
 export interface Props {
   /** Current value (0-100 or custom range) */
@@ -76,7 +81,7 @@ const displayLabel = $derived.by(() => {
     <div class="progress-header">
       <span class="progress-label">{displayLabel}</span>
       {#if value > max}
-        <span class="over-badge">Over by {Math.round(value - max).toLocaleString()}</span>
+        <span class="over-badge">{t(M['ui.progress_bar.over_by'], { amount: Math.round(value - max).toLocaleString() })}</span>
       {/if}
     </div>
   {/if}

--- a/packages/smrt-svelte/src/components/forms/AddressInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/AddressInput.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
 import { onDestroy, onMount } from 'svelte';
 import { useAppState } from '../../hooks/useAppState.svelte.js';
+import { M } from '../../i18n/strings.forms.js';
+import { useI18n } from '../../i18n/use-i18n.js';
 import {
   type FieldDefinition,
   tryGetFormContext,
 } from '../../state/form-context.js';
 import type { AddressValue } from './types.js';
+
+const { t } = useI18n();
 
 type AddressField = keyof AddressValue;
 
@@ -282,7 +286,7 @@ function handleCountryChange(e: Event) {
           id="{name}_street"
           name="{name}[street]"
           type="text"
-          placeholder="123 Main Street"
+          placeholder={t(M['ui.address_input.street_placeholder'])}
           value={street}
           {disabled}
           required={required && fields.includes('street')}
@@ -303,7 +307,7 @@ function handleCountryChange(e: Event) {
             id="{name}_city"
             name="{name}[city]"
             type="text"
-            placeholder="City"
+            placeholder={t(M['ui.address_input.city_placeholder'])}
             value={city}
             {disabled}
             required={required && fields.includes('city')}
@@ -348,7 +352,7 @@ function handleCountryChange(e: Event) {
             id="{name}_postal"
             name="{name}[postalCode]"
             type="text"
-            placeholder="A1A 1A1"
+            placeholder={t(M['ui.address_input.postal_code_placeholder'])}
             value={postalCode}
             {disabled}
             required={required && fields.includes('postalCode')}

--- a/packages/smrt-svelte/src/components/forms/DateRangeInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/DateRangeInput.svelte
@@ -2,11 +2,15 @@
 import { onDestroy, onMount } from 'svelte';
 import { useAppState } from '../../hooks/useAppState.svelte.js';
 import { useSTT } from '../../hooks/useSTT.svelte.js';
+import { M } from '../../i18n/strings.forms.js';
+import { useI18n } from '../../i18n/use-i18n.js';
 import {
   type FieldDefinition,
   tryGetFormContext,
 } from '../../state/form-context.js';
 import type { DateRangeValue } from './types.js';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Field name */
@@ -343,7 +347,7 @@ const primaryControlId = $derived(isSmrt ? `${name}_voice` : `${name}_start`);
           onmouseleave={handleMouseLeave}
           ontouchstart={handleTouchStart}
           ontouchend={handleTouchEnd}
-          aria-label="Hold to speak date range"
+          aria-label={t(M['ui.date_range_input.mic_aria_label'])}
         >
           {#if isParsing}
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="spinner">
@@ -409,14 +413,14 @@ const primaryControlId = $derived(isSmrt ? `${name}_voice` : `${name}_start`);
   {#if isRecording}
     <div class="listening-indicator">Recording... say "from [start] to [end]"</div>
   {:else if isParsing}
-    <div class="parsing-indicator">Parsing dates...</div>
+    <div class="parsing-indicator">{t(M['ui.date_range_input.parsing'])}</div>
   {:else if parseError}
     <div id={`${name}-error`} class="error-indicator" role="alert">{parseError}</div>
   {:else if error}
     <div id={`${name}-error`} class="error-indicator" role="alert">{error}</div>
   {:else if !isValidRange}
     <div id={`${name}-error`} class="error-indicator" role="alert">
-      End date must be after start date
+      {t(M['ui.date_range_input.end_after_start'])}
     </div>
   {/if}
 </div>

--- a/packages/smrt-svelte/src/components/forms/DateTimeInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/DateTimeInput.svelte
@@ -2,11 +2,15 @@
 import { onDestroy, onMount } from 'svelte';
 import { useAppState } from '../../hooks/useAppState.svelte.js';
 import { useSTT } from '../../hooks/useSTT.svelte.js';
+import { M } from '../../i18n/strings.forms.js';
+import { useI18n } from '../../i18n/use-i18n.js';
 import {
   type FieldDefinition,
   tryGetFormContext,
 } from '../../state/form-context.js';
 import { importOptional } from '../../utils/import-optional.js';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Field name */
@@ -320,7 +324,7 @@ function handleNativeChange(e: Event) {
         onmouseleave={handleMouseLeave}
         ontouchstart={handleMicTouchStart}
         ontouchend={handleTouchEnd}
-        aria-label="Hold to speak"
+        aria-label={t(M['ui.date_time_input.mic_aria_label'])}
       >
         {#if isParsing}
           <svg
@@ -372,7 +376,7 @@ function handleNativeChange(e: Event) {
   {#if isHolding}
     <div class="listening-indicator">Recording...</div>
   {:else if isParsing}
-    <div class="parsing-indicator">Parsing date...</div>
+    <div class="parsing-indicator">{t(M['ui.date_time_input.parsing'])}</div>
   {:else if parseError}
     <div id={`${name}-error`} class="error-indicator" role="alert">{parseError}</div>
   {/if}

--- a/packages/smrt-svelte/src/components/forms/FileUpload.svelte
+++ b/packages/smrt-svelte/src/components/forms/FileUpload.svelte
@@ -11,6 +11,11 @@
  * - Material 3 styling
  */
 
+import { M } from '../../i18n/strings.forms.js';
+import { useI18n } from '../../i18n/use-i18n.js';
+
+const { t } = useI18n();
+
 export interface Props {
   /** Accepted file types (e.g., '.pdf,.csv' or 'application/pdf,text/csv') */
   accept?: string;
@@ -211,7 +216,7 @@ function formatFileSize(bytes: number): string {
           <button
             class="file-list__remove"
             onclick={() => removeFile(i)}
-            aria-label="Remove {file.name}"
+            aria-label={t(M['ui.file_upload.remove_file'], { name: file.name })}
             type="button"
             {disabled}
           >

--- a/packages/smrt-svelte/src/components/forms/Form.svelte
+++ b/packages/smrt-svelte/src/components/forms/Form.svelte
@@ -3,12 +3,16 @@ import type { Snippet } from 'svelte';
 import { onDestroy } from 'svelte';
 import { useAppState } from '../../hooks/useAppState.svelte.js';
 import { useSTT } from '../../hooks/useSTT.svelte.js';
+import { M } from '../../i18n/strings.forms.js';
+import { useI18n } from '../../i18n/use-i18n.js';
 import {
   type FieldDefinition,
   type SMRTFormContext,
   setFormContext,
 } from '../../state/form-context.js';
 import type { LLMModelId, STTAdapterType } from './types.js';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Form children */
@@ -497,9 +501,9 @@ function getFormData(): Record<string, unknown> {
   -->
   <div class="smrt-form__status" role="status" aria-live="polite">
     {#if isExtracting}
-      Extracting form fields…
+      {t(M['ui.form.extracting'])}
     {:else if isFormListening}
-      Listening. Say "done" to finish.
+      {t(M['ui.form.listening_status'])}
     {/if}
   </div>
 
@@ -561,7 +565,7 @@ function getFormData(): Record<string, unknown> {
               <rect x="6" y="4" width="4" height="16"/>
               <rect x="14" y="4" width="4" height="16"/>
             </svg>
-            Listening... (say "done" to finish)
+            {t(M['ui.form.listening_button'])}
           {:else}
             <svg
               width="18"
@@ -577,7 +581,7 @@ function getFormData(): Record<string, unknown> {
               <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
               <line x1="12" x2="12" y1="19" y2="22"/>
             </svg>
-            Speak all fields
+            {t(M['ui.form.speak_all_fields'])}
           {/if}
         </button>
       {/if}
@@ -595,7 +599,7 @@ function getFormData(): Record<string, unknown> {
 
 {#if isFormListening && spokenText}
   <div class="spoken-toaster">
-    <strong>You said:</strong> {spokenText}
+    <strong>{t(M['ui.form.you_said'])}</strong> {spokenText}
   </div>
 {/if}
 

--- a/packages/smrt-svelte/src/components/forms/FormMicButton.svelte
+++ b/packages/smrt-svelte/src/components/forms/FormMicButton.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 import { useAppState } from '../../hooks/useAppState.svelte.js';
+import { M } from '../../i18n/strings.forms.js';
+import { useI18n } from '../../i18n/use-i18n.js';
 import { tryGetFormContext } from '../../state/form-context.js';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Size of the mic icon */
@@ -89,7 +93,7 @@ function handleClick() {
       </svg>
     {/if}
     {#if isListening}
-      <span class="tooltip">Speak to fill all fields. Click again to stop.</span>
+      <span class="tooltip">{t(M['ui.form_mic_button.tooltip'])}</span>
     {/if}
   </span>
 {/if}

--- a/packages/smrt-svelte/src/components/forms/MeasurementInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/MeasurementInput.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
 import { onDestroy, onMount } from 'svelte';
 import { useAppState } from '../../hooks/useAppState.svelte.js';
+import { M } from '../../i18n/strings.forms.js';
+import { useI18n } from '../../i18n/use-i18n.js';
 import {
   type FieldDefinition,
   tryGetFormContext,
 } from '../../state/form-context.js';
 import type { MeasurementUnit, MeasurementValue } from './types.js';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Field name */
@@ -377,9 +381,9 @@ function handleUnitChange(e: Event) {
   {:else if showInvalid && !isInRange}
     <div id={`${name}-error`} class="validation-error" role="alert">
       {#if min !== undefined && value !== null && value < min}
-        Value must be at least {min} {unitAbbreviations[unit]}
+        {t(M['ui.measurement_input.value_at_least'], { min, unit: unitAbbreviations[unit] })}
       {:else if max !== undefined && value !== null && value > max}
-        Value must be at most {max} {unitAbbreviations[unit]}
+        {t(M['ui.measurement_input.value_at_most'], { max, unit: unitAbbreviations[unit] })}
       {/if}
     </div>
   {/if}

--- a/packages/smrt-svelte/src/components/forms/MoneyInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/MoneyInput.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
 import { onDestroy, onMount } from 'svelte';
 import { useAppState } from '../../hooks/useAppState.svelte.js';
+import { M } from '../../i18n/strings.forms.js';
+import { useI18n } from '../../i18n/use-i18n.js';
 import {
   type FieldDefinition,
   tryGetFormContext,
 } from '../../state/form-context.js';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Field name */
@@ -316,9 +320,9 @@ function handleBlur() {
   {:else if showInvalid && !isInRange}
     <div id={`${name}-error`} class="validation-error" role="alert">
       {#if min !== undefined && value !== null && value < min}
-        Value must be at least ${(min / 100).toFixed(2)}
+        {t(M['ui.money_input.value_at_least'], { min: `${currencySymbol}${(min / 100).toFixed(2)}` })}
       {:else if max !== undefined && value !== null && value > max}
-        Value must be at most ${(max / 100).toFixed(2)}
+        {t(M['ui.money_input.value_at_most'], { max: `${currencySymbol}${(max / 100).toFixed(2)}` })}
       {/if}
     </div>
   {/if}

--- a/packages/smrt-svelte/src/components/forms/NumberInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/NumberInput.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
 import { onDestroy, onMount } from 'svelte';
 import { useAppState } from '../../hooks/useAppState.svelte.js';
+import { M } from '../../i18n/strings.forms.js';
+import { useI18n } from '../../i18n/use-i18n.js';
 import {
   type FieldDefinition,
   tryGetFormContext,
 } from '../../state/form-context.js';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Field name */
@@ -221,9 +225,9 @@ function handleInput(e: Event) {
   {#if showInvalid}
     <div id={`${name}-error`} class="validation-error" role="alert">
       {#if min !== undefined && value !== null && value < min}
-        Value must be at least {min}
+        {t(M['ui.number_input.value_at_least'], { min })}
       {:else if max !== undefined && value !== null && value > max}
-        Value must be at most {max}
+        {t(M['ui.number_input.value_at_most'], { max })}
       {/if}
     </div>
   {/if}

--- a/packages/smrt-svelte/src/components/forms/PhoneInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/PhoneInput.svelte
@@ -2,10 +2,14 @@
 import { onDestroy, onMount } from 'svelte';
 import { useAppState } from '../../hooks/useAppState.svelte.js';
 import { useSTT } from '../../hooks/useSTT.svelte.js';
+import { M } from '../../i18n/strings.forms.js';
+import { useI18n } from '../../i18n/use-i18n.js';
 import {
   type FieldDefinition,
   tryGetFormContext,
 } from '../../state/form-context.js';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Field name */
@@ -282,7 +286,7 @@ function handleInput(e: Event) {
         onmouseleave={handleMouseLeave}
         ontouchstart={handleTouchStart}
         ontouchend={handleTouchEnd}
-        aria-label="Hold to speak"
+        aria-label={t(M['ui.phone_input.mic_aria_label'])}
       >
         <svg
           width="16"
@@ -305,7 +309,7 @@ function handleInput(e: Event) {
   {#if isInitializing}
     <div class="downloading-indicator">
       <span class="processing-spinner"></span>
-      <span>Downloading Whisper model... {downloadProgress}%</span>
+      <span>{t(M['ui.phone_input.downloading_model'], { progress: downloadProgress })}</span>
     </div>
   {:else if isHolding}
     <div class="listening-indicator">
@@ -324,7 +328,7 @@ function handleInput(e: Event) {
   {/if}
 
   {#if showInvalid}
-    <div id={`${name}-error`} class="validation-error" role="alert">Invalid phone number</div>
+    <div id={`${name}-error`} class="validation-error" role="alert">{t(M['ui.phone_input.invalid'])}</div>
   {/if}
 </div>
 

--- a/packages/smrt-svelte/src/components/forms/SearchInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/SearchInput.svelte
@@ -11,6 +11,11 @@
  * - Material 3 styling
  */
 
+import { M } from '../../i18n/strings.forms.js';
+import { useI18n } from '../../i18n/use-i18n.js';
+
+const { t } = useI18n();
+
 export interface Props {
   /** Current search value */
   value?: string;
@@ -187,7 +192,7 @@ const sizeClasses = {
       type="button"
       class="search-input__clear"
       onclick={handleClear}
-      aria-label="Clear search"
+      aria-label={t(M['ui.search_input.clear_aria_label'])}
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/smrt-svelte/src/components/forms/TextInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/TextInput.svelte
@@ -3,12 +3,16 @@ import { onDestroy, onMount } from 'svelte';
 import { ripple } from '../../actions/ripple.js';
 import { useAppState } from '../../hooks/useAppState.svelte.js';
 import { useSTT } from '../../hooks/useSTT.svelte.js';
+import { M } from '../../i18n/strings.forms.js';
+import { useI18n } from '../../i18n/use-i18n.js';
 import {
   type FieldDefinition,
   tryGetFormContext,
 } from '../../state/form-context.js';
 import { formatEmail, formatText } from '../../utils/forms/formatters.js';
 import { Icon } from '../display/index.js';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Field name */
@@ -252,7 +256,7 @@ function handleInput(e: Event) {
         onmouseleave={handleMouseLeave}
         ontouchstart={(e) => { e.stopPropagation(); e.preventDefault(); startHoldRecording(); }}
         ontouchend={handleTouchEnd}
-        aria-label="Hold to speak"
+        aria-label={t(M['ui.text_input.mic_aria_label'])}
       >
         <Icon name="mic" size={20} />
       </button>
@@ -263,7 +267,7 @@ function handleInput(e: Event) {
 
   <div id={`${name}-supporting`} class="supporting-text" aria-live="polite">
     {#if isInitializing}
-      <span class="info">Downloading Whisper model... {downloadProgress}%</span>
+      <span class="info">{t(M['ui.text_input.downloading_model'], { progress: downloadProgress })}</span>
     {:else if isHolding}
       <span class="success">Recording...</span>
     {:else if isProcessing}
@@ -271,7 +275,7 @@ function handleInput(e: Event) {
     {:else if processError}
       <span class="error">{processError}</span>
     {:else if showInvalid}
-      <span class="error">Invalid email address</span>
+      <span class="error">{t(M['ui.text_input.invalid_email'])}</span>
     {:else if description && isFocused}
       <span class="info">{description}</span>
     {/if}

--- a/packages/smrt-svelte/src/components/forms/TextareaInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/TextareaInput.svelte
@@ -3,12 +3,16 @@ import { onDestroy, onMount } from 'svelte';
 import { ripple } from '../../actions/ripple.js';
 import { useAppState } from '../../hooks/useAppState.svelte.js';
 import { useSTT } from '../../hooks/useSTT.svelte.js';
+import { M } from '../../i18n/strings.forms.js';
+import { useI18n } from '../../i18n/use-i18n.js';
 import {
   type FieldDefinition,
   tryGetFormContext,
 } from '../../state/form-context.js';
 import { formatText } from '../../utils/forms/formatters.js';
 import { Icon } from '../display/index.js';
+
+const { t } = useI18n();
 
 export interface Props {
   /** Field name */
@@ -230,7 +234,7 @@ function handleInput(e: Event) {
         onmouseleave={handleMouseLeave}
         ontouchstart={(e) => { e.stopPropagation(); e.preventDefault(); startHoldRecording(); }}
         ontouchend={handleTouchEnd}
-        aria-label="Hold to speak"
+        aria-label={t(M['ui.textarea_input.mic_aria_label'])}
       >
         <Icon name="mic" size={20} />
       </button>
@@ -241,7 +245,7 @@ function handleInput(e: Event) {
 
   <div id={`${name}-supporting`} class="supporting-text" aria-live="polite">
     {#if isInitializing}
-      <span class="info">Downloading Whisper model... {downloadProgress}%</span>
+      <span class="info">{t(M['ui.textarea_input.downloading_model'], { progress: downloadProgress })}</span>
     {:else if isHolding}
       <span class="success">Recording...</span>
     {:else if isProcessing}

--- a/packages/smrt-svelte/src/components/layout/Footer.svelte
+++ b/packages/smrt-svelte/src/components/layout/Footer.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 import type { Snippet } from 'svelte';
+import { M } from '../../i18n/strings.ui.js';
+import { useI18n } from '../../i18n/use-i18n.js';
 import Container from './Container.svelte';
+
+const { t } = useI18n();
 
 export interface Props {
   children?: Snippet;
@@ -14,7 +18,7 @@ const currentYear = new Date().getFullYear();
 <footer class="site-footer">
   <Container>
     <div class="footer-content">
-      <p class="copyright">&copy; {currentYear} All rights reserved.</p>
+      <p class="copyright">&copy; {currentYear} {t(M['ui.footer.all_rights_reserved'])}</p>
 
       {#if children}
         <div class="footer-links">

--- a/packages/smrt-svelte/src/components/layout/Masthead.svelte
+++ b/packages/smrt-svelte/src/components/layout/Masthead.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 import type { Snippet } from 'svelte';
+import { M } from '../../i18n/strings.ui.js';
+import { useI18n } from '../../i18n/use-i18n.js';
 import Container from './Container.svelte';
+
+const { t } = useI18n();
 
 export interface Props {
   date?: string;
@@ -54,7 +58,7 @@ const {
     <!-- Mobile layout -->
     <div class="subheader mobile">
       <div class="left">
-        <a href={locationHref} class="home-icon" aria-label="Home">
+        <a href={locationHref} class="home-icon" aria-label={t(M['ui.masthead.home'])}>
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"/>
             <path d="M3 10a2 2 0 0 1 .709-1.528l7-5.999a2 2 0 0 1 2.582 0l7 5.999A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>

--- a/packages/smrt-svelte/src/components/memberships/MembershipCard.svelte
+++ b/packages/smrt-svelte/src/components/memberships/MembershipCard.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 import type { Membership, Role, Tenant } from '@happyvertical/smrt-users';
+import { M } from '../../i18n/strings.ui.js';
+import { useI18n } from '../../i18n/use-i18n.js';
 import RoleBadge from '../roles/RoleBadge.svelte';
+
+const { t } = useI18n();
 
 interface Props {
   membership: Membership;
@@ -53,7 +57,7 @@ function formatDate(date: Date | string | null | undefined): string {
     {#if onchangerole || onremove}
       <div class="actions">
         {#if onchangerole}
-          <button type="button" class="action-btn" onclick={onchangerole}>Change Role</button>
+          <button type="button" class="action-btn" onclick={onchangerole}>{t(M['ui.membership_card.change_role'])}</button>
         {/if}
         {#if onremove}
           <button type="button" class="action-btn danger" onclick={onremove}>Remove</button>

--- a/packages/smrt-svelte/src/components/memberships/MembershipList.svelte
+++ b/packages/smrt-svelte/src/components/memberships/MembershipList.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
 import type { Membership, Role, Tenant } from '@happyvertical/smrt-users';
 import type { Snippet } from 'svelte';
+import { M } from '../../i18n/strings.ui.js';
+import { useI18n } from '../../i18n/use-i18n.js';
 import MembershipCard from './MembershipCard.svelte';
+
+const { t } = useI18n();
 
 interface MembershipWithContext {
   membership: Membership;
@@ -32,7 +36,7 @@ const {
   {#if loading}
     <div class="loading">
       <div class="spinner"></div>
-      <span>Loading memberships...</span>
+      <span>{t(M['ui.membership_list.loading'])}</span>
     </div>
   {:else if memberships.length === 0}
     {#if empty}

--- a/packages/smrt-svelte/src/components/module/ModulePanel.svelte
+++ b/packages/smrt-svelte/src/components/module/ModulePanel.svelte
@@ -15,7 +15,11 @@ import type {
   ModuleUIBaseProps,
   SmrtModuleMeta,
 } from '@happyvertical/smrt-types';
+import { M } from '../../i18n/strings.ui.js';
+import { useI18n } from '../../i18n/use-i18n.js';
 import { ModuleUIRegistry } from '../../registry/module-registry.js';
+
+const { t } = useI18n();
 
 interface Props extends ModuleUIBaseProps {
   /** Module name (e.g., '@happyvertical/smrt-commerce') */
@@ -62,13 +66,13 @@ const slotMeta = $derived(moduleMeta?.uiSlots?.[slotId]);
       </svg>
     </div>
     <p class="module-panel-placeholder__title">
-      Component not registered
+      {t(M['ui.module_panel.component_not_registered'])}
     </p>
     <code class="module-panel-placeholder__code">
       {moduleName}/{slotId}
     </code>
     <p class="module-panel-placeholder__hint">
-      Import the module's Svelte package to register components.
+      {t(M['ui.module_panel.register_hint'])}
     </p>
     {#if slotMeta}
       <p class="module-panel-placeholder__meta">

--- a/packages/smrt-svelte/src/components/ui/Pagination.svelte
+++ b/packages/smrt-svelte/src/components/ui/Pagination.svelte
@@ -11,6 +11,11 @@
  * - Native list semantics for numbered pages
  */
 
+import { M } from '../../i18n/strings.ui.js';
+import { useI18n } from '../../i18n/use-i18n.js';
+
+const { t } = useI18n();
+
 /** Props for Pagination component */
 export interface Props {
   /** Current active page (1-based) */
@@ -105,11 +110,11 @@ const isLastPage = $derived(currentPage === totalPages);
     <!-- First page -->
     {#if showFirstLast}
       {#if onPageChange}
-        <button class="page-link nav-link first" type="button" disabled={isFirstPage} onclick={() => onPageChange(1)} aria-label="First page">
+        <button class="page-link nav-link first" type="button" disabled={isFirstPage} onclick={() => onPageChange(1)} aria-label={t(M['ui.pagination.first_page'])}>
           &laquo; First
         </button>
       {:else if !isFirstPage}
-        <a href={getPageUrl(1)} class="page-link nav-link first" aria-label="First page">
+        <a href={getPageUrl(1)} class="page-link nav-link first" aria-label={t(M['ui.pagination.first_page'])}>
           &laquo; First
         </a>
       {:else}
@@ -119,11 +124,11 @@ const isLastPage = $derived(currentPage === totalPages);
 
     <!-- Previous page -->
     {#if onPageChange}
-      <button class="page-link nav-link" type="button" disabled={!hasPrevPage} onclick={() => onPageChange(currentPage - 1)} aria-label="Previous page">
+      <button class="page-link nav-link" type="button" disabled={!hasPrevPage} onclick={() => onPageChange(currentPage - 1)} aria-label={t(M['ui.pagination.previous_page'])}>
         &larr; Prev
       </button>
     {:else if hasPrevPage}
-      <a href={getPageUrl(currentPage - 1)} class="page-link nav-link" aria-label="Previous page">
+      <a href={getPageUrl(currentPage - 1)} class="page-link nav-link" aria-label={t(M['ui.pagination.previous_page'])}>
         &larr; Prev
       </a>
     {:else}
@@ -138,15 +143,15 @@ const isLastPage = $derived(currentPage === totalPages);
           </li>
         {:else if page === currentPage}
           <li class="page-numbers__item">
-            <span class="page-link current" aria-current="page" aria-label="Page {page}, current">{page}</span>
+            <span class="page-link current" aria-current="page" aria-label={t(M['ui.pagination.page_current'], { page })}>{page}</span>
           </li>
         {:else if onPageChange}
           <li class="page-numbers__item">
-            <button class="page-link" type="button" onclick={() => onPageChange(page as number)} aria-label="Go to page {page}">{page}</button>
+            <button class="page-link" type="button" onclick={() => onPageChange(page as number)} aria-label={t(M['ui.pagination.go_to_page'], { page })}>{page}</button>
           </li>
         {:else}
           <li class="page-numbers__item">
-            <a href={getPageUrl(page)} class="page-link" aria-label="Go to page {page}">{page}</a>
+            <a href={getPageUrl(page)} class="page-link" aria-label={t(M['ui.pagination.go_to_page'], { page })}>{page}</a>
           </li>
         {/if}
       {/each}
@@ -154,11 +159,11 @@ const isLastPage = $derived(currentPage === totalPages);
 
     <!-- Next page -->
     {#if onPageChange}
-      <button class="page-link nav-link" type="button" disabled={!hasNextPage} onclick={() => onPageChange(currentPage + 1)} aria-label="Next page">
+      <button class="page-link nav-link" type="button" disabled={!hasNextPage} onclick={() => onPageChange(currentPage + 1)} aria-label={t(M['ui.pagination.next_page'])}>
         Next &rarr;
       </button>
     {:else if hasNextPage}
-      <a href={getPageUrl(currentPage + 1)} class="page-link nav-link" aria-label="Next page">
+      <a href={getPageUrl(currentPage + 1)} class="page-link nav-link" aria-label={t(M['ui.pagination.next_page'])}>
         Next &rarr;
       </a>
     {:else}
@@ -168,11 +173,11 @@ const isLastPage = $derived(currentPage === totalPages);
     <!-- Last page -->
     {#if showFirstLast}
       {#if onPageChange}
-        <button class="page-link nav-link last" type="button" disabled={isLastPage} onclick={() => onPageChange(totalPages)} aria-label="Last page ({totalPages})">
+        <button class="page-link nav-link last" type="button" disabled={isLastPage} onclick={() => onPageChange(totalPages)} aria-label={t(M['ui.pagination.last_page'], { totalPages })}>
           Last &raquo;
         </button>
       {:else if !isLastPage}
-        <a href={getPageUrl(totalPages)} class="page-link nav-link last" aria-label="Last page ({totalPages})">
+        <a href={getPageUrl(totalPages)} class="page-link nav-link last" aria-label={t(M['ui.pagination.last_page'], { totalPages })}>
           Last &raquo;
         </a>
       {:else}

--- a/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
 import type { Snippet } from 'svelte';
+import { M } from '../../i18n/strings.workspace.js';
+import { useI18n } from '../../i18n/use-i18n.js';
+
+const { t } = useI18n();
 
 /**
  * WorkspaceShell — SvelteKit-agnostic, SSR-safe admin shell primitive.
@@ -260,7 +264,7 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
   <button
     class="mobile-backdrop"
     type="button"
-    aria-label="Close navigation"
+    aria-label={t(M['ui.workspace_shell.close_navigation'])}
     tabindex={mobileNavOpen ? 0 : -1}
     onclick={closeMobileNav}
   ></button>
@@ -276,7 +280,7 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
       <button
         class="inspector-backdrop"
         type="button"
-        aria-label="Close inspector"
+        aria-label={t(M['ui.workspace_shell.close_inspector'])}
         onclick={handleInspectorClose}
       ></button>
     {:else}
@@ -286,7 +290,7 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
 
   <aside
     class="smrt-workspace-sidebar"
-    aria-label="Primary navigation"
+    aria-label={t(M['ui.workspace_shell.primary_navigation'])}
     inert={sidebarInert}
   >
     <div class="brand-row">
@@ -322,7 +326,7 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
     </div>
 
     {#if nav}
-      <nav class="nav-region" aria-label="Workspace navigation">
+      <nav class="nav-region" aria-label={t(M['ui.workspace_shell.workspace_navigation'])}>
         {@render nav()}
       </nav>
     {/if}
@@ -396,7 +400,7 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
                 class="inspector-close"
                 type="button"
                 onclick={handleInspectorClose}
-                aria-label="Close inspector"
+                aria-label={t(M['ui.workspace_shell.close_inspector'])}
               >
                 <span aria-hidden="true">×</span>
               </button>
@@ -412,7 +416,7 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
         <div
           class="smrt-workspace-inspector-rail"
           role="toolbar"
-          aria-label="Inspector tools"
+          aria-label={t(M['ui.workspace_shell.inspector_tools'])}
           aria-orientation="vertical"
         >
           {@render inspectorRail!()}

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
@@ -29,8 +29,12 @@
 
 <script lang="ts">
   import { onDestroy, onMount, tick } from 'svelte';
+  import { M } from '../../../i18n/strings.workspace.js';
+  import { useI18n } from '../../../i18n/use-i18n.js';
   import type { ToolsDockContext } from '../types.js';
   import type { ToolsDockInstance } from './define-tools-dock.svelte.js';
+
+  const { t } = useI18n();
 
   interface Props {
     /** Instance produced by `defineToolsDock(...)`. */
@@ -219,14 +223,14 @@
     <div class="tools-dock__panel-body">
       {#if dock.availableTools.length === 0}
         <div class="tools-dock__empty">
-          <strong>No tools available</strong>
-          <p>No tools are available for the current context.</p>
+          <strong>{t(M['ui.tools_dock.no_tools_available'])}</strong>
+          <p>{t(M['ui.tools_dock.no_tools_context'])}</p>
         </div>
       {:else if ActiveTool}
         <ActiveTool context={dock.context} {dock} />
       {:else}
         <div class="tools-dock__empty">
-          <p>Select a tool to begin.</p>
+          <p>{t(M['ui.tools_dock.select_tool'])}</p>
         </div>
       {/if}
     </div>
@@ -238,7 +242,7 @@
 
 {#if dock.layout === 'topbar'}
   <div class="tools-dock tools-dock--topbar">
-    <nav class="tools-dock__topbar" aria-label="Workspace tools">
+    <nav class="tools-dock__topbar" aria-label={t(M['ui.tools_dock.workspace_tools'])}>
       {#each dock.availableTools as tool (tool.id)}
         {@render toolButton(tool, 'topbar')}
       {/each}
@@ -258,7 +262,7 @@
       ></button>
     {/if}
     {@render panel()}
-    <nav class="tools-dock__rail" aria-label="Workspace tools">
+    <nav class="tools-dock__rail" aria-label={t(M['ui.tools_dock.workspace_tools'])}>
       {#each dock.availableTools as tool (tool.id)}
         {@render toolButton(tool, 'rail')}
       {/each}

--- a/packages/smrt-svelte/src/i18n/server.ts
+++ b/packages/smrt-svelte/src/i18n/server.ts
@@ -23,10 +23,14 @@ import {
 } from '@happyvertical/smrt-languages';
 import type { I18nSnapshot } from './context.svelte.js';
 import { getRegisteredDefaults } from './registry.js';
-// Side-effect: register smrt-svelte's own UI primitive defaults (ui.*) so they
-// are in every snapshot even when a consumer imports only `buildI18nSnapshot`
-// from this subpath and never the components themselves.
+// Side-effect: register ALL of smrt-svelte's own UI catalogs (ui.*) so they are
+// in every snapshot even when a consumer imports only `buildI18nSnapshot` from
+// this subpath and never the components themselves. Add any new smrt-svelte
+// catalog here so its keys are server-resolvable.
 import './strings.js';
+import './strings.forms.js';
+import './strings.ui.js';
+import './strings.workspace.js';
 
 export interface BuildI18nSnapshotOptions {
   /** Target locale (BCP-47-ish, e.g. `fr-CA`). */

--- a/packages/smrt-svelte/src/i18n/strings.forms.ts
+++ b/packages/smrt-svelte/src/i18n/strings.forms.ts
@@ -1,0 +1,70 @@
+/**
+ * Forms-component message catalog (i18n, Sweep S13 #1418).
+ *
+ * English code defaults for user-facing strings in
+ * `src/components/forms/*.svelte`, registered via `defineMessages`. Keys follow
+ * the `ui` namespace (`ui.<component>.<descriptor>`) for smrt-svelte primitives.
+ */
+import { defineMessages } from './registry.js';
+
+export const M = defineMessages({
+  // AddressInput
+  'ui.address_input.street_placeholder': '123 Main Street',
+  'ui.address_input.city_placeholder': 'City',
+  'ui.address_input.postal_code_placeholder': 'A1A 1A1',
+
+  // DateRangeInput
+  'ui.date_range_input.mic_aria_label': 'Hold to speak date range',
+  'ui.date_range_input.parsing': 'Parsing dates...',
+  'ui.date_range_input.end_after_start': 'End date must be after start date',
+
+  // DateTimeInput
+  'ui.date_time_input.mic_aria_label': 'Hold to speak',
+  'ui.date_time_input.parsing': 'Parsing date...',
+
+  // FileUpload
+  'ui.file_upload.remove_file': 'Remove {name}',
+
+  // Form
+  'ui.form.extracting': 'Extracting form fields…',
+  'ui.form.listening_status': 'Listening. Say "done" to finish.',
+  'ui.form.listening_button': 'Listening... (say "done" to finish)',
+  'ui.form.speak_all_fields': 'Speak all fields',
+  'ui.form.you_said': 'You said:',
+
+  // FormMicButton
+  'ui.form_mic_button.tooltip':
+    'Speak to fill all fields. Click again to stop.',
+
+  // MeasurementInput
+  'ui.measurement_input.value_at_least': 'Value must be at least {min} {unit}',
+  'ui.measurement_input.value_at_most': 'Value must be at most {max} {unit}',
+
+  // MoneyInput — the currency symbol lives in the {min}/{max} var (passed by the
+  // component) so a translation can place it per locale, and the template has no `${…}`.
+  'ui.money_input.value_at_least': 'Value must be at least {min}',
+  'ui.money_input.value_at_most': 'Value must be at most {max}',
+
+  // NumberInput
+  'ui.number_input.value_at_least': 'Value must be at least {min}',
+  'ui.number_input.value_at_most': 'Value must be at most {max}',
+
+  // PhoneInput
+  'ui.phone_input.mic_aria_label': 'Hold to speak',
+  'ui.phone_input.downloading_model':
+    'Downloading Whisper model... {progress}%',
+  'ui.phone_input.invalid': 'Invalid phone number',
+
+  // SearchInput
+  'ui.search_input.clear_aria_label': 'Clear search',
+
+  // TextInput
+  'ui.text_input.mic_aria_label': 'Hold to speak',
+  'ui.text_input.downloading_model': 'Downloading Whisper model... {progress}%',
+  'ui.text_input.invalid_email': 'Invalid email address',
+
+  // TextareaInput
+  'ui.textarea_input.mic_aria_label': 'Hold to speak',
+  'ui.textarea_input.downloading_model':
+    'Downloading Whisper model... {progress}%',
+});

--- a/packages/smrt-svelte/src/i18n/strings.ui.ts
+++ b/packages/smrt-svelte/src/i18n/strings.ui.ts
@@ -1,0 +1,53 @@
+/**
+ * smrt-svelte `ui`-namespace message catalog (i18n, Sweep S13 #1418).
+ *
+ * English code defaults for the `ui`, `feedback`, `layout`, `memberships`,
+ * `module`, and `calendar` component primitives. Registered through
+ * `defineMessages` (see `./registry.ts`); keys follow `<package>.<component>.<descriptor>`
+ * with the `ui` namespace for smrt-svelte primitives.
+ */
+
+import { defineMessages } from './registry.js';
+
+export const M = defineMessages({
+  // calendar/Calendar.svelte
+  'ui.calendar.previous_month': 'Previous month',
+  'ui.calendar.next_month': 'Next month',
+  'ui.calendar.select_month': 'Select month',
+  'ui.calendar.select_year': 'Select year',
+
+  // calendar/DayView.svelte
+  'ui.day_view.back_to_calendar': 'Back to Calendar',
+  'ui.day_view.no_events': 'No events scheduled for this day',
+
+  // feedback/Modal.svelte
+  'ui.modal.close': 'Close modal',
+
+  // feedback/ProgressBar.svelte
+  'ui.progress_bar.over_by': 'Over by {amount}',
+
+  // layout/Footer.svelte
+  'ui.footer.all_rights_reserved': 'All rights reserved.',
+
+  // layout/Masthead.svelte
+  'ui.masthead.home': 'Home',
+
+  // memberships/MembershipCard.svelte
+  'ui.membership_card.change_role': 'Change Role',
+
+  // memberships/MembershipList.svelte
+  'ui.membership_list.loading': 'Loading memberships...',
+
+  // module/ModulePanel.svelte
+  'ui.module_panel.component_not_registered': 'Component not registered',
+  'ui.module_panel.register_hint':
+    "Import the module's Svelte package to register components.",
+
+  // ui/Pagination.svelte
+  'ui.pagination.first_page': 'First page',
+  'ui.pagination.previous_page': 'Previous page',
+  'ui.pagination.page_current': 'Page {page}, current',
+  'ui.pagination.go_to_page': 'Go to page {page}',
+  'ui.pagination.next_page': 'Next page',
+  'ui.pagination.last_page': 'Last page ({totalPages})',
+});

--- a/packages/smrt-svelte/src/i18n/strings.workspace.ts
+++ b/packages/smrt-svelte/src/i18n/strings.workspace.ts
@@ -1,0 +1,52 @@
+/**
+ * Workspace / admin / browser-AI message catalog (i18n, Sweep S13 #1418).
+ *
+ * English code defaults for user-facing strings in the workspace shell, admin
+ * panels, and browser-AI test components. Keys use the `ui` namespace and follow
+ * `ui.<component_snake>.<descriptor_snake>`. Client-safe (no languages root
+ * import). Registered via `defineMessages` so the client `t` / `<Trans>` fall
+ * back to these defaults when no server snapshot is present.
+ */
+
+import { defineMessages } from './registry.js';
+
+export const M = defineMessages({
+  // browser-ai/svelte/components/STTTest.svelte
+  'ui.stt_test.heading': 'STT Adapter Test',
+  'ui.stt_test.adapter_browser': 'Browser (Web Speech API)',
+  'ui.stt_test.adapter_whisper_wasm': 'Whisper WASM (v2)',
+  'ui.stt_test.adapter_whisper_cpp': 'Whisper CPP',
+  'ui.stt_test.status_initializing': 'Initializing...',
+  'ui.stt_test.status_ready': 'Ready',
+  'ui.stt_test.status_not_initialized': 'Not initialized',
+
+  // components/admin/AgentAdminPanel.svelte
+  'ui.agent_admin_panel.no_panel_message': 'No admin panel registered for',
+  'ui.agent_admin_panel.no_panel_hint':
+    "Import the agent's admin package to register its panels.",
+
+  // components/admin/AgentAdminTabs.svelte
+  'ui.agent_admin_tabs.no_slots':
+    'No configuration slots available for this agent.',
+  'ui.agent_admin_tabs.tablist_label': 'Agent configuration tabs',
+
+  // components/admin/AgentSettingsShell.svelte
+  'ui.agent_settings_shell.no_agents_message':
+    'No agents configured for this site.',
+  'ui.agent_settings_shell.no_agents_hint':
+    'Agents are discovered by matching their context field to the site domain.',
+
+  // components/workspace/WorkspaceShell.svelte
+  'ui.workspace_shell.close_navigation': 'Close navigation',
+  'ui.workspace_shell.close_inspector': 'Close inspector',
+  'ui.workspace_shell.primary_navigation': 'Primary navigation',
+  'ui.workspace_shell.workspace_navigation': 'Workspace navigation',
+  'ui.workspace_shell.inspector_tools': 'Inspector tools',
+
+  // components/workspace/tools-dock/ToolsDock.svelte
+  'ui.tools_dock.no_tools_available': 'No tools available',
+  'ui.tools_dock.no_tools_context':
+    'No tools are available for the current context.',
+  'ui.tools_dock.select_tool': 'Select a tool to begin.',
+  'ui.tools_dock.workspace_tools': 'Workspace tools',
+});

--- a/scripts/check-hardcoded-strings.mjs
+++ b/scripts/check-hardcoded-strings.mjs
@@ -31,6 +31,7 @@ const PACKAGES = join(ROOT, 'packages');
 // i18n layer (`useI18n().t` / `<Trans>`). Add a package here once `pnpm
 // check:hardcoded-strings` reports 0 for it. S13 phase-2 wave 1 (#1418).
 const STRICT_PACKAGES = new Set([
+  'smrt-svelte',
   'users',
   'projects',
   'commerce',


### PR DESCRIPTION
## What

Phase-2 **wave 4** (final gate-clear package): route hardcoded user-facing strings
in the **smrt-svelte** UI library itself through its own i18n layer, and add it to
`STRICT_PACKAGES`.

## How

- Extraction ran as **3 parallel subagents** by component cluster (forms /
  ui+feedback+layout+memberships+module+calendar / workspace+admin+browser-ai),
  each writing a separate catalog under `src/i18n/` (`strings.forms.ts`,
  `strings.ui.ts`, `strings.workspace.ts`; **70 keys**, `ui.` namespace).
- Because this *is* smrt-svelte, components use **relative** i18n imports
  (`../../i18n/…`) — same pattern as the DataTable pilot — not the package name.
- All edits are string→`t()` swaps; no logic/`console.*`/markup changes
  (diff scope-checked). MoneyInput's currency symbol moved into the `{min}`/`{max}`
  var (per-locale placement; avoids a `${…}` template).

smrt-svelte is **exempt** from the coverage gate (v8 can't instrument `.svelte`),
so no coverage risk.

## Validation

- `turbo typecheck` **78/78** (a11y gate clean; validates all relative imports +
  3 catalogs across 29 components).
- **396 smrt-svelte tests pass** (golden tests hold via registered English defaults).
- Full build **50/50**; ratchet green with **13 strict packages**.

## S13 string-sweep status

This completes i18n extraction for **every gate-clear package**. Report-only
backlog is down to **192** — only the **coverage-blocked** set remains
(products 17%, messages 54%, images 13%, events 22%; all below their tier floors
on `main`, so extracting them trips the coverage gate). Those need a separate
**test** investment first, not i18n work — flagged for follow-up.