### PR TITLE
fix(users): lock RBAC/identity CRUD to read-only + fail-close tenant switch (S5 #1400)

### DIFF
--- a/packages/users/AGENTS.md
+++ b/packages/users/AGENTS.md
@@ -49,6 +49,33 @@ await destroySessionCookie(event, { db });
 await switchSessionTenant(event, tenantId, { db });
 ```
 
+## Security (S5 #1400)
+
+- **Generated REST/MCP surface is READ-ONLY for every RBAC/identity model.**
+  User, Tenant, Group, Membership, MembershipOverride, Role, Permission,
+  RolePermission, GroupRole, GroupMember, and TenantPermissionOverride generate
+  `list`/`get` only — `create`/`update`/`delete` are intentionally NOT
+  generated. The merged `requireRouteAuth` gate (#1540) enforces *authentication*,
+  not *authorization*, and these models are not `@TenantScoped`, so an
+  auto-generated mutating route would let any authenticated user self-grant a
+  role/permission, flip a tenant's cascade flags, or change another user's auth
+  identity. Mutate them through the permission-gated services (`TenantService`,
+  collection helpers) or consumer-owned, permission-checked handlers. A
+  structural regression test (`security-audit-1400.test.ts`) enumerates the
+  registry to assert no authority model exposes a mutating op. (`cli` stays
+  enabled — local-operator surface, outside the network/agent threat model.)
+- **`switchTenant` is fail-closed.** `SessionService.switchTenant` /
+  `switchSessionTenant` verify the session's user has an ACTIVE membership in the
+  target tenant before writing `session.tenantId` (the tenant-isolation key for
+  every `@TenantScoped` query). A non-member switch returns `false` without
+  mutating the session; `null` clears the context and is always allowed. The
+  low-level `SessionCollection.setSessionTenant` is the UNGUARDED primitive —
+  never call it with an untrusted tenant id.
+- **OIDC `email_verified` is enforced.** `UserCollection.getOrCreateFromOidc`
+  refuses to provision a user when the IdP explicitly returns
+  `email_verified: false` (opt out with `{ allowUnverifiedEmail: true }`). An
+  absent claim makes no assertion and is not enforced.
+
 ## Gotchas
 
 - **seedSystemRoles() required**: call `RoleCollection.seedSystemRoles()` at app init (creates owner/admin/member/viewer)

--- a/packages/users/src/__tests__/security-audit-1400.test.ts
+++ b/packages/users/src/__tests__/security-audit-1400.test.ts
@@ -1,0 +1,440 @@
+/**
+ * S5 security-audit regression tests (#1400).
+ *
+ * Covers the exploitable medium+ findings remediated for @happyvertical/smrt-users:
+ *  1. RBAC/identity generated CRUD lockdown — mutating an authority table over an
+ *     auth-only-gated generated route is privilege escalation. The generated
+ *     REST/MCP write surface must stay empty for every authority/identity model.
+ *  2. switchTenant membership verification — a session's tenantId is the
+ *     tenant-isolation key for every @TenantScoped query, so it must never be set
+ *     to a tenant the user is not an active member of (cross-tenant access).
+ *  3. deleteExpired atomicity — a session that is both expired AND revoked must
+ *     not be double-deleted (which could abort the cleanup job mid-run).
+ *  4. OIDC email_verified — refuse to provision a user from an email the IdP
+ *     explicitly reported unverified.
+ */
+
+import { existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+import {
+  createIsolatedTestDb,
+  type IsolatedTestDbResult,
+} from '@happyvertical/smrt-vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  generateSessionId,
+  MembershipCollection,
+  MembershipStatus,
+  RoleCollection,
+  SessionCollection,
+  SessionService,
+  SessionStatus,
+  TenantCollection,
+  UserCollection,
+} from '../index.js';
+
+// ---------------------------------------------------------------------------
+// 1. RBAC / identity generated CRUD lockdown (#1400)
+// ---------------------------------------------------------------------------
+
+const MUTATING_OPS = ['create', 'update', 'delete'] as const;
+const PACKAGE = '@happyvertical/smrt-users';
+
+/**
+ * Every model whose mutation is an authority change: granting a role/permission,
+ * adding a group/tenant override, flipping a tenant's cascade flags, or changing
+ * an auth identity. `requireRouteAuth` (the merged #1540 gate) only enforces
+ * authentication, not authorization, and none of these are `@TenantScoped`, so a
+ * generated create/update/delete would let any logged-in user escalate. The
+ * generated REST/MCP write surface must therefore be empty for all of them.
+ */
+const LOCKED_MODELS = [
+  'Membership',
+  'MembershipOverride',
+  'RolePermission',
+  'GroupRole',
+  'GroupMember',
+  'Role',
+  'Permission',
+  'TenantPermissionOverride',
+  'User',
+  'Tenant',
+  'Group',
+];
+
+type SurfaceConfig = {
+  api?: boolean | { include?: string[] };
+  mcp?: boolean | { include?: string[] };
+};
+
+/** Mirror how the REST/MCP generators read an `api`/`mcp` config value. */
+function surfaceFromConfig(config: SurfaceConfig): {
+  api: string[] | null;
+  mcp: string[] | null;
+} {
+  const toInclude = (
+    surface: boolean | { include?: string[] } | undefined,
+  ): string[] | null => {
+    if (surface === false || surface === undefined) return [];
+    if (surface === true) return null; // generates the full CRUD surface
+    return surface.include ?? null;
+  };
+  return { api: toInclude(config.api), mcp: toInclude(config.mcp) };
+}
+
+describe('RBAC/identity generated CRUD lockdown (#1400)', () => {
+  for (const modelName of LOCKED_MODELS) {
+    it(`${modelName} exposes no mutating REST/MCP operation`, () => {
+      const registered = ObjectRegistry.getClassInPackage(PACKAGE, modelName);
+      expect(registered, `${modelName} must be registered`).toBeTruthy();
+
+      const { api, mcp } = surfaceFromConfig(
+        (registered as { config: SurfaceConfig }).config,
+      );
+
+      // A `null` surface means `api: true` / `mcp: true` (full CRUD generated) —
+      // the dangerous default this finding is about. Authority tables must use an
+      // explicit read-only include list. (cli is intentionally not asserted: it
+      // is a local-operator surface, outside the network/agent threat model.)
+      for (const [name, surface] of [
+        ['api', api],
+        ['mcp', mcp],
+      ] as const) {
+        expect(
+          surface,
+          `${modelName}.${name} must be an explicit include list, not full CRUD`,
+        ).not.toBeNull();
+        for (const op of MUTATING_OPS) {
+          expect(
+            surface,
+            `${modelName}.${name} must not generate "${op}"`,
+          ).not.toContain(op);
+        }
+      }
+    });
+  }
+
+  it('still exposes read operations for admin UIs', () => {
+    const membership = ObjectRegistry.getClassInPackage(PACKAGE, 'Membership');
+    const { api } = surfaceFromConfig(
+      (membership as { config: SurfaceConfig }).config,
+    );
+    expect(api).toEqual(['list', 'get']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. switchTenant membership verification (#1400)
+// ---------------------------------------------------------------------------
+
+describe('switchTenant membership verification (#1400)', () => {
+  let dbPath: string;
+  let users: UserCollection;
+  let tenants: TenantCollection;
+  let roles: RoleCollection;
+  let memberships: MembershipCollection;
+  let sessions: SessionCollection;
+  let sessionService: SessionService;
+
+  beforeEach(async () => {
+    dbPath = join(tmpdir(), `smrt-1400-switch-${Date.now()}.db`);
+    const options = { db: { type: 'sqlite' as const, url: dbPath } };
+    users = await UserCollection.create(options);
+    tenants = await TenantCollection.create(options);
+    roles = await RoleCollection.create(options);
+    memberships = await MembershipCollection.create(options);
+    sessions = await SessionCollection.create(options);
+    sessionService = await SessionService.create(options);
+  });
+
+  afterEach(() => {
+    if (existsSync(dbPath)) {
+      try {
+        rmSync(dbPath, { force: true });
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+  });
+
+  async function seed(membershipStatus: MembershipStatus) {
+    const user = await users.create({ email: `u-${Date.now()}@example.com` });
+    await user.save();
+    const home = await tenants.create({ name: 'Home Org' });
+    await home.save();
+    const foreign = await tenants.create({ name: 'Foreign Org' });
+    await foreign.save();
+    const role = await roles.create({ name: 'Member' });
+    await role.save();
+    const membership = await memberships.create({
+      userId: user.id!,
+      tenantId: home.id!,
+      roleId: role.id!,
+      status: membershipStatus,
+    });
+    await membership.save();
+    const sessionId = await sessionService.createSession(user.id!);
+    return { user, home, foreign, sessionId };
+  }
+
+  it('switches into a tenant the user is an active member of', async () => {
+    const { home, sessionId } = await seed(MembershipStatus.ACTIVE);
+
+    const switched = await sessionService.switchTenant(sessionId, home.id!);
+
+    expect(switched).toBe(true);
+    const session = await sessions.findValidSession(sessionId);
+    expect(session?.tenantId).toBe(home.id);
+  });
+
+  it('refuses to switch into a tenant the user is not a member of', async () => {
+    const { foreign, sessionId } = await seed(MembershipStatus.ACTIVE);
+
+    const switched = await sessionService.switchTenant(sessionId, foreign.id!);
+
+    expect(switched).toBe(false);
+    // The session must NOT be tainted with the foreign tenant id.
+    const session = await sessions.findValidSession(sessionId);
+    expect(session?.tenantId).toBeNull();
+  });
+
+  it('refuses to switch when the membership is not active', async () => {
+    const { home, sessionId } = await seed(MembershipStatus.INACTIVE);
+
+    const switched = await sessionService.switchTenant(sessionId, home.id!);
+
+    expect(switched).toBe(false);
+    const session = await sessions.findValidSession(sessionId);
+    expect(session?.tenantId).toBeNull();
+  });
+
+  it('always allows clearing the tenant context (null)', async () => {
+    const { home, sessionId } = await seed(MembershipStatus.ACTIVE);
+    expect(await sessionService.switchTenant(sessionId, home.id!)).toBe(true);
+
+    const cleared = await sessionService.switchTenant(sessionId, null);
+
+    expect(cleared).toBe(true);
+    const session = await sessions.findValidSession(sessionId);
+    expect(session?.tenantId).toBeNull();
+  });
+
+  it('returns false for an unknown session', async () => {
+    const { home } = await seed(MembershipStatus.ACTIVE);
+    expect(await sessionService.switchTenant('not-a-session', home.id!)).toBe(
+      false,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. deleteExpired atomicity (#1400)
+// ---------------------------------------------------------------------------
+
+describe('deleteExpired atomic cleanup (#1400)', () => {
+  let dbPath: string;
+  let users: UserCollection;
+  let sessions: SessionCollection;
+
+  beforeEach(async () => {
+    dbPath = join(tmpdir(), `smrt-1400-cleanup-${Date.now()}.db`);
+    const options = { db: { type: 'sqlite' as const, url: dbPath } };
+    users = await UserCollection.create(options);
+    sessions = await SessionCollection.create(options);
+  });
+
+  afterEach(() => {
+    if (existsSync(dbPath)) {
+      try {
+        rmSync(dbPath, { force: true });
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+  });
+
+  it('reaps expired and revoked sessions in one pass, even a both-expired-and-revoked row', async () => {
+    const user = await users.create({ email: 'cleanup@example.com' });
+    await user.save();
+
+    const past = new Date(Date.now() - 60_000);
+    const future = new Date(Date.now() + 60_000);
+
+    // Expired (still marked active).
+    const expired = await sessions.create({
+      id: generateSessionId(),
+      userId: user.id!,
+      status: SessionStatus.ACTIVE,
+      expiresAt: past,
+    });
+    await expired.save();
+
+    // Revoked but not yet past its TTL.
+    const revoked = await sessions.create({
+      id: generateSessionId(),
+      userId: user.id!,
+      status: SessionStatus.REVOKED,
+      expiresAt: future,
+    });
+    await revoked.save();
+
+    // BOTH expired and revoked — the row the old two-pass cleanup deleted twice.
+    const both = await sessions.create({
+      id: generateSessionId(),
+      userId: user.id!,
+      status: SessionStatus.REVOKED,
+      expiresAt: past,
+    });
+    await both.save();
+
+    // A live session that must survive.
+    const valid = await sessions.createSession({ userId: user.id! });
+
+    const deleted = await sessions.deleteExpired();
+
+    // Each matching row removed exactly once — no double count, no throw.
+    expect(deleted).toBe(3);
+    expect(await sessions.get(expired.id!)).toBeNull();
+    expect(await sessions.get(revoked.id!)).toBeNull();
+    expect(await sessions.get(both.id!)).toBeNull();
+    expect(await sessions.findValidSession(valid.id!)).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. OIDC email_verified enforcement (#1400)
+// ---------------------------------------------------------------------------
+
+const PROFILE_SCHEMA = `
+CREATE TABLE IF NOT EXISTS "profile_types" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "slug" TEXT NOT NULL,
+  "context" TEXT NOT NULL DEFAULT '',
+  "_meta_type" TEXT NOT NULL,
+  "_meta_data" JSON,
+  "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "tenant_id" TEXT,
+  "name" TEXT DEFAULT '',
+  "description" TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "profile_types_slug_context_meta_type_idx" ON "profile_types" ("slug", "context", "_meta_type");
+
+CREATE TABLE IF NOT EXISTS "profiles" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "slug" TEXT NOT NULL,
+  "context" TEXT NOT NULL DEFAULT '',
+  "_meta_type" TEXT NOT NULL,
+  "_meta_data" JSON,
+  "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "tenant_id" TEXT,
+  "type_id" TEXT,
+  "email" TEXT,
+  "name" TEXT DEFAULT '',
+  "description" TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "profiles_slug_context_meta_type_idx" ON "profiles" ("slug", "context", "_meta_type");
+
+CREATE TABLE IF NOT EXISTS "oidc_identities" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "slug" TEXT NOT NULL,
+  "context" TEXT NOT NULL DEFAULT '',
+  "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "profile_id" TEXT,
+  "provider" TEXT DEFAULT '',
+  "issuer" TEXT DEFAULT '',
+  "subject" TEXT DEFAULT '',
+  "email" TEXT DEFAULT '',
+  "last_used_at" TIMESTAMP
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "oidc_identities_slug_context_idx" ON "oidc_identities" ("slug", "context");
+
+CREATE TABLE IF NOT EXISTS "users" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "slug" TEXT NOT NULL,
+  "context" TEXT NOT NULL DEFAULT '',
+  "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "profile_id" TEXT DEFAULT '',
+  "email" TEXT DEFAULT '',
+  "status" TEXT,
+  "last_login_at" TIMESTAMP
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "users_slug_context_idx" ON "users" ("slug", "context");
+`;
+
+describe('OIDC email_verified enforcement (#1400)', () => {
+  let isolated: IsolatedTestDbResult;
+  let users: UserCollection;
+
+  beforeEach(async () => {
+    isolated = await createIsolatedTestDb({ schema: PROFILE_SCHEMA });
+    users = await UserCollection.create({ db: isolated.db });
+  });
+
+  afterEach(async () => {
+    await isolated.cleanup();
+  });
+
+  const baseClaims = {
+    iss: 'https://idp.example.com',
+    name: 'Test User',
+  };
+
+  it('refuses to provision a user when the IdP reports email_verified: false', async () => {
+    await expect(
+      users.getOrCreateFromOidc(
+        {
+          ...baseClaims,
+          sub: 'sub-unverified',
+          email: 'unverified@example.com',
+          email_verified: false,
+        },
+        'test',
+      ),
+    ).rejects.toThrow(/unverified/i);
+  });
+
+  it('provisions a user when email_verified: true', async () => {
+    const result = await users.getOrCreateFromOidc(
+      {
+        ...baseClaims,
+        sub: 'sub-verified',
+        email: 'verified@example.com',
+        email_verified: true,
+      },
+      'test',
+    );
+    expect(result.user.email).toBe('verified@example.com');
+  });
+
+  it('provisions a user when the email_verified claim is absent (cannot enforce)', async () => {
+    const result = await users.getOrCreateFromOidc(
+      {
+        ...baseClaims,
+        sub: 'sub-absent',
+        email: 'absent@example.com',
+      },
+      'test',
+    );
+    expect(result.user.email).toBe('absent@example.com');
+  });
+
+  it('provisions an unverified email only with the explicit allowUnverifiedEmail opt-out', async () => {
+    const result = await users.getOrCreateFromOidc(
+      {
+        ...baseClaims,
+        sub: 'sub-optout',
+        email: 'optout@example.com',
+        email_verified: false,
+      },
+      'test',
+      { allowUnverifiedEmail: true },
+    );
+    expect(result.user.email).toBe('optout@example.com');
+  });
+});

--- a/packages/users/src/__tests__/security-audit-1400.test.ts
+++ b/packages/users/src/__tests__/security-audit-1400.test.ts
@@ -77,8 +77,13 @@ function surfaceFromConfig(config: SurfaceConfig): {
   const toInclude = (
     surface: boolean | { include?: string[] } | undefined,
   ): string[] | null => {
-    if (surface === false || surface === undefined) return [];
-    if (surface === true) return null; // generates the full CRUD surface
+    // `false` disables the surface (closed). An OMITTED config (undefined) does
+    // NOT mean closed: the REST + MCP generators emit the FULL CRUD surface by
+    // default (sveltekit-generator `resolveStandardCrudActions`, mcp.ts
+    // `shouldInclude`), exactly like `true`. Model both as `null` so the
+    // assertion rejects them — an authority model must use an explicit list.
+    if (surface === false) return [];
+    if (surface === true || surface === undefined) return null;
     return surface.include ?? null;
   };
   return { api: toInclude(config.api), mcp: toInclude(config.mcp) };

--- a/packages/users/src/__tests__/session.test.ts
+++ b/packages/users/src/__tests__/session.test.ts
@@ -520,6 +520,18 @@ describe('SessionService', () => {
     const tenant2 = await tenants.create({ name: 'Org 2' });
     await tenant2.save();
 
+    // #1400: switchTenant fail-closes on missing membership, so the user must
+    // be an active member of the tenant they switch into.
+    const role = await roles.create({ name: 'Member' });
+    await role.save();
+    await (
+      await memberships.create({
+        userId: user.id!,
+        tenantId: tenant2.id!,
+        roleId: role.id!,
+      })
+    ).save();
+
     const sessionService = await SessionService.create({
       db: { type: 'sqlite', url: dbPath },
     });
@@ -531,7 +543,8 @@ describe('SessionService', () => {
     expect(context?.tenantId).toBe(tenant1.id);
 
     // Switch tenant
-    await sessionService.switchTenant(sessionId, tenant2.id!);
+    const switched = await sessionService.switchTenant(sessionId, tenant2.id!);
+    expect(switched).toBe(true);
 
     // Check new tenant
     context = await sessionService.loadSessionContext(sessionId);

--- a/packages/users/src/collections/SessionCollection.ts
+++ b/packages/users/src/collections/SessionCollection.ts
@@ -169,33 +169,20 @@ export class SessionCollection extends SmrtCollection<Session> {
    * Returns the number of deleted sessions
    */
   async deleteExpired(): Promise<number> {
-    // Get all expired or revoked sessions
-    const now = new Date();
-    const sessions = await this.list({
-      where: {
-        'expiresAt <': now.toISOString(),
-      },
-    });
+    // #1400: a single atomic DELETE. The previous two-pass version listed
+    // expired-by-time and revoked sessions separately, so a session that was
+    // both got delete()'d twice — the second delete could throw and abort the
+    // cleanup job mid-run, leaving expired sessions un-reaped. One statement
+    // also avoids hydrating every row just to delete it.
+    const now = new Date().toISOString();
+    const { rowCount } = await this.db.query(
+      `DELETE FROM ${this.tableName}
+       WHERE expires_at < ? OR status = ?`,
+      now,
+      SessionStatus.REVOKED,
+    );
 
-    let count = 0;
-    for (const session of sessions) {
-      await session.delete();
-      count++;
-    }
-
-    // Also delete revoked sessions that are old
-    const revokedSessions = await this.list({
-      where: {
-        status: SessionStatus.REVOKED,
-      },
-    });
-
-    for (const session of revokedSessions) {
-      await session.delete();
-      count++;
-    }
-
-    return count;
+    return rowCount ?? 0;
   }
 
   /**
@@ -207,7 +194,13 @@ export class SessionCollection extends SmrtCollection<Session> {
   }
 
   /**
-   * Update tenant context for a session
+   * Update tenant context for a session (low-level primitive).
+   *
+   * SECURITY (#1400): this does NOT verify that the session's user is a member
+   * of `tenantId` — it is the unguarded storage primitive. Application/route
+   * code must go through {@link SessionService.switchTenant}, which fail-closes
+   * on a missing/inactive membership before calling this. Calling it directly
+   * with an untrusted `tenantId` reintroduces the cross-tenant access bug.
    */
   async setSessionTenant(
     sessionId: string,

--- a/packages/users/src/collections/UserCollection.ts
+++ b/packages/users/src/collections/UserCollection.ts
@@ -46,6 +46,14 @@ export interface OidcIdentityResult {
 export interface GetOrCreateFromOidcOptions {
   /** If false, skip recording login timestamp (default: true) */
   recordLogin?: boolean;
+  /**
+   * Provision a user even when the IdP explicitly reported the email as
+   * unverified (`email_verified: false`). Default false (#1400): refuse to
+   * create/resolve a user from a known-unverified address. Has no effect when
+   * the claim is absent — an IdP that omits `email_verified` makes no
+   * assertion, so it cannot be enforced.
+   */
+  allowUnverifiedEmail?: boolean;
 }
 
 /**
@@ -173,6 +181,16 @@ export class UserCollection extends SmrtCollection<User> {
     if (!claims.email) {
       throw new Error(
         'OIDC claims missing required "email" for user creation.',
+      );
+    }
+
+    // #1400: refuse an email the IdP explicitly marked unverified. Only an
+    // explicit `email_verified === false` hard-fails; an absent claim makes no
+    // assertion and cannot be enforced. Opt out with allowUnverifiedEmail.
+    const allowUnverified = options?.allowUnverifiedEmail === true;
+    if (claims.email_verified === false && !allowUnverified) {
+      throw new Error(
+        'OIDC claims report an unverified email; refusing to provision a user.',
       );
     }
 

--- a/packages/users/src/models/Group.ts
+++ b/packages/users/src/models/Group.ts
@@ -23,7 +23,9 @@ import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
  * ```
  */
 @smrt({
-  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  // #1400: read-only generated surface — RBAC/identity writes go through
+  // permission-gated services, not auth-only generated CRUD.
+  api: { include: ['list', 'get'] },
   mcp: { include: ['list', 'get'] },
   cli: true,
 })

--- a/packages/users/src/models/GroupMember.ts
+++ b/packages/users/src/models/GroupMember.ts
@@ -22,9 +22,11 @@ import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
  * ```
  */
 @smrt({
-  // #1400: read-only generated surface — RBAC/identity writes go through
-  // permission-gated services, not auth-only generated CRUD.
+  // #1400: read-only generated REST + MCP surface — RBAC/identity writes go
+  // through permission-gated services, not auth-only generated CRUD. mcp must
+  // be explicit: an omitted mcp config generates the FULL tool surface.
   api: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
   cli: true,
 })
 export class GroupMember extends SmrtObject {

--- a/packages/users/src/models/GroupMember.ts
+++ b/packages/users/src/models/GroupMember.ts
@@ -22,7 +22,9 @@ import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
  * ```
  */
 @smrt({
-  api: { include: ['list', 'get', 'create', 'delete'] },
+  // #1400: read-only generated surface — RBAC/identity writes go through
+  // permission-gated services, not auth-only generated CRUD.
+  api: { include: ['list', 'get'] },
   cli: true,
 })
 export class GroupMember extends SmrtObject {

--- a/packages/users/src/models/GroupRole.ts
+++ b/packages/users/src/models/GroupRole.ts
@@ -22,7 +22,9 @@ import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
  * ```
  */
 @smrt({
-  api: { include: ['list', 'get', 'create', 'delete'] },
+  // #1400: read-only generated surface — RBAC/identity writes go through
+  // permission-gated services, not auth-only generated CRUD.
+  api: { include: ['list', 'get'] },
   cli: true,
 })
 export class GroupRole extends SmrtObject {

--- a/packages/users/src/models/GroupRole.ts
+++ b/packages/users/src/models/GroupRole.ts
@@ -22,9 +22,11 @@ import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
  * ```
  */
 @smrt({
-  // #1400: read-only generated surface — RBAC/identity writes go through
-  // permission-gated services, not auth-only generated CRUD.
+  // #1400: read-only generated REST + MCP surface — RBAC/identity writes go
+  // through permission-gated services, not auth-only generated CRUD. mcp must
+  // be explicit: an omitted mcp config generates the FULL tool surface.
   api: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
   cli: true,
 })
 export class GroupRole extends SmrtObject {

--- a/packages/users/src/models/Membership.ts
+++ b/packages/users/src/models/Membership.ts
@@ -24,7 +24,10 @@ import { MembershipStatus } from '../types/index.js';
  * ```
  */
 @smrt({
-  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  // #1400: read-only generated surface — RBAC/identity writes go through
+  // permission-gated services, not auth-only generated CRUD (requireRouteAuth
+  // is authentication-only, so a generated POST/PUT here is privilege escalation).
+  api: { include: ['list', 'get'] },
   mcp: { include: ['list', 'get'] },
   cli: true,
 })

--- a/packages/users/src/models/MembershipOverride.ts
+++ b/packages/users/src/models/MembershipOverride.ts
@@ -31,7 +31,9 @@ import { OverrideEffect } from '../types/index.js';
  * ```
  */
 @smrt({
-  api: { include: ['list', 'get', 'create', 'delete'] },
+  // #1400: read-only generated surface — RBAC/identity writes go through
+  // permission-gated services, not auth-only generated CRUD.
+  api: { include: ['list', 'get'] },
   cli: true,
 })
 export class MembershipOverride extends SmrtObject {

--- a/packages/users/src/models/MembershipOverride.ts
+++ b/packages/users/src/models/MembershipOverride.ts
@@ -31,9 +31,11 @@ import { OverrideEffect } from '../types/index.js';
  * ```
  */
 @smrt({
-  // #1400: read-only generated surface — RBAC/identity writes go through
-  // permission-gated services, not auth-only generated CRUD.
+  // #1400: read-only generated REST + MCP surface — RBAC/identity writes go
+  // through permission-gated services, not auth-only generated CRUD. mcp must
+  // be explicit: an omitted mcp config generates the FULL tool surface.
   api: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
   cli: true,
 })
 export class MembershipOverride extends SmrtObject {

--- a/packages/users/src/models/Permission.ts
+++ b/packages/users/src/models/Permission.ts
@@ -68,7 +68,9 @@ export function isValidPermissionSlug(slug: string): boolean {
  * ```
  */
 @smrt({
-  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  // #1400: read-only generated surface — RBAC/identity writes go through
+  // permission-gated services, not auth-only generated CRUD.
+  api: { include: ['list', 'get'] },
   mcp: { include: ['list', 'get'] },
   cli: true,
 })

--- a/packages/users/src/models/Role.ts
+++ b/packages/users/src/models/Role.ts
@@ -31,7 +31,9 @@ import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
  * ```
  */
 @smrt({
-  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  // #1400: read-only generated surface — RBAC/identity writes go through
+  // permission-gated services, not auth-only generated CRUD.
+  api: { include: ['list', 'get'] },
   mcp: { include: ['list', 'get'] },
   cli: true,
 })

--- a/packages/users/src/models/RolePermission.ts
+++ b/packages/users/src/models/RolePermission.ts
@@ -22,9 +22,11 @@ import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
  * ```
  */
 @smrt({
-  // #1400: read-only generated surface — RBAC/identity writes go through
-  // permission-gated services, not auth-only generated CRUD.
+  // #1400: read-only generated REST + MCP surface — RBAC/identity writes go
+  // through permission-gated services, not auth-only generated CRUD. mcp must
+  // be explicit: an omitted mcp config generates the FULL tool surface.
   api: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
   cli: true,
 })
 export class RolePermission extends SmrtObject {

--- a/packages/users/src/models/RolePermission.ts
+++ b/packages/users/src/models/RolePermission.ts
@@ -22,7 +22,9 @@ import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
  * ```
  */
 @smrt({
-  api: { include: ['list', 'get', 'create', 'delete'] },
+  // #1400: read-only generated surface — RBAC/identity writes go through
+  // permission-gated services, not auth-only generated CRUD.
+  api: { include: ['list', 'get'] },
   cli: true,
 })
 export class RolePermission extends SmrtObject {

--- a/packages/users/src/models/Tenant.ts
+++ b/packages/users/src/models/Tenant.ts
@@ -63,7 +63,10 @@ export const MAX_TENANT_HIERARCHY_DEPTH = 10;
  */
 @smrt({
   tableStrategy: 'sti',
-  api: { include: ['list', 'get', 'create', 'update'] },
+  // #1400: read-only generated surface — tenant create/update (incl. the
+  // cascadePermissions/inheritPermissions flags that drive the permission
+  // cascade) goes through TenantService, not auth-only generated CRUD.
+  api: { include: ['list', 'get'] },
   mcp: { include: ['list', 'get'] },
   cli: true,
 })

--- a/packages/users/src/models/TenantPermissionOverride.ts
+++ b/packages/users/src/models/TenantPermissionOverride.ts
@@ -47,9 +47,11 @@ import { TenantPermissionEffect } from '../types/index.js';
  * ```
  */
 @smrt({
-  // #1400: read-only generated surface — RBAC/identity writes go through
-  // permission-gated services, not auth-only generated CRUD.
+  // #1400: read-only generated REST + MCP surface — RBAC/identity writes go
+  // through permission-gated services, not auth-only generated CRUD. mcp must
+  // be explicit: an omitted mcp config generates the FULL tool surface.
   api: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
   cli: true,
 })
 export class TenantPermissionOverride extends SmrtObject {

--- a/packages/users/src/models/TenantPermissionOverride.ts
+++ b/packages/users/src/models/TenantPermissionOverride.ts
@@ -47,7 +47,9 @@ import { TenantPermissionEffect } from '../types/index.js';
  * ```
  */
 @smrt({
-  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  // #1400: read-only generated surface — RBAC/identity writes go through
+  // permission-gated services, not auth-only generated CRUD.
+  api: { include: ['list', 'get'] },
   cli: true,
 })
 export class TenantPermissionOverride extends SmrtObject {

--- a/packages/users/src/models/User.ts
+++ b/packages/users/src/models/User.ts
@@ -54,7 +54,9 @@ export function normalizeEmail(email: string): string {
  * ```
  */
 @smrt({
-  api: { include: ['list', 'get', 'create', 'update'] },
+  // #1400: read-only generated surface — User is auth identity (email/status/
+  // profileId), provisioned via OIDC/magic-link, not arbitrary authed POST/PUT.
+  api: { include: ['list', 'get'] },
   mcp: { include: ['list', 'get'] },
   cli: true,
 })

--- a/packages/users/src/services/SessionService.ts
+++ b/packages/users/src/services/SessionService.ts
@@ -4,6 +4,7 @@
  */
 
 import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+import { MembershipCollection } from '../collections/MembershipCollection.js';
 import {
   type CreateSessionOptions,
   SessionCollection,
@@ -70,6 +71,7 @@ export class SessionService {
   private options: SessionServiceOptions;
   private sessionCollection!: SessionCollection;
   private userCollection!: UserCollection;
+  private membershipCollection!: MembershipCollection;
   private permissionResolver!: PermissionResolver;
   private defaultTTL: number;
   private autoExtend: boolean;
@@ -88,6 +90,9 @@ export class SessionService {
       this.options,
     );
     this.userCollection = await (UserCollection as any).create(this.options);
+    this.membershipCollection = await (MembershipCollection as any).create(
+      this.options,
+    );
     this.permissionResolver = await PermissionResolver.create(this.options);
   }
 
@@ -185,12 +190,33 @@ export class SessionService {
   }
 
   /**
-   * Switch tenant context for a session
+   * Switch tenant context for a session.
+   *
+   * A session's `tenantId` is the tenant-isolation key for every `@TenantScoped`
+   * query, so it must never be set to a tenant the session's user is not an
+   * active member of — otherwise a caller could read/write another tenant's data
+   * by feeding an arbitrary id here (e.g. straight from untrusted form data).
+   * Fail-closed (#1400): returns `false` without switching when the session is
+   * unknown or the user has no active membership in the target tenant. Passing
+   * `null` clears the tenant context and is always allowed.
    */
   async switchTenant(
     sessionId: string,
     tenantId: string | null,
   ): Promise<boolean> {
+    const session = await this.sessionCollection.findValidSession(sessionId);
+    if (!session) return false;
+
+    if (tenantId !== null) {
+      const membership = await this.membershipCollection.findByUserAndTenant(
+        session.userId,
+        tenantId,
+      );
+      if (!membership || !membership.isActive()) {
+        return false;
+      }
+    }
+
     return this.sessionCollection.setSessionTenant(sessionId, tenantId);
   }
 

--- a/packages/users/src/sveltekit/index.ts
+++ b/packages/users/src/sveltekit/index.ts
@@ -440,19 +440,28 @@ export async function destroySessionCookie(
 /**
  * Helper to switch tenant context for the current session.
  *
+ * Returns `false` without switching when there is no session, or — fail-closed
+ * (#1400) — when the session's user is not an active member of `tenantId`. The
+ * target tenant id is therefore safe to take straight from untrusted form data,
+ * but callers MUST honour the boolean result rather than assuming success.
+ *
  * @example
  * ```typescript
  * // +page.server.ts
  * import { switchSessionTenant } from '@happyvertical/smrt-users/sveltekit';
+ * import { fail } from '@sveltejs/kit';
  *
  * export const actions = {
  *   switchTenant: async (event) => {
  *     const data = await event.request.formData();
  *     const tenantId = data.get('tenantId') as string;
  *
- *     await switchSessionTenant(event, tenantId, {
+ *     const switched = await switchSessionTenant(event, tenantId, {
  *       db: { type: 'sqlite', url: 'app.db' }
  *     });
+ *     if (!switched) {
+ *       return fail(403, { error: 'Not a member of that tenant.' });
+ *     }
  *
  *     return { success: true };
  *   }


### PR DESCRIPTION
## Security audit + remediation: `@happyvertical/smrt-users` (T2)

Closes #1400. Last item of the S5 per-package audit batch (epic #1354).

**Posture:** strong hand-written security cores (PermissionResolver cascade, OIDC PKCE/state/nonce, MagicLink atomic single-use, TerminalAuth hashed device codes), but two **exploitable HIGH** gaps at the exposure/tenant boundary that the merged framework fixes (#1540) do **not** close, plus two cheap MEDIUM fixes. All four are remediated here with failing‑before/passing‑after regression tests.

### Why #1540 wasn't enough
I read the merged `requireRouteAuth` ([sveltekit-generator.ts:293](https://github.com/happyvertical/smrt/blob/main/packages/core/src/vite-plugin/sveltekit-generator.ts#L293)): it gates on **authentication only, never authorization**. Combined with (a) no users RBAC model being `@TenantScoped` (so `establishTenantContext` never runs for them) and (b) the mass-assignment guard stripping `tenantId` but **not** `roleId`/`permissionId`/`userId`, the privilege escalation was still fully live for any authenticated user.

### Findings & remediation

| # | Sev | Exploit (verified) | Fix |
|---|-----|--------------------|-----|
| 1 | **HIGH**¹ | Any authed user mutates authority tables via generated routes: `PUT /api/memberships/:id {roleId: ownerRoleId}` (viewer→owner), `POST /api/membershipoverrides`, `POST /api/rolepermissions`. | Lock generated REST/MCP surface to read-only (`list`/`get`) on all 11 RBAC/identity models; mutate via gated services. Structural registry regression test. |
| 2 | **HIGH** | `switchSessionTenant` writes an untrusted `tenantId` (straight from form data) onto the session with no membership check → `locals.tenantId` becomes the isolation key for every `@TenantScoped` query → cross-tenant read/write. | `SessionService.switchTenant` fail-closes on missing/inactive membership; `null` (clear) still allowed. |
| 3 | **MED** | `deleteExpired` double-deletes a both-expired-and-revoked row → second `delete()` can throw and abort the cleanup job. | Single atomic `DELETE … WHERE expires_at < ? OR status = ?`. |
| 4 | **MED** | `getOrCreateFromOidc` accepts an email the IdP explicitly reported `email_verified: false`. | Reject explicit-false (opt out with `allowUnverifiedEmail`). |

¹ codex's second-auditor pass elevated #1 to CRITICAL (trivial with open signup).

### Locked-down models (read-only generated REST/MCP surface)
`User`, `Tenant`, `Group`, `Membership`, `MembershipOverride`, `Role`, `Permission`, `RolePermission`, `GroupRole`, `GroupMember`, `TenantPermissionOverride`. Mirrors the chat read-only-surface lockdown (#1392). `cli` stays enabled (local-operator surface, outside the network/agent threat model). **Behavior change for consumers:** mutate these through `TenantService`/collection helpers or consumer-owned permission-gated handlers, not generated CRUD.

### Tenant-isolation checklist
- ✅ `switchTenant` now verifies active membership before binding a tenant to a session (was the one fail-open hole).
- ✅ `getGroupIdsForTenant` joins `groups` to scope group membership by tenant (`getGroupIds` is `@deprecated`, cross-tenant).
- ✅ Permission cascade is tenant-hierarchy-scoped; dangling ids drop (fail-closed).
- ✅ `loadRelated`/`loadRelatedMany` tenant enforcement is framework-level (not reached around here).
- ⚠️ Read surface (`list`/`get`) on the RBAC models is not yet `@TenantScoped`, so cross-tenant **reads** remain possible via generated routes — noted as residual (making them `@TenantScoped` would also constrain the resolver's own cross-hierarchy queries, so it's deliberately out of scope here).

### AuthZ coverage — generated surfaces (after)
- **Write surface:** empty for all 11 RBAC/identity models (was the escalation vector). Asserted structurally in `security-audit-1400.test.ts`.
- **Secret fields:** `MagicLinkToken`/`CliAuthRequest` already `api:[] mcp:[]` (closed); `Session` is `get`/`delete` only (ids are unguessable UUIDs, not enumerable). No passwords stored (auth is OIDC/magic-link/device-code).
- **Read surface:** `list`/`get` retained for admin UIs.

### Dependency audit
Single external runtime dep `jose@^6.1.3` — current, no advisories, used correctly (audience/issuer/clockTolerance/azp + nonce; `timingSafeEqual` for HMAC). All else workspace-internal. **No known-vuln runtime deps in this package.**

### Noted (LOW / accepted / cross-cutting) — not remediated here
- **LOW** session: no rotation on tenant-switch / no IP-UA binding (fixation is already mitigated — login mints a fresh id).
- **LOW** terminal user codes 32-bit + in-memory throttle (already mitigated by the per-user lockout; multi-instance store recommended).
- **LOW** `getGroupIdsForTenant` hardcodes the `groups` table name (parameterized → not injectable; fails closed under a custom `tableName`).
- **LOW** OIDC transaction cookie HMAC optional (state+nonce still validated server-side → no forgery).
- **MED (cross-cutting)** Svelte floor `<5.54.0` (mXSS GHSA-c27g-q93r-2cwf) — repo-wide lockfile/version-locked group; belongs in the deps PR, out of scope for this package.

### Tests
`pnpm --filter @happyvertical/smrt-users test` → **214 passed, 4 skipped** (`.optional` external-API tests). New `security-audit-1400.test.ts` covers all four findings; existing switch-tenant test updated to seed the now-required membership. `tsc --noEmit` clean; `biome check packages/users` clean (0 errors; pre-existing `noNonNullAssertion` test-style warnings only); strict knowledge-check fresh.
