### PR TITLE
fix(scanner): guard manifest extraction against prototype pollution (S5 #1384)

### DIFF
--- a/packages/scanner/src/__tests__/prototype-pollution.test.ts
+++ b/packages/scanner/src/__tests__/prototype-pollution.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Regression tests for prototype-pollution hardening (S5 #1384).
+ *
+ * The scanner builds plain metadata objects keyed by names taken from
+ * developer-authored source (class fields, `@smrt()` / `@field()` config
+ * properties, type aliases). A name of `__proto__`, `constructor`, or
+ * `prototype` must never mutate the object's prototype or land as a gadget in
+ * the emitted manifest. Scanner input is trusted build-time source, so this is
+ * defense-in-depth rather than a remotely reachable fix — but a corrupted
+ * metadata object would silently break downstream schema generation.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { ManifestAdapter } from '../manifest-adapter.js';
+import {
+  extractTypeAliases,
+  isSafeObjectKey,
+  parseSource,
+} from '../oxc-parser.js';
+import type { RawFieldDefinition, ResolvedClassDefinition } from '../types.js';
+
+/** Own-property check that satisfies biome's noPrototypeBuiltins rule. */
+function hasOwn(obj: unknown, key: string): boolean {
+  return obj != null && Object.hasOwn(obj as object, key);
+}
+
+/** Probe whether anything polluted the global Object prototype. */
+function globalProp(key: string): unknown {
+  return (Object.prototype as Record<string, unknown>)[key];
+}
+
+describe('prototype-pollution hardening', () => {
+  afterEach(() => {
+    // Ensure no test polluted the global Object prototype.
+    expect(globalProp('polluted')).toBeUndefined();
+    expect(globalProp('isAdmin')).toBeUndefined();
+  });
+
+  describe('isSafeObjectKey', () => {
+    it('rejects prototype-pollution keys', () => {
+      expect(isSafeObjectKey('__proto__')).toBe(false);
+      expect(isSafeObjectKey('constructor')).toBe(false);
+      expect(isSafeObjectKey('prototype')).toBe(false);
+    });
+
+    it('allows ordinary keys', () => {
+      expect(isSafeObjectKey('name')).toBe(true);
+      expect(isSafeObjectKey('tableStrategy')).toBe(true);
+    });
+  });
+
+  describe('@smrt() decorator config (extractObjectLiteral)', () => {
+    it('does not pollute prototype via a __proto__ config property', () => {
+      const source = `
+        @smrt({ "__proto__": { "polluted": true }, tableStrategy: 'sti' })
+        class Evil extends SmrtObject {
+          name: string = '';
+        }
+      `;
+
+      const config = parseSource(source).classes[0]?.decoratorConfig;
+
+      // Prototype must be untouched and the forbidden key dropped.
+      expect(Object.getPrototypeOf(config)).toBe(Object.prototype);
+      expect(hasOwn(config, '__proto__')).toBe(false);
+      // Legitimate sibling property is still captured.
+      expect(config?.tableStrategy).toBe('sti');
+      expect(globalProp('polluted')).toBeUndefined();
+    });
+
+    it('drops a constructor config property', () => {
+      const source = `
+        @smrt({ "constructor": { "evil": 1 } })
+        class Evil extends SmrtObject {}
+      `;
+      const config = parseSource(source).classes[0]?.decoratorConfig;
+      expect(hasOwn(config, 'constructor')).toBe(false);
+    });
+  });
+
+  describe('class field names (extractPropertyDefinition)', () => {
+    it('excludes a class field literally named __proto__ (review #1559)', () => {
+      const source = `
+        @smrt()
+        class Doc extends SmrtObject {
+          '__proto__': string = '';
+          title: string = '';
+        }
+      `;
+      const cls = parseSource(source).classes[0];
+      const names = (cls?.fields ?? []).map((f) => f.name);
+      expect(names).toContain('title');
+      expect(names).not.toContain('__proto__');
+    });
+  });
+
+  describe('type aliases (extractTypeAliases)', () => {
+    it('does not record a type alias named __proto__', () => {
+      const result = parseSource(`type __proto__ = 'a' | 'b';`);
+      expect(hasOwn(result.typeAliases, '__proto__')).toBe(false);
+      expect(Object.getPrototypeOf(result.typeAliases)).toBe(Object.prototype);
+    });
+
+    it('skips forbidden alias names but keeps legitimate ones', () => {
+      const src = `
+        type Status = 'on' | 'off';
+        type constructor = 'x' | 'y';
+      `;
+      const aliases = parseSource(src).typeAliases;
+      expect(aliases.Status).toBe("'on' | 'off'");
+      expect(hasOwn(aliases, 'constructor')).toBe(false);
+      // extractTypeAliases is exported and exercised by the parse path above.
+      expect(typeof extractTypeAliases).toBe('function');
+    });
+  });
+
+  describe('manifest adapter parseLiteralInitializer (sanitizeParsed)', () => {
+    const adapter = new ManifestAdapter();
+
+    function fieldWithDecorator(args: string[]): RawFieldDefinition {
+      return {
+        name: 'value',
+        accessibility: 'public',
+        typeAnnotation: 'string',
+        initializer: "''",
+        optional: false,
+        hasDecimalPoint: false,
+        numericValue: null,
+        decorators: [{ name: 'field', arguments: args }],
+        isStatic: false,
+        readonly: false,
+        line: 1,
+      };
+    }
+
+    it('strips __proto__ from a @field() options object', () => {
+      const field = fieldWithDecorator([
+        '{ "__proto__": { "isAdmin": true }, required: true }',
+      ]);
+      const result = adapter.convertField(field);
+      expect(result?.required).toBe(true);
+      // The polluting key must not appear in _meta or globally.
+      expect(hasOwn(result?._meta, '__proto__')).toBe(false);
+      expect(globalProp('isAdmin')).toBeUndefined();
+    });
+
+    it('strips constructor/prototype from a static uiSlots initializer', () => {
+      const staticField: RawFieldDefinition = {
+        name: 'uiSlots',
+        accessibility: 'public',
+        typeAnnotation: null,
+        initializer: '{ "constructor": { "x": 1 }, header: { label: "Hi" } }',
+        optional: false,
+        hasDecimalPoint: false,
+        numericValue: null,
+        decorators: [],
+        isStatic: true,
+        readonly: false,
+        line: 1,
+      };
+
+      const classDef: ResolvedClassDefinition = {
+        className: 'Widget',
+        filePath: 'Widget.ts',
+        extendsClause: 'SmrtObject',
+        extendsTypeArg: null,
+        decoratorConfig: {},
+        hasSmartDecorator: true,
+        fields: [staticField],
+        methods: [],
+        startLine: 1,
+        endLine: 1,
+        inheritanceChain: ['SmrtObject', 'Widget'],
+        stiBase: null,
+        effectiveTableStrategy: 'cti',
+        isSTI: false,
+        isFrameworkBase: false,
+        allFields: [staticField],
+        packageName: null,
+      };
+
+      const def = adapter.toSmartObjectDefinition(classDef);
+      const uiSlots = def.staticProperties?.uiSlots as Record<string, unknown>;
+      expect(uiSlots).toBeDefined();
+      // Legitimate slot preserved, polluting key dropped.
+      expect(uiSlots.header).toEqual({ label: 'Hi' });
+      expect(hasOwn(uiSlots, 'constructor')).toBe(false);
+    });
+
+    it('preserves built-in objects (Date) instead of emptying them (review #1559)', () => {
+      // sanitizeParsed must not iterate a built-in's keys — that would turn a
+      // `new Date()` default into `{}`. Built-ins carry no attacker-controlled
+      // own keys, so they pass through intact.
+      const field = fieldWithDecorator([
+        '{ sampleDate: new Date(0), required: true }',
+      ]);
+      const result = adapter.convertField(field);
+      expect(result?.required).toBe(true);
+      const meta = result?._meta as Record<string, unknown> | undefined;
+      expect(meta?.sampleDate).toBeInstanceOf(Date);
+      expect((meta?.sampleDate as Date)?.getTime()).toBe(0);
+    });
+  });
+});

--- a/packages/scanner/src/manifest-adapter.ts
+++ b/packages/scanner/src/manifest-adapter.ts
@@ -5,6 +5,7 @@
  * Ensures compatibility with existing manifest consumers.
  */
 
+import { isSafeObjectKey } from './oxc-parser.js';
 import type {
   FieldTypeInference,
   InferredFieldType,
@@ -165,11 +166,54 @@ interface SmartObjectManifest {
 // ============================================================================
 
 /**
+ * Property keys that must never appear as own properties on a manifest object.
+ * Object literals authored as `{ constructor: ... }` or `{ prototype: ... }`
+ * produce real own keys; spreading such a parsed object into a manifest
+ * `_meta` / `staticProperties` entry (or assigning it under a class field name)
+ * would carry a prototype-pollution gadget into the emitted JSON.
+ */
+/**
+ * Recursively strip prototype-pollution keys (via the shared
+ * {@link isSafeObjectKey} guard — single source of truth with oxc-parser) from a
+ * value parsed out of source. Returns a new plain object/array; primitives and
+ * built-in objects pass through unchanged.
+ */
+function sanitizeParsed(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (value === null || typeof value !== 'object') return value;
+
+  const isArray = Array.isArray(value);
+  // Preserve built-ins (Date, RegExp, Map, …) intact. They carry no
+  // attacker-controlled own keys, and iterating their enumerable keys would
+  // silently turn e.g. `@field({ default: new Date() })` into `{}` (review #1559).
+  const proto = Object.getPrototypeOf(value);
+  if (!isArray && proto !== Object.prototype && proto !== null) return value;
+
+  // Cycle guard: a cyclic literal (e.g. an IIFE returning a self-referential
+  // object) would otherwise recurse forever and hang the build (review #1559).
+  if (seen.has(value as object)) return undefined;
+  seen.add(value as object);
+
+  if (isArray) {
+    return (value as unknown[]).map((item) => sanitizeParsed(item, seen));
+  }
+  const clean: Record<string, unknown> = {};
+  for (const key of Object.keys(value as Record<string, unknown>)) {
+    if (!isSafeObjectKey(key)) continue;
+    clean[key] = sanitizeParsed((value as Record<string, unknown>)[key], seen);
+  }
+  return clean;
+}
+
+/**
  * Parse a JavaScript literal (object or array) from source text.
  *
  * Uses the Function constructor to evaluate literal syntax at build time.
  * This is intentional — AST-based extraction can't handle computed keys,
  * template literals, or spread syntax that may appear in static initializers.
+ *
+ * The parsed result is run through {@link sanitizeParsed} to strip
+ * prototype-pollution keys (`__proto__` / `constructor` / `prototype`) before
+ * it is merged into a manifest object.
  *
  * WARNING: This executes the source text. It is only safe when scanning
  * your own trusted codebase at build time. Never run the scanner against
@@ -186,7 +230,10 @@ function parseLiteralInitializer(
     // This runs at build time only, on trusted source code from our own codebase
     // The existing pattern (unchanged) uses Function constructor for object literal parsing
     // eslint-disable-next-line no-new-func
-    return new Function(`return (${source})`)() as Record<string, any>;
+    const parsed = new Function(`return (${source})`)() as
+      | Record<string, any>
+      | any[];
+    return sanitizeParsed(parsed) as Record<string, any> | any[];
   } catch {
     return null;
   }

--- a/packages/scanner/src/oxc-parser.ts
+++ b/packages/scanner/src/oxc-parser.ts
@@ -625,6 +625,33 @@ export function parseSource(
 // ============================================================================
 
 /**
+ * Property keys that must never be assigned onto a plain object built from
+ * parsed source. Assigning `obj['__proto__'] = value` mutates the object's
+ * prototype rather than adding an own property, which is a prototype-pollution
+ * vector. `constructor` / `prototype` are blocked for defense-in-depth.
+ *
+ * Scanner input is developer-authored source consumed at build time (trusted),
+ * so this is a hardening guard, not a fix for a remotely reachable bug: a class
+ * field, decorator-config property, or type alias literally named `__proto__`
+ * would otherwise silently corrupt the metadata object it is collected into.
+ */
+const FORBIDDEN_OBJECT_KEYS = new Set([
+  '__proto__',
+  'constructor',
+  'prototype',
+]);
+
+/**
+ * Whether a key is safe to assign as an own property on a plain object built
+ * from parsed AST. See {@link FORBIDDEN_OBJECT_KEYS}.
+ *
+ * @internal Exported for testing.
+ */
+export function isSafeObjectKey(key: string): boolean {
+  return !FORBIDDEN_OBJECT_KEYS.has(key);
+}
+
+/**
  * Extract import aliases from program body.
  * Maps local alias names to their original imported names.
  * e.g., `import { Performer as PerformerBase }` → Map { "PerformerBase" → "Performer" }
@@ -751,7 +778,7 @@ export function extractTypeAliases(body: Statement[]): Record<string, string> {
       const resolved = node.typeAnnotation
         ? extractTypeName(node.typeAnnotation)
         : null;
-      if (name && resolved) aliases[name] = resolved;
+      if (name && resolved && isSafeObjectKey(name)) aliases[name] = resolved;
     }
     // Also check `export type X = ...` (ExportNamedDeclaration wrapping)
     if (
@@ -763,7 +790,7 @@ export function extractTypeAliases(body: Statement[]): Record<string, string> {
       const resolved = decl.typeAnnotation
         ? extractTypeName(decl.typeAnnotation)
         : null;
-      if (name && resolved) aliases[name] = resolved;
+      if (name && resolved && isSafeObjectKey(name)) aliases[name] = resolved;
     }
 
     // Extract enum declarations as string union types
@@ -780,7 +807,7 @@ export function extractTypeAliases(body: Statement[]): Record<string, string> {
       const name = enumDecl.id?.name;
       // OXC wraps members in a TSEnumBody node: enumDecl.body.members
       const members = enumDecl.body?.members ?? enumDecl.members;
-      if (name && members?.length > 0) {
+      if (name && isSafeObjectKey(name) && members?.length > 0) {
         const values = members
           .map((m: any) => {
             if (m.initializer?.type === 'Literal') {
@@ -964,7 +991,10 @@ function extractObjectLiteral(
   for (const prop of node.properties) {
     if (prop.type === 'Property' && !prop.computed) {
       const key = getPropertyKey(prop.key);
-      if (key) {
+      // Skip prototype-pollution keys (__proto__/constructor/prototype) so a
+      // decorator-config property of that name cannot mutate the metadata
+      // object's prototype.
+      if (key && isSafeObjectKey(key)) {
         result[key] = extractValue(prop.value, sourceText);
       }
     }
@@ -1347,6 +1377,11 @@ function extractPropertyDefinition(
 
   const name = getPropertyKey(node.key);
   if (!name) return null;
+  // Reject prototype-polluting field names before they become manifest map keys
+  // (a field literally named `__proto__`/`constructor`/`prototype`). The
+  // type-alias/enum/object-literal extractors already gate on this; field
+  // definitions must too (review #1559).
+  if (!isSafeObjectKey(name)) return null;
 
   // Get type annotation
   const typeAnnotation = node.typeAnnotation


### PR DESCRIPTION
## Security audit + remediation — `packages/scanner` (T1, S5 epic #1354)

Final-wave per-package security audit of `@happyvertical/smrt-scanner`, the oxc-parser AST scanner that extracts class/field metadata for the SMRT manifest.

### Trust boundary
The scanner consumes **developer-authored TypeScript source from the local project at build time** — the same source the developer already compiles and runs (trust level of `vite.config.ts`). It is not exposed to network/untrusted input. So the findings below are build-time, developer-controlled; remediation is defense-in-depth against silently-corrupted metadata, not a remotely reachable exploit.

### Findings

| Sev | Finding | Location | Status |
|-----|---------|----------|--------|
| Medium | **Prototype pollution.** Plain metadata objects are keyed by names taken from parsed source; a class field / `@smrt()`/`@field()` config property / type alias / enum named `__proto__` (or `constructor`/`prototype`) was assigned via `obj[key] = ...`, which mutates the object's prototype instead of adding an own property (verified: `({})['__proto__']=x` changes the prototype). | `oxc-parser.ts` `extractObjectLiteral`, `extractTypeAliases`; `manifest-adapter.ts` `parseLiteralInitializer` output flowing into `_meta`/`staticProperties` | **Fixed** |
| Low (info) | **`new Function()` literal eval** in `parseLiteralInitializer`. Documented, accepted build-time trade-off; needs to evaluate JS object/array literals (computed keys, spread, template literals) that AST extraction can't reproduce. Verified `new Function('return ({__proto__:...})')` does **not** create an own key or pollute global. Left in place (ripping it out risks regressing valid `@field({ default: fn() })` usage); its output is now prototype-sanitized. | `manifest-adapter.ts:178` | Hardened (output sanitized) |
| Low (info) | **Regexes** in `inferFromAnnotation`/`parseDefaultValue` are linear (no catastrophic backtracking); `getLineColumn` is O(offset) but bounded by file size. Build-time only. | `manifest-adapter.ts` | No action |
| — | **Path reads** (`readFileSync` on glob/CLI-arg paths) are developer-controlled build inputs; no traversal from untrusted input. | `oxc-parser.ts`, `cli.ts`, `verify-completeness.ts` | No action (trust boundary) |
| — | **Dependency audit.** No advisory traces through `@happyvertical/smrt-scanner`. Direct deps clean: `oxc-parser@0.108.0`, `oxc-resolver@11.19.0`, `fast-glob@3.3.3`, `minimatch@10.2.3` (fixed line; the brace-expansion ReDoS advisory traces only through `spider>crawlee` and `@fastify/otel`, not the scanner). | — | Clean |

### Changes
- New shared `FORBIDDEN_OBJECT_KEYS` guard (`__proto__`/`constructor`/`prototype`).
- `oxc-parser.ts`: `extractObjectLiteral` + `extractTypeAliases` (alias + enum names) skip forbidden keys; exported `isSafeObjectKey` for testing.
- `manifest-adapter.ts`: `parseLiteralInitializer` runs its result through a recursive `sanitizeParsed` so author-written `{ constructor: ... }` literals can't carry a gadget into emitted manifest `_meta`/`staticProperties`.
- Regression tests (`__tests__/prototype-pollution.test.ts`): **fail-before / pass-after** confirmed (6 vuln-demonstrating assertions fail on unpatched source).

### Verification
- `pnpm --filter @happyvertical/smrt-scanner test` → **144 passed** (136 baseline + 8 new)
- `typecheck` clean; `biome check packages/scanner` introduces **0** new issues (3 pre-existing warnings unchanged)
- `pnpm build` rerun before push

closes #1384