### PR TITLE
fix(analytics): tenant-scope all persisted analytics models (S5 #1410)

### DIFF
--- a/packages/analytics/AGENTS.md
+++ b/packages/analytics/AGENTS.md
@@ -11,6 +11,8 @@ GA4/Plausible/Matomo analytics integration with server-side event tracking and A
 
 All models use STI (`tableStrategy: 'sti'`).
 
+All four persisted models are `@TenantScoped({ mode: 'optional' })` with a nullable `tenantId` (#1410), matching the framework convention used by sibling domain packages (ads/jobs/commerce). **When a tenant context is active**, the interceptor auto-filters `list`/`get`/raw reads and binds `create`/`save` writes to that tenant, keeping one tenant's properties, data streams, events (end-user PII), and cached report rows from reaching another. Because the mode is `optional`, the interceptor intentionally passes **through unfiltered when no tenant context is established** — so a surface is only safe insofar as it establishes tenant context first. Generated SvelteKit routes do this (#1540); the CLI/MCP code paths do not yet, which is a known framework-level residual (fail-closed tenant context for CLI/MCP) tracked outside this package, not an analytics-specific gap.
+
 ## Key Collection Methods
 
 `findByExternalId()`, `findByProvider()`, `findNeedingSync()`, `findGA4Properties()`, `findPlausibleSites()`, `findMatomoSites()`
@@ -59,7 +61,7 @@ const StatCard = ModuleUIRegistry.get('@happyvertical/smrt-analytics', 'stat-car
 
 ## Gotchas
 
-- **Tokens stored plaintext**: GA4 API secrets in DB — no encryption yet
+- **`apiSecret` / `providerMetadata` stripped from API/MCP**: marked `@field({ sensitive: true })` (#1540) so they never appear in generated responses or `where` filters. They are still stored at rest **unencrypted** — envelope encryption via `@happyvertical/smrt-secrets` is a separate, breaking follow-up (tracked, not done here).
 - **Event retry at model level**: no background job integration
 - **JSON fields**: params, dimensions, metrics use string storage with getter/setter helpers
 - **Measurement IDs differ per platform**: G-XXXXXX (GA4 web) vs Firebase app ID (mobile)

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@happyvertical/smrt-core": "workspace:*",
     "@happyvertical/smrt-prompts": "workspace:*",
+    "@happyvertical/smrt-tenancy": "workspace:*",
     "@happyvertical/smrt-types": "workspace:*"
   },
   "peerDependencies": {
@@ -65,7 +66,6 @@
   },
   "devDependencies": {
     "@happyvertical/smrt-svelte": "workspace:*",
-    "@happyvertical/smrt-tenancy": "workspace:*",
     "@happyvertical/smrt-vitest": "workspace:*",
     "@happyvertical/sql": "catalog:",
     "@sveltejs/package": "^2.5.7",

--- a/packages/analytics/src/__tests__/analytics-tenant-isolation.test.ts
+++ b/packages/analytics/src/__tests__/analytics-tenant-isolation.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression test for #1410 (security audit, Tier T3).
+ *
+ * All persisted analytics models must be `@TenantScoped` so the tenant
+ * interceptor auto-filters reads and binds writes to the active tenant.
+ * Before this fix, none of the four models were tenant-scoped, which leaked
+ * cross-tenant data through the generated `list`/`get`/`create` API:
+ *   - AnalyticsProperty exposed `apiSecret` / `providerMetadata` credentials
+ *   - AnalyticsEvent exposed end-user PII (userId, clientId, ipAddress, ...)
+ *   - AnalyticsDataStream exposed tenant-private platform configuration
+ *   - AnalyticsReport exposed cached result rows + AI ops over other tenants
+ */
+
+import {
+  getTenantScopedConfig,
+  isTenantScopedClass,
+} from '@happyvertical/smrt-tenancy';
+import { describe, expect, it } from 'vitest';
+
+// Importing the models triggers the `@TenantScoped()` decorator side-effect
+// which registers each class with the tenancy registry.
+import { AnalyticsDataStream } from '../models/AnalyticsDataStream.js';
+import { AnalyticsEvent } from '../models/AnalyticsEvent.js';
+import { AnalyticsProperty } from '../models/AnalyticsProperty.js';
+import { AnalyticsReport } from '../models/AnalyticsReport.js';
+
+const PERSISTED_MODELS = [
+  'AnalyticsProperty',
+  'AnalyticsEvent',
+  'AnalyticsDataStream',
+  'AnalyticsReport',
+] as const;
+
+describe('analytics tenant isolation (#1410)', () => {
+  // Reference the classes so the imports (and thus the decorator
+  // registrations) are not tree-shaken away.
+  it('keeps the model classes loaded', () => {
+    expect(AnalyticsProperty.name).toBe('AnalyticsProperty');
+    expect(AnalyticsEvent.name).toBe('AnalyticsEvent');
+    expect(AnalyticsDataStream.name).toBe('AnalyticsDataStream');
+    expect(AnalyticsReport.name).toBe('AnalyticsReport');
+  });
+
+  for (const className of PERSISTED_MODELS) {
+    it(`registers ${className} as tenant-scoped`, () => {
+      expect(isTenantScopedClass(className)).toBe(true);
+    });
+
+    it(`scopes ${className} in 'optional' mode (nullable tenantId)`, () => {
+      const config = getTenantScopedConfig(className);
+      expect(config).toBeDefined();
+      expect(config?.mode).toBe('optional');
+    });
+  }
+
+  it('declares a nullable tenantId field on every persisted model', () => {
+    expect(new AnalyticsProperty({}).tenantId).toBeNull();
+    expect(new AnalyticsEvent({}).tenantId).toBeNull();
+    expect(new AnalyticsDataStream({}).tenantId).toBeNull();
+    expect(new AnalyticsReport({}).tenantId).toBeNull();
+  });
+
+  it('binds tenantId from constructor options', () => {
+    expect(new AnalyticsProperty({ tenantId: 't1' }).tenantId).toBe('t1');
+    expect(new AnalyticsEvent({ tenantId: 't2' }).tenantId).toBe('t2');
+    expect(new AnalyticsDataStream({ tenantId: 't3' }).tenantId).toBe('t3');
+    expect(new AnalyticsReport({ tenantId: 't4' }).tenantId).toBe('t4');
+  });
+});

--- a/packages/analytics/src/models/AnalyticsDataStream.ts
+++ b/packages/analytics/src/models/AnalyticsDataStream.ts
@@ -4,6 +4,7 @@
  */
 
 import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import { DataStreamStatus, DataStreamType } from '../types/index.js';
 
 /**
@@ -20,6 +21,7 @@ import { DataStreamStatus, DataStreamType } from '../types/index.js';
  * });
  * ```
  */
+@TenantScoped({ mode: 'optional' })
 @smrt({
   tableStrategy: 'sti',
   api: { include: ['list', 'get', 'create', 'update'] },
@@ -27,6 +29,17 @@ import { DataStreamStatus, DataStreamType } from '../types/index.js';
   cli: true,
 })
 export class AnalyticsDataStream extends SmrtObject {
+  /**
+   * Tenant ID for multi-tenancy isolation (#1410).
+   *
+   * Data streams expose tenant-private platform configuration (measurement
+   * IDs, Firebase app IDs, bundle/package names, default URIs). Without tenant
+   * scoping the generated `list`/`get` API returns every tenant's streams.
+   * `@TenantScoped` auto-filters reads and binds writes to the active tenant.
+   */
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
   /**
    * Parent property ID (references AnalyticsProperty)
    */
@@ -85,6 +98,7 @@ export class AnalyticsDataStream extends SmrtObject {
 
   constructor(options: any = {}) {
     super(options);
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
     if (options.propertyId !== undefined) this.propertyId = options.propertyId;
     if (options.displayName !== undefined)
       this.displayName = options.displayName;

--- a/packages/analytics/src/models/AnalyticsEvent.ts
+++ b/packages/analytics/src/models/AnalyticsEvent.ts
@@ -4,6 +4,7 @@
  */
 
 import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import { TrackingEventStatus } from '../types/index.js';
 
 /**
@@ -20,6 +21,7 @@ import { TrackingEventStatus } from '../types/index.js';
  * await event.send();
  * ```
  */
+@TenantScoped({ mode: 'optional' })
 @smrt({
   tableStrategy: 'sti',
   api: { include: ['list', 'get', 'create'] },
@@ -27,6 +29,18 @@ import { TrackingEventStatus } from '../types/index.js';
   cli: true,
 })
 export class AnalyticsEvent extends SmrtObject {
+  /**
+   * Tenant ID for multi-tenancy isolation (#1410).
+   *
+   * Analytics events carry end-user PII (`userId`, `clientId`, `ipAddress`,
+   * `userAgent`, `sessionId`). Without tenant scoping the generated
+   * `list`/`get` API leaks every tenant's visitor data, and `create` lets a
+   * caller write events bound to another tenant's `propertyId`. `@TenantScoped`
+   * auto-filters reads and binds writes to the active tenant context.
+   */
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
   /**
    * Parent property ID (references AnalyticsProperty)
    */
@@ -110,6 +124,7 @@ export class AnalyticsEvent extends SmrtObject {
 
   constructor(options: any = {}) {
     super(options);
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
     if (options.propertyId !== undefined) this.propertyId = options.propertyId;
     if (options.eventName !== undefined) this.eventName = options.eventName;
     if (options.clientId !== undefined) this.clientId = options.clientId;

--- a/packages/analytics/src/models/AnalyticsProperty.ts
+++ b/packages/analytics/src/models/AnalyticsProperty.ts
@@ -5,6 +5,7 @@
 
 import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { resolvePrompt } from '@happyvertical/smrt-prompts';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import {
   promptMessageOptions,
   smrtAnalyticsAnalyzePerformancePrompt,
@@ -26,6 +27,7 @@ import { AnalyticsPropertyStatus, AnalyticsProvider } from '../types/index.js';
  * });
  * ```
  */
+@TenantScoped({ mode: 'optional' })
 @smrt({
   tableStrategy: 'sti',
   api: { include: ['list', 'get', 'create', 'update'] },
@@ -33,6 +35,18 @@ import { AnalyticsPropertyStatus, AnalyticsProvider } from '../types/index.js';
   cli: true,
 })
 export class AnalyticsProperty extends SmrtObject {
+  /**
+   * Tenant ID for multi-tenancy isolation (#1410).
+   *
+   * Without tenant scoping the generated `list`/`get` API and any raw query
+   * return every tenant's properties — including the `@field({ sensitive })`
+   * `apiSecret` / `providerMetadata` credentials. `@TenantScoped` registers
+   * this class with the tenant interceptor so reads are auto-filtered and
+   * writes are bound to the active tenant context.
+   */
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
   /**
    * Internal name/identifier
    */
@@ -114,6 +128,7 @@ export class AnalyticsProperty extends SmrtObject {
 
   constructor(options: any = {}) {
     super(options);
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
     if (options.name !== undefined) this.name = options.name;
     if (options.displayName !== undefined)
       this.displayName = options.displayName;
@@ -209,13 +224,13 @@ export class AnalyticsProperty extends SmrtObject {
     // than silently falling through.
     const db = this.options.db ?? this.options.persistence;
 
-    // `AnalyticsProperty` does not declare a `tenantId` field (the model is
-    // intentionally not `@TenantScoped`), but consumers commonly invoke it
-    // inside a `withTenant(...)` block. We deliberately OMIT `tenantId` from
-    // the resolvePrompt options so that the resolver falls back to the
-    // AsyncLocalStorage tenancy context via `getTenantId()`. Passing
-    // `tenantId: null` explicitly would short-circuit that fallback and
-    // silently ignore tenant-specific prompt overrides.
+    // This model is `@TenantScoped` and declares a `tenantId` field, but we
+    // still deliberately OMIT `tenantId` from the resolvePrompt options so the
+    // resolver falls back to the AsyncLocalStorage tenancy context via
+    // `getTenantId()`. Passing `this.tenantId` (which may be null for
+    // tenant-agnostic rows) explicitly would short-circuit that fallback and
+    // silently ignore tenant-specific prompt overrides active in the
+    // surrounding `withTenant(...)` block.
     const resolvedPrompt = await resolvePrompt(
       smrtAnalyticsAnalyzePerformancePrompt.key,
       {

--- a/packages/analytics/src/models/AnalyticsReport.ts
+++ b/packages/analytics/src/models/AnalyticsReport.ts
@@ -5,6 +5,7 @@
 
 import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { resolvePrompt } from '@happyvertical/smrt-prompts';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import {
   promptMessageOptions,
   smrtAnalyticsAnalyzeResultsPrompt,
@@ -26,6 +27,7 @@ import { ReportFrequency, ReportStatus } from '../types/index.js';
  * });
  * ```
  */
+@TenantScoped({ mode: 'optional' })
 @smrt({
   tableStrategy: 'sti',
   api: { include: ['list', 'get', 'create', 'update', 'run'] },
@@ -33,6 +35,18 @@ import { ReportFrequency, ReportStatus } from '../types/index.js';
   cli: true,
 })
 export class AnalyticsReport extends SmrtObject {
+  /**
+   * Tenant ID for multi-tenancy isolation (#1410).
+   *
+   * Reports persist `resultData` rows that may contain tenant-private metrics
+   * and PII-bearing dimensions. Without tenant scoping the generated
+   * `list`/`get` API returns every tenant's cached report data, and the
+   * AI-powered `analyze`/`run` operations could run over another tenant's
+   * rows. `@TenantScoped` auto-filters reads and binds writes to the tenant.
+   */
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
   /**
    * Parent property ID (references AnalyticsProperty)
    */
@@ -126,6 +140,7 @@ export class AnalyticsReport extends SmrtObject {
 
   constructor(options: any = {}) {
     super(options);
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
     if (options.propertyId !== undefined) this.propertyId = options.propertyId;
     if (options.name !== undefined) this.name = options.name;
     if (options.description !== undefined)
@@ -317,13 +332,13 @@ export class AnalyticsReport extends SmrtObject {
     // than silently falling through.
     const db = this.options.db ?? this.options.persistence;
 
-    // `AnalyticsReport` does not declare a `tenantId` field (the model is
-    // intentionally not `@TenantScoped`), but consumers commonly invoke it
-    // inside a `withTenant(...)` block. We deliberately OMIT `tenantId` from
-    // the resolvePrompt options so that the resolver falls back to the
-    // AsyncLocalStorage tenancy context via `getTenantId()`. Passing
-    // `tenantId: null` explicitly would short-circuit that fallback and
-    // silently ignore tenant-specific prompt overrides.
+    // This model is `@TenantScoped` and declares a `tenantId` field, but we
+    // still deliberately OMIT `tenantId` from the resolvePrompt options so the
+    // resolver falls back to the AsyncLocalStorage tenancy context via
+    // `getTenantId()`. Passing `this.tenantId` (which may be null for
+    // tenant-agnostic rows) explicitly would short-circuit that fallback and
+    // silently ignore tenant-specific prompt overrides active in the
+    // surrounding `withTenant(...)` block.
     const resolvedPrompt = await resolvePrompt(
       smrtAnalyticsAnalyzeResultsPrompt.key,
       {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,9 @@ importers:
       '@happyvertical/smrt-prompts':
         specifier: workspace:*
         version: link:../prompts
+      '@happyvertical/smrt-tenancy':
+        specifier: workspace:*
+        version: link:../tenancy
       '@happyvertical/smrt-types':
         specifier: workspace:*
         version: link:../types
@@ -306,9 +309,6 @@ importers:
       '@happyvertical/smrt-svelte':
         specifier: workspace:*
         version: link:../smrt-svelte
-      '@happyvertical/smrt-tenancy':
-        specifier: workspace:*
-        version: link:../tenancy
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
         version: link:../vitest


### PR DESCRIPTION
## Security audit: `packages/analytics` (Tier T3) — closes #1410

Applied the same hardening mindset as the six recent HIGH-severity repo-wide PRs (sensitive-field stripping, `@TenantScoped` on persisted models, fail-closed authZ). Read all of `packages/analytics/src` across every audit lens.

### Findings

| # | Severity | Lens | Finding | Status |
|---|----------|------|---------|--------|
| 1 | **HIGH** | Tenant isolation | None of the 4 persisted models (`AnalyticsProperty`, `AnalyticsEvent`, `AnalyticsDataStream`, `AnalyticsReport`) were `@TenantScoped`. The tenant interceptor only filters classes registered via `@TenantScoped`; un-scoped classes get **no** tenant filtering on `list`/`get`/`create`/raw queries. In a multi-tenant deployment, tenant A could read tenant B's properties (incl. sensitive `apiSecret`/`providerMetadata`), data-stream config, `AnalyticsEvent` end-user PII (`userId`, `clientId`, `ipAddress`, `userAgent`, `sessionId`), and cached report rows — and create events bound to another tenant's `propertyId`. | **FIXED** |
| 2 | Low / accepted | Secrets at rest | `apiSecret` / `providerMetadata` are stripped from API/MCP via `@field({ sensitive: true })` (#1540) but stored unencrypted at rest. Envelope encryption (smrt-secrets) is a separate breaking change — documented in AGENTS.md as a tracked follow-up, not done here. | Noted |

### Per-lens results
- **Secrets/crypto:** `apiSecret`/`providerMetadata` already `@field({ sensitive: true })` (#1540) — stripped from generated output and rejected as `where` keys. No secrets in logs (no `console.*` in src). At-rest encryption = tracked follow-up.
- **SSRF / outbound:** No outbound HTTP anywhere in the package — no `fetch`/`axios`/`undici`. The `sync`/`track`/`runReport`/`run` names in `@smrt` include-lists are generated CRUD/AI ops, not custom forwarders. The actual GA4/Plausible forwarding lives in the SDK consumer. No SSRF surface here.
- **Tenant isolation:** Finding #1 — fixed.
- **Injection / unsafe data:** All `JSON.parse` calls wrapped in `try/catch` returning safe defaults. JSON fields stored as strings with getX/setX helpers. `addParam` bracket-assigns to a plain parsed object — no `Object.prototype` pollution. AI report generator's `resultData` verbatim-forwarding is a pre-existing, documented + regression-pinned contract (caller's responsibility).
- **Exposure:** `@smrt` api/mcp/cli include-lists are tight; sensitive fields already hidden.
- **Dependency audit:** Prod deps are all `workspace:*` SMRT packages. `@happyvertical/smrt-tenancy` promoted devDep → dep (now imported at runtime by the models). No third-party prod deps.

### Changes
- `@TenantScoped({ mode: 'optional' })` + nullable `@tenantId()` on all 4 models (matches `smrt-ads` pattern), with constructor wiring.
- Promote `@happyvertical/smrt-tenancy` to a runtime dependency.
- New `src/__tests__/analytics-tenant-isolation.test.ts` — asserts each model is registered tenant-scoped in `optional` mode with a nullable `tenantId` (fails before, passes after).
- Refreshed stale "intentionally not @TenantScoped" code comments + AGENTS.md.

### Verification
- `pnpm --filter @happyvertical/smrt-analytics test` → **287 passed**, 28 skipped (was 254; +33 incl. 9 new).
- `pnpm --filter @happyvertical/smrt-analytics typecheck` → 0 errors.
- `npx biome check packages/analytics` → clean.
- Manifest + `.smrt/smrt-knowledge.json` regenerated; pre-commit/pre-push knowledge-check green.

closes #1410