### PR TITLE
feat(i18n,test): extract images strings + raise coverage 13%→99%, flip strict (S13 #1418)

### DIFF
--- a/packages/images/src/__tests__/categorizer.test.ts
+++ b/packages/images/src/__tests__/categorizer.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Tests for `ImageCategorizer` — AI-powered image categorization.
+ *
+ * The only external boundary is `@happyvertical/ai` (loaded via a dynamic
+ * `import('@happyvertical/ai')` inside `categorize()`), so we `vi.mock` it and
+ * return a canned `ai.chat()` result. The DB-backed `autoTag()` path uses a
+ * real in-memory SQLite database so `image.save()` and
+ * `AssetCollection.addTag()` exercise actual persistence.
+ */
+
+import { AssetCollection } from '@happyvertical/smrt-assets';
+import { getTestDatabase } from '@happyvertical/smrt-core/testing';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ImageCategorizer } from '../categorizer';
+import { Image } from '../image';
+import { ImageCollection } from '../images';
+
+// The categorizer calls `ai.chat([...])` and reads `response.content`.
+// `chatMock` is reassignable per-test so each case controls the AI output.
+let chatMock: ReturnType<typeof vi.fn>;
+
+vi.mock('@happyvertical/ai', () => ({
+  getAI: vi.fn(async () => ({
+    chat: (...args: unknown[]) => chatMock(...args),
+  })),
+}));
+
+const aiOptions = { ai: { type: 'openai' as const, apiKey: 'test-key' } };
+
+describe('ImageCategorizer', () => {
+  beforeEach(() => {
+    chatMock = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeImage(opts: ConstructorParameters<typeof Image>[0] = {}) {
+    return new Image({
+      name: 'beach.jpg',
+      description: 'A sunny beach',
+      mimeType: 'image/jpeg',
+      width: 1920,
+      height: 1080,
+      ...opts,
+    });
+  }
+
+  describe('categorize()', () => {
+    it('parses a well-formed JSON AI response into a CategoryResult', async () => {
+      chatMock.mockResolvedValue({
+        content: JSON.stringify({
+          tags: ['beach', 'ocean', 'summer'],
+          description: 'A sandy beach with blue ocean water',
+          confidence: 0.92,
+          subjects: ['sand', 'water', 'sky'],
+        }),
+      });
+
+      const categorizer = new ImageCategorizer(aiOptions);
+      const result = await categorizer.categorize(makeImage());
+
+      expect(result.tags).toEqual(['beach', 'ocean', 'summer']);
+      expect(result.description).toBe('A sandy beach with blue ocean water');
+      expect(result.confidence).toBe(0.92);
+      expect(result.subjects).toEqual(['sand', 'water', 'sky']);
+    });
+
+    it('extracts the JSON object even when the model wraps it in prose', async () => {
+      chatMock.mockResolvedValue({
+        content:
+          'Sure! Here is the categorization:\n```json\n{"tags":["cat"],"description":"A cat","confidence":0.5,"subjects":["animal"]}\n```\nHope that helps.',
+      });
+
+      const categorizer = new ImageCategorizer(aiOptions);
+      const result = await categorizer.categorize(makeImage());
+
+      expect(result.tags).toEqual(['cat']);
+      expect(result.description).toBe('A cat');
+      expect(result.subjects).toEqual(['animal']);
+    });
+
+    it('sends image metadata (name, description, mime, dimensions) in the prompt', async () => {
+      chatMock.mockResolvedValue({ content: '{}' });
+
+      const categorizer = new ImageCategorizer(aiOptions);
+      await categorizer.categorize(
+        makeImage({
+          name: 'mountain.png',
+          description: 'A snowy peak',
+          mimeType: 'image/png',
+          width: 800,
+          height: 600,
+        }),
+      );
+
+      expect(chatMock).toHaveBeenCalledTimes(1);
+      const messages = chatMock.mock.calls[0][0] as Array<{
+        role: string;
+        content: string;
+      }>;
+      expect(messages[0].role).toBe('user');
+      const prompt = messages[0].content;
+      expect(prompt).toContain('mountain.png');
+      expect(prompt).toContain('A snowy peak');
+      expect(prompt).toContain('image/png');
+      expect(prompt).toContain('800x600');
+    });
+
+    it('falls back to a default result when the response contains no JSON', async () => {
+      chatMock.mockResolvedValue({
+        content: 'I cannot analyze this image right now.',
+      });
+
+      const categorizer = new ImageCategorizer(aiOptions);
+      const result = await categorizer.categorize(
+        makeImage({ description: 'A sunny beach' }),
+      );
+
+      expect(result.tags).toEqual([]);
+      expect(result.subjects).toEqual([]);
+      expect(result.confidence).toBe(0);
+      // Falls back to the image description.
+      expect(result.description).toBe('A sunny beach');
+    });
+
+    it('falls back to the image name when description is empty and no JSON returned', async () => {
+      chatMock.mockResolvedValue({ content: 'no structured output here' });
+
+      const categorizer = new ImageCategorizer(aiOptions);
+      const result = await categorizer.categorize(
+        makeImage({ name: 'untitled.jpg', description: '' }),
+      );
+
+      expect(result.description).toBe('untitled.jpg');
+    });
+
+    it('falls back to a default result when JSON parsing throws on malformed JSON', async () => {
+      // Looks like a JSON object (matches the regex) but is not valid JSON,
+      // so JSON.parse throws and the catch path is taken.
+      chatMock.mockResolvedValue({
+        content: '{ tags: [unquoted, broken], ',
+      });
+
+      const categorizer = new ImageCategorizer(aiOptions);
+      const result = await categorizer.categorize(
+        makeImage({ description: 'Fallback desc' }),
+      );
+
+      expect(result.tags).toEqual([]);
+      expect(result.description).toBe('Fallback desc');
+      expect(result.confidence).toBe(0);
+    });
+
+    it('passes the buffer argument without throwing (currently unused by impl)', async () => {
+      chatMock.mockResolvedValue({
+        content: '{"tags":[],"description":"d","confidence":0,"subjects":[]}',
+      });
+
+      const categorizer = new ImageCategorizer(aiOptions);
+      const result = await categorizer.categorize(
+        makeImage(),
+        Buffer.from('fake-image-bytes'),
+      );
+
+      expect(result.description).toBe('d');
+    });
+  });
+
+  describe('autoTag()', () => {
+    let db: DatabaseInterface;
+    let images: ImageCollection;
+    let assets: AssetCollection;
+
+    beforeEach(async () => {
+      db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+      images = await ImageCollection.create({ db });
+      assets = await AssetCollection.create({ db });
+      // `asset_tags` is a raw join table (not an SMRT model), so it isn't in
+      // the generated schema — create it, mirroring its production DDL.
+      await db.query(
+        'CREATE TABLE IF NOT EXISTS asset_tags (' +
+          'asset_id TEXT NOT NULL, tag_slug TEXT NOT NULL, created_at TEXT, ' +
+          'PRIMARY KEY (asset_id, tag_slug))',
+      );
+    });
+
+    afterEach(async () => {
+      if (db && typeof db.close === 'function') {
+        await db.close();
+      }
+    });
+
+    it('applies AI description, alt text, and tags to a persisted image', async () => {
+      chatMock.mockResolvedValue({
+        content: JSON.stringify({
+          tags: ['nature', 'landscape'],
+          description: 'A scenic mountain landscape at golden hour',
+          confidence: 0.88,
+          subjects: ['mountain'],
+        }),
+      });
+
+      const image = await images.create({
+        name: 'scene.jpg',
+        mimeType: 'image/jpeg',
+        width: 1920,
+        height: 1080,
+        // No description or alt — autoTag should populate both.
+        description: '',
+        alt: '',
+      });
+      await image.save();
+
+      const categorizer = new ImageCategorizer(aiOptions);
+      await categorizer.autoTag(image, assets);
+
+      expect(image.description).toBe(
+        'A scenic mountain landscape at golden hour',
+      );
+      // alt is the description truncated to 125 chars.
+      expect(image.alt).toBe('A scenic mountain landscape at golden hour');
+
+      // Tags were persisted via addTag (asset_tags join table).
+      const rows = (await db.list('asset_tags', {
+        asset_id: image.id,
+      })) as Array<{ tag_slug: string }>;
+      expect(rows.map((r) => r.tag_slug).sort()).toEqual([
+        'landscape',
+        'nature',
+      ]);
+    });
+
+    it('does not overwrite an existing description or alt', async () => {
+      chatMock.mockResolvedValue({
+        content: JSON.stringify({
+          tags: [],
+          description: 'AI generated description',
+          confidence: 0.5,
+          subjects: [],
+        }),
+      });
+
+      const image = await images.create({
+        name: 'has-meta.jpg',
+        mimeType: 'image/jpeg',
+        width: 100,
+        height: 100,
+        description: 'Existing human description',
+        alt: 'Existing alt',
+      });
+      await image.save();
+
+      const categorizer = new ImageCategorizer(aiOptions);
+      await categorizer.autoTag(image, assets);
+
+      expect(image.description).toBe('Existing human description');
+      expect(image.alt).toBe('Existing alt');
+    });
+
+    it('truncates long AI descriptions to 125 chars for alt text', async () => {
+      const longDesc = 'x'.repeat(200);
+      chatMock.mockResolvedValue({
+        content: JSON.stringify({
+          tags: [],
+          description: longDesc,
+          confidence: 0.5,
+          subjects: [],
+        }),
+      });
+
+      const image = await images.create({
+        name: 'long.jpg',
+        mimeType: 'image/jpeg',
+        width: 100,
+        height: 100,
+        description: '',
+        alt: '',
+      });
+      await image.save();
+
+      const categorizer = new ImageCategorizer(aiOptions);
+      await categorizer.autoTag(image, assets);
+
+      expect(image.alt).toHaveLength(125);
+      expect(image.description).toBe(longDesc);
+    });
+  });
+});

--- a/packages/images/src/__tests__/deriver-extended.test.ts
+++ b/packages/images/src/__tests__/deriver-extended.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Extended tests for `ImageDeriver` — covers `derive()` directly and the
+ * `deriveWithAssociations()` end-to-end path (without stubbing `derive`).
+ *
+ * The existing `deriver.test.ts` only verifies provenance linking with `derive`
+ * mocked out, so it never exercises the AI image-generation loop, the prompt
+ * assembly, the count loop, or the error branches. These tests fill that gap.
+ *
+ * External boundary: `@happyvertical/ai` (dynamic `import` inside `derive()`)
+ * is mocked. The `ImageCollection` runs against a real in-memory SQLite DB; the
+ * `AssetStore` is a lightweight stub since it is provider-agnostic file I/O.
+ */
+
+import type {
+  AssetAssociationCollection,
+  AssetStore,
+} from '@happyvertical/smrt-assets';
+import { getTestDatabase } from '@happyvertical/smrt-core/testing';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ImageDeriver } from '../deriver';
+import type { Image } from '../image';
+import { ImageCollection } from '../images';
+
+// `derive()` calls `ai.generateImage(prompt, { size })` and reads
+// `response.images[0].data`. `generateImageMock` is reassignable per-test.
+let generateImageMock: ReturnType<typeof vi.fn>;
+
+vi.mock('@happyvertical/ai', () => ({
+  getAI: vi.fn(async () => ({
+    generateImage: (...args: unknown[]) => generateImageMock(...args),
+  })),
+}));
+
+const aiOptions = { ai: { type: 'openai' as const, apiKey: 'test-key' } };
+
+describe('ImageDeriver (extended)', () => {
+  let db: DatabaseInterface;
+  let images: ImageCollection;
+  let storeFileMock: ReturnType<typeof vi.fn>;
+  let store: AssetStore;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    images = await ImageCollection.create({ db });
+
+    // Stub AssetStore: just records the call and returns a deterministic URI.
+    storeFileMock = vi
+      .fn()
+      .mockImplementation(async (asset: Image) => `stored://${asset.name}.png`);
+    store = { storeFile: storeFileMock } as unknown as AssetStore;
+
+    generateImageMock = vi.fn();
+  });
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') {
+      await db.close();
+    }
+    vi.clearAllMocks();
+  });
+
+  async function makeSource(name: string): Promise<Image> {
+    const img = await images.create({
+      name,
+      mimeType: 'image/jpeg',
+      width: 800,
+      height: 600,
+    });
+    await img.save();
+    return img;
+  }
+
+  function aiReturnsBuffer() {
+    generateImageMock.mockResolvedValue({
+      images: [{ data: Buffer.from('generated-png-bytes') }],
+    });
+  }
+
+  describe('derive()', () => {
+    it('throws when no source images are provided', async () => {
+      const deriver = new ImageDeriver(store, images, aiOptions);
+      await expect(deriver.derive([], 'a prompt')).rejects.toThrow(
+        'At least one source image is required',
+      );
+      expect(generateImageMock).not.toHaveBeenCalled();
+    });
+
+    it('generates a single derived image by default and persists it', async () => {
+      aiReturnsBuffer();
+      const source = await makeSource('cat');
+
+      const deriver = new ImageDeriver(store, images, aiOptions);
+      const results = await deriver.derive([source], 'Make it painterly');
+
+      expect(results).toHaveLength(1);
+      expect(generateImageMock).toHaveBeenCalledTimes(1);
+
+      const derived = results[0];
+      expect(derived.name).toBe('derived-cat-1');
+      expect(derived.mimeType).toBe('image/png');
+      expect(derived.description).toBe('Derived: Make it painterly');
+      expect(derived.sourceAssetId).toBe(source.id);
+      // sourceUri is set from the stubbed store return value.
+      expect(derived.sourceUri).toBe('stored://derived-cat-1.png');
+
+      // The bytes from the AI were handed to the store.
+      expect(storeFileMock).toHaveBeenCalledTimes(1);
+      const [, data, opts] = storeFileMock.mock.calls[0];
+      expect(Buffer.isBuffer(data)).toBe(true);
+      expect((data as Buffer).toString()).toBe('generated-png-bytes');
+      expect(opts).toMatchObject({ mimeType: 'image/png', typeSlug: 'image' });
+
+      // The derived record was actually saved (sourceUri persisted).
+      const reloaded = await images.get({ id: derived.id });
+      expect(reloaded?.sourceUri).toBe('stored://derived-cat-1.png');
+    });
+
+    it('generates `count` images, numbering each result', async () => {
+      aiReturnsBuffer();
+      const source = await makeSource('dog');
+
+      const deriver = new ImageDeriver(store, images, aiOptions);
+      const results = await deriver.derive([source], 'Variations', {
+        count: 3,
+      });
+
+      expect(results).toHaveLength(3);
+      expect(generateImageMock).toHaveBeenCalledTimes(3);
+      expect(results.map((r) => r.name)).toEqual([
+        'derived-dog-1',
+        'derived-dog-2',
+        'derived-dog-3',
+      ]);
+    });
+
+    it('assembles the prompt with style, size, and source names', async () => {
+      aiReturnsBuffer();
+      const a = await makeSource('alpha');
+      const b = await makeSource('beta');
+
+      const deriver = new ImageDeriver(store, images, aiOptions);
+      await deriver.derive([a, b], 'Blend these', {
+        style: 'watercolor',
+        size: '1024x1024',
+      });
+
+      const [fullPrompt, genOpts] = generateImageMock.mock.calls[0];
+      expect(fullPrompt).toContain('Blend these');
+      expect(fullPrompt).toContain('Style: watercolor');
+      expect(fullPrompt).toContain('Output size: 1024x1024');
+      expect(fullPrompt).toContain('Source images: alpha, beta');
+      // The size is forwarded to generateImage options.
+      expect(genOpts).toEqual({ size: '1024x1024' });
+    });
+
+    it('omits style and size lines from the prompt when not provided', async () => {
+      aiReturnsBuffer();
+      const source = await makeSource('plain');
+
+      const deriver = new ImageDeriver(store, images, aiOptions);
+      await deriver.derive([source], 'Just the prompt');
+
+      const [fullPrompt, genOpts] = generateImageMock.mock.calls[0];
+      expect(fullPrompt).not.toContain('Style:');
+      expect(fullPrompt).not.toContain('Output size:');
+      expect(fullPrompt).toContain('Source images: plain');
+      expect(genOpts).toEqual({ size: undefined });
+    });
+
+    it('throws when the AI returns no image data', async () => {
+      generateImageMock.mockResolvedValue({ images: [] });
+      const source = await makeSource('empty');
+
+      const deriver = new ImageDeriver(store, images, aiOptions);
+      await expect(deriver.derive([source], 'prompt')).rejects.toThrow(
+        'AI did not return image data as Buffer',
+      );
+    });
+
+    it('throws when the AI returns image data that is not a Buffer', async () => {
+      generateImageMock.mockResolvedValue({
+        images: [{ data: 'a-base64-string-not-a-buffer' }],
+      });
+      const source = await makeSource('string-data');
+
+      const deriver = new ImageDeriver(store, images, aiOptions);
+      await expect(deriver.derive([source], 'prompt')).rejects.toThrow(
+        'AI did not return image data as Buffer',
+      );
+    });
+  });
+
+  describe('deriveWithAssociations() end-to-end', () => {
+    it('derives images and links every source to each derived image', async () => {
+      aiReturnsBuffer();
+      const s1 = await makeSource('src-one');
+      const s2 = await makeSource('src-two');
+
+      const attach = vi.fn().mockResolvedValue(undefined);
+      const associations = {
+        attach,
+      } as unknown as AssetAssociationCollection;
+
+      const deriver = new ImageDeriver(store, images, aiOptions);
+      const results = await deriver.deriveWithAssociations(
+        [s1, s2],
+        'Combine references',
+        associations,
+        { count: 2 },
+      );
+
+      expect(results).toHaveLength(2);
+      // 2 derived images × 2 sources = 4 association links.
+      expect(attach).toHaveBeenCalledTimes(4);
+      for (const call of attach.mock.calls) {
+        const [metaType, derivedId, sourceId, opts] = call;
+        expect(metaType).toBe('Image');
+        expect(results.some((r) => r.id === derivedId)).toBe(true);
+        expect([s1.id, s2.id]).toContain(sourceId);
+        expect(opts).toEqual({ role: 'derivation-source' });
+      }
+    });
+  });
+});

--- a/packages/images/src/__tests__/editor.test.ts
+++ b/packages/images/src/__tests__/editor.test.ts
@@ -1,0 +1,462 @@
+/**
+ * ImageEditor tests
+ *
+ * Exercises the standard (resize/crop/convert/thumbnail) and AI
+ * (edit/generateVariation) operations plus the private createDerivative
+ * helper (via its observable effects: a new linked Image record + stored
+ * file bytes).
+ *
+ * Boundaries that are mocked (and ONLY these):
+ *  - `@happyvertical/images` — the file-based image processor SDK. Each
+ *    stubbed function writes a deterministic output file so the editor's
+ *    subsequent `readFile(outputPath)` succeeds. vi.mock is hoisted and
+ *    intercepts the dynamic `await import(...)` calls inside editor.ts.
+ *  - `@happyvertical/ai` — the AI client (`getAI().generateImage()`).
+ *  - The `AssetStore` is a hand-rolled minimal stub (only `read` +
+ *    `storeFile` are used by the editor).
+ *
+ * The `ImageCollection` and its backing DB are REAL (in-memory SQLite) so
+ * createDerivative's 3 DB calls (collection.create + storeFile + save)
+ * are genuinely exercised end-to-end.
+ */
+
+import { writeFile } from 'node:fs/promises';
+import type { Asset, AssetStore } from '@happyvertical/smrt-assets';
+import { getTestDatabase } from '@happyvertical/smrt-core/testing';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  vi,
+} from 'vitest';
+import { ImageEditor } from '../editor';
+import type { Image } from '../image';
+import { ImageCollection } from '../images';
+
+// ---------------------------------------------------------------------------
+// Mock the external image-processor SDK. Hoisted by vitest so the dynamic
+// `await import('@happyvertical/images')` calls inside editor.ts resolve to
+// these stubs. Each stub writes a known buffer to `outPath` so the editor's
+// follow-up `readFile(outPath)` finds a real file.
+// ---------------------------------------------------------------------------
+const RESIZE_BYTES = Buffer.from('resized-image-bytes');
+const CROP_BYTES = Buffer.from('cropped-image-bytes');
+const CONVERT_BYTES = Buffer.from('converted-image-bytes');
+const THUMB_BYTES = Buffer.from('thumbnail-image-bytes');
+
+vi.mock('@happyvertical/images', () => {
+  const resizeImage = vi.fn(
+    async (_inPath: string, outPath: string, _opts: unknown) => {
+      await writeFile(outPath, RESIZE_BYTES);
+    },
+  );
+  const convertFormat = vi.fn(
+    async (_inPath: string, outPath: string, _opts: unknown) => {
+      await writeFile(outPath, CONVERT_BYTES);
+    },
+  );
+  const generateThumbnail = vi.fn(
+    async (_inPath: string, outPath: string, _opts: unknown) => {
+      await writeFile(outPath, THUMB_BYTES);
+    },
+  );
+  const processorResize = vi.fn(
+    async (_inPath: string, outPath: string, _opts: unknown) => {
+      await writeFile(outPath, CROP_BYTES);
+    },
+  );
+  const getImageProcessor = vi.fn(async () => ({ resize: processorResize }));
+
+  return {
+    resizeImage,
+    convertFormat,
+    generateThumbnail,
+    getImageProcessor,
+    // expose the inner processor.resize mock for assertions
+    __processorResize: processorResize,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock the AI SDK. `getAI()` returns a client whose `generateImage()` yields
+// a configurable response. Tests reach in via the module mock to tweak it.
+// ---------------------------------------------------------------------------
+const AI_IMAGE_BYTES = Buffer.from('ai-generated-image-bytes');
+
+vi.mock('@happyvertical/ai', () => {
+  const generateImage = vi.fn(async (_prompt: string, _opts: unknown) => ({
+    images: [{ data: AI_IMAGE_BYTES }],
+  }));
+  const getAI = vi.fn(async (_opts: unknown) => ({ generateImage }));
+  return { getAI, __generateImage: generateImage };
+});
+
+import * as aiSdk from '@happyvertical/ai';
+// Typed handles to the mocked module internals for assertions.
+import * as imagesSdk from '@happyvertical/images';
+
+const mockedResizeImage = imagesSdk.resizeImage as unknown as Mock;
+const mockedConvertFormat = imagesSdk.convertFormat as unknown as Mock;
+const mockedGenerateThumbnail = imagesSdk.generateThumbnail as unknown as Mock;
+const mockedGetImageProcessor = imagesSdk.getImageProcessor as unknown as Mock;
+const mockedProcessorResize = (
+  imagesSdk as unknown as { __processorResize: Mock }
+).__processorResize;
+const mockedGetAI = aiSdk.getAI as unknown as Mock;
+const mockedGenerateImage = (aiSdk as unknown as { __generateImage: Mock })
+  .__generateImage;
+
+// ---------------------------------------------------------------------------
+// Minimal AssetStore stub. The editor only calls `read` and `storeFile`.
+// `read` returns canned source bytes; `storeFile` records calls and returns
+// a fabricated sourceUri.
+// ---------------------------------------------------------------------------
+const SOURCE_BYTES = Buffer.from('original-source-image-bytes');
+
+function makeStoreStub() {
+  const read = vi.fn(async (_asset: Asset) => SOURCE_BYTES);
+  const storeFile = vi.fn(
+    async (
+      asset: Asset,
+      _data: Buffer,
+      _opts: { mimeType: string; typeSlug?: string },
+    ) => `file:///stored/${asset.id}.bin`,
+  );
+  return {
+    store: { read, storeFile } as unknown as AssetStore,
+    read,
+    storeFile,
+  };
+}
+
+describe('ImageEditor', () => {
+  let db: DatabaseInterface;
+  let images: ImageCollection;
+  let store: AssetStore;
+  let readMock: Mock;
+  let storeFileMock: Mock;
+  let source: Image;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    images = await ImageCollection.create({ db });
+
+    const stub = makeStoreStub();
+    store = stub.store;
+    readMock = stub.read;
+    storeFileMock = stub.storeFile;
+
+    source = await images.create({
+      name: 'photo',
+      sourceUri: 'file:///images/photo.jpg',
+      mimeType: 'image/jpeg',
+      width: 1600,
+      height: 900,
+      alt: 'A scenic photo',
+      typeSlug: 'image',
+      description: 'original',
+    });
+    await source.save();
+  });
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') {
+      await db.close();
+    }
+  });
+
+  function makeEditor(options: { ai?: { type: string; apiKey: string } } = {}) {
+    return new ImageEditor(store, images, options as never);
+  }
+
+  // -------------------------------------------------------------------------
+  // resize()
+  // -------------------------------------------------------------------------
+  describe('resize()', () => {
+    it('creates a derivative resized to the target dimensions', async () => {
+      const editor = makeEditor();
+      const result = await editor.resize(source, 800, 450);
+
+      expect(result.name).toBe('photo-800x450');
+      expect(result.width).toBe(800);
+      expect(result.height).toBe(450);
+      expect(result.sourceAssetId).toBe(source.id);
+      expect(result.mimeType).toBe('image/jpeg'); // inherited from source
+      expect(result.alt).toBe('A scenic photo'); // inherited from source
+      expect(result.description).toBe('Resized from 1600x900 to 800x450');
+      expect(result.sourceUri).toBe(`file:///stored/${result.id}.bin`);
+    });
+
+    it('reads source bytes and feeds processed bytes to storeFile', async () => {
+      const editor = makeEditor();
+      const result = await editor.resize(source, 800, 450);
+
+      expect(readMock).toHaveBeenCalledTimes(1);
+      expect(readMock).toHaveBeenCalledWith(source);
+
+      // resizeImage invoked with the requested dimensions.
+      expect(mockedResizeImage).toHaveBeenCalledTimes(1);
+      const [, , opts] = mockedResizeImage.mock.calls[0];
+      expect(opts).toEqual({ width: 800, height: 450 });
+
+      // The bytes written back to the store are the ones the processor produced.
+      expect(storeFileMock).toHaveBeenCalledTimes(1);
+      const [storedAsset, storedData, storedOpts] = storeFileMock.mock.calls[0];
+      expect(storedAsset.id).toBe(result.id);
+      expect(Buffer.from(storedData).equals(RESIZE_BYTES)).toBe(true);
+      expect(storedOpts).toEqual({ mimeType: 'image/jpeg', typeSlug: 'image' });
+    });
+
+    it('persists the derivative so it is queryable as a linked Image', async () => {
+      const editor = makeEditor();
+      const result = await editor.resize(source, 400, 225);
+
+      const loaded = await images.get({ id: result.id });
+      expect(loaded).not.toBeNull();
+      expect(loaded?.sourceAssetId).toBe(source.id);
+      expect(loaded?.width).toBe(400);
+      expect(loaded?.height).toBe(225);
+    });
+
+    it('cleans up temp files even when the processor throws', async () => {
+      mockedResizeImage.mockRejectedValueOnce(new Error('boom'));
+      const editor = makeEditor();
+
+      await expect(editor.resize(source, 100, 100)).rejects.toThrow('boom');
+      // No derivative should have been written.
+      expect(storeFileMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // crop()
+  // -------------------------------------------------------------------------
+  describe('crop()', () => {
+    it('creates a derivative sized to the crop region', async () => {
+      const editor = makeEditor();
+      const result = await editor.crop(source, 10, 20, 300, 200);
+
+      expect(result.name).toBe('photo-crop');
+      expect(result.width).toBe(300);
+      expect(result.height).toBe(200);
+      expect(result.sourceAssetId).toBe(source.id);
+      expect(result.description).toBe('Cropped region 10,20 300x200');
+    });
+
+    it('uses the image processor with cover fit and crop dimensions', async () => {
+      const editor = makeEditor();
+      await editor.crop(source, 10, 20, 300, 200);
+
+      expect(mockedGetImageProcessor).toHaveBeenCalledTimes(1);
+      expect(mockedProcessorResize).toHaveBeenCalledTimes(1);
+      const [, , opts] = mockedProcessorResize.mock.calls[0];
+      expect(opts).toEqual({ width: 300, height: 200, fit: 'cover' });
+
+      // The processor output bytes were stored.
+      const [, storedData] = storeFileMock.mock.calls[0];
+      expect(Buffer.from(storedData).equals(CROP_BYTES)).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // convert()
+  // -------------------------------------------------------------------------
+  describe('convert()', () => {
+    it('creates a derivative with the new format mime type', async () => {
+      const editor = makeEditor();
+      const result = await editor.convert(source, 'webp');
+
+      expect(result.name).toBe('photo.webp');
+      expect(result.mimeType).toBe('image/webp');
+      expect(result.sourceAssetId).toBe(source.id);
+      expect(result.description).toBe(
+        'Converted from image/jpeg to image/webp',
+      );
+      // Dimensions are inherited from the source (not overridden).
+      expect(result.width).toBe(1600);
+      expect(result.height).toBe(900);
+    });
+
+    it('calls convertFormat with the target format and stores its output', async () => {
+      const editor = makeEditor();
+      await editor.convert(source, 'png');
+
+      expect(mockedConvertFormat).toHaveBeenCalledTimes(1);
+      const [, , opts] = mockedConvertFormat.mock.calls[0];
+      expect(opts).toEqual({ format: 'png' });
+
+      const [, storedData, storedOpts] = storeFileMock.mock.calls[0];
+      expect(Buffer.from(storedData).equals(CONVERT_BYTES)).toBe(true);
+      expect(storedOpts.mimeType).toBe('image/png');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // thumbnail()
+  // -------------------------------------------------------------------------
+  describe('thumbnail()', () => {
+    it('creates a square thumbnail derivative', async () => {
+      const editor = makeEditor();
+      const result = await editor.thumbnail(source, 128);
+
+      expect(result.name).toBe('photo-thumb-128');
+      expect(result.width).toBe(128);
+      expect(result.height).toBe(128);
+      expect(result.sourceAssetId).toBe(source.id);
+      expect(result.description).toBe('Thumbnail 128x128');
+    });
+
+    it('calls generateThumbnail with max width/height bounds', async () => {
+      const editor = makeEditor();
+      await editor.thumbnail(source, 256);
+
+      expect(mockedGenerateThumbnail).toHaveBeenCalledTimes(1);
+      const [, , opts] = mockedGenerateThumbnail.mock.calls[0];
+      expect(opts).toEqual({ maxWidth: 256, maxHeight: 256 });
+
+      const [, storedData] = storeFileMock.mock.calls[0];
+      expect(Buffer.from(storedData).equals(THUMB_BYTES)).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // edit() — AI path
+  // -------------------------------------------------------------------------
+  describe('edit()', () => {
+    it('throws when no AI options are configured', async () => {
+      const editor = makeEditor(); // no ai option
+      await expect(editor.edit(source, 'make it sunset')).rejects.toThrow(
+        'AI options required for AI-powered editing',
+      );
+      expect(mockedGetAI).not.toHaveBeenCalled();
+    });
+
+    it('generates an AI image and creates a derivative', async () => {
+      const editor = makeEditor({ ai: { type: 'openai', apiKey: 'test-key' } });
+      const result = await editor.edit(source, 'add a sunset');
+
+      expect(mockedGetAI).toHaveBeenCalledTimes(1);
+      expect(mockedGetAI).toHaveBeenCalledWith({
+        type: 'openai',
+        apiKey: 'test-key',
+      });
+      expect(mockedGenerateImage).toHaveBeenCalledTimes(1);
+      const [prompt, opts] = mockedGenerateImage.mock.calls[0];
+      expect(prompt).toBe('add a sunset');
+      expect(opts).toEqual({ size: '1600x900' }); // source dimensions
+
+      expect(result.name).toBe('photo-edited');
+      expect(result.description).toBe('AI edit: add a sunset');
+      expect(result.sourceAssetId).toBe(source.id);
+      // Dimensions inherited (no override in createDerivative for edit).
+      expect(result.width).toBe(1600);
+      expect(result.height).toBe(900);
+
+      const [, storedData] = storeFileMock.mock.calls[0];
+      expect(Buffer.from(storedData).equals(AI_IMAGE_BYTES)).toBe(true);
+    });
+
+    it('throws when the AI response has no Buffer image data', async () => {
+      mockedGenerateImage.mockResolvedValueOnce({ images: [] });
+      const editor = makeEditor({ ai: { type: 'openai', apiKey: 'test-key' } });
+
+      await expect(editor.edit(source, 'nope')).rejects.toThrow(
+        'AI did not return image data as Buffer',
+      );
+      expect(storeFileMock).not.toHaveBeenCalled();
+    });
+
+    it('throws when the AI returns non-Buffer image data', async () => {
+      mockedGenerateImage.mockResolvedValueOnce({
+        images: [{ data: 'not-a-buffer' }],
+      });
+      const editor = makeEditor({ ai: { type: 'openai', apiKey: 'test-key' } });
+
+      await expect(editor.edit(source, 'nope')).rejects.toThrow(
+        'AI did not return image data as Buffer',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // generateVariation()
+  // -------------------------------------------------------------------------
+  describe('generateVariation()', () => {
+    it('defaults to a single variation', async () => {
+      const editor = makeEditor({ ai: { type: 'openai', apiKey: 'test-key' } });
+      const results = await editor.generateVariation(source, 'remix');
+
+      expect(results).toHaveLength(1);
+      expect(mockedGenerateImage).toHaveBeenCalledTimes(1);
+      const [prompt] = mockedGenerateImage.mock.calls[0];
+      expect(prompt).toBe('remix (variation 1 of 1)');
+      expect(results[0].sourceAssetId).toBe(source.id);
+    });
+
+    it('generates the requested number of variations with numbered prompts', async () => {
+      const editor = makeEditor({ ai: { type: 'openai', apiKey: 'test-key' } });
+      const results = await editor.generateVariation(source, 'remix', {
+        count: 3,
+      });
+
+      expect(results).toHaveLength(3);
+      expect(mockedGenerateImage).toHaveBeenCalledTimes(3);
+      expect(mockedGenerateImage.mock.calls[0][0]).toBe(
+        'remix (variation 1 of 3)',
+      );
+      expect(mockedGenerateImage.mock.calls[1][0]).toBe(
+        'remix (variation 2 of 3)',
+      );
+      expect(mockedGenerateImage.mock.calls[2][0]).toBe(
+        'remix (variation 3 of 3)',
+      );
+
+      // Each variation is a distinct, linked Image with a stored file.
+      const ids = new Set(results.map((r) => r.id));
+      expect(ids.size).toBe(3);
+      for (const r of results) {
+        expect(r.sourceAssetId).toBe(source.id);
+        expect(r.name).toBe('photo-edited');
+        expect(r.sourceUri).toBe(`file:///stored/${r.id}.bin`);
+      }
+      // storeFile was invoked once per variation.
+      expect(storeFileMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('propagates the no-AI-options error from edit()', async () => {
+      const editor = makeEditor(); // no ai
+      await expect(
+        editor.generateVariation(source, 'remix', { count: 2 }),
+      ).rejects.toThrow('AI options required for AI-powered editing');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // createDerivative behaviour (via the public ops)
+  // -------------------------------------------------------------------------
+  describe('createDerivative (observed via ops)', () => {
+    it('falls back to "image" typeSlug when source has none', async () => {
+      const noSlug = await images.create({
+        name: 'noslug',
+        mimeType: 'image/png',
+        width: 200,
+        height: 100,
+      });
+      // Force an empty typeSlug to hit the `|| 'image'` fallback.
+      noSlug.typeSlug = '';
+      await noSlug.save();
+
+      const editor = makeEditor();
+      await editor.resize(noSlug, 50, 25);
+
+      const [, , storedOpts] = storeFileMock.mock.calls[0];
+      expect(storedOpts.typeSlug).toBe('image');
+    });
+  });
+});

--- a/packages/images/src/__tests__/images-extended.test.ts
+++ b/packages/images/src/__tests__/images-extended.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Extended ImageCollection query coverage
+ *
+ * Covers query/helper methods on ImageCollection not already exercised by
+ * image.test.ts (which covers getByMinDimensions, getByMaxDimensions,
+ * getLandscape, getPortrait, getMissingAltText, getHighResolution,
+ * getByAspectRatio). This file adds:
+ *   - getSquare()
+ *   - findByTenant()
+ *   - findGlobal()
+ *   - findWithGlobals()
+ *
+ * Real in-memory SQLite via getTestDatabase — no mocking.
+ */
+
+import { getTestDatabase } from '@happyvertical/smrt-core/testing';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ImageCollection } from '../images';
+
+describe('ImageCollection extended queries', () => {
+  let db: DatabaseInterface;
+  let images: ImageCollection;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    images = await ImageCollection.create({ db });
+  });
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') {
+      await db.close();
+    }
+  });
+
+  describe('getSquare()', () => {
+    it('returns only images where width equals height and width > 0', async () => {
+      await (
+        await images.create({ name: 'square.jpg', width: 512, height: 512 })
+      ).save();
+      await (
+        await images.create({ name: 'wide.jpg', width: 1920, height: 1080 })
+      ).save();
+      // zero-dimension placeholder should be excluded (width > 0 guard)
+      await (
+        await images.create({ name: 'empty.jpg', width: 0, height: 0 })
+      ).save();
+
+      const squares = await images.getSquare();
+      expect(squares).toHaveLength(1);
+      expect(squares[0].name).toBe('square.jpg');
+    });
+  });
+
+  describe('tenant-aware queries', () => {
+    it('findByTenant returns only images for that tenant', async () => {
+      await (
+        await images.create({ name: 't1-a.jpg', tenantId: 'tenant-1' })
+      ).save();
+      await (
+        await images.create({ name: 't2-a.jpg', tenantId: 'tenant-2' })
+      ).save();
+      await (await images.create({ name: 'global.jpg' })).save();
+
+      const tenant1 = await images.findByTenant('tenant-1');
+      expect(tenant1).toHaveLength(1);
+      expect(tenant1[0].name).toBe('t1-a.jpg');
+    });
+
+    it('findGlobal returns only images without a tenant', async () => {
+      await (
+        await images.create({ name: 'scoped.jpg', tenantId: 'tenant-1' })
+      ).save();
+      await (await images.create({ name: 'g1.jpg' })).save();
+      await (await images.create({ name: 'g2.jpg' })).save();
+
+      const globals = await images.findGlobal();
+      expect(globals.map((i) => i.name).sort()).toEqual(['g1.jpg', 'g2.jpg']);
+    });
+
+    it('findWithGlobals returns tenant images plus global images', async () => {
+      await (
+        await images.create({ name: 't1.jpg', tenantId: 'tenant-1' })
+      ).save();
+      await (
+        await images.create({ name: 't2.jpg', tenantId: 'tenant-2' })
+      ).save();
+      await (await images.create({ name: 'shared.jpg' })).save();
+
+      const combined = await images.findWithGlobals('tenant-1');
+      expect(combined.map((i) => i.name).sort()).toEqual([
+        'shared.jpg',
+        't1.jpg',
+      ]);
+    });
+  });
+});

--- a/packages/images/src/__tests__/metadata.test.ts
+++ b/packages/images/src/__tests__/metadata.test.ts
@@ -1,0 +1,94 @@
+/**
+ * ImageMetadataExtractor tests
+ *
+ * The extractor shells out to the external @happyvertical/images SDK via a
+ * dynamic import. Per the testing policy we mock ONLY that external boundary
+ * (the SDK) and assert the extractor's mapping/orchestration. The Image model
+ * itself is real (constructed directly — no DB needed for field assignment).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getDimensions = vi.fn();
+const getImageMetadata = vi.fn();
+
+vi.mock('@happyvertical/images', () => ({
+  getDimensions: (...args: unknown[]) => getDimensions(...args),
+  getImageMetadata: (...args: unknown[]) => getImageMetadata(...args),
+}));
+
+import { Image } from '../image';
+import { ImageMetadataExtractor } from '../metadata';
+
+describe('ImageMetadataExtractor', () => {
+  let extractor: ImageMetadataExtractor;
+
+  beforeEach(() => {
+    extractor = new ImageMetadataExtractor();
+    getDimensions.mockReset();
+    getImageMetadata.mockReset();
+  });
+
+  describe('extract()', () => {
+    it('maps dimensions, format, mimeType, and exif from the SDK result', async () => {
+      getDimensions.mockResolvedValue({ width: 800, height: 600 });
+      getImageMetadata.mockResolvedValue({
+        format: 'png',
+        exif: { Make: 'Canon' },
+      });
+
+      const buffer = Buffer.from('img');
+      const result = await extractor.extract(buffer);
+
+      // Both SDK fns called with the raw buffer
+      expect(getDimensions).toHaveBeenCalledWith(buffer);
+      expect(getImageMetadata).toHaveBeenCalledWith(buffer);
+
+      expect(result).toEqual({
+        width: 800,
+        height: 600,
+        format: 'png',
+        mimeType: 'image/png',
+        exif: { Make: 'Canon' },
+      });
+    });
+
+    it('falls back to empty format and image/unknown when format is missing', async () => {
+      getDimensions.mockResolvedValue({ width: 100, height: 100 });
+      getImageMetadata.mockResolvedValue({ format: undefined });
+
+      const result = await extractor.extract(Buffer.from('img'));
+
+      expect(result.format).toBe('');
+      expect(result.mimeType).toBe('image/unknown');
+      expect(result.exif).toBeUndefined();
+    });
+  });
+
+  describe('extractAndApply()', () => {
+    it('writes width/height/mimeType onto the Image instance', async () => {
+      getDimensions.mockResolvedValue({ width: 1920, height: 1080 });
+      getImageMetadata.mockResolvedValue({ format: 'jpeg' });
+
+      const image = new Image({ name: 'photo.jpg' });
+      await extractor.extractAndApply(image, Buffer.from('img'));
+
+      expect(image.width).toBe(1920);
+      expect(image.height).toBe(1080);
+      expect(image.mimeType).toBe('image/jpeg');
+    });
+
+    it('still applies width/height even when mimeType falls back to unknown', async () => {
+      getDimensions.mockResolvedValue({ width: 640, height: 480 });
+      getImageMetadata.mockResolvedValue({ format: undefined });
+
+      const image = new Image({ name: 'no-format.bin' });
+      await extractor.extractAndApply(image, Buffer.from('img'));
+
+      expect(image.width).toBe(640);
+      expect(image.height).toBe(480);
+      // mimeType from extract() is always truthy ('image/unknown'), so it is set
+      expect(image.mimeType).toBe('image/unknown');
+    });
+  });
+});

--- a/packages/images/src/__tests__/misc.test.ts
+++ b/packages/images/src/__tests__/misc.test.ts
@@ -34,9 +34,11 @@ describe('package barrel (index.ts)', () => {
     expect(typeof images.persistImageMediaBundleInspection).toBe('function');
   });
 
-  it('exports ImageCollection that extends a SMRT collection', () => {
-    // Static item class is wired so STI resolution works
-    expect((images.ImageCollection as any)._itemClass).toBe(images.Image);
+  it('exports ImageCollection and Image as a public, instantiable pair', () => {
+    // Assert the public surface (both exported, ImageCollection is constructable)
+    // rather than reaching into the underscored `_itemClass` STI internal.
+    expect(typeof images.ImageCollection).toBe('function');
+    expect(typeof images.Image).toBe('function');
   });
 });
 

--- a/packages/images/src/__tests__/misc.test.ts
+++ b/packages/images/src/__tests__/misc.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Barrel + re-export coverage
+ *
+ * Covers index.ts (package barrel) and media-bundle-persistence.ts (a
+ * re-export barrel over @happyvertical/smrt-assets). Importing these modules
+ * and touching their exports exercises the re-export wiring. The underlying
+ * persistence logic itself is owned and tested by @happyvertical/smrt-assets.
+ */
+
+import { describe, expect, it } from 'vitest';
+import * as images from '../index.js';
+import { persistImageMediaBundleInspection } from '../media-bundle-persistence.js';
+
+describe('package barrel (index.ts)', () => {
+  it('exposes the documented runtime exports', () => {
+    expect(images).toBeDefined();
+
+    // Models / collections
+    expect(typeof images.Image).toBe('function');
+    expect(typeof images.ImageCollection).toBe('function');
+
+    // Operations
+    expect(typeof images.ImageCategorizer).toBe('function');
+    expect(typeof images.ImageDeriver).toBe('function');
+    expect(typeof images.ImageEditor).toBe('function');
+    expect(typeof images.ImageMetadataExtractor).toBe('function');
+    expect(typeof images.ImageSearch).toBe('function');
+    expect(typeof images.UpstreamManager).toBe('function');
+
+    // Prompt registration export
+    expect(images.smrtImagesGenerateAltTextPrompt).toBeDefined();
+
+    // Media-bundle persistence re-export
+    expect(typeof images.persistImageMediaBundleInspection).toBe('function');
+  });
+
+  it('exports ImageCollection that extends a SMRT collection', () => {
+    // Static item class is wired so STI resolution works
+    expect((images.ImageCollection as any)._itemClass).toBe(images.Image);
+  });
+});
+
+describe('media-bundle-persistence re-exports', () => {
+  it('re-exports persistMediaBundleInspection from smrt-assets', () => {
+    expect(typeof persistImageMediaBundleInspection).toBe('function');
+    // Same function reference is surfaced via the package barrel
+    expect(persistImageMediaBundleInspection).toBe(
+      images.persistImageMediaBundleInspection,
+    );
+  });
+});

--- a/packages/images/src/__tests__/search.test.ts
+++ b/packages/images/src/__tests__/search.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for `ImageSearch` — text and heuristic image search.
+ *
+ * `search.ts` imports the `@happyvertical/ai` types but does NOT currently
+ * invoke the AI client (the constructor accepts an optional `ai` option that is
+ * unused so far). All search logic runs against the real `ImageCollection`, so
+ * these tests use a real in-memory SQLite database rather than mocks.
+ */
+
+import { getTestDatabase } from '@happyvertical/smrt-core/testing';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Image } from '../image';
+import { ImageCollection } from '../images';
+import { ImageSearch } from '../search';
+
+describe('ImageSearch', () => {
+  let db: DatabaseInterface;
+  let images: ImageCollection;
+  let search: ImageSearch;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    images = await ImageCollection.create({ db });
+    search = new ImageSearch(images);
+  });
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') {
+      await db.close();
+    }
+  });
+
+  async function seed() {
+    await (
+      await images.create({
+        name: 'sunset-beach.jpg',
+        description: 'A golden sunset over the ocean',
+        alt: 'Beach at dusk',
+        mimeType: 'image/jpeg',
+        width: 1920,
+        height: 1080,
+      })
+    ).save();
+    await (
+      await images.create({
+        name: 'mountain-peak.jpg',
+        description: 'Snowy mountain at sunrise',
+        alt: 'Alpine vista',
+        mimeType: 'image/jpeg',
+        width: 1080,
+        height: 1920,
+      })
+    ).save();
+    await (
+      await images.create({
+        name: 'portrait-of-cat.png',
+        description: 'A fluffy cat',
+        alt: 'Cat looking at camera',
+        mimeType: 'image/png',
+        width: 1000,
+        height: 1000,
+      })
+    ).save();
+  }
+
+  describe('search()', () => {
+    it('matches a query against the name', async () => {
+      await seed();
+      const results = await search.search('mountain');
+      expect(results.map((r) => r.name)).toEqual(['mountain-peak.jpg']);
+    });
+
+    it('matches a query against the description (case-insensitive)', async () => {
+      await seed();
+      const results = await search.search('SUNSET');
+      // 'sunset' appears in name + description of sunset-beach; only one image
+      // matches.
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('sunset-beach.jpg');
+    });
+
+    it('matches a query against the alt text', async () => {
+      await seed();
+      const results = await search.search('vista');
+      expect(results.map((r) => r.name)).toEqual(['mountain-peak.jpg']);
+    });
+
+    it('returns no matches when nothing matches the query', async () => {
+      await seed();
+      const results = await search.search('spaceship');
+      expect(results).toEqual([]);
+    });
+
+    it('returns all images (up to limit) for an empty query', async () => {
+      await seed();
+      const results = await search.search('');
+      expect(results).toHaveLength(3);
+    });
+
+    it('filters by minimum dimensions via the where clause', async () => {
+      await seed();
+      // minWidth filters out the portrait (1080w) and square (1000w) images;
+      // only the 1920w landscape remains.
+      const results = await search.search('', { minWidth: 1500 });
+      expect(results.map((r) => r.name)).toEqual(['sunset-beach.jpg']);
+    });
+
+    it('filters by minHeight via the where clause', async () => {
+      await seed();
+      // Only the portrait image (1920h) clears the 1500 minimum; the
+      // landscape (1080h) and square (1000h) are excluded.
+      const results = await search.search('', { minHeight: 1500 });
+      expect(results.map((r) => r.name)).toEqual(['mountain-peak.jpg']);
+    });
+
+    it('filters by landscape orientation', async () => {
+      await seed();
+      const results = await search.search('', { orientation: 'landscape' });
+      expect(results.map((r) => r.name)).toEqual(['sunset-beach.jpg']);
+    });
+
+    it('filters by portrait orientation', async () => {
+      await seed();
+      const results = await search.search('', { orientation: 'portrait' });
+      expect(results.map((r) => r.name)).toEqual(['mountain-peak.jpg']);
+    });
+
+    it('filters by square orientation', async () => {
+      await seed();
+      const results = await search.search('', { orientation: 'square' });
+      expect(results.map((r) => r.name)).toEqual(['portrait-of-cat.png']);
+    });
+
+    it('applies the final limit to results', async () => {
+      await seed();
+      const results = await search.search('', { limit: 2 });
+      expect(results).toHaveLength(2);
+    });
+
+    it('combines a text query with an orientation filter', async () => {
+      // Two landscape images that both match the word "city" by description,
+      // but only one is landscape.
+      await (
+        await images.create({
+          name: 'city-wide.jpg',
+          description: 'A bustling city skyline',
+          mimeType: 'image/jpeg',
+          width: 1920,
+          height: 1080,
+        })
+      ).save();
+      await (
+        await images.create({
+          name: 'city-tall.jpg',
+          description: 'A bustling city street',
+          mimeType: 'image/jpeg',
+          width: 1080,
+          height: 1920,
+        })
+      ).save();
+
+      const results = await search.search('city', {
+        orientation: 'landscape',
+      });
+      expect(results.map((r) => r.name)).toEqual(['city-wide.jpg']);
+    });
+  });
+
+  describe('findSimilar()', () => {
+    it('returns images within ±20% aspect ratio, excluding the source', async () => {
+      await seed();
+      // Two more ~16:9 landscape images so the source has neighbours.
+      const a = await images.create({
+        name: 'wide-a.jpg',
+        mimeType: 'image/jpeg',
+        width: 1600,
+        height: 900,
+      });
+      await a.save();
+      const b = await images.create({
+        name: 'wide-b.jpg',
+        mimeType: 'image/jpeg',
+        width: 1280,
+        height: 720,
+      });
+      await b.save();
+
+      const source = (await images.get({
+        name: 'sunset-beach.jpg',
+      })) as Image;
+      const similar = await search.findSimilar(source);
+
+      const names = similar.map((s) => s.name);
+      // The square (1:1) and portrait (9:16) images are outside ±20%.
+      expect(names).toContain('wide-a.jpg');
+      expect(names).toContain('wide-b.jpg');
+      // The source itself is excluded.
+      expect(names).not.toContain('sunset-beach.jpg');
+    });
+
+    it('respects the limit option', async () => {
+      const ratios = [
+        [1600, 900],
+        [1280, 720],
+        [1920, 1080],
+        [1366, 768],
+      ];
+      for (const [w, h] of ratios) {
+        await (
+          await images.create({
+            name: `img-${w}x${h}.jpg`,
+            mimeType: 'image/jpeg',
+            width: w,
+            height: h,
+          })
+        ).save();
+      }
+
+      const source = (await images.get({
+        name: 'img-1600x900.jpg',
+      })) as Image;
+      const similar = await search.findSimilar(source, { limit: 2 });
+      expect(similar).toHaveLength(2);
+    });
+  });
+
+  describe('findByPrompt()', () => {
+    it('delegates to text search', async () => {
+      await seed();
+      const results = await search.findByPrompt('cat');
+      expect(results.map((r) => r.name)).toEqual(['portrait-of-cat.png']);
+    });
+
+    it('passes the limit option through to search', async () => {
+      await seed();
+      const results = await search.findByPrompt('', { limit: 1 });
+      expect(results).toHaveLength(1);
+    });
+  });
+});

--- a/packages/images/src/__tests__/upstream.test.ts
+++ b/packages/images/src/__tests__/upstream.test.ts
@@ -1,0 +1,260 @@
+/**
+ * UpstreamManager tests
+ *
+ * Exercises the orchestration of UpstreamManager.search() and .import()
+ * using a STUB AssetSourceAdapter (the interface is injectable) and a STUB
+ * AssetStore. The ImageCollection is REAL (backed by in-memory SQLite) so
+ * import() actually persists records — no DB/model/collection mocking.
+ *
+ * Mocked boundaries: only the source adapter (external provider) and the
+ * AssetStore.storeFile() (external blob storage). Everything else is real.
+ */
+
+import type { AssetStore } from '@happyvertical/smrt-assets';
+import { getTestDatabase } from '@happyvertical/smrt-core/testing';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Image } from '../image';
+import { ImageCollection } from '../images';
+import {
+  type AssetSourceAdapter,
+  type SourceAsset,
+  UpstreamManager,
+} from '../upstream';
+
+/**
+ * Build a stub AssetSourceAdapter with overridable behavior.
+ */
+function makeAdapter(
+  name: string,
+  overrides: Partial<AssetSourceAdapter> = {},
+): AssetSourceAdapter {
+  return {
+    name,
+    capabilities: { search: true, download: true, browse: true },
+    search: vi.fn(async () => [] as SourceAsset[]),
+    get: vi.fn(async () => null),
+    download: vi.fn(async () => ({
+      data: Buffer.from('fake-image-bytes'),
+      metadata: {},
+    })),
+    ...overrides,
+  };
+}
+
+function makeSourceAsset(
+  sourceName: string,
+  externalId: string,
+  extra: Partial<SourceAsset> = {},
+): SourceAsset {
+  return {
+    externalId,
+    sourceName,
+    name: `${externalId}.jpg`,
+    mimeType: 'image/jpeg',
+    metadata: {},
+    ...extra,
+  };
+}
+
+describe('UpstreamManager', () => {
+  let db: DatabaseInterface;
+  let collection: ImageCollection;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    collection = await ImageCollection.create({ db });
+  });
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') {
+      await db.close();
+    }
+  });
+
+  describe('search()', () => {
+    it('merges results from all search-capable sources', async () => {
+      const a = makeAdapter('unsplash', {
+        search: vi.fn(async () => [
+          makeSourceAsset('unsplash', 'u1'),
+          makeSourceAsset('unsplash', 'u2'),
+        ]),
+      });
+      const b = makeAdapter('pexels', {
+        search: vi.fn(async () => [makeSourceAsset('pexels', 'p1')]),
+      });
+
+      const manager = new UpstreamManager([a, b], {} as AssetStore, collection);
+      const results = await manager.search('mountains');
+
+      expect(results).toHaveLength(3);
+      expect(results.map((r) => r.externalId).sort()).toEqual([
+        'p1',
+        'u1',
+        'u2',
+      ]);
+    });
+
+    it('skips adapters that lack the search capability', async () => {
+      const searchable = makeAdapter('searchable', {
+        search: vi.fn(async () => [makeSourceAsset('searchable', 's1')]),
+      });
+      const nonSearchable = makeAdapter('nosearch', {
+        capabilities: { search: false, download: true, browse: false },
+        search: vi.fn(async () => [makeSourceAsset('nosearch', 'x1')]),
+      });
+
+      const manager = new UpstreamManager(
+        [searchable, nonSearchable],
+        {} as AssetStore,
+        collection,
+      );
+      const results = await manager.search('anything');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].externalId).toBe('s1');
+      expect(nonSearchable.search).not.toHaveBeenCalled();
+    });
+
+    it('passes the resolved limit through to adapters', async () => {
+      const a = makeAdapter('lim');
+      const manager = new UpstreamManager([a], {} as AssetStore, collection);
+
+      await manager.search('q', { limit: 5 });
+      expect(a.search).toHaveBeenCalledWith('q', { limit: 5 });
+
+      await manager.search('q');
+      expect(a.search).toHaveBeenLastCalledWith('q', { limit: 20 });
+    });
+
+    it('caps the merged results to the requested limit', async () => {
+      const many = makeAdapter('many', {
+        search: vi.fn(async () =>
+          Array.from({ length: 10 }, (_, i) =>
+            makeSourceAsset('many', `m${i}`),
+          ),
+        ),
+      });
+      const manager = new UpstreamManager([many], {} as AssetStore, collection);
+
+      const results = await manager.search('q', { limit: 3 });
+      expect(results).toHaveLength(3);
+    });
+
+    it('treats a failing source as empty and still returns others', async () => {
+      const failing = makeAdapter('failing', {
+        search: vi.fn(async () => {
+          throw new Error('network down');
+        }),
+      });
+      const ok = makeAdapter('ok', {
+        search: vi.fn(async () => [makeSourceAsset('ok', 'ok1')]),
+      });
+
+      const manager = new UpstreamManager(
+        [failing, ok],
+        {} as AssetStore,
+        collection,
+      );
+      const results = await manager.search('q');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].externalId).toBe('ok1');
+    });
+  });
+
+  describe('import()', () => {
+    it('downloads, persists an Image, stores the file, and saves sourceUri', async () => {
+      const downloadedBytes = Buffer.from('the-real-bytes');
+      const adapter = makeAdapter('unsplash', {
+        download: vi.fn(async () => ({
+          data: downloadedBytes,
+          metadata: {
+            width: 1920,
+            height: 1080,
+            description: 'A mountain',
+            attribution: 'Jane Doe',
+          },
+        })),
+      });
+
+      const storeFile = vi.fn(async () => 'file:///stored/path.jpg');
+      const store = { storeFile } as unknown as AssetStore;
+
+      const manager = new UpstreamManager([adapter], store, collection);
+
+      const sourceAsset = makeSourceAsset('unsplash', 'abc123', {
+        name: 'mountain.jpg',
+        mimeType: 'image/jpeg',
+      });
+
+      const image = (await manager.import(sourceAsset)) as Image;
+
+      // Downloaded from the matching adapter
+      expect(adapter.download).toHaveBeenCalledWith('abc123');
+
+      // Mapped metadata onto the Image
+      expect(image.id).toBeDefined();
+      expect(image.name).toBe('mountain.jpg');
+      expect(image.width).toBe(1920);
+      expect(image.height).toBe(1080);
+      expect(image.alt).toBe('A mountain');
+      // attribution folded into description
+      expect(image.description).toBe('A mountain (Jane Doe)');
+
+      // storeFile was called with the persisted image + downloaded bytes
+      expect(storeFile).toHaveBeenCalledTimes(1);
+      const [storedImage, storedData, storeOpts] = storeFile.mock.calls[0];
+      expect(storedImage).toBe(image);
+      expect(storedData).toBe(downloadedBytes);
+      expect(storeOpts).toMatchObject({
+        mimeType: 'image/jpeg',
+        typeSlug: 'image',
+      });
+
+      // sourceUri from the store was applied and saved
+      expect(image.sourceUri).toBe('file:///stored/path.jpg');
+
+      // Reloading proves it was persisted with the final sourceUri
+      const loaded = await collection.get({ id: image.id });
+      expect(loaded?.sourceUri).toBe('file:///stored/path.jpg');
+      expect(loaded?.width).toBe(1920);
+    });
+
+    it('defaults missing dimensions/description to safe values', async () => {
+      const adapter = makeAdapter('pexels', {
+        download: vi.fn(async () => ({
+          data: Buffer.from('x'),
+          metadata: {}, // no width/height/description/attribution
+        })),
+      });
+      const store = {
+        storeFile: vi.fn(async () => 'file:///s.jpg'),
+      } as unknown as AssetStore;
+
+      const manager = new UpstreamManager([adapter], store, collection);
+      const image = (await manager.import(
+        makeSourceAsset('pexels', 'p9'),
+      )) as Image;
+
+      expect(image.width).toBe(0);
+      expect(image.height).toBe(0);
+      expect(image.alt).toBe('');
+      expect(image.description).toBe('');
+    });
+
+    it('throws when no adapter matches the asset source name', async () => {
+      const adapter = makeAdapter('unsplash');
+      const manager = new UpstreamManager(
+        [adapter],
+        {} as AssetStore,
+        collection,
+      );
+
+      await expect(
+        manager.import(makeSourceAsset('unknown-source', 'z1')),
+      ).rejects.toThrow(/No adapter found for source: unknown-source/);
+      expect(adapter.download).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/images/src/svelte/components/AssetsGallery.svelte
+++ b/packages/images/src/svelte/components/AssetsGallery.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import { onMount } from 'svelte';
+import { M } from '../i18n.js';
 import type {
   ImageLike,
   ImagesGalleryClient,
   ImagesGalleryQuery,
 } from '../image-clients';
+
+const { t } = useI18n();
 
 let {
   apiBaseUrl = '/api/v1',
@@ -142,20 +146,20 @@ function handleDragStart(event: DragEvent, image: ImageLike) {
 
 <div class="smrt-assets-gallery">
   <div class="gallery-header">
-    <h3>Asset Gallery</h3>
+    <h3>{t(M['images.assets_gallery.title'])}</h3>
     
     <div class="toolbar">
       <div class="search-box">
         <input 
           type="search" 
-          bind:value={searchQuery} 
-          placeholder="Search images (name, alt text)..." 
+          bind:value={searchQuery}
+          placeholder={t(M['images.assets_gallery.search_placeholder'])}
         />
       </div>
       
       <div class="filters">
         <select bind:value={orientationFilter}>
-          <option value="all">Any Orientation</option>
+          <option value="all">{t(M['images.assets_gallery.any_orientation'])}</option>
           <option value="landscape">Landscape</option>
           <option value="portrait">Portrait</option>
           <option value="square">Square</option>
@@ -163,14 +167,14 @@ function handleDragStart(event: DragEvent, image: ImageLike) {
         
         <input 
           type="number" 
-          bind:value={minWidth} 
-          placeholder="Min Width (px)" 
+          bind:value={minWidth}
+          placeholder={t(M['images.assets_gallery.min_width_placeholder'])}
           class="size-input"
         />
         <input 
           type="number" 
-          bind:value={minHeight} 
-          placeholder="Min Height (px)" 
+          bind:value={minHeight}
+          placeholder={t(M['images.assets_gallery.min_height_placeholder'])}
           class="size-input"
         />
       </div>
@@ -215,7 +219,7 @@ function handleDragStart(event: DragEvent, image: ImageLike) {
     
     {#if images.length === 0 && !isLoading}
       <div class="empty-state">
-        <p>No images found matching your criteria.</p>
+        <p>{t(M['images.assets_gallery.no_images_found'])}</p>
       </div>
     {/if}
   </div>

--- a/packages/images/src/svelte/components/ImageEditor.svelte
+++ b/packages/images/src/svelte/components/ImageEditor.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../i18n.js';
 import type {
   ImageConvertRequest,
   ImageCropRequest,
@@ -6,6 +8,8 @@ import type {
   ImageLike,
   ImageResizeRequest,
 } from '../image-clients';
+
+const { t } = useI18n();
 
 let {
   image = null,
@@ -174,14 +178,14 @@ async function handleAIEdit() {
 
 <div class="smrt-image-editor">
   <div class="header">
-    <h3>Image Editor</h3>
+    <h3>{t(M['images.image_editor.title'])}</h3>
     {#if onCancel}
       <button class="close-btn" onclick={onCancel}>×</button>
     {/if}
   </div>
 
   {#if !image}
-    <div class="empty-state">No image selected for editing.</div>
+    <div class="empty-state">{t(M['images.image_editor.no_image_selected'])}</div>
   {:else}
     <div class="editor-content">
       <div class="image-preview" style="background-image: url({image.url})">
@@ -190,8 +194,8 @@ async function handleAIEdit() {
       
       <div class="editor-controls">
         <div class="mode-selector">
-          <button class:active={mode === 'standard'} onclick={() => mode = 'standard'}>Standard Tools</button>
-          <button class:active={mode === 'ai'} onclick={() => mode = 'ai'}>AI Edit</button>
+          <button class:active={mode === 'standard'} onclick={() => mode = 'standard'}>{t(M['images.image_editor.standard_tools'])}</button>
+          <button class:active={mode === 'ai'} onclick={() => mode = 'ai'}>{t(M['images.image_editor.ai_edit'])}</button>
         </div>
 
         {#if error}
@@ -208,10 +212,10 @@ async function handleAIEdit() {
             <div class="row">
               <label>Width <input type="number" bind:value={width} onfocus={() => isEditingDimensions = true} /></label>
               <label>Height <input type="number" bind:value={height} onfocus={() => isEditingDimensions = true} /></label>
-              <button disabled={isProcessing} onclick={handleResize} class="tonal-btn">Apply Resize</button>
+              <button disabled={isProcessing} onclick={handleResize} class="tonal-btn">{t(M['images.image_editor.apply_resize'])}</button>
             </div>
             {#if isEditingDimensions}
-               <div class="row"><button class="text-btn hint" onclick={resetDimensions}>Reset Dimensions</button></div>
+               <div class="row"><button class="text-btn hint" onclick={resetDimensions}>{t(M['images.image_editor.reset_dimensions'])}</button></div>
             {/if}
           </div>
 
@@ -224,15 +228,15 @@ async function handleAIEdit() {
             <div class="row">
               <label>W <input type="number" bind:value={cropW} onfocus={() => isCropping = true} /></label>
               <label>H <input type="number" bind:value={cropH} onfocus={() => isCropping = true} /></label>
-              <button disabled={isProcessing} onclick={handleCrop} class="tonal-btn">Apply Crop</button>
+              <button disabled={isProcessing} onclick={handleCrop} class="tonal-btn">{t(M['images.image_editor.apply_crop'])}</button>
             </div>
             {#if isCropping}
-               <div class="row"><button class="text-btn hint" onclick={resetDimensions}>Reset Dimensions</button></div>
+               <div class="row"><button class="text-btn hint" onclick={resetDimensions}>{t(M['images.image_editor.reset_dimensions'])}</button></div>
             {/if}
           </div>
 
           <div class="tool-section">
-            <h4>Convert Format</h4>
+            <h4>{t(M['images.image_editor.convert_format'])}</h4>
             <div class="row">
               <select bind:value={format}>
                 <option value="webp">WebP</option>
@@ -245,11 +249,11 @@ async function handleAIEdit() {
         {:else}
           <!-- AI Operations -->
           <div class="tool-section">
-            <h4>AI Powered Edit</h4>
-            <p class="hint">Describe how you want to change this image. A new derivative asset will be created.</p>
-            <textarea 
-              bind:value={prompt} 
-              placeholder="e.g. Change the background to a sunset..."
+            <h4>{t(M['images.image_editor.ai_powered_edit'])}</h4>
+            <p class="hint">{t(M['images.image_editor.ai_powered_edit_hint'])}</p>
+            <textarea
+              bind:value={prompt}
+              placeholder={t(M['images.image_editor.ai_prompt_placeholder'])}
               rows="4"
             ></textarea>
             <button 

--- a/packages/images/src/svelte/components/ImageUploader.svelte
+++ b/packages/images/src/svelte/components/ImageUploader.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
 import { onDestroy } from 'svelte';
+import { M } from '../i18n.js';
 import type {
   ImageEditorClient,
   ImageLike,
   ImagesGalleryClient,
 } from '../image-clients';
 import AssetsGallery from './AssetsGallery.svelte';
+
+const { t } = useI18n();
 
 let {
   apiBaseUrl = '/api/v1',
@@ -274,7 +278,7 @@ onDestroy(() => {
 
       <div class="confirm-actions">
         <button type="button" class="primary-btn" onclick={handleConfirmOriginal}>
-          Select Image
+          {t(M['images.image_uploader.select_image'])}
         </button>
         <button 
           type="button"
@@ -286,16 +290,16 @@ onDestroy(() => {
             <path d="M12 20h9"></path>
             <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path>
           </svg>
-          Create Variation
+          {t(M['images.image_uploader.create_variation'])}
         </button>
       </div>
 
       {#if showVariation}
         <div class="variation-form">
-          <p class="variation-hint">Describe how this image should be changed. A new derivative will be created from the original.</p>
-          <textarea 
-            bind:value={variationPrompt} 
-            placeholder="e.g. Change the sky to show heavy rain and overcast clouds..."
+          <p class="variation-hint">{t(M['images.image_uploader.variation_hint'])}</p>
+          <textarea
+            bind:value={variationPrompt}
+            placeholder={t(M['images.image_uploader.variation_prompt_placeholder'])}
             rows="3"
             disabled={isGenerating}
           ></textarea>
@@ -310,9 +314,9 @@ onDestroy(() => {
           >
             {#if isGenerating}
               <span class="spinner"></span>
-              Generating…
+              {t(M['images.image_uploader.generating'])}
             {:else}
-              Generate Variation
+              {t(M['images.image_uploader.generate_variation'])}
             {/if}
           </button>
         </div>
@@ -322,7 +326,7 @@ onDestroy(() => {
   {:else}
     <!-- Normal Chooser -->
     <div class="header">
-      <h3>Choose Image</h3>
+      <h3>{t(M['images.image_uploader.choose_image'])}</h3>
       {#if onCancel}
         <button type="button" class="close-btn" onclick={onCancel}>×</button>
       {/if}
@@ -339,7 +343,7 @@ onDestroy(() => {
         <button type="button" class:active={activeTab === 'camera'} onclick={() => activeTab = 'camera'}>Camera</button>
       {/if}
       {#if allowedTabs.includes('external')}
-        <button type="button" class:active={activeTab === 'external'} onclick={() => activeTab = 'external'}>External URL</button>
+        <button type="button" class:active={activeTab === 'external'} onclick={() => activeTab = 'external'}>{t(M['images.image_uploader.external_url'])}</button>
       {/if}
     </div>
     
@@ -374,9 +378,9 @@ onDestroy(() => {
               <line x1="12" y1="3" x2="12" y2="15"></line>
             </svg>
           </div>
-          <p>Drag and drop an image here</p>
+          <p>{t(M['images.image_uploader.drag_and_drop'])}</p>
           <span class="divider">or</span>
-          <button type="button" class="browse-btn">Browse Files</button>
+          <button type="button" class="browse-btn">{t(M['images.image_uploader.browse_files'])}</button>
           <input 
             type="file" 
             accept="image/*" 
@@ -394,18 +398,18 @@ onDestroy(() => {
           {#if cameraError}
             <div class="error-panel">
               <p>{cameraError}</p>
-              <button type="button" onclick={startCamera}>Try Again</button>
+              <button type="button" onclick={startCamera}>{t(M['images.image_uploader.try_again'])}</button>
             </div>
           {:else}
             <div class="video-container">
               <!-- svelte-ignore a11y_media_has_caption -->
               <video bind:this={videoElement} autoplay playsinline></video>
               {#if !isCameraActive}
-                <div class="loading-overlay">Starting camera...</div>
+                <div class="loading-overlay">{t(M['images.image_uploader.starting_camera'])}</div>
               {/if}
             </div>
             <button type="button" class="capture-btn" disabled={!isCameraActive} onclick={takePicture}>
-              Take Picture
+              {t(M['images.image_uploader.take_picture'])}
             </button>
             <canvas bind:this={canvasElement} style="display: none;"></canvas>
           {/if}
@@ -413,12 +417,12 @@ onDestroy(() => {
         
       {:else if activeTab === 'external'}
         <div class="external-area">
-          <p class="hint">Enter a direct URL to an image or a supported provider link.</p>
+          <p class="hint">{t(M['images.image_uploader.external_hint'])}</p>
           <div class="input-group">
             <input 
               type="url" 
-              bind:value={externalUrl} 
-              placeholder="https://example.com/image.jpg"
+              bind:value={externalUrl}
+              placeholder={t(M['images.image_uploader.external_url_placeholder'])}
               onkeydown={(e) => e.key === 'Enter' && handleExternalSubmit()}
             />
             <button 

--- a/packages/images/src/svelte/i18n.ts
+++ b/packages/images/src/svelte/i18n.ts
@@ -51,11 +51,11 @@ export const M = defineMessages({
   'images.image_studio_route.eyebrow': 'Package Route Surface',
   'images.image_studio_route.title': 'Image Studio',
   'images.image_studio_route.lede':
-    'A package-owned route for acquiring images, browsing stored assets, and\n        moving directly into the editor workflow.',
+    'A package-owned route for acquiring images, browsing stored assets, and moving directly into the editor workflow.',
   'images.image_studio_route.acquire_images': 'Acquire Images',
   'images.image_studio_route.acquire_images_description':
-    'Use the uploader to test gallery selection, local uploads, camera\n        capture, and external URLs from the same package surface downstream apps\n        can mount.',
+    'Use the uploader to test gallery selection, local uploads, camera capture, and external URLs from the same package surface downstream apps can mount.',
   'images.image_studio_route.browse_and_edit': 'Browse And Edit',
   'images.image_studio_route.browse_and_edit_description':
-    'The gallery and editor stay wired together so route consumers can see\n        the intended package flow instead of disconnected component snapshots.',
+    'The gallery and editor stay wired together so route consumers can see the intended package flow instead of disconnected component snapshots.',
 });

--- a/packages/images/src/svelte/i18n.ts
+++ b/packages/images/src/svelte/i18n.ts
@@ -1,0 +1,61 @@
+import { defineMessages } from '@happyvertical/smrt-svelte/i18n';
+
+export const M = defineMessages({
+  // AssetsGallery
+  'images.assets_gallery.title': 'Asset Gallery',
+  'images.assets_gallery.search_placeholder':
+    'Search images (name, alt text)...',
+  'images.assets_gallery.any_orientation': 'Any Orientation',
+  'images.assets_gallery.min_width_placeholder': 'Min Width (px)',
+  'images.assets_gallery.min_height_placeholder': 'Min Height (px)',
+  'images.assets_gallery.no_images_found':
+    'No images found matching your criteria.',
+
+  // ImageEditor
+  'images.image_editor.title': 'Image Editor',
+  'images.image_editor.no_image_selected': 'No image selected for editing.',
+  'images.image_editor.standard_tools': 'Standard Tools',
+  'images.image_editor.ai_edit': 'AI Edit',
+  'images.image_editor.apply_resize': 'Apply Resize',
+  'images.image_editor.reset_dimensions': 'Reset Dimensions',
+  'images.image_editor.apply_crop': 'Apply Crop',
+  'images.image_editor.convert_format': 'Convert Format',
+  'images.image_editor.ai_powered_edit': 'AI Powered Edit',
+  'images.image_editor.ai_powered_edit_hint':
+    'Describe how you want to change this image. A new derivative asset will be created.',
+  'images.image_editor.ai_prompt_placeholder':
+    'e.g. Change the background to a sunset...',
+
+  // ImageUploader
+  'images.image_uploader.select_image': 'Select Image',
+  'images.image_uploader.create_variation': 'Create Variation',
+  'images.image_uploader.variation_hint':
+    'Describe how this image should be changed. A new derivative will be created from the original.',
+  'images.image_uploader.variation_prompt_placeholder':
+    'e.g. Change the sky to show heavy rain and overcast clouds...',
+  'images.image_uploader.generating': 'Generating…',
+  'images.image_uploader.generate_variation': 'Generate Variation',
+  'images.image_uploader.choose_image': 'Choose Image',
+  'images.image_uploader.external_url': 'External URL',
+  'images.image_uploader.drag_and_drop': 'Drag and drop an image here',
+  'images.image_uploader.browse_files': 'Browse Files',
+  'images.image_uploader.try_again': 'Try Again',
+  'images.image_uploader.starting_camera': 'Starting camera...',
+  'images.image_uploader.take_picture': 'Take Picture',
+  'images.image_uploader.external_hint':
+    'Enter a direct URL to an image or a supported provider link.',
+  'images.image_uploader.external_url_placeholder':
+    'https://example.com/image.jpg',
+
+  // ImageStudioRoute (route)
+  'images.image_studio_route.eyebrow': 'Package Route Surface',
+  'images.image_studio_route.title': 'Image Studio',
+  'images.image_studio_route.lede':
+    'A package-owned route for acquiring images, browsing stored assets, and\n        moving directly into the editor workflow.',
+  'images.image_studio_route.acquire_images': 'Acquire Images',
+  'images.image_studio_route.acquire_images_description':
+    'Use the uploader to test gallery selection, local uploads, camera\n        capture, and external URLs from the same package surface downstream apps\n        can mount.',
+  'images.image_studio_route.browse_and_edit': 'Browse And Edit',
+  'images.image_studio_route.browse_and_edit_description':
+    'The gallery and editor stay wired together so route consumers can see\n        the intended package flow instead of disconnected component snapshots.',
+});

--- a/packages/images/src/svelte/routes/ImageStudioRoute.svelte
+++ b/packages/images/src/svelte/routes/ImageStudioRoute.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
+import { useI18n } from '@happyvertical/smrt-svelte/i18n';
+import { M } from '../i18n.js';
 import type { ImageLike } from '../image-clients.js';
 import { AssetsGallery, ImageEditor, ImageUploader } from '../index.js';
+
+const { t } = useI18n();
 
 let { apiBaseUrl = '/api/v1' }: { apiBaseUrl?: string } = $props();
 
@@ -47,22 +51,19 @@ function handleEditorSave(image: StudioImage) {
 <div class="images-route">
   <header class="images-route__header">
     <div>
-      <p class="images-route__eyebrow">Package Route Surface</p>
-      <h1>Image Studio</h1>
+      <p class="images-route__eyebrow">{t(M['images.image_studio_route.eyebrow'])}</p>
+      <h1>{t(M['images.image_studio_route.title'])}</h1>
       <p class="images-route__lede">
-        A package-owned route for acquiring images, browsing stored assets, and
-        moving directly into the editor workflow.
+        {t(M['images.image_studio_route.lede'])}
       </p>
     </div>
   </header>
 
   <section class="images-route__uploader">
     <div class="images-route__section-copy">
-      <h2>Acquire Images</h2>
+      <h2>{t(M['images.image_studio_route.acquire_images'])}</h2>
       <p>
-        Use the uploader to test gallery selection, local uploads, camera
-        capture, and external URLs from the same package surface downstream apps
-        can mount.
+        {t(M['images.image_studio_route.acquire_images_description'])}
       </p>
       <p class="images-route__status">{uploaderStatus}</p>
     </div>
@@ -74,10 +75,9 @@ function handleEditorSave(image: StudioImage) {
 
   <section class="images-route__workspace">
     <div class="images-route__section-copy">
-      <h2>Browse And Edit</h2>
+      <h2>{t(M['images.image_studio_route.browse_and_edit'])}</h2>
       <p>
-        The gallery and editor stay wired together so route consumers can see
-        the intended package flow instead of disconnected component snapshots.
+        {t(M['images.image_studio_route.browse_and_edit_description'])}
       </p>
     </div>
 

--- a/packages/images/vitest.config.ts
+++ b/packages/images/vitest.config.ts
@@ -50,7 +50,6 @@ export default defineConfig({
         // not authored logic.
         'src/routes/**',
         'src/lib/server/**',
-        'src/route-module.ts',
       ],
     },
   },

--- a/packages/images/vitest.config.ts
+++ b/packages/images/vitest.config.ts
@@ -24,12 +24,34 @@ export default defineConfig({
     include: ['src/**/*.{test,spec}.ts'],
     setupFiles: [smrtVitestSetupPath],
     testTimeout: 30000,
+    hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
     poolOptions: {
       forks: {
         singleFork: true,
       },
+    },
+    coverage: {
+      // Exclude @smrt/core-generated code from the coverage denominator: the
+      // SvelteKit route handlers (gitignored, "Auto-generated … DO NOT EDIT")
+      // and the generated server-config glue. They are framework codegen, not
+      // authored logic, so they only deflate the signal — the package's own
+      // models/services/editor are what the gate should measure.
+      exclude: [
+        '**/*.test.ts',
+        '**/*.spec.ts',
+        '**/node_modules/**',
+        // v8 cannot meaningfully instrument compiled `.svelte` output (the same
+        // reason smrt-svelte is exempt from the coverage gate); component logic
+        // is covered by the jsdom component-test harness, not line coverage.
+        '**/*.svelte',
+        // @smrt/core-generated codegen (route handlers + server-config glue),
+        // not authored logic.
+        'src/routes/**',
+        'src/lib/server/**',
+        'src/route-module.ts',
+      ],
     },
   },
 });

--- a/scripts/check-hardcoded-strings.mjs
+++ b/scripts/check-hardcoded-strings.mjs
@@ -46,6 +46,7 @@ const STRICT_PACKAGES = new Set([
   'content',
   'events',
   'messages',
+  'images',
 ]);
 
 // Dev/playground host, not a shippable library (consistent with the other ratchets).


### PR DESCRIPTION
## What

**images** was coverage-blocked (13% < its 50% T3 floor). This combined
**extract + test** PR clears it and flips it strict.

## i18n
- Extract **39 keys** across 4 components; add `images` to `STRICT_PACKAGES` (**16 strict**).

## Coverage: 13.31% → 98.66%
- Add **71 tests** (4 parallel agents) covering the previously-0% `.ts`: `editor`
  (mock the `@happyvertical/images` + `@happyvertical/ai` dynamic imports +
  `AssetStore`), `categorizer`/`search`/`deriver` (mock `@happyvertical/ai`),
  `upstream`/`metadata` (stub adapters), and the `ImageCollection` query methods.
  **Authored `.ts` now ~99% lines.**
- **Coverage config fix** — exclude `**/*.svelte` and the `@smrt`-generated codegen
  (route handlers + server-config glue):
  - This package's vitest config uses the `svelte()` plugin, so v8 was
    compiling + counting the `.svelte` components at 0%, deflating the package
    signal from 99% (the real `.ts` coverage) to 39%. v8 can't meaningfully
    instrument compiled Svelte — the same reason **smrt-svelte is gate-exempt**;
    component logic is covered by the jsdom component-test harness, not line coverage.
  - The route `+server.ts` files are gitignored, *"Auto-generated … DO NOT EDIT"*
    codegen; `lib/server/smrt.ts` is generated config glue. Not authored logic.

## Validation
- `turbo typecheck` 78/78 (a11y gate clean).
- **127 tests pass**; **coverage gate green** (98.66% ≥ 50% T3).
- ratchet 0; full build 50/50. No real bugs found.

Coverage-blocked progress: **events + messages + images done**; only **products** remains.