### PR TITLE
test(smrt-svelte): cover design-system primitives toward T2 + fix 2 a11y bugs (S11 #1416)

### DIFF
--- a/packages/smrt-svelte/src/components/display/__tests__/ConfidenceBadge.test.ts
+++ b/packages/smrt-svelte/src/components/display/__tests__/ConfidenceBadge.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Component tests for ConfidenceBadge (Sweep S11, #1416).
+ *
+ * ConfidenceBadge renders an ARIA meter for a 0-100 confidence score. Tests
+ * assert the real API from ConfidenceBadge.svelte — meter semantics
+ * (aria-valuenow/min/max/text), the >=80/>=50/else level→color mapping,
+ * clamping of out-of-range input, percent visibility, default vs custom
+ * aria-label, and axe-cleanliness across levels.
+ */
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import ConfidenceBadge from '../ConfidenceBadge.svelte';
+
+describe('ConfidenceBadge', () => {
+  it('exposes meter semantics with the confidence as aria-valuenow', () => {
+    render(ConfidenceBadge, { props: { confidence: 73 } });
+    const meter = screen.getByRole('meter');
+    expect(meter).toHaveAttribute('aria-valuenow', '73');
+    expect(meter).toHaveAttribute('aria-valuemin', '0');
+    expect(meter).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('shows the rounded percentage by default', () => {
+    render(ConfidenceBadge, { props: { confidence: 73.4 } });
+    expect(screen.getByText('73%')).toBeInTheDocument();
+  });
+
+  it('hides the percentage text when showPercent is false', () => {
+    render(ConfidenceBadge, { props: { confidence: 73, showPercent: false } });
+    expect(screen.queryByText('73%')).not.toBeInTheDocument();
+  });
+
+  it('derives a default aria-label from the rounded confidence', () => {
+    render(ConfidenceBadge, { props: { confidence: 91.6 } });
+    expect(screen.getByRole('meter')).toHaveAttribute(
+      'aria-label',
+      'Confidence: 92%',
+    );
+  });
+
+  it('uses a custom aria-label when provided', () => {
+    render(ConfidenceBadge, {
+      props: { confidence: 50, 'aria-label': 'OCR certainty' },
+    });
+    expect(screen.getByRole('meter')).toHaveAttribute(
+      'aria-label',
+      'OCR certainty',
+    );
+  });
+
+  it.each([
+    [95, 'high'],
+    [80, 'high'],
+    [65, 'medium'],
+    [50, 'medium'],
+    [30, 'low'],
+    [0, 'low'],
+  ])('reports "%s%%" as %s confidence in aria-valuetext', (value, level) => {
+    render(ConfidenceBadge, { props: { confidence: value } });
+    expect(screen.getByRole('meter')).toHaveAttribute(
+      'aria-valuetext',
+      `${level} confidence (${value}%)`,
+    );
+  });
+
+  it('clamps confidence above 100 down to 100', () => {
+    render(ConfidenceBadge, { props: { confidence: 150 } });
+    const meter = screen.getByRole('meter');
+    expect(meter).toHaveAttribute('aria-valuenow', '100');
+    expect(screen.getByText('100%')).toBeInTheDocument();
+  });
+
+  it('clamps negative confidence up to 0', () => {
+    render(ConfidenceBadge, { props: { confidence: -20 } });
+    const meter = screen.getByRole('meter');
+    expect(meter).toHaveAttribute('aria-valuenow', '0');
+    expect(screen.getByText('0%')).toBeInTheDocument();
+  });
+
+  it.each([
+    [90, 'primary'],
+    [60, 'secondary'],
+    [20, 'error'],
+  ])('maps %s%% to the %s color token for the bar', (value, token) => {
+    const { container } = render(ConfidenceBadge, {
+      props: { confidence: value },
+    });
+    const badge = container.querySelector('.confidence-badge') as HTMLElement;
+    expect(badge.style.getPropertyValue('--bar-color')).toContain(
+      `smrt-color-${token}`,
+    );
+  });
+
+  it('appends a custom class alongside the base class', () => {
+    const { container } = render(ConfidenceBadge, {
+      props: { confidence: 50, class: 'my-badge' },
+    });
+    const badge = container.querySelector('.confidence-badge');
+    expect(badge).toHaveClass('my-badge');
+  });
+
+  it.each([
+    ['sm', 'sm'],
+    ['lg', 'lg'],
+  ] as const)('applies the %s size class', (size, cls) => {
+    const { container } = render(ConfidenceBadge, {
+      props: { confidence: 50, size },
+    });
+    expect(container.querySelector('.confidence-badge')).toHaveClass(cls);
+  });
+
+  it.each([10, 60, 95])('is axe-clean at %s%% confidence', async (value) => {
+    const { container } = render(ConfidenceBadge, {
+      props: { confidence: value },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/display/__tests__/CurrencyDisplay.test.ts
+++ b/packages/smrt-svelte/src/components/display/__tests__/CurrencyDisplay.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Component tests for CurrencyDisplay (Sweep S11, #1416).
+ *
+ * CurrencyDisplay formats a numeric amount (cents or dollars) into a currency
+ * string via Intl.NumberFormat('en-CA'). Expected strings are derived with the
+ * SAME formatter the component uses so assertions stay locale-robust. Tests
+ * assert the real API from CurrencyDisplay.svelte — unit conversion, currency
+ * code, sign handling (negative/zero/showSign), highlight classes, size
+ * classes, and axe-cleanliness.
+ */
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import CurrencyDisplay from '../CurrencyDisplay.svelte';
+
+/** Mirror the component's absolute-value currency formatting. */
+function money(absDollars: number, currency: 'CAD' | 'USD' = 'CAD'): string {
+  return new Intl.NumberFormat('en-CA', {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(absDollars);
+}
+
+describe('CurrencyDisplay', () => {
+  it('formats cents into dollars by default', () => {
+    render(CurrencyDisplay, { props: { amount: 12345 } }); // cents → $123.45
+    expect(screen.getByText(money(123.45))).toBeInTheDocument();
+  });
+
+  it('treats the amount as dollars when unit=dollars', () => {
+    render(CurrencyDisplay, { props: { amount: 50, unit: 'dollars' } });
+    expect(screen.getByText(money(50))).toBeInTheDocument();
+  });
+
+  it('formats zero', () => {
+    render(CurrencyDisplay, { props: { amount: 0, unit: 'dollars' } });
+    expect(screen.getByText(money(0))).toBeInTheDocument();
+  });
+
+  it('prefixes a minus sign for negative amounts', () => {
+    render(CurrencyDisplay, { props: { amount: -2500 } }); // -$25.00
+    expect(screen.getByText(`-${money(25)}`)).toBeInTheDocument();
+  });
+
+  it('formats a USD amount with the USD currency code', () => {
+    render(CurrencyDisplay, {
+      props: { amount: 1000, unit: 'dollars', currency: 'USD' },
+    });
+    expect(screen.getByText(money(1000, 'USD'))).toBeInTheDocument();
+  });
+
+  it('shows an explicit + sign for positive amounts when showSign is set', () => {
+    render(CurrencyDisplay, {
+      props: { amount: 1000, unit: 'dollars', showSign: true },
+    });
+    expect(screen.getByText(`+${money(1000)}`)).toBeInTheDocument();
+  });
+
+  it('shows a - sign for negatives when showSign is set', () => {
+    render(CurrencyDisplay, {
+      props: { amount: -1000, unit: 'dollars', showSign: true },
+    });
+    expect(screen.getByText(`-${money(1000)}`)).toBeInTheDocument();
+  });
+
+  it('does not add a sign to zero even when showSign is set', () => {
+    render(CurrencyDisplay, {
+      props: { amount: 0, unit: 'dollars', showSign: true },
+    });
+    const text = money(0);
+    expect(screen.getByText(text)).toBeInTheDocument();
+    expect(screen.queryByText(`+${text}`)).not.toBeInTheDocument();
+  });
+
+  it('applies the negative highlight class only when highlightNegative and amount<0', () => {
+    const { container } = render(CurrencyDisplay, {
+      props: { amount: -100, unit: 'dollars', highlightNegative: true },
+    });
+    expect(container.querySelector('span')).toHaveClass('negative');
+  });
+
+  it('does not apply the negative class to a positive amount', () => {
+    const { container } = render(CurrencyDisplay, {
+      props: { amount: 100, unit: 'dollars', highlightNegative: true },
+    });
+    expect(container.querySelector('span')).not.toHaveClass('negative');
+  });
+
+  it('applies the positive highlight class only when highlightPositive and amount>0', () => {
+    const { container } = render(CurrencyDisplay, {
+      props: { amount: 100, unit: 'dollars', highlightPositive: true },
+    });
+    expect(container.querySelector('span')).toHaveClass('positive');
+  });
+
+  it.each([
+    ['sm', 'sm'],
+    ['lg', 'lg'],
+  ] as const)('applies the %s size class', (size, cls) => {
+    const { container } = render(CurrencyDisplay, {
+      props: { amount: 100, unit: 'dollars', size },
+    });
+    expect(container.querySelector('span')).toHaveClass(cls);
+  });
+
+  it('appends a custom class alongside the base class', () => {
+    const { container } = render(CurrencyDisplay, {
+      props: { amount: 100, unit: 'dollars', class: 'my-money' },
+    });
+    const span = container.querySelector('span');
+    expect(span).toHaveClass('currency-display');
+    expect(span).toHaveClass('my-money');
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(CurrencyDisplay, {
+      props: { amount: 12345 },
+    });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean for a highlighted negative value', async () => {
+    const { container } = render(CurrencyDisplay, {
+      props: { amount: -5000, highlightNegative: true },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/display/__tests__/DateDisplay.test.ts
+++ b/packages/smrt-svelte/src/components/display/__tests__/DateDisplay.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Component tests for DateDisplay (Sweep S11, #1416).
+ *
+ * DateDisplay parses a Date/ISO/timestamp and renders a <time datetime> element
+ * (or a fallback <span> for null/invalid input). Expected formatted strings are
+ * derived via Intl.DateTimeFormat with the SAME options the component uses, so
+ * assertions stay locale/timezone-robust. Relative mode is exercised with
+ * offsets from `now`. Tests assert the real API from DateDisplay.svelte.
+ */
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import DateDisplay from '../DateDisplay.svelte';
+
+const LOCALE = 'en-CA';
+
+/** Build the component's expected output for an absolute format. */
+function expected(
+  date: Date,
+  options: Intl.DateTimeFormatOptions,
+  locale = LOCALE,
+): string {
+  return new Intl.DateTimeFormat(locale, options).format(date);
+}
+
+const SHORT = { month: 'short', day: 'numeric' } as const;
+const MEDIUM = { year: 'numeric', month: 'short', day: 'numeric' } as const;
+const LONG = {
+  weekday: 'long',
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+} as const;
+
+describe('DateDisplay', () => {
+  // Use a fixed local-noon date so date-part is timezone-stable.
+  const sample = new Date(2024, 0, 15, 12, 0, 0); // 15 Jan 2024, local noon
+
+  it('renders a <time> element with the ISO datetime attribute', () => {
+    const { container } = render(DateDisplay, { props: { date: sample } });
+    const time = container.querySelector('time');
+    expect(time).toBeInTheDocument();
+    expect(time).toHaveAttribute('datetime', sample.toISOString());
+  });
+
+  it('formats with medium options by default', () => {
+    render(DateDisplay, { props: { date: sample } });
+    expect(screen.getByText(expected(sample, MEDIUM))).toBeInTheDocument();
+  });
+
+  it('formats with short options', () => {
+    render(DateDisplay, { props: { date: sample, format: 'short' } });
+    expect(screen.getByText(expected(sample, SHORT))).toBeInTheDocument();
+  });
+
+  it('formats with long options', () => {
+    render(DateDisplay, { props: { date: sample, format: 'long' } });
+    expect(screen.getByText(expected(sample, LONG))).toBeInTheDocument();
+  });
+
+  it('includes time when showTime is set', () => {
+    render(DateDisplay, { props: { date: sample, showTime: true } });
+    const withTime = expected(sample, {
+      ...MEDIUM,
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+    expect(screen.getByText(withTime)).toBeInTheDocument();
+  });
+
+  it('respects a custom locale', () => {
+    render(DateDisplay, {
+      props: { date: sample, format: 'long', locale: 'fr-CA' },
+    });
+    expect(
+      screen.getByText(expected(sample, LONG, 'fr-CA')),
+    ).toBeInTheDocument();
+  });
+
+  it('parses an ISO string input', () => {
+    const iso = '2024-01-15T12:00:00.000Z';
+    const d = new Date(iso);
+    const { container } = render(DateDisplay, { props: { date: iso } });
+    expect(container.querySelector('time')).toHaveAttribute(
+      'datetime',
+      d.toISOString(),
+    );
+  });
+
+  it('parses a numeric timestamp input', () => {
+    const ts = sample.getTime();
+    const { container } = render(DateDisplay, { props: { date: ts } });
+    expect(container.querySelector('time')).toHaveAttribute(
+      'datetime',
+      new Date(ts).toISOString(),
+    );
+  });
+
+  it('renders the fallback span for null input', () => {
+    const { container } = render(DateDisplay, {
+      props: { date: null, fallback: 'No date' },
+    });
+    expect(container.querySelector('time')).not.toBeInTheDocument();
+    const span = screen.getByText('No date');
+    expect(span).toHaveClass('date-fallback');
+  });
+
+  it('renders the default fallback for an invalid date string', () => {
+    render(DateDisplay, { props: { date: 'not-a-date' } });
+    expect(screen.getByText('N/A')).toBeInTheDocument();
+  });
+
+  it('renders "just now" for the current time in relative mode', () => {
+    render(DateDisplay, { props: { date: new Date(), format: 'relative' } });
+    expect(screen.getByText('just now')).toBeInTheDocument();
+  });
+
+  it('renders "yesterday" for ~1 day ago in relative mode', () => {
+    const d = new Date(Date.now() - 25 * 60 * 60 * 1000); // 25h ago → 1 day
+    render(DateDisplay, { props: { date: d, format: 'relative' } });
+    expect(screen.getByText('yesterday')).toBeInTheDocument();
+  });
+
+  it('renders "tomorrow" for a near-future date in relative mode', () => {
+    const d = new Date(Date.now() + 23 * 60 * 60 * 1000); // 23h ahead → tomorrow
+    render(DateDisplay, { props: { date: d, format: 'relative' } });
+    expect(screen.getByText('tomorrow')).toBeInTheDocument();
+  });
+
+  it('appends a custom class to the time element', () => {
+    const { container } = render(DateDisplay, {
+      props: { date: sample, class: 'my-date' },
+    });
+    expect(container.querySelector('time')).toHaveClass('my-date');
+  });
+
+  it('is axe-clean with a date', async () => {
+    const { container } = render(DateDisplay, { props: { date: sample } });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean with the fallback', async () => {
+    const { container } = render(DateDisplay, { props: { date: null } });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/display/__tests__/Icon.test.ts
+++ b/packages/smrt-svelte/src/components/display/__tests__/Icon.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Component tests for Icon (Sweep S11, #1416).
+ *
+ * Icon is a presentational SVG primitive: decorative by default (aria-hidden),
+ * informative when given an aria-label (role="img"). Tests assert the real API
+ * from Icon.svelte — preset/path resolution, size/color, and axe-cleanliness in
+ * both decorative and labelled modes.
+ */
+import { render } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import Icon from '../Icon.svelte';
+
+/** The 'check' preset path, used to assert preset resolution. */
+const CHECK_PATH = 'M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z';
+
+describe('Icon', () => {
+  it('renders an svg that is decorative (aria-hidden) by default', () => {
+    const { container } = render(Icon, { props: { name: 'check' } });
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+    expect(svg).not.toHaveAttribute('role');
+  });
+
+  it('resolves a named preset to its path', () => {
+    const { container } = render(Icon, { props: { name: 'check' } });
+    const path = container.querySelector('svg path');
+    expect(path).toHaveAttribute('d', CHECK_PATH);
+  });
+
+  it('renders a custom path verbatim, taking precedence over name', () => {
+    const custom = 'M0 0h10v10H0z';
+    const { container } = render(Icon, {
+      props: { name: 'check', path: custom },
+    });
+    const path = container.querySelector('svg path');
+    expect(path).toHaveAttribute('d', custom);
+  });
+
+  it('renders a path with no shape for an unknown preset name', () => {
+    // finalPath resolves to '' for an unknown preset; Svelte omits the empty
+    // `d` attribute entirely, so the path element renders without a shape.
+    const { container } = render(Icon, { props: { name: 'does-not-exist' } });
+    const path = container.querySelector('svg path');
+    expect(path).toBeInTheDocument();
+    expect(path).not.toHaveAttribute('d');
+  });
+
+  it('becomes informative (role=img + aria-label) when given an aria-label', () => {
+    const { container } = render(Icon, {
+      props: { name: 'search', 'aria-label': 'Search' },
+    });
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('role', 'img');
+    expect(svg).toHaveAttribute('aria-label', 'Search');
+    expect(svg).toHaveAttribute('aria-hidden', 'false');
+  });
+
+  it('converts a numeric size to a px width/height', () => {
+    const { container } = render(Icon, { props: { name: 'menu', size: 32 } });
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '32px');
+    expect(svg).toHaveAttribute('height', '32px');
+  });
+
+  it('passes a string size through unchanged', () => {
+    const { container } = render(Icon, {
+      props: { name: 'menu', size: '1.5em' },
+    });
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '1.5em');
+    expect(svg).toHaveAttribute('height', '1.5em');
+  });
+
+  it('applies the color prop as the svg fill', () => {
+    const { container } = render(Icon, {
+      props: { name: 'menu', color: '#ff0000' },
+    });
+    expect(container.querySelector('svg')).toHaveAttribute('fill', '#ff0000');
+  });
+
+  it('uses currentColor as the default fill', () => {
+    const { container } = render(Icon, { props: { name: 'menu' } });
+    expect(container.querySelector('svg')).toHaveAttribute(
+      'fill',
+      'currentColor',
+    );
+  });
+
+  it('applies a custom viewBox', () => {
+    const { container } = render(Icon, {
+      props: { name: 'menu', viewBox: '0 0 48 48' },
+    });
+    expect(container.querySelector('svg')).toHaveAttribute(
+      'viewBox',
+      '0 0 48 48',
+    );
+  });
+
+  it('is axe-clean when decorative', async () => {
+    const { container } = render(Icon, { props: { name: 'close' } });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean when labelled', async () => {
+    const { container } = render(Icon, {
+      props: { name: 'close', 'aria-label': 'Close dialog' },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/display/__tests__/StatusBadge.test.ts
+++ b/packages/smrt-svelte/src/components/display/__tests__/StatusBadge.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Component tests for StatusBadge (Sweep S11, #1416).
+ *
+ * StatusBadge is a presentational chip: it normalizes a status string, maps it
+ * to a color scheme per domain `type`, and renders a humanized label. Tests
+ * assert the real API from StatusBadge.svelte — label formatting, custom label
+ * override, size/variant classes, scheme-driven CSS custom properties, and
+ * axe-cleanliness across variants.
+ */
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import StatusBadge from '../StatusBadge.svelte';
+
+describe('StatusBadge', () => {
+  it('renders the status value as its label', () => {
+    render(StatusBadge, { props: { status: 'active' } });
+    expect(screen.getByText('active')).toBeInTheDocument();
+  });
+
+  it('humanizes underscores in the status into spaces', () => {
+    render(StatusBadge, { props: { status: 'on_hold', type: 'project' } });
+    expect(screen.getByText('on hold')).toBeInTheDocument();
+  });
+
+  it('prefers an explicit label over the status value', () => {
+    render(StatusBadge, {
+      props: { status: 'paid', type: 'invoice', label: 'Paid in full' },
+    });
+    expect(screen.getByText('Paid in full')).toBeInTheDocument();
+    expect(screen.queryByText('paid')).not.toBeInTheDocument();
+  });
+
+  it('always carries the base status-badge class', () => {
+    const { container } = render(StatusBadge, { props: { status: 'active' } });
+    expect(container.querySelector('span')).toHaveClass('status-badge');
+  });
+
+  it.each([
+    ['sm', 'sm'],
+    ['lg', 'lg'],
+  ] as const)('applies the %s size class', (size, cls) => {
+    const { container } = render(StatusBadge, {
+      props: { status: 'active', size },
+    });
+    expect(container.querySelector('span')).toHaveClass(cls);
+  });
+
+  it('omits a size class for the default md size', () => {
+    const { container } = render(StatusBadge, { props: { status: 'active' } });
+    const span = container.querySelector('span');
+    expect(span).not.toHaveClass('sm');
+    expect(span).not.toHaveClass('lg');
+  });
+
+  it('applies the outline class for the outline variant', () => {
+    const { container } = render(StatusBadge, {
+      props: { status: 'active', variant: 'outline' },
+    });
+    expect(container.querySelector('span')).toHaveClass('outline');
+  });
+
+  it('maps a known status to its scheme colors via CSS custom properties', () => {
+    const { container } = render(StatusBadge, {
+      props: { status: 'overdue', type: 'invoice' },
+    });
+    const span = container.querySelector('span') as HTMLElement;
+    // invoice/overdue → error container scheme
+    expect(span.style.getPropertyValue('--badge-bg')).toContain(
+      'smrt-color-error-container',
+    );
+    expect(span.style.getPropertyValue('--badge-text')).toContain(
+      'smrt-color-on-error-container',
+    );
+  });
+
+  it('falls back to a neutral scheme for an unknown status', () => {
+    const { container } = render(StatusBadge, {
+      props: { status: 'totally-unknown', type: 'invoice' },
+    });
+    const span = container.querySelector('span') as HTMLElement;
+    expect(span.style.getPropertyValue('--badge-bg')).toContain('#e5e7eb');
+    expect(span.style.getPropertyValue('--badge-text')).toContain('#374151');
+  });
+
+  it('normalizes spaces and hyphens when matching a scheme key', () => {
+    // 'On-Hold' normalizes to 'on_hold', a known project status.
+    const { container } = render(StatusBadge, {
+      props: { status: 'On-Hold', type: 'project' },
+    });
+    const span = container.querySelector('span') as HTMLElement;
+    expect(span.style.getPropertyValue('--badge-bg')).toContain(
+      'smrt-color-secondary-container',
+    );
+  });
+
+  it.each([
+    ['default', 'active'],
+    ['invoice', 'paid'],
+    ['project', 'completed'],
+    ['expense', 'reimbursed'],
+    ['time', 'approved'],
+    ['compliance', 'valid'],
+    ['estimate', 'accepted'],
+  ] as const)('is axe-clean for type=%s status=%s', async (type, status) => {
+    const { container } = render(StatusBadge, { props: { status, type } });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean for the outline variant', async () => {
+    const { container } = render(StatusBadge, {
+      props: { status: 'active', variant: 'outline' },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/feedback/ProgressBar.svelte
+++ b/packages/smrt-svelte/src/components/feedback/ProgressBar.svelte
@@ -89,6 +89,7 @@ const displayLabel = $derived.by(() => {
   <div
     class="progress-track"
     role="progressbar"
+    aria-label={label ?? t(M['ui.progress_bar.label'])}
     aria-valuenow={value}
     aria-valuemin={0}
     aria-valuemax={max}

--- a/packages/smrt-svelte/src/components/feedback/ProgressBar.svelte
+++ b/packages/smrt-svelte/src/components/feedback/ProgressBar.svelte
@@ -89,7 +89,7 @@ const displayLabel = $derived.by(() => {
   <div
     class="progress-track"
     role="progressbar"
-    aria-label={label ?? t(M['ui.progress_bar.label'])}
+    aria-label={label?.trim() ? label : t(M['ui.progress_bar.label'])}
     aria-valuenow={value}
     aria-valuemin={0}
     aria-valuemax={max}

--- a/packages/smrt-svelte/src/components/feedback/__tests__/ConfirmDialog.test.ts
+++ b/packages/smrt-svelte/src/components/feedback/__tests__/ConfirmDialog.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Golden test for ConfirmDialog (Sweep S11, #1416).
+ *
+ * ConfirmDialog renders a backdrop `<div role="dialog" aria-modal="true">` only
+ * while `open` is true, with a title, message, and cancel/confirm buttons. It
+ * exposes `onconfirm`/`oncancel` callbacks; Escape and backdrop clicks both
+ * route to `oncancel`.
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import ConfirmDialog from '../ConfirmDialog.svelte';
+
+const baseProps = {
+  open: true,
+  title: 'Delete item',
+  message: 'This action cannot be undone.',
+};
+
+describe('ConfirmDialog', () => {
+  it('renders a labelled dialog with title and message when open', () => {
+    render(ConfirmDialog, { props: baseProps });
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(
+      screen.getByRole('heading', { name: 'Delete item' }),
+    ).toBeInTheDocument();
+    expect(dialog).toHaveAccessibleName('Delete item');
+    expect(
+      screen.getByText('This action cannot be undone.'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders nothing when closed', () => {
+    render(ConfirmDialog, { props: { ...baseProps, open: false } });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('uses default Confirm / Cancel button labels', () => {
+    render(ConfirmDialog, { props: baseProps });
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('honors custom confirm/cancel labels', () => {
+    render(ConfirmDialog, {
+      props: { ...baseProps, confirmLabel: 'Delete', cancelLabel: 'Keep' },
+    });
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Keep' })).toBeInTheDocument();
+  });
+
+  it('fires onconfirm when the confirm button is clicked', async () => {
+    const onconfirm = vi.fn();
+    render(ConfirmDialog, { props: { ...baseProps, onconfirm } });
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(onconfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires oncancel when the cancel button is clicked', async () => {
+    const oncancel = vi.fn();
+    render(ConfirmDialog, { props: { ...baseProps, oncancel } });
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(oncancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires oncancel when Escape is pressed', async () => {
+    const oncancel = vi.fn();
+    render(ConfirmDialog, { props: { ...baseProps, oncancel } });
+    screen.getByRole('dialog').focus();
+    await userEvent.keyboard('{Escape}');
+    expect(oncancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires oncancel when the backdrop is clicked', async () => {
+    const oncancel = vi.fn();
+    render(ConfirmDialog, { props: { ...baseProps, oncancel } });
+    await userEvent.click(screen.getByRole('dialog'));
+    expect(oncancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire oncancel when clicking inside the dialog content', async () => {
+    const oncancel = vi.fn();
+    render(ConfirmDialog, { props: { ...baseProps, oncancel } });
+    await userEvent.click(screen.getByRole('heading', { name: 'Delete item' }));
+    expect(oncancel).not.toHaveBeenCalled();
+  });
+
+  it('disables both buttons while loading', () => {
+    render(ConfirmDialog, { props: { ...baseProps, loading: true } });
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+  });
+
+  it('does not fire callbacks from disabled buttons while loading', async () => {
+    const onconfirm = vi.fn();
+    const oncancel = vi.fn();
+    render(ConfirmDialog, {
+      props: { ...baseProps, loading: true, onconfirm, oncancel },
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onconfirm).not.toHaveBeenCalled();
+    expect(oncancel).not.toHaveBeenCalled();
+  });
+
+  it('applies destructive styling to the confirm button', () => {
+    render(ConfirmDialog, {
+      props: { ...baseProps, destructive: true, confirmLabel: 'Delete' },
+    });
+    expect(screen.getByRole('button', { name: 'Delete' })).toHaveClass(
+      'destructive',
+    );
+  });
+
+  it('omits destructive styling by default', () => {
+    render(ConfirmDialog, { props: baseProps });
+    expect(screen.getByRole('button', { name: 'Confirm' })).not.toHaveClass(
+      'destructive',
+    );
+  });
+
+  it('is axe-clean while open', async () => {
+    const { container } = render(ConfirmDialog, { props: baseProps });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean in the destructive loading state', async () => {
+    const { container } = render(ConfirmDialog, {
+      props: { ...baseProps, destructive: true, loading: true },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/feedback/__tests__/LoadingOverlay.test.ts
+++ b/packages/smrt-svelte/src/components/feedback/__tests__/LoadingOverlay.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Golden test for LoadingOverlay (Sweep S11, #1416).
+ *
+ * LoadingOverlay renders a full-screen `role="dialog"` busy surface only while
+ * `show` is true and not dismissed. It carries `aria-busy` (true unless an
+ * error is present), an `aria-labelledby` title from `message`, optional
+ * progress/items, an error message, and a dismiss button when `dismissible`.
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import LoadingOverlay from '../LoadingOverlay.svelte';
+
+describe('LoadingOverlay', () => {
+  it('renders nothing when not shown', () => {
+    render(LoadingOverlay, { props: { show: false } });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders a busy dialog labelled by its message when shown', () => {
+    render(LoadingOverlay, {
+      props: { show: true, message: 'Importing data' },
+    });
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-busy', 'true');
+    expect(dialog).toHaveAccessibleName('Importing data');
+    expect(
+      screen.getByRole('heading', { name: 'Importing data' }),
+    ).toBeInTheDocument();
+  });
+
+  it('uses a default message when none is provided', () => {
+    render(LoadingOverlay, { props: { show: true } });
+    expect(
+      screen.getByRole('heading', { name: 'Loading...' }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a progress percentage when progress > 0', () => {
+    render(LoadingOverlay, { props: { show: true, progress: 60 } });
+    expect(screen.getByText('60%')).toBeInTheDocument();
+  });
+
+  it('omits the progress readout when progress is 0', () => {
+    render(LoadingOverlay, { props: { show: true, progress: 0 } });
+    expect(screen.queryByText('0%')).toBeNull();
+  });
+
+  it('renders completed items', () => {
+    render(LoadingOverlay, {
+      props: { show: true, items: ['Profiles', 'Assets'] },
+    });
+    expect(screen.getByText('Profiles')).toBeInTheDocument();
+    expect(screen.getByText('Assets')).toBeInTheDocument();
+  });
+
+  it('clears aria-busy and shows the error message in the error state', () => {
+    render(LoadingOverlay, {
+      props: { show: true, error: { message: 'Import failed' } },
+    });
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-busy', 'false');
+    expect(screen.getByText('Import failed')).toBeInTheDocument();
+  });
+
+  it('omits the dismiss button unless dismissible', () => {
+    render(LoadingOverlay, { props: { show: true } });
+    expect(screen.queryByRole('button', { name: 'Continue' })).toBeNull();
+  });
+
+  it('fires ondismiss and hides the overlay when the dismiss button is clicked', async () => {
+    const ondismiss = vi.fn();
+    render(LoadingOverlay, {
+      props: { show: true, dismissible: true, ondismiss },
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    expect(ondismiss).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('dismisses via the Escape key when dismissible', async () => {
+    const ondismiss = vi.fn();
+    render(LoadingOverlay, {
+      props: { show: true, dismissible: true, ondismiss },
+    });
+    await userEvent.keyboard('{Escape}');
+    expect(ondismiss).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('ignores Escape when not dismissible', async () => {
+    render(LoadingOverlay, { props: { show: true, dismissible: false } });
+    await userEvent.keyboard('{Escape}');
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('is axe-clean in the loading state', async () => {
+    const { container } = render(LoadingOverlay, {
+      props: { show: true, message: 'Loading your workspace', progress: 45 },
+    });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean with completed items and a dismiss action', async () => {
+    const { container } = render(LoadingOverlay, {
+      props: {
+        show: true,
+        message: 'Almost done',
+        items: ['Step one'],
+        dismissible: true,
+      },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/feedback/__tests__/ProgressBar.test.ts
+++ b/packages/smrt-svelte/src/components/feedback/__tests__/ProgressBar.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Golden test for ProgressBar (Sweep S11, #1416).
+ *
+ * ProgressBar renders a `role="progressbar"` track carrying
+ * `aria-valuenow`/`aria-valuemin`/`aria-valuemax` from its `value`/`max` props.
+ * An optional header shows a percentage, a value/max pair, or a custom label,
+ * plus an "over by" badge when `value` exceeds `max`.
+ */
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import ProgressBar from '../ProgressBar.svelte';
+
+describe('ProgressBar', () => {
+  it('gives the progressbar an accessible name (default and custom label)', () => {
+    const { rerender } = render(ProgressBar, { props: { value: 40 } });
+    // Default accessible name comes from the i18n'd "Progress" label.
+    expect(
+      screen.getByRole('progressbar', { name: 'Progress' }),
+    ).toBeInTheDocument();
+    rerender({ value: 40, label: 'Upload' });
+    expect(
+      screen.getByRole('progressbar', { name: 'Upload' }),
+    ).toBeInTheDocument();
+  });
+
+  it('exposes progressbar role with aria-value attributes', () => {
+    render(ProgressBar, { props: { value: 40 } });
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '40');
+    expect(bar).toHaveAttribute('aria-valuemin', '0');
+    expect(bar).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('reflects a custom max in aria-valuemax', () => {
+    render(ProgressBar, { props: { value: 30, max: 200 } });
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '30');
+    expect(bar).toHaveAttribute('aria-valuemax', '200');
+  });
+
+  it('does not render a label by default', () => {
+    render(ProgressBar, { props: { value: 25 } });
+    expect(screen.queryByText('25%')).toBeNull();
+  });
+
+  it('shows a rounded percentage label when showLabel is set', () => {
+    render(ProgressBar, { props: { value: 33, showLabel: true } });
+    expect(screen.getByText('33%')).toBeInTheDocument();
+  });
+
+  it('shows a value / max label when showValue is set', () => {
+    render(ProgressBar, { props: { value: 75, max: 100, showValue: true } });
+    expect(screen.getByText('75 / 100')).toBeInTheDocument();
+  });
+
+  it('prefers a custom label over percentage and value', () => {
+    render(ProgressBar, {
+      props: { value: 50, showLabel: true, label: 'Almost there' },
+    });
+    expect(screen.getByText('Almost there')).toBeInTheDocument();
+    expect(screen.queryByText('50%')).toBeNull();
+  });
+
+  it('caps aria-valuenow display semantics but reports the raw over-budget value', () => {
+    render(ProgressBar, { props: { value: 120, max: 100, showLabel: true } });
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '120');
+    expect(bar).toHaveAttribute('aria-valuemax', '100');
+    expect(screen.getByText('Over by 20')).toBeInTheDocument();
+  });
+
+  it('is axe-clean at 0%', async () => {
+    const { container } = render(ProgressBar, {
+      props: { value: 0, showLabel: true },
+    });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean mid-progress', async () => {
+    const { container } = render(ProgressBar, {
+      props: { value: 50, showLabel: true },
+    });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean at 100%', async () => {
+    const { container } = render(ProgressBar, {
+      props: { value: 100, showLabel: true },
+    });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean in the over-budget state', async () => {
+    const { container } = render(ProgressBar, {
+      props: { value: 130, max: 100, showValue: true },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/feedback/__tests__/ProgressBar.test.ts
+++ b/packages/smrt-svelte/src/components/feedback/__tests__/ProgressBar.test.ts
@@ -12,15 +12,23 @@ import { expectNoA11yViolations } from '../../../test-support/a11y';
 import ProgressBar from '../ProgressBar.svelte';
 
 describe('ProgressBar', () => {
-  it('gives the progressbar an accessible name (default and custom label)', () => {
+  it('gives the progressbar an accessible name (default and custom label)', async () => {
     const { rerender } = render(ProgressBar, { props: { value: 40 } });
     // Default accessible name comes from the i18n'd "Progress" label.
     expect(
       screen.getByRole('progressbar', { name: 'Progress' }),
     ).toBeInTheDocument();
-    rerender({ value: 40, label: 'Upload' });
+    // rerender resolves the prop update asynchronously — await before querying.
+    await rerender({ value: 40, label: 'Upload' });
     expect(
       screen.getByRole('progressbar', { name: 'Upload' }),
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to the default name when label is empty or whitespace', () => {
+    render(ProgressBar, { props: { value: 40, label: '   ' } });
+    expect(
+      screen.getByRole('progressbar', { name: 'Progress' }),
     ).toBeInTheDocument();
   });
 

--- a/packages/smrt-svelte/src/components/forms/__tests__/AddressInput.behavior.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/AddressInput.behavior.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Behavior tests for AddressInput (Sweep S11, #1416).
+ *
+ * Exercises the sub-field wiring: typing/selecting each field composes a
+ * Partial<AddressValue> emitted via onchange, the `fields` prop gates which
+ * sub-fields render (and thus which keys appear in the composed value),
+ * province/country selects populate from options, and the error prop marks
+ * every field invalid with a single linked alert. useAppState (default mode)
+ * is mocked since the hook throws outside a <Provider>.
+ */
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+
+vi.mock('../../../hooks/useAppState.svelte.js', () => ({
+  useAppState: () => ({ state: { mode: 'default' }, setMode: vi.fn() }),
+}));
+
+import AddressInput from '../AddressInput.svelte';
+
+describe('AddressInput — behavior', () => {
+  it('typing the street composes a value including the street', async () => {
+    const onchange = vi.fn();
+    render(AddressInput, {
+      props: { name: 'addr', label: 'Address', onchange },
+    });
+    await userEvent.type(
+      screen.getByLabelText('Street Address'),
+      '123 Main St',
+    );
+    expect(onchange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ street: '123 Main St' }),
+    );
+  });
+
+  it('typing the city updates the composed value', async () => {
+    const onchange = vi.fn();
+    render(AddressInput, {
+      props: { name: 'addr', label: 'Address', onchange },
+    });
+    await userEvent.type(screen.getByLabelText('City'), 'Toronto');
+    expect(onchange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ city: 'Toronto' }),
+    );
+  });
+
+  it('selecting a province emits its value code', async () => {
+    const onchange = vi.fn();
+    render(AddressInput, {
+      props: { name: 'addr', label: 'Address', onchange },
+    });
+    await userEvent.selectOptions(
+      screen.getByLabelText('Province/State'),
+      'ON',
+    );
+    expect(onchange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ province: 'ON' }),
+    );
+  });
+
+  it('selecting a country emits its value code', async () => {
+    const onchange = vi.fn();
+    render(AddressInput, {
+      props: { name: 'addr', label: 'Address', onchange },
+    });
+    await userEvent.selectOptions(screen.getByLabelText('Country'), 'US');
+    expect(onchange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ country: 'US' }),
+    );
+  });
+
+  it('defaults the country to CA', () => {
+    render(AddressInput, { props: { name: 'addr', label: 'Address' } });
+    expect(screen.getByLabelText('Country')).toHaveValue('CA');
+  });
+
+  it('composes a complete address object across all fields', async () => {
+    const onchange = vi.fn();
+    render(AddressInput, {
+      props: { name: 'addr', label: 'Address', onchange },
+    });
+    await userEvent.type(screen.getByLabelText('Postal/ZIP Code'), 'M5V 2T6');
+    expect(onchange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        street: '',
+        city: '',
+        province: '',
+        postalCode: 'M5V 2T6',
+        country: 'CA',
+      }),
+    );
+  });
+
+  it('only emits keys for the fields it was told to render', async () => {
+    const onchange = vi.fn();
+    render(AddressInput, {
+      props: {
+        name: 'addr',
+        label: 'Address',
+        fields: ['city', 'country'],
+        onchange,
+      },
+    });
+    expect(screen.queryByLabelText('Street Address')).toBeNull();
+    expect(screen.queryByLabelText('Postal/ZIP Code')).toBeNull();
+    await userEvent.type(screen.getByLabelText('City'), 'Ottawa');
+    const composed = onchange.mock.calls.at(-1)?.[0];
+    expect(Object.keys(composed).sort()).toEqual(['city', 'country']);
+    expect(composed.city).toBe('Ottawa');
+  });
+
+  it('seeds sub-fields from the bound value object', () => {
+    render(AddressInput, {
+      props: {
+        name: 'addr',
+        label: 'Address',
+        value: { city: 'Calgary', province: 'AB', country: 'CA' },
+      },
+    });
+    expect(screen.getByLabelText('City')).toHaveValue('Calgary');
+    expect(screen.getByLabelText('Province/State')).toHaveValue('AB');
+  });
+
+  it('renders the province and country option sets', () => {
+    render(AddressInput, { props: { name: 'addr', label: 'Address' } });
+    const provinces = screen.getByLabelText('Province/State');
+    expect(provinces.querySelector('option[value="QC"]')?.textContent).toBe(
+      'Quebec',
+    );
+    const countries = screen.getByLabelText('Country');
+    expect(countries.querySelector('option[value="US"]')?.textContent).toBe(
+      'United States',
+    );
+  });
+
+  it('marks every field invalid and links one alert when error is set', () => {
+    render(AddressInput, {
+      props: { name: 'addr', label: 'Address', error: 'Address required' },
+    });
+    const street = screen.getByLabelText('Street Address');
+    expect(street).toHaveAttribute('aria-invalid', 'true');
+    expect(street).toHaveAttribute('aria-describedby', 'addr-error');
+    const err = document.getElementById('addr-error');
+    expect(err).toHaveTextContent('Address required');
+    expect(err).toHaveAttribute('role', 'alert');
+  });
+
+  it('is axe-clean with all fields labelled', async () => {
+    const { container } = render(AddressInput, {
+      props: { name: 'addr', label: 'Address' },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/CheckboxInput.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/CheckboxInput.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Component test for CheckboxInput (Sweep S11, #1416).
+ *
+ * Follows the golden pattern (src/components/ui/__tests__/Button.test.ts).
+ * CheckboxInput calls `useAppState` (throws outside a <Provider>), so we mock it
+ * to a stub default mode. Its form-context lookup uses `getContext` and safely
+ * returns undefined outside a provider, so no further stubbing is needed.
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+
+vi.mock('../../../hooks/useAppState.svelte.js', () => ({
+  useAppState: () => ({ state: { mode: 'default' }, setMode: vi.fn() }),
+}));
+
+import CheckboxInput from '../CheckboxInput.svelte';
+
+describe('CheckboxInput', () => {
+  it('renders a checkbox labelled by its label, wired via for/id', () => {
+    render(CheckboxInput, { props: { name: 'terms', label: 'Accept terms' } });
+    const checkbox = screen.getByRole('checkbox', { name: 'Accept terms' });
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).toHaveAttribute('id', 'terms');
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('reflects the checked prop', () => {
+    render(CheckboxInput, {
+      props: { name: 'terms', label: 'Accept terms', checked: true },
+    });
+    expect(
+      screen.getByRole('checkbox', { name: 'Accept terms' }),
+    ).toBeChecked();
+  });
+
+  it('reflects the disabled prop', () => {
+    render(CheckboxInput, {
+      props: { name: 'terms', label: 'Accept terms', disabled: true },
+    });
+    expect(
+      screen.getByRole('checkbox', { name: 'Accept terms' }),
+    ).toBeDisabled();
+  });
+
+  it('reflects the required prop (and marks the label with *)', () => {
+    render(CheckboxInput, {
+      props: { name: 'terms', label: 'Accept terms', required: true },
+    });
+    // Required appends a "*" to the visible label, so the accessible name is "Accept terms*".
+    expect(
+      screen.getByRole('checkbox', { name: 'Accept terms*' }),
+    ).toBeRequired();
+  });
+
+  it('toggles checked and fires onchange when clicked', async () => {
+    const onchange = vi.fn();
+    render(CheckboxInput, {
+      props: { name: 'terms', label: 'Accept terms', onchange },
+    });
+    const checkbox = screen.getByRole('checkbox', { name: 'Accept terms' });
+    await userEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+    expect(onchange).toHaveBeenCalledWith(true);
+    await userEvent.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+    expect(onchange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('toggles when its label text is clicked', async () => {
+    const onchange = vi.fn();
+    render(CheckboxInput, {
+      props: { name: 'terms', label: 'Accept terms', onchange },
+    });
+    await userEvent.click(screen.getByText('Accept terms'));
+    expect(
+      screen.getByRole('checkbox', { name: 'Accept terms' }),
+    ).toBeChecked();
+    expect(onchange).toHaveBeenCalledWith(true);
+  });
+
+  it('does not fire onchange when disabled', async () => {
+    const onchange = vi.fn();
+    render(CheckboxInput, {
+      props: { name: 'terms', label: 'Accept terms', disabled: true, onchange },
+    });
+    await userEvent.click(
+      screen.getByRole('checkbox', { name: 'Accept terms' }),
+    );
+    expect(onchange).not.toHaveBeenCalled();
+  });
+
+  it('is axe-clean with a label', async () => {
+    const { container } = render(CheckboxInput, {
+      props: { name: 'newsletter', label: 'Subscribe to the newsletter' },
+    });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean when checked, required, and disabled', async () => {
+    const { container } = render(CheckboxInput, {
+      props: {
+        name: 'newsletter',
+        label: 'Subscribe to the newsletter',
+        checked: true,
+        required: true,
+        disabled: true,
+      },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/DateRangeInput.behavior.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/DateRangeInput.behavior.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Behavior tests for DateRangeInput (Sweep S11, #1416).
+ *
+ * In default mode the component renders two native date pickers (Start / End)
+ * with cross-linked min/max, emits a { startDate, endDate } range via
+ * onchange, and validates start <= end. The hooks throw outside a <Provider>,
+ * so useAppState (default mode) + useSTT (stub) are mocked.
+ */
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+
+vi.mock('../../../hooks/useAppState.svelte.js', () => ({
+  useAppState: () => ({ state: { mode: 'default' }, setMode: vi.fn() }),
+}));
+vi.mock('../../../hooks/useSTT.svelte.js', () => ({
+  useSTT: () => ({
+    isListening: false,
+    isInitializing: false,
+    isReady: false,
+    adapterType: null,
+    downloadProgress: 0,
+    lastResult: '',
+    initialize: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+import DateRangeInput from '../DateRangeInput.svelte';
+
+describe('DateRangeInput — behavior', () => {
+  it('renders labelled Start and End date pickers', () => {
+    render(DateRangeInput, { props: { name: 'range', label: 'Dates' } });
+    expect(screen.getByLabelText('Start')).toHaveAttribute('type', 'date');
+    expect(screen.getByLabelText('End')).toHaveAttribute('type', 'date');
+  });
+
+  it('setting the start date emits the range with the new start', async () => {
+    const onchange = vi.fn();
+    render(DateRangeInput, {
+      props: { name: 'range', label: 'Dates', onchange },
+    });
+    await fireEvent.change(screen.getByLabelText('Start'), {
+      target: { value: '2024-01-10' },
+    });
+    expect(onchange).toHaveBeenLastCalledWith({
+      startDate: '2024-01-10',
+      endDate: '',
+    });
+  });
+
+  it('setting both dates emits the full range', async () => {
+    const onchange = vi.fn();
+    render(DateRangeInput, {
+      props: {
+        name: 'range',
+        label: 'Dates',
+        startDate: '2024-01-10',
+        onchange,
+      },
+    });
+    await fireEvent.change(screen.getByLabelText('End'), {
+      target: { value: '2024-03-20' },
+    });
+    expect(onchange).toHaveBeenLastCalledWith({
+      startDate: '2024-01-10',
+      endDate: '2024-03-20',
+    });
+  });
+
+  it('flags an end-before-start range as invalid with a linked alert', () => {
+    render(DateRangeInput, {
+      props: {
+        name: 'range',
+        label: 'Dates',
+        startDate: '2024-05-01',
+        endDate: '2024-01-01',
+      },
+    });
+    const start = screen.getByLabelText('Start');
+    expect(start).toHaveAttribute('aria-invalid', 'true');
+    expect(start).toHaveAttribute('aria-describedby', 'range-error');
+    const err = document.getElementById('range-error');
+    expect(err).toHaveAttribute('role', 'alert');
+    expect(err).toHaveTextContent('End date must be after start date');
+  });
+
+  it('treats start <= end as a valid range (no error)', () => {
+    render(DateRangeInput, {
+      props: {
+        name: 'range',
+        label: 'Dates',
+        startDate: '2024-01-01',
+        endDate: '2024-05-01',
+      },
+    });
+    expect(screen.getByLabelText('Start')).not.toHaveAttribute('aria-invalid');
+    expect(document.getElementById('range-error')).toBeNull();
+  });
+
+  it('caps the start picker max at the chosen end date', () => {
+    render(DateRangeInput, {
+      props: { name: 'range', label: 'Dates', endDate: '2024-03-20' },
+    });
+    expect(screen.getByLabelText('Start')).toHaveAttribute('max', '2024-03-20');
+  });
+
+  it('floors the end picker min at the chosen start date', () => {
+    render(DateRangeInput, {
+      props: { name: 'range', label: 'Dates', startDate: '2024-01-10' },
+    });
+    expect(screen.getByLabelText('End')).toHaveAttribute('min', '2024-01-10');
+  });
+
+  it('mirrors the dates into hidden submission inputs', async () => {
+    const { container } = render(DateRangeInput, {
+      props: { name: 'range', label: 'Dates', startDate: '2024-01-10' },
+    });
+    await fireEvent.change(screen.getByLabelText('End'), {
+      target: { value: '2024-03-20' },
+    });
+    expect(
+      container.querySelector<HTMLInputElement>('input[name="range_start"]'),
+    ).toHaveValue('2024-01-10');
+    expect(
+      container.querySelector<HTMLInputElement>('input[name="range_end"]'),
+    ).toHaveValue('2024-03-20');
+  });
+
+  it('renders an explicit error prop as a linked alert', () => {
+    render(DateRangeInput, {
+      props: { name: 'range', label: 'Dates', error: 'Pick a range' },
+    });
+    const err = document.getElementById('range-error');
+    expect(err).toHaveTextContent('Pick a range');
+    expect(err).toHaveAttribute('role', 'alert');
+  });
+
+  it('is axe-clean in a labelled + error state', async () => {
+    const { container } = render(DateRangeInput, {
+      props: {
+        name: 'range',
+        label: 'Dates',
+        startDate: '2024-05-01',
+        endDate: '2024-01-01',
+      },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/DateTimeInput.behavior.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/DateTimeInput.behavior.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Behavior tests for DateTimeInput (Sweep S11, #1416).
+ *
+ * In default (non-smrt) mode the component renders a native date /
+ * datetime-local picker, echoes the picked value through onchange, and
+ * formats the bound ISO value for display via Intl. The hooks throw outside a
+ * <Provider>, so useAppState (default mode) + useSTT (stub) are mocked.
+ *
+ * Date assertions are timezone/locale-robust: for date-only the component
+ * parses YYYY-MM-DD into a *local* Date, so we derive the expected display the
+ * same way (new Date(y, m-1, d).toLocaleDateString) rather than hardcoding.
+ */
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+
+vi.mock('../../../hooks/useAppState.svelte.js', () => ({
+  useAppState: () => ({ state: { mode: 'default' }, setMode: vi.fn() }),
+}));
+vi.mock('../../../hooks/useSTT.svelte.js', () => ({
+  useSTT: () => ({
+    isListening: false,
+    isInitializing: false,
+    isReady: false,
+    adapterType: null,
+    downloadProgress: 0,
+    lastResult: '',
+    initialize: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+import DateTimeInput from '../DateTimeInput.svelte';
+
+describe('DateTimeInput — behavior', () => {
+  it('renders a datetime-local input when includeTime is true (default)', () => {
+    render(DateTimeInput, { props: { name: 'when', label: 'When' } });
+    expect(screen.getByLabelText('When')).toHaveAttribute(
+      'type',
+      'datetime-local',
+    );
+  });
+
+  it('renders a date input when includeTime is false', () => {
+    render(DateTimeInput, {
+      props: { name: 'when', label: 'When', includeTime: false },
+    });
+    expect(screen.getByLabelText('When')).toHaveAttribute('type', 'date');
+  });
+
+  it('emits the picked date value via onchange', async () => {
+    const onchange = vi.fn();
+    render(DateTimeInput, {
+      props: { name: 'when', label: 'When', includeTime: false, onchange },
+    });
+    const input = screen.getByLabelText('When') as HTMLInputElement;
+    await fireEvent.change(input, { target: { value: '2024-03-15' } });
+    expect(onchange).toHaveBeenLastCalledWith('2024-03-15');
+  });
+
+  it('emits a datetime-local value through onchange unchanged', async () => {
+    const onchange = vi.fn();
+    render(DateTimeInput, {
+      props: { name: 'when', label: 'When', onchange },
+    });
+    const input = screen.getByLabelText('When') as HTMLInputElement;
+    await fireEvent.change(input, { target: { value: '2024-03-15T13:30' } });
+    expect(onchange).toHaveBeenLastCalledWith('2024-03-15T13:30');
+  });
+
+  it('seeds the native input with the bound ISO value', () => {
+    render(DateTimeInput, {
+      props: {
+        name: 'when',
+        label: 'When',
+        includeTime: false,
+        value: '1990-06-18',
+      },
+    });
+    expect(screen.getByLabelText('When')).toHaveValue('1990-06-18');
+  });
+
+  it('clearing the picker emits an empty string', async () => {
+    const onchange = vi.fn();
+    render(DateTimeInput, {
+      props: {
+        name: 'when',
+        label: 'When',
+        includeTime: false,
+        value: '2024-03-15',
+        onchange,
+      },
+    });
+    const input = screen.getByLabelText('When') as HTMLInputElement;
+    await fireEvent.change(input, { target: { value: '' } });
+    expect(onchange).toHaveBeenLastCalledWith('');
+  });
+
+  it('uses a date-aware placeholder for date-only mode', () => {
+    render(DateTimeInput, {
+      props: { name: 'when', label: 'When', includeTime: false },
+    });
+    // default mode native input has no placeholder attribute; the prop default
+    // still reflects includeTime — assert via the smrt-mode path being absent
+    // and the input rendering as a plain date control.
+    expect(screen.getByLabelText('When')).toHaveAttribute('type', 'date');
+  });
+
+  it('is axe-clean in a labelled state', async () => {
+    const { container } = render(DateTimeInput, {
+      props: { name: 'when', label: 'When', value: '2024-03-15T09:00' },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/FileUpload.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/FileUpload.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Component test for FileUpload (Sweep S11, #1416).
+ *
+ * Follows the golden pattern (src/components/ui/__tests__/Button.test.ts).
+ * The native `<input type="file">` is visually hidden (so not in the a11y tree);
+ * the interactive surface is a `role="button"` drop zone. We assert the input's
+ * accept/multiple wiring and that selecting a file fires the change handler.
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import FileUpload from '../FileUpload.svelte';
+
+function fileInput(container: HTMLElement): HTMLInputElement {
+  const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+  if (!input) throw new Error('file input not found');
+  return input;
+}
+
+const png = (name = 'photo.png') =>
+  new File(['data'], name, { type: 'image/png' });
+
+describe('FileUpload', () => {
+  it('renders a file input and a drop-zone button with the label', () => {
+    const { container } = render(FileUpload, {
+      props: { label: 'Drop files', hint: 'or browse' },
+    });
+    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.getByText('Drop files')).toBeInTheDocument();
+    expect(fileInput(container)).toBeInTheDocument();
+  });
+
+  it('forwards accept and multiple to the file input', () => {
+    const { container } = render(FileUpload, {
+      props: { accept: 'image/png,.pdf', multiple: true },
+    });
+    const input = fileInput(container);
+    expect(input).toHaveAttribute('accept', 'image/png,.pdf');
+    expect(input).toHaveAttribute('multiple');
+  });
+
+  it('omits the multiple attribute by default', () => {
+    const { container } = render(FileUpload);
+    expect(fileInput(container)).not.toHaveAttribute('multiple');
+  });
+
+  it('fires onchange and lists the file when one is selected', async () => {
+    const onchange = vi.fn();
+    const { container } = render(FileUpload, {
+      props: { accept: 'image/png', onchange },
+    });
+    await userEvent.upload(fileInput(container), png('selfie.png'));
+    expect(onchange).toHaveBeenCalledTimes(1);
+    expect(onchange.mock.calls[0][0]).toHaveLength(1);
+    expect(onchange.mock.calls[0][0][0].name).toBe('selfie.png');
+    expect(screen.getByText('selfie.png')).toBeInTheDocument();
+  });
+
+  it('removes a selected file via its remove button', async () => {
+    const onchange = vi.fn();
+    const { container } = render(FileUpload, { props: { onchange } });
+    await userEvent.upload(fileInput(container), png('doc.png'));
+    expect(screen.getByText('doc.png')).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole('button', { name: /remove doc\.png/i }),
+    );
+    expect(screen.queryByText('doc.png')).not.toBeInTheDocument();
+    expect(onchange).toHaveBeenLastCalledWith([]);
+  });
+
+  it('rejects an oversized file and shows a max-size error', async () => {
+    // userEvent.upload honors the `accept` filter, so we exercise rejection via
+    // maxSize (which it does not enforce). A 4-byte file exceeds maxSize: 1.
+    const onchange = vi.fn();
+    const { container } = render(FileUpload, {
+      props: { accept: 'image/png', maxSize: 1, onchange },
+    });
+    await userEvent.upload(fileInput(container), png('big.png'));
+    expect(screen.queryByText('big.png')).not.toBeInTheDocument();
+    expect(screen.getByText(/exceed the maximum size/i)).toBeInTheDocument();
+  });
+
+  it('disables the drop zone when disabled', () => {
+    render(FileUpload, { props: { disabled: true } });
+    expect(screen.getByRole('button')).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('is axe-clean in the default state', async () => {
+    const { container } = render(FileUpload, {
+      props: { label: 'Upload your documents' },
+    });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean after a file is selected', async () => {
+    const { container } = render(FileUpload, {
+      props: { label: 'Upload your documents' },
+    });
+    await userEvent.upload(fileInput(container), png('report.png'));
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/Form.behavior.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/Form.behavior.test.ts
@@ -105,12 +105,23 @@ describe('Form — submit value collection', () => {
   it('drops a field from the collected data once it unmounts (unregister)', async () => {
     const onsubmit = vi.fn();
     const { rerender } = render(FormWithFields, {
-      props: { onsubmit, textValue: 'Keep', numberValue: 7 },
+      props: { onsubmit, textValue: 'Keep', numberValue: 7, showAge: true },
     });
 
-    // Sanity: both fields present.
+    // Both fields registered → both collected.
     await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
     expect(onsubmit).toHaveBeenLastCalledWith({ fullname: 'Keep', age: 7 });
+
+    // Unmount the age field; Form.unregisterField drops it from the next submit.
+    await rerender({
+      onsubmit,
+      textValue: 'Keep',
+      numberValue: 7,
+      showAge: false,
+    });
+    expect(screen.queryByLabelText('Age')).toBeNull();
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(onsubmit).toHaveBeenLastCalledWith({ fullname: 'Keep' });
   });
 });
 

--- a/packages/smrt-svelte/src/components/forms/__tests__/Form.behavior.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/Form.behavior.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Deep behavior tests for Form (Sweep S11, #1416).
+ *
+ * The shallow golden test (Form.test.ts) only covers the <form> element, child
+ * rendering, the onsubmit contract, and axe. This suite exercises the real
+ * value-collection logic: Form registers child fields through its context, and
+ * on submit it walks every registered field's getValue() to build the data
+ * object. We mount Form via an inline fixture that nests TextInput +
+ * NumberInput so the registration → collection → onsubmit pipeline runs for
+ * real (no mocked field logic).
+ *
+ * Form depends on the Provider-backed useAppState/useSTT hooks (they throw
+ * outside a <Provider>), so both are mocked to non-listening stubs — the
+ * reference pattern from Form.test.ts.
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+
+vi.mock('../../../hooks/useAppState.svelte.js', () => ({
+  useAppState: () => ({ state: { mode: 'default' }, setMode: vi.fn() }),
+}));
+vi.mock('../../../hooks/useSTT.svelte.js', () => ({
+  useSTT: () => ({
+    isListening: false,
+    lastResult: '',
+    isReady: false,
+    adapterType: null,
+    isInitializing: false,
+    downloadProgress: 0,
+    initialize: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+import Form from '../Form.svelte';
+import FormWithFields from './form-with-fields.fixture.svelte';
+
+function submitButton() {
+  return createRawSnippet(() => ({
+    render: () => `<button type="submit">Submit</button>`,
+  }));
+}
+
+describe('Form — submit value collection', () => {
+  it('collects each registered field value into the onsubmit data object', async () => {
+    const onsubmit = vi.fn();
+    render(FormWithFields, {
+      props: { onsubmit, textValue: 'Ada Lovelace', numberValue: 36 },
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(onsubmit).toHaveBeenCalledTimes(1);
+    expect(onsubmit).toHaveBeenCalledWith({
+      fullname: 'Ada Lovelace',
+      age: 36,
+    });
+  });
+
+  it('reflects live typing into the collected submit data', async () => {
+    const onsubmit = vi.fn();
+    render(FormWithFields, { props: { onsubmit } });
+
+    await userEvent.type(screen.getByLabelText('Full name'), 'Grace');
+    await userEvent.type(screen.getByLabelText('Age'), '50');
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(onsubmit).toHaveBeenCalledWith({ fullname: 'Grace', age: 50 });
+  });
+
+  it('prevents native submission when an onsubmit handler is provided', async () => {
+    const onsubmit = vi.fn();
+    const { container } = render(FormWithFields, { props: { onsubmit } });
+    const form = container.querySelector('form');
+    expect(form).toBeInTheDocument();
+
+    const submitEvent = new Event('submit', {
+      bubbles: true,
+      cancelable: true,
+    });
+    (form as HTMLFormElement).dispatchEvent(submitEvent);
+
+    expect(onsubmit).toHaveBeenCalledTimes(1);
+    expect(submitEvent.defaultPrevented).toBe(true);
+  });
+
+  it('does NOT prevent native submission when no onsubmit handler is set', () => {
+    const { container } = render(FormWithFields, { props: {} });
+    const form = container.querySelector('form') as HTMLFormElement;
+
+    const submitEvent = new Event('submit', {
+      bubbles: true,
+      cancelable: true,
+    });
+    form.dispatchEvent(submitEvent);
+
+    // Native submission left intact for SvelteKit form actions / use:enhance.
+    expect(submitEvent.defaultPrevented).toBe(false);
+  });
+
+  it('drops a field from the collected data once it unmounts (unregister)', async () => {
+    const onsubmit = vi.fn();
+    const { rerender } = render(FormWithFields, {
+      props: { onsubmit, textValue: 'Keep', numberValue: 7 },
+    });
+
+    // Sanity: both fields present.
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(onsubmit).toHaveBeenLastCalledWith({ fullname: 'Keep', age: 7 });
+  });
+});
+
+describe('Form — native form attributes', () => {
+  it('forwards method and action onto the <form> element', () => {
+    const { container } = render(Form, {
+      props: { children: submitButton(), method: 'POST', action: '/save' },
+    });
+    const form = container.querySelector('form') as HTMLFormElement;
+    expect(form).toHaveAttribute('method', 'POST');
+    expect(form).toHaveAttribute('action', '/save');
+  });
+
+  it('submits empty data when no fields are registered', async () => {
+    const onsubmit = vi.fn();
+    render(Form, { props: { children: submitButton(), onsubmit } });
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(onsubmit).toHaveBeenCalledWith({});
+  });
+});
+
+describe('Form — status region & a11y', () => {
+  it('renders a polite, visually-hidden status region', () => {
+    render(Form, { props: { children: submitButton() } });
+    const status = screen.getByRole('status');
+    expect(status).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('is axe-clean with nested labelled fields', async () => {
+    const { container } = render(FormWithFields, {
+      props: { onsubmit: vi.fn() },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/FormMicButton.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/FormMicButton.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Component test for FormMicButton (Sweep S11, #1416).
+ *
+ * Follows the golden pattern (src/components/ui/__tests__/Button.test.ts).
+ * FormMicButton only renders when smrt mode is active AND a form context is
+ * present (`{#if isSmrt && formContext}`). Both come from Provider-backed
+ * lookups that throw / return null outside a <Provider>, so we mock
+ * `useAppState` (smrt mode) and `tryGetFormContext` (a stub form context). The
+ * stub stands in for the real form coordinator — we never mock business logic,
+ * only the context boundary that a <Provider> would otherwise supply.
+ *
+ * The component polls `formContext.isFormListening`/`isExtracting` on a 50ms
+ * interval to drive its label/state, so listening/extracting assertions wait
+ * for that poll via Testing Library's `findBy*`.
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+
+vi.mock('../../../hooks/useAppState.svelte.js', () => ({
+  useAppState: () => ({ state: { mode: 'smrt' }, setMode: vi.fn() }),
+}));
+
+const toggleListening = vi.fn();
+let formState: { isFormListening: boolean; isExtracting: boolean } = {
+  isFormListening: false,
+  isExtracting: false,
+};
+
+vi.mock('../../../state/form-context.js', () => ({
+  tryGetFormContext: () => ({
+    get mode() {
+      return 'smrt' as const;
+    },
+    get isFormListening() {
+      return formState.isFormListening;
+    },
+    get isExtracting() {
+      return formState.isExtracting;
+    },
+    toggleListening,
+    registerField: vi.fn(),
+    unregisterField: vi.fn(),
+    getFieldSchema: () => [],
+  }),
+}));
+
+import FormMicButton from '../FormMicButton.svelte';
+
+describe('FormMicButton', () => {
+  beforeEach(() => {
+    toggleListening.mockClear();
+    formState = { isFormListening: false, isExtracting: false };
+  });
+
+  it('renders a button labelled "Click to speak" when idle', () => {
+    render(FormMicButton);
+    expect(
+      screen.getByRole('button', { name: 'Click to speak' }),
+    ).toBeInTheDocument();
+  });
+
+  it('is keyboard-focusable (tabindex 0)', () => {
+    render(FormMicButton);
+    expect(
+      screen.getByRole('button', { name: 'Click to speak' }),
+    ).toHaveAttribute('tabindex', '0');
+  });
+
+  it('toggles listening on the form context when clicked', async () => {
+    render(FormMicButton);
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Click to speak' }),
+    );
+    expect(toggleListening).toHaveBeenCalledTimes(1);
+  });
+
+  it('toggles listening when activated with Enter', async () => {
+    render(FormMicButton);
+    const button = screen.getByRole('button', { name: 'Click to speak' });
+    button.focus();
+    await userEvent.keyboard('{Enter}');
+    expect(toggleListening).toHaveBeenCalledTimes(1);
+  });
+
+  it('relabels to "Stop listening" once the form is listening', async () => {
+    formState = { isFormListening: true, isExtracting: false };
+    render(FormMicButton);
+    expect(
+      await screen.findByRole('button', { name: 'Stop listening' }),
+    ).toBeInTheDocument();
+  });
+
+  it('is axe-clean in the idle state', async () => {
+    const { container } = render(FormMicButton);
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean in the listening state', async () => {
+    formState = { isFormListening: true, isExtracting: false };
+    const { container } = render(FormMicButton);
+    await screen.findByRole('button', { name: 'Stop listening' });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/MeasurementInput.behavior.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/MeasurementInput.behavior.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Behavior tests for MeasurementInput (Sweep S11, #1416).
+ *
+ * Exercises numeric value parsing, the unit <select>, real unit conversion on
+ * unit change, the emitted MeasurementValue shape, and min/max validation. The
+ * hooks throw outside a <Provider>, so useAppState is mocked to 'default' mode.
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+
+vi.mock('../../../hooks/useAppState.svelte.js', () => ({
+  useAppState: () => ({ state: { mode: 'default' }, setMode: vi.fn() }),
+}));
+
+import MeasurementInput from '../MeasurementInput.svelte';
+
+describe('MeasurementInput — behavior', () => {
+  it('typing a number emits { value, unit } via onchange', async () => {
+    const onchange = vi.fn();
+    render(MeasurementInput, {
+      props: { name: 'len', label: 'Length', onchange },
+    });
+    await userEvent.type(screen.getByLabelText('Length'), '12');
+    expect(onchange).toHaveBeenLastCalledWith({ value: 12, unit: 'ft' });
+  });
+
+  it('clearing the value emits null', async () => {
+    const onchange = vi.fn();
+    render(MeasurementInput, {
+      props: { name: 'len', label: 'Length', value: 5, onchange },
+    });
+    await userEvent.clear(screen.getByLabelText('Length'));
+    expect(onchange).toHaveBeenLastCalledWith(null);
+  });
+
+  it('renders the available units as <option>s with abbreviation + label', () => {
+    render(MeasurementInput, {
+      props: { name: 'len', label: 'Length', units: ['ft', 'm'] },
+    });
+    const select = screen.getByLabelText('Length unit');
+    const options = Array.from(
+      select.querySelectorAll('option'),
+    ) as HTMLOptionElement[];
+    expect(options.map((o) => o.value)).toEqual(['ft', 'm']);
+    expect(options[0].textContent).toContain('ft (Feet)');
+    expect(options[1].textContent).toContain('m (Meters)');
+  });
+
+  it('changing the unit converts the value to the new unit', async () => {
+    const onchange = vi.fn();
+    render(MeasurementInput, {
+      props: {
+        name: 'len',
+        label: 'Length',
+        value: 1,
+        unit: 'ft',
+        units: ['ft', 'in'],
+        onchange,
+      },
+    });
+    // 1 ft -> 12 in (rounded to 4 decimals)
+    await userEvent.selectOptions(screen.getByLabelText('Length unit'), 'in');
+    expect(onchange).toHaveBeenLastCalledWith({ value: 12, unit: 'in' });
+  });
+
+  it('1 m converts to 100 cm on unit change', async () => {
+    const onchange = vi.fn();
+    render(MeasurementInput, {
+      props: {
+        name: 'len',
+        label: 'Length',
+        value: 1,
+        unit: 'm',
+        units: ['m', 'cm'],
+        onchange,
+      },
+    });
+    await userEvent.selectOptions(screen.getByLabelText('Length unit'), 'cm');
+    expect(onchange).toHaveBeenLastCalledWith({ value: 100, unit: 'cm' });
+  });
+
+  it('changing the unit with no value just switches the unit (no onchange)', async () => {
+    const onchange = vi.fn();
+    render(MeasurementInput, {
+      props: {
+        name: 'len',
+        label: 'Length',
+        units: ['ft', 'm'],
+        onchange,
+      },
+    });
+    await userEvent.selectOptions(screen.getByLabelText('Length unit'), 'm');
+    expect(onchange).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Length unit')).toHaveValue('m');
+  });
+
+  it('writes a combined "value unit" string into the hidden input', async () => {
+    const { container } = render(MeasurementInput, {
+      props: { name: 'len', label: 'Length', units: ['ft'] },
+    });
+    await userEvent.type(screen.getByLabelText('Length'), '3');
+    const hidden = container.querySelector<HTMLInputElement>(
+      'input[type="hidden"][name="len_combined"]',
+    );
+    expect(hidden).toHaveValue('3 ft');
+  });
+
+  it('flags below-min with a linked error citing the unit abbreviation', () => {
+    render(MeasurementInput, {
+      props: { name: 'len', label: 'Length', min: 10, value: 5, unit: 'ft' },
+    });
+    const input = screen.getByLabelText('Length');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAttribute('aria-describedby', 'len-error');
+    const err = document.getElementById('len-error');
+    expect(err).toHaveAttribute('role', 'alert');
+    expect(err?.textContent).toContain('10');
+    expect(err?.textContent).toContain('ft');
+  });
+
+  it('flags above-max as invalid', () => {
+    render(MeasurementInput, {
+      props: { name: 'len', label: 'Length', max: 10, value: 50, unit: 'm' },
+    });
+    expect(screen.getByLabelText('Length')).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
+    expect(document.getElementById('len-error')?.textContent).toContain('10');
+  });
+
+  it('an in-range value is valid (no error)', () => {
+    render(MeasurementInput, {
+      props: { name: 'len', label: 'Length', min: 0, max: 100, value: 5 },
+    });
+    const input = screen.getByLabelText('Length');
+    expect(input).not.toHaveAttribute('aria-invalid');
+    expect(document.getElementById('len-error')).toBeNull();
+  });
+
+  it('is axe-clean in a labelled + error state', async () => {
+    const { container } = render(MeasurementInput, {
+      props: { name: 'len', label: 'Length', error: 'Required', value: 5 },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/MoneyInput.behavior.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/MoneyInput.behavior.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Behavior tests for MoneyInput (Sweep S11, #1416).
+ *
+ * Exercises the cents<->display formatting, parsing, currency symbol/code,
+ * negative/decimal handling, blur reformatting, and min/max range validation
+ * — the logic the shallow a11y suite never touches. The hooks throw outside a
+ * <Provider>, so useAppState is mocked to non-smrt ('default') mode.
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+
+vi.mock('../../../hooks/useAppState.svelte.js', () => ({
+  useAppState: () => ({ state: { mode: 'default' }, setMode: vi.fn() }),
+}));
+
+import MoneyInput from '../MoneyInput.svelte';
+
+describe('MoneyInput — behavior', () => {
+  it('renders an existing cents value as a 2-decimal dollar string', () => {
+    render(MoneyInput, {
+      props: { name: 'price', label: 'Price', value: 15000 },
+    });
+    expect(screen.getByLabelText('Price')).toHaveValue('150.00');
+  });
+
+  it('typing dollars emits the parsed value in cents via onchange', async () => {
+    const onchange = vi.fn();
+    render(MoneyInput, { props: { name: 'price', label: 'Price', onchange } });
+    const input = screen.getByLabelText('Price');
+    await userEvent.type(input, '12.34');
+    expect(onchange).toHaveBeenLastCalledWith(1234);
+  });
+
+  it('strips $ and comma noise when parsing', async () => {
+    const onchange = vi.fn();
+    render(MoneyInput, { props: { name: 'price', label: 'Price', onchange } });
+    await userEvent.type(screen.getByLabelText('Price'), '$1,200');
+    expect(onchange).toHaveBeenLastCalledWith(120000);
+  });
+
+  it('clearing the input emits null', async () => {
+    const onchange = vi.fn();
+    render(MoneyInput, {
+      props: { name: 'price', label: 'Price', value: 5000, onchange },
+    });
+    const input = screen.getByLabelText('Price');
+    await userEvent.clear(input);
+    expect(onchange).toHaveBeenLastCalledWith(null);
+  });
+
+  it('reformats the display to 2 decimals on blur', async () => {
+    render(MoneyInput, { props: { name: 'price', label: 'Price' } });
+    const input = screen.getByLabelText('Price');
+    await userEvent.type(input, '5');
+    expect(input).toHaveValue('5'); // not reformatted while focused
+    await userEvent.tab();
+    expect(input).toHaveValue('5.00'); // reformatted on blur
+  });
+
+  it('shows CA$ symbol and CAD code by default', () => {
+    const { container } = render(MoneyInput, {
+      props: { name: 'price', label: 'Price' },
+    });
+    expect(container.querySelector('.currency-symbol')?.textContent).toBe(
+      'CA$',
+    );
+    expect(container.querySelector('.currency-code')?.textContent).toBe('CAD');
+  });
+
+  it('shows US$ symbol and USD code when currency=USD', () => {
+    const { container } = render(MoneyInput, {
+      props: { name: 'price', label: 'Price', currency: 'USD' },
+    });
+    expect(container.querySelector('.currency-symbol')?.textContent).toBe(
+      'US$',
+    );
+    expect(container.querySelector('.currency-code')?.textContent).toBe('USD');
+  });
+
+  it('writes the cents value into the hidden submission input', async () => {
+    const { container } = render(MoneyInput, {
+      props: { name: 'price', label: 'Price' },
+    });
+    await userEvent.type(screen.getByLabelText('Price'), '7.50');
+    const hidden = container.querySelector<HTMLInputElement>(
+      'input[type="hidden"][name="price_cents"]',
+    );
+    expect(hidden).toHaveValue('750');
+  });
+
+  it('flags below-min as invalid with a linked error message', () => {
+    render(MoneyInput, {
+      props: { name: 'price', label: 'Price', min: 10000, value: 5000 },
+    });
+    const input = screen.getByLabelText('Price');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAttribute('aria-describedby', 'price-error');
+    const err = document.getElementById('price-error');
+    expect(err).toHaveAttribute('role', 'alert');
+    // CA$ symbol + 2-decimal min ($100.00)
+    expect(err?.textContent).toContain('CA$100.00');
+  });
+
+  it('flags above-max as invalid', () => {
+    render(MoneyInput, {
+      props: { name: 'price', label: 'Price', max: 10000, value: 20000 },
+    });
+    const input = screen.getByLabelText('Price');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(document.getElementById('price-error')?.textContent).toContain(
+      'CA$100.00',
+    );
+  });
+
+  it('treats an in-range value as valid (no error)', () => {
+    render(MoneyInput, {
+      props: {
+        name: 'price',
+        label: 'Price',
+        min: 0,
+        max: 100000,
+        value: 5000,
+      },
+    });
+    const input = screen.getByLabelText('Price');
+    expect(input).not.toHaveAttribute('aria-invalid');
+    expect(document.getElementById('price-error')).toBeNull();
+  });
+
+  it('renders an explicit error prop over range checks', () => {
+    render(MoneyInput, {
+      props: { name: 'price', label: 'Price', error: 'Required' },
+    });
+    const err = document.getElementById('price-error');
+    expect(err).toHaveTextContent('Required');
+    expect(err).toHaveAttribute('role', 'alert');
+  });
+
+  it('is axe-clean in a labelled + error state', async () => {
+    const { container } = render(MoneyInput, {
+      props: { name: 'price', label: 'Price', error: 'Required', value: 1000 },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/NumberInput.behavior.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/NumberInput.behavior.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Deep behavior tests for NumberInput (Sweep S11, #1416).
+ *
+ * The existing a11y suite covers labelling + a single out-of-range case. This
+ * suite drives the real numeric pipeline: typing → handleInput (parseFloat /
+ * empty→null) → onchange + bindable value; the min/max derived range-validation
+ * (aria-invalid, the linked role=alert error, its at-least/at-most message
+ * variants); and the step/required/disabled attribute wiring.
+ *
+ * NumberInput calls useAppState (it throws outside a <Provider>), so it is
+ * mocked to a non-listening stub — the reference pattern from
+ * rich-inputs-a11y.test.ts. (NumberInput does not use useSTT.)
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+
+vi.mock('../../../hooks/useAppState.svelte.js', () => ({
+  useAppState: () => ({ state: { mode: 'default' }, setMode: vi.fn() }),
+}));
+
+import NumberInput from '../NumberInput.svelte';
+
+describe('NumberInput — typing & parsing', () => {
+  it('fires onchange with the parsed number as the user types', async () => {
+    const onchange = vi.fn();
+    render(NumberInput, { props: { name: 'age', label: 'Age', onchange } });
+
+    await userEvent.type(screen.getByLabelText('Age'), '42');
+
+    expect(onchange).toHaveBeenLastCalledWith(42);
+  });
+
+  it('parses a decimal value', async () => {
+    const onchange = vi.fn();
+    render(NumberInput, {
+      props: { name: 'weight', label: 'Weight', step: 0.1, onchange },
+    });
+    await userEvent.type(screen.getByLabelText('Weight'), '3.5');
+    expect(onchange).toHaveBeenLastCalledWith(3.5);
+  });
+
+  it('emits null when the field is cleared back to empty', async () => {
+    const onchange = vi.fn();
+    render(NumberInput, {
+      props: { name: 'age', label: 'Age', value: 7, onchange },
+    });
+    const input = screen.getByLabelText('Age');
+    await userEvent.clear(input);
+    expect(onchange).toHaveBeenLastCalledWith(null);
+  });
+
+  it('renders the initial numeric value', () => {
+    render(NumberInput, { props: { name: 'age', label: 'Age', value: 99 } });
+    expect(screen.getByLabelText('Age')).toHaveValue(99);
+  });
+
+  it('renders an empty string for a null value', () => {
+    render(NumberInput, { props: { name: 'age', label: 'Age', value: null } });
+    expect(screen.getByLabelText('Age')).toHaveValue(null);
+  });
+});
+
+describe('NumberInput — range validation', () => {
+  it('flags aria-invalid and shows the at-most message above max', () => {
+    render(NumberInput, {
+      props: { name: 'age', label: 'Age', max: 10, value: 99 },
+    });
+    const input = screen.getByLabelText('Age');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAttribute('aria-describedby', 'age-error');
+    const error = document.getElementById('age-error');
+    expect(error).toHaveAttribute('role', 'alert');
+    expect(error).toHaveTextContent('Value must be at most 10');
+  });
+
+  it('flags aria-invalid and shows the at-least message below min', () => {
+    render(NumberInput, {
+      props: { name: 'age', label: 'Age', min: 18, value: 5 },
+    });
+    const input = screen.getByLabelText('Age');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(document.getElementById('age-error')).toHaveTextContent(
+      'Value must be at least 18',
+    );
+  });
+
+  it('is valid for a value inside the range', () => {
+    render(NumberInput, {
+      props: { name: 'age', label: 'Age', min: 0, max: 120, value: 30 },
+    });
+    const input = screen.getByLabelText('Age');
+    expect(input).not.toHaveAttribute('aria-invalid', 'true');
+    expect(document.getElementById('age-error')).toBeNull();
+  });
+
+  it('treats a boundary value (== max) as valid', () => {
+    render(NumberInput, {
+      props: { name: 'age', label: 'Age', max: 10, value: 10 },
+    });
+    expect(screen.getByLabelText('Age')).not.toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
+  });
+
+  it('treats a null value as valid even with a range', () => {
+    render(NumberInput, {
+      props: { name: 'age', label: 'Age', min: 1, max: 5, value: null },
+    });
+    expect(screen.getByLabelText('Age')).not.toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
+  });
+
+  it('clears the invalid state once the user types an in-range value', async () => {
+    render(NumberInput, {
+      props: { name: 'age', label: 'Age', max: 10, value: 99 },
+    });
+    const input = screen.getByLabelText('Age');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    await userEvent.clear(input);
+    await userEvent.type(input, '5');
+    expect(input).not.toHaveAttribute('aria-invalid', 'true');
+  });
+});
+
+describe('NumberInput — attributes', () => {
+  it('forwards min, max, and step onto the input', () => {
+    render(NumberInput, {
+      props: { name: 'age', label: 'Age', min: 1, max: 100, step: 5 },
+    });
+    const input = screen.getByLabelText('Age');
+    expect(input).toHaveAttribute('min', '1');
+    expect(input).toHaveAttribute('max', '100');
+    expect(input).toHaveAttribute('step', '5');
+  });
+
+  it('reflects required and disabled', async () => {
+    const onchange = vi.fn();
+    // NOTE: with required, the "*" lives inside the <label>, so the input's
+    // accessible name becomes "Age *" — query by id rather than label.
+    const { container } = render(NumberInput, {
+      props: {
+        name: 'age',
+        label: 'Age',
+        required: true,
+        disabled: true,
+        onchange,
+      },
+    });
+    const input = container.querySelector('#age') as HTMLInputElement;
+    expect(input).toBeRequired();
+    expect(input).toBeDisabled();
+    await userEvent.type(input, '5');
+    expect(onchange).not.toHaveBeenCalled();
+  });
+
+  it('is axe-clean when labelled', async () => {
+    const { container } = render(NumberInput, {
+      props: { name: 'age', label: 'Age' },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/PhoneInput.behavior.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/PhoneInput.behavior.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Behavior tests for PhoneInput (Sweep S11, #1416).
+ *
+ * Exercises the progressive digit-masking formatter (parens/space/dash, the
+ * +1 country-code branch), normalized emission via onchange, and the
+ * 10–11 digit validity check. The hooks throw outside a <Provider>, so
+ * useAppState (default mode) + useSTT (non-listening stub) are mocked.
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+
+vi.mock('../../../hooks/useAppState.svelte.js', () => ({
+  useAppState: () => ({ state: { mode: 'default' }, setMode: vi.fn() }),
+}));
+vi.mock('../../../hooks/useSTT.svelte.js', () => ({
+  useSTT: () => ({
+    isListening: false,
+    isInitializing: false,
+    isReady: false,
+    adapterType: null,
+    downloadProgress: 0,
+    lastResult: '',
+    initialize: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+import PhoneInput from '../PhoneInput.svelte';
+
+describe('PhoneInput — behavior', () => {
+  it('masks digits progressively as the user types a 10-digit number', async () => {
+    render(PhoneInput, { props: { name: 'phone', label: 'Phone' } });
+    const input = screen.getByLabelText('Phone') as HTMLInputElement;
+    await userEvent.type(input, '5551234567');
+    expect(input).toHaveValue('(555) 123-4567');
+  });
+
+  it('formats a partial number with an open paren', async () => {
+    render(PhoneInput, { props: { name: 'phone', label: 'Phone' } });
+    const input = screen.getByLabelText('Phone') as HTMLInputElement;
+    await userEvent.type(input, '55');
+    expect(input).toHaveValue('(55');
+  });
+
+  it('emits the formatted (normalized) value via onchange', async () => {
+    const onchange = vi.fn();
+    render(PhoneInput, { props: { name: 'phone', label: 'Phone', onchange } });
+    await userEvent.type(screen.getByLabelText('Phone'), '5551234567');
+    expect(onchange).toHaveBeenLastCalledWith('(555) 123-4567');
+  });
+
+  it('strips non-digit noise from pasted input', async () => {
+    render(PhoneInput, { props: { name: 'phone', label: 'Phone' } });
+    const input = screen.getByLabelText('Phone') as HTMLInputElement;
+    await userEvent.click(input);
+    await userEvent.paste('555-123-4567');
+    expect(input).toHaveValue('(555) 123-4567');
+  });
+
+  it('formats an 11-digit number starting with 1 as +1 (...)', async () => {
+    render(PhoneInput, { props: { name: 'phone', label: 'Phone' } });
+    const input = screen.getByLabelText('Phone') as HTMLInputElement;
+    await userEvent.click(input);
+    await userEvent.paste('15551234567');
+    expect(input).toHaveValue('+1 (555) 123-4567');
+  });
+
+  it('flags an incomplete number as invalid with a linked alert', () => {
+    render(PhoneInput, {
+      props: { name: 'phone', label: 'Phone', value: '(555) 12' },
+    });
+    const input = screen.getByLabelText('Phone');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAttribute('aria-describedby', 'phone-error');
+    const err = document.getElementById('phone-error');
+    expect(err).toHaveAttribute('role', 'alert');
+    expect(err).toHaveTextContent('Invalid phone number');
+  });
+
+  it('treats a complete 10-digit number as valid (no error)', () => {
+    render(PhoneInput, {
+      props: { name: 'phone', label: 'Phone', value: '(555) 123-4567' },
+    });
+    const input = screen.getByLabelText('Phone');
+    expect(input).not.toHaveAttribute('aria-invalid');
+    expect(document.getElementById('phone-error')).toBeNull();
+  });
+
+  it('treats an empty value as valid (not invalid)', () => {
+    render(PhoneInput, { props: { name: 'phone', label: 'Phone', value: '' } });
+    expect(screen.getByLabelText('Phone')).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('uses a tel input type', () => {
+    render(PhoneInput, { props: { name: 'phone', label: 'Phone' } });
+    expect(screen.getByLabelText('Phone')).toHaveAttribute('type', 'tel');
+  });
+
+  it('is axe-clean in a labelled invalid state', async () => {
+    const { container } = render(PhoneInput, {
+      props: { name: 'phone', label: 'Phone', value: '(555) 12' },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/SearchInput.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/SearchInput.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Component test for SearchInput (Sweep S11, #1416).
+ *
+ * Follows the golden pattern (src/components/ui/__tests__/Button.test.ts).
+ * A `type="search"` input surfaces as a `searchbox` role. The component is
+ * Provider-free (its i18n falls back to registered defaults outside a Provider).
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import SearchInput from '../SearchInput.svelte';
+
+describe('SearchInput', () => {
+  it('renders a searchbox with its default accessible name', () => {
+    render(SearchInput);
+    expect(
+      screen.getByRole('searchbox', { name: 'Search' }),
+    ).toBeInTheDocument();
+  });
+
+  it('uses ariaLabel as the accessible name and shows the placeholder', () => {
+    render(SearchInput, {
+      props: { ariaLabel: 'Find articles', placeholder: 'Type to search…' },
+    });
+    const box = screen.getByRole('searchbox', { name: 'Find articles' });
+    expect(box).toHaveAttribute('placeholder', 'Type to search…');
+  });
+
+  it('reflects the value and disabled props', () => {
+    render(SearchInput, {
+      props: { ariaLabel: 'Search', value: 'hello', disabled: true },
+    });
+    const box = screen.getByRole('searchbox', { name: 'Search' });
+    expect(box).toHaveValue('hello');
+    expect(box).toBeDisabled();
+  });
+
+  it('fires oninput immediately while typing (no debounce)', async () => {
+    const oninput = vi.fn();
+    render(SearchInput, {
+      props: { ariaLabel: 'Search', debounce: 0, oninput },
+    });
+    await userEvent.type(
+      screen.getByRole('searchbox', { name: 'Search' }),
+      'ab',
+    );
+    expect(oninput).toHaveBeenCalledTimes(2);
+    expect(oninput).toHaveBeenLastCalledWith('ab');
+  });
+
+  it('fires onsearch on Enter and onsubmit with the current value', async () => {
+    const onsearch = vi.fn();
+    const onsubmit = vi.fn();
+    render(SearchInput, {
+      props: { ariaLabel: 'Search', debounce: 0, onsearch, onsubmit },
+    });
+    const box = screen.getByRole('searchbox', { name: 'Search' });
+    await userEvent.type(box, 'query{Enter}');
+    expect(onsubmit).toHaveBeenCalledWith('query');
+    expect(onsearch).toHaveBeenLastCalledWith('query');
+  });
+
+  it('shows a clear button once there is a value and clears on click', async () => {
+    const oninput = vi.fn();
+    render(SearchInput, {
+      props: { ariaLabel: 'Search', debounce: 0, value: 'something', oninput },
+    });
+    const clear = screen.getByRole('button', { name: 'Clear search' });
+    await userEvent.click(clear);
+    expect(screen.getByRole('searchbox', { name: 'Search' })).toHaveValue('');
+    expect(oninput).toHaveBeenLastCalledWith('');
+  });
+
+  it('does not render a clear button when empty', () => {
+    render(SearchInput, { props: { ariaLabel: 'Search' } });
+    expect(
+      screen.queryByRole('button', { name: 'Clear search' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('is axe-clean in the default state', async () => {
+    const { container } = render(SearchInput, {
+      props: { ariaLabel: 'Search the catalog' },
+    });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean with a value (clear button visible)', async () => {
+    const { container } = render(SearchInput, {
+      props: { ariaLabel: 'Search the catalog', value: 'shoes' },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/SelectInput.behavior.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/SelectInput.behavior.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Deep behavior tests for SelectInput (Sweep S11, #1416).
+ *
+ * The existing a11y suite only asserts labelling + describedby + axe. This
+ * suite drives the real selection pipeline: choosing an option → handleChange →
+ * updateValue → onchange + bindable value; the placeholder option (disabled +
+ * selected when empty); option rendering from the options prop; and the
+ * required/disabled wiring.
+ *
+ * SelectInput calls useAppState (it throws outside a <Provider>), so it is
+ * mocked to a non-listening stub — the reference pattern from
+ * rich-inputs-a11y.test.ts. (SelectInput does not use useSTT.)
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+
+vi.mock('../../../hooks/useAppState.svelte.js', () => ({
+  useAppState: () => ({ state: { mode: 'default' }, setMode: vi.fn() }),
+}));
+
+import SelectInput from '../SelectInput.svelte';
+
+const COUNTRIES = [
+  { value: 'us', label: 'United States' },
+  { value: 'ca', label: 'Canada' },
+  { value: 'mx', label: 'Mexico' },
+];
+
+describe('SelectInput — selection', () => {
+  it('fires onchange with the chosen option value', async () => {
+    const onchange = vi.fn();
+    render(SelectInput, {
+      props: {
+        name: 'country',
+        label: 'Country',
+        options: COUNTRIES,
+        onchange,
+      },
+    });
+
+    await userEvent.selectOptions(screen.getByLabelText('Country'), 'ca');
+
+    expect(onchange).toHaveBeenCalledWith('ca');
+  });
+
+  it('reflects the selected value on the <select>', async () => {
+    render(SelectInput, {
+      props: { name: 'country', label: 'Country', options: COUNTRIES },
+    });
+    const select = screen.getByLabelText('Country') as HTMLSelectElement;
+    await userEvent.selectOptions(select, 'mx');
+    expect(select).toHaveValue('mx');
+  });
+
+  it('renders the initial value prop as the selected option', () => {
+    render(SelectInput, {
+      props: {
+        name: 'country',
+        label: 'Country',
+        options: COUNTRIES,
+        value: 'us',
+      },
+    });
+    expect(screen.getByLabelText('Country')).toHaveValue('us');
+  });
+});
+
+describe('SelectInput — options & placeholder', () => {
+  it('renders one <option> per provided option plus the placeholder', () => {
+    render(SelectInput, {
+      props: {
+        name: 'country',
+        label: 'Country',
+        options: COUNTRIES,
+        placeholder: 'Choose a country…',
+      },
+    });
+    // 3 countries + 1 placeholder option.
+    expect(screen.getAllByRole('option')).toHaveLength(4);
+    expect(
+      screen.getByRole('option', { name: 'United States' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the placeholder as a disabled option, selected when value is empty', () => {
+    render(SelectInput, {
+      props: {
+        name: 'country',
+        label: 'Country',
+        options: COUNTRIES,
+        placeholder: 'Choose a country…',
+      },
+    });
+    const placeholder = screen.getByRole('option', {
+      name: 'Choose a country…',
+    }) as HTMLOptionElement;
+    expect(placeholder).toBeDisabled();
+    expect(placeholder.value).toBe('');
+  });
+});
+
+describe('SelectInput — states & attributes', () => {
+  it('reflects required onto the select', () => {
+    // NOTE: with required, the "*" lives inside the <label>, so the select's
+    // accessible name becomes "Country *" — query by id rather than label.
+    const { container } = render(SelectInput, {
+      props: {
+        name: 'country',
+        label: 'Country',
+        options: COUNTRIES,
+        required: true,
+      },
+    });
+    expect(container.querySelector('#country')).toBeRequired();
+  });
+
+  it('disables the select and ignores selection when disabled', async () => {
+    const onchange = vi.fn();
+    render(SelectInput, {
+      props: {
+        name: 'country',
+        label: 'Country',
+        options: COUNTRIES,
+        disabled: true,
+        onchange,
+      },
+    });
+    const select = screen.getByLabelText('Country');
+    expect(select).toBeDisabled();
+    await userEvent.selectOptions(select, 'ca').catch(() => {});
+    expect(onchange).not.toHaveBeenCalled();
+  });
+
+  it('is axe-clean when labelled with a placeholder', async () => {
+    const { container } = render(SelectInput, {
+      props: {
+        name: 'country',
+        label: 'Country',
+        placeholder: 'Choose…',
+        options: COUNTRIES,
+      },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/TextInput.behavior.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/TextInput.behavior.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Deep behavior tests for TextInput (Sweep S11, #1416).
+ *
+ * The existing a11y suite only asserts labelling + describedby + axe. This
+ * suite exercises the real value pipeline: typing → handleInput → updateValue →
+ * onchange + bindable value, the email-validation derived state (aria-invalid,
+ * the invalid-email supporting message), disabled/required wiring, and the
+ * placeholder-on-focus behavior.
+ *
+ * TextInput calls useAppState/useSTT (they throw outside a <Provider>), so both
+ * are mocked to non-listening stubs — the reference pattern from
+ * rich-inputs-a11y.test.ts.
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+
+vi.mock('../../../hooks/useAppState.svelte.js', () => ({
+  useAppState: () => ({ state: { mode: 'default' }, setMode: vi.fn() }),
+}));
+vi.mock('../../../hooks/useSTT.svelte.js', () => ({
+  useSTT: () => ({
+    isListening: false,
+    isInitializing: false,
+    isReady: false,
+    adapterType: null,
+    downloadProgress: 0,
+    lastResult: '',
+    initialize: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+import TextInput from '../TextInput.svelte';
+
+describe('TextInput — typing & value', () => {
+  it('fires onchange with the current value on each keystroke', async () => {
+    const onchange = vi.fn();
+    render(TextInput, {
+      props: { name: 'fullname', label: 'Full name', onchange },
+    });
+
+    await userEvent.type(screen.getByLabelText('Full name'), 'Ada');
+
+    expect(onchange).toHaveBeenLastCalledWith('Ada');
+  });
+
+  it('renders the initial value prop into the input', () => {
+    render(TextInput, {
+      props: { name: 'fullname', label: 'Full name', value: 'Seed' },
+    });
+    expect(screen.getByLabelText('Full name')).toHaveValue('Seed');
+  });
+
+  it('updates the input value as the user types', async () => {
+    render(TextInput, { props: { name: 'fullname', label: 'Full name' } });
+    const input = screen.getByLabelText('Full name');
+    await userEvent.type(input, 'Lovelace');
+    expect(input).toHaveValue('Lovelace');
+  });
+});
+
+describe('TextInput — email validation', () => {
+  it('marks aria-invalid when an email value is malformed', () => {
+    render(TextInput, {
+      props: {
+        name: 'email',
+        label: 'Email',
+        type: 'email',
+        value: 'not-an-email',
+      },
+    });
+    expect(screen.getByLabelText('Email')).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
+  });
+
+  it('shows the invalid-email supporting message for a bad address', () => {
+    render(TextInput, {
+      props: { name: 'email', label: 'Email', type: 'email', value: 'nope' },
+    });
+    expect(screen.getByText('Invalid email address')).toBeInTheDocument();
+  });
+
+  it('is valid (no aria-invalid) for a well-formed email', () => {
+    render(TextInput, {
+      props: {
+        name: 'email',
+        label: 'Email',
+        type: 'email',
+        value: 'ada@example.com',
+      },
+    });
+    expect(screen.getByLabelText('Email')).not.toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
+  });
+
+  it('treats an empty email as valid (no error until the user types)', () => {
+    render(TextInput, {
+      props: { name: 'email', label: 'Email', type: 'email' },
+    });
+    expect(screen.getByLabelText('Email')).not.toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
+  });
+});
+
+describe('TextInput — states & attributes', () => {
+  it('reflects required onto the input', () => {
+    // NOTE: with required, the "*" lives inside the <label>, so the input's
+    // accessible name becomes "Full name *" — query by id rather than label.
+    const { container } = render(TextInput, {
+      props: { name: 'fullname', label: 'Full name', required: true },
+    });
+    expect(container.querySelector('#fullname')).toBeRequired();
+  });
+
+  it('disables the input and ignores typing when disabled', async () => {
+    const onchange = vi.fn();
+    render(TextInput, {
+      props: { name: 'fullname', label: 'Full name', disabled: true, onchange },
+    });
+    const input = screen.getByLabelText('Full name');
+    expect(input).toBeDisabled();
+    await userEvent.type(input, 'ignored');
+    expect(onchange).not.toHaveBeenCalled();
+  });
+
+  it('reveals the placeholder only while focused', async () => {
+    render(TextInput, {
+      props: {
+        name: 'fullname',
+        label: 'Full name',
+        placeholder: 'Enter name',
+      },
+    });
+    const input = screen.getByLabelText('Full name');
+    expect(input).toHaveAttribute('placeholder', '');
+    await userEvent.click(input);
+    expect(input).toHaveAttribute('placeholder', 'Enter name');
+  });
+
+  it('is axe-clean when labelled', async () => {
+    const { container } = render(TextInput, {
+      props: { name: 'fullname', label: 'Full name' },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/TextareaInput.behavior.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/TextareaInput.behavior.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Deep behavior tests for TextareaInput (Sweep S11, #1416).
+ *
+ * The existing a11y suite only asserts labelling + describedby + axe. This
+ * suite drives the real value pipeline: typing → handleInput → updateValue →
+ * onchange + bindable value, plus the rows/required/disabled wiring and the
+ * focus-gated placeholder.
+ *
+ * TextareaInput calls useAppState/useSTT (they throw outside a <Provider>), so
+ * both are mocked to non-listening stubs — the reference pattern from
+ * rich-inputs-a11y.test.ts.
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+
+vi.mock('../../../hooks/useAppState.svelte.js', () => ({
+  useAppState: () => ({ state: { mode: 'default' }, setMode: vi.fn() }),
+}));
+vi.mock('../../../hooks/useSTT.svelte.js', () => ({
+  useSTT: () => ({
+    isListening: false,
+    isInitializing: false,
+    isReady: false,
+    adapterType: null,
+    downloadProgress: 0,
+    lastResult: '',
+    initialize: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+import TextareaInput from '../TextareaInput.svelte';
+
+describe('TextareaInput — typing & value', () => {
+  it('fires onchange with the current value as the user types', async () => {
+    const onchange = vi.fn();
+    render(TextareaInput, { props: { name: 'bio', label: 'Bio', onchange } });
+
+    await userEvent.type(screen.getByLabelText('Bio'), 'Hello');
+
+    expect(onchange).toHaveBeenLastCalledWith('Hello');
+  });
+
+  it('renders the initial value prop', () => {
+    render(TextareaInput, {
+      props: { name: 'bio', label: 'Bio', value: 'Seeded text' },
+    });
+    expect(screen.getByLabelText('Bio')).toHaveValue('Seeded text');
+  });
+
+  it('captures multi-line input', async () => {
+    render(TextareaInput, { props: { name: 'bio', label: 'Bio' } });
+    const textarea = screen.getByLabelText('Bio');
+    await userEvent.type(textarea, 'line one{enter}line two');
+    expect(textarea).toHaveValue('line one\nline two');
+  });
+});
+
+describe('TextareaInput — states & attributes', () => {
+  it('forwards the rows prop onto the textarea', () => {
+    render(TextareaInput, { props: { name: 'bio', label: 'Bio', rows: 8 } });
+    expect(screen.getByLabelText('Bio')).toHaveAttribute('rows', '8');
+  });
+
+  it('defaults to 4 rows when not specified', () => {
+    render(TextareaInput, { props: { name: 'bio', label: 'Bio' } });
+    expect(screen.getByLabelText('Bio')).toHaveAttribute('rows', '4');
+  });
+
+  it('reflects required onto the textarea', () => {
+    // NOTE: with required, the "*" lives inside the <label>, so the textarea's
+    // accessible name becomes "Bio *" — query by id rather than label.
+    const { container } = render(TextareaInput, {
+      props: { name: 'bio', label: 'Bio', required: true },
+    });
+    expect(container.querySelector('#bio')).toBeRequired();
+  });
+
+  it('disables the textarea and ignores typing when disabled', async () => {
+    const onchange = vi.fn();
+    render(TextareaInput, {
+      props: { name: 'bio', label: 'Bio', disabled: true, onchange },
+    });
+    const textarea = screen.getByLabelText('Bio');
+    expect(textarea).toBeDisabled();
+    await userEvent.type(textarea, 'ignored');
+    expect(onchange).not.toHaveBeenCalled();
+  });
+
+  it('reveals the placeholder only while focused', async () => {
+    render(TextareaInput, {
+      props: { name: 'bio', label: 'Bio', placeholder: 'Tell us about you' },
+    });
+    const textarea = screen.getByLabelText('Bio');
+    expect(textarea).toHaveAttribute('placeholder', '');
+    await userEvent.click(textarea);
+    expect(textarea).toHaveAttribute('placeholder', 'Tell us about you');
+  });
+
+  it('is axe-clean when labelled', async () => {
+    const { container } = render(TextareaInput, {
+      props: { name: 'bio', label: 'Bio' },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/Toggle.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/Toggle.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Component test for Toggle (Sweep S11, #1416).
+ *
+ * Follows the golden pattern (src/components/ui/__tests__/Button.test.ts):
+ * render → assert role/name/state → drive with user-event → prove axe-clean.
+ * Toggle renders native checkbox semantics, so it surfaces as a `checkbox` role.
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import Toggle from '../Toggle.svelte';
+
+describe('Toggle', () => {
+  it('renders a checkbox with its label as the accessible name', () => {
+    render(Toggle, { props: { label: 'Email notifications' } });
+    const toggle = screen.getByRole('checkbox', {
+      name: 'Email notifications',
+    });
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).not.toBeChecked();
+  });
+
+  it('prefers ariaLabel over label for the accessible name', () => {
+    render(Toggle, { props: { label: 'Visible', ariaLabel: 'Wifi' } });
+    expect(screen.getByRole('checkbox', { name: 'Wifi' })).toBeInTheDocument();
+  });
+
+  it('reflects the checked prop', () => {
+    render(Toggle, { props: { ariaLabel: 'Active', checked: true } });
+    expect(screen.getByRole('checkbox', { name: 'Active' })).toBeChecked();
+  });
+
+  it('reflects the disabled prop', () => {
+    render(Toggle, { props: { ariaLabel: 'Active', disabled: true } });
+    expect(screen.getByRole('checkbox', { name: 'Active' })).toBeDisabled();
+  });
+
+  it('forwards name, value, and id to the input for form submission', () => {
+    render(Toggle, {
+      props: { ariaLabel: 'Sub', name: 'sub', value: 'on', id: 'sub-toggle' },
+    });
+    const toggle = screen.getByRole('checkbox', {
+      name: 'Sub',
+    }) as HTMLInputElement;
+    expect(toggle).toHaveAttribute('name', 'sub');
+    expect(toggle).toHaveAttribute('id', 'sub-toggle');
+    // Svelte binds `value` as the DOM property on checkboxes (not a reflected attribute).
+    expect(toggle.value).toBe('on');
+  });
+
+  it('toggles checked and fires onchange when clicked', async () => {
+    const onchange = vi.fn();
+    render(Toggle, { props: { ariaLabel: 'Active', onchange } });
+    const toggle = screen.getByRole('checkbox', { name: 'Active' });
+    await userEvent.click(toggle);
+    expect(toggle).toBeChecked();
+    expect(onchange).toHaveBeenCalledWith(true);
+    await userEvent.click(toggle);
+    expect(toggle).not.toBeChecked();
+    expect(onchange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('is keyboard-activatable with Space when focused', async () => {
+    const onchange = vi.fn();
+    render(Toggle, { props: { ariaLabel: 'Active', onchange } });
+    const toggle = screen.getByRole('checkbox', { name: 'Active' });
+    toggle.focus();
+    expect(toggle).toHaveFocus();
+    await userEvent.keyboard(' ');
+    expect(toggle).toBeChecked();
+    expect(onchange).toHaveBeenCalledWith(true);
+  });
+
+  it('does not fire onchange when disabled', async () => {
+    const onchange = vi.fn();
+    render(Toggle, {
+      props: { ariaLabel: 'Active', disabled: true, onchange },
+    });
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Active' }));
+    expect(onchange).not.toHaveBeenCalled();
+  });
+
+  it('is axe-clean with a label', async () => {
+    const { container } = render(Toggle, {
+      props: { label: 'Accessible toggle' },
+    });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean in the checked + disabled state', async () => {
+    const { container } = render(Toggle, {
+      props: { label: 'Locked on', checked: true, disabled: true },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/form-with-fields.fixture.svelte
+++ b/packages/smrt-svelte/src/components/forms/__tests__/form-with-fields.fixture.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+/** Test fixture (S11 #1416): a Form wrapping a TextInput + NumberInput so the
+ *  Form's field-registration → value-collection → onsubmit contract can be
+ *  exercised end-to-end (the submit handler reads each registered field's
+ *  getValue()). */
+import Form from '../Form.svelte';
+import NumberInput from '../NumberInput.svelte';
+import TextInput from '../TextInput.svelte';
+
+let {
+  onsubmit = undefined,
+  method = undefined,
+  action = undefined,
+  textValue = '',
+  numberValue = null,
+}: {
+  onsubmit?: (data: Record<string, unknown>) => void;
+  method?: 'GET' | 'POST';
+  action?: string;
+  textValue?: string;
+  numberValue?: number | null;
+} = $props();
+</script>
+
+<Form {onsubmit} {method} {action}>
+	<TextInput name="fullname" label="Full name" bind:value={textValue} />
+	<NumberInput name="age" label="Age" bind:value={numberValue} />
+	<button type="submit">Submit</button>
+</Form>

--- a/packages/smrt-svelte/src/components/forms/__tests__/form-with-fields.fixture.svelte
+++ b/packages/smrt-svelte/src/components/forms/__tests__/form-with-fields.fixture.svelte
@@ -13,17 +13,21 @@ let {
   action = undefined,
   textValue = '',
   numberValue = null,
+  showAge = true,
 }: {
   onsubmit?: (data: Record<string, unknown>) => void;
   method?: 'GET' | 'POST';
   action?: string;
   textValue?: string;
   numberValue?: number | null;
+  showAge?: boolean;
 } = $props();
 </script>
 
 <Form {onsubmit} {method} {action}>
 	<TextInput name="fullname" label="Full name" bind:value={textValue} />
-	<NumberInput name="age" label="Age" bind:value={numberValue} />
+	{#if showAge}
+		<NumberInput name="age" label="Age" bind:value={numberValue} />
+	{/if}
 	<button type="submit">Submit</button>
 </Form>

--- a/packages/smrt-svelte/src/components/layout/Masthead.svelte
+++ b/packages/smrt-svelte/src/components/layout/Masthead.svelte
@@ -48,7 +48,7 @@ const {
       </div>
       <div class="right">
         {#if nav}
-          <nav class="nav">
+          <nav class="nav" aria-label={t(M['ui.masthead.primary_nav'])}>
             {@render nav()}
           </nav>
         {/if}
@@ -67,11 +67,11 @@ const {
       </div>
       <div class="right">
         {#if mobileNav}
-          <nav class="nav mobile-nav">
+          <nav class="nav mobile-nav" aria-label={t(M['ui.masthead.mobile_nav'])}>
             {@render mobileNav()}
           </nav>
         {:else if nav}
-          <nav class="nav">
+          <nav class="nav" aria-label={t(M['ui.masthead.mobile_nav'])}>
             {@render nav()}
           </nav>
         {/if}

--- a/packages/smrt-svelte/src/components/layout/__tests__/Container.test.ts
+++ b/packages/smrt-svelte/src/components/layout/__tests__/Container.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Component tests for the Container layout primitive (Sweep S11, #1416).
+ *
+ * Mirrors the Button golden pattern: render via Testing Library, assert the
+ * rendered DOM/class/attribute API, and prove axe-clean output.
+ */
+import { render, screen } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import Container from '../Container.svelte';
+
+/** Build a text Snippet for the `children` prop. */
+function textSnippet(text: string) {
+  return createRawSnippet(() => ({ render: () => `<span>${text}</span>` }));
+}
+
+describe('Container', () => {
+  it('renders slotted children', () => {
+    render(Container, { props: { children: textSnippet('Inside') } });
+    expect(screen.getByText('Inside')).toBeInTheDocument();
+  });
+
+  it('applies the default lg max-width class', () => {
+    const { container } = render(Container, {
+      props: { children: textSnippet('x') },
+    });
+    const div = container.querySelector('div.container');
+    expect(div).not.toBeNull();
+    expect(div).toHaveClass('container', 'max-w-lg');
+  });
+
+  it.each([
+    'sm',
+    'md',
+    'lg',
+    'xl',
+    'full',
+  ] as const)('maps maxWidth=%s to the max-w-%s class', (maxWidth) => {
+    const { container } = render(Container, {
+      props: { maxWidth, children: textSnippet('x') },
+    });
+    expect(container.querySelector('div.container')).toHaveClass(
+      `max-w-${maxWidth}`,
+    );
+  });
+
+  it('passes ...rest attributes through to the root element', () => {
+    const { container } = render(Container, {
+      props: {
+        children: textSnippet('x'),
+        id: 'main-region',
+        'data-testid': 'wrap',
+        role: 'region',
+        'aria-label': 'Main content',
+      },
+    });
+    const div = container.querySelector('div.container');
+    expect(div).toHaveAttribute('id', 'main-region');
+    expect(div).toHaveAttribute('data-testid', 'wrap');
+    expect(screen.getByRole('region', { name: 'Main content' })).toBe(div);
+  });
+
+  it('is axe-clean with content', async () => {
+    const { container } = render(Container, {
+      props: { children: textSnippet('Accessible content') },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/layout/__tests__/EmptyState.test.ts
+++ b/packages/smrt-svelte/src/components/layout/__tests__/EmptyState.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Component tests for the EmptyState layout primitive (Sweep S11, #1416).
+ *
+ * Asserts the title/description render, the built-in vs. custom-snippet icon,
+ * the optional action (link vs. button + onaction callback), the size variant,
+ * and axe-clean output.
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import EmptyState from '../EmptyState.svelte';
+
+function iconSnippet(text: string) {
+  return createRawSnippet(() => ({
+    render: () => `<span data-testid="custom-icon">${text}</span>`,
+  }));
+}
+
+describe('EmptyState', () => {
+  it('renders the title as a heading', () => {
+    render(EmptyState, { props: { title: 'No results' } });
+    expect(
+      screen.getByRole('heading', { name: 'No results' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the optional description', () => {
+    render(EmptyState, {
+      props: { title: 'Empty', description: 'Try adjusting your filters.' },
+    });
+    expect(screen.getByText('Try adjusting your filters.')).toBeInTheDocument();
+  });
+
+  it('renders a default built-in icon when icon is a string name', () => {
+    const { container } = render(EmptyState, {
+      props: { title: 'Empty', icon: 'search' },
+    });
+    expect(container.querySelector('.icon-container svg')).not.toBeNull();
+  });
+
+  it('renders a custom icon snippet', () => {
+    render(EmptyState, {
+      props: { title: 'Empty', icon: iconSnippet('★') },
+    });
+    expect(screen.getByTestId('custom-icon')).toHaveTextContent('★');
+  });
+
+  it('renders the action as a link when actionHref is set', () => {
+    render(EmptyState, {
+      props: {
+        title: 'Empty',
+        actionLabel: 'Create one',
+        actionHref: '/new',
+      },
+    });
+    const link = screen.getByRole('link', { name: 'Create one' });
+    expect(link).toHaveAttribute('href', '/new');
+  });
+
+  it('renders the action as a button and fires onaction when clicked', async () => {
+    const onaction = vi.fn();
+    render(EmptyState, {
+      props: { title: 'Empty', actionLabel: 'Reload', onaction },
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'Reload' }));
+    expect(onaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders no action control when no actionLabel is provided', () => {
+    render(EmptyState, { props: { title: 'Empty' } });
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('applies the size variant class', () => {
+    const { container } = render(EmptyState, {
+      props: { title: 'Empty', size: 'sm' },
+    });
+    expect(container.querySelector('.empty-state')).toHaveClass('sm');
+  });
+
+  it('is axe-clean with a description and button action', async () => {
+    const { container } = render(EmptyState, {
+      props: {
+        title: 'Nothing here yet',
+        description: 'Add your first item to get started.',
+        actionLabel: 'Add item',
+        onaction: () => {},
+      },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/layout/__tests__/Footer.test.ts
+++ b/packages/smrt-svelte/src/components/layout/__tests__/Footer.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Component tests for the Footer layout primitive (Sweep S11, #1416).
+ *
+ * Footer renders a top-level <footer> (contentinfo landmark) with an
+ * i18n-resolved copyright line and optional children (footer links).
+ * useI18n() falls back to registered English defaults outside a Provider.
+ */
+import { render, screen } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import Footer from '../Footer.svelte';
+
+function snippet(html: string) {
+  return createRawSnippet(() => ({ render: () => html }));
+}
+
+describe('Footer', () => {
+  it('renders a top-level contentinfo landmark', () => {
+    render(Footer, { props: {} });
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+  });
+
+  it('renders the current year and i18n-resolved rights notice', () => {
+    render(Footer, { props: {} });
+    const year = String(new Date().getFullYear());
+    const copyright = screen.getByText(
+      (_, el) =>
+        el?.classList.contains('copyright') === true &&
+        el.textContent?.includes(year) === true &&
+        el.textContent?.includes('All rights reserved.') === true,
+    );
+    expect(copyright).toBeInTheDocument();
+  });
+
+  it('renders the children (footer links)', () => {
+    render(Footer, {
+      props: {
+        children: snippet('<a href="/privacy">Privacy</a>'),
+      },
+    });
+    const link = screen.getByRole('link', { name: 'Privacy' });
+    expect(link).toHaveAttribute('href', '/privacy');
+  });
+
+  it('omits the footer-links container when no children are provided', () => {
+    const { container } = render(Footer, { props: {} });
+    expect(container.querySelector('.footer-links')).toBeNull();
+  });
+
+  it('is axe-clean with footer links', async () => {
+    const { container } = render(Footer, {
+      props: {
+        children: snippet('<a href="/privacy">Privacy</a>'),
+      },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/layout/__tests__/Grid.test.ts
+++ b/packages/smrt-svelte/src/components/layout/__tests__/Grid.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Component tests for the Grid layout primitive (Sweep S11, #1416).
+ *
+ * Asserts the column/gap/alignment prop API maps to the expected
+ * classes/inline styles, snippet rendering, attribute pass-through, and
+ * axe-clean output.
+ */
+import { render, screen } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import Grid from '../Grid.svelte';
+
+function textSnippet(text: string) {
+  return createRawSnippet(() => ({ render: () => `<span>${text}</span>` }));
+}
+
+/** The grid element is the `.grid` div (the header lives in a sibling div). */
+function gridEl(container: HTMLElement): HTMLElement {
+  const el = container.querySelector<HTMLElement>('div.grid');
+  if (!el) throw new Error('grid element not found');
+  return el;
+}
+
+describe('Grid', () => {
+  it('renders slotted children', () => {
+    render(Grid, { props: { children: textSnippet('Cell') } });
+    expect(screen.getByText('Cell')).toBeInTheDocument();
+  });
+
+  it('uses auto-fill grid-template-columns by default (columns=auto)', () => {
+    const { container } = render(Grid, {
+      props: { children: textSnippet('x') },
+    });
+    expect(gridEl(container).getAttribute('style')).toContain(
+      'grid-template-columns: repeat(auto-fill, minmax(300px, 1fr))',
+    );
+  });
+
+  it('maps a numeric column count to a fixed-column template', () => {
+    const { container } = render(Grid, {
+      props: { columns: 3, children: textSnippet('x') },
+    });
+    expect(gridEl(container).getAttribute('style')).toContain(
+      'grid-template-columns: repeat(3, 1fr)',
+    );
+  });
+
+  it('emits responsive CSS variables and the grid-responsive class for a responsive columns object', () => {
+    const { container } = render(Grid, {
+      props: { columns: { md: 2, xl: 4 }, children: textSnippet('x') },
+    });
+    const el = gridEl(container);
+    expect(el).toHaveClass('grid-responsive');
+    const style = el.getAttribute('style') ?? '';
+    expect(style).toContain('--grid-columns-md: 2');
+    expect(style).toContain('--grid-columns-xl: 4');
+    // Unspecified breakpoints are not emitted (CSS cascade handles inheritance).
+    expect(style).not.toContain('--grid-columns-sm');
+  });
+
+  it('applies a uniform gap class when row and column gaps match (default md)', () => {
+    const { container } = render(Grid, {
+      props: { children: textSnippet('x') },
+    });
+    expect(gridEl(container)).toHaveClass('gap-md');
+  });
+
+  it.each([
+    'sm',
+    'md',
+    'lg',
+    'xl',
+  ] as const)('maps a uniform gap=%s to gap-%s', (gap) => {
+    const { container } = render(Grid, {
+      props: { gap, children: textSnippet('x') },
+    });
+    expect(gridEl(container)).toHaveClass(`gap-${gap}`);
+  });
+
+  it('splits row/column gap classes when they differ', () => {
+    const { container } = render(Grid, {
+      props: { gap: { row: 'sm', column: 'lg' }, children: textSnippet('x') },
+    });
+    const el = gridEl(container);
+    expect(el).toHaveClass('row-gap-sm', 'col-gap-lg');
+    expect(el).not.toHaveClass('gap-sm');
+  });
+
+  it('maps alignItems / justifyItems / autoFlow to inline styles', () => {
+    const { container } = render(Grid, {
+      props: {
+        alignItems: 'center',
+        justifyItems: 'end',
+        autoFlow: 'column',
+        children: textSnippet('x'),
+      },
+    });
+    const style = gridEl(container).getAttribute('style') ?? '';
+    expect(style).toContain('align-items: center');
+    expect(style).toContain('justify-items: end');
+    expect(style).toContain('grid-auto-flow: column');
+  });
+
+  it('renders the header snippet above the grid', () => {
+    render(Grid, {
+      props: {
+        header: textSnippet('Grid Heading'),
+        children: textSnippet('Cell'),
+      },
+    });
+    expect(screen.getByText('Grid Heading')).toBeInTheDocument();
+  });
+
+  it('passes ...rest attributes through to the grid element', () => {
+    const { container } = render(Grid, {
+      props: {
+        children: textSnippet('x'),
+        id: 'gallery',
+        'data-testid': 'grid',
+      },
+    });
+    const el = gridEl(container);
+    expect(el).toHaveAttribute('id', 'gallery');
+    expect(el).toHaveAttribute('data-testid', 'grid');
+  });
+
+  it('is axe-clean with content', async () => {
+    const { container } = render(Grid, {
+      props: {
+        header: textSnippet('Items'),
+        children: textSnippet('Accessible cell'),
+      },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/layout/__tests__/Header.test.ts
+++ b/packages/smrt-svelte/src/components/layout/__tests__/Header.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Component tests for the Header (site header) layout primitive (Sweep S11, #1416).
+ *
+ * Header renders a top-level <header> (banner landmark) wrapping a Container,
+ * with optional logo and nav snippets.
+ */
+import { render, screen } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import Header from '../Header.svelte';
+
+function snippet(html: string) {
+  return createRawSnippet(() => ({ render: () => html }));
+}
+
+describe('Header', () => {
+  it('renders a top-level banner landmark', () => {
+    render(Header, { props: {} });
+    expect(screen.getByRole('banner')).toBeInTheDocument();
+  });
+
+  it('renders the logo snippet', () => {
+    render(Header, {
+      props: { logo: snippet('<h1>Acme</h1>') },
+    });
+    expect(screen.getByRole('heading', { name: 'Acme' })).toBeInTheDocument();
+  });
+
+  it('renders the nav snippet inside a navigation landmark', () => {
+    render(Header, {
+      props: { nav: snippet('<a href="/about">About</a>') },
+    });
+    const nav = screen.getByRole('navigation');
+    expect(nav).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'About' })).toBeInTheDocument();
+  });
+
+  it('omits logo and nav when their snippets are not provided', () => {
+    const { container } = render(Header, { props: {} });
+    expect(container.querySelector('.logo')).toBeNull();
+    expect(container.querySelector('.nav')).toBeNull();
+  });
+
+  it('is axe-clean with logo and nav', async () => {
+    const { container } = render(Header, {
+      props: {
+        logo: snippet('<h1><a href="/">Acme</a></h1>'),
+        nav: snippet('<a href="/about">About</a>'),
+      },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/layout/__tests__/Masthead.test.ts
+++ b/packages/smrt-svelte/src/components/layout/__tests__/Masthead.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Component tests for the Masthead layout primitive (Sweep S11, #1416).
+ *
+ * Masthead renders a date (as a <time>), an optional location link, and
+ * nav/mobileNav snippets inside <nav> landmarks. The root is a plain <div>
+ * (no banner landmark). The mobile home icon's aria-label is i18n-resolved;
+ * useI18n() falls back to registered English defaults outside a Provider.
+ */
+import { render, screen } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import Masthead from '../Masthead.svelte';
+
+function snippet(html: string) {
+  return createRawSnippet(() => ({ render: () => html }));
+}
+
+describe('Masthead', () => {
+  it('renders a provided date string', () => {
+    render(Masthead, { props: { date: 'Monday, June 1, 2026' } });
+    expect(screen.getAllByText('Monday, June 1, 2026').length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it('renders the date inside a <time> element', () => {
+    const { container } = render(Masthead, {
+      props: { date: 'June 1, 2026' },
+    });
+    const time = container.querySelector('time');
+    expect(time).not.toBeNull();
+    expect(time).toHaveTextContent('June 1, 2026');
+  });
+
+  it('wraps the date in a link when dateHref is provided', () => {
+    render(Masthead, {
+      props: { date: 'June 1, 2026', dateHref: '/archive/2026-06-01' },
+    });
+    const link = screen.getByRole('link', { name: 'June 1, 2026' });
+    expect(link).toHaveAttribute('href', '/archive/2026-06-01');
+  });
+
+  it('renders the location as a link to locationHref', () => {
+    render(Masthead, {
+      props: { location: 'New York', locationHref: '/ny' },
+    });
+    const link = screen.getByRole('link', { name: 'New York' });
+    expect(link).toHaveAttribute('href', '/ny');
+  });
+
+  it('omits the location link when location is empty', () => {
+    const { container } = render(Masthead, { props: { location: '' } });
+    expect(container.querySelector('.location')).toBeNull();
+  });
+
+  it('renders the nav snippet inside a navigation landmark', () => {
+    render(Masthead, {
+      props: { nav: snippet('<a href="/sections">Sections</a>') },
+    });
+    // Masthead renders both a desktop and a mobile layout in the DOM (CSS hides
+    // one); with no `mobileNav`, the mobile layout falls back to `nav`, so the
+    // link appears in both. Assert at least one navigation landmark + link.
+    expect(screen.getAllByRole('navigation').length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole('link', { name: 'Sections' }).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('renders a distinct mobileNav snippet when provided', () => {
+    render(Masthead, {
+      props: {
+        nav: snippet('<a href="/sections">Sections</a>'),
+        mobileNav: snippet('<a href="/menu">Menu</a>'),
+      },
+    });
+    expect(screen.getByRole('link', { name: 'Menu' })).toBeInTheDocument();
+  });
+
+  it('exposes a home icon link with an accessible (i18n-resolved) label', () => {
+    render(Masthead, { props: { locationHref: '/home' } });
+    const link = screen.getByRole('link', { name: 'Home' });
+    expect(link).toHaveAttribute('href', '/home');
+  });
+
+  it('labels the desktop and mobile nav landmarks distinctly', () => {
+    // Masthead emits both a desktop and a mobile layout (one CSS-hidden). Each
+    // <nav> carries a distinct aria-label so the two landmarks stay unique.
+    render(Masthead, {
+      props: { nav: snippet('<a href="/sections">Sections</a>') },
+    });
+    expect(
+      screen.getByRole('navigation', { name: 'Primary' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('navigation', { name: 'Mobile' }),
+    ).toBeInTheDocument();
+  });
+
+  it('is axe-clean with date, location, and nav', async () => {
+    const { container } = render(Masthead, {
+      props: {
+        date: 'June 1, 2026',
+        dateHref: '/archive',
+        location: 'New York',
+        locationHref: '/ny',
+        nav: snippet('<a href="/sections">Sections</a>'),
+      },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/layout/__tests__/PageHeader.test.ts
+++ b/packages/smrt-svelte/src/components/layout/__tests__/PageHeader.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Component tests for the PageHeader layout primitive (Sweep S11, #1416).
+ *
+ * PageHeader renders a top-level <header> (banner landmark) with an <h1>
+ * title, optional subtitle, optional back link, and actions/children snippets.
+ */
+import { render, screen } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import PageHeader from '../PageHeader.svelte';
+
+function snippet(html: string) {
+  return createRawSnippet(() => ({ render: () => html }));
+}
+
+describe('PageHeader', () => {
+  it('renders the title as a level-1 heading', () => {
+    render(PageHeader, { props: { title: 'Dashboard' } });
+    const heading = screen.getByRole('heading', {
+      name: 'Dashboard',
+      level: 1,
+    });
+    expect(heading).toBeInTheDocument();
+  });
+
+  it('renders a top-level banner landmark', () => {
+    render(PageHeader, { props: { title: 'Dashboard' } });
+    expect(screen.getByRole('banner')).toBeInTheDocument();
+  });
+
+  it('renders the optional subtitle', () => {
+    render(PageHeader, {
+      props: { title: 'Dashboard', subtitle: 'Overview of your account' },
+    });
+    expect(screen.getByText('Overview of your account')).toBeInTheDocument();
+  });
+
+  it('renders a back link with the default label when backHref is set', () => {
+    render(PageHeader, {
+      props: { title: 'Detail', backHref: '/list' },
+    });
+    const link = screen.getByRole('link', { name: 'Back' });
+    expect(link).toHaveAttribute('href', '/list');
+  });
+
+  it('uses a custom back label', () => {
+    render(PageHeader, {
+      props: { title: 'Detail', backHref: '/list', backLabel: 'All items' },
+    });
+    expect(screen.getByRole('link', { name: 'All items' })).toBeInTheDocument();
+  });
+
+  it('renders the actions snippet', () => {
+    render(PageHeader, {
+      props: {
+        title: 'Detail',
+        actions: snippet('<button type="button">Edit</button>'),
+      },
+    });
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+  });
+
+  it('renders extra children below the title', () => {
+    render(PageHeader, {
+      props: {
+        title: 'Detail',
+        children: snippet('<p>Extra content</p>'),
+      },
+    });
+    expect(screen.getByText('Extra content')).toBeInTheDocument();
+  });
+
+  it('omits the back link when backHref is not provided', () => {
+    render(PageHeader, { props: { title: 'Detail' } });
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('is axe-clean with subtitle, back link, and actions', async () => {
+    const { container } = render(PageHeader, {
+      props: {
+        title: 'Settings',
+        subtitle: 'Manage your preferences',
+        backHref: '/home',
+        actions: snippet('<button type="button">Save</button>'),
+      },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/layout/__tests__/SummaryCard.test.ts
+++ b/packages/smrt-svelte/src/components/layout/__tests__/SummaryCard.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Component tests for the SummaryCard layout primitive (Sweep S11, #1416).
+ *
+ * Asserts the label/value render, the optional count badge and icon, the
+ * variant→value-color-class mapping, the clickable link variant, and
+ * axe-clean output across a couple of states.
+ */
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import SummaryCard from '../SummaryCard.svelte';
+
+describe('SummaryCard', () => {
+  it('renders the label and value', () => {
+    render(SummaryCard, { props: { label: 'Revenue', value: '$1,200' } });
+    expect(screen.getByText('Revenue')).toBeInTheDocument();
+    expect(screen.getByText('$1,200')).toBeInTheDocument();
+  });
+
+  it('renders a numeric value', () => {
+    render(SummaryCard, { props: { label: 'Orders', value: 42 } });
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('renders the optional count badge', () => {
+    const { container } = render(SummaryCard, {
+      props: { label: 'Tasks', value: 'Open', count: 7 },
+    });
+    expect(container.querySelector('.card-count')).toHaveTextContent('7');
+  });
+
+  it('renders a count badge of 0 (undefined check, not falsy)', () => {
+    const { container } = render(SummaryCard, {
+      props: { label: 'Tasks', value: 'Done', count: 0 },
+    });
+    expect(container.querySelector('.card-count')).toHaveTextContent('0');
+  });
+
+  it('omits the count badge when count is undefined', () => {
+    const { container } = render(SummaryCard, {
+      props: { label: 'Tasks', value: 'Open' },
+    });
+    expect(container.querySelector('.card-count')).toBeNull();
+  });
+
+  it('renders a raw SVG icon when icon starts with <svg', () => {
+    const { container } = render(SummaryCard, {
+      props: {
+        label: 'Visitors',
+        value: 99,
+        icon: '<svg data-testid="svg-icon" viewBox="0 0 24 24"></svg>',
+      },
+    });
+    expect(container.querySelector('.card-icon svg')).not.toBeNull();
+  });
+
+  it('renders as a clickable link when href is provided', () => {
+    render(SummaryCard, {
+      props: { label: 'Reports', value: 12, href: '/reports' },
+    });
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/reports');
+    expect(link).toHaveClass('clickable');
+  });
+
+  it('applies the highlight class when highlight is set', () => {
+    const { container } = render(SummaryCard, {
+      props: { label: 'Featured', value: 1, highlight: true },
+    });
+    expect(container.querySelector('.summary-card')).toHaveClass('highlight');
+  });
+
+  it.each([
+    ['default', 'color-default'],
+    ['success', 'color-success'],
+    ['warning', 'color-warning'],
+    ['danger', 'color-error'],
+  ] as const)('maps variant=%s to the %s value class', (variant, expected) => {
+    const { container } = render(SummaryCard, {
+      props: { label: 'Metric', value: 5, variant },
+    });
+    expect(container.querySelector('.card-value')).toHaveClass(expected);
+  });
+
+  it.each([
+    { label: 'Static', value: '$10' },
+    { label: 'Linked', value: 3, href: '/go', count: 2 },
+  ])('is axe-clean (%o)', async (props) => {
+    const { container } = render(SummaryCard, { props });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/nav/__tests__/FilterChips.test.ts
+++ b/packages/smrt-svelte/src/components/nav/__tests__/FilterChips.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Component test for FilterChips (Sweep S11, #1416).
+ *
+ * FilterChips is a single-select filter: a `role="radiogroup"` of
+ * `role="radio"` buttons where the selected option carries `aria-checked`.
+ * (There is no per-chip remove/dismiss affordance in the source — selection is
+ * the only interaction.) This suite asserts that structure/state, drives
+ * selection via click, and proves axe-cleanliness, including the optional
+ * "All" option.
+ */
+import { render, screen, within } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import FilterChips from '../FilterChips.svelte';
+import type { FilterOption } from '../types.js';
+
+const OPTIONS: FilterOption[] = [
+  { value: 'all-news', label: 'News', count: 12 },
+  { value: 'sports', label: 'Sports', count: 5 },
+  { value: 'tech', label: 'Tech' },
+];
+
+describe('FilterChips', () => {
+  it('renders a radiogroup with one radio per option', () => {
+    render(FilterChips, { props: { options: OPTIONS, selected: 'all-news' } });
+    const group = screen.getByRole('radiogroup');
+    expect(within(group).getAllByRole('radio')).toHaveLength(3);
+  });
+
+  it('marks the selected option with aria-checked=true and others false', () => {
+    render(FilterChips, { props: { options: OPTIONS, selected: 'sports' } });
+    expect(screen.getByRole('radio', { name: /Sports/ })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+    expect(screen.getByRole('radio', { name: /News/ })).toHaveAttribute(
+      'aria-checked',
+      'false',
+    );
+  });
+
+  it('renders the optional count alongside its chip label', () => {
+    render(FilterChips, { props: { options: OPTIONS, selected: 'all-news' } });
+    expect(screen.getByRole('radio', { name: /News/ })).toHaveTextContent('12');
+  });
+
+  it('fires onchange with the clicked option value', async () => {
+    const onchange = vi.fn();
+    render(FilterChips, {
+      props: { options: OPTIONS, selected: 'all-news', onchange },
+    });
+    await userEvent.click(screen.getByRole('radio', { name: /Tech/ }));
+    expect(onchange).toHaveBeenCalledWith('tech');
+  });
+
+  it('does not fire onchange when the already-selected chip is clicked', async () => {
+    const onchange = vi.fn();
+    render(FilterChips, {
+      props: { options: OPTIONS, selected: 'sports', onchange },
+    });
+    await userEvent.click(screen.getByRole('radio', { name: /Sports/ }));
+    expect(onchange).not.toHaveBeenCalled();
+  });
+
+  it('does not fire onchange for a disabled option', async () => {
+    const onchange = vi.fn();
+    const options: FilterOption[] = [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B', disabled: true },
+    ];
+    render(FilterChips, { props: { options, selected: 'a', onchange } });
+    const disabled = screen.getByRole('radio', { name: 'B' });
+    expect(disabled).toBeDisabled();
+    await userEvent.click(disabled);
+    expect(onchange).not.toHaveBeenCalled();
+  });
+
+  it('prepends an "All" option (empty value) when showAll is set', async () => {
+    const onchange = vi.fn();
+    render(FilterChips, {
+      props: {
+        options: OPTIONS,
+        selected: 'sports',
+        showAll: true,
+        allLabel: 'Everything',
+        onchange,
+      },
+    });
+    const radios = screen.getAllByRole('radio');
+    expect(radios).toHaveLength(4);
+    const all = screen.getByRole('radio', { name: /Everything/ });
+    expect(all).toHaveAttribute('aria-checked', 'false');
+    await userEvent.click(all);
+    expect(onchange).toHaveBeenCalledWith('');
+  });
+
+  it('is axe-clean for a default selected group', async () => {
+    const { container } = render(FilterChips, {
+      props: { options: OPTIONS, selected: 'all-news' },
+    });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean with the "All" option enabled', async () => {
+    const { container } = render(FilterChips, {
+      props: { options: OPTIONS, selected: '', showAll: true },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/nav/__tests__/Tabs.test.ts
+++ b/packages/smrt-svelte/src/components/nav/__tests__/Tabs.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Component test for Tabs (Sweep S11, #1416).
+ *
+ * Tabs renders an ARIA tablist of `role="tab"` buttons with roving tabindex,
+ * `aria-selected` on the active tab, and a `role="tabpanel"` for children.
+ * This suite asserts that structure/state, drives click + Arrow/Home/End
+ * keyboard navigation (which fire `onchange`), and proves axe-cleanliness.
+ */
+import { render, screen, within } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import Tabs from '../Tabs.svelte';
+import type { Tab } from '../types.js';
+
+const TABS: Tab[] = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'activity', label: 'Activity', count: 4 },
+  { id: 'settings', label: 'Settings' },
+];
+
+/** Build a text Snippet for the Tabs `children` (panel) prop. */
+function panelSnippet(text: string) {
+  return createRawSnippet(() => ({ render: () => `<span>${text}</span>` }));
+}
+
+describe('Tabs', () => {
+  it('renders a tablist with one tab button per tab', () => {
+    render(Tabs, {
+      props: { tabs: TABS, active: 'overview', 'aria-label': 'Sections' },
+    });
+    const tablist = screen.getByRole('tablist', { name: 'Sections' });
+    expect(within(tablist).getAllByRole('tab')).toHaveLength(3);
+  });
+
+  it('marks the active tab with aria-selected and a tabindex of 0', () => {
+    render(Tabs, { props: { tabs: TABS, active: 'activity' } });
+    const active = screen.getByRole('tab', { name: /Activity/ });
+    expect(active).toHaveAttribute('aria-selected', 'true');
+    expect(active).toHaveAttribute('tabindex', '0');
+
+    const inactive = screen.getByRole('tab', { name: 'Overview' });
+    expect(inactive).toHaveAttribute('aria-selected', 'false');
+    expect(inactive).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('renders the optional count alongside its tab label', () => {
+    render(Tabs, { props: { tabs: TABS, active: 'overview' } });
+    expect(screen.getByRole('tab', { name: /Activity/ })).toHaveTextContent(
+      '4',
+    );
+  });
+
+  it('renders children inside a tabpanel labelled by the active tab', () => {
+    render(Tabs, {
+      props: {
+        tabs: TABS,
+        active: 'overview',
+        children: panelSnippet('Overview content'),
+      },
+    });
+    const panel = screen.getByRole('tabpanel');
+    expect(within(panel).getByText('Overview content')).toBeInTheDocument();
+  });
+
+  it('fires onchange with the clicked tab id', async () => {
+    const onchange = vi.fn();
+    render(Tabs, { props: { tabs: TABS, active: 'overview', onchange } });
+    await userEvent.click(screen.getByRole('tab', { name: 'Settings' }));
+    expect(onchange).toHaveBeenCalledWith('settings');
+  });
+
+  it('does not fire onchange when the already-active tab is clicked', async () => {
+    const onchange = vi.fn();
+    render(Tabs, { props: { tabs: TABS, active: 'overview', onchange } });
+    await userEvent.click(screen.getByRole('tab', { name: 'Overview' }));
+    expect(onchange).not.toHaveBeenCalled();
+  });
+
+  // ArrowRight/ArrowLeft are asserted in separate renders rather than chained:
+  // the component moves focus to the newly-activated tab, so a second arrow key
+  // in the same render would target whichever tab focus landed on — racy across
+  // suite ordering. Each test focuses one known tab and asserts a single hop.
+  it('moves to the next tab with ArrowRight', async () => {
+    const onchange = vi.fn();
+    render(Tabs, { props: { tabs: TABS, active: 'overview', onchange } });
+    screen.getByRole('tab', { name: 'Overview' }).focus();
+    await userEvent.keyboard('{ArrowRight}');
+    expect(onchange).toHaveBeenLastCalledWith('activity');
+  });
+
+  it('moves to the previous tab with ArrowLeft', async () => {
+    const onchange = vi.fn();
+    // Render with Activity active so it owns the roving tabindex and is focusable.
+    // Activity carries a count badge, so its accessible name is "Activity 4".
+    render(Tabs, { props: { tabs: TABS, active: 'activity', onchange } });
+    screen.getByRole('tab', { name: /Activity/ }).focus();
+    await userEvent.keyboard('{ArrowLeft}');
+    expect(onchange).toHaveBeenLastCalledWith('overview');
+  });
+
+  it('wraps from the first tab to the last with ArrowLeft', async () => {
+    const onchange = vi.fn();
+    render(Tabs, { props: { tabs: TABS, active: 'overview', onchange } });
+    screen.getByRole('tab', { name: 'Overview' }).focus();
+    await userEvent.keyboard('{ArrowLeft}');
+    expect(onchange).toHaveBeenLastCalledWith('settings');
+  });
+
+  it('jumps to the first/last tab with Home/End', async () => {
+    const onchange = vi.fn();
+    render(Tabs, { props: { tabs: TABS, active: 'activity', onchange } });
+    screen.getByRole('tab', { name: /Activity/ }).focus();
+    await userEvent.keyboard('{End}');
+    expect(onchange).toHaveBeenLastCalledWith('settings');
+    await userEvent.keyboard('{Home}');
+    expect(onchange).toHaveBeenLastCalledWith('overview');
+  });
+
+  it('skips disabled tabs during keyboard navigation', async () => {
+    const onchange = vi.fn();
+    const tabs: Tab[] = [
+      { id: 'a', label: 'A' },
+      { id: 'b', label: 'B', disabled: true },
+      { id: 'c', label: 'C' },
+    ];
+    render(Tabs, { props: { tabs, active: 'a', onchange } });
+    expect(screen.getByRole('tab', { name: 'B' })).toBeDisabled();
+    screen.getByRole('tab', { name: 'A' }).focus();
+    await userEvent.keyboard('{ArrowRight}');
+    expect(onchange).toHaveBeenLastCalledWith('c');
+  });
+
+  it('is axe-clean with a labelled tablist and panel', async () => {
+    const { container } = render(Tabs, {
+      props: {
+        tabs: TABS,
+        active: 'overview',
+        'aria-label': 'Sections',
+        children: panelSnippet('Panel content'),
+      },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/ui/__tests__/Badge.test.ts
+++ b/packages/smrt-svelte/src/components/ui/__tests__/Badge.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Component test for Badge (Sweep S11, #1416).
+ *
+ * Badge is a presentational `<span>` — it renders children plus variant/size
+ * classes and forwards rest attributes. This suite asserts that real API
+ * (props from Badge.svelte) and proves the output is axe-clean.
+ */
+import { render, screen } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import Badge from '../Badge.svelte';
+
+/** Build a text Snippet for the Badge's `children` prop. */
+function textSnippet(text: string) {
+  return createRawSnippet(() => ({ render: () => `<span>${text}</span>` }));
+}
+
+describe('Badge', () => {
+  it('renders its children content', () => {
+    render(Badge, { props: { children: textSnippet('New') } });
+    expect(screen.getByText('New')).toBeInTheDocument();
+  });
+
+  it('applies the default variant and md size classes', () => {
+    const { container } = render(Badge, {
+      props: { children: textSnippet('Default') },
+    });
+    const badge = container.querySelector('.badge');
+    expect(badge).toHaveClass('default');
+    expect(badge).toHaveClass('md');
+  });
+
+  it.each([
+    'primary',
+    'success',
+    'warning',
+    'error',
+    'info',
+  ] as const)('reflects the %s variant as a class', (variant) => {
+    const { container } = render(Badge, {
+      props: { variant, children: textSnippet('Status') },
+    });
+    expect(container.querySelector('.badge')).toHaveClass(variant);
+  });
+
+  it('reflects the sm size as a class', () => {
+    const { container } = render(Badge, {
+      props: { size: 'sm', children: textSnippet('Small') },
+    });
+    expect(container.querySelector('.badge')).toHaveClass('sm');
+  });
+
+  it('forwards rest attributes (e.g. aria-label, data-testid) to the span', () => {
+    const { container } = render(Badge, {
+      props: {
+        'aria-label': 'Unread count: 3',
+        'data-testid': 'unread-badge',
+        children: textSnippet('3'),
+      },
+    });
+    const badge = container.querySelector('.badge');
+    expect(badge).toHaveAttribute('aria-label', 'Unread count: 3');
+    expect(badge).toHaveAttribute('data-testid', 'unread-badge');
+  });
+
+  it('is axe-clean for a default badge', async () => {
+    const { container } = render(Badge, {
+      props: { children: textSnippet('Accessible') },
+    });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean for a variant badge with an accessible label', async () => {
+    const { container } = render(Badge, {
+      props: {
+        variant: 'error',
+        'aria-label': '5 errors',
+        children: textSnippet('5'),
+      },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/ui/__tests__/Card.test.ts
+++ b/packages/smrt-svelte/src/components/ui/__tests__/Card.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Component test for Card (Sweep S11, #1416).
+ *
+ * Mirrors the Button golden pattern: render → assert structure/variant → axe.
+ * Card is a presentational surface — it has no interactive behavior of its own
+ * (no clickable/keyboard handler in the source), so this suite covers rendering
+ * of content/header/footer snippets, variant + padding classes, the hoverable
+ * flag, attribute pass-through (`...rest`), and a11y.
+ */
+import { render, screen } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import Card from '../Card.svelte';
+
+/** Build a text Snippet for a Card slot. */
+function textSnippet(text: string) {
+  return createRawSnippet(() => ({ render: () => `<span>${text}</span>` }));
+}
+
+describe('Card', () => {
+  it('renders children inside the card content region', () => {
+    render(Card, { props: { children: textSnippet('Body text') } });
+    expect(screen.getByText('Body text')).toBeInTheDocument();
+  });
+
+  it('applies the default variant and md padding classes', () => {
+    const { container } = render(Card, {
+      props: { children: textSnippet('Body') },
+    });
+    const card = container.querySelector('.card');
+    expect(card).toHaveClass('default');
+    expect(card).toHaveClass('padding-md');
+  });
+
+  it('reflects an explicit variant and padding', () => {
+    const { container } = render(Card, {
+      props: {
+        variant: 'elevated',
+        padding: 'lg',
+        children: textSnippet('Body'),
+      },
+    });
+    const card = container.querySelector('.card');
+    expect(card).toHaveClass('elevated');
+    expect(card).toHaveClass('padding-lg');
+  });
+
+  it('adds the hoverable class only when hoverable is true', () => {
+    const { container: plain } = render(Card, {
+      props: { children: textSnippet('Body') },
+    });
+    expect(plain.querySelector('.card')).not.toHaveClass('hoverable');
+
+    const { container: hover } = render(Card, {
+      props: { hoverable: true, children: textSnippet('Body') },
+    });
+    expect(hover.querySelector('.card')).toHaveClass('hoverable');
+  });
+
+  it('renders header and footer slots when provided', () => {
+    const { container } = render(Card, {
+      props: {
+        header: textSnippet('Header'),
+        footer: textSnippet('Footer'),
+        children: textSnippet('Body'),
+      },
+    });
+    expect(container.querySelector('.card-header')).toBeInTheDocument();
+    expect(container.querySelector('.card-footer')).toBeInTheDocument();
+    expect(screen.getByText('Header')).toBeInTheDocument();
+    expect(screen.getByText('Footer')).toBeInTheDocument();
+  });
+
+  it('omits header and footer regions when those slots are absent', () => {
+    const { container } = render(Card, {
+      props: { children: textSnippet('Body') },
+    });
+    expect(container.querySelector('.card-header')).toBeNull();
+    expect(container.querySelector('.card-footer')).toBeNull();
+  });
+
+  it('forwards rest attributes (e.g. data-testid, aria-label) to the root', () => {
+    const { container } = render(Card, {
+      props: {
+        'data-testid': 'profile-card',
+        'aria-label': 'Profile',
+        children: textSnippet('Body'),
+      },
+    });
+    const card = container.querySelector('.card');
+    expect(card).toHaveAttribute('data-testid', 'profile-card');
+    expect(card).toHaveAttribute('aria-label', 'Profile');
+  });
+
+  it('is axe-clean for a content-only card', async () => {
+    const { container } = render(Card, {
+      props: { children: textSnippet('Accessible body') },
+    });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean with header and footer regions', async () => {
+    const { container } = render(Card, {
+      props: {
+        variant: 'outlined',
+        header: textSnippet('Heading'),
+        footer: textSnippet('Actions'),
+        children: textSnippet('Accessible body'),
+      },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/components/ui/__tests__/Pagination.test.ts
+++ b/packages/smrt-svelte/src/components/ui/__tests__/Pagination.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Component test for Pagination (Sweep S11, #1416).
+ *
+ * Pagination has two modes: link mode (anchors, default) and callback mode
+ * (buttons + `onPageChange`). This suite exercises the callback mode for
+ * interaction (clicking pages/prev/next fires the callback; bounds disable the
+ * edge controls) and verifies the navigation landmark, current-page marking,
+ * and a11y. aria-labels resolve to their registered English defaults outside a
+ * Provider (e.g. "Previous page", "Go to page 2").
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import Pagination from '../Pagination.svelte';
+
+describe('Pagination', () => {
+  it('renders nothing when there is a single page', () => {
+    const { container } = render(Pagination, {
+      props: { currentPage: 1, totalPages: 1 },
+    });
+    expect(container.querySelector('.pagination')).toBeNull();
+  });
+
+  it('renders a navigation landmark with the provided aria-label', () => {
+    render(Pagination, {
+      props: { currentPage: 1, totalPages: 5, 'aria-label': 'Article pages' },
+    });
+    expect(
+      screen.getByRole('navigation', { name: 'Article pages' }),
+    ).toBeInTheDocument();
+  });
+
+  it('marks the current page with aria-current and renders it as a non-link', () => {
+    render(Pagination, {
+      props: { currentPage: 3, totalPages: 5, onPageChange: vi.fn() },
+    });
+    const current = screen.getByText('3');
+    expect(current).toHaveAttribute('aria-current', 'page');
+    // current page is a span, not a button
+    expect(current.tagName).toBe('SPAN');
+  });
+
+  it('fires onPageChange with the clicked page number (callback mode)', async () => {
+    const onPageChange = vi.fn();
+    render(Pagination, {
+      props: { currentPage: 1, totalPages: 5, onPageChange },
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'Go to page 3' }));
+    expect(onPageChange).toHaveBeenCalledWith(3);
+  });
+
+  it('fires onPageChange for prev and next relative to the current page', async () => {
+    const onPageChange = vi.fn();
+    render(Pagination, {
+      props: { currentPage: 3, totalPages: 5, onPageChange },
+    });
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Previous page' }),
+    );
+    expect(onPageChange).toHaveBeenLastCalledWith(2);
+    await userEvent.click(screen.getByRole('button', { name: 'Next page' }));
+    expect(onPageChange).toHaveBeenLastCalledWith(4);
+  });
+
+  it('disables prev/first on the first page and blocks their callback', async () => {
+    const onPageChange = vi.fn();
+    render(Pagination, {
+      props: { currentPage: 1, totalPages: 5, onPageChange },
+    });
+    const prev = screen.getByRole('button', { name: 'Previous page' });
+    const first = screen.getByRole('button', { name: 'First page' });
+    expect(prev).toBeDisabled();
+    expect(first).toBeDisabled();
+    await userEvent.click(prev);
+    expect(onPageChange).not.toHaveBeenCalled();
+  });
+
+  it('disables next/last on the last page and blocks their callback', async () => {
+    const onPageChange = vi.fn();
+    render(Pagination, {
+      props: { currentPage: 5, totalPages: 5, onPageChange },
+    });
+    const next = screen.getByRole('button', { name: 'Next page' });
+    const last = screen.getByRole('button', { name: /Last page/ });
+    expect(next).toBeDisabled();
+    expect(last).toBeDisabled();
+    await userEvent.click(next);
+    expect(onPageChange).not.toHaveBeenCalled();
+  });
+
+  it('renders numbered pages as links in link mode (no onPageChange)', () => {
+    render(Pagination, {
+      props: { currentPage: 1, totalPages: 3, baseUrl: '/articles' },
+    });
+    const page2 = screen.getByRole('link', { name: 'Go to page 2' });
+    expect(page2).toHaveAttribute('href', '/articles/page/2');
+  });
+
+  it('is axe-clean in callback mode on a middle page', async () => {
+    const { container } = render(Pagination, {
+      props: { currentPage: 3, totalPages: 10, onPageChange: vi.fn() },
+    });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean in link mode at the first-page boundary', async () => {
+    const { container } = render(Pagination, {
+      props: { currentPage: 1, totalPages: 4, baseUrl: '/articles' },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-svelte/src/i18n/strings.ui.ts
+++ b/packages/smrt-svelte/src/i18n/strings.ui.ts
@@ -24,6 +24,7 @@ export const M = defineMessages({
   'ui.modal.close': 'Close modal',
 
   // feedback/ProgressBar.svelte
+  'ui.progress_bar.label': 'Progress',
   'ui.progress_bar.over_by': 'Over by {amount}',
 
   // layout/Footer.svelte
@@ -31,6 +32,8 @@ export const M = defineMessages({
 
   // layout/Masthead.svelte
   'ui.masthead.home': 'Home',
+  'ui.masthead.primary_nav': 'Primary',
+  'ui.masthead.mobile_nav': 'Mobile',
 
   // memberships/MembershipCard.svelte
   'ui.membership_card.change_role': 'Change Role',


### PR DESCRIPTION
## Summary

Sweep **S11 (#1416)** — component test coverage for the `@happyvertical/smrt-svelte` design-system primitives. The harness (`@happyvertical/smrt-vitest/svelte` + `/a11y`) and the rollout into users/projects/chat/assets already landed; this PR covers the **untested primitives** and clears smrt-svelte's T2 coverage floor.

### Coverage: 59.56% → **71.78%** lines (T2 floor 70%)
~290 new component tests + ~115 deep behavior tests, following the Button golden pattern (render → role/name/state → user-event → axe-clean):

- **ui**: Card, Badge, Pagination
- **nav**: Tabs, FilterChips
- **feedback**: ConfirmDialog, LoadingOverlay (+ ProgressBar, see below)
- **display**: Icon, StatusBadge, ConfidenceBadge, DateDisplay, CurrencyDisplay
- **layout**: Container, Grid, EmptyState, SummaryCard, Header, PageHeader, Masthead, Footer
- **forms**: render/a11y for Toggle/CheckboxInput/SearchInput/FileUpload/FormMicButton, plus `*.behavior.test.ts` suites exercising the **parsing/formatting/validation logic** of `Form` and the text/number/select/money/measurement/phone/date/address inputs (the previously-uncovered bulk of the forms dir).

Date/currency assertions are derived via `Intl` (timezone/locale-robust).

### 2 real a11y bugs found by the new axe tests — and fixed (`fix:` commit)
- **ProgressBar**: `role="progressbar"` had no accessible name → added an i18n'd `aria-label` (default "Progress", or the custom `label`).
- **Masthead**: emits both desktop + mobile layouts (one CSS-hidden) → two unlabelled `<nav>` landmarks (`landmark-unique`) → gave each a distinct i18n'd label ("Primary"/"Mobile").

New labels route through the smrt-svelte i18n catalog to keep the hardcoded-string ratchet green; the affected tests now assert the components are fully axe-clean.

### Also
- Fixed a **flaky Tabs arrow-key test** — the chained ArrowRight→ArrowLeft raced on the component's focus-move and failed under full-suite ordering. Split into single-hop, explicitly-focused cases.

## Verification
- `vitest run` — **805 passed** (76 files).
- Coverage gate: smrt-svelte (T2) **71.78% ≥ 70%**.
- i18n ratchet: clean (smrt-svelte strict).
- `typecheck` + `svelte-check`: 0 errors.

Two commits: `fix:` (a11y) + `test:` (coverage), each independently scoped.