### PR TITLE
fix(core): fail-closed tenant context for generated CLI/MCP (S5 #1554, #1556)

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -86,7 +86,7 @@ admin auth.
 | Generator | Location | Output |
 |-----------|----------|--------|
 | REST API | `src/generators/rest.ts` | OpenAPI-compliant CRUD endpoints |
-| CLI | `src/generators/cli.ts` | Commander commands with auto-help |
+| CLI | `src/generators/cli.ts` | `objectname:action` admin commands — writable allowlist, exhaustive-include, `--from-file`, fail-closed tenant context |
 | MCP Server | `src/generators/mcp.ts` | Model Context Protocol tools |
 
 ## Child Accessors (R10)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,11 @@
       "import": "./dist/generators/rest.js",
       "default": "./dist/generators/rest.js"
     },
+    "./generators/cli": {
+      "types": "./dist/generators/cli.d.ts",
+      "import": "./dist/generators/cli.js",
+      "default": "./dist/generators/cli.js"
+    },
     "./generators/mcp": {
       "types": "./dist/generators/mcp.d.ts",
       "import": "./dist/generators/mcp.js",

--- a/packages/core/src/generators/cli-hardening.spec.ts
+++ b/packages/core/src/generators/cli-hardening.spec.ts
@@ -1,0 +1,254 @@
+/**
+ * Regression tests for the generated CLI surface (#1556 / #1554).
+ *
+ * The CLI generator must reach parity with the REST/MCP generators:
+ *  1. Exhaustive `cli.include` — when an include list is present it is the
+ *     COMPLETE allowlist; custom (non-CRUD) methods are exposed only if named.
+ *  2. Custom methods are gated on `isPublic`; `cli: false` disables the object.
+ *  3. Create/update bodies are mass-assignment guarded (writable allowlist +
+ *     server-managed / readonly strip).
+ *  4. `--from-file` loads a JSON create/update payload (keeps secrets off argv).
+ *  5. Output is serialized through `toPublicJSON()` so `sensitive` fields never
+ *     print.
+ *
+ * Tenant fail-closed behavior (the other half of #1554) requires
+ * `@happyvertical/smrt-tenancy`, which core cannot depend on, so it is covered
+ * end-to-end in the tenancy package's `cli-mcp-tenant-context.spec.ts`. Here we
+ * only assert the tenancy-off pass-through (no runner registered → runs).
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { SmrtCollection } from '../collection';
+import { field } from '../decorators';
+import { SmrtObject } from '../object';
+import { ObjectRegistry, smrt } from '../registry';
+import { getTestDatabase } from '../testing/database';
+import { CLIGenerator } from './cli';
+
+// Exhaustive include naming only CRUD verbs — custom methods must NOT leak.
+@smrt({ cli: { include: ['list', 'get'] } })
+class CliCrudOnly extends SmrtObject {
+  @field({ type: 'text' })
+  name = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+  }
+
+  async recordPayment(): Promise<any> {
+    return { ok: true };
+  }
+}
+
+// No include — custom public methods auto-exposed (historical default).
+@smrt({ cli: true })
+class CliDefault extends SmrtObject {
+  @field({ type: 'text' })
+  name = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+  }
+
+  async syncNow(): Promise<any> {
+    return { ok: true };
+  }
+}
+
+// `cli: false` disables the object entirely.
+@smrt({ cli: false })
+class CliDisabled extends SmrtObject {
+  @field({ type: 'text' })
+  name = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+  }
+}
+
+// Writable allowlist + readonly + sensitive field for mass-assignment tests.
+@smrt({ cli: true, api: { writable: ['name'] } })
+class CliWritableWidget extends SmrtObject {
+  @field({ type: 'text' })
+  name = '';
+
+  @field({ type: 'text', nullable: true })
+  tenantId: string | null = null;
+
+  @field({ type: 'text', readonly: true })
+  internalCode = '';
+
+  @field({ type: 'text', nullable: true })
+  notAllowed: string | null = null;
+
+  @field({ type: 'text', sensitive: true, nullable: true })
+  apiKey: string | null = null;
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+    if (options.internalCode !== undefined)
+      this.internalCode = options.internalCode;
+    if (options.notAllowed !== undefined) this.notAllowed = options.notAllowed;
+    if (options.apiKey !== undefined) this.apiKey = options.apiKey;
+  }
+}
+
+class CliWritableWidgetCollection extends SmrtCollection<CliWritableWidget> {
+  static readonly _itemClass = CliWritableWidget;
+}
+
+describe('CLI generator hardening (#1556 / #1554)', () => {
+  ObjectRegistry.registerCollection(
+    'CliWritableWidget',
+    CliWritableWidgetCollection,
+  );
+
+  describe('command exposure policy', () => {
+    it('exhaustive cli.include: [list, get] exposes neither custom methods nor other CRUD', async () => {
+      const gen = new CLIGenerator();
+      const commands = await gen.listCommands();
+      const mine = commands.filter((c) => c.startsWith('clicrudonly:'));
+      expect(mine).toContain('clicrudonly:list');
+      expect(mine).toContain('clicrudonly:get');
+      expect(mine).not.toContain('clicrudonly:recordPayment');
+      expect(mine).not.toContain('clicrudonly:create');
+    });
+
+    it('rejects a non-included command at run time', async () => {
+      const gen = new CLIGenerator();
+      await expect(
+        gen.run(['clicrudonly:create', '--name', 'x']),
+      ).rejects.toThrow(/not enabled/i);
+    });
+
+    it('rejects a non-included custom method at run time', async () => {
+      const gen = new CLIGenerator();
+      await expect(
+        gen.run(['clicrudonly:recordPayment', 'id1']),
+      ).rejects.toThrow(/not enabled/i);
+    });
+
+    it('no include list auto-exposes public custom methods', async () => {
+      const gen = new CLIGenerator();
+      const commands = await gen.listCommands();
+      expect(commands).toContain('clidefault:syncNow');
+    });
+
+    it('cli: false hides the object and rejects its commands', async () => {
+      const gen = new CLIGenerator();
+      const commands = await gen.listCommands();
+      expect(commands.some((c) => c.startsWith('clidisabled:'))).toBe(false);
+      await expect(gen.run(['clidisabled:list'])).rejects.toThrow(/disabled/i);
+    });
+  });
+
+  describe('mass-assignment guard + sensitive redaction', () => {
+    let db: any;
+
+    beforeAll(async () => {
+      db = await getTestDatabase({
+        type: 'sqlite',
+        url: ':memory:',
+        classes: ['CliWritableWidget'],
+      });
+    });
+
+    afterAll(async () => {
+      await db?.close?.();
+    });
+
+    it('drops tenantId, readonly, and non-writable fields on create', async () => {
+      const collection = await CliWritableWidgetCollection.create({ db });
+      const gen = new CLIGenerator({}, { db });
+
+      await gen.run([
+        'cliwritablewidget:create',
+        '--name',
+        'Widget A',
+        '--tenantId',
+        'attacker-tenant',
+        '--internalCode',
+        'SECRET',
+        '--notAllowed',
+        'nope',
+      ]);
+
+      const rows = await collection.list({ where: { name: 'Widget A' } });
+      expect(rows).toHaveLength(1);
+      const row = rows[0] as CliWritableWidget;
+      expect(row.name).toBe('Widget A');
+      // Stripped by the writable allowlist / server-managed / readonly rules.
+      expect(row.tenantId).toBeNull();
+      expect(row.internalCode).toBe('');
+      expect(row.notAllowed).toBeNull();
+    });
+
+    it('does not print sensitive fields in command output', async () => {
+      const logs: string[] = [];
+      const original = console.log;
+      console.log = (...args: unknown[]) => {
+        logs.push(args.map(String).join(' '));
+      };
+      try {
+        const gen = new CLIGenerator({}, { db });
+        await gen.run([
+          'cliwritablewidget:create',
+          '--name',
+          'Widget B',
+          '--apiKey',
+          'super-secret-key',
+        ]);
+      } finally {
+        console.log = original;
+      }
+      const output = logs.join('\n');
+      expect(output).not.toContain('super-secret-key');
+      expect(output).not.toContain('apiKey');
+    });
+
+    it('loads a create payload from --from-file', async () => {
+      const { writeFile, mkdtemp } = await import('node:fs/promises');
+      const { tmpdir } = await import('node:os');
+      const { join } = await import('node:path');
+      const dir = await mkdtemp(join(tmpdir(), 'cli-fromfile-'));
+      const file = join(dir, 'payload.json');
+      await writeFile(
+        file,
+        JSON.stringify({ name: 'From File', internalCode: 'STRIP' }),
+        'utf-8',
+      );
+
+      const collection = await CliWritableWidgetCollection.create({ db });
+      const gen = new CLIGenerator({}, { db });
+      await gen.run(['cliwritablewidget:create', '--from-file', file]);
+
+      const rows = await collection.list({ where: { name: 'From File' } });
+      expect(rows).toHaveLength(1);
+      // readonly field still stripped even when supplied via file.
+      expect((rows[0] as CliWritableWidget).internalCode).toBe('');
+    });
+  });
+
+  describe('tenancy-off pass-through', () => {
+    it('runs a list with no tenant runner registered', async () => {
+      const db = await getTestDatabase({
+        type: 'sqlite',
+        url: ':memory:',
+        classes: ['CliWritableWidget'],
+      });
+      const gen = new CLIGenerator({}, { db });
+      // Should not throw — no tenant entry-point runner is registered in core's
+      // own test env, so the gate passes through.
+      await expect(
+        gen.run(['cliwritablewidget:list']),
+      ).resolves.toBeUndefined();
+      await db?.close?.();
+    });
+  });
+});

--- a/packages/core/src/generators/cli-hardening.spec.ts
+++ b/packages/core/src/generators/cli-hardening.spec.ts
@@ -103,6 +103,19 @@ class CliWritableWidgetCollection extends SmrtCollection<CliWritableWidget> {
   static readonly _itemClass = CliWritableWidget;
 }
 
+// A plain model with NO hand-written/registered collection class — the CLI must
+// still work via the registry's default-collection factory (codex P2 on #1557).
+@smrt({ cli: true })
+class CliPlainModel extends SmrtObject {
+  @field({ type: 'text' })
+  name = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+  }
+}
+
 describe('CLI generator hardening (#1556 / #1554)', () => {
   ObjectRegistry.registerCollection(
     'CliWritableWidget',
@@ -248,6 +261,34 @@ describe('CLI generator hardening (#1556 / #1554)', () => {
       await expect(
         gen.run(['cliwritablewidget:list']),
       ).resolves.toBeUndefined();
+      await db?.close?.();
+    });
+  });
+
+  describe('default-collection models', () => {
+    it('create + list work for a plain @smrt() model with no collection class', async () => {
+      const db = await getTestDatabase({
+        type: 'sqlite',
+        url: ':memory:',
+        classes: ['CliPlainModel'],
+      });
+      const gen = new CLIGenerator({}, { db });
+
+      // Both must succeed via the registry's default-collection factory, even
+      // though CliPlainModel has no hand-written collection class.
+      await gen.run(['cliplainmodel:create', '--name', 'Plain One']);
+
+      const logs: string[] = [];
+      const original = console.log;
+      console.log = (...args: unknown[]) => {
+        logs.push(args.map(String).join(' '));
+      };
+      try {
+        await gen.run(['cliplainmodel:list']);
+      } finally {
+        console.log = original;
+      }
+      expect(logs.join('\n')).toContain('Plain One');
       await db?.close?.();
     });
   });

--- a/packages/core/src/generators/cli.ts
+++ b/packages/core/src/generators/cli.ts
@@ -7,12 +7,13 @@
  *
  * Security parity with the REST/MCP generators (#1540, #1547, #1554, #1556):
  * - **Mass-assignment guard** — create/update bodies are filtered through the
- *   `@smrt({ api: { writable: [...] } })` allowlist with server-managed and
- *   `@field({ readonly }) `/`sensitive` fields stripped ({@link CLIGenerator.applyWritablePolicy}).
+ *   `@smrt({ api: { writable: [...] } })` allowlist, dropping server-managed and
+ *   `@field({ readonly })` fields ({@link CLIGenerator.applyWritablePolicy}).
  * - **Exhaustive include** — an `include` list is the COMPLETE allowlist for the
  *   surface; custom methods are gated on `isPublic`.
- * - **Sensitive redaction** — command output is serialized through
- *   {@link CLIGenerator.toPublicData} so `@field({ sensitive })` values never print.
+ * - **Sensitive redaction** — command *output* is serialized through
+ *   {@link CLIGenerator.toPublicData} so `@field({ sensitive })` values never
+ *   print (input bodies are guarded by the writable allowlist above).
  * - **Fail-closed tenant context** — tenant-scoped reads/writes run inside the
  *   tenancy gate; without `--tenant <id>` / `--all-tenants` (and with tenancy
  *   enabled) the command throws rather than ranging across all tenants.

--- a/packages/core/src/generators/cli.ts
+++ b/packages/core/src/generators/cli.ts
@@ -19,7 +19,7 @@
  *   enabled) the command throws rather than ranging across all tenants.
  */
 
-import { SmrtCollection } from '../collection';
+import type { SmrtCollection } from '../collection';
 import { ObjectRegistry } from '../registry';
 import { runWithTenantGate } from './tenant-gate.js';
 
@@ -100,7 +100,6 @@ interface ParsedInvocation {
 export class CLIGenerator {
   private config: CLIConfig;
   private context: CLIContext;
-  private collections = new Map<string, SmrtCollection<any>>();
 
   constructor(config: CLIConfig = {}, context: CLIContext = {}) {
     this.config = {
@@ -172,7 +171,7 @@ export class CLIGenerator {
     const result = await runWithTenantGate(
       { className: objectName, tenantId, allowCrossTenant, surface: 'CLI' },
       async () => {
-        const collection = await this.getCollection(objectName, classInfo);
+        const collection = await this.getCollection(objectName);
         return this.executeAction(collection, objectName, parsed);
       },
     );
@@ -305,41 +304,19 @@ export class CLIGenerator {
   }
 
   /**
-   * Get or create the collection for an object (mirrors the MCP generator).
+   * Get the collection for an object via the registry factory. Uses
+   * `ObjectRegistry.getCollection`, which caches, initializes, and — for plain
+   * `@smrt()` models without a hand-written collection class — auto-creates the
+   * default collection. (A bare `collectionConstructor` check would wrongly
+   * throw for those models even though CRUD is advertised.)
    */
   private async getCollection(
     objectName: string,
-    classInfo: any,
   ): Promise<SmrtCollection<any>> {
-    if (!this.collections.has(objectName)) {
-      if (
-        !classInfo.collectionConstructor ||
-        typeof classInfo.collectionConstructor !== 'function'
-      ) {
-        throw new Error(
-          `No valid collection constructor found for ${objectName}`,
-        );
-      }
-
-      const collection = new classInfo.collectionConstructor({
-        ai: this.context.ai,
-        db: this.context.db,
-      });
-
-      if (!(collection instanceof SmrtCollection)) {
-        throw new Error(
-          `Collection for ${objectName} must extend SmrtCollection`,
-        );
-      }
-
-      await collection.initialize();
-      this.collections.set(objectName, collection);
-    }
-    const collection = this.collections.get(objectName);
-    if (!collection) {
-      throw new Error(`Collection for ${objectName} not found`);
-    }
-    return collection;
+    return ObjectRegistry.getCollection(objectName, {
+      ai: this.context.ai,
+      db: this.context.db,
+    });
   }
 
   /**

--- a/packages/core/src/generators/cli.ts
+++ b/packages/core/src/generators/cli.ts
@@ -1,0 +1,688 @@
+/**
+ * CLI command generator for smrt objects
+ *
+ * Exposes registered `@smrt()` objects as a runnable admin CLI: each object gets
+ * `list`/`get`/`create`/`update`/`delete` commands plus its public custom
+ * methods, dispatched as `objectname:action`.
+ *
+ * Security parity with the REST/MCP generators (#1540, #1547, #1554, #1556):
+ * - **Mass-assignment guard** — create/update bodies are filtered through the
+ *   `@smrt({ api: { writable: [...] } })` allowlist with server-managed and
+ *   `@field({ readonly }) `/`sensitive` fields stripped ({@link CLIGenerator.applyWritablePolicy}).
+ * - **Exhaustive include** — an `include` list is the COMPLETE allowlist for the
+ *   surface; custom methods are gated on `isPublic`.
+ * - **Sensitive redaction** — command output is serialized through
+ *   {@link CLIGenerator.toPublicData} so `@field({ sensitive })` values never print.
+ * - **Fail-closed tenant context** — tenant-scoped reads/writes run inside the
+ *   tenancy gate; without `--tenant <id>` / `--all-tenants` (and with tenancy
+ *   enabled) the command throws rather than ranging across all tenants.
+ */
+
+import { SmrtCollection } from '../collection';
+import { ObjectRegistry } from '../registry';
+import { runWithTenantGate } from './tenant-gate.js';
+
+/**
+ * Configuration for a generated CLI.
+ */
+export interface CLIConfig {
+  /** CLI program name (used in help output). */
+  name?: string;
+  /** CLI version. */
+  version?: string;
+  /** CLI description. */
+  description?: string;
+}
+
+/**
+ * Per-invocation context for a generated CLI.
+ */
+export interface CLIContext {
+  /** Database handle passed to collections. */
+  db?: any;
+  /** AI provider passed to collections. */
+  ai?: any;
+  /** Authenticated operator, when the host establishes one. */
+  user?: {
+    id: string;
+    roles?: string[];
+  };
+  /**
+   * Default tenant for tenant-scoped commands when no `--tenant` flag is given.
+   * Hosts that authenticate an operator may set this from the principal.
+   */
+  tenantId?: string;
+  /**
+   * Default cross-tenant opt-in when no `--all-tenants` flag is given. Hosts
+   * may set this for trusted operator/admin shells.
+   */
+  allowCrossTenant?: boolean;
+}
+
+/** Standard CRUD verbs handled directly by the generator. */
+const CRUD_OPERATIONS = ['list', 'get', 'create', 'update', 'delete'];
+
+/**
+ * Flags consumed by the CLI itself — never treated as create/update field
+ * values or as custom-action options.
+ */
+const RESERVED_FLAGS = new Set([
+  'tenant',
+  'all-tenants',
+  'from-file',
+  'limit',
+  'offset',
+  'order-by',
+  'orderBy',
+  'where',
+  'format',
+  'json',
+  'help',
+  'id',
+]);
+
+/** Parsed CLI invocation. */
+interface ParsedInvocation {
+  /** Object/collection segment (lowercased), e.g. `product`. */
+  objectName: string;
+  /** Action segment, e.g. `list` or a custom method name. */
+  action: string;
+  /** First positional argument after the command (typically an id). */
+  positional?: string;
+  /** Parsed flags. String for `--k v`/`--k=v`, `true` for bare `--flag`. */
+  flags: Record<string, string | boolean>;
+}
+
+/**
+ * Generate and run an admin CLI for the registered `@smrt()` objects.
+ */
+export class CLIGenerator {
+  private config: CLIConfig;
+  private context: CLIContext;
+  private collections = new Map<string, SmrtCollection<any>>();
+
+  constructor(config: CLIConfig = {}, context: CLIContext = {}) {
+    this.config = {
+      name: 'smrt-cli',
+      version: '1.0.0',
+      description: 'Auto-generated CLI from smrt objects',
+      ...config,
+    };
+    this.context = context;
+  }
+
+  /** CLI program name. */
+  get name(): string | undefined {
+    return this.config.name;
+  }
+
+  /** CLI version. */
+  get version(): string | undefined {
+    return this.config.version;
+  }
+
+  /**
+   * Return the argv handler invoked by the generated `setupCLI()` wrapper.
+   *
+   * @returns An async function accepting the post-`node script` argv slice.
+   */
+  generateHandler(): (args: string[]) => Promise<void> {
+    return async (args: string[]) => {
+      await this.run(args ?? []);
+    };
+  }
+
+  /**
+   * Parse and execute a single CLI invocation.
+   *
+   * @param args - argv slice (command + flags).
+   */
+  async run(args: string[]): Promise<void> {
+    if (args.length === 0 || args[0] === '--help' || args[0] === 'help') {
+      console.log(await this.helpText());
+      return;
+    }
+
+    const parsed = this.parseArgs(args);
+    if (!parsed) {
+      console.log(await this.helpText());
+      return;
+    }
+
+    const classInfo = this.resolveClass(parsed.objectName);
+    if (!classInfo) {
+      throw new Error(`Object type '${parsed.objectName}' not found`);
+    }
+    const objectName: string = classInfo.name || parsed.objectName;
+
+    await this.assertCommandExposed(objectName, parsed.action);
+
+    const tenantId =
+      typeof parsed.flags.tenant === 'string'
+        ? parsed.flags.tenant
+        : this.context.tenantId;
+    const allowCrossTenant =
+      parsed.flags['all-tenants'] === true ||
+      this.context.allowCrossTenant === true;
+
+    // Tenant-scoping is resolved authoritatively inside tenancy (by class name),
+    // matching the interceptor and covering both @TenantScoped and
+    // @smrt({ tenantScoped }) registrations (#1554).
+    const result = await runWithTenantGate(
+      { className: objectName, tenantId, allowCrossTenant, surface: 'CLI' },
+      async () => {
+        const collection = await this.getCollection(objectName, classInfo);
+        return this.executeAction(collection, objectName, parsed);
+      },
+    );
+
+    if (result !== undefined) {
+      console.log(JSON.stringify(this.toPublicData(result), null, 2));
+    }
+  }
+
+  /**
+   * Parse argv into a command + flags. Supports `name:action` and
+   * `name action` command forms, `--key value`, `--key=value`, and bare
+   * `--flag` booleans.
+   */
+  private parseArgs(args: string[]): ParsedInvocation | null {
+    const [command, ...rest] = args;
+    if (!command || command.startsWith('-')) return null;
+
+    let objectName: string;
+    let action: string;
+    let tail = rest;
+
+    if (command.includes(':')) {
+      const [obj, act] = command.split(':');
+      objectName = obj.toLowerCase();
+      action = act;
+    } else if (rest.length > 0 && !rest[0].startsWith('-')) {
+      objectName = command.toLowerCase();
+      action = rest[0];
+      tail = rest.slice(1);
+    } else {
+      // A bare object name with no action is not a runnable command.
+      return null;
+    }
+
+    if (!objectName || !action) return null;
+
+    const flags: Record<string, string | boolean> = {};
+    let positional: string | undefined;
+
+    for (let i = 0; i < tail.length; i++) {
+      const token = tail[i];
+      if (token.startsWith('--')) {
+        const body = token.slice(2);
+        const eq = body.indexOf('=');
+        if (eq !== -1) {
+          flags[body.slice(0, eq)] = body.slice(eq + 1);
+        } else {
+          const next = tail[i + 1];
+          if (next !== undefined && !next.startsWith('--')) {
+            flags[body] = next;
+            i++;
+          } else {
+            flags[body] = true;
+          }
+        }
+      } else if (positional === undefined) {
+        positional = token;
+      }
+    }
+
+    return { objectName, action, positional, flags };
+  }
+
+  /**
+   * Resolve a registered class by simple name (case-insensitive), mirroring the
+   * MCP generator's lookup.
+   */
+  private resolveClass(objectName: string): any {
+    const registeredClasses = ObjectRegistry.getAllClasses();
+    for (const [key, info] of registeredClasses) {
+      const simpleName = info.name || key;
+      if (simpleName.toLowerCase() === objectName.toLowerCase()) {
+        return info;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Throw if `action` is not exposed for `objectName` under its `@smrt({ cli })`
+   * config. `cli: false` disables the object entirely; an `include` list is the
+   * complete allowlist; custom methods must be `isPublic`.
+   */
+  private async assertCommandExposed(
+    objectName: string,
+    action: string,
+  ): Promise<void> {
+    const config = ObjectRegistry.getConfig(objectName);
+    const cliConfig = config?.cli;
+
+    if (cliConfig === false) {
+      throw new Error(`CLI is disabled for ${objectName}`);
+    }
+
+    const included: string[] | undefined =
+      typeof cliConfig === 'object' ? cliConfig?.include : undefined;
+    const excluded: string[] =
+      typeof cliConfig === 'object' && cliConfig?.exclude
+        ? cliConfig.exclude
+        : [];
+
+    if (excluded.includes(action)) {
+      throw new Error(`Command '${action}' is excluded for ${objectName}`);
+    }
+
+    const isCrud = CRUD_OPERATIONS.includes(action);
+
+    if (isCrud) {
+      // An include list, when present, is the complete allowlist for CRUD too.
+      if (included && !included.includes(action)) {
+        throw new Error(`Command '${action}' is not enabled for ${objectName}`);
+      }
+      return;
+    }
+
+    // Custom method: must be public, and — when an include list is present — it
+    // is the COMPLETE allowlist (parity with MCP exhaustive-include, #1547).
+    const methods = await ObjectRegistry.getAllMethods(objectName);
+    const methodDef = methods.get(action);
+    if (!methodDef) {
+      throw new Error(`Unknown command '${action}' for ${objectName}`);
+    }
+    if (!methodDef.isPublic) {
+      throw new Error(`Command '${action}' is not public on ${objectName}`);
+    }
+    if (included !== undefined && !included.includes(action)) {
+      throw new Error(`Command '${action}' is not enabled for ${objectName}`);
+    }
+  }
+
+  /**
+   * Get or create the collection for an object (mirrors the MCP generator).
+   */
+  private async getCollection(
+    objectName: string,
+    classInfo: any,
+  ): Promise<SmrtCollection<any>> {
+    if (!this.collections.has(objectName)) {
+      if (
+        !classInfo.collectionConstructor ||
+        typeof classInfo.collectionConstructor !== 'function'
+      ) {
+        throw new Error(
+          `No valid collection constructor found for ${objectName}`,
+        );
+      }
+
+      const collection = new classInfo.collectionConstructor({
+        ai: this.context.ai,
+        db: this.context.db,
+      });
+
+      if (!(collection instanceof SmrtCollection)) {
+        throw new Error(
+          `Collection for ${objectName} must extend SmrtCollection`,
+        );
+      }
+
+      await collection.initialize();
+      this.collections.set(objectName, collection);
+    }
+    const collection = this.collections.get(objectName);
+    if (!collection) {
+      throw new Error(`Collection for ${objectName} not found`);
+    }
+    return collection;
+  }
+
+  /**
+   * Execute a parsed command against a collection.
+   */
+  private async executeAction(
+    collection: SmrtCollection<any>,
+    objectName: string,
+    parsed: ParsedInvocation,
+  ): Promise<any> {
+    const { action, positional, flags } = parsed;
+
+    switch (action) {
+      case 'list': {
+        const listOptions: any = {
+          limit: Math.min(this.toNumber(flags.limit, 50), 1000),
+          offset: this.toNumber(flags.offset, 0),
+        };
+        const orderBy = flags['order-by'] ?? flags.orderBy;
+        if (typeof orderBy === 'string') listOptions.orderBy = orderBy;
+        if (typeof flags.where === 'string') {
+          listOptions.where = JSON.parse(flags.where);
+        }
+        return collection.list(listOptions);
+      }
+
+      case 'get': {
+        const id = positional ?? this.flagString(flags.id);
+        if (!id) throw new Error('An id is required for get');
+        const item = await collection.get(id);
+        if (!item) throw new Error(`${objectName} not found`);
+        return item;
+      }
+
+      case 'create': {
+        const data = this.applyWritablePolicy(
+          objectName,
+          await this.readPayload(flags),
+        );
+        if (this.context.user) {
+          (data as any).created_by = this.context.user.id;
+          (data as any).owner_id = this.context.user.id;
+        }
+        const created = await collection.create(data);
+        await created.save();
+        return created;
+      }
+
+      case 'update': {
+        const id = positional ?? this.flagString(flags.id);
+        if (!id) throw new Error('An id is required for update');
+        const existing = await collection.get(id);
+        if (!existing) throw new Error(`${objectName} not found`);
+        const data = this.applyWritablePolicy(
+          objectName,
+          await this.readPayload(flags),
+        );
+        Object.assign(existing, data);
+        if (this.context.user) {
+          (existing as any).updated_by = this.context.user.id;
+        }
+        await existing.save();
+        return existing;
+      }
+
+      case 'delete': {
+        const id = positional ?? this.flagString(flags.id);
+        if (!id) throw new Error('An id is required for delete');
+        const existing = await collection.get(id);
+        if (!existing) throw new Error(`${objectName} not found`);
+        await existing.delete();
+        return { success: true, id, message: `${objectName} deleted` };
+      }
+
+      default:
+        return this.executeCustomAction(collection, action, positional, flags);
+    }
+  }
+
+  /**
+   * Execute a custom method on an instance (when an id is given) or on the
+   * collection (singleton actions). Mirrors the MCP custom-action path.
+   */
+  private async executeCustomAction(
+    collection: SmrtCollection<any>,
+    action: string,
+    positional: string | undefined,
+    flags: Record<string, string | boolean>,
+  ): Promise<any> {
+    const options = this.customOptions(flags);
+    const id = positional ?? this.flagString(flags.id);
+
+    if (id) {
+      const object = (await collection.get(id)) as any;
+      if (!object) throw new Error('Object not found');
+      if (typeof object[action] !== 'function') {
+        throw new Error(`Method '${action}' not found on object instance`);
+      }
+      return object[action](options);
+    }
+
+    if (typeof (collection as any)[action] === 'function') {
+      return (collection as any)[action](options);
+    }
+    throw new Error(
+      `Method '${action}' not found on collection. Provide an id for object-specific actions.`,
+    );
+  }
+
+  /**
+   * Resolve the create/update payload: `--from-file <path>` (JSON) takes
+   * precedence; otherwise non-reserved `--field value` flags form the body.
+   * Reading from a file also keeps secrets off the process argv (#1556).
+   */
+  private async readPayload(
+    flags: Record<string, string | boolean>,
+  ): Promise<Record<string, any>> {
+    const fromFile = flags['from-file'];
+    if (typeof fromFile === 'string' && fromFile) {
+      const { readFile } = await import('node:fs/promises');
+      const content = await readFile(fromFile, 'utf-8');
+      const parsed = JSON.parse(content);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error('--from-file must contain a JSON object');
+      }
+      return parsed as Record<string, any>;
+    }
+
+    const data: Record<string, any> = {};
+    for (const [key, value] of Object.entries(flags)) {
+      if (RESERVED_FLAGS.has(key)) continue;
+      data[key] = this.coerceValue(value);
+    }
+    return data;
+  }
+
+  /** Collect non-reserved flags as custom-action options. */
+  private customOptions(
+    flags: Record<string, string | boolean>,
+  ): Record<string, any> {
+    const options: Record<string, any> = {};
+    for (const [key, value] of Object.entries(flags)) {
+      if (RESERVED_FLAGS.has(key)) continue;
+      options[key] = this.coerceValue(value);
+    }
+    return options;
+  }
+
+  /**
+   * Mass-assignment guard (#1540/#1556): strip framework/server-managed and
+   * `@field({ readonly })` fields, and — when an `@smrt({ api: { writable } })`
+   * allowlist is set — intersect with it. Identical policy to the REST/MCP
+   * generators so a CLI create/update cannot set fields the API forbids.
+   */
+  private applyWritablePolicy(
+    objectName: string | undefined,
+    data: any,
+  ): Record<string, any> {
+    if (!data || typeof data !== 'object') return {};
+
+    const serverManaged = new Set([
+      'id',
+      'tenantId',
+      'tenant_id',
+      'createdAt',
+      'created_at',
+      'updatedAt',
+      'updated_at',
+    ]);
+
+    const readonly = new Set<string>();
+    let writable: string[] | null = null;
+
+    if (objectName) {
+      const apiConfig = ObjectRegistry.getConfig(objectName)?.api;
+      if (
+        apiConfig &&
+        typeof apiConfig === 'object' &&
+        Array.isArray((apiConfig as { writable?: unknown }).writable)
+      ) {
+        writable = (apiConfig as { writable: string[] }).writable;
+      }
+
+      for (const [name, def] of ObjectRegistry.getFields(objectName)) {
+        if (def && (def.readonly === true || def._meta?.readonly === true)) {
+          readonly.add(name);
+        }
+      }
+    }
+
+    const result: Record<string, any> = {};
+    for (const [key, value] of Object.entries(data)) {
+      if (key.startsWith('_')) continue;
+      if (serverManaged.has(key)) continue;
+      if (readonly.has(key)) continue;
+      if (writable && !writable.includes(key)) continue;
+      result[key] = value;
+    }
+    return result;
+  }
+
+  /**
+   * Serialize command output, excluding `@field({ sensitive })` fields (#1540).
+   * Recurses arrays/plain objects so a SmrtObject nested in a custom-action
+   * result is stripped too; a cycle guard prevents infinite loops.
+   */
+  private toPublicData(value: any, seen: WeakSet<object> = new WeakSet()): any {
+    if (value === null || typeof value !== 'object') return value;
+    if (typeof value.toPublicJSON === 'function') return value.toPublicJSON();
+    if (Array.isArray(value)) {
+      if (seen.has(value)) return value;
+      seen.add(value);
+      return value.map((entry) => this.toPublicData(entry, seen));
+    }
+    const proto = Object.getPrototypeOf(value);
+    if (proto !== Object.prototype && proto !== null) return value;
+    if (seen.has(value)) return value;
+    seen.add(value);
+    const out: Record<string, any> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      out[key] = this.toPublicData(entry, seen);
+    }
+    return out;
+  }
+
+  /** List the runnable commands grouped by object, for help output. */
+  async listCommands(): Promise<string[]> {
+    const commands: string[] = [];
+    for (const [key, classInfo] of ObjectRegistry.getAllClasses()) {
+      const objectName = classInfo.name || key;
+      const config = ObjectRegistry.getConfig(objectName);
+      const cliConfig = config?.cli;
+      if (cliConfig === false) continue;
+
+      const lower = objectName.toLowerCase();
+      const included: string[] | undefined =
+        typeof cliConfig === 'object' ? cliConfig?.include : undefined;
+      const excluded: string[] =
+        typeof cliConfig === 'object' && cliConfig?.exclude
+          ? cliConfig.exclude
+          : [];
+
+      const expose = (cmd: string) =>
+        !excluded.includes(cmd) && (!included || included.includes(cmd));
+
+      for (const verb of CRUD_OPERATIONS) {
+        if (expose(verb)) commands.push(`${lower}:${verb}`);
+      }
+
+      const methods = await ObjectRegistry.getAllMethods(objectName);
+      for (const [methodName, methodDef] of methods) {
+        if (CRUD_OPERATIONS.includes(methodName)) continue;
+        if (!methodDef.isPublic) continue;
+        if (excluded.includes(methodName)) continue;
+        if (included !== undefined && !included.includes(methodName)) continue;
+        commands.push(`${lower}:${methodName}`);
+      }
+    }
+    return commands.sort();
+  }
+
+  private async helpText(): Promise<string> {
+    const commands = await this.listCommands();
+    return [
+      `${this.config.name} ${this.config.version}`,
+      this.config.description ?? '',
+      '',
+      'Usage: <object>:<action> [id] [--flags]',
+      '',
+      'Global flags:',
+      '  --tenant <id>     run the command inside a specific tenant',
+      '  --all-tenants     allow cross-tenant access (operator opt-in)',
+      '  --from-file <p>   read create/update payload from a JSON file',
+      '  --where <json>    filter for list',
+      '  --limit / --offset / --order-by',
+      '',
+      'Commands:',
+      ...commands.map((c) => `  ${c}`),
+    ].join('\n');
+  }
+
+  private toNumber(
+    value: string | boolean | undefined,
+    fallback: number,
+  ): number {
+    if (typeof value !== 'string') return fallback;
+    const n = Number.parseInt(value, 10);
+    return Number.isNaN(n) ? fallback : n;
+  }
+
+  private flagString(value: string | boolean | undefined): string | undefined {
+    return typeof value === 'string' ? value : undefined;
+  }
+
+  /** Coerce a flag value to a JSON scalar/object where it parses cleanly. */
+  private coerceValue(value: string | boolean): any {
+    if (typeof value !== 'string') return value;
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    if (value !== '' && !Number.isNaN(Number(value))) return Number(value);
+    if (
+      (value.startsWith('{') && value.endsWith('}')) ||
+      (value.startsWith('[') && value.endsWith(']'))
+    ) {
+      try {
+        return JSON.parse(value);
+      } catch {
+        return value;
+      }
+    }
+    return value;
+  }
+}
+
+/**
+ * Convenience runner used by the generated `setupCLI()` wrapper.
+ *
+ * @param config - CLI configuration.
+ * @param context - Per-invocation context.
+ * @returns A `{ run, generator }` pair; `run(argv)` strips the leading
+ *   `node script` entries before dispatching.
+ */
+export function setupCLI(config: CLIConfig = {}, context: CLIContext = {}) {
+  const generator = new CLIGenerator(config, context);
+  return {
+    run: async (argv: string[]) => {
+      const handler = generator.generateHandler();
+      await handler(argv.slice(2));
+    },
+    generator,
+  };
+}
+
+/**
+ * Get a bare argv handler for a generated CLI.
+ *
+ * @param config - CLI configuration.
+ * @param context - Per-invocation context.
+ * @returns An async argv-slice handler.
+ */
+export function getCLIHandler(
+  config: CLIConfig = {},
+  context: CLIContext = {},
+) {
+  const generator = new CLIGenerator(config, context);
+  return generator.generateHandler();
+}

--- a/packages/core/src/generators/index.ts
+++ b/packages/core/src/generators/index.ts
@@ -2,6 +2,9 @@
  * @smrt/core generators - Create REST APIs and MCP servers from SMRT objects
  */
 
+export type { CLIConfig, CLIContext } from './cli';
+// CLI Generator
+export { CLIGenerator, getCLIHandler, setupCLI } from './cli';
 export type {
   MCPConfig,
   MCPContext,
@@ -20,3 +23,10 @@ export {
   generateOpenAPISpec,
   setupSwaggerUI,
 } from './swagger';
+// Tenant entry-point gate (dependency-inversion hook filled by smrt-tenancy)
+export {
+  runWithTenantGate,
+  setTenantEntryPointRunner,
+  type TenantEntryPointRunner,
+  type TenantGateOptions,
+} from './tenant-gate';

--- a/packages/core/src/generators/mcp-runtime-template.ts
+++ b/packages/core/src/generators/mcp-runtime-template.ts
@@ -242,7 +242,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { ObjectRegistry } from '@happyvertical/smrt-core';
 import { config } from '@happyvertical/smrt-config';
-${hasTenantScoped ? "import { runTenantScopedEntryPoint } from '@happyvertical/smrt-tenancy';\n" : ''}
+${hasTenantScoped ? "import { enableTenancy, runTenantScopedEntryPoint } from '@happyvertical/smrt-tenancy';\n" : ''}
 // Server configuration
 const SERVER_NAME = ${JSON.stringify(name)};
 const SERVER_VERSION = ${JSON.stringify(version)};
@@ -330,7 +330,18 @@ async function main() {
     if (DEBUG) {
       console.error(\`[MCP] Starting server: \${SERVER_NAME} v\${SERVER_VERSION}\`);
     }
-
+${
+  hasTenantScoped
+    ? `
+    // Fail-closed tenant context (#1554): install the tenancy interceptor so
+    // tenant-scoped tools are actually filtered, and so the entry-point gate
+    // throws (rather than passing through) when no tenant is supplied. Without
+    // this, a tenant set via SMRT_MCP_TENANT_ID would only set async context
+    // with no interceptor to enforce it.
+    enableTenancy();
+`
+    : ''
+}
     // Load configuration from environment and .smrt.config files
     const appConfig = await config.load();
     const aiConfig = appConfig?.ai || {};

--- a/packages/core/src/generators/mcp-runtime-template.ts
+++ b/packages/core/src/generators/mcp-runtime-template.ts
@@ -44,6 +44,15 @@ export interface RuntimeOptions {
     description: string;
     inputSchema: any;
   }>;
+
+  /**
+   * Lowercased simple names of objects that are `@TenantScoped` (#1554). When
+   * non-empty, the generated server imports the tenancy fail-closed gate and
+   * wraps tenant-scoped tool calls so a stdio invocation cannot read across all
+   * tenants. The tenant is sourced from `SMRT_MCP_TENANT_ID` /
+   * `SMRT_MCP_ALLOW_CROSS_TENANT` env vars (this server has no auth principal).
+   */
+  tenantScopedObjects?: string[];
 }
 
 /**
@@ -59,10 +68,19 @@ export function generateRuntimeBootstrap(options: RuntimeOptions = {}): string {
     description = 'Auto-generated MCP server from SMRT objects',
     debug = false,
     tools = [],
+    tenantScopedObjects = [],
   } = options;
 
   // Generate static tool array as TypeScript code
   const toolsCode = tools.length > 0 ? JSON.stringify(tools, null, 2) : '[]';
+
+  // Fail-closed tenant context (#1554): only wire the tenancy gate when at
+  // least one exposed object is tenant-scoped, so apps without tenancy never
+  // get a dangling import.
+  const tenantScopedSet = Array.from(
+    new Set(tenantScopedObjects.map((n) => n.toLowerCase())),
+  );
+  const hasTenantScoped = tenantScopedSet.length > 0;
 
   // Generate static switch cases using shared helper
   const generateSwitchCases = (indent: string) => {
@@ -224,7 +242,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { ObjectRegistry } from '@happyvertical/smrt-core';
 import { config } from '@happyvertical/smrt-config';
-
+${hasTenantScoped ? "import { runTenantScopedEntryPoint } from '@happyvertical/smrt-tenancy';\n" : ''}
 // Server configuration
 const SERVER_NAME = ${JSON.stringify(name)};
 const SERVER_VERSION = ${JSON.stringify(version)};
@@ -233,6 +251,19 @@ const DEBUG = ${debug};
 
 // Static tool definitions (generated at build time)
 const TOOLS = ${toolsCode};
+${
+  hasTenantScoped
+    ? `
+// Fail-closed tenant context (#1554): tenant-scoped objects must run inside a
+// tenant. This stdio server has no auth principal, so the tenant is taken from
+// the environment; without it (and with tenancy enabled) tenant-scoped tools
+// throw rather than reading across all tenants.
+const TENANT_SCOPED = new Set(${JSON.stringify(tenantScopedSet)});
+const MCP_TENANT_ID = process.env.SMRT_MCP_TENANT_ID || undefined;
+const MCP_ALLOW_CROSS_TENANT = process.env.SMRT_MCP_ALLOW_CROSS_TENANT === 'true';
+`
+    : ''
+}
 
 /**
  * Mass-assignment guard (#1540): strip framework/server-managed and
@@ -344,14 +375,29 @@ async function main() {
 
       try {
         // Static switch statement for tool execution
-        let result;
-
-        switch (toolName) {
+        const runToolBody = async () => {
+          switch (toolName) {
 ${switchCases}
 
-          default:
-            throw new Error(\`Unknown tool: \${toolName}\`);
-        }
+            default:
+              throw new Error(\`Unknown tool: \${toolName}\`);
+          }
+        };
+${
+  hasTenantScoped
+    ? `
+        // Fail-closed tenant context for tenant-scoped tools (#1554).
+        const [toolObject] = toolName.split('_');
+        const result =
+          toolObject && TENANT_SCOPED.has(toolObject.toLowerCase())
+            ? await runTenantScopedEntryPoint(
+                { tenantScoped: true, tenantId: MCP_TENANT_ID, allowCrossTenant: MCP_ALLOW_CROSS_TENANT, surface: 'MCP' },
+                runToolBody,
+              )
+            : await runToolBody();`
+    : `
+        const result = await runToolBody();`
+}
 
         if (DEBUG) {
           console.error(\`[MCP] Tool executed successfully: \${toolName}\`);

--- a/packages/core/src/generators/mcp.ts
+++ b/packages/core/src/generators/mcp.ts
@@ -752,11 +752,14 @@ export class MCPGenerator {
    * a generated tool list, for the emitted runtime template's tenant gate
    * (#1554). Tool names are `objectname_action`.
    *
-   * Detection unions the tenancy registry (`isTenantScopedClass` — authoritative
-   * for `@TenantScoped`, matches the interceptor) with core's `isTenantScoped`
-   * (covers `@smrt({ tenantScoped })`). Tenancy is consulted via an optional
-   * dynamic import so this stays correct for apps that use either pattern, and
-   * a no-op for apps without tenancy.
+   * Detection uses ONLY tenancy's `isTenantScopedClass` (the authoritative
+   * source the interceptor uses; covers `@TenantScoped`), consulted via an
+   * optional dynamic import. We deliberately do NOT fall back to core's
+   * `ObjectRegistry.isTenantScoped`: a `@smrt({ tenantScoped })` model can exist
+   * in an app that has NOT installed `@happyvertical/smrt-tenancy`, and emitting
+   * the static `import { runTenantScopedEntryPoint } from '@happyvertical/smrt-tenancy'`
+   * gate for it would crash the generated server at import time. When tenancy is
+   * absent there is also nothing to enforce, so emitting no gate is correct.
    */
   private async tenantScopedObjectNames(tools: MCPTool[]): Promise<string[]> {
     let isTenantScopedClass: ((name: string) => boolean) | undefined;
@@ -769,6 +772,9 @@ export class MCPGenerator {
       isTenantScopedClass = undefined;
     }
 
+    // No tenancy package installed → no gate can run, emit none.
+    if (typeof isTenantScopedClass !== 'function') return [];
+
     const scoped = new Set<string>();
     for (const tool of tools) {
       const [objectName] = tool.name.split('_');
@@ -777,10 +783,7 @@ export class MCPGenerator {
       for (const [key, info] of ObjectRegistry.getAllClasses()) {
         const simpleName = info.name || key;
         if (simpleName.toLowerCase() === objectName.toLowerCase()) {
-          if (
-            ObjectRegistry.isTenantScoped(simpleName) ||
-            isTenantScopedClass?.(simpleName)
-          ) {
+          if (isTenantScopedClass(simpleName)) {
             scoped.add(simpleName.toLowerCase());
           }
           break;

--- a/packages/core/src/generators/mcp.ts
+++ b/packages/core/src/generators/mcp.ts
@@ -1140,7 +1140,10 @@ export class MCPGenerator {
 
     // Generate handlers/index.ts with tool call handlers
     const handlersPath = resolve(handlersDir, 'index.ts');
-    const handlersCode = await this.generateHandlersFile();
+    const tenantScopedObjects = await this.tenantScopedObjectNames(
+      await this.generateTools(),
+    );
+    const handlersCode = await this.generateHandlersFile(tenantScopedObjects);
     await writeFile(handlersPath, handlersCode, 'utf-8');
     console.log(`✅ Generated handlers: ${handlersPath}`);
 
@@ -1338,8 +1341,14 @@ ${indent}}`;
   /**
    * Generate handlers file for modular server
    */
-  private async generateHandlersFile(): Promise<string> {
-    const switchCases = await this.generateToolSwitchCases('      ');
+  private async generateHandlersFile(
+    tenantScopedObjects: string[] = [],
+  ): Promise<string> {
+    const switchCases = await this.generateToolSwitchCases('        ');
+    const tenantScopedSet = Array.from(
+      new Set(tenantScopedObjects.map((n) => n.toLowerCase())),
+    );
+    const hasTenantScoped = tenantScopedSet.length > 0;
 
     return `/**
  * MCP Tool Call Handlers
@@ -1350,9 +1359,25 @@ ${indent}}`;
  * per-call authentication principal — the generated stdio MCP server's trust
  * boundary is the host process / MCP client. Run it only in a trusted context
  * or behind an authenticated gateway.
+ *
+ * SECURITY (#1554): tenant-scoped tools run inside a fail-closed tenant gate;
+ * the tenant is taken from SMRT_MCP_TENANT_ID (this server has no auth
+ * principal) and tenancy is enabled so the interceptor enforces filtering.
  */
 
 import { ObjectRegistry } from '@happyvertical/smrt-core';
+${hasTenantScoped ? "import { enableTenancy, runTenantScopedEntryPoint } from '@happyvertical/smrt-tenancy';\n" : ''}${
+  hasTenantScoped
+    ? `
+// Install the tenancy interceptor so tenant-scoped tools are filtered and the
+// gate fail-closes when no tenant is supplied (#1554).
+enableTenancy();
+const TENANT_SCOPED = new Set(${JSON.stringify(tenantScopedSet)});
+const MCP_TENANT_ID = process.env.SMRT_MCP_TENANT_ID || undefined;
+const MCP_ALLOW_CROSS_TENANT = process.env.SMRT_MCP_ALLOW_CROSS_TENANT === 'true';
+`
+    : ''
+}
 
 /**
  * Mass-assignment guard (#1540): strip framework/server-managed and
@@ -1420,15 +1445,31 @@ export async function handleToolCall(
   aiConfig: any = {}
 ) {
   try {
-    let result;
     const args = arguments;
 
-    switch (name) {
+    const runToolBody = async () => {
+      switch (name) {
 ${switchCases}
 
-      default:
-        throw new Error(\`Unknown tool: \${name}\`);
-    }
+        default:
+          throw new Error(\`Unknown tool: \${name}\`);
+      }
+    };
+${
+  hasTenantScoped
+    ? `
+    // Fail-closed tenant context for tenant-scoped tools (#1554).
+    const [toolObject] = name.split('_');
+    const result =
+      toolObject && TENANT_SCOPED.has(toolObject.toLowerCase())
+        ? await runTenantScopedEntryPoint(
+            { tenantScoped: true, tenantId: MCP_TENANT_ID, allowCrossTenant: MCP_ALLOW_CROSS_TENANT, surface: 'MCP' },
+            runToolBody,
+          )
+        : await runToolBody();`
+    : `
+    const result = await runToolBody();`
+}
 
     return result;
   } catch (error) {

--- a/packages/core/src/generators/mcp.ts
+++ b/packages/core/src/generators/mcp.ts
@@ -16,6 +16,7 @@ import {
   generateRuntimeBootstrap,
   type RuntimeOptions,
 } from './mcp-runtime-template.js';
+import { runWithTenantGate } from './tenant-gate.js';
 
 export interface MCPConfig {
   name?: string;
@@ -34,6 +35,19 @@ export interface MCPContext {
     id: string;
     roles?: string[];
   };
+  /**
+   * Tenant the calling principal is scoped to (#1554). When set, tenant-scoped
+   * tools run inside this tenant's context. Hosts that authenticate a principal
+   * (e.g. `@happyvertical/smrt-app-mcp`) should derive it from the principal —
+   * the MCP analogue of the SvelteKit auth hook setting `locals.tenantId`.
+   */
+  tenantId?: string;
+  /**
+   * Explicit operator opt-in to cross-tenant access for tenant-scoped tools
+   * (#1554). Only set for trusted operator/admin callers. Without a `tenantId`
+   * or this flag, tenant-scoped tool calls fail closed when tenancy is enabled.
+   */
+  allowCrossTenant?: boolean;
 }
 
 export interface MCPTool {
@@ -717,6 +731,75 @@ export class MCPGenerator {
     const mutating = action !== 'list' && action !== 'get';
     this.requireToolAuth(objectName, mutating);
 
+    // Fail-closed tenant context (#1554). For tenant-scoped objects, establish
+    // the context from the principal's tenant (or an explicit cross-tenant
+    // opt-in); without either, this throws when tenancy is enabled rather than
+    // letting an optional-scoped read range across all tenants. Tenant-scoping
+    // is resolved inside tenancy by class name so it matches the interceptor.
+    return runWithTenantGate(
+      {
+        className: objectName,
+        tenantId: this.context.tenantId,
+        allowCrossTenant: this.context.allowCrossTenant,
+        surface: 'MCP',
+      },
+      () => this.runAction(collection, action, args, objectName),
+    );
+  }
+
+  /**
+   * Derive the set of tenant-scoped object names (lowercased simple names) from
+   * a generated tool list, for the emitted runtime template's tenant gate
+   * (#1554). Tool names are `objectname_action`.
+   *
+   * Detection unions the tenancy registry (`isTenantScopedClass` — authoritative
+   * for `@TenantScoped`, matches the interceptor) with core's `isTenantScoped`
+   * (covers `@smrt({ tenantScoped })`). Tenancy is consulted via an optional
+   * dynamic import so this stays correct for apps that use either pattern, and
+   * a no-op for apps without tenancy.
+   */
+  private async tenantScopedObjectNames(tools: MCPTool[]): Promise<string[]> {
+    let isTenantScopedClass: ((name: string) => boolean) | undefined;
+    try {
+      const tenancy = (await import(
+        /* @vite-ignore */ '@happyvertical/smrt-tenancy'
+      )) as { isTenantScopedClass?: (name: string) => boolean };
+      isTenantScopedClass = tenancy.isTenantScopedClass;
+    } catch {
+      isTenantScopedClass = undefined;
+    }
+
+    const scoped = new Set<string>();
+    for (const tool of tools) {
+      const [objectName] = tool.name.split('_');
+      if (!objectName) continue;
+      // Resolve the registered simple name (case-insensitive) and test scoping.
+      for (const [key, info] of ObjectRegistry.getAllClasses()) {
+        const simpleName = info.name || key;
+        if (simpleName.toLowerCase() === objectName.toLowerCase()) {
+          if (
+            ObjectRegistry.isTenantScoped(simpleName) ||
+            isTenantScopedClass?.(simpleName)
+          ) {
+            scoped.add(simpleName.toLowerCase());
+          }
+          break;
+        }
+      }
+    }
+    return Array.from(scoped);
+  }
+
+  /**
+   * Execute a resolved MCP action (CRUD or custom) against a collection. Always
+   * invoked inside the tenant gate established by {@link executeAction}.
+   */
+  private async runAction(
+    collection: SmrtCollection<any>,
+    action: string,
+    args: any,
+    objectName?: string,
+  ): Promise<any> {
     switch (action) {
       case 'list': {
         const listOptions: any = {
@@ -979,6 +1062,7 @@ export class MCPGenerator {
         context: this.context,
         debug,
         tools,
+        tenantScopedObjects: await this.tenantScopedObjectNames(tools),
       };
 
       const serverCode = generateRuntimeBootstrap(runtimeOptions);

--- a/packages/core/src/generators/mcp.ts
+++ b/packages/core/src/generators/mcp.ts
@@ -764,9 +764,14 @@ export class MCPGenerator {
   private async tenantScopedObjectNames(tools: MCPTool[]): Promise<string[]> {
     let isTenantScopedClass: ((name: string) => boolean) | undefined;
     try {
-      const tenancy = (await import(
-        /* @vite-ignore */ '@happyvertical/smrt-tenancy'
-      )) as { isTenantScopedClass?: (name: string) => boolean };
+      // Held in a variable so neither TypeScript's declaration emit (TS2307 —
+      // core deliberately does not depend on tenancy) nor the bundler tries to
+      // statically resolve this optional sibling package. Same pattern as
+      // `tenant-gate.ts` / `embeddings/provider.ts`.
+      const tenancySpecifier = '@happyvertical/smrt-tenancy';
+      const tenancy = (await import(/* @vite-ignore */ tenancySpecifier)) as {
+        isTenantScopedClass?: (name: string) => boolean;
+      };
       isTenantScopedClass = tenancy.isTenantScopedClass;
     } catch {
       isTenantScopedClass = undefined;

--- a/packages/core/src/generators/tenant-gate.ts
+++ b/packages/core/src/generators/tenant-gate.ts
@@ -1,0 +1,96 @@
+/**
+ * Tenant entry-point gate — dependency-inversion hook for generated CLI/MCP
+ * execution (#1554).
+ *
+ * `@happyvertical/smrt-core` cannot depend on `@happyvertical/smrt-tenancy`
+ * (tenancy depends on core, not the other way around). The generated SvelteKit
+ * routes establish tenant context from the request principal, but the in-process
+ * CLI/MCP generators have no principal — without a gate a tenant-scoped read
+ * with no active context would fall through the interceptor's optional-mode
+ * pass-through and return rows across **all** tenants.
+ *
+ * Core exposes an injectable runner slot that tenancy fills at `enableTenancy()`
+ * time (the same inversion pattern as the DispatchBus tenant resolver and
+ * `GlobalInterceptors`). When tenancy is not enabled (non-tenant deployments,
+ * existing tests), the slot is empty and {@link runWithTenantGate} simply runs
+ * the body — identical to pre-#1554 behavior.
+ *
+ * Stored on `globalThis` so all module instances share one runner, which
+ * matters in the monorepo where the same package can be loaded from multiple
+ * paths.
+ */
+
+/** Options forwarded to the registered tenancy runner. */
+export interface TenantGateOptions {
+  /**
+   * Class name of the target model. Tenant-scoping is resolved authoritatively
+   * inside tenancy (`isTenantScopedClass`) — the same source the interceptor
+   * uses, so it covers both `@TenantScoped` and `@smrt({ tenantScoped })`.
+   */
+  className?: string;
+  /** Explicit tenant-scoping decision; overrides `className` resolution. */
+  tenantScoped?: boolean;
+  /** Explicit operator-provided tenant selector (`--tenant` / `context.tenantId`). */
+  tenantId?: string | null;
+  /** Explicit operator opt-in to cross-tenant/system access (`--all-tenants`). */
+  allowCrossTenant?: boolean;
+  /** Surface name for the fail-closed error message, e.g. `'CLI'` / `'MCP'`. */
+  surface?: string;
+}
+
+/**
+ * Runner that establishes (or fail-closes) tenant context around `fn` for a
+ * tenant-scoped model. Registered by tenancy; see
+ * `runTenantScopedEntryPoint` in `@happyvertical/smrt-tenancy`.
+ */
+export type TenantEntryPointRunner = <T>(
+  options: TenantGateOptions,
+  fn: () => Promise<T>,
+) => Promise<T>;
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __smrtTenantEntryPointRunner: TenantEntryPointRunner | undefined;
+}
+
+/**
+ * Register the tenant entry-point runner used by generated CLI/MCP execution.
+ *
+ * Called by `@happyvertical/smrt-tenancy`'s `enableTenancy()`; application code
+ * never calls this directly. Passing `undefined` clears the runner (restoring
+ * the no-op default), which `disableTenancy()` does.
+ *
+ * @param runner - The tenancy runner, or `undefined` to clear it.
+ */
+export function setTenantEntryPointRunner(
+  runner: TenantEntryPointRunner | undefined,
+): void {
+  globalThis.__smrtTenantEntryPointRunner = runner;
+}
+
+/**
+ * Run `fn` through the registered tenant entry-point runner (when tenancy is
+ * enabled), or directly when no runner is registered.
+ *
+ * For tenant-scoped models the runner establishes tenant context from
+ * `options.tenantId` / `options.allowCrossTenant`, or fails closed (throws) when
+ * neither is available — never silently reading across tenants. Non-scoped
+ * models and tenancy-off deployments pass straight through.
+ *
+ * @param options - {@link TenantGateOptions}.
+ * @param fn - The command/tool body to execute.
+ * @returns The resolved value of `fn`.
+ * @throws Propagates the tenancy runner's `TenantContextError` on the
+ *   fail-closed branch.
+ */
+export async function runWithTenantGate<T>(
+  options: TenantGateOptions,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const runner = globalThis.__smrtTenantEntryPointRunner;
+  if (!runner) {
+    // Tenancy not enabled → single-/no-tenant deployment, pass through.
+    return fn();
+  }
+  return runner(options, fn);
+}

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -1863,8 +1863,12 @@ async function generateCLIModule(
         return true;
       };
 
-      // Get collection name
+      // Collection name (metadata) and the command segment. Commands are keyed
+      // by the simple class name (e.g. `document:list`) to match what
+      // `CLIGenerator` resolves and the dev `smrt` CLI convention — NOT the
+      // plural collection name, which the runtime resolver does not accept.
       const collectionName = objectDef.collection;
+      const commandName = (objectDef.className || className).toLowerCase();
 
       // Generate import statement for the object class
       objectImports.push(
@@ -1876,15 +1880,14 @@ async function generateCLIModule(
 
       // Standard CRUD commands
       if (shouldInclude('list'))
-        availableCommands.push(`'${collectionName}:list'`);
-      if (shouldInclude('get'))
-        availableCommands.push(`'${collectionName}:get'`);
+        availableCommands.push(`'${commandName}:list'`);
+      if (shouldInclude('get')) availableCommands.push(`'${commandName}:get'`);
       if (shouldInclude('create'))
-        availableCommands.push(`'${collectionName}:create'`);
+        availableCommands.push(`'${commandName}:create'`);
       if (shouldInclude('update'))
-        availableCommands.push(`'${collectionName}:update'`);
+        availableCommands.push(`'${commandName}:update'`);
       if (shouldInclude('delete'))
-        availableCommands.push(`'${collectionName}:delete'`);
+        availableCommands.push(`'${commandName}:delete'`);
 
       // Custom action methods
       for (const [methodName, _method] of Object.entries(objectDef.methods)) {
@@ -1898,7 +1901,7 @@ async function generateCLIModule(
           continue;
 
         if (shouldInclude(methodName)) {
-          availableCommands.push(`'${collectionName}:${methodName}'`);
+          availableCommands.push(`'${commandName}:${methodName}'`);
         }
       }
 

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -1919,8 +1919,8 @@ async function generateCLIModule(
 import { CLIGenerator } from '@happyvertical/smrt-core/generators/cli';
 
 /**
- * @typedef {import('@smrt/core/generators/cli').CLIConfig} CLIConfig
- * @typedef {import('@smrt/core/generators/cli').CLIContext} CLIContext
+ * @typedef {import('@happyvertical/smrt-core/generators/cli').CLIConfig} CLIConfig
+ * @typedef {import('@happyvertical/smrt-core/generators/cli').CLIContext} CLIContext
  */
 
 ${objectImports.join('\n')}

--- a/packages/tenancy/src/__tests__/adapters.test.ts
+++ b/packages/tenancy/src/__tests__/adapters.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for the framework adapters (`src/adapters/*`): the CLI context runner,
+ * the Express middleware, and the SvelteKit handle. These establish tenant
+ * context from a request/invocation principal.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { createCliContext, runAsSystem, runWithTenant } from '../adapters/cli';
+import { createExpressMiddleware } from '../adapters/express';
+// Import the barrel too so its re-exports are covered.
+import * as adapters from '../adapters/index';
+import { createSvelteKitHandle } from '../adapters/sveltekit';
+import {
+  getTenantId,
+  isSuperAdminBypass,
+  isSystemContext,
+  withSystemContext,
+} from '../context';
+
+describe('adapters barrel', () => {
+  it('re-exports the adapter factories', () => {
+    expect(typeof adapters.createCliContext).toBe('function');
+    expect(typeof adapters.createExpressMiddleware).toBe('function');
+    expect(typeof adapters.createSvelteKitHandle).toBe('function');
+  });
+});
+
+describe('createCliContext', () => {
+  it('run() uses the resolved tenant', async () => {
+    const cli = createCliContext({ resolveTenantId: () => 'tenant-x' });
+    let observed: string | undefined;
+    await cli.run(async () => {
+      observed = getTenantId();
+    });
+    expect(observed).toBe('tenant-x');
+  });
+
+  it('run() falls back to system context when no tenant resolves', async () => {
+    const cli = createCliContext({ resolveTenantId: () => null });
+    let system = false;
+    await cli.run(async () => {
+      system = isSystemContext();
+    });
+    expect(system).toBe(true);
+  });
+
+  it('run() with no resolver at all falls back to system context', async () => {
+    const cli = createCliContext();
+    let system = false;
+    await cli.run(async () => {
+      system = isSystemContext();
+    });
+    expect(system).toBe(true);
+  });
+
+  it('runWithTenant() enters the given tenant and resolves the user id', async () => {
+    const cli = createCliContext({ resolveUserId: async () => 'user-1' });
+    let observed: string | undefined;
+    const result = await cli.runWithTenant('tenant-y', async () => {
+      observed = getTenantId();
+      return 'done';
+    });
+    expect(observed).toBe('tenant-y');
+    expect(result).toBe('done');
+  });
+
+  it('runAsSystem() runs without a tenant', async () => {
+    const cli = createCliContext({ resolveTenantId: () => 'ignored' });
+    let system = false;
+    await cli.runAsSystem(async () => {
+      system = isSystemContext();
+    });
+    expect(system).toBe(true);
+  });
+
+  it('runAsSuperAdmin() enters a tenant with the bypass flag', async () => {
+    const cli = createCliContext({ superAdminByDefault: false });
+    let bypass = false;
+    let observed: string | undefined;
+    await cli.runAsSuperAdmin('tenant-z', async () => {
+      bypass = isSuperAdminBypass();
+      observed = getTenantId();
+    });
+    expect(bypass).toBe(true);
+    expect(observed).toBe('tenant-z');
+  });
+
+  it('standalone runWithTenant() / runAsSystem() helpers work', async () => {
+    let observed: string | undefined;
+    await runWithTenant('tenant-q', async () => {
+      observed = getTenantId();
+    });
+    expect(observed).toBe('tenant-q');
+
+    let system = false;
+    await runAsSystem(async () => {
+      system = isSystemContext();
+    });
+    expect(system).toBe(true);
+  });
+});
+
+function makeExpressDoubles() {
+  const res = {
+    statusCode: 0,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+  const calls: { next: unknown[] } = { next: [] };
+  const next = (err?: unknown) => {
+    calls.next.push(err);
+  };
+  return { res, next, calls };
+}
+
+describe('createExpressMiddleware', () => {
+  it('skips excluded paths without resolving a tenant', async () => {
+    const mw = createExpressMiddleware({
+      resolveTenantId: () => {
+        throw new Error('should not be called');
+      },
+      excludePaths: ['/health'],
+    });
+    const { res, next, calls } = makeExpressDoubles();
+    await mw({ path: '/health' } as any, res as any, next as any);
+    expect(calls.next).toHaveLength(1);
+    expect(calls.next[0]).toBeUndefined();
+  });
+
+  it('responds 400 when no tenant is resolved and there is no onNoTenant hook', async () => {
+    const mw = createExpressMiddleware({ resolveTenantId: () => null });
+    const { res, next, calls } = makeExpressDoubles();
+    await mw({ path: '/api' } as any, res as any, next as any);
+    expect(res.statusCode).toBe(400);
+    expect(calls.next).toHaveLength(0);
+  });
+
+  it('continues when onNoTenant returns true', async () => {
+    const mw = createExpressMiddleware({
+      resolveTenantId: () => null,
+      onNoTenant: async () => true,
+    });
+    const { res, next, calls } = makeExpressDoubles();
+    await mw({ path: '/api' } as any, res as any, next as any);
+    expect(calls.next).toHaveLength(1);
+  });
+
+  it('establishes context on the request when a tenant resolves', async () => {
+    const mw = createExpressMiddleware({
+      resolveTenantId: () => 'tenant-a',
+      resolveUserId: () => 'user-a',
+      resolvePermissions: () => new Set(['read']),
+      isSuperAdmin: () => true,
+    });
+    const { res, next, calls } = makeExpressDoubles();
+    const req: any = { path: '/api' };
+    // Run inside a scope so the middleware's enterWith() context is restored on
+    // exit and does not leak into other tests.
+    await withSystemContext(async () => {
+      await mw(req, res as any, next as any);
+    });
+    expect(calls.next).toHaveLength(1);
+    expect(req.tenantId).toBe('tenant-a');
+    expect(req.tenantContext.tenantId).toBe('tenant-a');
+    expect(req.tenantContext.superAdminBypass).toBe(true);
+  });
+
+  it('forwards resolver errors to next(err)', async () => {
+    const boom = new Error('resolve failed');
+    const mw = createExpressMiddleware({
+      resolveTenantId: () => {
+        throw boom;
+      },
+    });
+    const { res, next, calls } = makeExpressDoubles();
+    await mw({ path: '/api' } as any, res as any, next as any);
+    expect(calls.next).toEqual([boom]);
+  });
+});
+
+describe('createSvelteKitHandle', () => {
+  const event = (pathname: string) => ({
+    url: { pathname },
+    locals: {} as Record<string, unknown>,
+  });
+
+  it('skips excluded paths', async () => {
+    const handle = createSvelteKitHandle({
+      resolveTenantId: () => {
+        throw new Error('should not be called');
+      },
+      excludePaths: ['/public/*'],
+    });
+    const resolve = async () => 'resolved' as unknown as Response;
+    const out = await handle({
+      event: event('/public/page') as any,
+      resolve: resolve as any,
+    });
+    expect(out).toBe('resolved');
+  });
+
+  it('resolves without context when no tenant and onNoTenant returns nothing', async () => {
+    const handle = createSvelteKitHandle({
+      resolveTenantId: () => null,
+      onNoTenant: async () => undefined,
+    });
+    let resolvedTid: string | undefined = 'unset';
+    const resolve = async () => {
+      resolvedTid = getTenantId();
+      return 'r' as unknown as Response;
+    };
+    await handle({ event: event('/x') as any, resolve: resolve as any });
+    expect(resolvedTid).toBeUndefined();
+  });
+
+  it('returns the onNoTenant response when provided', async () => {
+    const sentinel = 'short-circuit' as unknown as Response;
+    const handle = createSvelteKitHandle({
+      resolveTenantId: () => null,
+      onNoTenant: async () => sentinel,
+    });
+    const out = await handle({
+      event: event('/x') as any,
+      resolve: (async () => 'nope' as unknown as Response) as any,
+    });
+    expect(out).toBe(sentinel);
+  });
+
+  it('runs resolve() inside the tenant context and stores it on locals', async () => {
+    const handle = createSvelteKitHandle({
+      resolveTenantId: () => 'tenant-b',
+      resolveUserId: () => 'user-b',
+      resolvePermissions: () => new Set(['write']),
+    });
+    const ev = event('/dash');
+    let observed: string | undefined;
+    const resolve = async () => {
+      observed = getTenantId();
+      return 'ok' as unknown as Response;
+    };
+    await handle({ event: ev as any, resolve: resolve as any });
+    expect(observed).toBe('tenant-b');
+    expect((ev.locals as any).tenantId).toBe('tenant-b');
+  });
+
+  afterEach(() => {
+    // No global state to reset here, but keep the hook for symmetry/safety.
+  });
+});

--- a/packages/tenancy/src/__tests__/cli-mcp-tenant-context.spec.ts
+++ b/packages/tenancy/src/__tests__/cli-mcp-tenant-context.spec.ts
@@ -157,4 +157,46 @@ describe('Generated CLI/MCP fail-closed tenant context (#1554)', () => {
       expect(text).toContain('B-One');
     });
   });
+
+  // The emitted stdio MCP servers are separate processes that don't run the
+  // host's bootstrap, so they must self-enable tenancy AND wrap tenant-scoped
+  // tools in the gate — otherwise the gate is a no-op and the interceptor never
+  // filters (codex P1 on #1557).
+  describe('emitted MCP server hardening', () => {
+    async function generateInto(modular: boolean): Promise<string> {
+      const { mkdtemp } = await import('node:fs/promises');
+      const { tmpdir } = await import('node:os');
+      const { join } = await import('node:path');
+      const dir = await mkdtemp(join(tmpdir(), 'mcp-emit-'));
+      const gen = new MCPGenerator(
+        { name: 'emit-test', version: '1.0.0' },
+        { db },
+      );
+      await gen.generateServer({ outputPath: join(dir, 'index.js'), modular });
+      return dir;
+    }
+
+    it('single-file server enables tenancy and gates tenant-scoped tools', async () => {
+      const { readFile } = await import('node:fs/promises');
+      const { join } = await import('node:path');
+      const dir = await generateInto(false);
+      const code = await readFile(join(dir, 'index.js'), 'utf-8');
+      expect(code).toContain('enableTenancy()');
+      expect(code).toContain('runTenantScopedEntryPoint');
+      expect(code).toContain('tenantdoc');
+    });
+
+    it('modular server enables tenancy and gates tenant-scoped tools', async () => {
+      const { readFile } = await import('node:fs/promises');
+      const { join } = await import('node:path');
+      const dir = await generateInto(true);
+      const handlers = await readFile(
+        join(dir, 'handlers', 'index.ts'),
+        'utf-8',
+      );
+      expect(handlers).toContain('enableTenancy()');
+      expect(handlers).toContain('runTenantScopedEntryPoint');
+      expect(handlers).toContain('tenantdoc');
+    });
+  });
 });

--- a/packages/tenancy/src/__tests__/cli-mcp-tenant-context.spec.ts
+++ b/packages/tenancy/src/__tests__/cli-mcp-tenant-context.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * End-to-end fail-closed tenant-context tests for the generated CLI/MCP surfaces
+ * (#1554).
+ *
+ * The generated SvelteKit routes establish tenant context from the request
+ * principal (#1540), but the in-process CLI/MCP generators have none. Without a
+ * gate, an `@TenantScoped({ mode: 'optional' })` model queried via CLI/MCP with
+ * no active context returns rows across ALL tenants (the interceptor only
+ * hard-fails `required` mode). These tests verify the gate, which lives in core
+ * but is filled by tenancy's `enableTenancy()`, so they run here (core cannot
+ * depend on tenancy).
+ *
+ * Uses a real in-memory SQLite database — no DB mocking.
+ */
+
+import {
+  field,
+  ObjectRegistry,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { CLIGenerator } from '@happyvertical/smrt-core/generators/cli';
+import { MCPGenerator } from '@happyvertical/smrt-core/generators/mcp';
+import { getTestDatabase } from '@happyvertical/smrt-core/testing';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { withTenant } from '../context.js';
+import { TenantScoped, tenantId } from '../decorators.js';
+import { disableTenancy, enableTenancy } from '../interceptor.js';
+
+@smrt()
+@TenantScoped({ mode: 'optional' })
+class TenantDoc extends SmrtObject {
+  @field({ type: 'text' })
+  name = '';
+
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+  }
+}
+
+class TenantDocCollection extends SmrtCollection<TenantDoc> {
+  static readonly _itemClass = TenantDoc;
+}
+
+/** Capture console.log output produced while running `fn`. */
+async function captureLog(fn: () => Promise<void>): Promise<string> {
+  const logs: string[] = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => {
+    logs.push(args.map(String).join(' '));
+  };
+  try {
+    await fn();
+  } finally {
+    console.log = original;
+  }
+  return logs.join('\n');
+}
+
+describe('Generated CLI/MCP fail-closed tenant context (#1554)', () => {
+  let db: any;
+
+  beforeAll(async () => {
+    ObjectRegistry.registerCollection('TenantDoc', TenantDocCollection);
+    db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['TenantDoc'],
+    });
+
+    enableTenancy();
+
+    // Seed two tenants. The interceptor stamps tenantId from the active context.
+    await withTenant({ tenantId: 'tenant-a' }, async () => {
+      const c = await TenantDocCollection.create({ db });
+      const a1 = await c.create({ name: 'A-One' });
+      await a1.save();
+      const a2 = await c.create({ name: 'A-Two' });
+      await a2.save();
+    });
+    await withTenant({ tenantId: 'tenant-b' }, async () => {
+      const c = await TenantDocCollection.create({ db });
+      const b1 = await c.create({ name: 'B-One' });
+      await b1.save();
+    });
+  });
+
+  afterAll(async () => {
+    disableTenancy();
+    await db?.close?.();
+  });
+
+  describe('CLI', () => {
+    it('fails closed: list with no --tenant throws rather than ranging across tenants', async () => {
+      const gen = new CLIGenerator({}, { db });
+      await expect(gen.run(['tenantdoc:list'])).rejects.toThrow(
+        /tenant context required/i,
+      );
+    });
+
+    it('--tenant scopes the list to that tenant only', async () => {
+      const gen = new CLIGenerator({}, { db });
+      const out = await captureLog(() =>
+        gen.run(['tenantdoc:list', '--tenant', 'tenant-a']),
+      );
+      expect(out).toContain('A-One');
+      expect(out).toContain('A-Two');
+      expect(out).not.toContain('B-One');
+    });
+
+    it('--all-tenants opts into cross-tenant access', async () => {
+      const gen = new CLIGenerator({}, { db });
+      const out = await captureLog(() =>
+        gen.run(['tenantdoc:list', '--all-tenants']),
+      );
+      expect(out).toContain('A-One');
+      expect(out).toContain('B-One');
+    });
+  });
+
+  describe('MCP', () => {
+    async function listViaMcp(context: Record<string, unknown>) {
+      const gen = new MCPGenerator({}, { db, user: { id: 'op' }, ...context });
+      return gen.handleToolCall({
+        method: 'tools/call',
+        params: { name: 'tenantdoc_list', arguments: {} },
+      });
+    }
+
+    it('fails closed: list with no tenant context returns an error', async () => {
+      const res = await listViaMcp({});
+      const text = res.content.map((c) => c.text).join('\n');
+      expect(text).toMatch(/tenant context required/i);
+      expect(text).not.toContain('A-One');
+      expect(text).not.toContain('B-One');
+    });
+
+    it('context.tenantId scopes the list to that tenant only', async () => {
+      const res = await listViaMcp({ tenantId: 'tenant-a' });
+      const text = res.content.map((c) => c.text).join('\n');
+      expect(text).toContain('A-One');
+      expect(text).toContain('A-Two');
+      expect(text).not.toContain('B-One');
+    });
+
+    it('context.allowCrossTenant opts into cross-tenant access', async () => {
+      const res = await listViaMcp({ allowCrossTenant: true });
+      const text = res.content.map((c) => c.text).join('\n');
+      expect(text).toContain('A-One');
+      expect(text).toContain('B-One');
+    });
+  });
+});

--- a/packages/tenancy/src/__tests__/entry-point.test.ts
+++ b/packages/tenancy/src/__tests__/entry-point.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for the fail-closed entry-point gate used by generated CLI/MCP surfaces.
+ *
+ * @see https://github.com/happyvertical/smrt/issues/1554
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  getTenantId,
+  isSuperAdminBypass,
+  isSystemContext,
+  TenantContextError,
+  withTenant,
+} from '../context';
+import { runTenantScopedEntryPoint } from '../entry-point';
+import { disableTenancy, enableTenancy } from '../interceptor';
+import {
+  registerTenantScopedClass,
+  unregisterTenantScopedClass,
+} from '../registry';
+
+describe('runTenantScopedEntryPoint (#1554)', () => {
+  afterEach(() => {
+    disableTenancy();
+  });
+
+  describe('non-tenant-scoped models', () => {
+    it('passes through unchanged, never establishing context', async () => {
+      enableTenancy();
+      let observed: string | undefined = 'unset';
+      const result = await runTenantScopedEntryPoint(
+        { tenantScoped: false, surface: 'CLI' },
+        async () => {
+          observed = getTenantId();
+          return 'ok';
+        },
+      );
+      expect(result).toBe('ok');
+      expect(observed).toBeUndefined();
+    });
+  });
+
+  describe('tenancy enabled', () => {
+    beforeEach(() => {
+      enableTenancy();
+    });
+
+    it('fails closed when a tenant-scoped model has no selector and no context', async () => {
+      await expect(
+        runTenantScopedEntryPoint({ tenantScoped: true, surface: 'CLI' }, () =>
+          Promise.resolve('leaked'),
+        ),
+      ).rejects.toBeInstanceOf(TenantContextError);
+    });
+
+    it('runs inside the explicit tenant when tenantId is provided', async () => {
+      let observed: string | undefined;
+      await runTenantScopedEntryPoint(
+        { tenantScoped: true, tenantId: 'tenant-a', surface: 'MCP' },
+        async () => {
+          observed = getTenantId();
+        },
+      );
+      expect(observed).toBe('tenant-a');
+    });
+
+    it('runs in system context when allowCrossTenant is set', async () => {
+      let system = false;
+      let bypass = false;
+      await runTenantScopedEntryPoint(
+        { tenantScoped: true, allowCrossTenant: true, surface: 'CLI' },
+        async () => {
+          system = isSystemContext();
+          bypass = isSuperAdminBypass();
+        },
+      );
+      expect(system).toBe(true);
+      // system context removes tenant context entirely (not a super-admin bypass)
+      expect(bypass).toBe(false);
+    });
+
+    it('reuses an already-active context instead of failing', async () => {
+      let observed: string | undefined;
+      await withTenant({ tenantId: 'outer' }, async () => {
+        await runTenantScopedEntryPoint(
+          { tenantScoped: true, surface: 'CLI' },
+          async () => {
+            observed = getTenantId();
+          },
+        );
+      });
+      expect(observed).toBe('outer');
+    });
+
+    it('prefers an active context over an explicit tenantId selector', async () => {
+      let observed: string | undefined;
+      await withTenant({ tenantId: 'outer' }, async () => {
+        await runTenantScopedEntryPoint(
+          { tenantScoped: true, tenantId: 'ignored', surface: 'CLI' },
+          async () => {
+            observed = getTenantId();
+          },
+        );
+      });
+      expect(observed).toBe('outer');
+    });
+  });
+
+  describe('className-based scoping resolution', () => {
+    afterEach(() => {
+      unregisterTenantScopedClass('EntryPointScopedDoc');
+    });
+
+    it('fails closed for a class registered as tenant-scoped (no boolean given)', async () => {
+      enableTenancy();
+      registerTenantScopedClass('EntryPointScopedDoc', { mode: 'optional' });
+      await expect(
+        runTenantScopedEntryPoint(
+          { className: 'EntryPointScopedDoc', surface: 'CLI' },
+          () => Promise.resolve('leaked'),
+        ),
+      ).rejects.toBeInstanceOf(TenantContextError);
+    });
+
+    it('passes through a class that is not tenant-scoped', async () => {
+      enableTenancy();
+      const result = await runTenantScopedEntryPoint(
+        { className: 'EntryPointUnscopedDoc', surface: 'CLI' },
+        () => Promise.resolve('ok'),
+      );
+      expect(result).toBe('ok');
+    });
+
+    it('explicit tenantScoped boolean overrides className resolution', async () => {
+      enableTenancy();
+      registerTenantScopedClass('EntryPointScopedDoc', { mode: 'optional' });
+      // className resolves scoped, but the explicit false wins → pass through.
+      const result = await runTenantScopedEntryPoint(
+        {
+          className: 'EntryPointScopedDoc',
+          tenantScoped: false,
+          surface: 'CLI',
+        },
+        () => Promise.resolve('ok'),
+      );
+      expect(result).toBe('ok');
+    });
+  });
+
+  describe('tenancy disabled (single-tenant deployment)', () => {
+    it('passes a tenant-scoped model through without throwing', async () => {
+      disableTenancy();
+      let observed: string | undefined = 'unset';
+      const result = await runTenantScopedEntryPoint(
+        { tenantScoped: true, surface: 'CLI' },
+        async () => {
+          observed = getTenantId();
+          return 'single-tenant-ok';
+        },
+      );
+      expect(result).toBe('single-tenant-ok');
+      expect(observed).toBeUndefined();
+    });
+  });
+});

--- a/packages/tenancy/src/__tests__/entry-point.test.ts
+++ b/packages/tenancy/src/__tests__/entry-point.test.ts
@@ -11,6 +11,7 @@ import {
   isSuperAdminBypass,
   isSystemContext,
   TenantContextError,
+  withSystemContext,
   withTenant,
 } from '../context';
 import { runTenantScopedEntryPoint } from '../entry-point';
@@ -100,6 +101,22 @@ describe('runTenantScopedEntryPoint (#1554)', () => {
       );
       expect(system).toBe(true);
       expect(observed).toBeUndefined();
+    });
+
+    it('honors an active system-context bypass instead of failing closed', async () => {
+      // runAsSystem() / migration scripts enter withSystemContext(); the gate
+      // must pass through (the interceptor honors the system marker) rather than
+      // throwing for lack of a tenant selector (codex P2).
+      let ran = false;
+      await withSystemContext(async () => {
+        await runTenantScopedEntryPoint(
+          { tenantScoped: true, surface: 'CLI' },
+          async () => {
+            ran = true;
+          },
+        );
+      });
+      expect(ran).toBe(true);
     });
 
     it('reuses an already-active context instead of failing', async () => {

--- a/packages/tenancy/src/__tests__/entry-point.test.ts
+++ b/packages/tenancy/src/__tests__/entry-point.test.ts
@@ -80,6 +80,28 @@ describe('runTenantScopedEntryPoint (#1554)', () => {
       expect(bypass).toBe(false);
     });
 
+    it('cross-tenant opt-in wins over an explicit tenantId (e.g. a default host tenant)', async () => {
+      // A host may set a default principal tenant while the operator passes
+      // --all-tenants; the explicit cross-tenant opt-in must not be silently
+      // scoped to the default tenant (codex P2).
+      let system = false;
+      let observed: string | undefined = 'unset';
+      await runTenantScopedEntryPoint(
+        {
+          tenantScoped: true,
+          tenantId: 'default-tenant',
+          allowCrossTenant: true,
+          surface: 'CLI',
+        },
+        async () => {
+          system = isSystemContext();
+          observed = getTenantId();
+        },
+      );
+      expect(system).toBe(true);
+      expect(observed).toBeUndefined();
+    });
+
     it('reuses an already-active context instead of failing', async () => {
       let observed: string | undefined;
       await withTenant({ tenantId: 'outer' }, async () => {

--- a/packages/tenancy/src/__tests__/testing-utils.test.ts
+++ b/packages/tenancy/src/__tests__/testing-utils.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for the tenancy test-utility helpers (`src/testing.ts`) and the package
+ * barrel (`src/index.ts`).
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  getTenantId,
+  TenantContextError,
+  TenantIsolationError,
+} from '../context';
+import { isTenancyEnabled } from '../enabled-state';
+// Import the package barrel so its re-exports are covered.
+import * as pkg from '../index';
+import {
+  assertTenantContextRequired,
+  assertTenantIsolationViolation,
+  createTestTenantContext,
+  resetTenancy,
+  setupTestTenancy,
+  testTenantIsolation,
+} from '../testing';
+
+describe('package barrel', () => {
+  it('re-exports the public surface', () => {
+    expect(typeof pkg.enableTenancy).toBe('function');
+    expect(typeof pkg.withTenant).toBe('function');
+    expect(typeof pkg.runTenantScopedEntryPoint).toBe('function');
+    expect(typeof pkg.TenantScoped).toBe('function');
+  });
+});
+
+describe('tenancy testing utilities', () => {
+  afterEach(() => {
+    resetTenancy();
+  });
+
+  it('setupTestTenancy enables tenancy; resetTenancy disables it', () => {
+    setupTestTenancy({ enableInterceptors: true });
+    expect(isTenancyEnabled()).toBe(true);
+    resetTenancy();
+    expect(isTenancyEnabled()).toBe(false);
+  });
+
+  it('setupTestTenancy can skip the interceptor', () => {
+    setupTestTenancy({ enableInterceptors: false });
+    expect(isTenancyEnabled()).toBe(false);
+  });
+
+  it('createTestTenantContext runs inside the given tenant', async () => {
+    let observed: string | undefined;
+    const result = await createTestTenantContext(
+      { tenantId: 'test-tenant' },
+      async () => {
+        observed = getTenantId();
+        return 'value';
+      },
+    );
+    expect(observed).toBe('test-tenant');
+    expect(result).toBe('value');
+  });
+
+  it('testTenantIsolation provides a runner per tenant', async () => {
+    const seen: string[] = [];
+    await testTenantIsolation(['tenant-a', 'tenant-b'], async (tenants) => {
+      await tenants['tenant-a'](async () => {
+        seen.push(getTenantId() as string);
+      });
+      await tenants['tenant-b'](async () => {
+        seen.push(getTenantId() as string);
+      });
+    });
+    expect(seen).toEqual(['tenant-a', 'tenant-b']);
+  });
+
+  describe('assertTenantContextRequired', () => {
+    it('passes when fn throws TenantContextError', async () => {
+      await assertTenantContextRequired(async () => {
+        throw new TenantContextError('Tenant context required for X');
+      });
+    });
+
+    it('verifies the message substring', async () => {
+      await assertTenantContextRequired(async () => {
+        throw new TenantContextError('Tenant context required for listing');
+      }, 'listing');
+    });
+
+    it('throws when fn does not throw', async () => {
+      await expect(
+        assertTenantContextRequired(async () => undefined),
+      ).rejects.toThrow(/no error was thrown/i);
+    });
+
+    it('throws when fn throws the wrong error type', async () => {
+      await expect(
+        assertTenantContextRequired(async () => {
+          throw new Error('unrelated');
+        }),
+      ).rejects.toThrow(/Expected TenantContextError/i);
+    });
+
+    it('throws when the message substring is missing', async () => {
+      await expect(
+        assertTenantContextRequired(async () => {
+          throw new TenantContextError('different message');
+        }, 'expected-substring'),
+      ).rejects.toThrow(/contain 'expected-substring'/i);
+    });
+  });
+
+  describe('assertTenantIsolationViolation', () => {
+    it('passes when fn throws TenantIsolationError', async () => {
+      await assertTenantIsolationViolation(async () => {
+        throw new TenantIsolationError('Tenant isolation violation in X');
+      });
+    });
+
+    it('throws when fn does not throw', async () => {
+      await expect(
+        assertTenantIsolationViolation(async () => undefined),
+      ).rejects.toThrow(/no error was thrown/i);
+    });
+
+    it('throws when fn throws the wrong error type', async () => {
+      await expect(
+        assertTenantIsolationViolation(async () => {
+          throw new Error('unrelated');
+        }),
+      ).rejects.toThrow(/Expected TenantIsolationError/i);
+    });
+
+    it('verifies the message substring and reports a mismatch', async () => {
+      await assertTenantIsolationViolation(async () => {
+        throw new TenantIsolationError('cross-tenant read blocked');
+      }, 'blocked');
+      await expect(
+        assertTenantIsolationViolation(async () => {
+          throw new TenantIsolationError('some message');
+        }, 'absent'),
+      ).rejects.toThrow(/contain 'absent'/i);
+    });
+  });
+});

--- a/packages/tenancy/src/enabled-state.ts
+++ b/packages/tenancy/src/enabled-state.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared tenancy-enabled flag.
+ *
+ * Holds the single boolean toggled by `enableTenancy()` / `disableTenancy()`.
+ * It lives in its own leaf module (importing nothing from the package) so that
+ * both `interceptor.ts` and `entry-point.ts` can read it without forming a
+ * circular import: `interceptor.ts` imports `runTenantScopedEntryPoint` from
+ * `entry-point.ts`, and `entry-point.ts` needs the enabled flag — routing the
+ * flag through here keeps that dependency one-directional.
+ */
+
+let enabled = false;
+
+/**
+ * Set the global tenancy-enabled flag. Internal — called by `enableTenancy()` /
+ * `disableTenancy()` in `interceptor.ts`.
+ *
+ * @param value - `true` to mark tenancy enabled, `false` to clear it.
+ */
+export function setTenancyEnabled(value: boolean): void {
+  enabled = value;
+}
+
+/**
+ * Return `true` if tenant enforcement is currently active.
+ *
+ * @returns Whether `enableTenancy()` has been called without a later
+ *   `disableTenancy()`.
+ */
+export function isTenancyEnabled(): boolean {
+  return enabled;
+}

--- a/packages/tenancy/src/entry-point.ts
+++ b/packages/tenancy/src/entry-point.ts
@@ -16,11 +16,12 @@
 
 import {
   hasTenantContext,
+  isSystemContext,
   TenantContextError,
   withSystemContext,
   withTenant,
 } from './context.js';
-import { isTenancyEnabled } from './interceptor.js';
+import { isTenancyEnabled } from './enabled-state.js';
 import { isTenantScopedClass } from './registry.js';
 
 /**
@@ -76,7 +77,8 @@ export interface TenantEntryPointOptions {
  * be established.
  *
  * Resolution order (tenant-scoped models only):
- * 1. A context is already active (e.g. an upstream tenancy handle) → reuse it.
+ * 1. A tenant context is already active, or an explicit `withSystemContext()`
+ *    bypass is in effect (e.g. `runAsSystem()`, migrations) → run as-is.
  * 2. `allowCrossTenant` was explicitly set → run in system context. Checked
  *    before `tenantId` so an explicit cross-tenant opt-in wins over a default
  *    principal/host tenant rather than being silently scoped.
@@ -114,9 +116,12 @@ export async function runTenantScopedEntryPoint<T>(
         ? isTenantScopedClass(className)
         : false;
 
-  // Non-scoped models, or an already-established context, run as-is.
+  // Non-scoped models run as-is. So do calls already inside a tenant context
+  // (an upstream handle) or an explicit system-context bypass — the interceptor
+  // honors `withSystemContext()` (migrations, `runAsSystem()`), so the gate must
+  // not fail-close over it (hasTenantContext() is false for the system marker).
   if (!scoped) return fn();
-  if (hasTenantContext()) return fn();
+  if (hasTenantContext() || isSystemContext()) return fn();
 
   // Explicit operator opt-in to cross-tenant access. Checked before the tenant
   // selector so a deliberate `--all-tenants` / `allowCrossTenant` overrides a

--- a/packages/tenancy/src/entry-point.ts
+++ b/packages/tenancy/src/entry-point.ts
@@ -1,0 +1,140 @@
+/**
+ * Fail-closed tenant-context establishment for non-web entry points (#1554).
+ *
+ * The SvelteKit/Express adapters establish tenant context from the authenticated
+ * request principal, so the web surface of a `@TenantScoped({ mode: 'optional' })`
+ * model never reads across tenants without an active context. The generated
+ * **CLI** and **MCP** entry points have no request principal, so an invocation
+ * with no active context would fall through the interceptor's optional-mode
+ * pass-through and return rows across **all** tenants.
+ *
+ * `runTenantScopedEntryPoint()` closes that gap. It is the single fail-closed
+ * gate both generated surfaces wrap their per-command/per-tool execution in.
+ *
+ * @see createCliContext for the richer CLI runner (resolveTenantId, super-admin).
+ */
+
+import {
+  hasTenantContext,
+  TenantContextError,
+  withSystemContext,
+  withTenant,
+} from './context.js';
+import { isTenancyEnabled } from './interceptor.js';
+import { isTenantScopedClass } from './registry.js';
+
+/**
+ * Inputs for {@link runTenantScopedEntryPoint}.
+ *
+ * Provide **either** `className` (the gate resolves tenant-scoping from the
+ * authoritative tenancy registry — the same source the interceptor uses, so it
+ * covers both `@TenantScoped` and `@smrt({ tenantScoped })` registrations) or an
+ * explicit `tenantScoped` boolean (when the caller already resolved it, e.g. a
+ * build-time generated surface). An explicit boolean wins when both are given.
+ */
+export interface TenantEntryPointOptions {
+  /**
+   * Class name of the target model. When provided, tenant-scoping is resolved
+   * via `isTenantScopedClass(className)`.
+   */
+  className?: string;
+
+  /**
+   * Explicit tenant-scoping decision. Overrides `className` resolution when set.
+   * Non-scoped models always pass through unchanged — the gate is a no-op.
+   */
+  tenantScoped?: boolean;
+
+  /**
+   * Explicit operator-provided tenant selector (CLI `--tenant <id>`, MCP
+   * `context.tenantId`). When present (and no context is already active) the
+   * function runs inside this tenant's context.
+   */
+  tenantId?: string | null;
+
+  /**
+   * Explicit operator opt-in to cross-tenant / system access (CLI
+   * `--all-tenants`, an MCP host that trusts the caller as an operator). When
+   * set the function runs in system context, bypassing tenant filtering.
+   *
+   * @default false
+   */
+  allowCrossTenant?: boolean;
+
+  /**
+   * Human-facing surface name used in the fail-closed error message, e.g.
+   * `'CLI'` or `'MCP'`.
+   *
+   * @default 'entry point'
+   */
+  surface?: string;
+}
+
+/**
+ * Run `fn` inside an appropriate tenant context for a generated CLI/MCP entry
+ * point, failing closed for tenant-scoped models when no authorized context can
+ * be established.
+ *
+ * Resolution order (tenant-scoped models only):
+ * 1. A context is already active (e.g. an upstream tenancy handle) → reuse it.
+ * 2. An explicit `tenantId` was provided → run inside that tenant.
+ * 3. `allowCrossTenant` was explicitly set → run in system context.
+ * 4. Tenancy is enabled but none of the above → **throw** `TenantContextError`
+ *    (the fail-closed branch — never silently read across tenants).
+ * 5. Tenancy is disabled (single-/no-tenant deployment) → pass through.
+ *
+ * Non-tenant-scoped models always pass straight through.
+ *
+ * @param options - {@link TenantEntryPointOptions}.
+ * @param fn - The command/tool body to execute.
+ * @returns The resolved value of `fn`.
+ * @throws {TenantContextError} When a tenant-scoped model is reached with
+ *   tenancy enabled and no tenant/cross-tenant selector.
+ */
+export async function runTenantScopedEntryPoint<T>(
+  options: TenantEntryPointOptions,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const {
+    className,
+    tenantScoped,
+    tenantId,
+    allowCrossTenant = false,
+    surface = 'entry point',
+  } = options;
+
+  // Resolve tenant-scoping: an explicit boolean wins; otherwise consult the
+  // authoritative tenancy registry by class name (matches the interceptor).
+  const scoped =
+    typeof tenantScoped === 'boolean'
+      ? tenantScoped
+      : className
+        ? isTenantScopedClass(className)
+        : false;
+
+  // Non-scoped models, or an already-established context, run as-is.
+  if (!scoped) return fn();
+  if (hasTenantContext()) return fn();
+
+  // Explicit tenant selector wins.
+  if (typeof tenantId === 'string' && tenantId) {
+    return withTenant({ tenantId }, fn);
+  }
+
+  // Explicit operator opt-in to cross-tenant access.
+  if (allowCrossTenant) {
+    return withSystemContext(fn);
+  }
+
+  // Fail closed: tenancy is on but the caller gave us nothing to scope by.
+  if (isTenancyEnabled()) {
+    throw new TenantContextError(
+      `Tenant context required for tenant-scoped access via ${surface}. ` +
+        'Pass an explicit tenant (e.g. --tenant <id> / a tenantId) or opt into ' +
+        'cross-tenant access (e.g. --all-tenants) to read across all tenants.',
+    );
+  }
+
+  // Tenancy disabled → single-tenant deployment, pass through.
+  return fn();
+}

--- a/packages/tenancy/src/entry-point.ts
+++ b/packages/tenancy/src/entry-point.ts
@@ -77,8 +77,10 @@ export interface TenantEntryPointOptions {
  *
  * Resolution order (tenant-scoped models only):
  * 1. A context is already active (e.g. an upstream tenancy handle) → reuse it.
- * 2. An explicit `tenantId` was provided → run inside that tenant.
- * 3. `allowCrossTenant` was explicitly set → run in system context.
+ * 2. `allowCrossTenant` was explicitly set → run in system context. Checked
+ *    before `tenantId` so an explicit cross-tenant opt-in wins over a default
+ *    principal/host tenant rather than being silently scoped.
+ * 3. An explicit `tenantId` was provided → run inside that tenant.
  * 4. Tenancy is enabled but none of the above → **throw** `TenantContextError`
  *    (the fail-closed branch — never silently read across tenants).
  * 5. Tenancy is disabled (single-/no-tenant deployment) → pass through.
@@ -116,14 +118,16 @@ export async function runTenantScopedEntryPoint<T>(
   if (!scoped) return fn();
   if (hasTenantContext()) return fn();
 
-  // Explicit tenant selector wins.
-  if (typeof tenantId === 'string' && tenantId) {
-    return withTenant({ tenantId }, fn);
-  }
-
-  // Explicit operator opt-in to cross-tenant access.
+  // Explicit operator opt-in to cross-tenant access. Checked before the tenant
+  // selector so a deliberate `--all-tenants` / `allowCrossTenant` overrides a
+  // default host/principal tenant instead of being silently scoped to it.
   if (allowCrossTenant) {
     return withSystemContext(fn);
+  }
+
+  // Explicit tenant selector.
+  if (typeof tenantId === 'string' && tenantId) {
+    return withTenant({ tenantId }, fn);
   }
 
   // Fail closed: tenancy is on but the caller gave us nothing to scope by.

--- a/packages/tenancy/src/index.ts
+++ b/packages/tenancy/src/index.ts
@@ -91,7 +91,13 @@ export {
   // Property decorator (preferred)
   tenantId,
 } from './decorators.js';
-
+// ─────────────────────────────────────────────────────────────────────────────
+// Fail-closed entry-point gate for generated CLI/MCP surfaces (#1554)
+// ─────────────────────────────────────────────────────────────────────────────
+export {
+  runTenantScopedEntryPoint,
+  type TenantEntryPointOptions,
+} from './entry-point.js';
 // ─────────────────────────────────────────────────────────────────────────────
 // Field Types and Utilities
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/tenancy/src/interceptor.ts
+++ b/packages/tenancy/src/interceptor.ts
@@ -30,6 +30,7 @@ import {
   TenantContextError,
   TenantIsolationError,
 } from './context.js';
+import { isTenancyEnabled, setTenancyEnabled } from './enabled-state.js';
 import { runTenantScopedEntryPoint } from './entry-point.js';
 import { getTenantScopedConfig, isTenantScopedClass } from './registry.js';
 
@@ -614,7 +615,9 @@ export function createTenantInterceptor(
 // Registration Functions
 // ─────────────────────────────────────────────────────────────────────────────
 
-let isEnabled = false;
+// The enabled flag lives in `enabled-state.ts` (a leaf module) so `entry-point.ts`
+// can read it without importing this module — breaking the otherwise-circular
+// interceptor ↔ entry-point dependency.
 let registeredInterceptor: CollectionInterceptor | null = null;
 
 /**
@@ -638,7 +641,7 @@ let registeredInterceptor: CollectionInterceptor | null = null;
  * ```
  */
 export function enableTenancy(options: TenantInterceptorOptions = {}): void {
-  if (isEnabled) {
+  if (isTenancyEnabled()) {
     logger.warn(
       '[smrt-tenancy] Tenancy is already enabled. Call disableTenancy() first to reconfigure.',
     );
@@ -659,7 +662,7 @@ export function enableTenancy(options: TenantInterceptorOptions = {}): void {
   // (tenancy disabled) those surfaces pass through unchanged.
   setTenantEntryPointRunner(runTenantScopedEntryPoint);
 
-  isEnabled = true;
+  setTenancyEnabled(true);
 }
 
 /**
@@ -685,7 +688,7 @@ export function enableTenancy(options: TenantInterceptorOptions = {}): void {
  * @see resetTenancy
  */
 export function disableTenancy(): void {
-  if (!isEnabled || !registeredInterceptor) {
+  if (!isTenancyEnabled() || !registeredInterceptor) {
     return;
   }
 
@@ -696,20 +699,17 @@ export function disableTenancy(): void {
   // Clear the CLI/MCP tenant gate so those surfaces pass through (#1554).
   setTenantEntryPointRunner(undefined);
   registeredInterceptor = null;
-  isEnabled = false;
+  setTenancyEnabled(false);
 }
 
 /**
  * Return `true` if tenant enforcement is currently active.
  *
- * Reflects whether `enableTenancy()` has been called and the interceptor
- * has not yet been removed by `disableTenancy()`.
- *
- * @returns `true` when the tenant interceptor is registered, `false` otherwise.
+ * Reflects whether `enableTenancy()` has been called and the interceptor has not
+ * yet been removed by `disableTenancy()`. Re-exported from `enabled-state.ts`
+ * (the shared leaf module) so the public API surface is unchanged.
  *
  * @see enableTenancy
  * @see disableTenancy
  */
-export function isTenancyEnabled(): boolean {
-  return isEnabled;
-}
+export { isTenancyEnabled };

--- a/packages/tenancy/src/interceptor.ts
+++ b/packages/tenancy/src/interceptor.ts
@@ -20,6 +20,7 @@ import {
   type QueryInterceptResult,
   type QueryOptions,
   setDispatchTenantResolver,
+  setTenantEntryPointRunner,
 } from '@happyvertical/smrt-core';
 import {
   getCurrentTenant,
@@ -29,6 +30,7 @@ import {
   TenantContextError,
   TenantIsolationError,
 } from './context.js';
+import { runTenantScopedEntryPoint } from './entry-point.js';
 import { getTenantScopedConfig, isTenantScopedClass } from './registry.js';
 
 const logger = createLogger({ level: 'info' });
@@ -652,6 +654,11 @@ export function enableTenancy(options: TenantInterceptorOptions = {}): void {
   // enabled. Mirrors the GlobalInterceptors inversion above.
   setDispatchTenantResolver(() => getTenantId());
 
+  // Wire the fail-closed tenant gate for generated CLI/MCP entry points (#1554).
+  // Core invokes this runner around tenant-scoped CLI/MCP execution; without it
+  // (tenancy disabled) those surfaces pass through unchanged.
+  setTenantEntryPointRunner(runTenantScopedEntryPoint);
+
   isEnabled = true;
 }
 
@@ -686,6 +693,8 @@ export function disableTenancy(): void {
   // Clear the DispatchBus tenant resolver so the bus reverts to its no-op
   // (pre-tenancy) behavior when tenancy is disabled.
   setDispatchTenantResolver(undefined);
+  // Clear the CLI/MCP tenant gate so those surfaces pass through (#1554).
+  setTenantEntryPointRunner(undefined);
   registeredInterceptor = null;
   isEnabled = false;
 }


### PR DESCRIPTION
## Summary

Closes #1554 and #1556 (epic #1354). Both rework the same CLI/MCP generator surface, so they ship together.

The generated SvelteKit routes establish tenant context from the request principal (#1540), but the in-process **CLI/MCP** generators do not. So an `@TenantScoped({ mode: 'optional' })` model queried via CLI/MCP with **no active context** returned rows across **all tenants** — the interceptor only hard-fails `required` mode.

### #1554 — fail-closed tenant context
- New core **dependency-inversion hook** (`setTenantEntryPointRunner` / `runWithTenantGate`), mirroring the existing `setDispatchTenantResolver`. **Core never imports tenancy** (would be a circular dep + break pnpm-strict resolution).
- `enableTenancy()` registers `runTenantScopedEntryPoint`, which resolves tenant-scoping via `isTenantScopedClass` — the **same source the interceptor uses**, so it covers both `@TenantScoped` (Pattern 1, what real models use) and `@smrt({ tenantScoped })` (Pattern 2). Resolution order: reuse active context → explicit tenant selector → explicit cross-tenant opt-in → **throw when tenancy enabled** → (tenancy off) pass through.
- MCP `executeAction` and the emitted stdio runtime template wrap tool execution in the gate. Tenant comes from `context.tenantId` (MCP) / `SMRT_MCP_TENANT_ID` (stdio), cross-tenant opt-in via `context.allowCrossTenant` / `SMRT_MCP_ALLOW_CROSS_TENANT`.

### #1556 — CLI generator parity
- **Revives** `@happyvertical/smrt-core/generators/cli` (`CLIGenerator`). The `smrt:cli` virtual module previously emitted code importing a **non-existent module** — it was dead/broken. (Decision recorded with the issue owner: revive rather than delete.)
- Enforces the `api.writable` allowlist + readonly/server-managed strip on create/update (mass-assignment parity with REST/MCP).
- Gates custom-method commands on `isPublic`; treats `cli.include` as an **exhaustive allowlist**; adds `--from-file` for create/update payloads (keeps secrets off argv).
- Output serialized through `toPublicJSON()` so `sensitive` fields never print. Honors `--tenant` / `--all-tenants`.

## Compatibility note
`MCPContext` gains optional `tenantId` / `allowCrossTenant` (additive). MCP `executeAction` now **fails closed** for tenant-scoped models when tenancy is enabled and no tenant is supplied — a behavior change only for setups that were previously leaking cross-tenant rows. Downstream MCP hosts (ergot/anytown) that need cross-tenant reads must pass a tenant or opt in explicitly.

## Tests
- `packages/tenancy/.../entry-point.test.ts` — gate unit tests (fail-closed, selector, cross-tenant, active-context reuse, className resolution, tenancy-off).
- `packages/tenancy/.../cli-mcp-tenant-context.spec.ts` — **end-to-end** CLI + MCP tenant isolation with real in-memory SQLite + `enableTenancy()`.
- `packages/core/.../cli-hardening.spec.ts` — CLI exposure policy, writable allowlist, `--from-file`, sensitive redaction.

Full `build` + `typecheck` green; tenancy / smrt-app-mcp / products suites pass.