### PR TITLE
feat(i18n,test,fix): extract messages strings + raise coverage 54%→88%, flip strict (S13 #1418)

### DIFF
--- a/packages/messages/src/__tests__/account-message-extended.test.ts
+++ b/packages/messages/src/__tests__/account-message-extended.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Extended Account + Message coverage using real in-memory SQLite.
+ *
+ * Covers DB-backed lifecycle methods (activate/deactivate, markRead/markUnread,
+ * toggleFlagged), relationship loaders (getAccount/getThreadMessages/
+ * getAttachments), credential fallback to settings, and the send()/retrySend()
+ * orchestration (status transitions).
+ *
+ * Mocking policy: only the external SDK transport getMessageClient() from
+ * '@happyvertical/messages' is mocked (used indirectly via SlackSender during
+ * Message.send). All models/collections/DB are real.
+ */
+
+import { getTestDatabase } from '@happyvertical/smrt-core';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sendMock = vi.fn();
+vi.mock('@happyvertical/messages', () => ({
+  getMessageClient: async () => ({
+    connect: async () => undefined,
+    disconnect: async () => undefined,
+    send: (...args: any[]) => sendMock(...args),
+  }),
+}));
+
+import { AccountCollection } from '../collections/AccountCollection';
+import { MessageCollection } from '../collections/MessageCollection';
+import { Account } from '../models/Account';
+import { Attachment } from '../models/Attachment';
+import { Message } from '../models/Message';
+import { SlackAccount } from '../models/SlackAccount';
+import { SlackMessage } from '../models/SlackMessage';
+
+let db: DatabaseInterface;
+
+beforeEach(async () => {
+  db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+});
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  if (db && typeof db.close === 'function') {
+    await db.close();
+  }
+});
+
+// ============================================================================
+// Account — lifecycle + credentials
+// ============================================================================
+
+describe('Account lifecycle', () => {
+  it('activate()/deactivate() persist isActive', async () => {
+    const account = new Account({
+      name: 'Acct',
+      providerType: 'generic',
+      isActive: true,
+      db,
+    });
+    await account.initialize();
+    await account.save();
+
+    await account.deactivate();
+    expect(account.isActive).toBe(false);
+
+    const collection = await (AccountCollection as any).create({ db });
+    let loaded = await collection.get({ id: account.id });
+    expect(loaded.isActive).toBe(false);
+
+    await account.activate();
+    expect(account.isActive).toBe(true);
+    loaded = await collection.get({ id: account.id });
+    expect(loaded.isActive).toBe(true);
+  });
+
+  it('setSettings/getSettings round-trip through the database', async () => {
+    const account = new Account({ name: 'Acct', db });
+    await account.initialize();
+    account.setSettings({ host: 'mail.example.com', port: 587 });
+    await account.save();
+
+    const collection = await (AccountCollection as any).create({ db });
+    const loaded = await collection.get({ id: account.id });
+    expect(loaded.getSettings()).toEqual({
+      host: 'mail.example.com',
+      port: 587,
+    });
+  });
+
+  it('getCredentials falls back to settings when no credentialSecretId', async () => {
+    const account = new Account({ name: 'Acct', db });
+    await account.initialize();
+    account.setSettings({ apiKey: 'abc', token: 'xyz' });
+
+    const creds = await account.getCredentials();
+    expect(creds).toEqual({ apiKey: 'abc', token: 'xyz' });
+  });
+
+  it('base Account.createSender throws not-implemented', async () => {
+    const account = new Account({ providerType: 'mystery', db });
+    await account.initialize();
+    await expect(account.createSender()).rejects.toThrow(
+      "not implemented for account type 'mystery'",
+    );
+  });
+});
+
+// ============================================================================
+// Message — DB-backed lifecycle + relationships
+// ============================================================================
+
+describe('Message lifecycle (persisted)', () => {
+  it('markRead/markUnread/toggleFlagged persist', async () => {
+    const msg = new Message({ subject: 'S', body: 'B', isRead: false, db });
+    await msg.initialize();
+    await msg.save();
+
+    await msg.markRead();
+    expect(msg.isRead).toBe(true);
+
+    const coll = await (MessageCollection as any).create({ db });
+    expect((await coll.get({ id: msg.id })).isRead).toBe(true);
+
+    await msg.markUnread();
+    expect(msg.isRead).toBe(false);
+    expect(msg.isUnread()).toBe(true);
+
+    expect(msg.isFlagged).toBe(false);
+    await msg.toggleFlagged();
+    expect(msg.isFlagged).toBe(true);
+    await msg.toggleFlagged();
+    expect(msg.isFlagged).toBe(false);
+
+    expect((await coll.get({ id: msg.id })).isFlagged).toBe(false);
+  });
+
+  it('getAccount returns null with no accountId and resolves a saved account', async () => {
+    const noAccount = new Message({ subject: 'S', db });
+    await noAccount.initialize();
+    expect(await noAccount.getAccount()).toBeNull();
+
+    const account = new Account({ name: 'Owner', providerType: 'generic', db });
+    await account.initialize();
+    await account.save();
+
+    const msg = new Message({ subject: 'S', accountId: account.id!, db });
+    await msg.initialize();
+    await msg.save();
+
+    const resolved = await msg.getAccount();
+    expect(resolved).not.toBeNull();
+    expect(resolved.id).toBe(account.id);
+    expect(resolved.name).toBe('Owner');
+  });
+
+  it('getThreadMessages returns [this] when no threadId, else thread members', async () => {
+    const solo = new Message({ subject: 'Solo', db });
+    await solo.initialize();
+    await solo.save();
+    const soloThread = await solo.getThreadMessages();
+    expect(soloThread).toHaveLength(1);
+    expect(soloThread[0].id).toBe(solo.id);
+
+    const a = new Message({ subject: 'A', threadId: 'thread-x', db });
+    await a.initialize();
+    await a.save();
+    const b = new Message({ subject: 'B', threadId: 'thread-x', db });
+    await b.initialize();
+    await b.save();
+
+    const members = await a.getThreadMessages();
+    expect(members.map((m) => m.id).sort()).toEqual([a.id, b.id].sort());
+  });
+
+  it('getAttachments lists attachments for the message', async () => {
+    const msg = new Message({ subject: 'WithAtt', db });
+    await msg.initialize();
+    await msg.save();
+
+    const att = new Attachment({
+      messageId: msg.id!,
+      filename: 'doc.pdf',
+      contentType: 'application/pdf',
+      db,
+    });
+    await att.initialize();
+    await att.save();
+
+    const attachments = await msg.getAttachments();
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0].filename).toBe('doc.pdf');
+  });
+});
+
+// ============================================================================
+// Message — send() / retrySend() orchestration
+// ============================================================================
+
+describe('Message.send orchestration', () => {
+  it('fails and marks status failed when no account is associated', async () => {
+    const msg = new Message({ subject: 'Orphan', db });
+    await msg.initialize();
+    await msg.save();
+
+    const result = await msg.send();
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('No account associated');
+    expect(msg.sendStatus).toBe('failed');
+    expect(msg.sendError).toContain('No account associated');
+  });
+
+  it('marks status sent on a successful provider send', async () => {
+    const account = new SlackAccount({
+      name: 'WS',
+      botUserId: 'U-BOT',
+      isActive: true,
+      db,
+    });
+    await account.initialize();
+    account.setSettings({ botToken: 'xoxb-token' });
+    await account.save();
+
+    const sentAt = new Date();
+    sendMock.mockResolvedValueOnce({
+      success: true,
+      messageId: 'slack-1',
+      providerResponse: { ok: true },
+      timestamp: sentAt,
+    });
+
+    const msg = new SlackMessage({
+      body: 'hi',
+      channelId: 'C1',
+      accountId: account.id!,
+      db,
+    });
+    await msg.initialize();
+    await msg.save();
+
+    const result = await msg.send();
+    expect(result.success).toBe(true);
+    expect(msg.sendStatus).toBe('sent');
+    expect(msg.sentAt).toEqual(sentAt);
+    expect(msg.sendError).toBe('');
+  });
+
+  it('marks status failed when the provider reports failure, then retrySend re-attempts', async () => {
+    const account = new SlackAccount({
+      name: 'WS',
+      botUserId: 'U-BOT',
+      isActive: true,
+      db,
+    });
+    await account.initialize();
+    account.setSettings({ botToken: 'xoxb-token' });
+    await account.save();
+
+    // First attempt fails at the provider level.
+    sendMock.mockResolvedValueOnce({
+      success: false,
+      messageId: undefined,
+      providerResponse: {},
+      timestamp: new Date(),
+    });
+
+    const msg = new SlackMessage({
+      body: 'hi',
+      channelId: 'C1',
+      accountId: account.id!,
+      db,
+    });
+    await msg.initialize();
+    await msg.save();
+
+    const first = await msg.send();
+    expect(first.success).toBe(false);
+    expect(msg.sendStatus).toBe('failed');
+
+    // Second attempt (retrySend) succeeds; retryCount increments.
+    const sentAt = new Date();
+    sendMock.mockResolvedValueOnce({
+      success: true,
+      messageId: 'slack-2',
+      providerResponse: { ok: true },
+      timestamp: sentAt,
+    });
+
+    const retried = await msg.retrySend();
+    expect(retried.success).toBe(true);
+    expect(msg.retryCount).toBe(1);
+    expect(msg.sendStatus).toBe('sent');
+  });
+});

--- a/packages/messages/src/__tests__/collections.test.ts
+++ b/packages/messages/src/__tests__/collections.test.ts
@@ -1,0 +1,867 @@
+/**
+ * Integration tests for the messages COLLECTION classes (coverage gate #1411).
+ *
+ * Every test runs against a REAL in-memory SQLite database created from the
+ * registered model schemas via `getTestDatabase()`. We never mock the DB,
+ * collections, or models — only public query/helper methods are exercised.
+ *
+ * Schema note
+ * -----------
+ * `getTestDatabase()` builds its schema from the classes registered in
+ * `ObjectRegistry`. We import every model the collections touch (Account /
+ * EmailAccount / Message / Email / Attachment) so the `accounts`, `messages`,
+ * and `attachments` tables exist when tests run this file in isolation.
+ *
+ * Dedup note
+ * ----------
+ * Base Account / Message rows have no name-derived slug, so distinct names are
+ * not strictly required — but we still use distinct, meaningful field values so
+ * each assertion targets exactly the rows it intends.
+ */
+
+import { getTestDatabase } from '@happyvertical/smrt-core';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  AccountCollection,
+  AttachmentCollection,
+  EmailAccountCollection,
+  EmailCollection,
+  MessageCollection,
+} from '../index.js';
+// Importing the models registers their schemas so getTestDatabase() creates
+// the underlying tables.
+import { Account } from '../models/Account';
+import { Attachment } from '../models/Attachment';
+import { Email } from '../models/Email';
+import { EmailAccount } from '../models/EmailAccount';
+import { Message } from '../models/Message';
+
+// ---------------------------------------------------------------------------
+// Persistence helper — initialize() then save() is the supported write path.
+// ---------------------------------------------------------------------------
+
+async function persist<
+  T extends { initialize(): Promise<any>; save(): Promise<any> },
+>(model: T): Promise<T> {
+  await model.initialize();
+  await model.save();
+  return model;
+}
+
+// ===========================================================================
+// MessageCollection
+// ===========================================================================
+
+describe('MessageCollection', () => {
+  let db: DatabaseInterface;
+  let col: MessageCollection;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    col = await MessageCollection.create({ db });
+  });
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') await db.close();
+  });
+
+  /** Seed a representative set of messages (base Message + STI Email rows). */
+  async function seed() {
+    // Base messages on account A
+    await persist(
+      new Message({
+        db,
+        accountId: 'acct-A',
+        subject: 'Quarterly report',
+        body: 'numbers inside',
+        fromAddress: 'boss@corp.com',
+        fromName: 'The Boss',
+        toAddresses: JSON.stringify([{ address: 'me@corp.com' }]),
+        threadId: 'thread-1',
+        isRead: false,
+        isFlagged: true,
+        sendStatus: 'sent',
+        date: new Date('2025-03-01'),
+      }),
+    );
+    await persist(
+      new Message({
+        db,
+        accountId: 'acct-A',
+        subject: 'Lunch?',
+        body: 'wanna grab lunch',
+        fromAddress: 'pal@friend.com',
+        threadId: 'thread-2',
+        isRead: true,
+        sendStatus: 'draft',
+        date: new Date('2025-03-05'),
+      }),
+    );
+    // STI Email row on account B, also unread/flagged
+    await persist(
+      new Email({
+        db,
+        accountId: 'acct-B',
+        subject: 'Newsletter',
+        body: 'weekly digest',
+        fromAddress: 'news@list.com',
+        threadId: 'thread-1',
+        isRead: false,
+        isFlagged: false,
+        sendStatus: 'scheduled',
+        date: new Date('2025-03-10'),
+      }),
+    );
+  }
+
+  it('search() matches query across subject/body/from and applies filters', async () => {
+    await seed();
+
+    expect(await col.search('quarterly')).toHaveLength(1);
+    expect(await col.search('boss')).toHaveLength(1); // fromName/fromAddress
+    expect(await col.search('')).toHaveLength(3); // empty query => all
+
+    const onAcctA = await col.search('', { accountIds: ['acct-A'] });
+    expect(onAcctA).toHaveLength(2);
+
+    const emailsOnly = await col.search('', { messageType: 'Email' });
+    expect(emailsOnly).toHaveLength(1);
+    expect(emailsOnly[0].subject).toBe('Newsletter');
+
+    const unread = await col.search('', { isRead: false });
+    expect(unread).toHaveLength(2);
+
+    const flagged = await col.search('', { isFlagged: true });
+    expect(flagged).toHaveLength(1);
+
+    const fromFiltered = await col.search('', { from: 'news@list.com' });
+    expect(fromFiltered).toHaveLength(1);
+
+    const toFiltered = await col.search('', { to: 'me@corp.com' });
+    expect(toFiltered).toHaveLength(1);
+
+    const sinceFiltered = await col.search('', {
+      sinceDate: new Date('2025-03-04'),
+    });
+    expect(sinceFiltered).toHaveLength(2);
+
+    const beforeFiltered = await col.search('', {
+      beforeDate: new Date('2025-03-04'),
+    });
+    expect(beforeFiltered).toHaveLength(1);
+
+    const innerQuery = await col.search('', { query: 'digest' });
+    expect(innerQuery).toHaveLength(1);
+  });
+
+  it('getByAccounts() returns messages across the given account ids', async () => {
+    await seed();
+    expect(await col.getByAccounts(['acct-A'])).toHaveLength(2);
+    expect(await col.getByAccounts(['acct-A', 'acct-B'])).toHaveLength(3);
+    expect(await col.getByAccounts(['nope'])).toHaveLength(0);
+  });
+
+  it('getByType() resolves both short names and full discriminators', async () => {
+    await seed();
+    const byShort = await col.getByType('Email');
+    expect(byShort).toHaveLength(1);
+
+    const byFull = await col.getByType('@happyvertical/smrt-messages:Email');
+    expect(byFull).toHaveLength(1);
+
+    expect(await col.getByType('Tweet')).toHaveLength(0);
+  });
+
+  it('getUnread() and getFlagged() filter with optional account scope', async () => {
+    await seed();
+    expect(await col.getUnread()).toHaveLength(2);
+    expect(await col.getUnread('acct-A')).toHaveLength(1);
+    expect(await col.getFlagged()).toHaveLength(1);
+    expect(await col.getFlagged('acct-B')).toHaveLength(0);
+  });
+
+  it('getRecent() returns newest-first and honours the limit', async () => {
+    await seed();
+    const recent = await col.getRecent(2);
+    expect(recent).toHaveLength(2);
+    // Newest date first: 2025-03-10 (Newsletter) then 2025-03-05 (Lunch?)
+    expect(recent[0].subject).toBe('Newsletter');
+    expect(recent[1].subject).toBe('Lunch?');
+
+    const recentA = await col.getRecent(20, 'acct-A');
+    expect(recentA).toHaveLength(2);
+  });
+
+  it('getByThread() groups messages sharing a threadId', async () => {
+    await seed();
+    expect(await col.getByThread('thread-1')).toHaveLength(2);
+    expect(await col.getByThread('thread-2')).toHaveLength(1);
+  });
+
+  it('markAllRead() marks each id as read', async () => {
+    await seed();
+    const unread = await col.getUnread();
+    const ids = unread.map((m) => m.id as string);
+    await col.markAllRead(ids);
+    expect(await col.getUnread()).toHaveLength(0);
+  });
+
+  it('markAllRead() ignores ids that do not resolve to a message', async () => {
+    await seed();
+    await expect(col.markAllRead(['does-not-exist'])).resolves.toBeUndefined();
+  });
+
+  it('getAccountStats() tallies totals, unread, flagged, and byType', async () => {
+    await seed();
+    const stats = await col.getAccountStats('acct-A');
+    expect(stats.total).toBe(2);
+    expect(stats.unread).toBe(1);
+    expect(stats.flagged).toBe(1);
+    expect(stats.byType.Message).toBe(2);
+  });
+
+  it('send-status queries return the matching rows', async () => {
+    await seed();
+    expect(await col.getDrafts()).toHaveLength(1);
+    expect(await col.getDrafts('acct-A')).toHaveLength(1);
+    expect(await col.getSent()).toHaveLength(1);
+    expect(await col.getScheduled()).toHaveLength(1);
+    expect(await col.getFailedSends()).toHaveLength(0);
+  });
+
+  it('getOutbox() returns pending/sending/scheduled messages', async () => {
+    await seed();
+    // Only the scheduled Email qualifies from the seed set.
+    const outbox = await col.getOutbox();
+    expect(outbox).toHaveLength(1);
+    expect(outbox[0].sendStatus).toBe('scheduled');
+    expect(await col.getOutbox('acct-A')).toHaveLength(0);
+  });
+
+  it('tenant helpers filter by tenant and globals', async () => {
+    await persist(
+      new Message({
+        db,
+        accountId: 'acct-T',
+        subject: 'tenant',
+        tenantId: 't1',
+      }),
+    );
+    await persist(new Message({ db, accountId: 'acct-G', subject: 'global' }));
+
+    expect(await col.findByTenant('t1')).toHaveLength(1);
+    expect(await col.findGlobal()).toHaveLength(1);
+    const withGlobals = await col.findWithGlobals('t1');
+    expect(withGlobals).toHaveLength(2);
+  });
+});
+
+// ===========================================================================
+// EmailCollection (extends MessageCollection; STI auto-filters to Email)
+// ===========================================================================
+
+describe('EmailCollection', () => {
+  let db: DatabaseInterface;
+  let col: EmailCollection;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    col = await EmailCollection.create({ db });
+  });
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') await db.close();
+  });
+
+  async function seedEmails() {
+    await persist(
+      new Email({
+        db,
+        accountId: 'acct-A',
+        folderId: 'folder-inbox',
+        threadId: 'thr-1',
+        messageId: '<a1@x>',
+        subject: 'Invoice attached',
+        textBody: 'see the pdf',
+        fromAddress: 'billing@vendor.com',
+        fromName: 'Vendor Billing',
+        toAddresses: JSON.stringify([{ address: 'me@corp.com' }]),
+        isRead: false,
+        isFlagged: true,
+        hasAttachments: true,
+        date: new Date('2025-02-01'),
+      }),
+    );
+    await persist(
+      new Email({
+        db,
+        accountId: 'acct-A',
+        folderId: 'folder-inbox',
+        threadId: 'thr-2',
+        messageId: '<a2@x>',
+        subject: 'Re: Meeting',
+        textBody: 'sounds good',
+        fromAddress: 'pal@friend.com',
+        isRead: true,
+        isFlagged: false,
+        hasAttachments: false,
+        date: new Date('2025-02-10'),
+      }),
+    );
+    await persist(
+      new Email({
+        db,
+        accountId: 'acct-B',
+        folderId: 'folder-archive',
+        threadId: 'thr-1',
+        messageId: '<b1@x>',
+        subject: 'Archived note',
+        textBody: 'old stuff',
+        fromAddress: 'system@corp.com',
+        isRead: false,
+        isFlagged: false,
+        hasAttachments: false,
+        date: new Date('2025-01-15'),
+      }),
+    );
+  }
+
+  it('getByMessageId() finds a single email scoped by account', async () => {
+    await seedEmails();
+    const found = await col.getByMessageId('acct-A', '<a1@x>');
+    expect(found?.subject).toBe('Invoice attached');
+    expect(await col.getByMessageId('acct-A', '<missing@x>')).toBeNull();
+    // Right messageId, wrong account => not found.
+    expect(await col.getByMessageId('acct-B', '<a1@x>')).toBeNull();
+  });
+
+  it('getByAccount() / getByFolder() / getByThread() scope correctly', async () => {
+    await seedEmails();
+    expect(await col.getByAccount('acct-A')).toHaveLength(2);
+    expect(await col.getByFolder('folder-inbox')).toHaveLength(2);
+    expect(await col.getByThread('thr-1')).toHaveLength(2);
+  });
+
+  it('getUnread() / getFlagged() / getWithAttachments() filter by flag', async () => {
+    await seedEmails();
+    expect(await col.getUnread()).toHaveLength(2);
+    expect(await col.getUnread('acct-A')).toHaveLength(1);
+    expect(await col.getFlagged()).toHaveLength(1);
+    expect(await col.getWithAttachments()).toHaveLength(1);
+    expect(await col.getWithAttachments('acct-B')).toHaveLength(0);
+  });
+
+  it('getRecent() returns newest-first', async () => {
+    await seedEmails();
+    const recent = await col.getRecent(2);
+    expect(recent[0].subject).toBe('Re: Meeting'); // 2025-02-10
+    expect(recent).toHaveLength(2);
+  });
+
+  it('counts by folder and account', async () => {
+    await seedEmails();
+    expect(await col.countByFolder('folder-inbox')).toBe(2);
+    expect(await col.countUnreadByFolder('folder-inbox')).toBe(1);
+    expect(await col.countUnreadByAccount('acct-A')).toBe(1);
+  });
+
+  it('searchEmails() applies query plus the full filter surface', async () => {
+    await seedEmails();
+    expect(await col.searchEmails('invoice')).toHaveLength(1);
+    expect(await col.searchEmails('vendor billing')).toHaveLength(1); // fromName
+
+    const filtered = await col.searchEmails('', {
+      accountId: 'acct-A',
+      isRead: false,
+      isFlagged: true,
+      hasAttachments: true,
+      folderId: 'folder-inbox',
+      threadId: 'thr-1',
+      from: 'billing@vendor.com',
+      to: 'me@corp.com',
+      subject: 'invoice',
+    });
+    expect(filtered).toHaveLength(1);
+
+    const dated = await col.searchEmails('', {
+      sincDate: new Date('2025-02-05'),
+      beforeDate: new Date('2025-03-01'),
+    });
+    expect(dated).toHaveLength(1);
+    expect(dated[0].subject).toBe('Re: Meeting');
+  });
+
+  it('search() aliases searchEmails()', async () => {
+    await seedEmails();
+    expect(await col.search('archived')).toHaveLength(1);
+  });
+
+  it('markFolderRead() marks all unread emails in a folder read', async () => {
+    await seedEmails();
+    await col.markFolderRead('folder-inbox');
+    expect(await col.countUnreadByFolder('folder-inbox')).toBe(0);
+    // The archive folder is untouched.
+    expect(await col.getByFolder('folder-archive')).toHaveLength(1);
+  });
+
+  it('deleteByFolder() removes and counts emails in a folder', async () => {
+    await seedEmails();
+    const deleted = await col.deleteByFolder('folder-inbox');
+    expect(deleted).toBe(2);
+    expect(await col.getByFolder('folder-inbox')).toHaveLength(0);
+    expect(await col.getByFolder('folder-archive')).toHaveLength(1);
+  });
+
+  it('getAccountStats() summarizes the account', async () => {
+    await seedEmails();
+    const stats = await col.getAccountStats('acct-A');
+    expect(stats.total).toBe(2);
+    expect(stats.unread).toBe(1);
+    expect(stats.flagged).toBe(1);
+    expect(stats.withAttachments).toBe(1);
+    expect(stats.byType.Email).toBe(2);
+  });
+
+  it('tenant helpers filter by tenant and globals', async () => {
+    await persist(
+      new Email({
+        db,
+        accountId: 'acct-T',
+        messageId: '<t@x>',
+        tenantId: 't1',
+      }),
+    );
+    await persist(new Email({ db, accountId: 'acct-G', messageId: '<g@x>' }));
+    expect(await col.findByTenant('t1')).toHaveLength(1);
+    expect(await col.findGlobal()).toHaveLength(1);
+    expect(await col.findWithGlobals('t1')).toHaveLength(2);
+  });
+});
+
+// ===========================================================================
+// AccountCollection
+// ===========================================================================
+
+describe('AccountCollection', () => {
+  let db: DatabaseInterface;
+  let col: AccountCollection;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    col = await AccountCollection.create({ db });
+  });
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') await db.close();
+  });
+
+  async function seedAccounts() {
+    await persist(
+      new Account({
+        db,
+        name: 'Acme IMAP',
+        providerType: 'imap',
+        isActive: true,
+      }),
+    );
+    await persist(
+      new Account({
+        db,
+        name: 'Beta SMTP',
+        providerType: 'smtp',
+        isActive: false,
+      }),
+    );
+    // An EmailAccount STI row to exercise getByType discriminator filtering.
+    await persist(
+      new EmailAccount({
+        db,
+        name: 'Gamma Gmail',
+        email: 'gamma@gmail.com',
+        providerType: 'gmail',
+        isActive: true,
+      }),
+    );
+  }
+
+  it('getActive() / getInactive() filter on isActive', async () => {
+    await seedAccounts();
+    expect(await col.getActive()).toHaveLength(2);
+    expect(await col.getInactive()).toHaveLength(1);
+  });
+
+  it('getByProviderType() filters on providerType', async () => {
+    await seedAccounts();
+    expect(await col.getByProviderType('imap')).toHaveLength(1);
+    expect(await col.getByProviderType('gmail')).toHaveLength(1);
+    expect(await col.getByProviderType('pop3')).toHaveLength(0);
+  });
+
+  it('getByType() resolves short names and full discriminators', async () => {
+    await seedAccounts();
+    expect(await col.getByType('EmailAccount')).toHaveLength(1);
+    expect(
+      await col.getByType('@happyvertical/smrt-messages:Account'),
+    ).toHaveLength(2);
+    expect(await col.getByType('Account')).toHaveLength(2);
+  });
+
+  it('search() filters by query, providerType, isActive, accountType', async () => {
+    await seedAccounts();
+    expect(await col.search('acme')).toHaveLength(1);
+    expect(await col.search('', { providerType: 'smtp' })).toHaveLength(1);
+    expect(await col.search('', { isActive: true })).toHaveLength(2);
+    expect(await col.search('', { accountType: 'EmailAccount' })).toHaveLength(
+      1,
+    );
+  });
+
+  it('getStats() tallies totals/active/inactive and byType', async () => {
+    await seedAccounts();
+    const stats = await col.getStats();
+    expect(stats.total).toBe(3);
+    expect(stats.active).toBe(2);
+    expect(stats.inactive).toBe(1);
+    expect(stats.byType.Account).toBe(2);
+    expect(stats.byType.EmailAccount).toBe(1);
+  });
+
+  it('tenant helpers filter by tenant and globals', async () => {
+    await persist(
+      new Account({
+        db,
+        name: 'Tenant Acct',
+        providerType: 'imap',
+        tenantId: 't1',
+      }),
+    );
+    await persist(
+      new Account({ db, name: 'Global Acct', providerType: 'imap' }),
+    );
+    expect(await col.findByTenant('t1')).toHaveLength(1);
+    expect(await col.findGlobal()).toHaveLength(1);
+    expect(await col.findWithGlobals('t1')).toHaveLength(2);
+  });
+});
+
+// ===========================================================================
+// EmailAccountCollection (extends AccountCollection)
+// ===========================================================================
+
+describe('EmailAccountCollection', () => {
+  let db: DatabaseInterface;
+  let col: EmailAccountCollection;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    col = await EmailAccountCollection.create({ db });
+  });
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') await db.close();
+  });
+
+  async function seedEmailAccounts() {
+    await persist(
+      new EmailAccount({
+        db,
+        name: 'Work IMAP',
+        email: 'work@corp.com',
+        providerType: 'imap',
+        isActive: true,
+        lastSyncAt: new Date('2020-01-01'), // very stale => needs sync
+      }),
+    );
+    await persist(
+      new EmailAccount({
+        db,
+        name: 'Personal Gmail',
+        email: 'me@gmail.com',
+        providerType: 'gmail',
+        isActive: true,
+        lastSyncAt: new Date(), // just synced => does not need sync
+      }),
+    );
+    await persist(
+      new EmailAccount({
+        db,
+        name: 'Old SMTP',
+        email: 'old@smtp.com',
+        providerType: 'smtp',
+        isActive: false,
+      }),
+    );
+  }
+
+  it('getByEmail() finds an account by address', async () => {
+    await seedEmailAccounts();
+    const found = await col.getByEmail('work@corp.com');
+    expect(found?.name).toBe('Work IMAP');
+    expect(await col.getByEmail('nobody@nowhere.com')).toBeNull();
+  });
+
+  it('getByEmailProviderType() / getByProviderType() alias filter on type', async () => {
+    await seedEmailAccounts();
+    expect(await col.getByEmailProviderType('imap')).toHaveLength(1);
+    expect(await col.getByProviderType('gmail')).toHaveLength(1);
+  });
+
+  it('getActive() / getInactive() return only email accounts in that state', async () => {
+    await seedEmailAccounts();
+    expect(await col.getActive()).toHaveLength(2);
+    expect(await col.getInactive()).toHaveLength(1);
+  });
+
+  it('getNeedingSync() returns active accounts past the cutoff', async () => {
+    await seedEmailAccounts();
+    const needing = await col.getNeedingSync(60);
+    // Work IMAP is stale, Personal Gmail just synced, Old SMTP is inactive.
+    expect(needing).toHaveLength(1);
+    expect(needing[0].email).toBe('work@corp.com');
+  });
+
+  it('searchEmailAccounts() / search() alias filter by query and fields', async () => {
+    await seedEmailAccounts();
+    expect(await col.search('work')).toHaveLength(1); // name match
+    expect(await col.search('gmail')).toHaveLength(1); // email match
+    expect(
+      await col.searchEmailAccounts('', { providerType: 'imap' }),
+    ).toHaveLength(1);
+    expect(
+      await col.searchEmailAccounts('', { email: 'corp.com' }),
+    ).toHaveLength(1);
+    expect(await col.searchEmailAccounts('', { isActive: false })).toHaveLength(
+      1,
+    );
+  });
+
+  it('getStats() / getEmailStats() tally totals and per-provider counts', async () => {
+    await seedEmailAccounts();
+    const emailStats = await col.getEmailStats();
+    expect(emailStats.total).toBe(3);
+    expect(emailStats.active).toBe(2);
+    expect(emailStats.inactive).toBe(1);
+    expect(emailStats.byProvider.imap).toBe(1);
+    expect(emailStats.byProvider.gmail).toBe(1);
+    expect(emailStats.byProvider.smtp).toBe(1);
+    expect(emailStats.byProvider.pop3).toBe(0);
+
+    const stats = await col.getStats();
+    expect(stats.total).toBe(3);
+    expect(stats.active).toBe(2);
+    expect(stats.byType).toEqual(emailStats.byProvider as any);
+  });
+
+  it('getTotalUnreadCount() sums unread emails across active accounts', async () => {
+    const account = await persist(
+      new EmailAccount({
+        db,
+        name: 'Counter IMAP',
+        email: 'counter@corp.com',
+        providerType: 'imap',
+        isActive: true,
+      }),
+    );
+    // Two unread + one read email for this account.
+    await persist(
+      new Email({
+        db,
+        accountId: account.id,
+        messageId: '<c1@x>',
+        isRead: false,
+      }),
+    );
+    await persist(
+      new Email({
+        db,
+        accountId: account.id,
+        messageId: '<c2@x>',
+        isRead: false,
+      }),
+    );
+    await persist(
+      new Email({
+        db,
+        accountId: account.id,
+        messageId: '<c3@x>',
+        isRead: true,
+      }),
+    );
+
+    expect(await col.getTotalUnreadCount()).toBe(2);
+  });
+
+  it('syncAll() reports a per-account result map', async () => {
+    // Each account's syncFrom() will fail internally (no real IMAP), but
+    // EmailAccount.syncFrom swallows its own errors and returns a result, so
+    // syncAll records success per active account. We assert the shape/scope.
+    await seedEmailAccounts();
+    const results = await col.syncAll();
+    // Only the two active accounts are synced.
+    expect(results.size).toBe(2);
+    for (const outcome of results.values()) {
+      expect(typeof outcome.success).toBe('boolean');
+    }
+  });
+
+  it('tenant helpers filter by tenant and globals', async () => {
+    await persist(
+      new EmailAccount({
+        db,
+        name: 'Tenant Email',
+        email: 'tenant@corp.com',
+        providerType: 'imap',
+        tenantId: 't1',
+      }),
+    );
+    await persist(
+      new EmailAccount({
+        db,
+        name: 'Global Email',
+        email: 'global@corp.com',
+        providerType: 'imap',
+      }),
+    );
+    expect(await col.findByTenant('t1')).toHaveLength(1);
+    expect(await col.findGlobal()).toHaveLength(1);
+    expect(await col.findWithGlobals('t1')).toHaveLength(2);
+  });
+});
+
+// ===========================================================================
+// AttachmentCollection
+// ===========================================================================
+
+describe('AttachmentCollection', () => {
+  let db: DatabaseInterface;
+  let col: AttachmentCollection;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    col = await AttachmentCollection.create({ db });
+  });
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') await db.close();
+  });
+
+  async function seedAttachments() {
+    await persist(
+      new Attachment({
+        db,
+        messageId: 'msg-1',
+        filename: 'report.pdf',
+        contentType: 'application/pdf',
+        size: 2048,
+        contentDisposition: 'attachment',
+        filePath: '/tmp/report.pdf',
+      }),
+    );
+    await persist(
+      new Attachment({
+        db,
+        messageId: 'msg-1',
+        filename: 'logo.png',
+        contentType: 'image/png',
+        size: 512,
+        contentDisposition: 'inline',
+        contentId: 'logo123',
+      }),
+    );
+    await persist(
+      new Attachment({
+        db,
+        messageId: 'msg-2',
+        filename: 'archive.zip',
+        contentType: 'application/zip',
+        size: 4096,
+        contentDisposition: 'attachment',
+      }),
+    );
+  }
+
+  it('getByMessage() / getByContentType() scope correctly', async () => {
+    await seedAttachments();
+    expect(await col.getByMessage('msg-1')).toHaveLength(2);
+    expect(await col.getByMessage('msg-2')).toHaveLength(1);
+    expect(await col.getByContentType('image/png')).toHaveLength(1);
+  });
+
+  it('type predicates filter images, pdfs, inline, and regular', async () => {
+    await seedAttachments();
+    expect(await col.getImages()).toHaveLength(1);
+    expect(await col.getImages('msg-1')).toHaveLength(1);
+    expect(await col.getImages('msg-2')).toHaveLength(0);
+    expect(await col.getPdfs()).toHaveLength(1);
+    expect(await col.getPdfs('msg-1')).toHaveLength(1);
+    expect(await col.getInline('msg-1')).toHaveLength(1);
+    expect(await col.getRegular('msg-1')).toHaveLength(1);
+  });
+
+  it('getWithExternalFiles() returns attachments with a filePath', async () => {
+    await seedAttachments();
+    const external = await col.getWithExternalFiles();
+    expect(external).toHaveLength(1);
+    expect(external[0].filename).toBe('report.pdf');
+  });
+
+  it('getTotalSize() sums sizes for a message', async () => {
+    await seedAttachments();
+    expect(await col.getTotalSize('msg-1')).toBe(2560); // 2048 + 512
+    expect(await col.getTotalSize('msg-2')).toBe(4096);
+  });
+
+  it('getLargest() returns attachments sorted by size desc', async () => {
+    await seedAttachments();
+    const largest = await col.getLargest(2);
+    expect(largest).toHaveLength(2);
+    expect(largest[0].size).toBe(4096);
+    expect(largest[1].size).toBe(2048);
+  });
+
+  it('searchByFilename() / getByExtension() match filename patterns', async () => {
+    await seedAttachments();
+    expect(await col.searchByFilename('report')).toHaveLength(1);
+    expect(await col.searchByFilename('.png')).toHaveLength(1);
+    expect(await col.getByExtension('pdf')).toHaveLength(1);
+    expect(await col.getByExtension('.png')).toHaveLength(1); // leading dot stripped
+    expect(await col.getByExtension('docx')).toHaveLength(0);
+  });
+
+  it('getStats() summarizes count, size, byType, inline/regular', async () => {
+    await seedAttachments();
+    const stats = await col.getStats();
+    expect(stats.total).toBe(3);
+    expect(stats.totalSize).toBe(6656); // 2048 + 512 + 4096
+    expect(stats.inline).toBe(1);
+    expect(stats.regular).toBe(2);
+    expect(stats.byType.application).toBe(2); // pdf + zip
+    expect(stats.byType.image).toBe(1);
+  });
+
+  it('deleteByMessage() removes and counts a message’s attachments', async () => {
+    await seedAttachments();
+    const deleted = await col.deleteByMessage('msg-1');
+    expect(deleted).toBe(2);
+    expect(await col.getByMessage('msg-1')).toHaveLength(0);
+    expect(await col.getByMessage('msg-2')).toHaveLength(1);
+  });
+
+  it('tenant helpers filter by tenant and globals', async () => {
+    await persist(
+      new Attachment({
+        db,
+        messageId: 'msg-T',
+        filename: 't.txt',
+        tenantId: 't1',
+      }),
+    );
+    await persist(
+      new Attachment({ db, messageId: 'msg-G', filename: 'g.txt' }),
+    );
+    expect(await col.findByTenant('t1')).toHaveLength(1);
+    expect(await col.findGlobal()).toHaveLength(1);
+    expect(await col.findWithGlobals('t1')).toHaveLength(2);
+  });
+});

--- a/packages/messages/src/__tests__/email-account.test.ts
+++ b/packages/messages/src/__tests__/email-account.test.ts
@@ -381,6 +381,30 @@ describe('EmailAccount DB-backed operations', () => {
         true,
       );
     });
+
+    it('gives each synced email its own id when the account carries id/slug (hydrated)', async () => {
+      // A DB-hydrated account has its row id/slug in `this.options`; child rows
+      // must NOT inherit them (else every email upserts under the account's PK).
+      const account = await makeAccount(db);
+      (account as any).options.id = account.id;
+      (account as any).options.slug = 'account-slug';
+      await makeFolder(db, account.id!);
+      const { client } = makeMockClient({
+        messages: [
+          makeServerMessage({ messageId: '<a@example.com>' }),
+          makeServerMessage({ messageId: '<b@example.com>' }),
+        ],
+      });
+      vi.spyOn(account, 'createClient').mockResolvedValue(client as any);
+
+      const result = await account.syncFrom();
+
+      expect(result.messagesDownloaded).toBe(2);
+      const emails = await account.getEmails();
+      const ids = new Set(emails.map((e: any) => e.id));
+      expect(ids.size).toBe(2); // two distinct rows, not collided under one PK
+      expect(ids.has(account.id)).toBe(false); // none reuse the account's id
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/messages/src/__tests__/email-account.test.ts
+++ b/packages/messages/src/__tests__/email-account.test.ts
@@ -1,0 +1,588 @@
+/**
+ * Unit/integration tests for the EmailAccount model.
+ *
+ * Boundary strategy
+ * -----------------
+ * The ONLY external boundary is `createClient()`, which dynamically imports
+ * `@happyvertical/email` (an IMAP/email client) and `@happyvertical/smrt-secrets`
+ * (SecretService for credentials). We mock that single boundary with
+ * `vi.spyOn(account, 'createClient').mockResolvedValue(mockClient)` so the
+ * model's own sync/fetch/read LOGIC runs against a controllable fake client.
+ * Everything else — the DB-backed reads/writes performed by the collections —
+ * runs against a real in-memory SQLite database. We never mock the model under
+ * test or its DB.
+ *
+ * Schema note
+ * -----------
+ * `getTestDatabase()` builds its schema from the classes registered in
+ * `ObjectRegistry`. When this file runs in isolation only the classes it
+ * imports get registered, so we import every model the EmailAccount code path
+ * touches (Account / Message / Email / EmailFolder) to guarantee the
+ * `accounts`, `messages`, and `email_folders` tables exist.
+ *
+ * Write-path note
+ * ---------------
+ * This file surfaced (and this PR fixes) a real bug: `EmailAccount.syncFrom()`
+ * created child rows with `new EmailFolder(...)` / `new Email(...)` and called
+ * `.save()` WITHOUT first calling `.initialize()`, so the inline saves threw
+ * "Database accessed before initialization" (caught into `result.errors`) and
+ * sync silently persisted nothing. The model now initializes those instances
+ * before save, so the tests below assert the working persist path
+ * (messagesDownloaded increments, rows are retrievable).
+ */
+
+import { getTestDatabase } from '@happyvertical/smrt-core';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+// Importing these registers their schemas so getTestDatabase() creates the tables.
+import '../models/Account';
+import '../models/Message';
+import { Email } from '../models/Email';
+import { EmailAccount } from '../models/EmailAccount';
+import { EmailFolder } from '../models/EmailFolder';
+import { EmailSender } from '../senders/EmailSender';
+
+// ---------------------------------------------------------------------------
+// Mock email-client factory (mirrors the EmailClient surface EmailAccount uses)
+// ---------------------------------------------------------------------------
+
+interface FakeClientOptions {
+  /** Messages returned by `fetch()`. */
+  messages?: any[];
+  /** Throw from `connect()` to exercise the top-level error path. */
+  connectError?: Error;
+  /** Throw from `fetch()` to exercise the per-folder error path. */
+  fetchError?: Error;
+}
+
+function makeMockClient(opts: FakeClientOptions = {}) {
+  const calls = {
+    connect: 0,
+    disconnect: 0,
+    fetch: [] as any[],
+  };
+  const client = {
+    isConnected: () => true,
+    async connect() {
+      calls.connect++;
+      if (opts.connectError) throw opts.connectError;
+    },
+    async disconnect() {
+      calls.disconnect++;
+    },
+    async fetch(fetchOptions: Record<string, any>) {
+      calls.fetch.push(fetchOptions);
+      if (opts.fetchError) throw opts.fetchError;
+      return opts.messages ?? [];
+    },
+    async send() {
+      return {
+        messageId: 'sent-1',
+        accepted: ['x@y.com'],
+        rejected: [],
+        response: 'ok',
+      };
+    },
+  };
+  return { client, calls };
+}
+
+/** Build a server-side message shape consumed by `syncFrom`. */
+function makeServerMessage(overrides: Record<string, any> = {}) {
+  return {
+    messageId: `<msg-${Math.random().toString(36).slice(2)}@example.com>`,
+    threadId: 'thread-1',
+    from: { address: 'alice@example.com', name: 'Alice' },
+    to: [{ address: 'me@example.com', name: 'Me' }],
+    subject: 'Hello',
+    date: new Date('2025-01-15T10:00:00Z'),
+    text: 'Plain text body',
+    html: '<p>HTML body</p>',
+    ...overrides,
+  };
+}
+
+/** Initialize then save a model — the supported persistence path. */
+async function persist<
+  T extends { initialize(): Promise<any>; save(): Promise<any> },
+>(model: T): Promise<T> {
+  await model.initialize();
+  await model.save();
+  return model;
+}
+
+let accountCounter = 0;
+
+async function makeAccount(
+  db: DatabaseInterface,
+  overrides: Record<string, any> = {},
+): Promise<EmailAccount> {
+  // Distinct name per account: the auto-generated slug derives from `name`, and
+  // identical slugs upsert over each other (natural-key dedup), silently
+  // collapsing multiple accounts into one row.
+  const n = ++accountCounter;
+  return persist(
+    new EmailAccount({
+      name: `Test Account ${n}`,
+      email: `account${n}@example.com`,
+      providerType: 'imap',
+      db,
+      ...overrides,
+    }),
+  );
+}
+
+let folderCounter = 0;
+
+async function makeFolder(
+  db: DatabaseInterface,
+  accountId: string,
+  path = 'INBOX',
+): Promise<EmailFolder> {
+  // The folder slug derives from `name`; identical slugs upsert over each other
+  // (natural-key dedup), so give every folder a globally-unique name while
+  // keeping `path` semantically meaningful (syncFrom looks folders up by path).
+  const n = ++folderCounter;
+  return persist(
+    new EmailFolder({ db, accountId, name: `${path} ${n}`, path }),
+  );
+}
+
+// ===========================================================================
+// Pure logic — no DB, no mocks
+// ===========================================================================
+
+describe('EmailAccount constructor & field defaults', () => {
+  it('applies email-specific defaults', () => {
+    const account = new EmailAccount();
+    expect(account.email).toBe('');
+    expect(account.syncIntervalMinutes).toBe(60);
+  });
+
+  it('applies constructor options', () => {
+    const account = new EmailAccount({
+      email: 'user@gmail.com',
+      providerType: 'gmail',
+      syncIntervalMinutes: 15,
+    });
+    expect(account.email).toBe('user@gmail.com');
+    expect(account.providerType).toBe('gmail');
+    expect(account.syncIntervalMinutes).toBe(15);
+  });
+
+  it('inherits base Account fields', () => {
+    const account = new EmailAccount({
+      name: 'Inbox',
+      isActive: false,
+      credentialSecretId: 'secret-123',
+    });
+    expect(account.name).toBe('Inbox');
+    expect(account.isActive).toBe(false);
+    expect(account.credentialSecretId).toBe('secret-123');
+  });
+
+  it('leaves providerType empty when not supplied', () => {
+    const account = new EmailAccount({ email: 'a@b.com' });
+    expect(account.providerType).toBe('');
+  });
+});
+
+// ===========================================================================
+// createSender() — uses the createClient() boundary, returns an EmailSender
+// ===========================================================================
+
+describe('EmailAccount.createSender', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('connects the client and returns an EmailSender', async () => {
+    const account = new EmailAccount({ email: 'me@example.com' });
+    const { client, calls } = makeMockClient();
+    vi.spyOn(account, 'createClient').mockResolvedValue(client as any);
+
+    const sender = await account.createSender();
+
+    expect(sender).toBeInstanceOf(EmailSender);
+    expect(sender.providerType).toBe('email');
+    expect(calls.connect).toBe(1);
+    expect(sender.isReady()).toBe(true);
+  });
+});
+
+// ===========================================================================
+// DB-backed methods (real in-memory SQLite, createClient mocked where needed)
+// ===========================================================================
+
+describe('EmailAccount DB-backed operations', () => {
+  let db: DatabaseInterface;
+
+  beforeEach(async () => {
+    db = await getTestDatabase();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (db && typeof db.close === 'function') {
+      await db.close();
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // syncFrom — orchestration, fetch options, lifecycle, error handling
+  // -------------------------------------------------------------------------
+
+  describe('syncFrom', () => {
+    it('connects, fetches the default INBOX, and completes cleanly when there are no new messages', async () => {
+      const account = await makeAccount(db);
+      // Pre-create the INBOX folder so getByPath() returns it (supported path).
+      await makeFolder(db, account.id!);
+
+      const { client, calls } = makeMockClient({ messages: [] });
+      vi.spyOn(account, 'createClient').mockResolvedValue(client as any);
+
+      const result = await account.syncFrom();
+
+      expect(result.folders).toEqual(['INBOX']);
+      expect(result.messagesProcessed).toBe(0);
+      expect(result.messagesDownloaded).toBe(0);
+      expect(result.errors).toEqual([]);
+      expect(result.duration).toBeGreaterThanOrEqual(0);
+
+      // Full client lifecycle exercised.
+      expect(calls.connect).toBe(1);
+      expect(calls.disconnect).toBe(1);
+      expect(calls.fetch[0]).toMatchObject({ folder: 'INBOX', limit: 100 });
+
+      // Sync state advanced.
+      expect(account.lastSyncAt).toBeInstanceOf(Date);
+    });
+
+    it('passes custom folders, batchSize, since and before into the client fetch', async () => {
+      const account = await makeAccount(db);
+      await makeFolder(db, account.id!, 'INBOX');
+      await makeFolder(db, account.id!, 'Sent');
+
+      const { client, calls } = makeMockClient({ messages: [] });
+      vi.spyOn(account, 'createClient').mockResolvedValue(client as any);
+
+      const since = new Date('2025-01-01');
+      const before = new Date('2025-02-01');
+      const result = await account.syncFrom({
+        folders: ['INBOX', 'Sent'],
+        batchSize: 25,
+        since,
+        before,
+      });
+
+      expect(result.folders).toEqual(['INBOX', 'Sent']);
+      expect(calls.fetch).toHaveLength(2);
+      expect(calls.fetch[0]).toMatchObject({
+        folder: 'INBOX',
+        limit: 25,
+        since,
+        before,
+      });
+      expect(calls.fetch[1]).toMatchObject({ folder: 'Sent', limit: 25 });
+      expect(result.errors).toEqual([]);
+    });
+
+    it('reuses an existing folder row instead of creating a duplicate', async () => {
+      const account = await makeAccount(db);
+      const existing = await makeFolder(db, account.id!);
+
+      const { client } = makeMockClient({ messages: [] });
+      vi.spyOn(account, 'createClient').mockResolvedValue(client as any);
+      await account.syncFrom();
+
+      const { EmailFolderCollection } = await import(
+        '../collections/EmailFolderCollection'
+      );
+      const folderCollection = await (EmailFolderCollection as any).create({
+        db,
+      });
+      const inboxFolders = (
+        await folderCollection.getByAccount(account.id)
+      ).filter((f: any) => f.path === 'INBOX');
+      expect(inboxFolders).toHaveLength(1);
+      expect(inboxFolders[0].id).toBe(existing.id);
+    });
+
+    it('records a top-level error and calls onError when connect throws', async () => {
+      const account = await makeAccount(db);
+      const connectError = new Error('IMAP down');
+      const { client, calls } = makeMockClient({ connectError });
+      vi.spyOn(account, 'createClient').mockResolvedValue(client as any);
+
+      const errors: Error[] = [];
+      const result = await account.syncFrom({ onError: (e) => errors.push(e) });
+
+      expect(result.messagesDownloaded).toBe(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toBe('IMAP down');
+      expect(errors[0]).toBe(connectError);
+      // Never got far enough to fetch.
+      expect(calls.fetch).toHaveLength(0);
+    });
+
+    it('records a per-folder error and calls onError when fetch throws', async () => {
+      const account = await makeAccount(db);
+      await makeFolder(db, account.id!);
+      const fetchError = new Error('fetch failed');
+      const { client, calls } = makeMockClient({ fetchError });
+      vi.spyOn(account, 'createClient').mockResolvedValue(client as any);
+
+      const errors: Error[] = [];
+      const result = await account.syncFrom({
+        folders: ['INBOX'],
+        onError: (e) => errors.push(e),
+      });
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toBe('fetch failed');
+      expect(errors[0].message).toBe('fetch failed');
+      // Sync still completed: client disconnected and account saved.
+      expect(calls.disconnect).toBe(1);
+      expect(account.lastSyncAt).toBeInstanceOf(Date);
+    });
+
+    it('coerces non-Error throwables from the client into Error instances', async () => {
+      const account = await makeAccount(db);
+      const { client } = makeMockClient();
+      // connect rejects with a plain string.
+      client.connect = async () => {
+        throw 'string failure';
+      };
+      vi.spyOn(account, 'createClient').mockResolvedValue(client as any);
+
+      const result = await account.syncFrom();
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toBeInstanceOf(Error);
+      expect(result.errors[0].message).toBe('string failure');
+    });
+
+    it('processes and downloads each fetched message, persisting it', async () => {
+      // The per-message Email row is now initialized before save() (the init
+      // bug is fixed), so a fetched message is processed AND downloaded.
+      const account = await makeAccount(db);
+      await makeFolder(db, account.id!);
+      const serverMsg = makeServerMessage({ messageId: '<x@example.com>' });
+      const { client } = makeMockClient({ messages: [serverMsg] });
+      vi.spyOn(account, 'createClient').mockResolvedValue(client as any);
+
+      const onError = vi.fn();
+      const result = await account.syncFrom({ onError });
+
+      expect(result.messagesProcessed).toBe(1);
+      expect(result.messagesDownloaded).toBe(1);
+      expect(result.errors).toHaveLength(0);
+      expect(onError).not.toHaveBeenCalled();
+      // The email was persisted and is retrievable for the account.
+      const emails = await account.getEmails();
+      expect(emails.some((e: any) => e.messageId === '<x@example.com>')).toBe(
+        true,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getFolders — DB-backed read via EmailFolderCollection
+  // -------------------------------------------------------------------------
+
+  describe('getFolders', () => {
+    it('returns only folders for this account', async () => {
+      const account = await makeAccount(db);
+      const other = await makeAccount(db, { email: 'other@example.com' });
+
+      await makeFolder(db, account.id!, 'INBOX');
+      await makeFolder(db, account.id!, 'Sent');
+      await makeFolder(db, other.id!, 'INBOX');
+
+      const folders = await account.getFolders();
+      expect(folders).toHaveLength(2);
+      expect(folders.every((f: any) => f.accountId === account.id)).toBe(true);
+    });
+
+    it('returns an empty list when there are no folders', async () => {
+      const account = await makeAccount(db);
+      expect(await account.getFolders()).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getEmails — DB-backed read with optional limit
+  // -------------------------------------------------------------------------
+
+  describe('getEmails', () => {
+    it('returns emails for this account and honours the limit', async () => {
+      const account = await makeAccount(db);
+      await persist(
+        new Email({ db, accountId: account.id, messageId: '<e1@x>' }),
+      );
+      await persist(
+        new Email({ db, accountId: account.id, messageId: '<e2@x>' }),
+      );
+      await persist(
+        new Email({ db, accountId: account.id, messageId: '<e3@x>' }),
+      );
+
+      expect(await account.getEmails()).toHaveLength(3);
+      expect(await account.getEmails(2)).toHaveLength(2);
+    });
+
+    it('returns only this account’s emails', async () => {
+      const account = await makeAccount(db);
+      const other = await makeAccount(db, { email: 'other@example.com' });
+      await persist(
+        new Email({ db, accountId: account.id, messageId: '<mine@x>' }),
+      );
+      await persist(
+        new Email({ db, accountId: other.id, messageId: '<theirs@x>' }),
+      );
+
+      const emails = await account.getEmails();
+      expect(emails).toHaveLength(1);
+      expect(emails[0].accountId).toBe(account.id);
+    });
+
+    it('returns an empty list when there are no emails', async () => {
+      const account = await makeAccount(db);
+      expect(await account.getEmails()).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getUnreadCount — DB-backed count
+  // -------------------------------------------------------------------------
+
+  describe('getUnreadCount', () => {
+    it('counts only unread emails for the account', async () => {
+      const account = await makeAccount(db);
+      await persist(
+        new Email({
+          db,
+          accountId: account.id,
+          messageId: '<u1@x>',
+          isRead: false,
+        }),
+      );
+      await persist(
+        new Email({
+          db,
+          accountId: account.id,
+          messageId: '<u2@x>',
+          isRead: false,
+        }),
+      );
+      await persist(
+        new Email({
+          db,
+          accountId: account.id,
+          messageId: '<r1@x>',
+          isRead: true,
+        }),
+      );
+
+      expect(await account.getUnreadCount()).toBe(2);
+    });
+
+    it('returns 0 when there are no emails', async () => {
+      const account = await makeAccount(db);
+      expect(await account.getUnreadCount()).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // syncAll — class-wide operation routed through the collection
+  // -------------------------------------------------------------------------
+
+  describe('syncAll', () => {
+    it('syncs all active accounts and reports a per-account result, ignoring inactive ones', async () => {
+      await makeAccount(db, { email: 'a1@example.com' });
+      await makeAccount(db, { email: 'a2@example.com' });
+      // An inactive account that must be excluded from the run.
+      await makeAccount(db, {
+        email: 'inactive@example.com',
+        isActive: false,
+      });
+
+      // syncAll re-loads accounts from the collection, so we can't spy on the
+      // freshly-loaded instances individually. Spy on the prototype so every
+      // loaded instance gets a mock client. (syncFrom swallows its own per-row
+      // errors, so each account reports success.)
+      const protoSpy = vi
+        .spyOn(EmailAccount.prototype, 'createClient')
+        .mockImplementation(
+          async () => makeMockClient({ messages: [] }).client as any,
+        );
+
+      const anchor = await makeAccount(db, { email: 'anchor@example.com' });
+      const results = await anchor.syncAll();
+
+      // Three active accounts (a1, a2, anchor); inactive excluded.
+      expect(results.size).toBe(3);
+      for (const outcome of results.values()) {
+        expect(outcome).toEqual({ success: true });
+      }
+
+      protoSpy.mockRestore();
+    });
+  });
+});
+
+// ===========================================================================
+// migrateToSecrets — branch coverage without entangling SecretService
+// ===========================================================================
+
+describe('EmailAccount.migrateToSecrets', () => {
+  let db: DatabaseInterface;
+
+  beforeEach(async () => {
+    db = await getTestDatabase();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (db && typeof db.close === 'function') {
+      await db.close();
+    }
+  });
+
+  it('does nothing when credentialSecretId is already set', async () => {
+    const account = await makeAccount(db, {
+      credentialSecretId: 'existing-secret',
+      settings: JSON.stringify({ host: 'imap.example.com' }),
+    });
+    const setCredsSpy = vi.spyOn(account, 'setCredentials');
+
+    await account.migrateToSecrets();
+
+    expect(setCredsSpy).not.toHaveBeenCalled();
+    expect(account.credentialSecretId).toBe('existing-secret');
+  });
+
+  it('does nothing when there are no settings to migrate', async () => {
+    const account = await makeAccount(db); // settings = ''
+    const setCredsSpy = vi.spyOn(account, 'setCredentials');
+
+    await account.migrateToSecrets();
+
+    expect(setCredsSpy).not.toHaveBeenCalled();
+    expect(account.credentialSecretId).toBeNull();
+  });
+
+  it('delegates to setCredentials when plain-text settings exist', async () => {
+    const account = await makeAccount(db, {
+      settings: JSON.stringify({ host: 'imap.example.com', port: 993 }),
+    });
+    // Stub the SecretService boundary by faking setCredentials itself.
+    const setCredsSpy = vi
+      .spyOn(account, 'setCredentials')
+      .mockResolvedValue(undefined);
+
+    await account.migrateToSecrets();
+
+    expect(setCredsSpy).toHaveBeenCalledTimes(1);
+    const [creds, opts] = setCredsSpy.mock.calls[0];
+    expect(creds).toEqual({ host: 'imap.example.com', port: 993 });
+    expect(opts?.description).toContain('Migrated IMAP credentials');
+  });
+});

--- a/packages/messages/src/__tests__/senders-extended.test.ts
+++ b/packages/messages/src/__tests__/senders-extended.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Extended sender tests — exercises the send() paths of EmailSender,
+ * SlackSender, and TweetSender.
+ *
+ * Mocking policy: only the EXTERNAL transport is mocked.
+ *  - EmailSender takes an injected EmailClient — we pass a fake client.
+ *  - SlackSender / TweetSender dynamically import getMessageClient() from the
+ *    SDK package '@happyvertical/messages'; that single external boundary is
+ *    mocked with vi.mock. Accounts/messages are real model instances.
+ *
+ * Account credentials are provided via `settings` (no secret store): Account
+ * .getCredentials() falls back to getSettings() when credentialSecretId is null.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mock the SDK transport used by SlackSender / TweetSender ────────────────
+const sendMock = vi.fn();
+const connectMock = vi.fn(async () => undefined);
+const disconnectMock = vi.fn(async () => undefined);
+const getMessageClientMock = vi.fn(async () => ({
+  connect: connectMock,
+  disconnect: disconnectMock,
+  send: sendMock,
+}));
+
+vi.mock('@happyvertical/messages', () => ({
+  getMessageClient: (...args: any[]) => getMessageClientMock(...args),
+}));
+
+import { Email } from '../models/Email';
+import { EmailAccount } from '../models/EmailAccount';
+import { SlackAccount } from '../models/SlackAccount';
+import { SlackMessage } from '../models/SlackMessage';
+import { Tweet } from '../models/Tweet';
+import { TwitterAccount } from '../models/TwitterAccount';
+import { EmailSender } from '../senders/EmailSender';
+import { SlackSender } from '../senders/SlackSender';
+import { TweetSender } from '../senders/TweetSender';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ============================================================================
+// EmailSender.send (injected client)
+// ============================================================================
+
+describe('EmailSender.send', () => {
+  function makeClient(overrides: Record<string, any> = {}) {
+    return {
+      isConnected: () => true,
+      send: vi.fn(async () => ({
+        messageId: 'provider-msg-1',
+        accepted: ['to@example.com'],
+        rejected: [],
+        response: '250 OK',
+      })),
+      ...overrides,
+    } as any;
+  }
+
+  it('sends a message and maps the success result', async () => {
+    const client = makeClient();
+    const account = new EmailAccount({
+      name: 'Sender Name',
+      email: 'sender@example.com',
+    });
+    const sender = new EmailSender(client, account);
+
+    const email = new Email({
+      subject: 'Hi',
+      textBody: 'Body text',
+      htmlBody: '<p>Body text</p>',
+      toAddresses: JSON.stringify([
+        { address: 'to@example.com', name: 'Recipient' },
+      ]),
+    });
+
+    const result = await sender.send(email);
+
+    expect(result.success).toBe(true);
+    expect(result.providerMessageId).toBe('provider-msg-1');
+    expect(result.accepted).toEqual(['to@example.com']);
+    expect(result.providerResponse).toEqual({ response: '250 OK' });
+    expect(result.sentAt).toBeInstanceOf(Date);
+
+    // Verify the payload handed to the external client.
+    const payload = client.send.mock.calls[0][0];
+    expect(payload.from).toEqual({
+      name: 'Sender Name',
+      address: 'sender@example.com',
+    });
+    expect(payload.to).toEqual([
+      { name: 'Recipient', address: 'to@example.com' },
+    ]);
+    expect(payload.subject).toBe('Hi');
+    expect(payload.text).toBe('Body text');
+    expect(payload.html).toBe('<p>Body text</p>');
+  });
+
+  it('falls back to account name/email when message lacks from fields', async () => {
+    const client = makeClient();
+    const account = new EmailAccount({
+      name: 'Account Name',
+      email: 'account@example.com',
+    });
+    const sender = new EmailSender(client, account);
+
+    const email = new Email({
+      subject: 'No From',
+      textBody: 'x',
+      toAddresses: JSON.stringify([{ address: 'to@example.com' }]),
+    });
+    await sender.send(email);
+
+    const payload = client.send.mock.calls[0][0];
+    expect(payload.from.name).toBe('Account Name');
+    expect(payload.from.address).toBe('account@example.com');
+  });
+
+  it('includes cc and bcc only when present', async () => {
+    const client = makeClient();
+    const account = new EmailAccount({ email: 'a@b.com' });
+    const sender = new EmailSender(client, account);
+
+    const withCc = new Email({
+      subject: 's',
+      textBody: 'x',
+      toAddresses: JSON.stringify([{ address: 'to@example.com' }]),
+      ccAddresses: JSON.stringify([{ address: 'cc@example.com', name: 'CC' }]),
+      bccAddresses: JSON.stringify([{ address: 'bcc@example.com' }]),
+    });
+    await sender.send(withCc);
+    const p1 = client.send.mock.calls[0][0];
+    expect(p1.cc).toEqual([{ name: 'CC', address: 'cc@example.com' }]);
+    expect(p1.bcc).toEqual([{ name: undefined, address: 'bcc@example.com' }]);
+
+    client.send.mockClear();
+    const noCc = new Email({
+      subject: 's',
+      textBody: 'x',
+      toAddresses: JSON.stringify([{ address: 'to@example.com' }]),
+    });
+    await sender.send(noCc);
+    const p2 = client.send.mock.calls[0][0];
+    expect(p2.cc).toBeUndefined();
+    expect(p2.bcc).toBeUndefined();
+  });
+
+  it('uses body when textBody is empty and passes inReplyTo', async () => {
+    const client = makeClient();
+    const account = new EmailAccount({ email: 'a@b.com' });
+    const sender = new EmailSender(client, account);
+
+    const email = new Email({
+      subject: 's',
+      body: 'plain body',
+      inReplyTo: '<parent@example.com>',
+      toAddresses: JSON.stringify([{ address: 'to@example.com' }]),
+    });
+    await sender.send(email);
+
+    const payload = client.send.mock.calls[0][0];
+    expect(payload.text).toBe('plain body');
+    expect(payload.html).toBeUndefined();
+    expect(payload.inReplyTo).toBe('<parent@example.com>');
+  });
+
+  it('returns a failure result when the client throws', async () => {
+    const client = makeClient({
+      send: vi.fn(async () => {
+        throw new Error('SMTP down');
+      }),
+    });
+    const account = new EmailAccount({ email: 'a@b.com' });
+    const sender = new EmailSender(client, account);
+
+    const email = new Email({
+      subject: 's',
+      textBody: 'x',
+      toAddresses: JSON.stringify([{ address: 'to@example.com' }]),
+    });
+    const result = await sender.send(email);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('SMTP down');
+    expect(result.sentAt).toBeInstanceOf(Date);
+  });
+
+  it('stringifies non-Error throwables', async () => {
+    const client = makeClient({
+      send: vi.fn(async () => {
+        // biome-ignore lint/complexity/noUselessCatch: intentional non-Error throw
+        throw 'string failure';
+      }),
+    });
+    const account = new EmailAccount({ email: 'a@b.com' });
+    const sender = new EmailSender(client, account);
+
+    const email = new Email({
+      subject: 's',
+      textBody: 'x',
+      toAddresses: JSON.stringify([{ address: 'to@example.com' }]),
+    });
+    const result = await sender.send(email);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('string failure');
+  });
+});
+
+// ============================================================================
+// SlackSender.send
+// ============================================================================
+
+describe('SlackSender.send', () => {
+  it('returns failure when no botToken in credentials', async () => {
+    const account = new SlackAccount({ name: 'WS', isActive: true });
+    // settings double as credentials; no botToken present
+    account.setSettings({ workspaceId: 'W1' });
+
+    const sender = new SlackSender(account);
+    const result = await sender.send(new SlackMessage({ body: 'hi' }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('No botToken');
+    expect(getMessageClientMock).not.toHaveBeenCalled();
+  });
+
+  it('connects, sends, disconnects and maps a successful result', async () => {
+    const account = new SlackAccount({
+      name: 'WS',
+      botUserId: 'U-BOT',
+      isActive: true,
+    });
+    account.setSettings({ botToken: 'xoxb-token' });
+
+    const ts = new Date();
+    sendMock.mockResolvedValueOnce({
+      success: true,
+      messageId: 'slack-123',
+      providerResponse: { ok: true },
+      timestamp: ts,
+    });
+
+    const message = new SlackMessage({
+      body: 'hello team',
+      channelId: 'C100',
+      slackThreadTs: '1700.0001',
+    });
+
+    const sender = new SlackSender(account);
+    const result = await sender.send(message);
+
+    expect(getMessageClientMock).toHaveBeenCalledWith({
+      type: 'slack',
+      botToken: 'xoxb-token',
+    });
+    expect(connectMock).toHaveBeenCalledOnce();
+    expect(disconnectMock).toHaveBeenCalledOnce();
+
+    const [payload, opts] = sendMock.mock.calls[0];
+    expect(payload.from).toEqual({ id: 'U-BOT', name: 'WS' });
+    expect(payload.channelId).toBe('C100');
+    expect(payload.content).toBe('hello team');
+    expect(opts).toEqual({ replyTo: '1700.0001' });
+
+    expect(result.success).toBe(true);
+    expect(result.providerMessageId).toBe('slack-123');
+    expect(result.providerResponse).toEqual({ ok: true });
+    expect(result.sentAt).toBe(ts);
+  });
+
+  it('returns failure when the client send throws', async () => {
+    const account = new SlackAccount({ name: 'WS', isActive: true });
+    account.setSettings({ botToken: 'xoxb-token' });
+
+    sendMock.mockRejectedValueOnce(new Error('slack api error'));
+
+    const sender = new SlackSender(account);
+    const result = await sender.send(
+      new SlackMessage({ body: 'x', channelId: 'C1' }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('slack api error');
+  });
+});
+
+// ============================================================================
+// TweetSender.send
+// ============================================================================
+
+describe('TweetSender.send', () => {
+  const fullCreds = {
+    apiKey: 'k',
+    apiSecret: 's',
+    accessToken: 't',
+    accessSecret: 'as',
+  };
+
+  it('returns failure when credentials are incomplete', async () => {
+    const account = new TwitterAccount({ handle: '@me', isActive: true });
+    account.setSettings({ apiKey: 'k' }); // missing the rest
+
+    const sender = new TweetSender(account);
+    const result = await sender.send(new Tweet({ body: 'gm' }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Missing Twitter API credentials');
+    expect(getMessageClientMock).not.toHaveBeenCalled();
+  });
+
+  it('sends a tweet and maps the result', async () => {
+    const account = new TwitterAccount({
+      handle: '@me',
+      twitterUserId: 'U-1',
+      isActive: true,
+    });
+    account.setSettings(fullCreds);
+
+    const ts = new Date();
+    sendMock.mockResolvedValueOnce({
+      success: true,
+      messageId: 'tweet-9',
+      providerResponse: { id: 'tweet-9' },
+      timestamp: ts,
+    });
+
+    const sender = new TweetSender(account);
+    const result = await sender.send(new Tweet({ body: 'hello world' }));
+
+    expect(getMessageClientMock).toHaveBeenCalledWith({
+      type: 'twitter',
+      ...fullCreds,
+    });
+    const [payload, opts] = sendMock.mock.calls[0];
+    expect(payload.from).toEqual({ id: 'U-1', name: '@me' });
+    expect(payload.content).toBe('hello world');
+    // No reply -> options omitted
+    expect(opts).toBeUndefined();
+
+    expect(result.success).toBe(true);
+    expect(result.providerMessageId).toBe('tweet-9');
+    expect(result.sentAt).toBe(ts);
+  });
+
+  it('passes replyTo when the tweet is a reply', async () => {
+    const account = new TwitterAccount({
+      handle: '@me',
+      twitterUserId: 'U-1',
+      isActive: true,
+    });
+    account.setSettings(fullCreds);
+
+    sendMock.mockResolvedValueOnce({
+      success: true,
+      messageId: 'tweet-reply',
+      providerResponse: {},
+      timestamp: new Date(),
+    });
+
+    const tweet = new Tweet({
+      body: 'a reply',
+      isReply: true,
+      inReplyToMessageId: 'orig-tweet-id',
+    });
+
+    const sender = new TweetSender(account);
+    await sender.send(tweet);
+
+    const opts = sendMock.mock.calls[0][1];
+    expect(opts).toEqual({ replyTo: 'orig-tweet-id' });
+  });
+
+  it('returns failure when the client send throws', async () => {
+    const account = new TwitterAccount({
+      handle: '@me',
+      twitterUserId: 'U-1',
+      isActive: true,
+    });
+    account.setSettings(fullCreds);
+
+    sendMock.mockRejectedValueOnce(new Error('rate limited'));
+
+    const sender = new TweetSender(account);
+    const result = await sender.send(new Tweet({ body: 'x' }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('rate limited');
+  });
+});

--- a/packages/messages/src/__tests__/small-models.test.ts
+++ b/packages/messages/src/__tests__/small-models.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Tests for the small / previously-untested models:
+ * Whitelist, Blacklist, EmailFolder, EmailAttachment.
+ *
+ * Uses real in-memory SQLite (getTestDatabase) for persistence so these
+ * modules enter the coverage report. External APIs are never mocked here —
+ * these models only touch the database and pure logic.
+ */
+
+import { getTestDatabase } from '@happyvertical/smrt-core';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { BlacklistCollection } from '../collections/BlacklistCollection';
+import { EmailFolderCollection } from '../collections/EmailFolderCollection';
+import { WhitelistCollection } from '../collections/WhitelistCollection';
+import { Blacklist } from '../models/Blacklist';
+import { EmailAttachment } from '../models/EmailAttachment';
+import { EmailFolder } from '../models/EmailFolder';
+import { Whitelist } from '../models/Whitelist';
+
+let db: DatabaseInterface;
+
+beforeEach(async () => {
+  db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+});
+
+afterEach(async () => {
+  if (db && typeof db.close === 'function') {
+    await db.close();
+  }
+});
+
+// ============================================================================
+// Whitelist
+// ============================================================================
+
+describe('Whitelist.matches()', () => {
+  it('matches an exact email (case-insensitive, trimmed)', () => {
+    const entry = new Whitelist({ pattern: 'User@Example.com', type: 'email' });
+    expect(entry.matches('  user@example.com  ')).toBe(true);
+    expect(entry.matches('other@example.com')).toBe(false);
+  });
+
+  it('matches a domain pattern', () => {
+    const entry = new Whitelist({ pattern: 'Example.com', type: 'domain' });
+    expect(entry.matches('anyone@example.com')).toBe(true);
+    expect(entry.matches('anyone@other.com')).toBe(false);
+  });
+
+  it('matches a regex pattern (case-insensitive)', () => {
+    const entry = new Whitelist({
+      pattern: '^vip-.*@corp\\.com$',
+      type: 'regex',
+    });
+    expect(entry.matches('VIP-alice@corp.com')).toBe(true);
+    expect(entry.matches('regular@corp.com')).toBe(false);
+  });
+
+  it('returns false for an empty regex pattern', () => {
+    const entry = new Whitelist({ pattern: '   ', type: 'regex' });
+    expect(entry.matches('anyone@corp.com')).toBe(false);
+  });
+
+  it('returns false for an invalid regex pattern', () => {
+    const entry = new Whitelist({ pattern: '([', type: 'regex' });
+    expect(entry.matches('anyone@corp.com')).toBe(false);
+  });
+
+  it('persists and round-trips through the collection', async () => {
+    const collection = await (WhitelistCollection as any).create({ db });
+    const entry = new Whitelist({
+      pattern: 'allow@example.com',
+      type: 'email',
+      db,
+    });
+    entry.category = 'newsletter';
+    entry.description = 'Trusted sender';
+    await entry.initialize();
+    await entry.save();
+
+    const loaded = await collection.get({ id: entry.id });
+    expect(loaded).not.toBeNull();
+    expect(loaded.pattern).toBe('allow@example.com');
+    expect(loaded.type).toBe('email');
+    expect(loaded.category).toBe('newsletter');
+    expect(loaded.description).toBe('Trusted sender');
+  });
+
+  it('collection.isWhitelisted respects category scoping', async () => {
+    const collection = await (WhitelistCollection as any).create({ db });
+
+    const scoped = new Whitelist({
+      pattern: 'support@vendor.com',
+      type: 'email',
+      db,
+    });
+    scoped.category = 'billing';
+    await scoped.initialize();
+    await scoped.save();
+
+    expect(await collection.isWhitelisted('support@vendor.com')).toBe(true);
+    expect(
+      await collection.isWhitelisted('support@vendor.com', 'billing'),
+    ).toBe(true);
+    expect(await collection.isWhitelisted('support@vendor.com', 'other')).toBe(
+      false,
+    );
+    expect(await collection.isWhitelisted('nobody@vendor.com')).toBe(false);
+  });
+});
+
+// ============================================================================
+// Blacklist
+// ============================================================================
+
+describe('Blacklist.matches()', () => {
+  it('matches an exact email', () => {
+    const entry = new Blacklist({ pattern: 'spam@bad.com', type: 'email' });
+    expect(entry.matches('SPAM@bad.com')).toBe(true);
+    expect(entry.matches('ok@bad.com')).toBe(false);
+  });
+
+  it('matches a domain pattern', () => {
+    const entry = new Blacklist({ pattern: 'spam.com', type: 'domain' });
+    expect(entry.matches('anything@spam.com')).toBe(true);
+    expect(entry.matches('anything@good.com')).toBe(false);
+  });
+
+  it('matches a regex pattern', () => {
+    const entry = new Blacklist({ pattern: 'phish', type: 'regex' });
+    expect(entry.matches('big-PHISH@bad.com')).toBe(true);
+    expect(entry.matches('clean@bad.com')).toBe(false);
+  });
+
+  it('returns false for an empty or invalid regex', () => {
+    expect(
+      new Blacklist({ pattern: '', type: 'regex' }).matches('x@y.com'),
+    ).toBe(false);
+    expect(
+      new Blacklist({ pattern: '(', type: 'regex' }).matches('x@y.com'),
+    ).toBe(false);
+  });
+
+  it('defaults autoArchive to true', () => {
+    expect(new Blacklist().autoArchive).toBe(true);
+  });
+
+  it('persists and is found via collection.isBlacklisted / getMatchingEntry', async () => {
+    const collection = await (BlacklistCollection as any).create({ db });
+    const entry = new Blacklist({
+      pattern: 'evil.com',
+      type: 'domain',
+      db,
+    });
+    entry.reason = 'known spammer';
+    await entry.initialize();
+    await entry.save();
+
+    expect(await collection.isBlacklisted('hacker@evil.com')).toBe(true);
+    expect(await collection.isBlacklisted('friend@nice.com')).toBe(false);
+
+    const match = await collection.getMatchingEntry('hacker@evil.com');
+    expect(match).not.toBeNull();
+    expect(match.reason).toBe('known spammer');
+
+    const noMatch = await collection.getMatchingEntry('friend@nice.com');
+    expect(noMatch).toBeNull();
+  });
+});
+
+// ============================================================================
+// EmailFolder
+// ============================================================================
+
+describe('EmailFolder special-folder predicates', () => {
+  it('detects inbox by specialUse and by path', () => {
+    expect(new EmailFolder({ specialUse: '\\Inbox' }).isInbox()).toBe(true);
+    expect(new EmailFolder({ path: 'INBOX' }).isInbox()).toBe(true);
+    expect(new EmailFolder({ path: 'Other' }).isInbox()).toBe(false);
+  });
+
+  it('detects sent / drafts / trash / spam folders', () => {
+    expect(new EmailFolder({ specialUse: '\\Sent' }).isSent()).toBe(true);
+    expect(new EmailFolder({ path: 'sent' }).isSent()).toBe(true);
+
+    expect(new EmailFolder({ specialUse: '\\Drafts' }).isDrafts()).toBe(true);
+    expect(new EmailFolder({ path: 'drafts' }).isDrafts()).toBe(true);
+
+    expect(new EmailFolder({ specialUse: '\\Trash' }).isTrash()).toBe(true);
+    expect(new EmailFolder({ path: 'trash' }).isTrash()).toBe(true);
+
+    expect(new EmailFolder({ specialUse: '\\Junk' }).isSpam()).toBe(true);
+    expect(new EmailFolder({ path: 'spam' }).isSpam()).toBe(true);
+    expect(new EmailFolder({ path: 'junk' }).isSpam()).toBe(true);
+  });
+
+  it('detects system folders only when specialUse is set', () => {
+    expect(new EmailFolder({ specialUse: '\\Inbox' }).isSystemFolder()).toBe(
+      true,
+    );
+    expect(new EmailFolder({ name: 'Custom' }).isSystemFolder()).toBe(false);
+  });
+
+  it('returns null account when accountId is empty', async () => {
+    const folder = new EmailFolder({ db });
+    await folder.initialize();
+    expect(await folder.getAccount()).toBeNull();
+  });
+
+  it('persists folder fields through the collection', async () => {
+    const collection = await (EmailFolderCollection as any).create({ db });
+    const folder = new EmailFolder({
+      accountId: 'acct-1',
+      name: 'Projects',
+      path: 'Projects',
+      delimiter: '/',
+      messageCount: 7,
+      unreadCount: 2,
+      subscribed: true,
+      db,
+    });
+    await folder.initialize();
+    await folder.save();
+
+    const loaded = await collection.get({ id: folder.id });
+    expect(loaded.name).toBe('Projects');
+    expect(loaded.path).toBe('Projects');
+    expect(loaded.messageCount).toBe(7);
+    expect(loaded.unreadCount).toBe(2);
+    expect(loaded.subscribed).toBe(true);
+  });
+
+  it('subscribe()/unsubscribe() toggle and persist', async () => {
+    const folder = new EmailFolder({
+      accountId: 'acct-1',
+      name: 'Archive',
+      path: 'Archive',
+      db,
+    });
+    await folder.initialize();
+    await folder.save();
+
+    await folder.unsubscribe();
+    expect(folder.subscribed).toBe(false);
+
+    await folder.subscribe();
+    expect(folder.subscribed).toBe(true);
+
+    const collection = await (EmailFolderCollection as any).create({ db });
+    const loaded = await collection.get({ id: folder.id });
+    expect(loaded.subscribed).toBe(true);
+  });
+});
+
+describe('EmailFolderCollection queries', () => {
+  // Helper: seed folders bound to the test db (createSystemFolders builds
+  // folders without injecting the collection's db, so we seed explicitly).
+  async function seedFolder(data: Record<string, any>) {
+    const folder = new EmailFolder({ ...data, db });
+    await folder.initialize();
+    await folder.save();
+    return folder;
+  }
+
+  it('classifies system folders via the special-use getters', async () => {
+    const collection = await (EmailFolderCollection as any).create({ db });
+    await seedFolder({
+      accountId: 'acct-sys',
+      name: 'INBOX',
+      path: 'INBOX',
+      specialUse: '\\Inbox',
+    });
+    await seedFolder({
+      accountId: 'acct-sys',
+      name: 'Sent',
+      path: 'Sent',
+      specialUse: '\\Sent',
+    });
+    await seedFolder({
+      accountId: 'acct-sys',
+      name: 'Drafts',
+      path: 'Drafts',
+      specialUse: '\\Drafts',
+    });
+    await seedFolder({
+      accountId: 'acct-sys',
+      name: 'Trash',
+      path: 'Trash',
+      specialUse: '\\Trash',
+    });
+    await seedFolder({
+      accountId: 'acct-sys',
+      name: 'Spam',
+      path: 'Spam',
+      specialUse: '\\Junk',
+    });
+    // A user-created (non-system) folder.
+    await seedFolder({
+      accountId: 'acct-sys',
+      name: 'Projects',
+      path: 'Projects',
+    });
+
+    expect((await collection.getInbox('acct-sys'))?.specialUse).toBe('\\Inbox');
+    expect((await collection.getSent('acct-sys'))?.specialUse).toBe('\\Sent');
+    expect((await collection.getDrafts('acct-sys'))?.specialUse).toBe(
+      '\\Drafts',
+    );
+    expect((await collection.getTrash('acct-sys'))?.specialUse).toBe('\\Trash');
+    expect((await collection.getSpam('acct-sys'))?.specialUse).toBe('\\Junk');
+
+    const systemFolders = await collection.getSystemFolders('acct-sys');
+    expect(systemFolders).toHaveLength(5);
+    const userFolders = await collection.getUserFolders('acct-sys');
+    expect(userFolders).toHaveLength(1);
+    expect(userFolders[0].name).toBe('Projects');
+  });
+
+  it('getByPath, getStats and unread filtering work', async () => {
+    const collection = await (EmailFolderCollection as any).create({ db });
+    await seedFolder({
+      accountId: 'acct-stats',
+      name: 'INBOX',
+      path: 'INBOX',
+      specialUse: '\\Inbox',
+      messageCount: 10,
+      unreadCount: 4,
+    });
+    await seedFolder({
+      accountId: 'acct-stats',
+      name: 'Sent',
+      path: 'Sent',
+      specialUse: '\\Sent',
+      messageCount: 3,
+      unreadCount: 0,
+    });
+
+    const byPath = await collection.getByPath('acct-stats', 'INBOX');
+    expect(byPath?.name).toBe('INBOX');
+    expect(await collection.getByPath('acct-stats', 'Nope')).toBeNull();
+
+    const withUnread = await collection.getWithUnread('acct-stats');
+    expect(withUnread).toHaveLength(1);
+    expect(withUnread[0].unreadCount).toBe(4);
+
+    const stats = await collection.getAccountStats('acct-stats');
+    expect(stats.totalFolders).toBe(2);
+    expect(stats.systemFolders).toBe(2);
+    expect(stats.userFolders).toBe(0);
+    expect(stats.totalUnread).toBe(4);
+    expect(stats.totalMessages).toBe(13);
+  });
+
+  it('getSubscribed and search filter by account and flags', async () => {
+    const collection = await (EmailFolderCollection as any).create({ db });
+    await seedFolder({
+      accountId: 'acct-sub',
+      name: 'Newsletters',
+      path: 'Newsletters',
+      subscribed: true,
+    });
+    await seedFolder({
+      accountId: 'acct-sub',
+      name: 'Muted',
+      path: 'Muted',
+      subscribed: false,
+    });
+
+    const subscribed = await collection.getSubscribed('acct-sub');
+    expect(subscribed).toHaveLength(1);
+    expect(subscribed[0].name).toBe('Newsletters');
+
+    const byName = await collection.search('news', { accountId: 'acct-sub' });
+    expect(byName).toHaveLength(1);
+    expect(byName[0].name).toBe('Newsletters');
+
+    const subscribedOnly = await collection.search('', { subscribed: true });
+    expect(subscribedOnly.map((f: EmailFolder) => f.name)).toContain(
+      'Newsletters',
+    );
+    expect(subscribedOnly.map((f: EmailFolder) => f.name)).not.toContain(
+      'Muted',
+    );
+  });
+});
+
+// ============================================================================
+// EmailAttachment (deprecated alias of Attachment with emailId mapping)
+// ============================================================================
+
+describe('EmailAttachment legacy emailId mapping', () => {
+  it('maps emailId constructor option to messageId', () => {
+    const att = new EmailAttachment({ emailId: 'email-42', filename: 'a.txt' });
+    expect(att.messageId).toBe('email-42');
+    expect(att.emailId).toBe('email-42');
+  });
+
+  it('prefers emailId over messageId when both supplied', () => {
+    const att = new EmailAttachment({
+      emailId: 'from-email',
+      messageId: 'from-message',
+    });
+    expect(att.messageId).toBe('from-email');
+  });
+
+  it('falls back to messageId when emailId absent', () => {
+    const att = new EmailAttachment({ messageId: 'msg-7' });
+    expect(att.emailId).toBe('msg-7');
+    expect(att.messageId).toBe('msg-7');
+  });
+
+  it('emailId setter writes through to messageId', () => {
+    const att = new EmailAttachment();
+    att.emailId = 'msg-99';
+    expect(att.messageId).toBe('msg-99');
+  });
+
+  it('inherits Attachment helper methods', () => {
+    const att = new EmailAttachment({
+      emailId: 'e1',
+      filename: 'photo.PNG',
+      contentType: 'image/png',
+      size: 2048,
+      contentDisposition: 'inline',
+    });
+    expect(att.isImage()).toBe(true);
+    expect(att.isInline()).toBe(true);
+    expect(att.getExtension()).toBe('png');
+    expect(att.getFormattedSize()).toBe('2.0 KB');
+  });
+
+  it('getEmail returns null when no messageId', async () => {
+    const att = new EmailAttachment({ db });
+    await att.initialize();
+    expect(await att.getEmail()).toBeNull();
+  });
+});

--- a/packages/messages/src/collections/EmailFolderCollection.ts
+++ b/packages/messages/src/collections/EmailFolderCollection.ts
@@ -187,7 +187,10 @@ export class EmailFolderCollection extends SmrtCollection<EmailFolder> {
     for (const folderData of standardFolders) {
       const existing = await this.getByPath(accountId, folderData.path);
       if (!existing) {
-        const folder = new EmailFolder({
+        // Create through the collection so the DB connection is bound; a bare
+        // `new EmailFolder(...)` + save() throws "Database accessed before
+        // initialization" under per-instance DB injection.
+        const folder = await this.create({
           accountId,
           ...folderData,
         });

--- a/packages/messages/src/models/EmailAccount.ts
+++ b/packages/messages/src/models/EmailAccount.ts
@@ -35,6 +35,22 @@ export class EmailAccount extends Account {
   }
 
   /**
+   * Options for child rows (folders/emails) created during sync: carries the DB
+   * connection + tenant context from this account, but strips this account's own
+   * identity fields. When this account was hydrated from the DB, `this.options`
+   * holds the account row's `id`/`slug`/`_skipLoad`; spreading those into a new
+   * child would make every synced row inherit the account's primary key and
+   * upsert over each other.
+   */
+  private childOptions(): Record<string, unknown> {
+    const rest = { ...(this.options as Record<string, unknown>) };
+    delete rest.id;
+    delete rest.slug;
+    delete rest._skipLoad;
+    return rest;
+  }
+
+  /**
    * Create a sender for this email account
    */
   override async createSender(): Promise<MessageSenderInterface> {
@@ -118,7 +134,7 @@ export class EmailAccount extends Account {
             // Create folder record
             const { EmailFolder } = await import('./EmailFolder');
             folder = new EmailFolder({
-              ...this.options,
+              ...this.childOptions(),
               accountId,
               name: folderName,
               path: folderName,
@@ -164,7 +180,7 @@ export class EmailAccount extends Account {
               let email = existingEmail;
               if (!email) {
                 email = new Email({
-                  ...this.options,
+                  ...this.childOptions(),
                   accountId,
                 });
                 // Bind the DB connection before save() (existingEmail is already

--- a/packages/messages/src/models/EmailAccount.ts
+++ b/packages/messages/src/models/EmailAccount.ts
@@ -123,6 +123,9 @@ export class EmailAccount extends Account {
               name: folderName,
               path: folderName,
             });
+            // initialize() binds the DB connection; without it save() throws
+            // "Database accessed before initialization" and sync persists nothing.
+            await folder.initialize();
             await folder.save();
           }
 
@@ -158,12 +161,16 @@ export class EmailAccount extends Account {
 
               // Create or update email record
               const { Email } = await import('./Email');
-              const email =
-                existingEmail ||
-                new Email({
+              let email = existingEmail;
+              if (!email) {
+                email = new Email({
                   ...this.options,
                   accountId,
                 });
+                // Bind the DB connection before save() (existingEmail is already
+                // initialized via the query that loaded it).
+                await email.initialize();
+              }
 
               // Update fields
               email.messageId = msg.messageId || '';

--- a/packages/messages/src/svelte/components/AccountList.svelte
+++ b/packages/messages/src/svelte/components/AccountList.svelte
@@ -2,9 +2,13 @@
 /**
  * AccountList - Account management list
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import { Grid } from '@happyvertical/smrt-svelte/layout';
+import { M } from '../i18n.js';
 import type { AccountData } from '../types.js';
 import AccountCard from './AccountCard.svelte';
+
+const { t } = useI18n();
 
 export interface Props {
   accounts: AccountData[];
@@ -38,17 +42,17 @@ function handleAccountKeydown(event: KeyboardEvent, account: AccountData) {
 }
 </script>
 
-<div class="account-list" role="list" aria-label="Accounts">
+<div class="account-list" role="list" aria-label={t(M['messages.account_list.accounts'])}>
   {#if loading}
     <div class="loading" role="status" aria-live="polite">
-      <p>Loading accounts...</p>
+      <p>{t(M['messages.account_list.loading'])}</p>
     </div>
   {:else if accounts.length === 0}
     <div class="empty" role="status" aria-live="polite">
-      <p>No accounts configured.</p>
+      <p>{t(M['messages.account_list.empty'])}</p>
     </div>
   {:else}
-    <Grid columns="auto" role="list" aria-label="Accounts">
+    <Grid columns="auto" role="list" aria-label={t(M['messages.account_list.accounts'])}>
       {#each accounts as account (account.id)}
         <div role="listitem">
           {#if onaccountclick}

--- a/packages/messages/src/svelte/components/AttachmentUpload.svelte
+++ b/packages/messages/src/svelte/components/AttachmentUpload.svelte
@@ -10,6 +10,11 @@ export interface Props {
 </script>
 
 <script lang="ts">
+  import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+  import { M } from '../i18n.js';
+
+  const { t } = useI18n();
+
   let {
     attachments = [],
     onattach,
@@ -79,7 +84,7 @@ export interface Props {
         class="file-input"
         onchange={(e) => handleFiles((e.target as HTMLInputElement).files)}
       />
-      <span class="upload-text">Drop files or click to attach</span>
+      <span class="upload-text">{t(M['messages.attachment_upload.drop_files'])}</span>
     </label>
   </div>
 </div>

--- a/packages/messages/src/svelte/components/ComposeForm.svelte
+++ b/packages/messages/src/svelte/components/ComposeForm.svelte
@@ -17,8 +17,12 @@ export interface Props {
 </script>
 
 <script lang="ts">
+  import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+  import { M } from '../i18n.js';
   import RecipientInput from './RecipientInput.svelte';
   import AttachmentUpload from './AttachmentUpload.svelte';
+
+  const { t } = useI18n();
 
   let {
     type = 'email',
@@ -183,7 +187,7 @@ export interface Props {
         class="text-input"
         bind:value={subject}
         oninput={markDirty}
-        placeholder="Subject"
+        placeholder={t(M['messages.compose_form.subject_placeholder'])}
       />
     </div>
   {:else if type === 'slack'}
@@ -195,7 +199,7 @@ export interface Props {
         class="text-input"
         bind:value={channelId}
         oninput={markDirty}
-        placeholder="Channel ID"
+        placeholder={t(M['messages.compose_form.channel_id_placeholder'])}
       />
     </div>
   {/if}
@@ -246,7 +250,7 @@ export interface Props {
       {isSending ? 'Sending...' : 'Send'}
     </button>
     <button type="button" class="btn-secondary" onclick={handleSaveDraft}>
-      Save Draft
+      {t(M['messages.compose_form.save_draft'])}
     </button>
     <button type="button" class="btn-text" onclick={() => ondiscard?.()}>
       Discard

--- a/packages/messages/src/svelte/components/EmailAccountManager.svelte
+++ b/packages/messages/src/svelte/components/EmailAccountManager.svelte
@@ -5,7 +5,11 @@
  * Reusable component for adding, editing, testing, and removing
  * email accounts. Works with any backend via callback props.
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../i18n.js';
 import type { EmailAccountData } from '../types.js';
+
+const { t } = useI18n();
 
 export interface Props {
   accounts: EmailAccountData[];
@@ -153,28 +157,28 @@ function getProviderLabel(type: string): string {
 <div class="email-account-manager">
   <div class="section-header-row">
     <div class="section-description">
-      Configure email accounts for mailbox access and message routing.
+      {t(M['messages.email_account_manager.section_description'])}
     </div>
     {#if !isReadonly && onsave}
       <button
         class="add-btn"
         onclick={() => { resetForm(); showForm = true; }}
-      >+ Add Account</button>
+      >{t(M['messages.email_account_manager.add_account'])}</button>
     {/if}
   </div>
 
   {#if showForm}
     <div class="entry-form">
-      <div class="form-title">{editingId ? 'Edit' : 'Add'} Mail Account</div>
+      <div class="form-title">{editingId ? 'Edit' : 'Add'} {t(M['messages.email_account_manager.mail_account'])}</div>
 
       <div class="form-row">
         <div class="form-field" style="flex: 1;">
-          <label class="form-label" for="ea-name">Account Name</label>
-          <input id="ea-name" class="form-input" type="text" bind:value={maName} placeholder="e.g. Work, Personal" />
+          <label class="form-label" for="ea-name">{t(M['messages.email_account_manager.account_name'])}</label>
+          <input id="ea-name" class="form-input" type="text" bind:value={maName} placeholder={t(M['messages.email_account_manager.account_name_placeholder'])} />
         </div>
         <div class="form-field" style="flex: 1;">
-          <label class="form-label" for="ea-email">Email Address</label>
-          <input id="ea-email" class="form-input" type="email" bind:value={maEmail} placeholder="user@example.com" />
+          <label class="form-label" for="ea-email">{t(M['messages.email_account_manager.email_address'])}</label>
+          <input id="ea-email" class="form-input" type="email" bind:value={maEmail} placeholder={t(M['messages.email_account_manager.email_placeholder'])} />
         </div>
         <div class="form-field" style="flex: 0 0 130px;">
           <label class="form-label" for="ea-provider">Provider</label>
@@ -187,11 +191,11 @@ function getProviderLabel(type: string): string {
         </div>
       </div>
 
-      <div class="form-section-label">Incoming Mail (IMAP)</div>
+      <div class="form-section-label">{t(M['messages.email_account_manager.incoming_mail'])}</div>
       <div class="form-row">
         <div class="form-field" style="flex: 2;">
           <label class="form-label" for="ea-imap-host">Host</label>
-          <input id="ea-imap-host" class="form-input" type="text" bind:value={maImapHost} placeholder="imap.example.com" />
+          <input id="ea-imap-host" class="form-input" type="text" bind:value={maImapHost} placeholder={t(M['messages.email_account_manager.imap_host_placeholder'])} />
         </div>
         <div class="form-field" style="flex: 0 0 90px;">
           <label class="form-label" for="ea-imap-port">Port</label>
@@ -207,11 +211,11 @@ function getProviderLabel(type: string): string {
         </div>
       </div>
 
-      <div class="form-section-label">Outgoing Mail (SMTP)</div>
+      <div class="form-section-label">{t(M['messages.email_account_manager.outgoing_mail'])}</div>
       <div class="form-row">
         <div class="form-field" style="flex: 2;">
           <label class="form-label" for="ea-smtp-host">Host</label>
-          <input id="ea-smtp-host" class="form-input" type="text" bind:value={maSmtpHost} placeholder="smtp.example.com" />
+          <input id="ea-smtp-host" class="form-input" type="text" bind:value={maSmtpHost} placeholder={t(M['messages.email_account_manager.smtp_host_placeholder'])} />
         </div>
         <div class="form-field" style="flex: 0 0 90px;">
           <label class="form-label" for="ea-smtp-port">Port</label>
@@ -231,7 +235,7 @@ function getProviderLabel(type: string): string {
       <div class="form-row">
         <div class="form-field" style="flex: 1;">
           <label class="form-label" for="ea-username">Username</label>
-          <input id="ea-username" class="form-input" type="text" bind:value={maUsername} placeholder="user@example.com" />
+          <input id="ea-username" class="form-input" type="text" bind:value={maUsername} placeholder={t(M['messages.email_account_manager.username_placeholder'])} />
         </div>
         <div class="form-field" style="flex: 1;">
           <label class="form-label" for="ea-password">Password</label>
@@ -257,16 +261,16 @@ function getProviderLabel(type: string): string {
   {#if testResult}
     <div class="test-result" class:success={testResult.success} class:failure={!testResult.success}>
       {#if testResult.success}
-        Connection successful
+        {t(M['messages.email_account_manager.connection_successful'])}
       {:else}
-        Connection failed: {testResult.error ?? 'Unknown error'}
+        {t(M['messages.email_account_manager.connection_failed'])} {testResult.error ?? 'Unknown error'}
       {/if}
       <button class="dismiss-btn" onclick={() => testResult = null}>&times;</button>
     </div>
   {/if}
 
   {#if accounts.length === 0 && !showForm}
-    <p class="placeholder">No mail accounts configured yet.</p>
+    <p class="placeholder">{t(M['messages.email_account_manager.empty'])}</p>
   {:else}
     <div class="entries-list">
       {#each accounts as acct}
@@ -291,7 +295,7 @@ function getProviderLabel(type: string): string {
               <span class="entry-description">{acct.email}</span>
             </div>
             {#if acct.imapHost}
-              <span class="host-tag" title="IMAP: {acct.imapHost}:{acct.imapPort}">{acct.imapHost}</span>
+              <span class="host-tag" title={t(M['messages.email_account_manager.imap_host_title'], { host: acct.imapHost, port: acct.imapPort })}>{acct.imapHost}</span>
             {/if}
             {#if !acct.isActive}
               <span class="inactive-tag">inactive</span>
@@ -304,7 +308,7 @@ function getProviderLabel(type: string): string {
                   class="test-btn"
                   onclick={(e) => { e.stopPropagation(); testConnection(acct); }}
                   disabled={testingId === acct.id}
-                  title="Test connection"
+                  title={t(M['messages.email_account_manager.test_connection'])}
                 >
                   {testingId === acct.id ? '...' : 'Test'}
                 </button>
@@ -313,7 +317,7 @@ function getProviderLabel(type: string): string {
                 <button
                   class="delete-btn"
                   onclick={(e) => { e.stopPropagation(); remove(acct); }}
-                  title="Remove"
+                  title={t(M['messages.email_account_manager.remove'])}
                 >&times;</button>
               {/if}
             </div>

--- a/packages/messages/src/svelte/components/EmailFilterManager.svelte
+++ b/packages/messages/src/svelte/components/EmailFilterManager.svelte
@@ -5,7 +5,11 @@
  * Reusable component for managing email allow/block lists.
  * Works with any backend via callback props.
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../i18n.js';
 import type { BlacklistEntry, WhitelistEntry } from '../types.js';
+
+const { t } = useI18n();
 
 export interface Props {
   whitelist: WhitelistEntry[];
@@ -162,7 +166,7 @@ function getPatternPlaceholder(type: string): string {
     <div class="section-content">
       <div class="section-header-row">
         <div class="section-description">
-          Whitelisted senders bypass blacklist checks and are always allowed through.
+          {t(M['messages.email_filter_manager.whitelist_description'])}
         </div>
         {#if !isReadonly && onaddwhitelist}
           <button
@@ -174,7 +178,7 @@ function getPatternPlaceholder(type: string): string {
 
       {#if showWhitelistForm}
         <div class="entry-form">
-          <div class="form-title">Add Whitelist Entry</div>
+          <div class="form-title">{t(M['messages.email_filter_manager.add_whitelist_entry'])}</div>
           <div class="form-row">
             <div class="form-field" style="flex: 0 0 120px;">
               <label class="form-label" for="wl-type">Type</label>
@@ -203,7 +207,7 @@ function getPatternPlaceholder(type: string): string {
                 class="form-input"
                 type="text"
                 bind:value={wlCategory}
-                placeholder="e.g. support, sales"
+                placeholder={t(M['messages.email_filter_manager.category_placeholder'])}
               />
             </div>
             <div class="form-field" style="flex: 2;">
@@ -213,7 +217,7 @@ function getPatternPlaceholder(type: string): string {
                 class="form-input"
                 type="text"
                 bind:value={wlDescription}
-                placeholder="Why is this entry whitelisted?"
+                placeholder={t(M['messages.email_filter_manager.whitelist_description_placeholder'])}
               />
             </div>
           </div>
@@ -227,7 +231,7 @@ function getPatternPlaceholder(type: string): string {
       {/if}
 
       {#if whitelist.length === 0 && !showWhitelistForm}
-        <p class="placeholder">No whitelist entries yet.</p>
+        <p class="placeholder">{t(M['messages.email_filter_manager.no_whitelist_entries'])}</p>
       {:else}
         <div class="entries-list">
           {#each whitelist as entry}
@@ -248,7 +252,7 @@ function getPatternPlaceholder(type: string): string {
                 <button
                   class="delete-btn"
                   onclick={() => removeWhitelistEntry(entry)}
-                  title="Remove"
+                  title={t(M['messages.email_filter_manager.whitelist_remove'])}
                 >&times;</button>
               {/if}
             </div>
@@ -262,7 +266,7 @@ function getPatternPlaceholder(type: string): string {
     <div class="section-content">
       <div class="section-header-row">
         <div class="section-description">
-          Blacklisted senders are automatically blocked or archived.
+          {t(M['messages.email_filter_manager.blacklist_description'])}
         </div>
         {#if !isReadonly && onaddblacklist}
           <button
@@ -274,7 +278,7 @@ function getPatternPlaceholder(type: string): string {
 
       {#if showBlacklistForm}
         <div class="entry-form">
-          <div class="form-title">Add Blacklist Entry</div>
+          <div class="form-title">{t(M['messages.email_filter_manager.add_blacklist_entry'])}</div>
           <div class="form-row">
             <div class="form-field" style="flex: 0 0 120px;">
               <label class="form-label" for="bl-type">Type</label>
@@ -303,7 +307,7 @@ function getPatternPlaceholder(type: string): string {
                 class="form-input"
                 type="text"
                 bind:value={blReason}
-                placeholder="Why is this entry blocked?"
+                placeholder={t(M['messages.email_filter_manager.reason_placeholder'])}
               />
             </div>
             <div class="form-field checkbox-field">
@@ -323,7 +327,7 @@ function getPatternPlaceholder(type: string): string {
       {/if}
 
       {#if blacklist.length === 0 && !showBlacklistForm}
-        <p class="placeholder">No blacklist entries yet.</p>
+        <p class="placeholder">{t(M['messages.email_filter_manager.no_blacklist_entries'])}</p>
       {:else}
         <div class="entries-list">
           {#each blacklist as entry}
@@ -344,7 +348,7 @@ function getPatternPlaceholder(type: string): string {
                 <button
                   class="delete-btn"
                   onclick={() => removeBlacklistEntry(entry)}
-                  title="Remove"
+                  title={t(M['messages.email_filter_manager.blacklist_remove'])}
                 >&times;</button>
               {/if}
             </div>

--- a/packages/messages/src/svelte/components/FolderNav.svelte
+++ b/packages/messages/src/svelte/components/FolderNav.svelte
@@ -2,7 +2,11 @@
 /**
  * FolderNav - Folder/label navigation sidebar
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../i18n.messages.js';
 import type { FolderData } from '../types.js';
+
+const { t } = useI18n();
 
 export interface Props {
   folders: FolderData[];
@@ -41,7 +45,7 @@ function getFolderIcon(specialUse?: string): string {
 }
 </script>
 
-<nav class="folder-nav" aria-label="Folders">
+<nav class="folder-nav" aria-label={t(M['messages.folder_nav.folders'])}>
   {#if _systemFolders.length > 0}
     <ul class="folder-list" role="list">
       {#each _systemFolders as folder (folder.id)}

--- a/packages/messages/src/svelte/components/ForwardForm.svelte
+++ b/packages/messages/src/svelte/components/ForwardForm.svelte
@@ -9,7 +9,11 @@ export interface Props {
 </script>
 
 <script lang="ts">
+  import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+  import { M } from '../i18n.js';
   import RecipientInput from './RecipientInput.svelte';
+
+  const { t } = useI18n();
 
   let { originalMessage, onsend, oncancel }: Props = $props();
 
@@ -45,7 +49,7 @@ export interface Props {
 </script>
 
 <div class="forward-form">
-  <div class="forward-header">Forward message</div>
+  <div class="forward-header">{t(M['messages.forward_form.header'])}</div>
 
   <RecipientInput
     label="To"
@@ -56,7 +60,7 @@ export interface Props {
   <textarea
     class="forward-body"
     bind:value={body}
-    placeholder="Add a note (optional)..."
+    placeholder={t(M['messages.forward_form.note_placeholder'])}
     rows={3}
   ></textarea>
 

--- a/packages/messages/src/svelte/components/MessageCard.svelte
+++ b/packages/messages/src/svelte/components/MessageCard.svelte
@@ -3,10 +3,14 @@
  * MessageCard - Single message row with type-adaptive rendering
  */
 
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type { Snippet } from 'svelte';
+import { M } from '../i18n.messages.js';
 import type { AccountData, MessageData } from '../types.js';
 import MessageStatusIndicator from './MessageStatusIndicator.svelte';
 import MessageTypeBadge from './MessageTypeBadge.svelte';
+
+const { t } = useI18n();
 
 export interface Props {
   message: MessageData;
@@ -97,7 +101,7 @@ const _slackMeta = $derived.by(() => {
         type="checkbox"
         checked={selected}
         onchange={() => onselect?.(message)}
-        aria-label="Select message"
+        aria-label={t(M['messages.message_card.select_message'])}
       />
     </div>
   {/if}

--- a/packages/messages/src/svelte/components/MessageFilters.svelte
+++ b/packages/messages/src/svelte/components/MessageFilters.svelte
@@ -2,12 +2,16 @@
 /**
  * MessageFilters - Filter/sort controls bar
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../i18n.messages.js';
 import type {
   AccountData,
   MessageFilterState,
   MessageSort,
   MessageType,
 } from '../types.js';
+
+const { t } = useI18n();
 
 export interface Props {
   filters?: MessageFilterState;
@@ -71,15 +75,15 @@ const _hasActiveFilters = $derived(
 );
 </script>
 
-<div class="message-filters" role="search" aria-label="Message filters">
+<div class="message-filters" role="search" aria-label={t(M['messages.message_filters.filters_label'])}>
   <div class="search-row">
     <input
       type="search"
       class="search-input"
-      placeholder="Search messages..."
+      placeholder={t(M['messages.message_filters.search_placeholder'])}
       bind:value={searchValue}
       onkeydown={(e) => { if (e.key === 'Enter') handleSearch(); }}
-      aria-label="Search messages"
+      aria-label={t(M['messages.message_filters.search_label'])}
     />
     <button class="search-btn" type="button" onclick={handleSearch}>Search</button>
   </div>
@@ -89,9 +93,9 @@ const _hasActiveFilters = $derived(
       class="filter-select"
       value={filters.type || ''}
       onchange={(e) => updateFilter('type', (e.target as HTMLSelectElement).value)}
-      aria-label="Filter by type"
+      aria-label={t(M['messages.message_filters.filter_by_type'])}
     >
-      <option value="">All types</option>
+      <option value="">{t(M['messages.message_filters.all_types'])}</option>
       {#each availableTypes as type}
         <option value={type}>{type === 'email' ? 'Email' : type === 'tweet' ? 'Tweet' : type === 'slack' ? 'Slack' : type}</option>
       {/each}
@@ -102,9 +106,9 @@ const _hasActiveFilters = $derived(
         class="filter-select"
         value={filters.accountId || ''}
         onchange={(e) => updateFilter('accountId', (e.target as HTMLSelectElement).value)}
-        aria-label="Filter by account"
+        aria-label={t(M['messages.message_filters.filter_by_account'])}
       >
-        <option value="">All accounts</option>
+        <option value="">{t(M['messages.message_filters.all_accounts'])}</option>
         {#each accounts as account}
           <option value={account.id}>{account.name}</option>
         {/each}
@@ -118,11 +122,11 @@ const _hasActiveFilters = $derived(
         const val = (e.target as HTMLSelectElement).value;
         updateFilter('isRead', val === '' ? undefined : val === 'read');
       }}
-      aria-label="Filter by read status"
+      aria-label={t(M['messages.message_filters.filter_by_read_status'])}
     >
       <option value="">Read & unread</option>
-      <option value="unread">Unread only</option>
-      <option value="read">Read only</option>
+      <option value="unread">{t(M['messages.message_filters.unread_only'])}</option>
+      <option value="read">{t(M['messages.message_filters.read_only'])}</option>
     </select>
 
     <label class="filter-checkbox">
@@ -136,7 +140,7 @@ const _hasActiveFilters = $derived(
 
     {#if _hasActiveFilters}
       <button class="clear-btn" type="button" onclick={clearFilters}>
-        Clear filters
+        {t(M['messages.message_filters.clear_filters'])}
       </button>
     {/if}
   </div>

--- a/packages/messages/src/svelte/components/MessageList.svelte
+++ b/packages/messages/src/svelte/components/MessageList.svelte
@@ -2,9 +2,13 @@
 /**
  * MessageList - Unified message list with selection
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type { Snippet } from 'svelte';
+import { M } from '../i18n.messages.js';
 import type { AccountData, MessageData } from '../types.js';
 import MessageCard from './MessageCard.svelte';
+
+const { t } = useI18n();
 
 export interface Props {
   messages: MessageData[];
@@ -43,10 +47,10 @@ function getAccount(accountId: string): AccountData | undefined {
 }
 </script>
 
-<div class="message-list" role="grid" aria-label="Messages">
+<div class="message-list" role="grid" aria-label={t(M['messages.message_list.messages_label'])}>
   {#if loading}
     <div class="loading" role="status" aria-live="polite">
-      <p>Loading messages...</p>
+      <p>{t(M['messages.message_list.loading'])}</p>
     </div>
   {:else if messages.length === 0}
     <div class="empty" role="status" aria-live="polite">

--- a/packages/messages/src/svelte/components/MessageStatusIndicator.svelte
+++ b/packages/messages/src/svelte/components/MessageStatusIndicator.svelte
@@ -2,6 +2,10 @@
 /**
  * MessageStatusIndicator - Read/flag/attachment indicators
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../i18n.messages.js';
+
+const { t } = useI18n();
 
 export interface Props {
   isRead: boolean;
@@ -20,23 +24,23 @@ const {
 }: Props = $props();
 </script>
 
-<span class="status-indicators" role="group" aria-label="Message status">
+<span class="status-indicators" role="group" aria-label={t(M['messages.message_status_indicator.status'])}>
   {#if !isRead}
-    <span class="indicator unread" title="Unread" aria-label="Unread">
+    <span class="indicator unread" title={t(M['messages.message_status_indicator.unread'])} aria-label={t(M['messages.message_status_indicator.unread'])}>
       <span class="dot"></span>
     </span>
   {/if}
   {#if isFlagged}
-    <span class="indicator flagged" title="Flagged" aria-label="Flagged">⚑</span>
+    <span class="indicator flagged" title={t(M['messages.message_status_indicator.flagged'])} aria-label={t(M['messages.message_status_indicator.flagged'])}>⚑</span>
   {/if}
   {#if hasAttachments}
-    <span class="indicator attachment" title="Has attachments" aria-label="Has attachments">📎</span>
+    <span class="indicator attachment" title={t(M['messages.message_status_indicator.has_attachments'])} aria-label={t(M['messages.message_status_indicator.has_attachments'])}>📎</span>
   {/if}
   {#if isAnswered}
-    <span class="indicator answered" title="Replied" aria-label="Replied">↩</span>
+    <span class="indicator answered" title={t(M['messages.message_status_indicator.replied'])} aria-label={t(M['messages.message_status_indicator.replied'])}>↩</span>
   {/if}
   {#if isDraft}
-    <span class="indicator draft" title="Draft" aria-label="Draft">✎</span>
+    <span class="indicator draft" title={t(M['messages.message_status_indicator.draft'])} aria-label={t(M['messages.message_status_indicator.draft'])}>✎</span>
   {/if}
 </span>
 

--- a/packages/messages/src/svelte/components/MessageToolbar.svelte
+++ b/packages/messages/src/svelte/components/MessageToolbar.svelte
@@ -2,8 +2,12 @@
 /**
  * MessageToolbar - Bulk action toolbar
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import type { Snippet } from 'svelte';
+import { M } from '../i18n.messages.js';
 import type { BulkAction } from '../types.js';
+
+const { t } = useI18n();
 
 export interface Props {
   selectedCount: number;
@@ -24,10 +28,10 @@ const {
 }: Props = $props();
 </script>
 
-<div class="toolbar" role="toolbar" aria-label="Message actions">
+<div class="toolbar" role="toolbar" aria-label={t(M['messages.message_toolbar.actions_label'])}>
   <div class="selection-info">
     {#if selectedCount > 0}
-      <span class="count">{selectedCount} of {totalCount} selected</span>
+      <span class="count">{t(M['messages.message_toolbar.count_selected'], { selectedCount, totalCount })}</span>
       {#if onclearselection}
         <button class="link-btn" type="button" onclick={onclearselection}>
           Clear
@@ -38,7 +42,7 @@ const {
     {/if}
     {#if onselectall && selectedCount < totalCount}
       <button class="link-btn" type="button" onclick={onselectall}>
-        Select all
+        {t(M['messages.message_toolbar.select_all'])}
       </button>
     {/if}
   </div>
@@ -46,10 +50,10 @@ const {
   {#if selectedCount > 0 && onaction}
     <div class="actions">
       <button class="action-btn" type="button" onclick={() => onaction?.('markRead')}>
-        Mark read
+        {t(M['messages.message_toolbar.mark_read'])}
       </button>
       <button class="action-btn" type="button" onclick={() => onaction?.('markUnread')}>
-        Mark unread
+        {t(M['messages.message_toolbar.mark_unread'])}
       </button>
       <button class="action-btn" type="button" onclick={() => onaction?.('flag')}>
         Flag

--- a/packages/messages/src/svelte/components/ReplyForm.svelte
+++ b/packages/messages/src/svelte/components/ReplyForm.svelte
@@ -10,6 +10,11 @@ export interface Props {
 </script>
 
 <script lang="ts">
+  import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+  import { M } from '../i18n.js';
+
+  const { t } = useI18n();
+
   let {
     originalMessage,
     replyAll = false,
@@ -47,7 +52,7 @@ export interface Props {
   <textarea
     class="reply-body"
     bind:value={body}
-    placeholder="Write your reply..."
+    placeholder={t(M['messages.reply_form.body_placeholder'])}
     rows={5}
   ></textarea>
 

--- a/packages/messages/src/svelte/components/ThreadView.svelte
+++ b/packages/messages/src/svelte/components/ThreadView.svelte
@@ -2,8 +2,12 @@
 /**
  * ThreadView - Conversation thread with collapsible messages
  */
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../i18n.messages.js';
 import type { MessageData } from '../types.js';
 import MessageDetail from './MessageDetail.svelte';
+
+const { t } = useI18n();
 
 export interface Props {
   messages: MessageData[];
@@ -81,7 +85,7 @@ const _sortedMessages = $derived(
 );
 </script>
 
-<div class="thread-view" role="list" aria-label="Conversation thread">
+<div class="thread-view" role="list" aria-label={t(M['messages.thread_view.conversation_thread'])}>
   {#each _sortedMessages as message, i (message.id)}
     <div
       class="thread-message"
@@ -114,8 +118,8 @@ const _sortedMessages = $derived(
               class="collapse-btn"
               type="button"
               onclick={() => toggleCollapse(message.id)}
-              title="Collapse"
-              aria-label="Collapse message"
+              title={t(M['messages.thread_view.collapse'])}
+              aria-label={t(M['messages.thread_view.collapse_message'])}
             >
               ▼
             </button>

--- a/packages/messages/src/svelte/i18n.messages.ts
+++ b/packages/messages/src/svelte/i18n.messages.ts
@@ -1,0 +1,54 @@
+/**
+ * Messages component message catalog (i18n, Sweep S13 #1418).
+ *
+ * English code defaults for user-facing strings in a subset of the messages
+ * Svelte components under `components/`. Keys follow
+ * `messages.<component>.<descriptor>`.
+ */
+import { defineMessages } from '@happyvertical/smrt-svelte/i18n';
+
+export const M = defineMessages({
+  // MessageStatusIndicator
+  'messages.message_status_indicator.status': 'Message status',
+  'messages.message_status_indicator.unread': 'Unread',
+  'messages.message_status_indicator.flagged': 'Flagged',
+  'messages.message_status_indicator.has_attachments': 'Has attachments',
+  'messages.message_status_indicator.replied': 'Replied',
+  'messages.message_status_indicator.draft': 'Draft',
+
+  // MessageFilters
+  'messages.message_filters.filters_label': 'Message filters',
+  'messages.message_filters.search_placeholder': 'Search messages...',
+  'messages.message_filters.search_label': 'Search messages',
+  'messages.message_filters.filter_by_type': 'Filter by type',
+  'messages.message_filters.all_types': 'All types',
+  'messages.message_filters.filter_by_account': 'Filter by account',
+  'messages.message_filters.all_accounts': 'All accounts',
+  'messages.message_filters.filter_by_read_status': 'Filter by read status',
+  'messages.message_filters.unread_only': 'Unread only',
+  'messages.message_filters.read_only': 'Read only',
+  'messages.message_filters.clear_filters': 'Clear filters',
+
+  // MessageList
+  'messages.message_list.messages_label': 'Messages',
+  'messages.message_list.loading': 'Loading messages...',
+
+  // MessageToolbar
+  'messages.message_toolbar.actions_label': 'Message actions',
+  'messages.message_toolbar.count_selected':
+    '{selectedCount} of {totalCount} selected',
+  'messages.message_toolbar.select_all': 'Select all',
+  'messages.message_toolbar.mark_read': 'Mark read',
+  'messages.message_toolbar.mark_unread': 'Mark unread',
+
+  // ThreadView
+  'messages.thread_view.conversation_thread': 'Conversation thread',
+  'messages.thread_view.collapse': 'Collapse',
+  'messages.thread_view.collapse_message': 'Collapse message',
+
+  // MessageCard
+  'messages.message_card.select_message': 'Select message',
+
+  // FolderNav
+  'messages.folder_nav.folders': 'Folders',
+});

--- a/packages/messages/src/svelte/i18n.ts
+++ b/packages/messages/src/svelte/i18n.ts
@@ -1,0 +1,76 @@
+/**
+ * smrt-messages Svelte component message catalog (Sweep S13 #1418).
+ *
+ * English code defaults for user-facing strings in a subset of the messages
+ * components under `src/svelte/components/`. Keys use the `messages.` namespace
+ * (`messages.<component>.<descriptor>`). Importing this module registers the
+ * defaults so `useI18n().t` renders correctly even without a server snapshot.
+ *
+ * `M` is a typed key map — `M['messages.account_list.loading']` is the key
+ * literal — so component call sites stay typo-safe.
+ */
+import { defineMessages } from '@happyvertical/smrt-svelte/i18n';
+
+export const M = defineMessages({
+  // AccountList
+  'messages.account_list.accounts': 'Accounts',
+  'messages.account_list.loading': 'Loading accounts...',
+  'messages.account_list.empty': 'No accounts configured.',
+
+  // AttachmentUpload
+  'messages.attachment_upload.drop_files': 'Drop files or click to attach',
+
+  // ComposeForm
+  'messages.compose_form.subject_placeholder': 'Subject',
+  'messages.compose_form.channel_id_placeholder': 'Channel ID',
+  'messages.compose_form.save_draft': 'Save Draft',
+
+  // EmailAccountManager
+  'messages.email_account_manager.section_description':
+    'Configure email accounts for mailbox access and message routing.',
+  'messages.email_account_manager.add_account': '+ Add Account',
+  'messages.email_account_manager.mail_account': 'Mail Account',
+  'messages.email_account_manager.account_name': 'Account Name',
+  'messages.email_account_manager.account_name_placeholder':
+    'e.g. Work, Personal',
+  'messages.email_account_manager.email_address': 'Email Address',
+  'messages.email_account_manager.email_placeholder': 'user@example.com',
+  'messages.email_account_manager.incoming_mail': 'Incoming Mail (IMAP)',
+  'messages.email_account_manager.imap_host_placeholder': 'imap.example.com',
+  'messages.email_account_manager.outgoing_mail': 'Outgoing Mail (SMTP)',
+  'messages.email_account_manager.smtp_host_placeholder': 'smtp.example.com',
+  'messages.email_account_manager.username_placeholder': 'user@example.com',
+  'messages.email_account_manager.connection_successful':
+    'Connection successful',
+  'messages.email_account_manager.connection_failed': 'Connection failed:',
+  'messages.email_account_manager.empty': 'No mail accounts configured yet.',
+  'messages.email_account_manager.imap_host_title': 'IMAP: {host}:{port}',
+  'messages.email_account_manager.test_connection': 'Test connection',
+  'messages.email_account_manager.remove': 'Remove',
+
+  // EmailFilterManager
+  'messages.email_filter_manager.whitelist_description':
+    'Whitelisted senders bypass blacklist checks and are always allowed through.',
+  'messages.email_filter_manager.add_whitelist_entry': 'Add Whitelist Entry',
+  'messages.email_filter_manager.category_placeholder': 'e.g. support, sales',
+  'messages.email_filter_manager.whitelist_description_placeholder':
+    'Why is this entry whitelisted?',
+  'messages.email_filter_manager.no_whitelist_entries':
+    'No whitelist entries yet.',
+  'messages.email_filter_manager.whitelist_remove': 'Remove',
+  'messages.email_filter_manager.blacklist_description':
+    'Blacklisted senders are automatically blocked or archived.',
+  'messages.email_filter_manager.add_blacklist_entry': 'Add Blacklist Entry',
+  'messages.email_filter_manager.reason_placeholder':
+    'Why is this entry blocked?',
+  'messages.email_filter_manager.no_blacklist_entries':
+    'No blacklist entries yet.',
+  'messages.email_filter_manager.blacklist_remove': 'Remove',
+
+  // ForwardForm
+  'messages.forward_form.header': 'Forward message',
+  'messages.forward_form.note_placeholder': 'Add a note (optional)...',
+
+  // ReplyForm
+  'messages.reply_form.body_placeholder': 'Write your reply...',
+});

--- a/scripts/check-hardcoded-strings.mjs
+++ b/scripts/check-hardcoded-strings.mjs
@@ -45,6 +45,7 @@ const STRICT_PACKAGES = new Set([
   'chat',
   'content',
   'events',
+  'messages',
 ]);
 
 // Dev/playground host, not a shippable library (consistent with the other ratchets).


### PR DESCRIPTION
## What

**messages** was coverage-blocked (54% < its 70% T2 floor). This combined
**extract + test** PR clears it — and **fixes two real bugs** the new tests surfaced.

## i18n
- Extract **65 keys** across 14 components (catalogs `i18n.ts` + `i18n.messages.ts`).
- Add `messages` to `STRICT_PACKAGES` (**15 strict** now).

## Coverage: 54.38% → 87.89%
~170 new tests (orchestrated as 5 parallel subagents on disjoint files):
- **EmailAccount** (6.71%→82%) — mock only the `createClient()` email/secrets
  boundary (`vi.spyOn`), real DB otherwise.
- **senders** — injected mock client (per the existing `senders.test.ts` pattern).
- **Account / Message** extensions, the small models (Whitelist/Blacklist/
  EmailFolder/EmailAttachment), and all **collection** classes
  (Message/Email/Account/EmailAccount/Attachment → **98–100%**).

## Bug fixes (found by the new tests)
`EmailAccount.syncFrom()` and `EmailFolderCollection.createSystemFolders()`
created child rows via `new Model(...)` + `save()` **without `initialize()`**, so
the DB connection was never bound and `save()` threw *"Database accessed before
initialization"* — meaning **`syncFrom` silently persisted nothing**. Both now
initialize (or create through the collection) before save.

## Validation
- `turbo typecheck` 78/78 (a11y gate clean).
- **221 tests pass** (15 skipped incl. the pre-existing #717 `describe.skip`);
  **coverage gate green** (87.89% ≥ 70% T2).
- ratchet 0; full build 50/50.

Coverage-blocked progress: **events + messages done**; products / images remain.