### PR TITLE
fix(agents): secret-sanitize TenantAgent config in serialized client payload (S5 #1553)

### DIFF
--- a/packages/agents/src/server/serialization.test.ts
+++ b/packages/agents/src/server/serialization.test.ts
@@ -177,6 +177,12 @@ describe('serializeResolvedAgent', () => {
   });
 
   it('secret-sanitizes config before it reaches the client (#1553)', () => {
+    // Assemble fake secret tokens from fragments so the test source never
+    // contains a contiguous secret-shaped literal (repo convention — avoids
+    // tripping secret-scanning / push-protection on fake keys).
+    const fakeSkValue = ['sk', 'ant', 'deadbeefdeadbeefdeadbeef'].join('-');
+    const fakeApiKeyValue = ['sk', 'ant', 'fakekeyfakekeyfakekey'].join('-');
+
     const resolved: ResolvedAgentAvailability = {
       agentClass: 'Praeco',
       agentType: PRAECO_TYPE,
@@ -190,10 +196,10 @@ describe('serializeResolvedAgent', () => {
         model: 'sonnet',
         nested: { region: 'us-east', password: 'hunter2' },
         // Secret-shaped keys must be dropped.
-        apiKey: 'sk-ant-abc123',
+        apiKey: fakeApiKeyValue,
         authToken: 'super-secret',
         // Secret-shaped value under a benign key must be masked.
-        note: 'use sk-ant-deadbeefdeadbeefdeadbeef for access',
+        note: `use ${fakeSkValue} for access`,
       },
     };
 
@@ -210,14 +216,18 @@ describe('serializeResolvedAgent', () => {
     expect(config.authToken).toBeUndefined();
     expect(config.nested.password).toBeUndefined();
 
-    // Secret-shaped value masked, not passed through verbatim.
-    expect(config.note).not.toContain('sk-ant-deadbeefdeadbeefdeadbeef');
+    // Secret-shaped value under a benign key is masked (not removed, not
+    // passed through verbatim).
+    expect(config.note).toBe('use *** for access');
+    expect(config.note).toContain('***');
+    expect(config.note).not.toContain(fakeSkValue);
 
     // No raw secret material anywhere in the serialized payload.
     const serialized = JSON.stringify(result);
     expect(serialized).not.toContain('super-secret');
     expect(serialized).not.toContain('hunter2');
-    expect(serialized).not.toContain('sk-ant-abc123');
+    expect(serialized).not.toContain(fakeApiKeyValue);
+    expect(serialized).not.toContain(fakeSkValue);
   });
 
   it('should handle empty permissions', () => {

--- a/packages/agents/src/server/serialization.test.ts
+++ b/packages/agents/src/server/serialization.test.ts
@@ -53,7 +53,9 @@ describe('serializeResolvedAgent', () => {
       permissions: { read: true, write: false },
       agentId: 'agent-123',
       manifest,
-      config: { key: 'value' },
+      // Non-secret key — survives sanitizeConfig (#1553). A bare `key` would be
+      // stripped as secret-shaped; secret handling is covered by its own test.
+      config: { setting: 'value' },
     };
 
     const result = serializeResolvedAgent(resolved);
@@ -67,7 +69,7 @@ describe('serializeResolvedAgent', () => {
     expect(result.sourceTenantId).toBe('tenant-1');
     expect(result.permissions).toEqual({ read: true, write: false });
     expect(result.icon).toBe('newspaper');
-    expect(result.config).toEqual({ key: 'value' });
+    expect(result.config).toEqual({ setting: 'value' });
   });
 
   it('should include slots from manifest', () => {
@@ -172,6 +174,50 @@ describe('serializeResolvedAgent', () => {
     const result = serializeResolvedAgent(resolved);
 
     expect(result.config).toBeUndefined();
+  });
+
+  it('secret-sanitizes config before it reaches the client (#1553)', () => {
+    const resolved: ResolvedAgentAvailability = {
+      agentClass: 'Praeco',
+      agentType: PRAECO_TYPE,
+      status: 'active',
+      source: 'explicit',
+      sourceTenantId: 'tenant-1',
+      permissions: {},
+      config: {
+        // Non-secret keys must survive for the admin UI to display.
+        endpoint: 'https://api.example.com',
+        model: 'sonnet',
+        nested: { region: 'us-east', password: 'hunter2' },
+        // Secret-shaped keys must be dropped.
+        apiKey: 'sk-ant-abc123',
+        authToken: 'super-secret',
+        // Secret-shaped value under a benign key must be masked.
+        note: 'use sk-ant-deadbeefdeadbeefdeadbeef for access',
+      },
+    };
+
+    const result = serializeResolvedAgent(resolved);
+    const config = result.config as Record<string, any>;
+
+    // Non-secret keys preserved.
+    expect(config.endpoint).toBe('https://api.example.com');
+    expect(config.model).toBe('sonnet');
+    expect(config.nested.region).toBe('us-east');
+
+    // Secret-shaped keys stripped (top-level and nested).
+    expect(config.apiKey).toBeUndefined();
+    expect(config.authToken).toBeUndefined();
+    expect(config.nested.password).toBeUndefined();
+
+    // Secret-shaped value masked, not passed through verbatim.
+    expect(config.note).not.toContain('sk-ant-deadbeefdeadbeefdeadbeef');
+
+    // No raw secret material anywhere in the serialized payload.
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain('super-secret');
+    expect(serialized).not.toContain('hunter2');
+    expect(serialized).not.toContain('sk-ant-abc123');
   });
 
   it('should handle empty permissions', () => {

--- a/packages/agents/src/server/serialization.ts
+++ b/packages/agents/src/server/serialization.ts
@@ -84,6 +84,6 @@ export function serializeResolvedAgent(
     permissions: resolved.permissions,
     icon: manifest?.icon,
     // Secret-sanitize before the blob crosses into the client payload (#1553).
-    config: sanitizeConfig(resolved.config) as Record<string, any> | undefined,
+    config: sanitizeConfig(resolved.config) as SerializedAgent['config'],
   };
 }

--- a/packages/agents/src/server/serialization.ts
+++ b/packages/agents/src/server/serialization.ts
@@ -7,6 +7,7 @@
  * @module @happyvertical/smrt-agents/server
  */
 
+import { sanitizeConfig } from '@happyvertical/smrt-config';
 import type { ResolvedAgentAvailability } from '../tenant-agent.js';
 import type { AgentAdminRoute, AgentUISlots } from '../ui.js';
 
@@ -40,17 +41,21 @@ export interface SerializedAgent {
   /** Agent icon from manifest */
   icon?: string;
   /**
-   * Tenant-level config overrides.
+   * Tenant-level config overrides, **secret-sanitized** for client transport.
    *
-   * SECURITY (review #1552): this is the tenant's own override blob, carried
-   * verbatim into the client payload. The model field `TenantAgent.config` is
-   * `@field({ sensitive: true })`, which strips it from the generated CRUD
-   * api/mcp surfaces — but this hand-written admin serialization deliberately
-   * bypasses that for the authorized admin UI. Do NOT store raw secrets (API
-   * keys, tokens) in tenant config; reference them by id via
-   * `@happyvertical/smrt-secrets` so only an opaque handle reaches the browser.
-   * Dropping this field outright is a breaking change to a public API consumed
-   * downstream and is tracked as a separate follow-up.
+   * SECURITY (#1553, follow-up to #1552): the raw `TenantAgent.config` is the
+   * tenant's own override blob and is `@field({ sensitive: true })` (stripped
+   * from the generated CRUD api/mcp surfaces). This hand-written admin
+   * serialization runs it through `sanitizeConfig()` from
+   * `@happyvertical/smrt-config` before it leaves the server, so secret-shaped
+   * keys (apiKey/token/password/…) are dropped and secret-shaped values
+   * (`sk-…`, `AKIA…`, `Bearer …`, URL credentials, PEM blocks) are masked —
+   * non-secret config still reaches the authorized admin UI for display.
+   *
+   * This is **display-only**: do not edit-round-trip it back to the server
+   * (a masked value would overwrite the real secret). Best practice remains to
+   * reference secrets by id via `@happyvertical/smrt-secrets` so only an opaque
+   * handle is ever stored in tenant config.
    */
   config?: Record<string, any>;
 }
@@ -78,6 +83,7 @@ export function serializeResolvedAgent(
     sourceTenantId: resolved.sourceTenantId,
     permissions: resolved.permissions,
     icon: manifest?.icon,
-    config: resolved.config,
+    // Secret-sanitize before the blob crosses into the client payload (#1553).
+    config: sanitizeConfig(resolved.config) as Record<string, any> | undefined,
   };
 }


### PR DESCRIPTION
## Summary

Closes #1553 (epic #1354, follow-up to #1552). Phase B coordination signaled, so this lands now.

`serializeResolvedAgent()` shipped `TenantAgent.config` — the tenant's override blob — **verbatim** into the admin-UI client payload. The model field is `@field({ sensitive: true })` (stripped from generated CRUD api/mcp), but this hand-written admin serialization bypassed that, so a raw secret stored in tenant config would reach the authorized admin's browser. **P2** — own-tenant data to an authorized admin, not a cross-tenant/unauth leak.

## Decision: redact (not drop)

Per the issue's drop / allowlist / redact options, I chose **redact** via the existing shared `sanitizeConfig()` from `@happyvertical/smrt-config` (the #1381 redactor):
- Secret-shaped **keys** dropped (`apiKey`/`token`/`password`/`auth`/`secret`/`credential`/`private`/`key`…), recursively.
- Secret-shaped **values** masked (`sk-…`, `AKIA…`, `Bearer …`, `scheme://user:pass@host`, PEM blocks).
- Non-secret config still reaches the UI for display.

**Why redact over drop:** non-breaking (the `config` field/shape is unchanged) and preserves legitimate non-secret display. Verified no downstream shape change is needed — anytown's dashboard reads slot config from the separate `agent_configs` table (`loadSlotConfigs`), **not** `SerializedAgent.config`; ergot doesn't use `serializeResolvedAgent`.

## Notes
- **Display-only**: documented in the JSDoc not to edit-round-trip a sanitized blob back to the server (a masked value would overwrite the real secret). Editing still goes through the CRUD api, which strips the sensitive field. Best practice remains referencing secrets by id via `@happyvertical/smrt-secrets`.
- Not a breaking API change → standard `fix:` changeset.

## Tests
Regression test in `serialization.test.ts`: secret-shaped keys/values never appear in the serialized output; non-secret keys (incl. nested) survive. Existing test updated from a bare `key` (which is secret-shaped) to a non-secret key to reflect sanitized behavior. Full suite green; build + typecheck + biome clean.