### PR TITLE
fix(agents): tenant-scope legacy dispatch migration + lock down TenantAgent.config (S5 #1398)

### DIFF
--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -6,7 +6,9 @@ import {
   createDispatchBus,
   type DispatchBus,
   type DispatchMetadata,
+  type DispatchTenantScope,
   ObjectRegistry,
+  resolveDispatchTenantScope,
   type SmrtCollection,
   SmrtObject,
   type SmrtObjectOptions,
@@ -687,6 +689,18 @@ export abstract class Agent extends SmrtObject {
       await dispatch.unsubscribe(subscription.signalType, legacySubscriber);
     }
 
+    // Tenant isolation (S5 #1398): the bus's subscribe/unsubscribe calls above
+    // are tenant-scoped server-side, but this raw UPDATE reaches around the bus
+    // directly into `_smrt_dispatch`. Without a tenant predicate it would
+    // rewrite the target/processor of EVERY tenant's dispatch rows matching the
+    // legacy subscriber name, letting an agent under one tenant retarget another
+    // tenant's pending dispatches. Derive the active scope server-side (never
+    // from caller input) and restrict the UPDATE to the rows the bus would let
+    // this scope read/claim.
+    const [tenantClause, tenantParams] = buildDispatchTenantUpdatePredicate(
+      resolveDispatchTenantScope(),
+    );
+
     await this._db.query(
       `UPDATE _smrt_dispatch
        SET target_subscriber = CASE
@@ -697,13 +711,14 @@ export abstract class Agent extends SmrtObject {
              WHEN processed_by = ? THEN ?
              ELSE processed_by
            END
-       WHERE target_subscriber = ? OR processed_by = ?`,
+       WHERE (target_subscriber = ? OR processed_by = ?)${tenantClause}`,
       legacySubscriber,
       canonicalSubscriber,
       legacySubscriber,
       canonicalSubscriber,
       legacySubscriber,
       legacySubscriber,
+      ...tenantParams,
     );
   }
 
@@ -1134,4 +1149,31 @@ export abstract class Agent extends SmrtObject {
       return 0;
     });
   }
+}
+
+/**
+ * Build the SQL tenant predicate (clause + params) for a raw `_smrt_dispatch`
+ * write under the active {@link DispatchTenantScope} (S5 #1398).
+ *
+ * Mirrors core's `pushTenantPredicate` read/claim semantics so a raw migration
+ * UPDATE only ever touches the rows the DispatchBus would let this scope
+ * read/claim:
+ *
+ * - tenancy off (`enforced: false`) → no predicate (pre-tenancy behavior).
+ * - active tenant `T` → `(tenant_id = ? OR tenant_id IS NULL)` (own + global).
+ * - tenancy on, no active tenant → `tenant_id IS NULL` (fail-closed to global).
+ *
+ * The returned clause is prefixed with ` AND ` (or empty) so it can be appended
+ * directly to an existing `WHERE (...)`.
+ */
+function buildDispatchTenantUpdatePredicate(
+  scope: DispatchTenantScope,
+): [clause: string, params: string[]] {
+  if (!scope.enforced) {
+    return ['', []];
+  }
+  if (scope.tenantId !== null) {
+    return [' AND (tenant_id = ? OR tenant_id IS NULL)', [scope.tenantId]];
+  }
+  return [' AND tenant_id IS NULL', []];
 }

--- a/packages/agents/src/dispatch-tenant-migration.test.ts
+++ b/packages/agents/src/dispatch-tenant-migration.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Regression tests for S5 #1398 (agents): the legacy dispatch-subscription
+ * migration must not rewrite other tenants' `_smrt_dispatch` rows.
+ *
+ * `Agent.initialize()` calls `migrateLegacyDispatchSubscriptions()`, which
+ * issues a raw `UPDATE _smrt_dispatch` to re-target rows from a legacy
+ * simple-name subscriber to the canonical (qualified) subscriber. The bus's
+ * own subscribe/unsubscribe calls are tenant-scoped server-side, but this raw
+ * UPDATE reached around the bus. Without a tenant predicate, an agent running
+ * under tenant A would retarget tenant B's pending dispatches.
+ */
+
+import {
+  ObjectRegistry,
+  setDispatchTenantResolver,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Agent } from './agent.js';
+
+@smrt()
+class MigrationAgent extends Agent {
+  protected config = {};
+  async run(): Promise<void> {}
+}
+
+function canonicalSubscriber(): string {
+  return (
+    ObjectRegistry.getClass('MigrationAgent')?.qualifiedName || 'MigrationAgent'
+  );
+}
+
+describe('migrateLegacyDispatchSubscriptions tenant isolation (S5 #1398)', () => {
+  let activeTenant: string | null = null;
+
+  beforeEach(() => {
+    // Register a resolver so the DispatchBus + the raw UPDATE both treat
+    // tenancy as ENABLED. The active tenant id is driven by `activeTenant`.
+    setDispatchTenantResolver(() => activeTenant);
+  });
+
+  afterEach(() => {
+    setDispatchTenantResolver(undefined);
+    activeTenant = null;
+  });
+
+  it("does not retarget another tenant's dispatch rows", async () => {
+    const db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+    const legacy = 'MigrationAgent';
+    const canonical = canonicalSubscriber();
+    expect(canonical).not.toBe(legacy);
+
+    // Bootstrap the dispatch tables via an initialize() under tenant A.
+    activeTenant = 'tenant-a';
+    const bootstrap = new MigrationAgent({ name: 'bootstrap', db });
+    await bootstrap.initialize();
+
+    // Seed a legacy-subscriber row owned by tenant B and a row owned by
+    // tenant A, both targeted at the legacy subscriber name.
+    await db.query(
+      `INSERT INTO _smrt_dispatch
+        (id, type, source, status, target_subscriber, tenant_id, created_at, updated_at)
+       VALUES (?, ?, ?, 'pending', ?, ?, ?, ?)`,
+      'd-tenant-b',
+      'thing.happened',
+      'src',
+      legacy,
+      'tenant-b',
+      new Date().toISOString(),
+      new Date().toISOString(),
+    );
+    await db.query(
+      `INSERT INTO _smrt_dispatch
+        (id, type, source, status, target_subscriber, tenant_id, created_at, updated_at)
+       VALUES (?, ?, ?, 'pending', ?, ?, ?, ?)`,
+      'd-tenant-a',
+      'thing.happened',
+      'src',
+      legacy,
+      'tenant-a',
+      new Date().toISOString(),
+      new Date().toISOString(),
+    );
+
+    // A legacy subscription owned by tenant A so the migration has work to do.
+    await db.query(
+      `INSERT INTO _smrt_dispatch_subscriptions
+        (id, signal_type, subscriber, handler, delivery, enabled, tenant_id, created_at, updated_at)
+       VALUES (?, ?, ?, 'handleDispatch', 'compete', 1, ?, ?, ?)`,
+      'sub-legacy-a',
+      'thing.happened',
+      legacy,
+      'tenant-a',
+      new Date().toISOString(),
+      new Date().toISOString(),
+    );
+
+    // Run the migration as tenant A.
+    activeTenant = 'tenant-a';
+    const agent = new MigrationAgent({ name: 'migrating', db });
+    await agent.initialize();
+
+    const rowB = await db.query(
+      `SELECT target_subscriber FROM _smrt_dispatch WHERE id = ?`,
+      'd-tenant-b',
+    );
+    const rowA = await db.query(
+      `SELECT target_subscriber FROM _smrt_dispatch WHERE id = ?`,
+      'd-tenant-a',
+    );
+
+    // Tenant B's row must be untouched (the bug rewrote it to the canonical
+    // subscriber); tenant A's own row is correctly migrated.
+    expect(rowB.rows[0].target_subscriber).toBe(legacy);
+    expect(rowA.rows[0].target_subscriber).toBe(canonical);
+  });
+
+  it('migrates all rows when tenancy is disabled (no resolver)', async () => {
+    // Clear the resolver → tenancy off → pre-tenancy behavior (no filtering).
+    setDispatchTenantResolver(undefined);
+
+    const db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+    const legacy = 'MigrationAgent';
+    const canonical = canonicalSubscriber();
+
+    const bootstrap = new MigrationAgent({ name: 'bootstrap-2', db });
+    await bootstrap.initialize();
+
+    await db.query(
+      `INSERT INTO _smrt_dispatch
+        (id, type, source, status, target_subscriber, tenant_id, created_at, updated_at)
+       VALUES (?, ?, ?, 'pending', ?, NULL, ?, ?)`,
+      'd-global',
+      'thing.happened',
+      'src',
+      legacy,
+      new Date().toISOString(),
+      new Date().toISOString(),
+    );
+    await db.query(
+      `INSERT INTO _smrt_dispatch_subscriptions
+        (id, signal_type, subscriber, handler, delivery, enabled, tenant_id, created_at, updated_at)
+       VALUES (?, ?, ?, 'handleDispatch', 'compete', 1, NULL, ?, ?)`,
+      'sub-legacy-global',
+      'thing.happened',
+      legacy,
+      new Date().toISOString(),
+      new Date().toISOString(),
+    );
+
+    const agent = new MigrationAgent({ name: 'migrating-2', db });
+    await agent.initialize();
+
+    const row = await db.query(
+      `SELECT target_subscriber FROM _smrt_dispatch WHERE id = ?`,
+      'd-global',
+    );
+    expect(row.rows[0].target_subscriber).toBe(canonical);
+  });
+
+  it('only migrates global rows when tenancy is on but no tenant is active (fail-closed)', async () => {
+    // Third security-critical state (review #1552): resolver present (tenancy
+    // ENABLED) but no active tenant → scope is { enforced: true, tenantId: null }
+    // → the predicate must be `tenant_id IS NULL`, touching ONLY global rows and
+    // never any tenant's rows. Exercises the scope.tenantId === null branch of
+    // buildDispatchTenantUpdatePredicate.
+    const db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+    const legacy = 'MigrationAgent';
+    const canonical = canonicalSubscriber();
+
+    // Bootstrap tables under a tenant.
+    activeTenant = 'tenant-a';
+    const bootstrap = new MigrationAgent({ name: 'bootstrap-3', db });
+    await bootstrap.initialize();
+
+    // A global (tenant_id NULL) row and a tenant-A row, both at the legacy name.
+    await db.query(
+      `INSERT INTO _smrt_dispatch
+        (id, type, source, status, target_subscriber, tenant_id, created_at, updated_at)
+       VALUES (?, ?, ?, 'pending', ?, NULL, ?, ?)`,
+      'd-global-3',
+      'thing.happened',
+      'src',
+      legacy,
+      new Date().toISOString(),
+      new Date().toISOString(),
+    );
+    await db.query(
+      `INSERT INTO _smrt_dispatch
+        (id, type, source, status, target_subscriber, tenant_id, created_at, updated_at)
+       VALUES (?, ?, ?, 'pending', ?, ?, ?, ?)`,
+      'd-tenant-a-3',
+      'thing.happened',
+      'src',
+      legacy,
+      'tenant-a',
+      new Date().toISOString(),
+      new Date().toISOString(),
+    );
+
+    // A global legacy subscription so the migration has work to do.
+    await db.query(
+      `INSERT INTO _smrt_dispatch_subscriptions
+        (id, signal_type, subscriber, handler, delivery, enabled, tenant_id, created_at, updated_at)
+       VALUES (?, ?, ?, 'handleDispatch', 'compete', 1, NULL, ?, ?)`,
+      'sub-legacy-global-3',
+      'thing.happened',
+      legacy,
+      new Date().toISOString(),
+      new Date().toISOString(),
+    );
+
+    // Run the migration with tenancy ENABLED but NO active tenant.
+    activeTenant = null;
+    const agent = new MigrationAgent({ name: 'migrating-3', db });
+    await agent.initialize();
+
+    const rowGlobal = await db.query(
+      `SELECT target_subscriber FROM _smrt_dispatch WHERE id = ?`,
+      'd-global-3',
+    );
+    const rowA = await db.query(
+      `SELECT target_subscriber FROM _smrt_dispatch WHERE id = ?`,
+      'd-tenant-a-3',
+    );
+
+    // Fail-closed: only the global row migrates; the tenant's row is untouched.
+    expect(rowGlobal.rows[0].target_subscriber).toBe(canonical);
+    expect(rowA.rows[0].target_subscriber).toBe(legacy);
+  });
+});

--- a/packages/agents/src/server/serialization.ts
+++ b/packages/agents/src/server/serialization.ts
@@ -39,7 +39,19 @@ export interface SerializedAgent {
   permissions?: Record<string, boolean>;
   /** Agent icon from manifest */
   icon?: string;
-  /** Tenant-level config overrides */
+  /**
+   * Tenant-level config overrides.
+   *
+   * SECURITY (review #1552): this is the tenant's own override blob, carried
+   * verbatim into the client payload. The model field `TenantAgent.config` is
+   * `@field({ sensitive: true })`, which strips it from the generated CRUD
+   * api/mcp surfaces — but this hand-written admin serialization deliberately
+   * bypasses that for the authorized admin UI. Do NOT store raw secrets (API
+   * keys, tokens) in tenant config; reference them by id via
+   * `@happyvertical/smrt-secrets` so only an opaque handle reaches the browser.
+   * Dropping this field outright is a breaking change to a public API consumed
+   * downstream and is tracked as a separate follow-up.
+   */
   config?: Record<string, any>;
 }
 

--- a/packages/agents/src/tenant-agent.test.ts
+++ b/packages/agents/src/tenant-agent.test.ts
@@ -515,4 +515,42 @@ describe('TenantAgentCollection', () => {
       expect(praeco.permissions['manage:sources']).toBe(true);
     });
   });
+
+  describe('config field exposure (S5 #1398)', () => {
+    it('excludes the credential-bearing config blob from toPublicJSON()', async () => {
+      const tid = tenantId('config-sensitive');
+      const entry = await collection.create({
+        tenantId: tid,
+        agentClass: 'Praeco',
+        status: 'active',
+        config: { apiKey: 'sk-live-should-not-leak', region: 'us-east-1' },
+      });
+      await entry.save();
+
+      const publicJson = entry.toPublicJSON() as Record<string, unknown>;
+      // Sensitive override blob must not be serialized to API/MCP responses.
+      expect('config' in publicJson).toBe(false);
+      expect(JSON.stringify(publicJson)).not.toContain(
+        'sk-live-should-not-leak',
+      );
+
+      // Non-sensitive metadata is still present.
+      expect(publicJson.agentClass).toBe('Praeco');
+
+      // Server-side reads (e.g. serializeResolvedAgent) still see the value.
+      const loaded = await collection.list({ where: { tenantId: tid } });
+      expect(loaded[0].config?.apiKey).toBe('sk-live-should-not-leak');
+    });
+
+    it('rejects config as a WHERE filter key (no value probing) (review #1552)', async () => {
+      // The other half of the @field({ sensitive }) contract: a sensitive field
+      // must not be usable as a WHERE filter, else its value could be probed via
+      // the generated list/get surfaces. Core's convertWhereKeys throws.
+      await expect(
+        collection.list({
+          where: { config: { apiKey: 'sk-live-should-not-leak' } },
+        }),
+      ).rejects.toThrow(/sensitive fields is not allowed/i);
+    });
+  });
 });

--- a/packages/agents/src/tenant-agent.ts
+++ b/packages/agents/src/tenant-agent.ts
@@ -95,8 +95,17 @@ export class TenantAgent extends SmrtObject {
   @field({ type: 'json', nullable: true })
   permissions: Record<string, boolean> | null = null;
 
-  /** Tenant-level agent config overrides (JSON) */
-  @field({ type: 'json', nullable: true })
+  /**
+   * Tenant-level agent config overrides (JSON).
+   *
+   * Sensitive (S5 #1398): like {@link AgentConfig.configData} and
+   * {@link AgentSchedule.agentConfig} (both marked sensitive in #1540), these
+   * per-tenant override blobs routinely carry API keys/credentials. Exclude
+   * them from generated API/MCP responses and reject them as a `where` filter
+   * key. Server-side helpers (e.g. `serializeResolvedAgent`) still read the
+   * property directly, so the admin dashboard flow is unaffected.
+   */
+  @field({ type: 'json', nullable: true, sensitive: true })
   config: Record<string, any> | null = null;
 }
 


### PR DESCRIPTION
## Security audit: packages/agents (Tier T2, S5 #1398)

Audited `@happyvertical/smrt-agents` against the now-merged tenant-scoped DispatchBus core (#1398: 3-state fail-closed resolver, server-derived source, atomic claim). The bus's `emit`/`subscribe`/`process`/`unsubscribe`/`list` are all tenant-scoped server-side, so the agents package inherits that isolation by delegation. The two exploitable gaps were where the package reached around the bus or exposed credential blobs.

### Findings

| # | Sev | Lens | Location | Issue | Fix |
|---|-----|------|----------|-------|-----|
| 1 | HIGH | Tenant isolation | `src/agent.ts` `migrateLegacyDispatchSubscriptions()` (raw `UPDATE _smrt_dispatch`) | The bus's calls are tenant-scoped, but the trailing raw UPDATE had **no tenant predicate**. An agent initializing under tenant A rewrote `target_subscriber`/`processed_by` of **every** tenant's pending dispatch rows matching the legacy simple-name subscriber, retargeting other tenants' dispatches. | Derive the active `DispatchTenantScope` server-side via `resolveDispatchTenantScope()` and append a tenant predicate mirroring core's `pushTenantPredicate` read/claim semantics (own + global; fail-closed to global when no active tenant; no filter when tenancy is off). |
| 2 | MEDIUM | Exposure / secrets | `src/tenant-agent.ts` `TenantAgent.config` | Per-tenant agent config override blob (routinely carries API keys/credentials) was returned unredacted via the generated `api`/`mcp` list/get/create/update surfaces. Inconsistent with `AgentConfig.configData` and `AgentSchedule.agentConfig`, both marked sensitive in #1540. | Mark `@field({ sensitive: true })` → stripped from `toPublicJSON()` (generated REST/MCP serializer) and rejected as a `where` filter key. Server-side `serializeResolvedAgent` reads the property directly, so the admin dashboard is unaffected. |

### Per-lens results
- **Tenant isolation:** Finding #1 fixed. All other persisted queries delegate to the tenant-scoped bus or `@TenantScoped` collections; `loadRelated` not used cross-tenant.
- **AuthZ:** `Agent` base is `api:false/mcp:false/cli:false`. Exposed models (`AgentSchedule`, `TenantAgent`, `AgentConfig`) carry `@TenantScoped`; CLI-only operator commands (`enable`/`disable`) intentionally not over HTTP.
- **Exposure:** Finding #2 fixed; sensitive config blobs now consistent across all three models.
- **Injection / unsafe data:** All `JSON.parse` calls are build-time over trusted manifest files. Cron parser is integer/`parseInt`-based, no shell/path use. Interest `query` functions are developer-supplied (compile-time), not user input.
- **Secrets:** `AgentSchedule.lastError` is redacted by the canonical writer (ScheduleRunner, #1402) before persistence. `recordFailure(error)` is a model method with no in-framework unredacted caller — noted as residual LOW, not fixed (would require a cross-package dep on `smrt-jobs` for one regex helper).
- **Dependency audit:** No direct external runtime deps in agents beyond workspace `@happyvertical/*` packages; nothing flagged.

### Tests
- `src/dispatch-tenant-migration.test.ts` (new): cross-tenant UPDATE isolation (red-green verified — fails without the predicate) + tenancy-disabled passthrough.
- `src/tenant-agent.test.ts`: `config` excluded from `toPublicJSON()` while still readable server-side.
- 170 agents tests pass; `typecheck` clean; biome clean on changed source (3 remaining warnings are pre-existing `noNonNullAssertion` in untouched test lines).

closes #1398