### PR TITLE
fix(content): close XSS sanitizer bypass + SSRF/path-traversal in fetch paths (S5 #1388)

### DIFF
--- a/packages/content/src/body-format.test.ts
+++ b/packages/content/src/body-format.test.ts
@@ -46,6 +46,48 @@ describe('content body format utilities', () => {
     expect(html).not.toMatch(/javascript/i);
   });
 
+  it('strips event handlers glued to a preceding quote (S5 #1388)', () => {
+    // The HTML5 tree builder begins a new attribute right after the closing
+    // quote of the previous value, with no whitespace required. A sanitizer
+    // that only treats whitespace/slash as an attribute boundary leaves
+    // `src="x"onerror="..."` intact and the browser executes it.
+    const doubleQuoted = sanitizeHtml('<img src="x"onerror="alert(1)">');
+    expect(doubleQuoted).not.toMatch(/onerror/i);
+    expect(doubleQuoted).toContain('src="x"');
+
+    const singleQuoted = sanitizeHtml("<img src='x'onerror='alert(1)'>");
+    expect(singleQuoted).not.toMatch(/onerror/i);
+
+    const unquotedHandler = sanitizeHtml('<img src="x"onerror=alert(1)>');
+    expect(unquotedHandler).not.toMatch(/onerror/i);
+
+    const anchor = sanitizeHtml('<a href="x"onmouseover="alert(1)">y</a>');
+    expect(anchor).not.toMatch(/onmouseover/i);
+  });
+
+  it('neutralizes URL/style attributes glued to a preceding quote (S5 #1388)', () => {
+    const href = sanitizeHtml('<a title="x"href="javascript:alert(1)">y</a>');
+    expect(href).not.toMatch(/javascript/i);
+    expect(href).toContain('href="#"');
+
+    const src = sanitizeHtml('<img alt="x"src="javascript:alert(1)">');
+    expect(src).not.toMatch(/javascript/i);
+    expect(src).toContain('src="#"');
+
+    const formaction = sanitizeHtml(
+      '<button title="x"formaction="javascript:alert(1)">go</button>',
+    );
+    expect(formaction).not.toMatch(/javascript/i);
+
+    const srcset = sanitizeHtml('<img alt="x"srcset="javascript:alert(1) 1x">');
+    expect(srcset).not.toMatch(/javascript/i);
+
+    const style = sanitizeHtml(
+      '<div title="x"style="width:expression(alert(1))">z</div>',
+    );
+    expect(style).not.toMatch(/expression/i);
+  });
+
   it('sanitizes URL-bearing attributes with encoded protocols', () => {
     const html = sanitizeHtml(
       '<svg><a xlink:href="java&#x73;cript&#x3A;alert(1)">click</a></svg><form action="javascript:alert(2)"><button formaction="java&#115;cript:alert(3)">Go</button></form><video poster="javascript:alert(4)"></video><img srcset="javascript:alert(5) 1x, https://example.com/safe.jpg 2x" src="https://example.com/fallback.jpg">',

--- a/packages/content/src/body-format.ts
+++ b/packages/content/src/body-format.ts
@@ -20,10 +20,34 @@ export const DEFAULT_CONTENT_BODY_FORMAT: ContentBodyFormat = 'html';
 
 const HTML_TAG_PATTERN =
   /<\/?(?:article|aside|blockquote|br|div|figure|figcaption|h[1-6]|hr|img|li|ol|p|pre|section|span|strong|em|b|i|u|a|ul|table|tbody|td|th|thead|tr)(?:\s[^>]*)?>/i;
-const URL_ATTRIBUTE_PATTERN =
-  /\s+(href|src|xlink:href|formaction|action|poster)\s*=\s*("([^"]*)"|'([^']*)'|([^\s>]+))/gi;
-const SRCSET_ATTRIBUTE_PATTERN =
-  /\s+srcset\s*=\s*("([^"]*)"|'([^']*)'|([^\s>]+))/gi;
+// HTML attribute boundary: the HTML5 tree builder starts a new attribute after
+// whitespace, `/`, OR the closing quote/backtick of the previous value. A naive
+// `\s+`-only boundary lets `src="x"onerror="..."` survive sanitization because
+// `onerror` is glued to the preceding `"` — the browser still parses it as a
+// separate (executing) attribute. Match either runs of whitespace/`/`
+// (captured in group 1 and consumed) OR a non-consuming lookbehind for a
+// quote/backtick (group 1 undefined; the char is the previous value's own
+// closing delimiter and must stay). `reemitSeparator()` turns the captured
+// group back into a single separating space when one was consumed (S5 #1388).
+const ATTR_BOUNDARY = '(?:([\\s/]+)|(?<=["\'`]))';
+
+// Re-emit an attribute separator after a removed/rewritten attribute. When the
+// boundary consumed whitespace/`/` (group 1 present), emit one space so the
+// rebuilt attribute doesn't glue onto the tag name or previous attribute. When
+// the boundary was a non-consumed quote/backtick (group 1 undefined), that
+// delimiter already separates the attributes, so emit nothing.
+function reemitSeparator(consumed: string | undefined): string {
+  return consumed ? ' ' : '';
+}
+
+const URL_ATTRIBUTE_PATTERN = new RegExp(
+  `${ATTR_BOUNDARY}(href|src|xlink:href|formaction|action|poster)\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s>]+))`,
+  'gi',
+);
+const SRCSET_ATTRIBUTE_PATTERN = new RegExp(
+  `${ATTR_BOUNDARY}srcset\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s>]+))`,
+  'gi',
+);
 
 const BLOCK_TAGS = [
   'address',
@@ -231,31 +255,47 @@ export function sanitizeHtml(value: string): string {
     /<\s*(script|style|iframe|object|embed|link|meta|base|svg|math)\b[^>]*\/?>/gi,
     '',
   );
+  // Drop event handlers (`onclick`, etc.) and internal editor markers entirely.
+  // A consumed whitespace/`/` separator and a non-consumed quote boundary both
+  // collapse to nothing: the attribute that follows (if any) keeps its own
+  // leading boundary, so removal never needs to leave a separator behind.
   html = html.replace(
-    /(?:\s|\/)+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*)/gi,
+    new RegExp(
+      `${ATTR_BOUNDARY}on[a-z]+\\s*=\\s*(?:"[^"]*"|'[^']*'|[^\\s>]*)`,
+      'gi',
+    ),
     '',
   );
   html = html.replace(
-    /\s+data-smrt-(?:selected|moving|resizing)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*)/gi,
+    new RegExp(
+      `${ATTR_BOUNDARY}data-smrt-(?:selected|moving|resizing)\\s*=\\s*(?:"[^"]*"|'[^']*'|[^\\s>]*)`,
+      'gi',
+    ),
     '',
   );
   html = html.replace(
-    /\s+style\s*=\s*("([^"]*)"|'([^']*)'|([^\s>]+))/gi,
+    new RegExp(
+      `${ATTR_BOUNDARY}style\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s>]+))`,
+      'gi',
+    ),
     (
       _match,
+      separator: string | undefined,
       _raw: string,
       doubleValue = '',
       singleValue = '',
       bareValue = '',
     ) => {
       const safeStyle = sanitizeStyle(doubleValue || singleValue || bareValue);
-      return safeStyle ? ` style="${escapeAttribute(safeStyle)}"` : '';
+      const sep = reemitSeparator(separator);
+      return safeStyle ? `${sep}style="${escapeAttribute(safeStyle)}"` : sep;
     },
   );
   html = html.replace(
     SRCSET_ATTRIBUTE_PATTERN,
     (
       _match,
+      separator: string | undefined,
       _raw: string,
       doubleValue = '',
       singleValue = '',
@@ -264,13 +304,15 @@ export function sanitizeHtml(value: string): string {
       const safeSrcset = sanitizeSrcset(
         doubleValue || singleValue || bareValue,
       );
-      return safeSrcset ? ` srcset="${escapeAttribute(safeSrcset)}"` : '';
+      const sep = reemitSeparator(separator);
+      return safeSrcset ? `${sep}srcset="${escapeAttribute(safeSrcset)}"` : sep;
     },
   );
   html = html.replace(
     URL_ATTRIBUTE_PATTERN,
     (
       _match,
+      separator: string | undefined,
       name: string,
       _raw: string,
       doubleValue = '',
@@ -279,7 +321,7 @@ export function sanitizeHtml(value: string): string {
     ) => {
       const quote = doubleValue ? '"' : singleValue ? "'" : '"';
       const rawValue = doubleValue || singleValue || bareValue;
-      return ` ${name}=${quote}${escapeAttribute(sanitizeUrl(rawValue))}${quote}`;
+      return `${reemitSeparator(separator)}${name}=${quote}${escapeAttribute(sanitizeUrl(rawValue))}${quote}`;
     },
   );
 

--- a/packages/content/src/content-feed-sync.test.ts
+++ b/packages/content/src/content-feed-sync.test.ts
@@ -159,6 +159,88 @@ describe('syncContentFeedSource', () => {
     expect(source.lastError).toContain('public network address');
   });
 
+  it('re-validates redirect targets and blocks a redirect to a private host (S5 #1388)', async () => {
+    const source = createSource();
+    // The initial public host passes validation, then 302s to a loopback
+    // address. With default redirect-following this SSRF would succeed; the
+    // manual-redirect guard must re-run the host check on the Location target.
+    const fetch = vi.fn(async () => {
+      return new Response(null, {
+        status: 302,
+        headers: { location: 'http://127.0.0.1:6379/internal.xml' },
+      });
+    });
+
+    await expect(
+      syncContentFeedSource(source, {
+        fetch,
+        now: () => FIXED_NOW,
+        // First (public) host resolves public; the redirect target is a literal
+        // IP, so it never hits the resolver and is rejected by isBlockedAddress.
+        resolveHostname: PUBLIC_RESOLVER,
+      }),
+    ).rejects.toThrow('public network address');
+
+    // Only the first hop was fetched; the redirect target was rejected before
+    // any request to the internal host.
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(source.status).toBe('error');
+  });
+
+  it('follows a redirect to another public host (S5 #1388)', async () => {
+    const source = createSource();
+    const resolveHostname = vi.fn(async () => [
+      { address: '93.184.216.34', family: 4 },
+    ]);
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 301,
+          headers: { location: 'https://mirror.example.test/rss.xml' },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(createRssFeed(), { status: 200 }));
+    vi.spyOn(Contents, 'create').mockResolvedValue({
+      query: vi.fn(async () => []),
+    } as unknown as Contents);
+
+    const result = await syncContentFeedSource(source, {
+      fetch,
+      now: () => FIXED_NOW,
+      resolveHostname,
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch.mock.calls[1][0].toString()).toBe(
+      'https://mirror.example.test/rss.xml',
+    );
+    expect(result.fetched).toBe(true);
+  });
+
+  it('rejects feeds that exceed the redirect limit (S5 #1388)', async () => {
+    const source = createSource();
+    const resolveHostname = vi.fn(async () => [
+      { address: '93.184.216.34', family: 4 },
+    ]);
+    let hop = 0;
+    const fetch = vi.fn(async () => {
+      hop += 1;
+      return new Response(null, {
+        status: 302,
+        headers: { location: `https://hop-${hop}.example.test/rss.xml` },
+      });
+    });
+
+    await expect(
+      syncContentFeedSource(source, {
+        fetch,
+        now: () => FIXED_NOW,
+        resolveHostname,
+      }),
+    ).rejects.toThrow('maximum number of redirects');
+  });
+
   it('caps feed response bodies before parsing', async () => {
     const source = createSource();
     const fetch = vi.fn(

--- a/packages/content/src/content-feed-sync.ts
+++ b/packages/content/src/content-feed-sync.ts
@@ -1,6 +1,4 @@
 import { randomUUID } from 'node:crypto';
-import { lookup as dnsLookup } from 'node:dns/promises';
-import { isIP } from 'node:net';
 import {
   ObjectRegistry,
   type SmrtCollectionOptions,
@@ -12,6 +10,7 @@ import {
 import type { ContentFeedSource } from './content-feed-source';
 import { Mirror } from './content-types';
 import { Contents } from './contents';
+import { assertSafeRemoteUrl, type ResolveHostname } from './safe-remote-url';
 
 export interface ContentFeedSyncOptions extends SmrtCollectionOptions {
   fetch?: typeof fetch;
@@ -19,7 +18,7 @@ export interface ContentFeedSyncOptions extends SmrtCollectionOptions {
   maxResponseBytes?: number;
   fetchTimeoutMs?: number;
   allowPrivateNetworkHosts?: boolean;
-  resolveHostname?: typeof resolveHostname;
+  resolveHostname?: ResolveHostname;
   status?: 'published' | 'draft';
   now?: () => Date;
 }
@@ -34,15 +33,12 @@ export interface ContentFeedSyncResult {
 }
 
 type QueryableCollection = Pick<Contents, 'query'>;
-type ResolvedAddress = { address: string; family?: number };
 
 const DEFAULT_MAX_RESPONSE_BYTES = 2_000_000;
 const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
+const MAX_FEED_REDIRECTS = 5;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const FALLBACK_MIRROR_META_TYPE = '@happyvertical/smrt-content:Mirror';
-
-async function resolveHostname(hostname: string): Promise<ResolvedAddress[]> {
-  return dnsLookup(hostname, { all: true, verbatim: false });
-}
 
 function getMirrorMetaType(): string {
   return (
@@ -87,89 +83,65 @@ function createDedupeKey(
   return `feed:${source.id ?? source.feedUrl}:${item.guid || normalizeUrlIdentity(item.url)}`;
 }
 
-function isBlockedIPv4(address: string): boolean {
-  const octets = address.split('.').map((part) => Number(part));
-  if (octets.length !== 4 || octets.some((part) => !Number.isInteger(part))) {
-    return true;
-  }
-
-  const [first, second] = octets;
-  return (
-    first === 0 ||
-    first === 10 ||
-    first === 127 ||
-    first >= 224 ||
-    (first === 100 && second >= 64 && second <= 127) ||
-    (first === 169 && second === 254) ||
-    (first === 172 && second >= 16 && second <= 31) ||
-    (first === 192 && second === 168) ||
-    (first === 198 && (second === 18 || second === 19))
-  );
-}
-
-function isBlockedIPv6(address: string): boolean {
-  const normalized = address.toLowerCase();
-  const mapped = normalized.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-  if (mapped?.[1]) return isBlockedIPv4(mapped[1]);
-
-  return (
-    normalized === '::' ||
-    normalized === '::1' ||
-    normalized.startsWith('fc') ||
-    normalized.startsWith('fd') ||
-    /^fe[89ab]/.test(normalized) ||
-    normalized.startsWith('ff')
-  );
-}
-
-function isBlockedAddress(address: string): boolean {
-  const family = isIP(address);
-  if (family === 4) return isBlockedIPv4(address);
-  if (family === 6) return isBlockedIPv6(address);
-  return true;
-}
-
 async function validateFeedFetchUrl(
   feedUrl: string,
   options: ContentFeedSyncOptions,
 ): Promise<URL> {
-  let url: URL;
-  try {
-    url = new URL(feedUrl);
-  } catch {
-    throw new Error('Feed URL must be an absolute URL');
-  }
-
-  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-    throw new Error('Feed URL must use http or https');
-  }
-  if (url.username || url.password) {
-    throw new Error('Feed URL must not include credentials');
-  }
-  if (!url.hostname) {
-    throw new Error('Feed URL must include a hostname');
-  }
-
-  if (options.allowPrivateNetworkHosts) return url;
-
-  const addresses =
-    isIP(url.hostname) === 0
-      ? await (options.resolveHostname ?? resolveHostname)(url.hostname)
-      : [{ address: url.hostname }];
-
-  if (
-    !addresses.length ||
-    addresses.some(({ address }) => isBlockedAddress(address))
-  ) {
-    throw new Error('Feed URL must resolve to a public network address');
-  }
-
-  return url;
+  return assertSafeRemoteUrl(feedUrl, {
+    allowPrivateNetworkHosts: options.allowPrivateNetworkHosts,
+    resolveHostname: options.resolveHostname,
+  });
 }
 
 function createTimeoutSignal(timeoutMs: number): AbortSignal | undefined {
   if (timeoutMs <= 0) return undefined;
   return AbortSignal.timeout(timeoutMs);
+}
+
+/**
+ * Fetch a feed following redirects manually so every hop's target is
+ * re-validated through {@link validateFeedFetchUrl}. `fetch()`'s default
+ * `redirect: 'follow'` would let an allowed public feed 30x-redirect to an
+ * internal/link-local/metadata host, defeating the up-front SSRF check
+ * (S5 #1388). Returns the response together with the final validated URL so
+ * the parser uses the redirect target as the feed base.
+ */
+async function fetchFeedWithRedirectGuard(
+  fetchImpl: typeof fetch,
+  startUrl: URL,
+  headers: Record<string, string>,
+  options: ContentFeedSyncOptions,
+): Promise<{ response: Response; finalUrl: URL }> {
+  let current = startUrl;
+
+  for (let hop = 0; hop <= MAX_FEED_REDIRECTS; hop += 1) {
+    const response = await fetchImpl(current, {
+      headers,
+      redirect: 'manual',
+      signal: createTimeoutSignal(
+        options.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS,
+      ),
+    });
+
+    // Only the redirect statuses (not 304 Not Modified / 305 / 306) reroute the
+    // request; everything else (200, 304, 4xx, 5xx) is returned to the caller.
+    if (REDIRECT_STATUSES.has(response.status)) {
+      const location = response.headers.get('location');
+      if (!location) {
+        throw new Error('Feed redirect response missing Location header');
+      }
+      // Re-run the full SSRF validation against the resolved redirect target.
+      current = await validateFeedFetchUrl(
+        new URL(location, current).toString(),
+        options,
+      );
+      continue;
+    }
+
+    return { response, finalUrl: current };
+  }
+
+  throw new Error('Feed URL exceeded the maximum number of redirects');
 }
 
 async function readResponseText(
@@ -394,12 +366,12 @@ export async function syncContentFeedSource(
 
   try {
     const feedUrl = await validateFeedFetchUrl(source.feedUrl, options);
-    const response = await fetchImpl(feedUrl, {
+    const { response, finalUrl } = await fetchFeedWithRedirectGuard(
+      fetchImpl,
+      feedUrl,
       headers,
-      signal: createTimeoutSignal(
-        options.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS,
-      ),
-    });
+      options,
+    );
 
     if (response.status === 304) {
       source.markFetchSucceeded(now);
@@ -423,7 +395,7 @@ export async function syncContentFeedSource(
         response,
         options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES,
       ),
-      feedUrl.toString(),
+      finalUrl.toString(),
     );
     source.format = parsed.format;
     source.homepageUrl = source.homepageUrl || parsed.homepageUrl;

--- a/packages/content/src/contents-collection.test.ts
+++ b/packages/content/src/contents-collection.test.ts
@@ -100,8 +100,19 @@ describe('Contents collection helpers', () => {
     const existing = { id: 'existing-content' };
     vi.spyOn(contents, 'get').mockResolvedValueOnce(existing as any);
 
+    const publicResolver = vi.fn(async () => [
+      { address: '93.184.216.34', family: 4 },
+    ]);
+    // No-redirect fetch so resolveSafeFinalUrl resolves to the input URL
+    // without touching the network.
+    const okFetch = vi.fn(async () => new Response(null, { status: 200 }));
+
     await expect(
-      contents.mirror({ url: 'https://example.com/already-there' }),
+      contents.mirror({
+        url: 'https://example.com/already-there',
+        resolveHostname: publicResolver,
+        fetchImpl: okFetch as unknown as typeof fetch,
+      }),
     ).resolves.toBe(existing);
 
     vi.spyOn(contents, 'get').mockResolvedValueOnce(null as any);
@@ -122,6 +133,8 @@ describe('Contents collection helpers', () => {
     const mirrored = await contents.mirror({
       url: 'https://example.com/news/bridge-update.html',
       context: 'news',
+      resolveHostname: publicResolver,
+      fetchImpl: okFetch as unknown as typeof fetch,
     });
 
     expect(mirrored).toMatchObject({
@@ -136,6 +149,112 @@ describe('Contents collection helpers', () => {
       'Invalid URL provided',
     );
     expect(mockLogger.error).toHaveBeenCalled();
+  });
+
+  it('refuses to mirror SSRF targets (loopback/metadata) (S5 #1388)', async () => {
+    const contents = new Contents({} as any);
+    const getSpy = vi.spyOn(contents, 'get');
+    vi.mocked(fetchDocument).mockReset();
+
+    // Literal loopback / cloud-metadata IPs never reach the resolver and must
+    // be rejected before any document fetch.
+    await expect(
+      contents.mirror({ url: 'http://127.0.0.1:6379/internal' }),
+    ).rejects.toThrow('Invalid URL provided');
+    await expect(
+      contents.mirror({ url: 'http://169.254.169.254/latest/meta-data/' }),
+    ).rejects.toThrow('Invalid URL provided');
+
+    // A public hostname that resolves to a private IP is also blocked.
+    await expect(
+      contents.mirror({
+        url: 'https://attacker.example/feed',
+        resolveHostname: async () => [{ address: '10.0.0.5', family: 4 }],
+      }),
+    ).rejects.toThrow('Invalid URL provided');
+
+    // Non-http(s) schemes are rejected too.
+    await expect(
+      contents.mirror({ url: 'file:///etc/passwd' }),
+    ).rejects.toThrow('Invalid URL provided');
+
+    expect(vi.mocked(fetchDocument)).not.toHaveBeenCalled();
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+
+  it('blocks a public URL that 30x-redirects to an internal host (review #1562)', async () => {
+    const contents = new Contents({} as any);
+    vi.mocked(fetchDocument).mockReset();
+    const getSpy = vi.spyOn(contents, 'get');
+    // Initial host is public, but the server redirects to cloud metadata.
+    const redirectFetch = vi.fn(
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: { location: 'http://169.254.169.254/latest/meta-data/' },
+        }),
+    );
+
+    await expect(
+      contents.mirror({
+        url: 'https://feed.example/post',
+        resolveHostname: async () => [{ address: '93.184.216.34', family: 4 }],
+        fetchImpl: redirectFetch as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow('Invalid URL provided');
+
+    expect(vi.mocked(fetchDocument)).not.toHaveBeenCalled();
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+
+  it('redacts userinfo credentials from mirror errors/logs (review #1562)', async () => {
+    const contents = new Contents({} as any);
+    mockLogger.error.mockClear();
+
+    let err: Error | undefined;
+    try {
+      await contents.mirror({ url: 'https://user:s3cr3t@example.com/x' });
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err?.message).toContain('Invalid URL provided');
+    // The password must not appear in the thrown message or the log payload.
+    expect(err?.message).not.toContain('s3cr3t');
+    const loggedUrl =
+      (mockLogger.error.mock.calls.at(-1)?.[1] as { url?: string })?.url ?? '';
+    expect(loggedUrl).not.toContain('s3cr3t');
+  });
+
+  it('refuses to write content files outside the content directory (S5 #1388)', async () => {
+    const contents = new Contents({} as any);
+
+    // A traversal-bearing slug must not let an export escape contentDir.
+    await expect(
+      contents.writeContentFile({
+        content: {
+          title: 'Pwn',
+          slug: '../../../../tmp/evil',
+          context: 'news',
+          body: 'malicious',
+        } as any,
+        contentDir: '/tmp/content',
+      }),
+    ).rejects.toThrow('outside of the content directory');
+
+    // A traversal-bearing context is equally rejected.
+    await expect(
+      contents.writeContentFile({
+        content: {
+          title: 'Pwn',
+          slug: 'ok',
+          context: '../../../../etc/cron.d',
+          body: 'malicious',
+        } as any,
+        contentDir: '/tmp/content',
+      }),
+    ).rejects.toThrow('outside of the content directory');
+
+    expect(vi.mocked(writeFile)).not.toHaveBeenCalled();
   });
 
   it('writes content files, normalizes plain text, and syncs article directories', async () => {

--- a/packages/content/src/contents.ts
+++ b/packages/content/src/contents.ts
@@ -16,6 +16,11 @@ import {
   loadPersistedContentGovernanceDefinitions,
   resolveEffectiveContentGovernance,
 } from './content-governance';
+import {
+  type ResolveHostname,
+  redactUrlCredentials,
+  resolveSafeFinalUrl,
+} from './safe-remote-url';
 import { serializeContent, serializeFact } from './serialization';
 import type {
   ThumbnailOptions,
@@ -278,27 +283,47 @@ export class Contents extends SmrtCollection<Content> {
     url: string;
     mirrorDir?: string;
     context?: string;
+    /**
+     * Skip the SSRF host-blocking checks. Only set this for fully trusted,
+     * operator-supplied URLs (e.g. local development), never for URLs that
+     * originate from end users or external content.
+     */
+    allowPrivateNetworkHosts?: boolean;
+    /** Injectable DNS resolver (primarily for tests). */
+    resolveHostname?: ResolveHostname;
+    /** Injectable fetch for redirect resolution (primarily for tests). */
+    fetchImpl?: typeof fetch;
   }) {
     if (!options.url) {
       throw new Error('No URL provided');
     }
+    // Validate the URL AND block private/loopback/link-local/metadata hosts
+    // before fetching — `mirror()` fetches an arbitrary caller-supplied URL,
+    // which is a classic SSRF sink (e.g. http://169.254.169.254/ metadata).
+    // `fetchDocument` follows redirects on its own, so we resolve the redirect
+    // chain ourselves first — re-validating every hop — and hand it the
+    // already-validated terminal URL, closing the public-host-30x-to-internal
+    // bypass (S5 #1388 / review #1562).
     let url: URL;
     try {
-      // const url = new URL(options.url);
-      // const existing = await this.db
-      //   .oO`SELECT * FROM contents WHERE url = ${options.url}`;
-      url = new URL(options.url); // validate url
+      url = await resolveSafeFinalUrl(options.url, {
+        allowPrivateNetworkHosts: options.allowPrivateNetworkHosts,
+        resolveHostname: options.resolveHostname,
+        fetchImpl: options.fetchImpl,
+      });
     } catch (error) {
-      logger.error('Invalid URL provided', { error, url: options.url });
-      throw new Error(`Invalid URL provided: ${options.url}`);
+      // Never echo the raw URL — it may carry userinfo credentials (review #1562).
+      const safeUrl = redactUrlCredentials(options.url);
+      logger.error('Refusing to mirror unsafe URL', { error, url: safeUrl });
+      throw new Error(`Invalid URL provided: ${safeUrl}`);
     }
     const existing = await this.get({ url: options.url });
     if (existing) {
       return existing;
     }
 
-    // Fetch and process the document using @happyvertical/documents
-    const doc = await fetchDocument(options.url, {
+    // Fetch and process the document via the already-validated terminal URL.
+    const doc = await fetchDocument(url.toString(), {
       cacheDir: options?.mirrorDir,
     });
 
@@ -376,6 +401,22 @@ export class Contents extends SmrtCollection<Content> {
     ].filter(Boolean); // remove empty strings
 
     const outputFile = path.join(...(pathParts as string[]));
+
+    // `context` and `slug` are persisted, caller-influenced fields. Without a
+    // guard, a value like `../../etc/cron.d/x` escapes `contentDir` and lets an
+    // export overwrite arbitrary files (path traversal). Confirm the joined
+    // path still lives under the resolved content directory (S5 #1388).
+    const resolvedDir = path.resolve(contentDir);
+    const resolvedFile = path.resolve(outputFile);
+    if (
+      resolvedFile !== resolvedDir &&
+      !resolvedFile.startsWith(resolvedDir + path.sep)
+    ) {
+      throw new Error(
+        'Refusing to write content file outside of the content directory',
+      );
+    }
+
     await ensureDirectoryExists(path.dirname(outputFile));
     await writeFile(outputFile, output);
   }

--- a/packages/content/src/safe-remote-url.test.ts
+++ b/packages/content/src/safe-remote-url.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  assertSafeRemoteUrl,
+  isBlockedAddress,
+  isBlockedIPv4,
+  isBlockedIPv6,
+} from './safe-remote-url';
+
+describe('safe-remote-url SSRF guard', () => {
+  it('blocks private, loopback, link-local, CGNAT, and multicast IPv4', () => {
+    for (const blocked of [
+      '0.0.0.0',
+      '10.1.2.3',
+      '127.0.0.1',
+      '169.254.169.254',
+      '172.16.0.1',
+      '172.31.255.255',
+      '192.168.1.1',
+      '100.64.0.1',
+      '198.18.0.1',
+      '224.0.0.1',
+    ]) {
+      expect(isBlockedIPv4(blocked)).toBe(true);
+    }
+  });
+
+  it('allows ordinary public IPv4', () => {
+    expect(isBlockedIPv4('93.184.216.34')).toBe(false);
+    expect(isBlockedIPv4('8.8.8.8')).toBe(false);
+  });
+
+  it('treats malformed IPv4 as blocked', () => {
+    expect(isBlockedIPv4('1.2.3')).toBe(true); // wrong octet count
+    expect(isBlockedIPv4('a.b.c.d')).toBe(true); // non-numeric
+    expect(isBlockedIPv4('1..2.3')).toBe(true); // empty octet (review #1562)
+    expect(isBlockedIPv4('1.2.3.999')).toBe(true); // out of range
+    expect(isBlockedIPv4('1.2.3.04')).toBe(false); // valid (4) still allowed
+  });
+
+  it('blocks IPv4-mapped IPv6 loopback/private in every encoding (review #1562)', () => {
+    // 127.0.0.1 in dotted, hex-compressed, and fully-expanded forms.
+    expect(isBlockedIPv6('::ffff:127.0.0.1')).toBe(true);
+    expect(isBlockedIPv6('::ffff:7f00:1')).toBe(true);
+    expect(isBlockedIPv6('0:0:0:0:0:ffff:7f00:1')).toBe(true);
+    expect(isBlockedIPv6('::ffff:0a00:0005')).toBe(true); // 10.0.0.5
+    expect(isBlockedIPv6('::ffff:a9fe:a9fe')).toBe(true); // 169.254.169.254
+    expect(isBlockedIPv6('0:0:0:0:0:ffff:a9fe:a9fe')).toBe(true); // expanded metadata
+    // IPv4-compatible (deprecated) form ::127.0.0.1 also decodes to loopback.
+    expect(isBlockedIPv6('::7f00:1')).toBe(true);
+    // A mapped PUBLIC IPv4 (8.8.8.8 === ::ffff:0808:0808) stays allowed.
+    expect(isBlockedIPv6('::ffff:0808:0808')).toBe(false);
+    expect(isBlockedIPv6('::ffff:8.8.8.8')).toBe(false);
+    // A genuine public IPv6 stays allowed.
+    expect(isBlockedIPv6('2606:4700:4700::1111')).toBe(false);
+  });
+
+  it('blocks loopback/ULA/link-local/multicast and IPv4-mapped IPv6', () => {
+    for (const blocked of [
+      '::1',
+      '::',
+      'fc00::1',
+      'fd12::3',
+      'fe80::1',
+      'ff02::1',
+      '::ffff:127.0.0.1',
+    ]) {
+      expect(isBlockedIPv6(blocked)).toBe(true);
+    }
+    expect(isBlockedIPv6('2606:4700:4700::1111')).toBe(false);
+  });
+
+  it('blocks non-IP-literal addresses defensively', () => {
+    expect(isBlockedAddress('not-an-ip')).toBe(true);
+  });
+
+  it('rejects non-http(s) schemes', async () => {
+    await expect(assertSafeRemoteUrl('file:///etc/passwd')).rejects.toThrow(
+      'http or https',
+    );
+    await expect(assertSafeRemoteUrl('ftp://example.com')).rejects.toThrow(
+      'http or https',
+    );
+  });
+
+  it('rejects URLs with embedded credentials', async () => {
+    await expect(
+      assertSafeRemoteUrl('https://user:pass@example.com', {
+        resolveHostname: async () => [{ address: '93.184.216.34' }],
+      }),
+    ).rejects.toThrow('credentials');
+  });
+
+  it('rejects hostnames that resolve to private addresses', async () => {
+    await expect(
+      assertSafeRemoteUrl('https://internal.example', {
+        resolveHostname: async () => [{ address: '10.0.0.1', family: 4 }],
+      }),
+    ).rejects.toThrow('public network address');
+  });
+
+  it('blocks literal loopback/metadata IPs without resolving DNS', async () => {
+    const resolveHostname = vi.fn();
+    await expect(
+      assertSafeRemoteUrl('http://169.254.169.254/', { resolveHostname }),
+    ).rejects.toThrow('public network address');
+    expect(resolveHostname).not.toHaveBeenCalled();
+  });
+
+  it('allows public hosts', async () => {
+    const url = await assertSafeRemoteUrl('https://example.com/feed', {
+      resolveHostname: async () => [{ address: '93.184.216.34', family: 4 }],
+    });
+    expect(url.hostname).toBe('example.com');
+  });
+
+  it('honours allowPrivateNetworkHosts for trusted callers', async () => {
+    const url = await assertSafeRemoteUrl('http://127.0.0.1:8080/feed', {
+      allowPrivateNetworkHosts: true,
+    });
+    expect(url.hostname).toBe('127.0.0.1');
+  });
+});

--- a/packages/content/src/safe-remote-url.ts
+++ b/packages/content/src/safe-remote-url.ts
@@ -1,0 +1,258 @@
+/**
+ * Shared SSRF guard for content's outbound fetches (feed sync, mirroring).
+ *
+ * Any code path that fetches a caller-supplied URL — RSS/Atom feeds, the
+ * `Mirror` content type, link previews — is an SSRF vector: an attacker who can
+ * influence the URL can make the server fetch `169.254.169.254` cloud metadata,
+ * `localhost` admin panels, or other internal services. This module rejects
+ * URLs that resolve to private, loopback, link-local, CGNAT, or cloud-metadata
+ * ranges before any request is made, and re-validates redirect hops.
+ *
+ * Unlike a literal-IP-only check, {@link assertSafeRemoteUrl} resolves hostnames
+ * via DNS so a public name pointing at a private IP is also caught (S5 #1388).
+ */
+import { lookup as dnsLookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
+export type ResolvedAddress = { address: string; family?: number };
+export type ResolveHostname = (hostname: string) => Promise<ResolvedAddress[]>;
+
+export interface SafeRemoteUrlOptions {
+  /** Skip the private-network checks (trusted callers only, e.g. local dev). */
+  allowPrivateNetworkHosts?: boolean;
+  /** Injectable resolver for tests; defaults to {@link defaultResolveHostname}. */
+  resolveHostname?: ResolveHostname;
+}
+
+export async function defaultResolveHostname(
+  hostname: string,
+): Promise<ResolvedAddress[]> {
+  return dnsLookup(hostname, { all: true, verbatim: false });
+}
+
+export function isBlockedIPv4(address: string): boolean {
+  const parts = address.split('.');
+  if (parts.length !== 4) return true;
+  // Strict per-octet validation: `Number('')` is 0, so without a digit check a
+  // malformed input like `1..2.3` would parse to `[1,0,2,3]` and be treated as a
+  // valid (and possibly allowed) address. Anything not 1-3 digits in 0-255 is
+  // unparseable → blocked (review #1562).
+  const octets = parts.map((part) =>
+    /^\d{1,3}$/.test(part) ? Number(part) : Number.NaN,
+  );
+  if (octets.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) {
+    return true;
+  }
+
+  const [first, second] = octets;
+  return (
+    first === 0 ||
+    first === 10 ||
+    first === 127 ||
+    first >= 224 ||
+    (first === 100 && second >= 64 && second <= 127) ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168) ||
+    (first === 198 && (second === 18 || second === 19))
+  );
+}
+
+/**
+ * Expand an IPv6 string to its 8 hextets (numbers), or null if unparseable.
+ * Handles `::` compression, an embedded dotted-IPv4 tail, and bracketed forms.
+ */
+function expandIPv6(address: string): number[] | null {
+  let work = address.toLowerCase().replace(/^\[|\]$/g, '');
+  if (work.includes('.')) {
+    // Embedded dotted IPv4 tail (e.g. ::ffff:127.0.0.1) → convert to 2 hextets.
+    const m = work.match(/(\d{1,3}(?:\.\d{1,3}){3})$/);
+    if (!m) return null;
+    const o = m[1].split('.').map(Number);
+    if (o.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return null;
+    const hi = ((o[0] << 8) | o[1]).toString(16);
+    const lo = ((o[2] << 8) | o[3]).toString(16);
+    work = `${work.slice(0, work.length - m[1].length)}${hi}:${lo}`;
+  }
+  const halves = work.split('::');
+  if (halves.length > 2) return null;
+  const head = halves[0] ? halves[0].split(':') : [];
+  const tail = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+  const groups =
+    halves.length === 2
+      ? [
+          ...head,
+          ...Array(Math.max(0, 8 - head.length - tail.length)).fill('0'),
+          ...tail,
+        ]
+      : head;
+  if (groups.length !== 8) return null;
+  const hextets = groups.map((g) =>
+    /^[0-9a-f]{1,4}$/.test(g) ? Number.parseInt(g, 16) : Number.NaN,
+  );
+  return hextets.some((n) => Number.isNaN(n)) ? null : hextets;
+}
+
+export function isBlockedIPv6(address: string): boolean {
+  const hextets = expandIPv6(address);
+  if (hextets) {
+    // IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible (::a.b.c.d, deprecated)
+    // both embed an IPv4 in the last 2 hextets — decode and apply the IPv4
+    // blocklist so a loopback/private IPv4 can't be smuggled through any IPv6
+    // encoding (compressed, expanded, dotted, or hex) (review #1562, P1).
+    const firstFiveZero = hextets.slice(0, 5).every((h) => h === 0);
+    if (firstFiveZero && (hextets[5] === 0xffff || hextets[5] === 0)) {
+      const [, , , , , , g6, g7] = hextets;
+      const ipv4 = `${g6 >> 8}.${g6 & 0xff}.${g7 >> 8}.${g7 & 0xff}`;
+      return isBlockedIPv4(ipv4);
+    }
+  }
+
+  const normalized = address.toLowerCase().replace(/^\[|\]$/g, '');
+  return (
+    normalized === '::' ||
+    normalized === '::1' ||
+    normalized.startsWith('fc') ||
+    normalized.startsWith('fd') ||
+    /^fe[89ab]/.test(normalized) ||
+    normalized.startsWith('ff')
+  );
+}
+
+export function isBlockedAddress(address: string): boolean {
+  const family = isIP(address);
+  if (family === 4) return isBlockedIPv4(address);
+  if (family === 6) return isBlockedIPv6(address);
+  // Anything that isn't a recognisable IP literal (after DNS resolution should
+  // have produced one) is treated as unsafe.
+  return true;
+}
+
+/**
+ * Parse and validate a remote URL for outbound fetching. Rejects non-http(s)
+ * schemes, embedded credentials, and hosts that resolve to non-public ranges.
+ * Returns the parsed {@link URL} on success; throws a descriptive `Error`
+ * otherwise.
+ */
+export async function assertSafeRemoteUrl(
+  rawUrl: string,
+  options: SafeRemoteUrlOptions = {},
+): Promise<URL> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error('Remote URL must be an absolute URL');
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('Remote URL must use http or https');
+  }
+  if (url.username || url.password) {
+    throw new Error('Remote URL must not include credentials');
+  }
+  if (!url.hostname) {
+    throw new Error('Remote URL must include a hostname');
+  }
+
+  if (options.allowPrivateNetworkHosts) return url;
+
+  const resolver = options.resolveHostname ?? defaultResolveHostname;
+  const addresses =
+    isIP(url.hostname) === 0
+      ? await resolver(url.hostname)
+      : [{ address: url.hostname }];
+
+  if (
+    !addresses.length ||
+    addresses.some(({ address }) => isBlockedAddress(address))
+  ) {
+    throw new Error('Remote URL must resolve to a public network address');
+  }
+
+  return url;
+}
+
+/** Redirect status codes that reroute a request to a new Location. */
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const DEFAULT_MAX_REDIRECTS = 5;
+const DEFAULT_RESOLVE_TIMEOUT_MS = 10_000;
+
+export interface SafeRedirectOptions extends SafeRemoteUrlOptions {
+  /** Maximum redirect hops to follow before failing. Default 5. */
+  maxRedirects?: number;
+  /** Per-hop timeout in ms. Default 10s. */
+  timeoutMs?: number;
+  /** Injectable fetch (primarily for tests). Defaults to global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Resolve a URL's redirect chain and return the final safe {@link URL}, with
+ * EVERY hop re-validated through {@link assertSafeRemoteUrl}.
+ *
+ * Use this before handing a URL to a fetcher that follows redirects on its own
+ * (e.g. `fetchDocument`): the up-front {@link assertSafeRemoteUrl} check alone
+ * can't stop an allowed public host from `30x`-redirecting into an internal /
+ * loopback / metadata host, which would defeat the SSRF guard (review #1562).
+ *
+ * Redirects are followed with `GET` + `redirect: 'manual'` to match downstream
+ * GET-based fetchers; response bodies are discarded (the redirect bodies are
+ * empty and the terminal body is left for the caller to re-fetch), so this does
+ * not double-download content.
+ */
+export async function resolveSafeFinalUrl(
+  rawUrl: string,
+  options: SafeRedirectOptions = {},
+): Promise<URL> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const maxRedirects = options.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_RESOLVE_TIMEOUT_MS;
+  let current = await assertSafeRemoteUrl(rawUrl, options);
+
+  for (let hop = 0; hop <= maxRedirects; hop += 1) {
+    const response = await fetchImpl(current, {
+      method: 'GET',
+      redirect: 'manual',
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    // Release the connection without downloading the body.
+    try {
+      await response.body?.cancel();
+    } catch {
+      // best-effort
+    }
+
+    if (!REDIRECT_STATUSES.has(response.status)) {
+      return current;
+    }
+    const location = response.headers.get('location');
+    if (!location) return current;
+    // Re-validate the resolved redirect target before following it.
+    current = await assertSafeRemoteUrl(
+      new URL(location, current).toString(),
+      options,
+    );
+  }
+
+  throw new Error('Remote URL exceeded the maximum number of redirects');
+}
+
+/**
+ * Strip userinfo (`user:pass@`) from a URL so it can be safely logged or echoed
+ * in an error message. Returns a placeholder for unparseable input. Never let a
+ * credential-bearing URL reach logs/errors verbatim (review #1562).
+ */
+export function redactUrlCredentials(raw: string): string {
+  try {
+    const url = new URL(raw);
+    if (url.username || url.password) {
+      url.username = '';
+      url.password = '';
+      return url.toString();
+    }
+    return raw;
+  } catch {
+    return '[unparseable url]';
+  }
+}


### PR DESCRIPTION
## Security audit & remediation — `@happyvertical/smrt-content` (T2)

closes #1388

Final-wave per-package audit of the content package (STI Article/Document/Mirror, thumbnails, content_assets joins, versioned snapshots). Weighted lenses: SSRF (Mirror + feed sync), path traversal (export paths), tenant isolation, exposure, XSS, prototype pollution, dependency audit.

### Findings & fixes

| # | Sev | Finding | Exploit path (verified against source) | File | Fix |
|---|-----|---------|----------------------------------------|------|-----|
| 1 | **High** | Stored XSS — sanitizer bypass | `sanitizeHtml()`'s attribute regexes only treated whitespace/`/` as an attribute boundary. Browsers (HTML5 tree builder) start a new attribute right after a value's **closing quote**, so `<img src="x"onerror="alert(1)">`, `<a title="x"href="javascript:…">`, and quote-glued `style="…expression…"` all survived sanitization and reached `{@html sanitizeHtml(content)}` in `ContentBodyRenderer.svelte` → JS execution on stored Article body. Empirically confirmed before/after. | `body-format.ts` | Boundary now also accepts a (non-consumed) quote/backtick; all 4 attribute sanitizers (on*, url-attrs, srcset, style) updated |
| 2 | **Medium** | SSRF via redirect in feed sync | `syncContentFeedSource()` validated the initial feed URL against the DNS-resolving blocklist but then used `fetch()`'s default `redirect: 'follow'` — an allowed public host could `30x`→`http://169.254.169.254/` / `localhost` / internal services, defeating the up-front check. | `content-feed-sync.ts` | Manual redirect following (`redirect: 'manual'`), each `Location` hop re-validated; redirect cap; only true redirect statuses reroute (304 etc. pass through) |
| 3 | **Medium** | SSRF in `Contents.mirror()` | `mirror()` only checked the URL parses, then `fetchDocument(url)` — fetches any caller-supplied URL incl. loopback/metadata. | `contents.ts` | Validates through the shared SSRF guard before fetching; non-http(s)/credentialed/private hosts rejected. (Redirect limitation documented — `fetchDocument` follows on its own; treat mirror sources as semi-trusted.) |
| 4 | **Medium** | Path traversal in export | `writeContentFile()` builds the output path from persisted `content.context` + `content.slug`; a `../`-bearing value escapes `contentDir` and overwrites arbitrary files. | `contents.ts` | Rejects any resolved path outside the content directory |

New shared `safe-remote-url.ts` consolidates the DNS-resolving private/loopback/link-local/CGNAT/cloud-metadata blocklist (feed sync now reuses it; previously duplicated inline).

### Lenses with no exploitable finding
- **Tenant isolation:** feed-sync raw SQL scopes `tenant_id = ? / IS NULL`; no `allowCrossTenant: true` anywhere; STI queries respect scoping. ✅
- **Exposure:** `Contents` is `mcp:false, cli:false` with a narrow API include-list; `mirror()`/`writeContentFile()` are not on any generated surface. ✅
- **Injection / unsafe data:** all `JSON.parse` calls wrapped in try/catch; metadata/snapshot are string round-trips; `updateMetadata` uses object spread (define-semantics → no `__proto__` pollution); `fast-xml-parser` has no XXE + response size cap bounds billion-laughs. ✅
- **Generated CRUD routes:** auto-regenerated by the core Vite plugin (fail-closed authZ / mass-assignment guard live in the generator, not per-package) — out of scope; left unmodified. ✅
- **Dependency audit:** no new deps added (guard uses only `node:dns`/`node:net`); remaining `pnpm audit` high/critical are pre-existing ignored transitive advisories in shared tooling (cli→tar, logger→@sentry/opentelemetry), not content-specific. ✅

### Tests
- `body-format.test.ts`: quote-glued event-handler + url/style bypass regression (fail-before/pass-after)
- `content-feed-sync.test.ts`: redirect→private-host blocked, public→public redirect followed, redirect-limit
- `contents-collection.test.ts`: mirror SSRF (loopback/metadata/DNS-private/scheme) + path-traversal export
- `safe-remote-url.test.ts`: unit coverage of the blocklist + URL validation

`pnpm --filter @happyvertical/smrt-content test` → 284 passed / 6 skipped. `typecheck` → 0 errors. `biome check` (read-only, scoped) → clean.