### PR TITLE
feat(i18n,test): extract events strings + raise coverage 22%→87%, flip strict (S13 #1418)

### DIFF
--- a/packages/events/src/__tests__/event-collection.test.ts
+++ b/packages/events/src/__tests__/event-collection.test.ts
@@ -6,7 +6,7 @@
  * Event-specific getRootEvent/isRoot, status transitions, in-progress
  * detection, relationship loads, and the collection's query helpers
  * (series/type/place/status/date/upcoming/search/tree) and tenant scoping.
- * Real in-memory SQLite, no mocks.
+ * Real temp-file SQLite (file:tmpdir), no mocks.
  */
 
 import { randomUUID } from 'node:crypto';

--- a/packages/events/src/__tests__/event-collection.test.ts
+++ b/packages/events/src/__tests__/event-collection.test.ts
@@ -1,0 +1,383 @@
+/**
+ * Event model + EventCollection integration tests.
+ *
+ * Covers the hierarchy traversal Event inherits from SmrtHierarchical
+ * (getParent/getChildren/getAncestors/getDescendants/moveTo) plus the
+ * Event-specific getRootEvent/isRoot, status transitions, in-progress
+ * detection, relationship loads, and the collection's query helpers
+ * (series/type/place/status/date/upcoming/search/tree) and tenant scoping.
+ * Real in-memory SQLite, no mocks.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { Event, EventCollection } from '../index.js';
+
+function getTestDbUrl(name: string): string {
+  return `file:${join(tmpdir(), `${name}-${randomUUID()}.db`)}`;
+}
+
+async function makeEvents(name: string) {
+  const dbUrl = getTestDbUrl(name);
+  const events = await EventCollection.create({
+    db: { type: 'sqlite', url: dbUrl },
+  });
+  return { dbUrl, events };
+}
+
+describe('Event model', () => {
+  it('persists core fields and applies defaults', async () => {
+    const { events } = await makeEvents('event-persist');
+
+    const e = await events.create({
+      name: 'Opening Ceremony',
+      description: 'Kickoff',
+      round: 1,
+      externalId: 'ext-1',
+      source: 'manual',
+    });
+    await e.save();
+
+    const loaded = await events.get({ id: e.id });
+    expect(loaded?.name).toBe('Opening Ceremony');
+    expect(loaded?.description).toBe('Kickoff');
+    expect(loaded?.round).toBe(1);
+    expect(loaded?.status).toBe('scheduled');
+    expect(loaded?.isRoot()).toBe(true);
+  });
+
+  it('updateStatus moves through the lifecycle and persists', async () => {
+    const { events } = await makeEvents('event-status');
+    const e = await events.create({ name: 'Match' });
+    await e.save();
+
+    await e.updateStatus('in_progress');
+    expect(e.status).toBe('in_progress');
+    let loaded = await events.get({ id: e.id });
+    expect(loaded?.status).toBe('in_progress');
+
+    await e.updateStatus('completed');
+    loaded = await events.get({ id: e.id });
+    expect(loaded?.status).toBe('completed');
+  });
+
+  it('isInProgress requires in_progress status within the date window', () => {
+    const past = new Date('2000-01-01');
+    const future = new Date('2999-01-01');
+
+    expect(
+      new Event({
+        name: 'a',
+        status: 'in_progress',
+        startDate: past,
+        endDate: future,
+      }).isInProgress(),
+    ).toBe(true);
+
+    // Right status but the window has not opened yet.
+    expect(
+      new Event({
+        name: 'b',
+        status: 'in_progress',
+        startDate: future,
+      }).isInProgress(),
+    ).toBe(false);
+
+    // Scheduled events are never "in progress".
+    expect(
+      new Event({
+        name: 'c',
+        status: 'scheduled',
+        startDate: past,
+        endDate: future,
+      }).isInProgress(),
+    ).toBe(false);
+  });
+
+  it('round-trips metadata through get/set/update helpers', async () => {
+    const { events } = await makeEvents('event-metadata');
+    const e = await events.create({
+      name: 'Tracked',
+      metadata: '{"score":0}',
+    });
+    expect(e.getMetadata()).toEqual({ score: 0 });
+
+    e.updateMetadata({ attendance: 500 });
+    await e.save();
+
+    const loaded = await events.get({ id: e.id });
+    expect(loaded?.getMetadata()).toEqual({ score: 0, attendance: 500 });
+  });
+
+  it('getSeries/getType return null when their FK is unset', async () => {
+    const { events } = await makeEvents('event-rel-null');
+    const e = await events.create({ name: 'Standalone' });
+    await e.save();
+    expect(await e.getSeries()).toBeNull();
+    expect(await e.getType()).toBeNull();
+  });
+
+  it('getParticipants returns the event participant rows', async () => {
+    const dbUrl = getTestDbUrl('event-participants-load');
+    const events = await EventCollection.create({
+      db: { type: 'sqlite', url: dbUrl },
+    });
+    const { EventParticipantCollection } = await import('../index.js');
+    const participants = await EventParticipantCollection.create({
+      db: { type: 'sqlite', url: dbUrl },
+    });
+
+    const e = await events.create({ name: 'Game with players' });
+    await e.save();
+
+    const p = await participants.create({
+      eventId: e.id,
+      profileId: 'player-1',
+      role: 'home',
+    });
+    await p.save();
+
+    const loaded = await e.getParticipants();
+    expect(loaded.map((row: { profileId?: string }) => row.profileId)).toEqual([
+      'player-1',
+    ]);
+  });
+});
+
+describe('Event hierarchy', () => {
+  async function buildTree(name: string) {
+    const { events } = await makeEvents(name);
+    const game = await events.create({ name: 'Game' });
+    await game.save();
+    const period = await events.create({ name: 'Period 1', parentId: game.id });
+    await period.save();
+    const goal = await events.create({ name: 'Goal', parentId: period.id });
+    await goal.save();
+    return { events, game, period, goal };
+  }
+
+  it('getParent/getChildren traverse one level each way', async () => {
+    const { game, period, goal } = await buildTree('hier-parent-child');
+
+    const parent = await period.getParent();
+    expect(parent?.id).toBe(game.id);
+
+    const children = await game.getChildren();
+    expect(children.map((c) => c.id)).toEqual([period.id]);
+
+    expect(await goal.getChildren()).toEqual([]);
+  });
+
+  it('getAncestors/getDescendants walk the full chain', async () => {
+    const { game, period, goal } = await buildTree('hier-ancestors');
+
+    const ancestors = await goal.getAncestors();
+    expect(ancestors.map((a) => a.id)).toContain(game.id);
+    expect(ancestors.map((a) => a.id)).toContain(period.id);
+
+    const descendants = await game.getDescendants();
+    expect(descendants.map((d) => d.id)).toContain(period.id);
+    expect(descendants.map((d) => d.id)).toContain(goal.id);
+  });
+
+  it('getRootEvent and isRoot identify the top-level ancestor', async () => {
+    const { game, period, goal } = await buildTree('hier-root');
+
+    expect(game.isRoot()).toBe(true);
+    expect(period.isRoot()).toBe(false);
+
+    const rootFromLeaf = await goal.getRootEvent();
+    expect(rootFromLeaf.id).toBe(game.id);
+
+    const rootFromRoot = await game.getRootEvent();
+    expect(rootFromRoot.id).toBe(game.id);
+  });
+
+  it('moveTo reparents a subtree', async () => {
+    const { events, game, period, goal } = await buildTree('hier-move');
+
+    const otherGame = await events.create({ name: 'Game 2' });
+    await otherGame.save();
+
+    await period.moveTo(otherGame.id);
+
+    const reloadedPeriod = await events.get({ id: period.id });
+    expect(reloadedPeriod?.parentId).toBe(otherGame.id);
+    // The original game no longer lists the period as a child.
+    expect(await game.getChildren()).toEqual([]);
+    // The goal still hangs under the moved period.
+    const movedChildren = await reloadedPeriod?.getChildren();
+    expect(movedChildren?.map((c) => c.id)).toEqual([goal.id]);
+  });
+});
+
+describe('EventCollection queries', () => {
+  it('filters by series, place, type, status, and parent', async () => {
+    const { events } = await makeEvents('coll-filters');
+
+    const a = await events.create({
+      name: 'A',
+      seriesId: 's1',
+      placeId: 'pl1',
+      typeId: 't1',
+      status: 'scheduled',
+    });
+    await a.save();
+    const b = await events.create({
+      name: 'B',
+      seriesId: 's2',
+      placeId: 'pl2',
+      typeId: 't2',
+      status: 'completed',
+    });
+    await b.save();
+    const child = await events.create({ name: 'Child', parentId: a.id });
+    await child.save();
+
+    expect((await events.getBySeriesId('s1')).map((e) => e.id)).toEqual([a.id]);
+    expect((await events.getByPlace('pl2')).map((e) => e.id)).toEqual([b.id]);
+    expect((await events.getByType('t1')).map((e) => e.id)).toEqual([a.id]);
+    expect((await events.getByStatus('completed')).map((e) => e.id)).toEqual([
+      b.id,
+    ]);
+    expect((await events.getByParent(a.id as string)).map((e) => e.id)).toEqual(
+      [child.id],
+    );
+  });
+
+  it('getRootEvents returns only events without a parent', async () => {
+    const { events } = await makeEvents('coll-roots');
+    const root = await events.create({ name: 'Root' });
+    await root.save();
+    const child = await events.create({ name: 'Child', parentId: root.id });
+    await child.save();
+
+    const roots = await events.getRootEvents();
+    expect(roots.map((e) => e.id)).toContain(root.id);
+    expect(roots.map((e) => e.id)).not.toContain(child.id);
+  });
+
+  it('getByDateRange and getUpcoming partition by startDate', async () => {
+    const { events } = await makeEvents('coll-dates');
+
+    const inRange = await events.create({
+      name: 'In range',
+      startDate: new Date('2024-06-15'),
+    });
+    await inRange.save();
+    const future = await events.create({
+      name: 'Future',
+      startDate: new Date('2999-01-01'),
+    });
+    await future.save();
+
+    const ranged = await events.getByDateRange(
+      new Date('2024-06-01'),
+      new Date('2024-06-30'),
+    );
+    expect(ranged.map((e) => e.id)).toEqual([inRange.id]);
+
+    const upcoming = await events.getUpcoming();
+    expect(upcoming.map((e) => e.id)).toContain(future.id);
+    expect(upcoming.map((e) => e.id)).not.toContain(inRange.id);
+  });
+
+  it('getUpcoming respects the limit and sorts ascending', async () => {
+    const { events } = await makeEvents('coll-upcoming-limit');
+    for (let i = 1; i <= 3; i++) {
+      const e = await events.create({
+        name: `Future ${i}`,
+        startDate: new Date(`299${i}-01-01`),
+      });
+      await e.save();
+    }
+    const limited = await events.getUpcoming(2);
+    expect(limited).toHaveLength(2);
+    expect(limited[0].name).toBe('Future 1');
+  });
+
+  it('getInProgress returns only events that are truly in progress', async () => {
+    const { events } = await makeEvents('coll-inprogress');
+
+    const live = await events.create({
+      name: 'Live',
+      status: 'in_progress',
+      startDate: new Date('2000-01-01'),
+      endDate: new Date('2999-01-01'),
+    });
+    await live.save();
+    const stale = await events.create({
+      name: 'Stale',
+      status: 'in_progress',
+      startDate: new Date('2999-06-01'),
+    });
+    await stale.save();
+
+    const inProgress = await events.getInProgress();
+    expect(inProgress.map((e) => e.id)).toEqual([live.id]);
+  });
+
+  it('search matches name/description and applies status array filters', async () => {
+    const { events } = await makeEvents('coll-search');
+
+    const a = await events.create({
+      name: 'Championship Final',
+      description: 'The big game',
+      status: 'completed',
+    });
+    await a.save();
+    const b = await events.create({
+      name: 'Qualifier',
+      description: 'Early round',
+      status: 'scheduled',
+    });
+    await b.save();
+
+    expect((await events.search('championship')).map((e) => e.id)).toEqual([
+      a.id,
+    ]);
+    expect(
+      (await events.search('', { status: ['scheduled'] })).map((e) => e.id),
+    ).toEqual([b.id]);
+  });
+
+  it('getEventTree returns the resolved root event', async () => {
+    const { events } = await makeEvents('coll-tree');
+    const root = await events.create({ name: 'Tournament' });
+    await root.save();
+    const child = await events.create({ name: 'Round 1', parentId: root.id });
+    await child.save();
+
+    const tree = await events.getEventTree(root.id as string);
+    expect(tree?.id).toBe(root.id);
+
+    expect(await events.getEventTree('missing-id')).toBeNull();
+  });
+
+  it('scopes events by tenant and resolves globals', async () => {
+    const { events } = await makeEvents('coll-tenant');
+
+    const tenantEvent = await events.create({
+      name: 'Tenant event',
+      tenantId: 'tenant-a',
+    });
+    await tenantEvent.save();
+    const globalEvent = await events.create({
+      name: 'Global event',
+      tenantId: null,
+    });
+    await globalEvent.save();
+
+    expect((await events.findByTenant('tenant-a')).map((e) => e.id)).toEqual([
+      tenantEvent.id,
+    ]);
+    expect((await events.findGlobal()).map((e) => e.id)).toEqual([
+      globalEvent.id,
+    ]);
+    const both = (await events.findWithGlobals('tenant-a')).map((e) => e.id);
+    expect(both).toContain(tenantEvent.id);
+    expect(both).toContain(globalEvent.id);
+  });
+});

--- a/packages/events/src/__tests__/event-participants.test.ts
+++ b/packages/events/src/__tests__/event-participants.test.ts
@@ -1,0 +1,368 @@
+/**
+ * EventParticipant model + EventParticipantCollection integration tests.
+ *
+ * Covers roles, numeric placement (home=0/away=1), group membership,
+ * placement-ordered queries, participant statistics, the home/away
+ * accessors, search filters, and tenant scoping. The collection extends
+ * SmrtJunction with leftField=eventId / rightField=profileId.
+ * Real in-memory SQLite, no mocks.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  EventCollection,
+  EventParticipant,
+  EventParticipantCollection,
+} from '../index.js';
+
+function getTestDbUrl(name: string): string {
+  return `file:${join(tmpdir(), `${name}-${randomUUID()}.db`)}`;
+}
+
+async function setup(name: string) {
+  const dbUrl = getTestDbUrl(name);
+  const participants = await EventParticipantCollection.create({
+    db: { type: 'sqlite', url: dbUrl },
+  });
+  const events = await EventCollection.create({
+    db: { type: 'sqlite', url: dbUrl },
+  });
+  return { dbUrl, participants, events };
+}
+
+describe('EventParticipant model', () => {
+  it('persists role, placement, and group fields', async () => {
+    const { participants } = await setup('participant-persist');
+
+    const p = await participants.create({
+      eventId: 'event-1',
+      profileId: 'profile-1',
+      role: 'speaker',
+      placement: 3,
+      groupId: 'team-blue',
+      source: 'manual',
+    });
+    await p.save();
+
+    const loaded = await participants.get({ id: p.id });
+    expect(loaded?.role).toBe('speaker');
+    expect(loaded?.placement).toBe(3);
+    expect(loaded?.groupId).toBe('team-blue');
+    expect(loaded?.profileId).toBe('profile-1');
+    expect(loaded?.source).toBe('manual');
+  });
+
+  it('isHome/isAway reflect placement 0 and 1', () => {
+    expect(new EventParticipant({ placement: 0 }).isHome()).toBe(true);
+    expect(new EventParticipant({ placement: 1 }).isHome()).toBe(false);
+    expect(new EventParticipant({ placement: 1 }).isAway()).toBe(true);
+    expect(new EventParticipant({ placement: 0 }).isAway()).toBe(false);
+    // null placement is neither home nor away.
+    const neutral = new EventParticipant({ role: 'attendee' });
+    expect(neutral.isHome()).toBe(false);
+    expect(neutral.isAway()).toBe(false);
+  });
+
+  it('manages metadata through get/set/update helpers', async () => {
+    const { participants } = await setup('participant-metadata');
+    const p = await participants.create({
+      eventId: 'e',
+      profileId: 'pr',
+      role: 'home',
+      metadata: '{"jersey":10}',
+    });
+    expect(p.getMetadata()).toEqual({ jersey: 10 });
+
+    p.setMetadata({ jersey: 23 });
+    p.updateMetadata({ captain: true });
+    await p.save();
+
+    const loaded = await participants.get({ id: p.id });
+    expect(loaded?.getMetadata()).toEqual({ jersey: 23, captain: true });
+  });
+
+  it('returns empty metadata for malformed JSON', () => {
+    const p = new EventParticipant({ role: 'host' });
+    expect(p.getMetadata()).toEqual({});
+    p.metadata = 'broken{';
+    expect(p.getMetadata()).toEqual({});
+  });
+
+  it('loads the related event via getEvent()', async () => {
+    const { participants, events } = await setup('participant-getevent');
+    const event = await events.create({ name: 'Final Match' });
+    await event.save();
+
+    const p = await participants.create({
+      eventId: event.id,
+      profileId: 'profile-x',
+      role: 'competitor',
+    });
+    await p.save();
+
+    const linkedEvent = await p.getEvent();
+    expect(linkedEvent?.id).toBe(event.id);
+    expect(linkedEvent?.name).toBe('Final Match');
+  });
+
+  it('getEvent returns null when eventId is unset', async () => {
+    const { participants } = await setup('participant-getevent-null');
+    const p = await participants.create({ profileId: 'p', role: 'attendee' });
+    expect(await p.getEvent()).toBeNull();
+  });
+
+  it('getGroupParticipants returns same-group teammates excluding self', async () => {
+    const { participants } = await setup('participant-group');
+
+    const a = await participants.create({
+      eventId: 'game-1',
+      profileId: 'player-a',
+      role: 'home',
+      groupId: 'team-red',
+    });
+    await a.save();
+    const b = await participants.create({
+      eventId: 'game-1',
+      profileId: 'player-b',
+      role: 'home',
+      groupId: 'team-red',
+    });
+    await b.save();
+    const other = await participants.create({
+      eventId: 'game-1',
+      profileId: 'player-c',
+      role: 'away',
+      groupId: 'team-blue',
+    });
+    await other.save();
+
+    const teammates = await a.getGroupParticipants();
+    expect(teammates.map((p) => p.profileId)).toEqual(['player-b']);
+  });
+
+  it('getGroupParticipants returns empty when no groupId', async () => {
+    const { participants } = await setup('participant-group-empty');
+    const p = await participants.create({
+      eventId: 'g',
+      profileId: 'solo',
+      role: 'competitor',
+    });
+    await p.save();
+    expect(await p.getGroupParticipants()).toEqual([]);
+  });
+});
+
+describe('EventParticipantCollection', () => {
+  async function seedGame(name: string) {
+    const ctx = await setup(name);
+    const home = await ctx.participants.create({
+      eventId: 'game',
+      profileId: 'team-home',
+      role: 'home',
+      placement: 0,
+      groupId: 'home-roster',
+    });
+    await home.save();
+    const away = await ctx.participants.create({
+      eventId: 'game',
+      profileId: 'team-away',
+      role: 'away',
+      placement: 1,
+      groupId: 'away-roster',
+    });
+    await away.save();
+    const bench = await ctx.participants.create({
+      eventId: 'game',
+      profileId: 'sub-1',
+      role: 'competitor',
+      placement: null,
+    });
+    await bench.save();
+    return { ...ctx, home, away, bench };
+  }
+
+  it('getByPlacement orders ascending with nulls last', async () => {
+    const { participants } = await seedGame('coll-by-placement');
+    const ordered = await participants.getByPlacement('game');
+    expect(ordered.map((p) => p.profileId)).toEqual([
+      'team-home',
+      'team-away',
+      'sub-1',
+    ]);
+  });
+
+  it('getHome and getAway resolve placement 0 and 1', async () => {
+    const { participants } = await seedGame('coll-home-away');
+    const home = await participants.getHome('game');
+    const away = await participants.getAway('game');
+    expect(home.map((p) => p.profileId)).toEqual(['team-home']);
+    expect(away.map((p) => p.profileId)).toEqual(['team-away']);
+  });
+
+  it('getByGroup filters participants by groupId within an event', async () => {
+    const { participants } = await seedGame('coll-by-group');
+    const homeRoster = await participants.getByGroup('game', 'home-roster');
+    expect(homeRoster.map((p) => p.profileId)).toEqual(['team-home']);
+  });
+
+  it('byLeft / byRight resolve the junction in both directions', async () => {
+    const { participants } = await seedGame('coll-junction');
+    const forEvent = await participants.byLeft('game');
+    expect(forEvent).toHaveLength(3);
+
+    const forProfile = await participants.byRight('team-home');
+    expect(forProfile.map((p) => p.eventId)).toEqual(['game']);
+  });
+
+  it('search filters by event, profile, role, and group', async () => {
+    const { participants } = await seedGame('coll-search');
+
+    expect(
+      (await participants.search({ role: 'home' })).map((p) => p.profileId),
+    ).toEqual(['team-home']);
+    expect(
+      (await participants.search({ profileId: 'sub-1' })).map((p) => p.role),
+    ).toEqual(['competitor']);
+    expect(
+      (await participants.search({ groupId: 'away-roster' })).map(
+        (p) => p.profileId,
+      ),
+    ).toEqual(['team-away']);
+    expect(await participants.search({ eventId: 'no-such-event' })).toEqual([]);
+  });
+
+  it('getParticipantStats aggregates totals by role and placement', async () => {
+    const { participants } = await setup('coll-stats');
+
+    // Same profile competing across two events with different roles.
+    const g1 = await participants.create({
+      eventId: 'g1',
+      profileId: 'star',
+      role: 'home',
+      placement: 0,
+    });
+    await g1.save();
+    const g2 = await participants.create({
+      eventId: 'g2',
+      profileId: 'star',
+      role: 'away',
+      placement: 1,
+    });
+    await g2.save();
+    const g3 = await participants.create({
+      eventId: 'g3',
+      profileId: 'star',
+      role: 'home',
+      placement: 0,
+    });
+    await g3.save();
+
+    const stats = await participants.getParticipantStats('star');
+    expect(stats.totalEvents).toBe(3);
+    expect(stats.byRole).toEqual({ home: 2, away: 1 });
+    expect(stats.byPlacement).toEqual({ 0: 2, 1: 1 });
+  });
+
+  it('getParticipantStats filters by event type when requested', async () => {
+    const dbUrl = getTestDbUrl('coll-stats-typed');
+    const participants = await EventParticipantCollection.create({
+      db: { type: 'sqlite', url: dbUrl },
+    });
+    const events = await EventCollection.create({
+      db: { type: 'sqlite', url: dbUrl },
+    });
+
+    const basketball = await events.create({
+      name: 'BBall',
+      typeId: 'type-basketball',
+    });
+    await basketball.save();
+    const soccer = await events.create({
+      name: 'Soccer',
+      typeId: 'type-soccer',
+    });
+    await soccer.save();
+
+    const p1 = await participants.create({
+      eventId: basketball.id,
+      profileId: 'athlete',
+      role: 'home',
+      placement: 0,
+    });
+    await p1.save();
+    const p2 = await participants.create({
+      eventId: soccer.id,
+      profileId: 'athlete',
+      role: 'away',
+      placement: 1,
+    });
+    await p2.save();
+
+    const stats = await participants.getParticipantStats(
+      'athlete',
+      'type-basketball',
+    );
+    expect(stats.totalEvents).toBe(1);
+    expect(stats.byRole).toEqual({ home: 1 });
+    expect(stats.byPlacement).toEqual({ 0: 1 });
+  });
+
+  it('enforces the event_id+profile_id+role natural key on upsert', async () => {
+    const { participants } = await setup('coll-conflict');
+
+    const first = await participants.create({
+      eventId: 'evt',
+      profileId: 'prof',
+      role: 'speaker',
+      placement: 5,
+    });
+    await first.save();
+
+    // Same (event, profile, role) — should upsert onto the same row.
+    const dup = await participants.create({
+      eventId: 'evt',
+      profileId: 'prof',
+      role: 'speaker',
+      placement: 9,
+    });
+    await dup.save();
+
+    const all = await participants.search({ eventId: 'evt' });
+    expect(all).toHaveLength(1);
+    expect(all[0].placement).toBe(9);
+  });
+
+  it('scopes participants by tenant and resolves globals', async () => {
+    const { participants } = await setup('coll-tenant');
+
+    const tenantP = await participants.create({
+      eventId: 'e1',
+      profileId: 'p1',
+      role: 'home',
+      tenantId: 'tenant-a',
+    });
+    await tenantP.save();
+    const globalP = await participants.create({
+      eventId: 'e2',
+      profileId: 'p2',
+      role: 'away',
+      tenantId: null,
+    });
+    await globalP.save();
+
+    expect(
+      (await participants.findByTenant('tenant-a')).map((p) => p.id),
+    ).toEqual([tenantP.id]);
+    expect((await participants.findGlobal()).map((p) => p.id)).toEqual([
+      globalP.id,
+    ]);
+    const both = (await participants.findWithGlobals('tenant-a')).map(
+      (p) => p.id,
+    );
+    expect(both).toContain(tenantP.id);
+    expect(both).toContain(globalP.id);
+  });
+});

--- a/packages/events/src/__tests__/event-participants.test.ts
+++ b/packages/events/src/__tests__/event-participants.test.ts
@@ -5,7 +5,7 @@
  * placement-ordered queries, participant statistics, the home/away
  * accessors, search filters, and tenant scoping. The collection extends
  * SmrtJunction with leftField=eventId / rightField=profileId.
- * Real in-memory SQLite, no mocks.
+ * Real temp-file SQLite (file:tmpdir), no mocks.
  */
 
 import { randomUUID } from 'node:crypto';

--- a/packages/events/src/__tests__/event-series.test.ts
+++ b/packages/events/src/__tests__/event-series.test.ts
@@ -1,0 +1,277 @@
+/**
+ * EventSeries model + EventSeriesCollection integration tests.
+ *
+ * Exercises recurrence patterns (daily/weekly/monthly/yearly), metadata
+ * helpers, active-window checks, relationship loads to events and type,
+ * and the collection's organizer/type/date filters and tenant scoping.
+ * Real in-memory SQLite, no mocks.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  EventCollection,
+  EventSeries,
+  EventSeriesCollection,
+} from '../index.js';
+import type { RecurrencePattern } from '../types';
+
+function getTestDbUrl(name: string): string {
+  return `file:${join(tmpdir(), `${name}-${randomUUID()}.db`)}`;
+}
+
+async function makeSeries(name: string, dbUrl = getTestDbUrl(name)) {
+  const series = await EventSeriesCollection.create({
+    db: { type: 'sqlite', url: dbUrl },
+  });
+  return { dbUrl, series };
+}
+
+describe('EventSeries model', () => {
+  it('persists core fields and round-trips a weekly recurrence pattern', async () => {
+    const { series } = await makeSeries('series-recurrence');
+
+    const pattern: RecurrencePattern = {
+      frequency: 'weekly',
+      interval: 1,
+      byDay: ['MO', 'WE', 'FR'],
+      count: 12,
+    };
+
+    const created = await series.create({
+      name: 'Summer League 2024',
+      description: 'Weekly summer league',
+      source: 'espn',
+      externalId: 'ext-123',
+    });
+    created.setRecurrence(pattern);
+    await created.save();
+
+    const loaded = await series.get({ id: created.id });
+    expect(loaded?.name).toBe('Summer League 2024');
+    expect(loaded?.source).toBe('espn');
+    expect(loaded?.externalId).toBe('ext-123');
+    expect(loaded?.getRecurrence()).toEqual(pattern);
+  });
+
+  it.each<RecurrencePattern>([
+    { frequency: 'daily', interval: 2 },
+    { frequency: 'weekly', byDay: ['TU'] },
+    { frequency: 'monthly', byMonthDay: [1, 15] },
+    { frequency: 'yearly', byMonth: [6] },
+  ])('round-trips a %s recurrence frequency', async (pattern) => {
+    const { series } = await makeSeries(`series-freq-${pattern.frequency}`);
+    const created = await series.create({
+      name: `${pattern.frequency} series`,
+      recurrence: JSON.stringify(pattern),
+    });
+    await created.save();
+
+    const loaded = await series.get({ id: created.id });
+    expect(loaded?.getRecurrence()).toEqual(pattern);
+  });
+
+  it('accepts a recurrence supplied as a JSON string', async () => {
+    const s = new EventSeries({
+      name: 'String recurrence',
+      recurrence: '{"frequency":"monthly","interval":3}',
+    });
+    expect(s.getRecurrence()).toEqual({ frequency: 'monthly', interval: 3 });
+  });
+
+  it('returns null recurrence when unset or malformed', async () => {
+    const s = new EventSeries({ name: 'No recurrence' });
+    expect(s.getRecurrence()).toBeNull();
+
+    s.recurrence = 'broken{json';
+    expect(s.getRecurrence()).toBeNull();
+  });
+
+  it('supports the setRecurrence setter', async () => {
+    const { series } = await makeSeries('series-set-recurrence');
+    const s = await series.create({ name: 'Mutable series' });
+    s.setRecurrence({ frequency: 'daily', interval: 1 });
+    await s.save();
+
+    const loaded = await series.get({ id: s.id });
+    expect(loaded?.getRecurrence()).toEqual({
+      frequency: 'daily',
+      interval: 1,
+    });
+  });
+
+  it('merges metadata via updateMetadata and persists it', async () => {
+    const { series } = await makeSeries('series-metadata');
+    const s = await series.create({
+      name: 'Metadata series',
+      metadata: '{"season":2024}',
+    });
+    s.updateMetadata({ sponsor: 'Acme' });
+    await s.save();
+
+    const loaded = await series.get({ id: s.id });
+    expect(loaded?.getMetadata()).toEqual({ season: 2024, sponsor: 'Acme' });
+  });
+
+  it('isActive reflects the start/end window', () => {
+    const past = new Date('2000-01-01');
+    const future = new Date('2999-01-01');
+
+    expect(new EventSeries({ name: 'open-ended' }).isActive()).toBe(true);
+    expect(
+      new EventSeries({
+        name: 'current',
+        startDate: past,
+        endDate: future,
+      }).isActive(),
+    ).toBe(true);
+    expect(
+      new EventSeries({ name: 'not-started', startDate: future }).isActive(),
+    ).toBe(false);
+    expect(new EventSeries({ name: 'ended', endDate: past }).isActive()).toBe(
+      false,
+    );
+  });
+
+  it('loads events that belong to the series via getEvents()', async () => {
+    const dbUrl = getTestDbUrl('series-getevents');
+    const { series } = await makeSeries('series-getevents', dbUrl);
+    const events = await EventCollection.create({
+      db: { type: 'sqlite', url: dbUrl },
+    });
+
+    const s = await series.create({ name: 'Linked series' });
+    await s.save();
+
+    const e1 = await events.create({ name: 'Game 1', seriesId: s.id });
+    await e1.save();
+    const e2 = await events.create({ name: 'Game 2', seriesId: s.id });
+    await e2.save();
+    const other = await events.create({ name: 'Standalone' });
+    await other.save();
+
+    const linked = await s.getEvents();
+    expect(linked.map((e: { id?: string }) => e.id).sort()).toEqual(
+      [e1.id, e2.id].sort(),
+    );
+  });
+
+  it('getType returns null when no typeId is set', async () => {
+    const { series } = await makeSeries('series-gettype-null');
+    const s = await series.create({ name: 'Typeless' });
+    expect(await s.getType()).toBeNull();
+  });
+});
+
+describe('EventSeriesCollection', () => {
+  it('filters by organizer and type', async () => {
+    const { series } = await makeSeries('seriescoll-filters');
+
+    const a = await series.create({
+      name: 'A',
+      organizerId: 'org-1',
+      typeId: 'type-x',
+    });
+    await a.save();
+    const b = await series.create({
+      name: 'B',
+      organizerId: 'org-2',
+      typeId: 'type-y',
+    });
+    await b.save();
+
+    expect((await series.getByOrganizer('org-1')).map((s) => s.id)).toEqual([
+      a.id,
+    ]);
+    expect((await series.getByType('type-y')).map((s) => s.id)).toEqual([b.id]);
+  });
+
+  it('getActive and getUpcoming partition by date window', async () => {
+    const { series } = await makeSeries('seriescoll-active-upcoming');
+
+    const active = await series.create({
+      name: 'Active',
+      startDate: new Date('2000-01-01'),
+      endDate: new Date('2999-01-01'),
+    });
+    await active.save();
+    const future = await series.create({
+      name: 'Future',
+      startDate: new Date('2999-06-01'),
+    });
+    await future.save();
+
+    const activeList = await series.getActive();
+    expect(activeList.map((s) => s.id)).toContain(active.id);
+    expect(activeList.map((s) => s.id)).not.toContain(future.id);
+
+    const upcoming = await series.getUpcoming();
+    expect(upcoming.map((s) => s.id)).toContain(future.id);
+    expect(upcoming.map((s) => s.id)).not.toContain(active.id);
+  });
+
+  it('getUpcoming honours the limit argument', async () => {
+    const { series } = await makeSeries('seriescoll-upcoming-limit');
+    for (let i = 1; i <= 3; i++) {
+      const s = await series.create({
+        name: `Future ${i}`,
+        startDate: new Date(`299${i}-01-01`),
+      });
+      await s.save();
+    }
+    const limited = await series.getUpcoming(2);
+    expect(limited).toHaveLength(2);
+    // Sorted ascending by startDate.
+    expect(limited[0].name).toBe('Future 1');
+  });
+
+  it('search matches name/description and applies filters', async () => {
+    const { series } = await makeSeries('seriescoll-search');
+
+    const a = await series.create({
+      name: 'World Tour',
+      description: 'Global concert tour',
+      typeId: 'concert',
+    });
+    await a.save();
+    const b = await series.create({
+      name: 'Local Meetups',
+      description: 'Community gatherings',
+      typeId: 'meeting',
+    });
+    await b.save();
+
+    const byQuery = await series.search('tour');
+    expect(byQuery.map((s) => s.id)).toEqual([a.id]);
+
+    const byFilter = await series.search('', { typeId: 'meeting' });
+    expect(byFilter.map((s) => s.id)).toEqual([b.id]);
+  });
+
+  it('scopes series by tenant and resolves globals', async () => {
+    const { series } = await makeSeries('seriescoll-tenant');
+
+    const tenantSeries = await series.create({
+      name: 'Tenant series',
+      tenantId: 'tenant-a',
+    });
+    await tenantSeries.save();
+    const globalSeries = await series.create({
+      name: 'Global series',
+      tenantId: null,
+    });
+    await globalSeries.save();
+
+    expect((await series.findByTenant('tenant-a')).map((s) => s.id)).toEqual([
+      tenantSeries.id,
+    ]);
+    expect((await series.findGlobal()).map((s) => s.id)).toEqual([
+      globalSeries.id,
+    ]);
+    const both = (await series.findWithGlobals('tenant-a')).map((s) => s.id);
+    expect(both).toContain(tenantSeries.id);
+    expect(both).toContain(globalSeries.id);
+  });
+});

--- a/packages/events/src/__tests__/event-series.test.ts
+++ b/packages/events/src/__tests__/event-series.test.ts
@@ -4,7 +4,7 @@
  * Exercises recurrence patterns (daily/weekly/monthly/yearly), metadata
  * helpers, active-window checks, relationship loads to events and type,
  * and the collection's organizer/type/date filters and tenant scoping.
- * Real in-memory SQLite, no mocks.
+ * Real temp-file SQLite (file:tmpdir), no mocks.
  */
 
 import { randomUUID } from 'node:crypto';

--- a/packages/events/src/__tests__/event-types.test.ts
+++ b/packages/events/src/__tests__/event-types.test.ts
@@ -1,0 +1,165 @@
+/**
+ * EventType model + EventTypeCollection integration tests.
+ *
+ * Exercises the real create -> save -> query flow against an in-memory
+ * SQLite database (no mocks). Covers JSON schema helpers, slug-based
+ * lookup/get-or-create, default seeding, and tenant scoping.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { EventType, EventTypeCollection } from '../index.js';
+
+function getTestDbUrl(name: string): string {
+  return `file:${join(tmpdir(), `${name}-${randomUUID()}.db`)}`;
+}
+
+async function makeTypes(name: string) {
+  const dbUrl = getTestDbUrl(name);
+  const types = await EventTypeCollection.create({
+    db: { type: 'sqlite', url: dbUrl },
+  });
+  return { dbUrl, types };
+}
+
+describe('EventType model', () => {
+  it('persists name, description, and round-trips schema JSON', async () => {
+    const { types } = await makeTypes('eventtype-persist');
+
+    const type = await types.create({
+      name: 'Basketball Game',
+      slug: 'basketball-game',
+      description: 'A regulation basketball game',
+      schema: { properties: { quarters: { type: 'number' } } },
+    });
+    await type.save();
+
+    const loaded = await types.get({ id: type.id });
+    expect(loaded).not.toBeNull();
+    expect(loaded?.name).toBe('Basketball Game');
+    expect(loaded?.description).toBe('A regulation basketball game');
+    expect(loaded?.getSchema()).toEqual({
+      properties: { quarters: { type: 'number' } },
+    });
+  });
+
+  it('accepts schema supplied as a JSON string and parses it back', async () => {
+    const { types } = await makeTypes('eventtype-schema-string');
+
+    const type = await types.create({
+      name: 'Concert',
+      slug: 'concert',
+      schema: '{"setlist":true}',
+      participantSchema: '{"instrument":"string"}',
+    });
+    await type.save();
+
+    expect(type.getSchema()).toEqual({ setlist: true });
+    expect(type.getParticipantSchema()).toEqual({ instrument: 'string' });
+  });
+
+  it('returns empty objects for missing or malformed schema JSON', async () => {
+    const type = new EventType({ name: 'Empty' });
+    expect(type.getSchema()).toEqual({});
+    expect(type.getParticipantSchema()).toEqual({});
+
+    type.schema = 'not-valid-json{';
+    type.participantSchema = 'also-broken';
+    expect(type.getSchema()).toEqual({});
+    expect(type.getParticipantSchema()).toEqual({});
+  });
+
+  it('mutates schema and participant schema via setters', async () => {
+    const { types } = await makeTypes('eventtype-setters');
+
+    const type = await types.create({ name: 'Conference', slug: 'conference' });
+    type.setSchema({ tracks: 3 });
+    type.setParticipantSchema({ badge: 'required' });
+    await type.save();
+
+    const loaded = await types.get({ id: type.id });
+    expect(loaded?.getSchema()).toEqual({ tracks: 3 });
+    expect(loaded?.getParticipantSchema()).toEqual({ badge: 'required' });
+  });
+});
+
+describe('EventTypeCollection', () => {
+  it('getOrCreate creates a new type and auto-generates a display name', async () => {
+    const { types } = await makeTypes('eventtype-getorcreate');
+
+    const created = await types.getOrCreate('town-hall');
+    expect(created.slug).toBe('town-hall');
+    // Slug 'town-hall' -> 'Town Hall'
+    expect(created.name).toBe('Town Hall');
+  });
+
+  it('getOrCreate returns the existing type on a second call', async () => {
+    const { types } = await makeTypes('eventtype-getorcreate-existing');
+
+    const first = await types.getOrCreate('meeting', 'Council Meeting');
+    const second = await types.getOrCreate('meeting', 'Ignored Name');
+
+    expect(second.id).toBe(first.id);
+    expect(second.name).toBe('Council Meeting');
+  });
+
+  it('getBySlug finds a saved type and returns null for unknown slugs', async () => {
+    const { types } = await makeTypes('eventtype-getbyslug');
+
+    const created = await types.getOrCreate('keynote', 'Keynote');
+    const found = await types.getBySlug('keynote');
+    expect(found?.id).toBe(created.id);
+
+    const missing = await types.getBySlug('does-not-exist');
+    expect(missing).toBeNull();
+  });
+
+  it('initializeDefaults seeds the full default catalogue idempotently', async () => {
+    const { types } = await makeTypes('eventtype-defaults');
+
+    const seeded = await types.initializeDefaults();
+    expect(seeded.length).toBeGreaterThan(20);
+    expect(seeded.map((t) => t.slug)).toContain('game');
+    expect(seeded.map((t) => t.slug)).toContain('vote');
+
+    const all = await types.list({});
+    const firstCount = all.length;
+
+    // Re-seeding must not duplicate existing slugs.
+    await types.initializeDefaults();
+    const allAgain = await types.list({});
+    expect(allAgain.length).toBe(firstCount);
+  });
+
+  it('scopes types by tenant and resolves globals with findWithGlobals', async () => {
+    const { types } = await makeTypes('eventtype-tenant');
+
+    const tenantType = await types.create({
+      name: 'Tenant Game',
+      slug: 'tenant-game',
+      tenantId: 'tenant-a',
+    });
+    await tenantType.save();
+
+    const globalType = await types.create({
+      name: 'Global Game',
+      slug: 'global-game',
+      tenantId: null,
+    });
+    await globalType.save();
+
+    const byTenant = await types.findByTenant('tenant-a');
+    expect(byTenant.map((t) => t.id)).toContain(tenantType.id);
+    expect(byTenant.map((t) => t.id)).not.toContain(globalType.id);
+
+    const globals = await types.findGlobal();
+    expect(globals.map((t) => t.id)).toContain(globalType.id);
+
+    const withGlobals = await types.findWithGlobals('tenant-a');
+    const ids = withGlobals.map((t) => t.id);
+    expect(ids).toContain(tenantType.id);
+    expect(ids).toContain(globalType.id);
+  });
+});

--- a/packages/events/src/__tests__/event-types.test.ts
+++ b/packages/events/src/__tests__/event-types.test.ts
@@ -1,7 +1,7 @@
 /**
  * EventType model + EventTypeCollection integration tests.
  *
- * Exercises the real create -> save -> query flow against an in-memory
+ * Exercises the real create -> save -> query flow against a temp-file (file:tmpdir)
  * SQLite database (no mocks). Covers JSON schema helpers, slug-based
  * lookup/get-or-create, default seeding, and tenant scoping.
  */

--- a/packages/events/src/__tests__/utils.test.ts
+++ b/packages/events/src/__tests__/utils.test.ts
@@ -162,7 +162,7 @@ describe('checkSchedulingConflict', () => {
     expect(checkSchedulingConflict(e1Start, null, e2Start, null)).toBe(false);
   });
 
-  it('reports a conflict between two identical instantaneous events', () => {
+  it('treats two identical instantaneous events as non-conflicting (start must be strictly before end)', () => {
     const at = new Date('2026-01-15T10:00:00Z');
     // start < end requires start < start which is false for identical instants
     expect(

--- a/packages/events/src/__tests__/utils.test.ts
+++ b/packages/events/src/__tests__/utils.test.ts
@@ -1,0 +1,437 @@
+import { describe, expect, it } from 'vitest';
+import type { RecurrencePattern } from '../types.js';
+import {
+  calculateDuration,
+  calculateNextOccurrence,
+  checkSchedulingConflict,
+  formatDuration,
+  formatEventDateRange,
+  generateEventSlug,
+  getEventStatusFromDates,
+  isEventNow,
+  parseRecurrencePattern,
+  sortEventsByDate,
+  validateEventStatus,
+} from '../utils.js';
+
+describe('validateEventStatus', () => {
+  it('allows a scheduled event to start, cancel, or postpone', () => {
+    expect(validateEventStatus('scheduled', 'in_progress')).toBe(true);
+    expect(validateEventStatus('scheduled', 'cancelled')).toBe(true);
+    expect(validateEventStatus('scheduled', 'postponed')).toBe(true);
+  });
+
+  it('rejects jumping a scheduled event straight to completed', () => {
+    expect(validateEventStatus('scheduled', 'completed')).toBe(false);
+  });
+
+  it('allows an in-progress event to complete or cancel', () => {
+    expect(validateEventStatus('in_progress', 'completed')).toBe(true);
+    expect(validateEventStatus('in_progress', 'cancelled')).toBe(true);
+  });
+
+  it('forbids re-scheduling an in-progress event', () => {
+    expect(validateEventStatus('in_progress', 'scheduled')).toBe(false);
+    expect(validateEventStatus('in_progress', 'postponed')).toBe(false);
+  });
+
+  it('treats completed as a terminal state with no valid transitions', () => {
+    expect(validateEventStatus('completed', 'scheduled')).toBe(false);
+    expect(validateEventStatus('completed', 'in_progress')).toBe(false);
+    expect(validateEventStatus('completed', 'cancelled')).toBe(false);
+  });
+
+  it('allows a cancelled event to be rescheduled but nothing else', () => {
+    expect(validateEventStatus('cancelled', 'scheduled')).toBe(true);
+    expect(validateEventStatus('cancelled', 'in_progress')).toBe(false);
+    expect(validateEventStatus('cancelled', 'completed')).toBe(false);
+  });
+
+  it('allows a postponed event to be rescheduled or cancelled', () => {
+    expect(validateEventStatus('postponed', 'scheduled')).toBe(true);
+    expect(validateEventStatus('postponed', 'cancelled')).toBe(true);
+    expect(validateEventStatus('postponed', 'in_progress')).toBe(false);
+  });
+
+  it('returns false when transitioning a status to itself', () => {
+    expect(validateEventStatus('scheduled', 'scheduled')).toBe(false);
+    expect(validateEventStatus('completed', 'completed')).toBe(false);
+  });
+});
+
+describe('formatEventDateRange', () => {
+  it('returns just the start date when no end date is given', () => {
+    const start = new Date('2026-01-15T10:00:00Z');
+    expect(formatEventDateRange(start)).toBe(start.toLocaleDateString());
+  });
+
+  it('treats an explicit null end date the same as no end date', () => {
+    const start = new Date('2026-01-15T10:00:00Z');
+    expect(formatEventDateRange(start, null)).toBe(start.toLocaleDateString());
+  });
+
+  it('shows a time range when start and end fall on the same day', () => {
+    const start = new Date('2026-01-15T10:00:00Z');
+    const end = new Date('2026-01-15T12:30:00Z');
+    const expected = `${start.toLocaleDateString()} ${start.toLocaleTimeString()} - ${end.toLocaleTimeString()}`;
+    expect(formatEventDateRange(start, end)).toBe(expected);
+  });
+
+  it('shows a date-to-date range when the event spans multiple days', () => {
+    const start = new Date('2026-01-15T10:00:00Z');
+    const end = new Date('2026-01-18T12:00:00Z');
+    const expected = `${start.toLocaleDateString()} - ${end.toLocaleDateString()}`;
+    expect(formatEventDateRange(start, end)).toBe(expected);
+  });
+});
+
+describe('generateEventSlug', () => {
+  it('builds a lowercased, hyphenated slug with the ISO date suffix', () => {
+    const date = new Date('2026-01-15T10:00:00Z');
+    expect(generateEventSlug('Summer Festival', date)).toBe(
+      'summer-festival-2026-01-15',
+    );
+  });
+
+  it('collapses runs of special characters and spaces into single hyphens', () => {
+    const date = new Date('2026-03-09T00:00:00Z');
+    expect(generateEventSlug('Hello,   World!! & Friends', date)).toBe(
+      'hello-world-friends-2026-03-09',
+    );
+  });
+
+  it('trims leading and trailing hyphens produced by edge characters', () => {
+    const date = new Date('2026-03-09T00:00:00Z');
+    expect(generateEventSlug('***Gala***', date)).toBe('gala-2026-03-09');
+  });
+
+  it('produces only the date suffix when the name has no alphanumerics', () => {
+    const date = new Date('2026-03-09T00:00:00Z');
+    expect(generateEventSlug('!!!', date)).toBe('-2026-03-09');
+  });
+
+  it('preserves existing numbers in the name', () => {
+    const date = new Date('2026-12-31T00:00:00Z');
+    expect(generateEventSlug('Race 500', date)).toBe('race-500-2026-12-31');
+  });
+});
+
+describe('checkSchedulingConflict', () => {
+  it('detects an overlap between two ranged events', () => {
+    const e1Start = new Date('2026-01-15T10:00:00Z');
+    const e1End = new Date('2026-01-15T12:00:00Z');
+    const e2Start = new Date('2026-01-15T11:00:00Z');
+    const e2End = new Date('2026-01-15T13:00:00Z');
+    expect(checkSchedulingConflict(e1Start, e1End, e2Start, e2End)).toBe(true);
+  });
+
+  it('reports no conflict for fully separated events', () => {
+    const e1Start = new Date('2026-01-15T10:00:00Z');
+    const e1End = new Date('2026-01-15T11:00:00Z');
+    const e2Start = new Date('2026-01-15T12:00:00Z');
+    const e2End = new Date('2026-01-15T13:00:00Z');
+    expect(checkSchedulingConflict(e1Start, e1End, e2Start, e2End)).toBe(false);
+  });
+
+  it('treats back-to-back events (touching at the boundary) as non-conflicting', () => {
+    const e1Start = new Date('2026-01-15T10:00:00Z');
+    const e1End = new Date('2026-01-15T11:00:00Z');
+    const e2Start = new Date('2026-01-15T11:00:00Z');
+    const e2End = new Date('2026-01-15T12:00:00Z');
+    expect(checkSchedulingConflict(e1Start, e1End, e2Start, e2End)).toBe(false);
+  });
+
+  it('treats a null end date as an instantaneous event for the first event', () => {
+    const e1Start = new Date('2026-01-15T11:00:00Z');
+    const e2Start = new Date('2026-01-15T10:00:00Z');
+    const e2End = new Date('2026-01-15T12:00:00Z');
+    // instant at 11:00 falls inside [10:00, 12:00)
+    expect(checkSchedulingConflict(e1Start, null, e2Start, e2End)).toBe(true);
+  });
+
+  it('treats a null end date as an instantaneous event for the second event', () => {
+    const e1Start = new Date('2026-01-15T10:00:00Z');
+    const e1End = new Date('2026-01-15T12:00:00Z');
+    const e2Start = new Date('2026-01-15T11:00:00Z');
+    expect(checkSchedulingConflict(e1Start, e1End, e2Start, null)).toBe(true);
+  });
+
+  it('reports no conflict between two distinct instantaneous events', () => {
+    const e1Start = new Date('2026-01-15T10:00:00Z');
+    const e2Start = new Date('2026-01-15T11:00:00Z');
+    expect(checkSchedulingConflict(e1Start, null, e2Start, null)).toBe(false);
+  });
+
+  it('reports a conflict between two identical instantaneous events', () => {
+    const at = new Date('2026-01-15T10:00:00Z');
+    // start < end requires start < start which is false for identical instants
+    expect(
+      checkSchedulingConflict(at, null, new Date(at.getTime()), null),
+    ).toBe(false);
+  });
+});
+
+describe('parseRecurrencePattern', () => {
+  it('returns null for a null pattern', () => {
+    expect(parseRecurrencePattern(null)).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(parseRecurrencePattern('')).toBeNull();
+  });
+
+  it('parses a valid JSON string into a pattern object', () => {
+    const json = '{"frequency":"weekly","interval":2}';
+    expect(parseRecurrencePattern(json)).toEqual({
+      frequency: 'weekly',
+      interval: 2,
+    });
+  });
+
+  it('returns null for a malformed JSON string', () => {
+    expect(parseRecurrencePattern('{not valid json')).toBeNull();
+  });
+
+  it('returns the same object when passed an existing pattern object', () => {
+    const pattern: RecurrencePattern = { frequency: 'daily', interval: 1 };
+    expect(parseRecurrencePattern(pattern)).toBe(pattern);
+  });
+});
+
+describe('calculateNextOccurrence', () => {
+  const from = new Date('2026-01-15T10:00:00Z');
+
+  it('advances by one day for a daily pattern with default interval', () => {
+    const result = calculateNextOccurrence({ frequency: 'daily' }, from);
+    expect(result).toEqual(new Date('2026-01-16T10:00:00Z'));
+  });
+
+  it('advances by the given interval for a daily pattern', () => {
+    const result = calculateNextOccurrence(
+      { frequency: 'daily', interval: 3 },
+      from,
+    );
+    expect(result).toEqual(new Date('2026-01-18T10:00:00Z'));
+  });
+
+  it('advances by interval weeks for a weekly pattern', () => {
+    const result = calculateNextOccurrence(
+      { frequency: 'weekly', interval: 2 },
+      from,
+    );
+    expect(result).toEqual(new Date('2026-01-29T10:00:00Z'));
+  });
+
+  it('advances by interval months for a monthly pattern', () => {
+    const result = calculateNextOccurrence(
+      { frequency: 'monthly', interval: 1 },
+      from,
+    );
+    expect(result).toEqual(new Date('2026-02-15T10:00:00Z'));
+  });
+
+  it('advances by interval years for a yearly pattern', () => {
+    const result = calculateNextOccurrence(
+      { frequency: 'yearly', interval: 1 },
+      from,
+    );
+    expect(result).toEqual(new Date('2027-01-15T10:00:00Z'));
+  });
+
+  it('returns null for an unrecognized frequency', () => {
+    const result = calculateNextOccurrence(
+      { frequency: 'fortnightly' as unknown as 'daily' },
+      from,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null when fromDate is already at or past the until date', () => {
+    const until = new Date('2026-01-15T10:00:00Z');
+    expect(
+      calculateNextOccurrence({ frequency: 'daily', until }, from),
+    ).toBeNull();
+  });
+
+  it('returns null when the computed next date would exceed the until date', () => {
+    const until = new Date('2026-01-15T20:00:00Z');
+    // next daily occurrence is 2026-01-16, which is after the until bound
+    expect(
+      calculateNextOccurrence({ frequency: 'daily', until }, from),
+    ).toBeNull();
+  });
+
+  it('returns the next occurrence when it falls on or before the until date', () => {
+    const until = new Date('2026-01-20T10:00:00Z');
+    const result = calculateNextOccurrence({ frequency: 'daily', until }, from);
+    expect(result).toEqual(new Date('2026-01-16T10:00:00Z'));
+  });
+});
+
+describe('calculateDuration', () => {
+  it('returns the millisecond gap between start and end', () => {
+    const start = new Date('2026-01-15T10:00:00Z');
+    const end = new Date('2026-01-15T11:00:00Z');
+    expect(calculateDuration(start, end)).toBe(60 * 60 * 1000);
+  });
+
+  it('returns zero for identical timestamps', () => {
+    const at = new Date('2026-01-15T10:00:00Z');
+    expect(calculateDuration(at, new Date(at.getTime()))).toBe(0);
+  });
+
+  it('returns a negative value when the end precedes the start', () => {
+    const start = new Date('2026-01-15T11:00:00Z');
+    const end = new Date('2026-01-15T10:00:00Z');
+    expect(calculateDuration(start, end)).toBe(-60 * 60 * 1000);
+  });
+});
+
+describe('formatDuration', () => {
+  it('formats sub-minute durations in seconds only', () => {
+    expect(formatDuration(45 * 1000)).toBe('45s');
+  });
+
+  it('formats zero duration as 0s', () => {
+    expect(formatDuration(0)).toBe('0s');
+  });
+
+  it('formats minute-scale durations as minutes and seconds', () => {
+    expect(formatDuration(5 * 60 * 1000 + 30 * 1000)).toBe('5m 30s');
+  });
+
+  it('formats exact minutes with zero seconds', () => {
+    expect(formatDuration(5 * 60 * 1000)).toBe('5m 0s');
+  });
+
+  it('formats hour-scale durations as hours and minutes', () => {
+    expect(formatDuration(2 * 60 * 60 * 1000 + 15 * 60 * 1000)).toBe('2h 15m');
+  });
+
+  it('formats day-scale durations as days and remaining hours', () => {
+    expect(formatDuration(3 * 24 * 60 * 60 * 1000 + 5 * 60 * 60 * 1000)).toBe(
+      '3d 5h',
+    );
+  });
+
+  it('drops sub-unit remainders at the day tier', () => {
+    // exactly 1 day -> remaining hours is 0
+    expect(formatDuration(24 * 60 * 60 * 1000)).toBe('1d 0h');
+  });
+});
+
+describe('isEventNow', () => {
+  it('returns false for an event that has not started yet', () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000);
+    expect(isEventNow(future)).toBe(false);
+  });
+
+  it('returns true for an event that started and has no end date', () => {
+    const past = new Date(Date.now() - 60 * 60 * 1000);
+    expect(isEventNow(past)).toBe(true);
+  });
+
+  it('returns true for an event currently within its start/end window', () => {
+    const start = new Date(Date.now() - 60 * 60 * 1000);
+    const end = new Date(Date.now() + 60 * 60 * 1000);
+    expect(isEventNow(start, end)).toBe(true);
+  });
+
+  it('returns false for an event whose end date has already passed', () => {
+    const start = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    const end = new Date(Date.now() - 60 * 60 * 1000);
+    expect(isEventNow(start, end)).toBe(false);
+  });
+
+  it('treats a null end date the same as an open-ended event', () => {
+    const past = new Date(Date.now() - 60 * 60 * 1000);
+    expect(isEventNow(past, null)).toBe(true);
+  });
+});
+
+describe('getEventStatusFromDates', () => {
+  it('preserves a cancelled status regardless of dates', () => {
+    const start = new Date(Date.now() - 60 * 60 * 1000);
+    expect(getEventStatusFromDates(start, null, 'cancelled')).toBe('cancelled');
+  });
+
+  it('preserves a postponed status regardless of dates', () => {
+    const start = new Date(Date.now() - 60 * 60 * 1000);
+    expect(getEventStatusFromDates(start, null, 'postponed')).toBe('postponed');
+  });
+
+  it('returns scheduled for an event still in the future', () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000);
+    expect(getEventStatusFromDates(future)).toBe('scheduled');
+  });
+
+  it('returns completed when the end date is in the past', () => {
+    const start = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    const end = new Date(Date.now() - 60 * 60 * 1000);
+    expect(getEventStatusFromDates(start, end)).toBe('completed');
+  });
+
+  it('returns in_progress when started and within the window', () => {
+    const start = new Date(Date.now() - 60 * 60 * 1000);
+    const end = new Date(Date.now() + 60 * 60 * 1000);
+    expect(getEventStatusFromDates(start, end)).toBe('in_progress');
+  });
+
+  it('returns in_progress for a started open-ended event', () => {
+    const start = new Date(Date.now() - 60 * 60 * 1000);
+    expect(getEventStatusFromDates(start)).toBe('in_progress');
+  });
+
+  it('still derives status from dates when current status is non-terminal', () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000);
+    expect(getEventStatusFromDates(future, null, 'scheduled')).toBe(
+      'scheduled',
+    );
+  });
+});
+
+describe('sortEventsByDate', () => {
+  it('sorts events ascending by start date by default', () => {
+    const a = { id: 'a', startDate: new Date('2026-01-17T00:00:00Z') };
+    const b = { id: 'b', startDate: new Date('2026-01-15T00:00:00Z') };
+    const c = { id: 'c', startDate: new Date('2026-01-16T00:00:00Z') };
+    const sorted = sortEventsByDate([a, b, c]);
+    expect(sorted.map((e) => e.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('sorts events descending when ascending is false', () => {
+    const a = { id: 'a', startDate: new Date('2026-01-17T00:00:00Z') };
+    const b = { id: 'b', startDate: new Date('2026-01-15T00:00:00Z') };
+    const c = { id: 'c', startDate: new Date('2026-01-16T00:00:00Z') };
+    const sorted = sortEventsByDate([a, b, c], false);
+    expect(sorted.map((e) => e.id)).toEqual(['a', 'c', 'b']);
+  });
+
+  it('pushes events with a null start date to the end when ascending', () => {
+    const a = { id: 'a', startDate: new Date('2026-01-15T00:00:00Z') };
+    const n = { id: 'n', startDate: null };
+    const b = { id: 'b', startDate: new Date('2026-01-16T00:00:00Z') };
+    const sorted = sortEventsByDate([n, a, b]);
+    expect(sorted.map((e) => e.id)).toEqual(['a', 'b', 'n']);
+  });
+
+  it('keeps two null-dated events in their relative order', () => {
+    const n1 = { id: 'n1', startDate: null };
+    const n2 = { id: 'n2', startDate: null };
+    const sorted = sortEventsByDate([n1, n2]);
+    expect(sorted.map((e) => e.id)).toEqual(['n1', 'n2']);
+  });
+
+  it('returns an empty array unchanged', () => {
+    expect(sortEventsByDate([])).toEqual([]);
+  });
+
+  it('sorts in place and returns the same array reference', () => {
+    const events = [
+      { id: 'a', startDate: new Date('2026-01-17T00:00:00Z') },
+      { id: 'b', startDate: new Date('2026-01-15T00:00:00Z') },
+    ];
+    const result = sortEventsByDate(events);
+    expect(result).toBe(events);
+  });
+});

--- a/packages/events/src/svelte/components/MeetingView.svelte
+++ b/packages/events/src/svelte/components/MeetingView.svelte
@@ -4,7 +4,11 @@
  * Displays details for a council meeting with links to agenda, minutes, video
  */
 
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../i18n.js';
 import type { Meeting } from '../types.js';
+
+const { t } = useI18n();
 
 interface Props {
   meeting: Meeting;
@@ -47,7 +51,7 @@ const hasDocuments = $derived(
       <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
         <path d="M10 12L6 8L10 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
-      Back to Calendar
+      {t(M['events.meeting_view.back_to_calendar'])}
     </a>
 
     {#if meeting.council}
@@ -68,7 +72,7 @@ const hasDocuments = $derived(
   <div class="meeting-content">
     {#if hasDocuments}
       <section class="documents-section">
-        <h2 class="section-title">Documents & Resources</h2>
+        <h2 class="section-title">{t(M['events.meeting_view.documents_and_resources'])}</h2>
 
         <div class="documents-grid">
           {#if meeting.agendaUrl}
@@ -76,7 +80,7 @@ const hasDocuments = $derived(
               <span class="document-icon">{'\u{1F4CB}'}</span>
               <div class="document-info">
                 <span class="document-name">Agenda</span>
-                <span class="document-desc">Meeting agenda and items</span>
+                <span class="document-desc">{t(M['events.meeting_view.agenda_desc'])}</span>
               </div>
               <span class="document-arrow">{'\u2197'}</span>
             </a>
@@ -87,7 +91,7 @@ const hasDocuments = $derived(
               <span class="document-icon">{'\u{1F4DD}'}</span>
               <div class="document-info">
                 <span class="document-name">Minutes</span>
-                <span class="document-desc">Official meeting minutes</span>
+                <span class="document-desc">{t(M['events.meeting_view.minutes_desc'])}</span>
               </div>
               <span class="document-arrow">{'\u2197'}</span>
             </a>
@@ -98,7 +102,7 @@ const hasDocuments = $derived(
               <span class="document-icon">{'\u{1F3AC}'}</span>
               <div class="document-info">
                 <span class="document-name">Video</span>
-                <span class="document-desc">Watch the recording</span>
+                <span class="document-desc">{t(M['events.meeting_view.video_desc'])}</span>
               </div>
               <span class="document-arrow">{'\u2197'}</span>
             </a>
@@ -109,7 +113,7 @@ const hasDocuments = $derived(
               <span class="document-icon">{'\u{2728}'}</span>
               <div class="document-info">
                 <span class="document-name">Highlights</span>
-                <span class="document-desc">Key decisions summary</span>
+                <span class="document-desc">{t(M['events.meeting_view.highlights_desc'])}</span>
               </div>
               <span class="document-arrow">{'\u2197'}</span>
             </a>
@@ -119,7 +123,7 @@ const hasDocuments = $derived(
     {:else}
       <div class="empty-state">
         <span class="empty-icon">{'\u{1F4C4}'}</span>
-        <p class="empty-text">No documents available yet for this meeting</p>
+        <p class="empty-text">{t(M['events.meeting_view.no_documents'])}</p>
       </div>
     {/if}
   </div>

--- a/packages/events/src/svelte/i18n.ts
+++ b/packages/events/src/svelte/i18n.ts
@@ -1,0 +1,13 @@
+import { defineMessages } from '@happyvertical/smrt-svelte/i18n';
+
+export const M = defineMessages({
+  // MeetingView
+  'events.meeting_view.back_to_calendar': 'Back to Calendar',
+  'events.meeting_view.documents_and_resources': 'Documents & Resources',
+  'events.meeting_view.agenda_desc': 'Meeting agenda and items',
+  'events.meeting_view.minutes_desc': 'Official meeting minutes',
+  'events.meeting_view.video_desc': 'Watch the recording',
+  'events.meeting_view.highlights_desc': 'Key decisions summary',
+  'events.meeting_view.no_documents':
+    'No documents available yet for this meeting',
+});

--- a/packages/events/vitest.config.ts
+++ b/packages/events/vitest.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
     environment: 'node',
     include: ['src/**/*.test.ts'],
     testTimeout: 30000,
+    // smrt-vitest's async afterAll teardown can exceed the default 10s under
+    // loaded CI runners; bump it so a slow teardown doesn't fail the suite.
+    hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
     poolOptions: {

--- a/scripts/check-hardcoded-strings.mjs
+++ b/scripts/check-hardcoded-strings.mjs
@@ -44,6 +44,7 @@ const STRICT_PACKAGES = new Set([
   'assets',
   'chat',
   'content',
+  'events',
 ]);
 
 // Dev/playground host, not a shippable library (consistent with the other ratchets).


### PR DESCRIPTION
## What

**events** was one of the four coverage-blocked packages (22% < its 50% T3
floor), so its i18n extraction was deferred from the wave sweep. This combined
**extract + test** PR clears the floor and flips it strict.

## i18n

- Extract MeetingView's 7 user-facing strings (incl. the `&`-split *"Documents &
  Resources"* heading the ratchet misses) into `events.meeting_view.*`.
- Add `events` to `STRICT_PACKAGES` (**14 strict** now).

## Coverage: 22.24% → 87.31%

Added **127 tests** (orchestrated as parallel subagents on disjoint files):
- `utils.test.ts` — 66 cases covering all 11 pure functions in `utils.ts` (was **0%**).
- `event-{types,series,participants,collection}.test.ts` — 61 cases over the
  low-coverage models/collections, using real in-memory SQLite per the existing
  `event-assets.test.ts` pattern (never mocks the DB).
- `events/vitest.config.ts`: add `hookTimeout: 30000` (the smrt-vitest teardown flake).

## Validation

- `turbo typecheck` 78/78 (a11y gate clean).
- **135 events tests pass**; **coverage gate green** (87.31% ≥ 50% T3).
- ratchet 0; full build 50/50.

## Note (pre-existing, not fixed here)

`EventSeriesCollection.create({ recurrence: {…} })` assigns the raw object to the
string column (no constructor stringify) → `[object Object]`; callers must pass a
JSON string or use the setter. Surfaced by the new tests — worth a follow-up.

Progress on the coverage-blocked set: **events done**; messages / products /
images remain.