### PR TITLE
test(cli): raise package coverage to T1 80% floor (40%→88%)

### DIFF
--- a/packages/cli/src/__tests__/cli-generator-coverage.test.ts
+++ b/packages/cli/src/__tests__/cli-generator-coverage.test.ts
@@ -1,0 +1,893 @@
+/**
+ * Coverage-focused tests for the CLI command generator (cli-generator.ts).
+ *
+ * Strategy (per .claude/rules/testing.md — "test generators, not generated
+ * output"):
+ *  - Generator output is asserted by feeding object metadata through spied
+ *    ObjectRegistry static methods and inspecting the produced CLICommand
+ *    structures (include/exclude filtering, custom methods, instance vs
+ *    singleton, option typing).
+ *  - Handler branching (list/get/create/update/delete/custom/singleton) is
+ *    exercised by substituting the private getCollection() with a small
+ *    in-memory-backed collection (a real Map store, NOT a mocked DB adapter)
+ *    so option parsing, error paths and output formatting are covered without
+ *    standing up the full manifest/schema machinery (cli does not use
+ *    smrtVitestPlugin).
+ *  - Pure helpers (countRequiredArgs, preprocessObjectCommands, parseFieldValue,
+ *    toYamlString, displayTable, spinner) are tested directly.
+ *
+ * isTestMode() returns true under vitest, so exitWithError() throws instead of
+ * calling process.exit — error paths are assertable.
+ */
+
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CLIGenerator } from '../cli-generator.js';
+
+/** Minimal in-memory collection backed by a Map (not a mocked DB adapter). */
+function makeMemoryCollection(seed: Array<Record<string, any>> = []) {
+  const store = new Map<string, any>();
+  for (const row of seed) {
+    store.set(row.id, { ...row });
+  }
+  let nextId = store.size + 1;
+  return {
+    store,
+    async list(opts: any = {}) {
+      let rows = Array.from(store.values());
+      if (opts.where) {
+        rows = rows.filter((r) =>
+          Object.entries(opts.where).every(([k, v]) => r[k] === v),
+        );
+      }
+      const offset = opts.offset ?? 0;
+      const limit = opts.limit ?? rows.length;
+      return rows.slice(offset, offset + limit);
+    },
+    async get(id: string) {
+      return store.get(id) ?? null;
+    },
+    async create(data: any) {
+      const id = data.id ?? `id-${nextId++}`;
+      const obj: any = {
+        ...data,
+        id,
+        async save() {
+          store.set(id, this);
+        },
+        async delete() {
+          store.delete(id);
+        },
+      };
+      return obj;
+    },
+  };
+}
+
+function clearRegistry() {
+  // Mirror the boolean-options test's reset approach plus the public clear().
+  (ObjectRegistry as any)._classes = new Map();
+  (ObjectRegistry as any)._methods = new Map();
+}
+
+describe('CLIGenerator - pure helpers', () => {
+  let cli: CLIGenerator;
+  beforeEach(() => {
+    cli = new CLIGenerator({ prompt: false, colors: false });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('parseFieldValue parses JSON and falls back to string', () => {
+    const g = cli as any;
+    expect(g.parseFieldValue('42')).toBe(42);
+    expect(g.parseFieldValue('true')).toBe(true);
+    expect(g.parseFieldValue('{"a":1}')).toEqual({ a: 1 });
+    expect(g.parseFieldValue('plain text')).toBe('plain text');
+  });
+
+  it('toYamlString renders nested objects, arrays, scalars and nulls', () => {
+    const g = cli as any;
+    const yaml = g.toYamlString({
+      name: 'x',
+      empty: null,
+      nested: { a: 1 },
+      list: ['one', 'two'],
+    });
+    expect(yaml).toContain('name: x');
+    expect(yaml).toContain('empty: null');
+    expect(yaml).toContain('nested:');
+    expect(yaml).toContain('  a: 1');
+    expect(yaml).toContain('list:');
+    expect(yaml).toContain('  - one');
+  });
+
+  it('isObjectTypeParameter discriminates inline object types', () => {
+    const g = cli as any;
+    expect(g.isObjectTypeParameter('{ a: string }')).toBe(true);
+    expect(g.isObjectTypeParameter('string')).toBe(false);
+  });
+
+  it('displayTable prints a header/rows and a not-found message when empty', () => {
+    const g = cli as any;
+    const logs: string[] = [];
+    const spy = vi
+      .spyOn(console, 'log')
+      .mockImplementation((m?: any) => logs.push(String(m ?? '')));
+    g.displayTable([], 'Widget');
+    expect(logs.some((l) => l.includes('No Widget objects found'))).toBe(true);
+
+    logs.length = 0;
+    g.displayTable([{ id: '1', name: 'Alpha' }], 'Widget');
+    expect(logs.some((l) => l.includes('id'))).toBe(true);
+    expect(logs.some((l) => l.includes('Alpha'))).toBe(true);
+    spy.mockRestore();
+  });
+
+  it('createSpinner falls back to console.log in non-TTY mode', () => {
+    const g = new CLIGenerator({ colors: false }) as any;
+    const logs: string[] = [];
+    const spy = vi
+      .spyOn(console, 'log')
+      .mockImplementation((m?: any) => logs.push(String(m ?? '')));
+    const spinner = g.createSpinner('Working');
+    expect(logs).toContain('Working');
+    spinner.succeed('Done');
+    spinner.fail('Bad');
+    expect(logs).toContain('Done');
+    expect(logs).toContain('Bad');
+    spy.mockRestore();
+  });
+});
+
+describe('CLIGenerator - countRequiredArgs / arg validation', () => {
+  it('validates required vs optional args during executeCommand', async () => {
+    const cli = new CLIGenerator({ prompt: false, colors: false });
+    const handler = vi.fn();
+    const commands = [
+      { name: 'thing:do', description: 'd', args: ['id'], handler },
+    ];
+    // Missing the required 'id' arg -> exitWithError throws in test mode.
+    await expect(
+      (cli as any).executeCommand(
+        { command: 'thing:do', args: [], options: {} },
+        commands,
+        [],
+      ),
+    ).rejects.toThrow(/Missing required arguments: id/);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('treats [optional...] args as not required', async () => {
+    const cli = new CLIGenerator({ prompt: false, colors: false });
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const commands = [
+      { name: 'thing:do', description: 'd', args: ['[pattern...]'], handler },
+    ];
+    await (cli as any).executeCommand(
+      { command: 'thing:do', args: [], options: {} },
+      commands,
+      [],
+    );
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a missing handler', async () => {
+    const cli = new CLIGenerator({ prompt: false, colors: false });
+    const commands = [{ name: 'thing:do', description: 'd' }];
+    await expect(
+      (cli as any).executeCommand(
+        { command: 'thing:do', args: [], options: {} },
+        commands,
+        [],
+      ),
+    ).rejects.toThrow(/has no handler defined/);
+  });
+
+  it('wraps handler errors via exitWithError', async () => {
+    const cli = new CLIGenerator({ prompt: false, colors: false });
+    const handler = vi.fn().mockRejectedValue(new Error('boom'));
+    const commands = [{ name: 'thing:do', description: 'd', handler }];
+    await expect(
+      (cli as any).executeCommand(
+        { command: 'thing:do', args: [], options: {} },
+        commands,
+        [],
+      ),
+    ).rejects.toThrow(/Error: boom/);
+  });
+});
+
+describe('CLIGenerator - generateObjectCommands', () => {
+  let cli: CLIGenerator;
+  beforeEach(() => {
+    cli = new CLIGenerator({ prompt: false, colors: false });
+    clearRegistry();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    clearRegistry();
+  });
+
+  function stubRegistry(opts: {
+    cli?: any;
+    fields?: Map<string, any>;
+    methods?: Map<string, any>;
+  }) {
+    vi.spyOn(ObjectRegistry, 'getClass').mockReturnValue({
+      constructor: class Mock {},
+      packageName: 'test',
+    } as any);
+    vi.spyOn(ObjectRegistry, 'getConfig').mockReturnValue({
+      cli: opts.cli,
+      api: false,
+      mcp: false,
+    } as any);
+    vi.spyOn(ObjectRegistry, 'getFields').mockReturnValue(
+      opts.fields ?? new Map(),
+    );
+    vi.spyOn(ObjectRegistry, 'getAllMethods').mockResolvedValue(
+      opts.methods ?? new Map(),
+    );
+  }
+
+  it('returns no commands when cli config is false', async () => {
+    stubRegistry({ cli: false });
+    const cmds = await (cli as any).generateObjectCommands('Widget', {});
+    expect(cmds).toEqual([]);
+  });
+
+  it('generates full CRUD command set with field options when cli is true', async () => {
+    const fields = new Map<string, any>([
+      ['title', { type: 'text', options: { description: 'the title' } }],
+      ['is_active', { type: 'boolean', options: {} }],
+    ]);
+    stubRegistry({ cli: true, fields });
+    const cmds = await (cli as any).generateObjectCommands('Widget', {});
+    const names = cmds.map((c: any) => c.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'widget:list',
+        'widget:get',
+        'widget:create',
+        'widget:update',
+        'widget:delete',
+      ]),
+    );
+    // Field names become kebab-case create options with descriptions.
+    const create = cmds.find((c: any) => c.name === 'widget:create');
+    expect(create.options.title.description).toBe('the title');
+    expect(create.options['is-active']).toBeDefined();
+    // list has aliases + pagination options.
+    const list = cmds.find((c: any) => c.name === 'widget:list');
+    expect(list.aliases).toContain('widget:ls');
+    expect(list.options.limit.default).toBe('50');
+  });
+
+  it('honors include list (only listed CRUD commands generated)', async () => {
+    stubRegistry({ cli: { include: ['list', 'get'] } });
+    const cmds = await (cli as any).generateObjectCommands('Widget', {});
+    const names = cmds.map((c: any) => c.name);
+    expect(names).toContain('widget:list');
+    expect(names).toContain('widget:get');
+    expect(names).not.toContain('widget:create');
+    expect(names).not.toContain('widget:delete');
+  });
+
+  it('honors exclude list', async () => {
+    stubRegistry({ cli: { exclude: ['delete', 'update'] } });
+    const cmds = await (cli as any).generateObjectCommands('Widget', {});
+    const names = cmds.map((c: any) => c.name);
+    expect(names).toContain('widget:list');
+    expect(names).not.toContain('widget:delete');
+    expect(names).not.toContain('widget:update');
+  });
+
+  it('includes public custom methods by default and skips non-public ones', async () => {
+    const methods = new Map<string, any>([
+      ['analyze', { name: 'analyze', isPublic: true, parameters: [] }],
+      [
+        'internalCalc',
+        { name: 'internalCalc', isPublic: false, parameters: [] },
+      ],
+    ]);
+    stubRegistry({ cli: true, methods });
+    const cmds = await (cli as any).generateObjectCommands('Widget', {});
+    const names = cmds.map((c: any) => c.name);
+    expect(names).toContain('widget:analyze');
+    expect(names).not.toContain('widget:internalcalc');
+  });
+
+  it('uses strict mode when include lists custom methods', async () => {
+    const methods = new Map<string, any>([
+      ['analyze', { name: 'analyze', isPublic: true, parameters: [] }],
+      ['summarize', { name: 'summarize', isPublic: true, parameters: [] }],
+    ]);
+    stubRegistry({ cli: { include: ['analyze'] }, methods });
+    const cmds = await (cli as any).generateObjectCommands('Widget', {});
+    const names = cmds.map((c: any) => c.name);
+    expect(names).toContain('widget:analyze');
+    expect(names).not.toContain('widget:summarize');
+  });
+
+  it('marks methods with a leading id param as instance methods needing <id>', async () => {
+    const methods = new Map<string, any>([
+      [
+        'rename',
+        {
+          name: 'rename',
+          isPublic: true,
+          parameters: [
+            { name: 'id', type: 'string' },
+            { name: 'newName', type: 'string' },
+          ],
+        },
+      ],
+      [
+        'ping',
+        {
+          name: 'ping',
+          isPublic: true,
+          parameters: [{ name: 'host', type: 'string' }],
+        },
+      ],
+    ]);
+    stubRegistry({ cli: true, methods });
+    const cmds = await (cli as any).generateObjectCommands('Widget', {});
+    const rename = cmds.find((c: any) => c.name === 'widget:rename');
+    const ping = cmds.find((c: any) => c.name === 'widget:ping');
+    expect(rename.args).toEqual(['id']); // instance method
+    expect(ping.args).toEqual([]); // singleton method
+    // camelCase param -> kebab-case option.
+    expect(rename.options['new-name']).toBeDefined();
+  });
+
+  it('builds JSON-string options for import() object property types', async () => {
+    const methods = new Map<string, any>([
+      [
+        'configure',
+        {
+          name: 'configure',
+          isPublic: true,
+          parameters: [
+            {
+              name: 'opts',
+              type: '{ payload?: import("x").Thing; name?: string }',
+              optional: true,
+            },
+          ],
+        },
+      ],
+    ]);
+    stubRegistry({ cli: true, methods });
+    const cmds = await (cli as any).generateObjectCommands('Widget', {});
+    const configure = cmds.find((c: any) => c.name === 'widget:configure');
+    expect(configure.options.payload.type).toBe('string');
+    expect(configure.options.payload.description).toContain('JSON object');
+  });
+
+  it('respects default values on flat parameters', async () => {
+    const methods = new Map<string, any>([
+      [
+        'retry',
+        {
+          name: 'retry',
+          isPublic: true,
+          parameters: [{ name: 'count', type: 'number', default: 3 }],
+        },
+      ],
+    ]);
+    stubRegistry({ cli: true, methods });
+    const cmds = await (cli as any).generateObjectCommands('Widget', {});
+    const retry = cmds.find((c: any) => c.name === 'widget:retry');
+    expect(retry.options.count.default).toBe('3');
+  });
+});
+
+describe('CLIGenerator - utility commands', () => {
+  let cli: CLIGenerator;
+  beforeEach(() => {
+    cli = new CLIGenerator({
+      name: 'smrt',
+      version: '9.9.9',
+      prompt: false,
+      colors: false,
+    });
+    clearRegistry();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    clearRegistry();
+  });
+
+  it('version handler prints name and version', async () => {
+    const cmds = cli.generateUtilityCommands();
+    const version = cmds.find((c) => c.name === 'version');
+    const logs: string[] = [];
+    const spy = vi
+      .spyOn(console, 'log')
+      .mockImplementation((m?: any) => logs.push(String(m ?? '')));
+    await version?.handler?.([], {});
+    expect(logs.join('\n')).toContain('smrt v9.9.9');
+    spy.mockRestore();
+  });
+
+  it('status handler reports connection state', async () => {
+    const withCtx = new CLIGenerator(
+      { name: 'smrt', version: '1.0.0', colors: false },
+      { db: {}, user: { id: 'u1' } },
+    );
+    const status = withCtx
+      .generateUtilityCommands()
+      .find((c) => c.name === 'status');
+    const logs: string[] = [];
+    const spy = vi
+      .spyOn(console, 'log')
+      .mockImplementation((m?: any) => logs.push(String(m ?? '')));
+    await status?.handler?.([], {});
+    const out = logs.join('\n');
+    expect(out).toContain('Database: Connected');
+    expect(out).toContain('AI: Not available');
+    expect(out).toContain('User: u1');
+    spy.mockRestore();
+  });
+
+  it('objects handler prints empty-state guidance when nothing registered', async () => {
+    vi.spyOn(ObjectRegistry, 'getAllClasses').mockReturnValue(new Map());
+    const objects = cli
+      .generateUtilityCommands()
+      .find((c) => c.name === 'objects');
+    const logs: string[] = [];
+    const spy = vi
+      .spyOn(console, 'log')
+      .mockImplementation((m?: any) => logs.push(String(m ?? '')));
+    await objects?.handler?.([], {});
+    expect(logs.join('\n')).toContain('No SMRT objects found');
+    spy.mockRestore();
+  });
+
+  it('objects handler emits JSON output when --json passed', async () => {
+    const classes = new Map<string, any>([
+      [
+        'test:Widget',
+        { name: 'Widget', packageName: 'test', qualifiedName: 'test:Widget' },
+      ],
+    ]);
+    vi.spyOn(ObjectRegistry, 'getAllClasses').mockReturnValue(classes);
+    vi.spyOn(ObjectRegistry, 'getConfig').mockReturnValue({ cli: true } as any);
+    vi.spyOn(ObjectRegistry, 'getFields').mockReturnValue(
+      new Map([['title', { type: 'text' }]]),
+    );
+    vi.spyOn(ObjectRegistry, 'getAllMethods').mockResolvedValue(
+      new Map([['analyze', { name: 'analyze', isPublic: true }]]),
+    );
+    const objects = cli
+      .generateUtilityCommands()
+      .find((c) => c.name === 'objects');
+    const logs: string[] = [];
+    const spy = vi
+      .spyOn(console, 'log')
+      .mockImplementation((m?: any) => logs.push(String(m ?? '')));
+    await objects?.handler?.([], { json: true });
+    const json = JSON.parse(logs.join('\n'));
+    expect(json['test:Widget'].name).toBe('Widget');
+    expect(json['test:Widget'].package).toBe('test');
+    spy.mockRestore();
+  });
+
+  it('objects handler groups by package in human mode (verbose)', async () => {
+    const classes = new Map<string, any>([
+      ['test:Widget', { name: 'Widget', packageName: 'test' }],
+    ]);
+    vi.spyOn(ObjectRegistry, 'getAllClasses').mockReturnValue(classes);
+    vi.spyOn(ObjectRegistry, 'getConfig').mockReturnValue({
+      cli: { include: ['analyze'] },
+    } as any);
+    vi.spyOn(ObjectRegistry, 'getFields').mockReturnValue(
+      new Map([['title', { type: 'text' }]]),
+    );
+    vi.spyOn(ObjectRegistry, 'getAllMethods').mockResolvedValue(
+      new Map([['analyze', { name: 'analyze', isPublic: true }]]),
+    );
+    const objects = cli
+      .generateUtilityCommands()
+      .find((c) => c.name === 'objects');
+    const logs: string[] = [];
+    const spy = vi
+      .spyOn(console, 'log')
+      .mockImplementation((m?: any) => logs.push(String(m ?? '')));
+    await objects?.handler?.([], { verbose: true });
+    const out = logs.join('\n');
+    expect(out).toContain('test:');
+    expect(out).toContain('Widget');
+    expect(out).toContain('CLI: analyze');
+    spy.mockRestore();
+  });
+
+  it('schema handler prints fields or errors on unknown object', async () => {
+    vi.spyOn(ObjectRegistry, 'getFields').mockReturnValue(
+      new Map([
+        [
+          'title',
+          { type: 'text', options: { required: true, description: 'd' } },
+        ],
+      ]),
+    );
+    const schema = cli
+      .generateUtilityCommands()
+      .find((c) => c.name === 'schema');
+    const logs: string[] = [];
+    const spy = vi
+      .spyOn(console, 'log')
+      .mockImplementation((m?: any) => logs.push(String(m ?? '')));
+    await schema?.handler?.(['Widget'], {});
+    expect(logs.join('\n')).toContain('title: text (required)');
+    spy.mockRestore();
+
+    vi.spyOn(ObjectRegistry, 'getFields').mockReturnValue(new Map());
+    await expect(schema?.handler?.(['Missing'], {})).rejects.toThrow(
+      /Object Missing not found/,
+    );
+  });
+});
+
+describe('CLIGenerator - preprocessObjectCommands', () => {
+  let cli: CLIGenerator;
+  beforeEach(() => {
+    cli = new CLIGenerator({ prompt: false, colors: false });
+    clearRegistry();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    clearRegistry();
+  });
+
+  it('returns argv unchanged when fewer than 2 args', () => {
+    const g = cli as any;
+    expect(g.preprocessObjectCommands(['council'], [])).toEqual(['council']);
+  });
+
+  it('skips when first arg already uses colon syntax or is an option', () => {
+    const g = cli as any;
+    expect(g.preprocessObjectCommands(['a:b', 'x'], [])).toEqual(['a:b', 'x']);
+    expect(g.preprocessObjectCommands(['--flag', 'x'], [])).toEqual([
+      '--flag',
+      'x',
+    ]);
+    expect(g.preprocessObjectCommands(['a', '--flag'], [])).toEqual([
+      'a',
+      '--flag',
+    ]);
+  });
+
+  it('combines space-separated into colon syntax when it matches a command', () => {
+    const g = cli as any;
+    const commands = [{ name: 'council:list', description: 'd' }];
+    expect(
+      g.preprocessObjectCommands(['council', 'list', 'extra'], commands),
+    ).toEqual(['council:list', 'extra']);
+  });
+
+  it('combines for known built-in namespaces', () => {
+    const g = cli as any;
+    expect(g.preprocessObjectCommands(['git', 'status'], [])).toEqual([
+      'git:status',
+    ]);
+  });
+
+  it('combines when first arg is a registered object name', () => {
+    vi.spyOn(ObjectRegistry, 'getAllClasses').mockReturnValue(
+      new Map([['test:Council', { name: 'Council', packageName: 'test' }]]),
+    );
+    const g = cli as any;
+    expect(g.preprocessObjectCommands(['council', 'analyze'], [])).toEqual([
+      'council:analyze',
+    ]);
+  });
+
+  it('returns argv unchanged when nothing matches', () => {
+    vi.spyOn(ObjectRegistry, 'getAllClasses').mockReturnValue(new Map());
+    const g = cli as any;
+    expect(g.preprocessObjectCommands(['random', 'thing'], [])).toEqual([
+      'random',
+      'thing',
+    ]);
+  });
+});
+
+describe('CLIGenerator - handlers (in-memory collection)', () => {
+  let cli: CLIGenerator;
+  beforeEach(() => {
+    cli = new CLIGenerator({ prompt: false, colors: false });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('handleList outputs JSON when format=json and filters via where', async () => {
+    const coll = makeMemoryCollection([
+      { id: '1', name: 'A', kind: 'x' },
+      { id: '2', name: 'B', kind: 'y' },
+    ]);
+    vi.spyOn(cli as any, 'getCollection').mockResolvedValue(coll as any);
+    const logs: string[] = [];
+    const spy = vi
+      .spyOn(console, 'log')
+      .mockImplementation((m?: any) => logs.push(String(m ?? '')));
+    await (cli as any).handleList('Widget', {
+      limit: '50',
+      offset: '0',
+      where: JSON.stringify({ kind: 'x' }),
+      format: 'json',
+    });
+    const out = logs.join('\n');
+    expect(out).toContain('"name": "A"');
+    expect(out).not.toContain('"name": "B"');
+    spy.mockRestore();
+  });
+
+  it('handleList renders a table by default', async () => {
+    const coll = makeMemoryCollection([{ id: '1', name: 'A' }]);
+    vi.spyOn(cli as any, 'getCollection').mockResolvedValue(coll as any);
+    const logs: string[] = [];
+    const spy = vi
+      .spyOn(console, 'log')
+      .mockImplementation((m?: any) => logs.push(String(m ?? '')));
+    await (cli as any).handleList('Widget', {
+      limit: '50',
+      offset: '0',
+      format: 'table',
+    });
+    expect(logs.some((l) => l.includes('A'))).toBe(true);
+    spy.mockRestore();
+  });
+
+  it('handleList surfaces collection errors via exitWithError', async () => {
+    vi.spyOn(cli as any, 'getCollection').mockRejectedValue(
+      new Error('db down'),
+    );
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    await expect(
+      (cli as any).handleList('Widget', { limit: '50', offset: '0' }),
+    ).rejects.toThrow(/db down/);
+  });
+
+  it('handleGet returns JSON and yaml, and errors when not found', async () => {
+    const coll = makeMemoryCollection([{ id: '1', name: 'A', meta: { z: 1 } }]);
+    vi.spyOn(cli as any, 'getCollection').mockResolvedValue(coll as any);
+    const logs: string[] = [];
+    const spy = vi
+      .spyOn(console, 'log')
+      .mockImplementation((m?: any) => logs.push(String(m ?? '')));
+
+    await (cli as any).handleGet('Widget', '1', { format: 'json' });
+    expect(logs.join('\n')).toContain('"name": "A"');
+
+    logs.length = 0;
+    await (cli as any).handleGet('Widget', '1', { format: 'yaml' });
+    expect(logs.join('\n')).toContain('name: A');
+    spy.mockRestore();
+
+    await expect(
+      (cli as any).handleGet('Widget', 'missing', { format: 'json' }),
+    ).rejects.toThrow(/not found/);
+  });
+
+  it('handleCreate builds data from field options and saves', async () => {
+    const coll = makeMemoryCollection();
+    vi.spyOn(cli as any, 'getCollection').mockResolvedValue(coll as any);
+    vi.spyOn(ObjectRegistry, 'getFields').mockReturnValue(
+      new Map([
+        ['title', { type: 'text' }],
+        ['count', { type: 'integer' }],
+      ]),
+    );
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    await (cli as any).handleCreate('Widget', { title: 'Hi', count: '5' });
+    const created = Array.from(coll.store.values())[0];
+    expect(created.title).toBe('Hi');
+    expect(created.count).toBe(5); // parseFieldValue coerces numeric strings
+  });
+
+  it('handleCreate reads from a JSON file when --from-file given', async () => {
+    const coll = makeMemoryCollection();
+    vi.spyOn(cli as any, 'getCollection').mockResolvedValue(coll as any);
+    // Use a real temp file (node:fs/promises readFile cannot be spied in ESM).
+    const { mkdtemp, writeFile } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const dir = await mkdtemp(join(tmpdir(), 'smrt-cli-'));
+    const filePath = join(dir, 'x.json');
+    await writeFile(filePath, JSON.stringify({ title: 'FromFile' }));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    await (cli as any).handleCreate('Widget', { fromFile: filePath });
+    const created = Array.from(coll.store.values())[0];
+    expect(created.title).toBe('FromFile');
+  });
+
+  it('handleUpdate merges fields into an existing object', async () => {
+    const coll = makeMemoryCollection([{ id: '1', title: 'Old' }]);
+    // Provide save/delete on the stored object so update path works.
+    const stored = coll.store.get('1');
+    stored.save = async () => coll.store.set('1', stored);
+    vi.spyOn(cli as any, 'getCollection').mockResolvedValue(coll as any);
+    vi.spyOn(ObjectRegistry, 'getFields').mockReturnValue(
+      new Map([['title', { type: 'text' }]]),
+    );
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    await (cli as any).handleUpdate('Widget', '1', { title: 'New' });
+    expect(coll.store.get('1').title).toBe('New');
+  });
+
+  it('handleUpdate errors when the object is not found', async () => {
+    const coll = makeMemoryCollection();
+    vi.spyOn(cli as any, 'getCollection').mockResolvedValue(coll as any);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    await expect(
+      (cli as any).handleUpdate('Widget', 'nope', { title: 'x' }),
+    ).rejects.toThrow(/not found/);
+  });
+
+  it('handleDelete removes when --force is set', async () => {
+    const coll = makeMemoryCollection([{ id: '1', name: 'A' }]);
+    const stored = coll.store.get('1');
+    stored.delete = async () => coll.store.delete('1');
+    vi.spyOn(cli as any, 'getCollection').mockResolvedValue(coll as any);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    await (cli as any).handleDelete('Widget', '1', { force: true });
+    expect(coll.store.has('1')).toBe(false);
+  });
+
+  it('handleDelete cancels when confirmation is declined', async () => {
+    const promptCli = new CLIGenerator({ prompt: true, colors: false });
+    const coll = makeMemoryCollection([{ id: '1', name: 'A' }]);
+    const stored = coll.store.get('1');
+    stored.delete = vi.fn();
+    vi.spyOn(promptCli as any, 'getCollection').mockResolvedValue(coll as any);
+    vi.spyOn(promptCli as any, 'confirm').mockResolvedValue(false);
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((m?: any) =>
+      logs.push(String(m ?? '')),
+    );
+    await (promptCli as any).handleDelete('Widget', '1', { force: false });
+    expect(logs.join('\n')).toContain('Cancelled');
+    expect(coll.store.has('1')).toBe(true);
+  });
+
+  it('handleDelete errors when object not found', async () => {
+    const coll = makeMemoryCollection();
+    vi.spyOn(cli as any, 'getCollection').mockResolvedValue(coll as any);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    await expect(
+      (cli as any).handleDelete('Widget', 'nope', { force: true }),
+    ).rejects.toThrow(/not found/);
+  });
+});
+
+describe('CLIGenerator - handleCustomMethod', () => {
+  let cli: CLIGenerator;
+  beforeEach(() => {
+    cli = new CLIGenerator({ prompt: false, colors: false });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('invokes the instance method with mapped flat + object params', async () => {
+    const analyze = vi.fn().mockResolvedValue({ ok: true });
+    const obj = { id: '1', analyze };
+    const coll = { get: async () => obj };
+    vi.spyOn(cli as any, 'getCollection').mockResolvedValue(coll as any);
+    vi.spyOn(ObjectRegistry, 'getAllMethods').mockResolvedValue(
+      new Map([
+        [
+          'analyze',
+          {
+            name: 'analyze',
+            isPublic: true,
+            parameters: [
+              { name: 'id', type: 'string' },
+              {
+                name: 'opts',
+                type: '{ depth?: number; payload?: object }',
+                optional: true,
+              },
+            ],
+          },
+        ],
+      ]),
+    );
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    await (cli as any).handleCustomMethod('Widget', '1', 'analyze', {
+      depth: '3',
+      payload: '{"a":1}',
+    });
+    expect(analyze).toHaveBeenCalledTimes(1);
+    const callArgs = analyze.mock.calls[0];
+    // Both params are mapped from CLI options. The flat 'id' param has no --id
+    // option provided, so it maps to undefined; the object param is
+    // reconstructed from --depth/--payload (with JSON auto-parsing).
+    expect(callArgs[0]).toBeUndefined();
+    expect(callArgs[1]).toEqual({ depth: '3', payload: { a: 1 } });
+  });
+
+  it('errors when the object is not found', async () => {
+    vi.spyOn(cli as any, 'getCollection').mockResolvedValue({
+      get: async () => null,
+    } as any);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    await expect(
+      (cli as any).handleCustomMethod('Widget', 'x', 'analyze', {}),
+    ).rejects.toThrow(/not found/);
+  });
+
+  it('errors when the method definition is missing', async () => {
+    vi.spyOn(cli as any, 'getCollection').mockResolvedValue({
+      get: async () => ({ id: '1' }),
+    } as any);
+    vi.spyOn(ObjectRegistry, 'getAllMethods').mockResolvedValue(new Map());
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    await expect(
+      (cli as any).handleCustomMethod('Widget', '1', 'analyze', {}),
+    ).rejects.toThrow(/Method analyze not found/);
+  });
+
+  it('errors when the method is not callable on the instance', async () => {
+    vi.spyOn(cli as any, 'getCollection').mockResolvedValue({
+      get: async () => ({ id: '1', analyze: 'not-a-fn' }),
+    } as any);
+    vi.spyOn(ObjectRegistry, 'getAllMethods').mockResolvedValue(
+      new Map([
+        ['analyze', { name: 'analyze', isPublic: true, parameters: [] }],
+      ]),
+    );
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    await expect(
+      (cli as any).handleCustomMethod('Widget', '1', 'analyze', {}),
+    ).rejects.toThrow(/not callable/);
+  });
+});
+
+describe('CLIGenerator - handleSingletonMethod', () => {
+  let cli: CLIGenerator;
+  beforeEach(() => {
+    cli = new CLIGenerator({ prompt: false, colors: false });
+    clearRegistry();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    clearRegistry();
+  });
+
+  it('errors with troubleshooting text when class constructor is absent', async () => {
+    vi.spyOn(ObjectRegistry, 'getClass').mockReturnValue(undefined as any);
+    vi.spyOn(ObjectRegistry, 'getAllClasses').mockReturnValue(new Map());
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(
+      (cli as any).handleSingletonMethod(
+        'Widget',
+        'doThing',
+        {},
+        {
+          parameters: [],
+        },
+      ),
+    ).rejects.toThrow(/not found/);
+  });
+
+  it('errors when constructor is a manifest stub', async () => {
+    const stub: any = vi.fn();
+    stub._isManifestStub = true;
+    vi.spyOn(ObjectRegistry, 'getClass').mockReturnValue({
+      constructor: stub,
+      packageName: 'test',
+    } as any);
+    vi.spyOn(ObjectRegistry, 'getAllClasses').mockReturnValue(new Map());
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(
+      (cli as any).handleSingletonMethod(
+        'Widget',
+        'doThing',
+        {},
+        {
+          parameters: [],
+        },
+      ),
+    ).rejects.toThrow(/registered from manifest/);
+  });
+});

--- a/packages/cli/src/__tests__/cli-generator-dispatch.test.ts
+++ b/packages/cli/src/__tests__/cli-generator-dispatch.test.ts
@@ -1,0 +1,493 @@
+/**
+ * Coverage for CLIGenerator dispatch/lazy-loading/help flows.
+ *
+ * These exercise the orchestration layer — ensureManifestLoaded(),
+ * getObjectCommandsLazy(), findObjectCommand(), generateAllCommands(),
+ * executeCommand() built-in + object-help branches, showObjectHelp(),
+ * getCollection(), promptForFields(), and the singleton-method happy path.
+ *
+ * tryLoadUserClasses() is stubbed to a no-op (it imports the consumer's
+ * compiled classes from disk, irrelevant here) and ObjectRegistry getters are
+ * spied to feed controlled object metadata. A real in-memory SQLite database is
+ * used for getCollection() — no DB mocking.
+ */
+
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CLIGenerator } from '../cli-generator.js';
+
+function silenceConsole() {
+  const logs: string[] = [];
+  const log = vi
+    .spyOn(console, 'log')
+    .mockImplementation((m?: any) => logs.push(String(m ?? '')));
+  const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+  return {
+    logs,
+    restore: () => {
+      log.mockRestore();
+      err.mockRestore();
+    },
+  };
+}
+
+/** Register a single object's metadata into the spied registry. */
+function stubObject(opts: {
+  name: string;
+  key?: string;
+  packageName?: string;
+  cli?: any;
+  constructor?: any;
+  collectionConstructor?: any;
+  fields?: Map<string, any>;
+  methods?: Map<string, any>;
+}) {
+  const key = opts.key ?? `${opts.packageName ?? 'project'}:${opts.name}`;
+  const info: any = {
+    name: opts.name,
+    packageName: opts.packageName ?? 'project',
+    qualifiedName: key,
+    constructor: opts.constructor,
+    collectionConstructor: opts.collectionConstructor,
+  };
+  vi.spyOn(ObjectRegistry, 'getAllClasses').mockReturnValue(
+    new Map([[key, info]]),
+  );
+  vi.spyOn(ObjectRegistry, 'getClass').mockReturnValue(info);
+  vi.spyOn(ObjectRegistry, 'getConfig').mockReturnValue({
+    cli: opts.cli ?? true,
+    api: false,
+    mcp: false,
+  } as any);
+  vi.spyOn(ObjectRegistry, 'getFields').mockReturnValue(
+    opts.fields ?? new Map(),
+  );
+  vi.spyOn(ObjectRegistry, 'getAllMethods').mockResolvedValue(
+    opts.methods ?? new Map(),
+  );
+  return { key, info };
+}
+
+describe('CLIGenerator - lazy command resolution', () => {
+  let cli: CLIGenerator;
+  beforeEach(() => {
+    cli = new CLIGenerator({ prompt: false, colors: false });
+    // Prevent disk class loading; we drive the registry via spies.
+    vi.spyOn(cli as any, 'tryLoadUserClasses').mockResolvedValue(undefined);
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('ensureManifestLoaded builds the registered-name set once', async () => {
+    stubObject({ name: 'Council', cli: { include: ['list'] } });
+    await (cli as any).ensureManifestLoaded();
+    expect((cli as any).manifestLoaded).toBe(true);
+    expect((cli as any).registeredObjectNames.has('council')).toBe(true);
+    // Second call short-circuits (no throw, idempotent).
+    await (cli as any).ensureManifestLoaded();
+    expect((cli as any).manifestLoaded).toBe(true);
+  });
+
+  it('getObjectCommandsLazy returns and caches commands for a known object', async () => {
+    stubObject({ name: 'Council', cli: { include: ['list', 'get'] } });
+    await (cli as any).ensureManifestLoaded();
+    const first = await (cli as any).getObjectCommandsLazy('council');
+    expect(first.map((c: any) => c.name)).toEqual(
+      expect.arrayContaining(['council:list', 'council:get']),
+    );
+    // Cached on second call.
+    const second = await (cli as any).getObjectCommandsLazy('council');
+    expect(second).toBe(first);
+  });
+
+  it('getObjectCommandsLazy returns [] for an unknown object', async () => {
+    stubObject({ name: 'Council' });
+    await (cli as any).ensureManifestLoaded();
+    expect(await (cli as any).getObjectCommandsLazy('nonexistent')).toEqual([]);
+  });
+
+  it('findObjectCommand resolves colon-form commands and rejects non-objects', async () => {
+    stubObject({ name: 'Council', cli: { include: ['list'] } });
+    const found = await (cli as any).findObjectCommand('council:list');
+    expect(found?.name).toBe('council:list');
+    // Non-colon command -> undefined.
+    expect(await (cli as any).findObjectCommand('list')).toBeUndefined();
+    // Colon command for unknown object -> undefined.
+    expect(
+      await (cli as any).findObjectCommand('mystery:list'),
+    ).toBeUndefined();
+  });
+
+  it('generateAllCommands merges utility + object commands', async () => {
+    stubObject({ name: 'Council', cli: { include: ['list'] } });
+    const all = await (cli as any).generateAllCommands();
+    const names = all.map((c: any) => c.name);
+    expect(names).toContain('objects'); // utility
+    expect(names).toContain('council:list'); // object
+  });
+});
+
+describe('CLIGenerator - executeCommand dispatch', () => {
+  let cli: CLIGenerator;
+  beforeEach(() => {
+    cli = new CLIGenerator({ prompt: false, colors: false });
+    vi.spyOn(cli as any, 'tryLoadUserClasses').mockResolvedValue(undefined);
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('shows full help when no command is given', async () => {
+    vi.spyOn(ObjectRegistry, 'getAllClasses').mockReturnValue(new Map());
+    const showHelp = vi
+      .spyOn(cli as any, 'showHelp')
+      .mockResolvedValue(undefined);
+    await (cli as any).executeCommand(
+      { command: undefined, args: [], options: {} },
+      [],
+    );
+    expect(showHelp).toHaveBeenCalled();
+  });
+
+  it('dispatches a lazily-resolved object command', async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(cli as any, 'findObjectCommand').mockResolvedValue({
+      name: 'council:list',
+      description: 'd',
+      handler,
+    });
+    await (cli as any).executeCommand(
+      { command: 'council:list', args: [], options: {} },
+      [],
+      ['council:list'],
+    );
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('raises "Unknown command" after exhausting object + built-in lookups', async () => {
+    // No object command and no built-in command matches. This drives the full
+    // fall-through: lazy object lookup, the built-in command loaders, and the
+    // registered-object-name check, ending in the unknown-command error.
+    vi.spyOn(cli as any, 'findObjectCommand').mockResolvedValue(undefined);
+    vi.spyOn(ObjectRegistry, 'getAllClasses').mockReturnValue(new Map());
+    const { restore } = silenceConsole();
+    await expect(
+      (cli as any).executeCommand(
+        { command: 'definitely-not-a-command', args: [], options: {} },
+        [],
+        ['definitely-not-a-command'],
+      ),
+    ).rejects.toThrow(/Unknown command/);
+    restore();
+  });
+
+  it('shows object help when command matches a registered object name', async () => {
+    stubObject({ name: 'Council', cli: { include: ['list'] } });
+    vi.spyOn(cli as any, 'findObjectCommand').mockResolvedValue(undefined);
+    const showObjectHelp = vi
+      .spyOn(cli as any, 'showObjectHelp')
+      .mockResolvedValue(undefined);
+    await (cli as any).executeCommand(
+      { command: 'council', args: [], options: {} },
+      [],
+      ['council'],
+    );
+    expect(showObjectHelp).toHaveBeenCalledWith('Council', expect.anything());
+  });
+});
+
+describe('CLIGenerator - showObjectHelp', () => {
+  let cli: CLIGenerator;
+  beforeEach(() => {
+    cli = new CLIGenerator({ prompt: false, colors: false });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('lists commands, options and fields for an object', async () => {
+    vi.spyOn(ObjectRegistry, 'getClass').mockReturnValue({
+      name: 'Council',
+      packageName: 'test',
+    } as any);
+    vi.spyOn(ObjectRegistry, 'getFields').mockReturnValue(
+      new Map([['title', { type: 'text', options: { required: true } }]]),
+    );
+    const { logs, restore } = silenceConsole();
+    await (cli as any).showObjectHelp('Council', [
+      {
+        name: 'council:list',
+        description: 'List councils',
+        args: ['id'],
+        options: { limit: { description: 'max', short: 'l', default: '50' } },
+      },
+    ]);
+    const out = logs.join('\n');
+    expect(out).toContain('Council');
+    expect(out).toContain('Package: test');
+    expect(out).toContain('smrt council list <id>');
+    expect(out).toContain('--limit');
+    expect(out).toContain('title: text (required)');
+    restore();
+  });
+
+  it('shows guidance when an object has no CLI commands', async () => {
+    vi.spyOn(ObjectRegistry, 'getClass').mockReturnValue({
+      name: 'Council',
+    } as any);
+    vi.spyOn(ObjectRegistry, 'getFields').mockReturnValue(new Map());
+    const { logs, restore } = silenceConsole();
+    await (cli as any).showObjectHelp('Council', []);
+    expect(logs.join('\n')).toContain('No CLI commands available');
+    restore();
+  });
+});
+
+describe('CLIGenerator - getCollection (real in-memory SQLite)', () => {
+  let cli: CLIGenerator;
+  afterEach(() => vi.restoreAllMocks());
+
+  it('throws a helpful error when no collection constructor is registered', async () => {
+    cli = new CLIGenerator({ prompt: false, colors: false });
+    vi.spyOn(ObjectRegistry, 'getClass').mockReturnValue(undefined as any);
+    vi.spyOn(ObjectRegistry, 'getAllClasses').mockReturnValue(new Map());
+    await expect((cli as any).getCollection('Widget')).rejects.toThrow(
+      /not found or has no collection constructor/,
+    );
+  });
+
+  it('constructs and initializes a collection using the context db', async () => {
+    const { getDatabase } = await import('@happyvertical/sql');
+    const db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+    cli = new CLIGenerator({ prompt: false, colors: false }, { db });
+
+    const initialize = vi.fn().mockResolvedValue(undefined);
+    const captured: any[] = [];
+    class FakeCollection {
+      constructor(opts: any) {
+        captured.push(opts);
+      }
+      initialize = initialize;
+    }
+    vi.spyOn(ObjectRegistry, 'getClass').mockReturnValue({
+      name: 'Widget',
+      collectionConstructor: FakeCollection as any,
+    } as any);
+
+    const coll = await (cli as any).getCollection('Widget');
+    expect(coll).toBeInstanceOf(FakeCollection);
+    expect(initialize).toHaveBeenCalled();
+    // Real db handle passed through.
+    expect(captured[0].db).toBe(db);
+    // Cached on second call (same instance, no re-init).
+    initialize.mockClear();
+    const again = await (cli as any).getCollection('Widget');
+    expect(again).toBe(coll);
+    expect(initialize).not.toHaveBeenCalled();
+  });
+});
+
+describe('CLIGenerator - promptForFields', () => {
+  let cli: CLIGenerator;
+  beforeEach(() => {
+    cli = new CLIGenerator({ prompt: true, colors: false });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('collects text and boolean fields, falling back to current values', async () => {
+    vi.spyOn(ObjectRegistry, 'getFields').mockReturnValue(
+      new Map([
+        ['title', { type: 'text', options: { description: 'the title' } }],
+        ['active', { type: 'boolean', options: {} }],
+        ['keep', { type: 'text', options: {} }],
+      ]),
+    );
+    // title -> typed value, active -> confirm true, keep -> empty (use current).
+    vi.spyOn(cli as any, 'prompt').mockImplementation(async (msg: any) => {
+      if (String(msg).startsWith('title')) return 'My Title';
+      return ''; // 'keep' returns empty
+    });
+    vi.spyOn(cli as any, 'confirm').mockResolvedValue(true);
+
+    const result = await (cli as any).promptForFields('Widget', {
+      keep: 'existing',
+    });
+    expect(result.title).toBe('My Title');
+    expect(result.active).toBe(true);
+    expect(result.keep).toBe('existing');
+  });
+});
+
+describe('CLIGenerator - handleSingletonMethod happy path', () => {
+  let cli: CLIGenerator;
+  beforeEach(() => {
+    cli = new CLIGenerator({ prompt: false, colors: false });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('constructs the class, initializes it, and calls the method with mapped params', async () => {
+    const doThing = vi.fn().mockResolvedValue({ done: true });
+    const initialize = vi.fn().mockResolvedValue(undefined);
+    class Widget {
+      doThing = doThing;
+      initialize = initialize;
+    }
+    vi.spyOn(ObjectRegistry, 'getClass').mockReturnValue({
+      name: 'Widget',
+      constructor: Widget as any,
+      packageName: 'test',
+    } as any);
+    const { logs, restore } = silenceConsole();
+    await (cli as any).handleSingletonMethod(
+      'Widget',
+      'doThing',
+      { count: '7' },
+      {
+        parameters: [{ name: 'count', type: 'number' }],
+      },
+    );
+    expect(initialize).toHaveBeenCalled();
+    expect(doThing).toHaveBeenCalledWith('7');
+    expect(logs.join('\n')).toContain('"done": true');
+    restore();
+  });
+
+  it('errors when the named method is not a function', async () => {
+    class Widget {
+      label = 'widget';
+    }
+    vi.spyOn(ObjectRegistry, 'getClass').mockReturnValue({
+      name: 'Widget',
+      constructor: Widget as any,
+    } as any);
+    const { restore } = silenceConsole();
+    await expect(
+      (cli as any).handleSingletonMethod(
+        'Widget',
+        'missing',
+        {},
+        {
+          parameters: [],
+        },
+      ),
+    ).rejects.toThrow();
+    restore();
+  });
+
+  it('passes {} for a required object param with no options and uses flat defaults', async () => {
+    const doThing = vi.fn().mockResolvedValue(undefined);
+    class Widget {
+      doThing = doThing;
+    }
+    vi.spyOn(ObjectRegistry, 'getClass').mockReturnValue({
+      name: 'Widget',
+      constructor: Widget as any,
+    } as any);
+    const { restore } = silenceConsole();
+    await (cli as any).handleSingletonMethod(
+      'Widget',
+      'doThing',
+      {},
+      {
+        parameters: [
+          { name: 'opts', type: '{ a?: string }', optional: false },
+          { name: 'retries', type: 'number', default: 5 },
+        ],
+      },
+    );
+    // Required object param with no matching options -> {}; flat default -> 5.
+    expect(doThing).toHaveBeenCalledWith({}, 5);
+    restore();
+  });
+
+  it('runs in JSON mode and silences spinner output', async () => {
+    const doThing = vi.fn().mockResolvedValue({ v: 1 });
+    class Widget {
+      doThing = doThing;
+    }
+    vi.spyOn(ObjectRegistry, 'getClass').mockReturnValue({
+      name: 'Widget',
+      constructor: Widget as any,
+    } as any);
+    const logs: string[] = [];
+    const spy = vi
+      .spyOn(console, 'log')
+      .mockImplementation((m?: any) => logs.push(String(m ?? '')));
+    await (cli as any).handleSingletonMethod(
+      'Widget',
+      'doThing',
+      { json: true },
+      {
+        parameters: [],
+      },
+    );
+    // Only the JSON result should be printed.
+    expect(logs.join('\n')).toContain('"v": 1');
+    spy.mockRestore();
+  });
+});
+
+describe('CLIGenerator - handleCustomMethod param edge cases', () => {
+  let cli: CLIGenerator;
+  beforeEach(() => {
+    cli = new CLIGenerator({ prompt: false, colors: false });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('passes {} for required object param, undefined for optional, and flat default', async () => {
+    const run = vi.fn().mockResolvedValue('ok');
+    vi.spyOn(cli as any, 'getCollection').mockResolvedValue({
+      get: async () => ({ id: '1', run }),
+    } as any);
+    vi.spyOn(ObjectRegistry, 'getAllMethods').mockResolvedValue(
+      new Map([
+        [
+          'run',
+          {
+            name: 'run',
+            isPublic: true,
+            parameters: [
+              { name: 'required', type: '{ a?: string }', optional: false },
+              { name: 'optionalObj', type: '{ b?: string }', optional: true },
+              { name: 'count', type: 'number', default: 9 },
+            ],
+          },
+        ],
+      ]),
+    );
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    await (cli as any).handleCustomMethod('Widget', '1', 'run', {});
+    expect(run).toHaveBeenCalledWith({}, undefined, 9);
+  });
+});
+
+describe('CLIGenerator - createSpinner TTY branch', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('writes spinner frames and uses clearLine/cursorTo when TTY + colors', () => {
+    const cli = new CLIGenerator({ colors: true });
+    const writes: string[] = [];
+    const stdout = process.stdout as any;
+    const origIsTTY = stdout.isTTY;
+    const origClear = stdout.clearLine;
+    const origCursor = stdout.cursorTo;
+    const origWrite = stdout.write;
+    try {
+      stdout.isTTY = true;
+      stdout.clearLine = vi.fn();
+      stdout.cursorTo = vi.fn();
+      stdout.write = vi.fn((s: string) => {
+        writes.push(s);
+        return true;
+      });
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const spinner = (cli as any).createSpinner('Loading');
+      spinner.succeed('Loaded');
+      spinner.fail('Failed');
+      expect(writes.some((w) => w.includes('Loading'))).toBe(true);
+      expect(stdout.clearLine).toHaveBeenCalled();
+      expect(stdout.cursorTo).toHaveBeenCalled();
+      logSpy.mockRestore();
+    } finally {
+      stdout.isTTY = origIsTTY;
+      stdout.clearLine = origClear;
+      stdout.cursorTo = origCursor;
+      stdout.write = origWrite;
+    }
+  });
+});

--- a/packages/cli/src/commands/__tests__/config-export.test.ts
+++ b/packages/cli/src/commands/__tests__/config-export.test.ts
@@ -1,0 +1,256 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { configExportCommand } from '../config-export.js';
+
+// ---------------------------------------------------------------------------
+// Mocks for the dynamically imported dependencies. The handler calls
+// `await import(...)` for each of these, so the factory return shape must match
+// the named exports the handler reads.
+// ---------------------------------------------------------------------------
+
+const getPackageConfig = vi.fn();
+vi.mock('@happyvertical/smrt-config', () => ({
+  getPackageConfig: (...args: unknown[]) => getPackageConfig(...args),
+  // exportConfig / sanitizeConfig are the real implementations re-exported so
+  // we exercise the genuine secret-stripping behaviour.
+  exportConfig: (data: Record<string, unknown>, opts: any) => {
+    const payload = opts?.includeSecrets ? data : sanitizeImpl(data);
+    if (opts?.format === 'js') {
+      return `export default ${JSON.stringify(payload, null, 2)};\n`;
+    }
+    return JSON.stringify(payload, null, 2);
+  },
+  sanitizeConfig: (data: Record<string, unknown>) => sanitizeImpl(data),
+}));
+
+// A tiny stand-in for the real sanitizeConfig: strips obvious secret keys.
+function sanitizeImpl(data: any): any {
+  if (Array.isArray(data)) return data.map(sanitizeImpl);
+  if (data && typeof data === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(data)) {
+      if (/password|secret|token|apikey|api_key/i.test(k)) {
+        out[k] = '***';
+      } else {
+        out[k] = sanitizeImpl(v);
+      }
+    }
+    return out;
+  }
+  return data;
+}
+
+vi.mock('../config.js', () => ({
+  DEFAULT_CLI_CONFIG: { database: { type: 'sqlite', url: ':memory:' } },
+}));
+
+const getDatabase = vi.fn();
+vi.mock('@happyvertical/sql', () => ({
+  getDatabase: (...args: unknown[]) => getDatabase(...args),
+}));
+
+const listFn = vi.fn();
+const createCollection = vi.fn(async () => ({ list: listFn }));
+vi.mock('@happyvertical/smrt-agents', () => ({
+  AgentConfigCollection: {
+    create: (...args: unknown[]) => createCollection(...args),
+  },
+}));
+
+describe('config:export command', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  const tempDirs: string[] = [];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = undefined;
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
+      code?: string | number | null,
+    ) => {
+      throw new Error(`exit:${code ?? ''}`);
+    }) as typeof process.exit);
+    // default: a configured DB and a mock connection with a close()
+    getPackageConfig.mockReturnValue({
+      database: { type: 'sqlite', url: './dev.db' },
+    });
+    getDatabase.mockResolvedValue({ close: vi.fn() });
+  });
+
+  afterEach(async () => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+    tempDirs.length = 0;
+    process.exitCode = undefined;
+  });
+
+  function logged(): string {
+    return logSpy.mock.calls.flat().join('\n');
+  }
+  function errored(): string {
+    return errSpy.mock.calls.flat().join('\n');
+  }
+
+  it('errors and exits when no agent id is supplied', async () => {
+    // process.exit() throws our sentinel, but it is raised inside the handler's
+    // try block and swallowed by its catch, which sets exitCode + returns.
+    await configExportCommand.handler([], {});
+    expect(errored()).toContain('Agent ID is required');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('errors and exits when the database is not configured', async () => {
+    getPackageConfig.mockReturnValue({ database: { url: ':memory:' } });
+    await configExportCommand.handler([], { agent: 'a1' });
+    expect(errored()).toContain('Database configuration required');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('emits a JSON error object when db missing and --json is set', async () => {
+    getPackageConfig.mockReturnValue({ database: undefined });
+    await configExportCommand.handler([], { agent: 'a1', json: true });
+    expect(logged()).toContain('"error":"Database not configured"');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('reports when no configurations are found for an agent', async () => {
+    listFn.mockResolvedValue([]);
+    await configExportCommand.handler([], { agent: 'missing' });
+    expect(logged()).toContain('No configurations found for agent: missing');
+  });
+
+  it('mentions the slot filter when no configs found with --slot', async () => {
+    listFn.mockResolvedValue([]);
+    await configExportCommand.handler([], {
+      agent: 'missing',
+      slot: 'sources',
+    });
+    expect(logged()).toContain('Slot filter: sources');
+    expect(createCollection).toHaveBeenCalled();
+  });
+
+  it('returns empty JSON config object when none found and --json', async () => {
+    listFn.mockResolvedValue([]);
+    await configExportCommand.handler([], { agent: 'x', json: true });
+    expect(logged()).toContain('"configs":{}');
+  });
+
+  it('writes a sanitized JSON file by default', async () => {
+    const dir = await mkdtemp(resolve(process.cwd(), '.tmp-cfg-export-'));
+    tempDirs.push(dir);
+    const outFile = join(dir, 'nested', 'smrt.exported.json');
+    listFn.mockResolvedValue([
+      {
+        slotId: 'settings',
+        configData: { apiKey: 'sekret', label: 'visible' },
+      },
+    ]);
+
+    await configExportCommand.handler([], {
+      agent: 'agent-1',
+      output: outFile,
+      format: 'json',
+    });
+
+    const written = await readFile(outFile, 'utf-8');
+    expect(written).toContain('"apiKey": "***"');
+    expect(written).toContain('"label": "visible"');
+    expect(logged()).toContain('Exported configuration for agent: agent-1');
+    expect(logged()).toContain('Secrets: filtered');
+    // JSON-format usage hint
+    expect(logged()).toContain("with { type: 'json' }");
+  });
+
+  it('includes secrets and emits js usage hint when requested', async () => {
+    const dir = await mkdtemp(resolve(process.cwd(), '.tmp-cfg-export-js-'));
+    tempDirs.push(dir);
+    const outFile = join(dir, 'smrt.exported.js');
+    listFn.mockResolvedValue([
+      { slotId: 'settings', configData: { apiKey: 'sekret' } },
+    ]);
+
+    await configExportCommand.handler([], {
+      agent: 'agent-1',
+      output: outFile,
+      format: 'js',
+      'include-secrets': true,
+    });
+
+    const written = await readFile(outFile, 'utf-8');
+    expect(written).toContain('export default');
+    expect(written).toContain('"apiKey": "sekret"');
+    expect(logged()).toContain('Secrets: INCLUDED');
+    expect(logged()).toContain('export default {');
+  });
+
+  it('outputs sanitized JSON to stdout with --json (no file write)', async () => {
+    listFn.mockResolvedValue([
+      {
+        slotId: 'settings',
+        configData: { password: 'p', name: 'ok' },
+      },
+    ]);
+    await configExportCommand.handler([], { agent: 'agent-1', json: true });
+    const out = logged();
+    expect(out).toContain('"agentId": "agent-1"');
+    expect(out).toContain('"password": "***"');
+    expect(out).toContain('"name": "ok"');
+  });
+
+  it('preserves secrets in stdout JSON with --json --include-secrets', async () => {
+    listFn.mockResolvedValue([
+      { slotId: 'settings', configData: { password: 'p' } },
+    ]);
+    await configExportCommand.handler([], {
+      agent: 'agent-1',
+      json: true,
+      'include-secrets': true,
+    });
+    expect(logged()).toContain('"password": "p"');
+  });
+
+  it('passes the slot filter through to the collection query', async () => {
+    listFn.mockResolvedValue([{ slotId: 'sources', configData: { url: 'x' } }]);
+    await configExportCommand.handler([], {
+      agent: 'agent-1',
+      json: true,
+      slot: 'sources',
+    });
+    expect(listFn).toHaveBeenCalledWith({
+      where: { agentId: 'agent-1', slotId: 'sources' },
+    });
+  });
+
+  it('handles thrown errors and sets exitCode, with --json error output', async () => {
+    getDatabase.mockRejectedValue(new Error('connection refused'));
+    await configExportCommand.handler([], { agent: 'agent-1', json: true });
+    expect(logged()).toContain('"error":"connection refused"');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('handles thrown errors in non-json mode', async () => {
+    getDatabase.mockRejectedValue(new Error('boom'));
+    await configExportCommand.handler([], { agent: 'agent-1' });
+    expect(errored()).toContain('Failed to export configuration');
+    expect(errored()).toContain('boom');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('closes the database connection in the finally block', async () => {
+    const close = vi.fn();
+    getDatabase.mockResolvedValue({ close });
+    listFn.mockResolvedValue([
+      { slotId: 'settings', configData: { name: 'ok' } },
+    ]);
+    await configExportCommand.handler([], { agent: 'agent-1', json: true });
+    expect(close).toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/__tests__/db-diff.test.ts
+++ b/packages/cli/src/commands/__tests__/db-diff.test.ts
@@ -1,0 +1,357 @@
+import { rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { clearCache, setConfig } from '@happyvertical/smrt-config';
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { autoDiscoverAndLoadMock } = vi.hoisted(() => ({
+  autoDiscoverAndLoadMock: vi.fn(),
+}));
+
+vi.mock('../../discovery/index.js', () => ({
+  autoDiscoverAndLoad: autoDiscoverAndLoadMock,
+}));
+
+import { dbDiffCommand } from '../db-diff.js';
+
+/**
+ * db:diff against a REAL SQLite database and the REAL SchemaComparer.
+ *
+ * Discovery is mocked (it would scan the filesystem for manifests), and the
+ * declared schema is supplied via a spy on
+ * `ObjectRegistry.getAllSchemasAsDefinitions` — the same source the command
+ * uses. Everything else (the comparer, the live introspection) runs for real
+ * against a temp SQLite file we control, so the diff output reflects genuine
+ * schema drift rather than a hand-built fixture.
+ */
+describe('db:diff (real SQLite + real SchemaComparer)', () => {
+  let dbUrl: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let getSchemasSpy: ReturnType<typeof vi.spyOn>;
+
+  async function createTable(sql: string): Promise<void> {
+    const db = await getDatabase({ type: 'sqlite', url: dbUrl });
+    await db.query(sql);
+    await db.close?.();
+  }
+
+  function declareSchema(defs: Record<string, any>): void {
+    getSchemasSpy.mockReturnValue(defs as any);
+  }
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    dbUrl = join(
+      tmpdir(),
+      `cov-diff-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+    );
+    clearCache();
+    setConfig({
+      packages: { cli: { database: { type: 'sqlite', url: dbUrl } } },
+    } as any);
+
+    autoDiscoverAndLoadMock.mockResolvedValue({
+      discovered: [{ path: '/fake/.smrt/manifest.json', source: 'project' }],
+      totalObjects: 1,
+    });
+
+    getSchemasSpy = vi.spyOn(ObjectRegistry, 'getAllSchemasAsDefinitions');
+    declareSchema({});
+
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    clearCache();
+    try {
+      rmSync(dbUrl, { force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  function output(): string {
+    return logSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+  }
+
+  function errorOutput(): string {
+    return errorSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+  }
+
+  it('rejects unsupported file-migration options with a guidance error', async () => {
+    await dbDiffCommand.handler([], { generate: true });
+
+    expect(process.exitCode).toBe(1);
+    expect(errorOutput()).toContain('--generate');
+    expect(errorOutput()).toContain('manifest-driven');
+  });
+
+  it('rejects unsupported file-migration options in JSON mode', async () => {
+    await dbDiffCommand.handler([], { name: 'my_migration', json: true });
+
+    expect(process.exitCode).toBe(1);
+    const parsed = JSON.parse(output());
+    expect(parsed.error).toContain('--name');
+  });
+
+  it('errors out when the database is configured as :memory:', async () => {
+    clearCache();
+    setConfig({
+      packages: { cli: { database: { type: 'sqlite', url: ':memory:' } } },
+    } as any);
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined as never) as any);
+
+    await dbDiffCommand.handler([], {});
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorOutput()).toContain('Database configuration required');
+    exitSpy.mockRestore();
+  });
+
+  it('exits when no manifests are discovered', async () => {
+    autoDiscoverAndLoadMock.mockResolvedValue({
+      discovered: [],
+      totalObjects: 0,
+    });
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined as never) as any);
+
+    await dbDiffCommand.handler([], {});
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorOutput()).toContain('No SMRT manifests found');
+    exitSpy.mockRestore();
+  });
+
+  it('emits a JSON error when no manifests are discovered (json mode)', async () => {
+    autoDiscoverAndLoadMock.mockResolvedValue({
+      discovered: [],
+      totalObjects: 0,
+    });
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined as never) as any);
+
+    await dbDiffCommand.handler([], { json: true });
+
+    expect(output()).toContain('No manifests found');
+    exitSpy.mockRestore();
+  });
+
+  it('reports an up-to-date schema when the manifest matches the live DB', async () => {
+    await createTable('CREATE TABLE widgets (id TEXT PRIMARY KEY, name TEXT)');
+    declareSchema({
+      widgets: {
+        tableName: 'widgets',
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          name: { type: 'TEXT' },
+        },
+        indexes: [],
+      },
+    });
+
+    await dbDiffCommand.handler([], {});
+
+    expect(output()).toContain('up to date');
+  });
+
+  it('detects a missing table as an added-table change', async () => {
+    declareSchema({
+      gadgets: {
+        tableName: 'gadgets',
+        columns: { id: { type: 'TEXT', primaryKey: true } },
+        indexes: [],
+      },
+    });
+
+    await dbDiffCommand.handler([], {});
+
+    const out = output();
+    expect(out).toContain('Changes Detected');
+    expect(out).toContain('New tables');
+    expect(out).toContain('gadgets');
+  });
+
+  it('detects a missing column as an add_column change', async () => {
+    await createTable('CREATE TABLE widgets (id TEXT PRIMARY KEY)');
+    declareSchema({
+      widgets: {
+        tableName: 'widgets',
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          price: { type: 'REAL' },
+        },
+        indexes: [],
+      },
+    });
+
+    await dbDiffCommand.handler([], {});
+
+    const out = output();
+    expect(out).toContain('New columns');
+    expect(out).toContain('widgets.price');
+  });
+
+  it('emits the structured diff as JSON', async () => {
+    await createTable('CREATE TABLE widgets (id TEXT PRIMARY KEY)');
+    declareSchema({
+      widgets: {
+        tableName: 'widgets',
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          price: { type: 'REAL' },
+        },
+        indexes: [],
+      },
+    });
+
+    await dbDiffCommand.handler([], { json: true });
+
+    const parsed = JSON.parse(output());
+    expect(parsed.hasChanges).toBe(true);
+    expect(parsed.changes.some((c: any) => c.type === 'add_column')).toBe(true);
+  });
+
+  it('lists new indexes the manifest declares but the live DB lacks', async () => {
+    await createTable('CREATE TABLE widgets (id TEXT PRIMARY KEY, name TEXT)');
+    declareSchema({
+      widgets: {
+        tableName: 'widgets',
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          name: { type: 'TEXT' },
+        },
+        indexes: [{ name: 'idx_widgets_name', columns: ['name'] }],
+      },
+    });
+
+    await dbDiffCommand.handler([], {});
+
+    const out = output();
+    expect(out).toContain('New indexes');
+    expect(out).toContain('idx_widgets_name');
+  });
+
+  it('reports type mismatches that require manual migration', async () => {
+    // Live `status` is INTEGER while the manifest declares TEXT.
+    await createTable(
+      'CREATE TABLE widgets (id TEXT PRIMARY KEY, status INTEGER)',
+    );
+    declareSchema({
+      widgets: {
+        tableName: 'widgets',
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          status: { type: 'TEXT' },
+        },
+        indexes: [],
+      },
+    });
+
+    await dbDiffCommand.handler([], {});
+
+    const out = output();
+    expect(out).toContain('Type');
+    expect(out).toContain('widgets.status');
+  });
+
+  it('lists orphan indexes to drop when --drop-indexes is set', async () => {
+    await createTable('CREATE TABLE widgets (id TEXT PRIMARY KEY, name TEXT)');
+    const db = await getDatabase({ type: 'sqlite', url: dbUrl });
+    await db.query('CREATE INDEX idx_widgets_orphan ON widgets(name)');
+    await db.close?.();
+    declareSchema({
+      widgets: {
+        tableName: 'widgets',
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          name: { type: 'TEXT' },
+        },
+        indexes: [],
+      },
+    });
+
+    await dbDiffCommand.handler([], { 'drop-indexes': true });
+
+    const out = output();
+    expect(out).toContain('Indexes to drop');
+    expect(out).toContain('idx_widgets_orphan');
+  });
+
+  it('groups a drop+add of the same index name as a recreate', async () => {
+    await createTable(
+      'CREATE TABLE widgets (id TEXT PRIMARY KEY, name TEXT, code TEXT)',
+    );
+    const db = await getDatabase({ type: 'sqlite', url: dbUrl });
+    await db.query('CREATE INDEX idx_widgets_name ON widgets(name)');
+    await db.close?.();
+    // Manifest keeps the same index name but on a different column → the live
+    // index must be dropped and recreated, which the command renders as a single
+    // "recreate" action.
+    declareSchema({
+      widgets: {
+        tableName: 'widgets',
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          name: { type: 'TEXT' },
+          code: { type: 'TEXT' },
+        },
+        indexes: [{ name: 'idx_widgets_name', columns: ['code'] }],
+      },
+    });
+
+    await dbDiffCommand.handler([], { 'drop-indexes': true });
+
+    const out = output();
+    expect(out).toContain('Indexes to recreate');
+    expect(out).toContain('idx_widgets_name');
+  });
+
+  it('reports a failure when schema comparison throws', async () => {
+    // An invalid schema definition (missing the columns/indexes shape) makes
+    // the real comparer throw, exercising the command's error branch.
+    await createTable('CREATE TABLE broken (id TEXT PRIMARY KEY)');
+    // Existing table with a malformed manifest entry (no `indexes`) makes the
+    // real comparer throw while comparing the live table, hitting the error
+    // branch.
+    declareSchema({
+      broken: {
+        tableName: 'broken',
+        columns: { id: { type: 'TEXT', primaryKey: true } },
+      },
+    });
+
+    await dbDiffCommand.handler([], {});
+
+    expect(process.exitCode).toBe(1);
+    expect(errorOutput()).toContain('Failed to generate diff');
+  });
+
+  it('reports a JSON failure when schema comparison throws', async () => {
+    await createTable('CREATE TABLE broken (id TEXT PRIMARY KEY)');
+    // Existing table with a malformed manifest entry (no `indexes`) makes the
+    // real comparer throw while comparing the live table, hitting the error
+    // branch.
+    declareSchema({
+      broken: {
+        tableName: 'broken',
+        columns: { id: { type: 'TEXT', primaryKey: true } },
+      },
+    });
+
+    await dbDiffCommand.handler([], { json: true });
+
+    expect(process.exitCode).toBe(1);
+    const parsed = JSON.parse(output());
+    expect(parsed.error).toBeDefined();
+  });
+});

--- a/packages/cli/src/commands/__tests__/db-history-real.test.ts
+++ b/packages/cli/src/commands/__tests__/db-history-real.test.ts
@@ -1,0 +1,192 @@
+import { rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { clearCache, setConfig } from '@happyvertical/smrt-config';
+import { MigrationTracker } from '@happyvertical/smrt-core/migrations';
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { autoDiscoverAndLoadMock } = vi.hoisted(() => ({
+  autoDiscoverAndLoadMock: vi.fn(),
+}));
+
+vi.mock('../../discovery/index.js', () => ({
+  autoDiscoverAndLoad: autoDiscoverAndLoadMock,
+}));
+
+import { dbHistoryCommand } from '../db-history.js';
+
+/**
+ * db:history against a REAL SQLite database, focusing on the human-readable
+ * rendering and query-filter paths the existing mock-based suite does not
+ * exercise. Real migration rows are written via the real MigrationTracker, then
+ * the command re-opens the same file and renders them.
+ *
+ * Discovery is mocked so the failed-migration live-schema comparison short-
+ * circuits (db.getTableSchema is undefined on the SQLite adapter for these
+ * tests is handled by the command's typeof guard); the rendering and summary
+ * logic still runs for real.
+ */
+describe('db:history (real SQLite rendering)', () => {
+  let dbUrl: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  async function seed(): Promise<void> {
+    const db = await getDatabase({ type: 'sqlite', url: dbUrl });
+    const tracker = new MigrationTracker({ db });
+    await tracker.initialize();
+    await tracker.apply({
+      id: 'create_alpha',
+      description: 'alpha',
+      version: '1.0.0',
+      up: ['CREATE TABLE alpha (id TEXT PRIMARY KEY)'],
+      down: ['DROP TABLE alpha'],
+    });
+    await tracker.apply({
+      id: 'create_beta',
+      description: 'beta',
+      version: '1.1.0',
+      up: ['CREATE TABLE beta (id TEXT PRIMARY KEY)'],
+      down: [],
+    });
+    await db.close?.();
+  }
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    dbUrl = join(
+      tmpdir(),
+      `cov-history-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+    );
+    clearCache();
+    setConfig({
+      packages: { cli: { database: { type: 'sqlite', url: dbUrl } } },
+    } as any);
+    autoDiscoverAndLoadMock.mockResolvedValue({
+      discovered: [{ path: '/fake/.smrt/manifest.json' }],
+      totalObjects: 1,
+    });
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    clearCache();
+    try {
+      rmSync(dbUrl, { force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  function output(): string {
+    return logSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+  }
+
+  function errorOutput(): string {
+    return errorSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+  }
+
+  it('errors out when the database is configured as :memory:', async () => {
+    clearCache();
+    setConfig({
+      packages: { cli: { database: { type: 'sqlite', url: ':memory:' } } },
+    } as any);
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined as never) as any);
+
+    await dbHistoryCommand.handler([], {});
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorOutput()).toContain('Database configuration required');
+    exitSpy.mockRestore();
+  });
+
+  it('emits a JSON error when the database is not configured', async () => {
+    clearCache();
+    setConfig({ packages: { cli: { database: { url: '' } } } } as any);
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined as never) as any);
+
+    await dbHistoryCommand.handler([], { json: true });
+
+    expect(output()).toContain('Database not configured');
+    exitSpy.mockRestore();
+  });
+
+  it('renders the applied migrations in compact human-readable form', async () => {
+    await seed();
+
+    await dbHistoryCommand.handler([], {});
+
+    const out = output();
+    expect(out).toContain('Migration History');
+    expect(out).toContain('create_alpha');
+    expect(out).toContain('create_beta');
+    expect(out).toContain('Summary:');
+    expect(out).toContain('2 completed');
+  });
+
+  it('renders verbose details including version and checksum', async () => {
+    await seed();
+
+    await dbHistoryCommand.handler([], { verbose: true });
+
+    const out = output();
+    expect(out).toContain('Version: 1.0.0');
+    expect(out).toContain('Checksum:');
+  });
+
+  it('serializes the full history as JSON', async () => {
+    await seed();
+
+    await dbHistoryCommand.handler([], { json: true });
+
+    const parsed = JSON.parse(output());
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.map((m: any) => m.name)).toContain('create_alpha');
+    expect(parsed[0].status).toBe('completed');
+  });
+
+  it('reports no matching migrations when none have been applied', async () => {
+    // Initialize the tracker tables but apply nothing.
+    const db = await getDatabase({ type: 'sqlite', url: dbUrl });
+    const tracker = new MigrationTracker({ db });
+    await tracker.initialize();
+    await db.close?.();
+
+    await dbHistoryCommand.handler([], {});
+
+    expect(output()).toContain('No migrations found matching criteria');
+  });
+
+  it('filters by status, hiding non-matching rows', async () => {
+    await seed();
+
+    await dbHistoryCommand.handler([], { status: 'failed' });
+
+    // No failed migrations were seeded, so the filtered result is empty.
+    expect(output()).toContain('No migrations found matching criteria');
+  });
+
+  it('applies a --since lower bound on applied_at', async () => {
+    await seed();
+
+    // A future cutoff filters out every applied migration.
+    await dbHistoryCommand.handler([], { since: '2999-01-01' });
+
+    expect(output()).toContain('No migrations found matching criteria');
+  });
+
+  it('honors a numeric --limit', async () => {
+    await seed();
+
+    await dbHistoryCommand.handler([], { limit: 1 });
+
+    expect(output()).toContain('Showing 1 migration');
+  });
+});

--- a/packages/cli/src/commands/__tests__/db-migrate-actions-names.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-actions-names.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyTypeUpgradeSql,
+  getSyntheticMigrationNameForAction,
+  getSyntheticMigrationNameForChange,
+  getUnresolvedGeneratedMigrationNames,
+  partitionSchemaChanges,
+} from '../db-migrate-actions.js';
+
+/**
+ * Synthetic migration-name derivation and schema-change partitioning.
+ *
+ * These are the pure helpers `db:migrate` / `db:status` use to give each
+ * generated schema repair a stable tracker id (with a shape fingerprint so a
+ * recreated index of a different shape gets a fresh row) and to split a schema
+ * diff into auto-applicable migrations vs. manual interventions.
+ */
+describe('classifyTypeUpgradeSql', () => {
+  it('treats an empty/undefined sql as manual', () => {
+    expect(classifyTypeUpgradeSql(undefined)).toBe('manual');
+    expect(classifyTypeUpgradeSql('   ')).toBe('manual');
+  });
+
+  it('treats a real SQL statement as executable', () => {
+    expect(
+      classifyTypeUpgradeSql(
+        'ALTER TABLE contents ALTER COLUMN status TYPE jsonb',
+      ),
+    ).toBe('executable');
+  });
+
+  it('treats a "no change needed" comment as a no-op', () => {
+    expect(
+      classifyTypeUpgradeSql(
+        '-- SQLite: "metadata" already stores JSON as TEXT (no change needed)',
+      ),
+    ).toBe('noop');
+  });
+
+  it('treats a non-no-op comment as manual', () => {
+    expect(
+      classifyTypeUpgradeSql(
+        '-- SQLite: type upgrade requires table recreation',
+      ),
+    ).toBe('manual');
+  });
+});
+
+describe('getSyntheticMigrationNameForAction', () => {
+  it('names an add_column action', () => {
+    expect(
+      getSyntheticMigrationNameForAction({
+        type: 'add_column',
+        tableName: 'widgets',
+        className: 'Widget',
+        column: { name: 'price', type: 'REAL' },
+      } as any),
+    ).toBe('add_column_widgets_price');
+  });
+
+  it('returns null for an add_column action with no column', () => {
+    expect(
+      getSyntheticMigrationNameForAction({
+        type: 'add_column',
+        tableName: 'widgets',
+        className: 'Widget',
+      } as any),
+    ).toBeNull();
+  });
+
+  it('names an add_index action with a shape fingerprint from the index', () => {
+    const name = getSyntheticMigrationNameForAction({
+      type: 'add_index',
+      tableName: 'widgets',
+      className: 'Widget',
+      index: { name: 'idx_widgets_name', columns: ['name'], unique: false },
+    } as any);
+    expect(name).toMatch(/^add_index_idx_widgets_name_[0-9a-f]{8}$/);
+  });
+
+  it('uses provided SQL statements for the add_index fingerprint', () => {
+    const name = getSyntheticMigrationNameForAction({
+      type: 'add_index',
+      tableName: 'widgets',
+      className: 'Widget',
+      index: { name: 'idx_widgets_name', columns: ['name'] },
+      sqlStatements: ['CREATE INDEX idx_widgets_name ON widgets(name)'],
+    } as any);
+    expect(name).toMatch(/^add_index_idx_widgets_name_[0-9a-f]{8}$/);
+  });
+
+  it('returns null for an add_index action with no index', () => {
+    expect(
+      getSyntheticMigrationNameForAction({
+        type: 'add_index',
+        tableName: 'widgets',
+        className: 'Widget',
+      } as any),
+    ).toBeNull();
+  });
+
+  it('names a drop_index action with a fingerprint', () => {
+    const name = getSyntheticMigrationNameForAction({
+      type: 'drop_index',
+      tableName: 'widgets',
+      className: 'Widget',
+      indexName: 'idx_orphan',
+      sql: 'DROP INDEX idx_orphan',
+    } as any);
+    expect(name).toMatch(/^drop_index_idx_orphan_[0-9a-f]{8}$/);
+  });
+
+  it('falls back to the bare drop_index name when no fingerprint material exists', () => {
+    expect(
+      getSyntheticMigrationNameForAction({
+        type: 'drop_index',
+        tableName: 'widgets',
+        className: 'Widget',
+        indexName: 'idx_orphan',
+      } as any),
+    ).toBe('drop_index_idx_orphan');
+  });
+
+  it('returns null for a drop_index action with no index name', () => {
+    expect(
+      getSyntheticMigrationNameForAction({
+        type: 'drop_index',
+        tableName: 'widgets',
+        className: 'Widget',
+      } as any),
+    ).toBeNull();
+  });
+
+  it('names a type_upgrade action and returns null without a column', () => {
+    expect(
+      getSyntheticMigrationNameForAction({
+        type: 'type_upgrade',
+        tableName: 'widgets',
+        className: 'Widget',
+        column: { name: 'status', type: 'TEXT' },
+      } as any),
+    ).toBe('type_upgrade_widgets_status');
+    expect(
+      getSyntheticMigrationNameForAction({
+        type: 'type_upgrade',
+        tableName: 'widgets',
+        className: 'Widget',
+      } as any),
+    ).toBeNull();
+  });
+
+  it('returns null for an unknown action type', () => {
+    expect(
+      getSyntheticMigrationNameForAction({
+        type: 'drop_table',
+        tableName: 'widgets',
+        className: 'Widget',
+      } as any),
+    ).toBeNull();
+  });
+});
+
+describe('getSyntheticMigrationNameForChange', () => {
+  it('names an add_column change and guards a missing name', () => {
+    expect(
+      getSyntheticMigrationNameForChange({
+        type: 'add_column',
+        table: 'widgets',
+        name: 'price',
+      } as any),
+    ).toBe('add_column_widgets_price');
+    expect(
+      getSyntheticMigrationNameForChange({
+        type: 'add_column',
+        table: 'widgets',
+      } as any),
+    ).toBeNull();
+  });
+
+  it('derives the add_index name from change.index.name or change.name', () => {
+    expect(
+      getSyntheticMigrationNameForChange({
+        type: 'add_index',
+        table: 'widgets',
+        index: { name: 'idx_a', columns: ['a'] },
+      } as any),
+    ).toMatch(/^add_index_idx_a_[0-9a-f]{8}$/);
+    expect(
+      getSyntheticMigrationNameForChange({
+        type: 'add_index',
+        table: 'widgets',
+        name: 'idx_b',
+      } as any),
+    ).toBe('add_index_idx_b');
+    expect(
+      getSyntheticMigrationNameForChange({
+        type: 'add_index',
+        table: 'widgets',
+      } as any),
+    ).toBeNull();
+  });
+
+  it('names a drop_index change with and without a fingerprint', () => {
+    expect(
+      getSyntheticMigrationNameForChange({
+        type: 'drop_index',
+        table: 'widgets',
+        name: 'idx_orphan',
+        sql: 'DROP INDEX idx_orphan',
+      } as any),
+    ).toMatch(/^drop_index_idx_orphan_[0-9a-f]{8}$/);
+    expect(
+      getSyntheticMigrationNameForChange({
+        type: 'drop_index',
+        table: 'widgets',
+        name: 'idx_orphan',
+      } as any),
+    ).toBe('drop_index_idx_orphan');
+    expect(
+      getSyntheticMigrationNameForChange({
+        type: 'drop_index',
+        table: 'widgets',
+      } as any),
+    ).toBeNull();
+  });
+
+  it('names a type_upgrade change and returns null for unknown types', () => {
+    expect(
+      getSyntheticMigrationNameForChange({
+        type: 'type_upgrade',
+        table: 'widgets',
+        name: 'status',
+      } as any),
+    ).toBe('type_upgrade_widgets_status');
+    expect(
+      getSyntheticMigrationNameForChange({
+        type: 'drop_table',
+        table: 'widgets',
+      } as any),
+    ).toBeNull();
+  });
+});
+
+describe('getUnresolvedGeneratedMigrationNames', () => {
+  it('skips no-op type upgrades and unrelated change types', () => {
+    const names = getUnresolvedGeneratedMigrationNames([
+      { type: 'add_column', table: 'widgets', name: 'price' },
+      {
+        type: 'type_upgrade',
+        table: 'widgets',
+        name: 'metadata',
+        sql: '-- already stores JSON as TEXT (no change needed)',
+      },
+      { type: 'drop_table', table: 'widgets' },
+    ] as any);
+
+    expect(names.has('add_column_widgets_price')).toBe(true);
+    expect(names.has('type_upgrade_widgets_metadata')).toBe(false);
+  });
+});
+
+describe('partitionSchemaChanges index + guard branches', () => {
+  const getClassForTable = (table: string) => `${table}Class`;
+
+  it('partitions add_index and drop_index into executable migrations', () => {
+    const { migrations, manualInterventions } = partitionSchemaChanges(
+      [
+        {
+          type: 'add_index',
+          table: 'widgets',
+          index: { name: 'idx_a', columns: ['a'], unique: true },
+          sql: 'CREATE UNIQUE INDEX idx_a ON widgets(a)',
+        },
+        {
+          type: 'drop_index',
+          table: 'widgets',
+          name: 'idx_old',
+          sql: 'DROP INDEX idx_old',
+        },
+      ] as any,
+      getClassForTable,
+    );
+
+    expect(migrations.map((m) => m.type)).toEqual(['add_index', 'drop_index']);
+    expect(manualInterventions).toEqual([]);
+  });
+
+  it('skips malformed add_index/drop_index/add_column/type changes', () => {
+    const { migrations, manualInterventions } = partitionSchemaChanges(
+      [
+        { type: 'add_index', table: 'widgets' }, // no index → skipped
+        { type: 'drop_index', table: 'widgets' }, // no name → skipped
+        { type: 'add_column', table: 'widgets' }, // no name/column → skipped
+        { type: 'type_mismatch', table: 'widgets' }, // no name/mismatch → skipped
+        { type: 'type_upgrade', table: 'widgets', name: 'x' }, // no mismatch → skipped
+      ] as any,
+      getClassForTable,
+    );
+
+    expect(migrations).toEqual([]);
+    expect(manualInterventions).toEqual([]);
+  });
+
+  it('routes a type_mismatch into manual interventions', () => {
+    const { migrations, manualInterventions } = partitionSchemaChanges(
+      [
+        {
+          type: 'type_mismatch',
+          table: 'widgets',
+          name: 'status',
+          mismatch: { expected: 'TEXT', actual: 'INTEGER' },
+        },
+      ] as any,
+      getClassForTable,
+    );
+
+    expect(migrations).toEqual([]);
+    expect(manualInterventions[0]).toMatchObject({
+      type: 'type_mismatch',
+      tableName: 'widgets',
+    });
+  });
+});

--- a/packages/cli/src/commands/__tests__/db-migrate-uuid-handler.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-uuid-handler.test.ts
@@ -1,0 +1,204 @@
+import { rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { clearCache, setConfig } from '@happyvertical/smrt-config';
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { autoDiscoverAndLoadMock } = vi.hoisted(() => ({
+  autoDiscoverAndLoadMock: vi.fn(),
+}));
+
+vi.mock('../../discovery/index.js', () => ({
+  autoDiscoverAndLoad: autoDiscoverAndLoadMock,
+}));
+
+import { dbMigrateUuidCommand } from '../db-migrate-uuid.js';
+
+/**
+ * db:migrate-uuid handler against a REAL SQLite database.
+ *
+ * The native TEXT→uuid conversion only runs on PostgreSQL; on SQLite the
+ * command performs the R3 rename backfills and then reports the conversion is a
+ * no-op. These tests exercise the non-Postgres handler branches (config
+ * validation, rename parsing, real rename backfill, no-op conversion message,
+ * --skip-convert, --dry-run, and error handling) end-to-end against a temp
+ * SQLite file. The Postgres conversion gating itself is covered by the pure
+ * unit tests and the DATABASE_URL-gated suite in db-migrate-uuid.test.ts.
+ */
+describe('db:migrate-uuid handler (real SQLite, non-Postgres branches)', () => {
+  let dbUrl: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  async function freshDb(): Promise<any> {
+    return getDatabase({ type: 'sqlite', url: dbUrl });
+  }
+
+  async function columns(table: string): Promise<string[]> {
+    const db = await freshDb();
+    const { rows } = await db.query(`PRAGMA table_info(${table})`);
+    await db.close?.();
+    return (rows as any[]).map((r) => r.name);
+  }
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    dbUrl = join(
+      tmpdir(),
+      `cov-uuid-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+    );
+    clearCache();
+    setConfig({
+      packages: { cli: { database: { type: 'sqlite', url: dbUrl } } },
+    } as any);
+    autoDiscoverAndLoadMock.mockResolvedValue({
+      discovered: [],
+      totalObjects: 0,
+    });
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    clearCache();
+    try {
+      rmSync(dbUrl, { force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  function output(): string {
+    return logSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+  }
+
+  function errorOutput(): string {
+    return errorSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+  }
+
+  it('errors out when the database is configured as :memory:', async () => {
+    clearCache();
+    setConfig({
+      packages: { cli: { database: { type: 'sqlite', url: ':memory:' } } },
+    } as any);
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined as never) as any);
+
+    await dbMigrateUuidCommand.handler([], {});
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorOutput()).toContain('Database configuration required');
+    exitSpy.mockRestore();
+  });
+
+  it('fails with exit code 1 when a --rename entry is malformed', async () => {
+    await dbMigrateUuidCommand.handler([], { rename: 'no_colon', table: 't' });
+
+    expect(process.exitCode).toBe(1);
+    expect(errorOutput()).toContain('uuid migration failed');
+  });
+
+  it('reports the conversion is a no-op on SQLite when no renames are given', async () => {
+    const db = await freshDb();
+    await db.query('CREATE TABLE things (id TEXT PRIMARY KEY)');
+    await db.close?.();
+
+    await dbMigrateUuidCommand.handler([], {});
+
+    expect(output()).toContain('no native uuid column type');
+  });
+
+  it('backfills an R3 rename and drops the old column on SQLite', async () => {
+    const db = await freshDb();
+    await db.query(
+      'CREATE TABLE tags (id TEXT PRIMARY KEY, parent_slug TEXT, parent_id TEXT)',
+    );
+    await db.query(
+      "INSERT INTO tags (id, parent_slug, parent_id) VALUES ('a', 'p1', NULL)",
+    );
+    await db.close?.();
+
+    await dbMigrateUuidCommand.handler([], {
+      rename: 'parent_slug:parent_id',
+      table: 'tags',
+    });
+
+    const cols = await columns('tags');
+    expect(cols).toContain('parent_id');
+    expect(cols).not.toContain('parent_slug');
+
+    const after = await freshDb();
+    const { rows } = await after.query('SELECT parent_id FROM tags');
+    await after.close?.();
+    expect((rows as any[])[0].parent_id).toBe('p1');
+    expect(output()).toContain('no native uuid column type');
+  });
+
+  it('skips a rename whose source column is already gone (idempotent re-run)', async () => {
+    const db = await freshDb();
+    await db.query('CREATE TABLE tags (id TEXT PRIMARY KEY, parent_id TEXT)');
+    await db.close?.();
+
+    await dbMigrateUuidCommand.handler([], {
+      rename: 'parent_slug:parent_id',
+      table: 'tags',
+    });
+
+    expect(output()).toContain('already migrated');
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it('fails when the rename destination column is missing', async () => {
+    const db = await freshDb();
+    await db.query('CREATE TABLE tags (id TEXT PRIMARY KEY, parent_slug TEXT)');
+    await db.close?.();
+
+    await dbMigrateUuidCommand.handler([], {
+      rename: 'parent_slug:parent_id',
+      table: 'tags',
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(errorOutput()).toContain('uuid migration failed');
+  });
+
+  it('skips the conversion pass entirely with --skip-convert', async () => {
+    const db = await freshDb();
+    await db.query(
+      'CREATE TABLE tags (id TEXT PRIMARY KEY, parent_slug TEXT, parent_id TEXT)',
+    );
+    await db.close?.();
+
+    await dbMigrateUuidCommand.handler([], {
+      rename: 'parent_slug:parent_id',
+      table: 'tags',
+      'skip-convert': true,
+    });
+
+    expect(output()).toContain('Skipping TEXT');
+    const cols = await columns('tags');
+    expect(cols).not.toContain('parent_slug');
+  });
+
+  it('previews the rename without mutating the table in --dry-run mode', async () => {
+    const db = await freshDb();
+    await db.query(
+      'CREATE TABLE tags (id TEXT PRIMARY KEY, parent_slug TEXT, parent_id TEXT)',
+    );
+    await db.close?.();
+
+    await dbMigrateUuidCommand.handler([], {
+      rename: 'parent_slug:parent_id',
+      table: 'tags',
+      'dry-run': true,
+    });
+
+    expect(output()).toContain('DRY RUN');
+    const cols = await columns('tags');
+    // Nothing was actually applied.
+    expect(cols).toContain('parent_slug');
+  });
+});

--- a/packages/cli/src/commands/__tests__/db-rollback.test.ts
+++ b/packages/cli/src/commands/__tests__/db-rollback.test.ts
@@ -1,0 +1,371 @@
+import { rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { clearCache, setConfig } from '@happyvertical/smrt-config';
+import { MigrationTracker } from '@happyvertical/smrt-core/migrations';
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbRollbackCommand } from '../db-rollback.js';
+
+// The command prompts via node:readline/promises when not forced. Stub the
+// module so the "confirm"/"decline" branches can be exercised deterministically
+// without real stdin. The default answer ('y') keeps any forced-path tests
+// unaffected since they never reach the prompt.
+const questionMock = vi.fn(async () => 'y');
+vi.mock('node:readline/promises', () => ({
+  createInterface: () => ({
+    question: questionMock,
+    close: vi.fn(),
+  }),
+}));
+
+/**
+ * db:rollback against a REAL SQLite database.
+ *
+ * The command opens its own connection from config (and closes it in a
+ * `finally`), so each test uses a unique on-disk SQLite file that the command
+ * and the test both open by URL — letting us pre-seed real migration history
+ * with the real MigrationTracker, run the command, then re-open the file to
+ * assert how it mutated the `_smrt_schema_migrations` rows.
+ *
+ * Note on reversibility: the command builds a synthetic rollback definition with
+ * an empty `down`, so a row recorded as reversible (a real `down` was present at
+ * apply time) FAILS the tracker rollback, while a non-reversible row (applied
+ * with an empty `down`) is force-marked `rolled_back`. The tests below seed each
+ * kind deliberately to drive both branches.
+ */
+describe('db:rollback (real SQLite)', () => {
+  let dbUrl: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  function reversibleDef(id: string) {
+    return {
+      id,
+      description: `Migration ${id}`,
+      version: '1.0.0',
+      up: [`CREATE TABLE ${id} (id TEXT PRIMARY KEY)`],
+      down: [`DROP TABLE ${id}`],
+    };
+  }
+
+  function nonReversibleDef(id: string) {
+    return {
+      id,
+      description: `Migration ${id}`,
+      version: '1.0.0',
+      up: [`CREATE TABLE ${id} (id TEXT PRIMARY KEY)`],
+      down: [],
+    };
+  }
+
+  async function freshDb(): Promise<any> {
+    return getDatabase({ type: 'sqlite', url: dbUrl });
+  }
+
+  async function seedMigrations(
+    defs: Array<ReturnType<typeof reversibleDef>>,
+  ): Promise<void> {
+    const db = await freshDb();
+    const tracker = new MigrationTracker({ db });
+    await tracker.initialize();
+    for (const def of defs) {
+      await tracker.apply(def);
+    }
+    await db.close?.();
+  }
+
+  async function readHistory(): Promise<
+    Array<{ name: string; status: string }>
+  > {
+    const db = await freshDb();
+    const tracker = new MigrationTracker({ db });
+    await tracker.initialize();
+    const history = await tracker.getHistory({ limit: 100 });
+    await db.close?.();
+    return history.map((m: any) => ({ name: m.name, status: m.status }));
+  }
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    questionMock.mockClear();
+    questionMock.mockResolvedValue('y');
+    dbUrl = join(
+      tmpdir(),
+      `cov-rollback-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+    );
+    clearCache();
+    setConfig({
+      packages: { cli: { database: { type: 'sqlite', url: dbUrl } } },
+    } as any);
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    clearCache();
+    try {
+      rmSync(dbUrl, { force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  function output(): string {
+    return logSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+  }
+
+  // JSON mode can emit multiple JSON documents (e.g. a non-reversible warning
+  // followed by the final summary); the meaningful payload is the last one.
+  function lastJson(): any {
+    const jsonCalls = logSpy.mock.calls
+      .map((call) => call.join(''))
+      .filter((line) => line.trim().startsWith('{'));
+    return JSON.parse(jsonCalls[jsonCalls.length - 1]);
+  }
+
+  function errorOutput(): string {
+    return errorSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+  }
+
+  it('errors out when the database is configured as :memory:', async () => {
+    clearCache();
+    setConfig({
+      packages: { cli: { database: { type: 'sqlite', url: ':memory:' } } },
+    } as any);
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined as never) as any);
+
+    await dbRollbackCommand.handler([], {});
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorOutput()).toContain('Database configuration required');
+    exitSpy.mockRestore();
+  });
+
+  it('emits a JSON error when the database is not configured (json mode)', async () => {
+    clearCache();
+    setConfig({ packages: { cli: { database: { url: '' } } } } as any);
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined as never) as any);
+
+    await dbRollbackCommand.handler([], { json: true });
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(output()).toContain('Database not configured');
+    exitSpy.mockRestore();
+  });
+
+  it('reports nothing to roll back when no migrations have been applied', async () => {
+    await seedMigrations([]);
+
+    await dbRollbackCommand.handler([], { force: true });
+
+    expect(output()).toContain('No applied migrations to rollback');
+  });
+
+  it('reports nothing to roll back in JSON mode when history is empty', async () => {
+    await seedMigrations([]);
+
+    await dbRollbackCommand.handler([], { json: true, force: true });
+
+    const parsed = JSON.parse(output());
+    expect(parsed.message).toBe('No migrations to rollback');
+  });
+
+  it('force-marks the most recent non-reversible migration rolled back by default', async () => {
+    await seedMigrations([
+      nonReversibleDef('m_one'),
+      nonReversibleDef('m_two'),
+      nonReversibleDef('m_three'),
+    ]);
+
+    await dbRollbackCommand.handler([], { force: true });
+
+    const byName = Object.fromEntries(
+      (await readHistory()).map((m) => [m.name, m.status]),
+    );
+    expect(byName.m_three).toBe('rolled_back');
+    expect(byName.m_two).toBe('completed');
+    expect(byName.m_one).toBe('completed');
+    expect(output()).toContain('Successfully rolled back 1 migration');
+  });
+
+  it('rolls back N migrations when --steps is provided', async () => {
+    await seedMigrations([
+      nonReversibleDef('s_one'),
+      nonReversibleDef('s_two'),
+      nonReversibleDef('s_three'),
+    ]);
+
+    await dbRollbackCommand.handler([], { steps: 2, force: true });
+
+    const byName = Object.fromEntries(
+      (await readHistory()).map((m) => [m.name, m.status]),
+    );
+    expect(byName.s_three).toBe('rolled_back');
+    expect(byName.s_two).toBe('rolled_back');
+    expect(byName.s_one).toBe('completed');
+  });
+
+  it('rolls back everything after a target migration with --to (exclusive)', async () => {
+    await seedMigrations([
+      nonReversibleDef('t_one'),
+      nonReversibleDef('t_two'),
+      nonReversibleDef('t_three'),
+    ]);
+
+    await dbRollbackCommand.handler([], { to: 't_one', force: true });
+
+    const byName = Object.fromEntries(
+      (await readHistory()).map((m) => [m.name, m.status]),
+    );
+    expect(byName.t_three).toBe('rolled_back');
+    expect(byName.t_two).toBe('rolled_back');
+    expect(byName.t_one).toBe('completed');
+  });
+
+  it('warns about non-reversible migrations in the rollback set', async () => {
+    await seedMigrations([nonReversibleDef('w_one')]);
+
+    await dbRollbackCommand.handler([], { force: true });
+
+    expect(output()).toContain('not reversible');
+  });
+
+  it('reports a JSON error when some migrations are not reversible', async () => {
+    await seedMigrations([nonReversibleDef('jn_one')]);
+
+    await dbRollbackCommand.handler([], { json: true, force: true });
+
+    const lines = logSpy.mock.calls.map((call) => call.join(' '));
+    const nonReversibleLine = lines.find((line) =>
+      line.includes('not reversible'),
+    );
+    expect(nonReversibleLine).toBeDefined();
+  });
+
+  it('records a failed result when a reversible migration cannot run its (empty) DOWN script', async () => {
+    // A reversible row drives the tracker.rollback path; the synthetic
+    // definition the command builds has an empty `down`, so the tracker reports
+    // the migration as not reversible and the command counts it as an error.
+    await seedMigrations([reversibleDef('rev_one')]);
+
+    await dbRollbackCommand.handler([], { json: true, force: true });
+
+    const parsed = lastJson();
+    expect(parsed.success).toBe(false);
+    expect(parsed.errorCount).toBe(1);
+    expect(parsed.results[0].success).toBe(false);
+  });
+
+  it('prints a stack trace for reversible rollback failures in verbose mode', async () => {
+    await seedMigrations([reversibleDef('rev_v')]);
+
+    await dbRollbackCommand.handler([], { force: true, verbose: true });
+
+    expect(errorOutput()).toContain('failed');
+  });
+
+  it('errors when --to references an unknown migration', async () => {
+    await seedMigrations([nonReversibleDef('only_one')]);
+
+    await dbRollbackCommand.handler([], { to: 'does_not_exist', force: true });
+
+    expect(process.exitCode).toBe(1);
+    expect(errorOutput()).toContain('not found in history');
+  });
+
+  it('returns a JSON error when --to references an unknown migration', async () => {
+    await seedMigrations([nonReversibleDef('only_one')]);
+
+    await dbRollbackCommand.handler([], {
+      to: 'does_not_exist',
+      json: true,
+      force: true,
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(output()).toContain('not found');
+  });
+
+  it('reports nothing to rollback when --to targets the latest migration', async () => {
+    await seedMigrations([
+      nonReversibleDef('top_one'),
+      nonReversibleDef('top_two'),
+    ]);
+
+    // The latest applied migration is at index 0; nothing comes after it.
+    await dbRollbackCommand.handler([], { to: 'top_two', force: true });
+
+    expect(output()).toContain('Nothing to rollback');
+  });
+
+  it('previews a rollback without mutating history in --dry-run mode', async () => {
+    await seedMigrations([
+      nonReversibleDef('d_one'),
+      nonReversibleDef('d_two'),
+    ]);
+
+    await dbRollbackCommand.handler([], { dryRun: true, force: true });
+
+    expect(output()).toContain('Dry-run');
+    const history = await readHistory();
+    expect(history.every((m) => m.status === 'completed')).toBe(true);
+  });
+
+  it('emits structured dry-run output in JSON mode', async () => {
+    await seedMigrations([nonReversibleDef('dj_one')]);
+
+    await dbRollbackCommand.handler([], {
+      dryRun: true,
+      json: true,
+      force: true,
+    });
+
+    const parsed = lastJson();
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.migrationsToRollback[0].name).toBe('dj_one');
+  });
+
+  it('emits a JSON summary of a successful rollback', async () => {
+    await seedMigrations([
+      nonReversibleDef('jr_one'),
+      nonReversibleDef('jr_two'),
+    ]);
+
+    await dbRollbackCommand.handler([], { json: true, force: true });
+
+    const parsed = lastJson();
+    expect(parsed.success).toBe(true);
+    expect(parsed.successCount).toBe(1);
+    expect(parsed.errorCount).toBe(0);
+    expect(parsed.results[0].name).toBe('jr_two');
+  });
+
+  it('cancels the rollback when the interactive prompt is declined', async () => {
+    await seedMigrations([nonReversibleDef('c_one')]);
+    questionMock.mockResolvedValue('n');
+
+    await dbRollbackCommand.handler([], {});
+
+    expect(output()).toContain('Cancelled by user');
+    const history = await readHistory();
+    expect(history[0].status).toBe('completed');
+  });
+
+  it('proceeds with the rollback when the interactive prompt is confirmed', async () => {
+    await seedMigrations([nonReversibleDef('p_one')]);
+    questionMock.mockResolvedValue('yes');
+
+    await dbRollbackCommand.handler([], {});
+
+    const history = await readHistory();
+    expect(history[0].status).toBe('rolled_back');
+    expect(questionMock).toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/__tests__/db-status-real.test.ts
+++ b/packages/cli/src/commands/__tests__/db-status-real.test.ts
@@ -1,0 +1,282 @@
+import { rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { clearCache, setConfig } from '@happyvertical/smrt-config';
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+import { MigrationTracker } from '@happyvertical/smrt-core/migrations';
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { autoDiscoverAndLoadMock } = vi.hoisted(() => ({
+  autoDiscoverAndLoadMock: vi.fn(),
+}));
+
+vi.mock('../../discovery/index.js', () => ({
+  autoDiscoverAndLoad: autoDiscoverAndLoadMock,
+}));
+
+import { dbStatusCommand } from '../db-status.js';
+
+/**
+ * db:status against a REAL SQLite database, focusing on the human-readable
+ * rendering paths the existing JSON-focused mock suite does not cover. The
+ * MigrationTracker, SchemaComparer, and schema-contract evaluation all run for
+ * real against a temp SQLite file; only manifest discovery and the declared
+ * schema source (ObjectRegistry.getAllSchemasAsDefinitions) are injected.
+ */
+describe('db:status (real SQLite rendering)', () => {
+  let dbUrl: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let getSchemasSpy: ReturnType<typeof vi.spyOn>;
+
+  async function createWidgets(): Promise<void> {
+    const db = await getDatabase({ type: 'sqlite', url: dbUrl });
+    await db.query('CREATE TABLE widgets (id TEXT PRIMARY KEY, name TEXT)');
+    await db.close?.();
+  }
+
+  async function applyMigration(): Promise<void> {
+    const db = await getDatabase({ type: 'sqlite', url: dbUrl });
+    const tracker = new MigrationTracker({ db });
+    await tracker.initialize();
+    await tracker.apply({
+      id: 'create_widgets',
+      description: 'widgets',
+      version: '1.0.0',
+      up: ['CREATE TABLE widgets (id TEXT PRIMARY KEY, name TEXT)'],
+      down: ['DROP TABLE widgets'],
+    });
+    await db.close?.();
+  }
+
+  function declareSchema(defs: Record<string, any>): void {
+    getSchemasSpy.mockReturnValue(defs as any);
+  }
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    dbUrl = join(
+      tmpdir(),
+      `cov-status-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+    );
+    clearCache();
+    setConfig({
+      packages: { cli: { database: { type: 'sqlite', url: dbUrl } } },
+    } as any);
+    autoDiscoverAndLoadMock.mockResolvedValue({
+      discovered: [
+        {
+          path: '/fake/.smrt/manifest.json',
+          source: 'project',
+          objectCount: 1,
+          objectNames: ['@fake/app:Widget'],
+        },
+      ],
+      totalObjects: 1,
+    });
+    getSchemasSpy = vi.spyOn(ObjectRegistry, 'getAllSchemasAsDefinitions');
+    declareSchema({
+      widgets: {
+        tableName: 'widgets',
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          name: { type: 'TEXT' },
+        },
+        indexes: [],
+      },
+    });
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    clearCache();
+    try {
+      rmSync(dbUrl, { force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  function output(): string {
+    return logSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+  }
+
+  function errorOutput(): string {
+    return errorSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+  }
+
+  it('errors out when the database is configured as :memory:', async () => {
+    clearCache();
+    setConfig({
+      packages: { cli: { database: { type: 'sqlite', url: ':memory:' } } },
+    } as any);
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined as never) as any);
+
+    await dbStatusCommand.handler([], {});
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorOutput()).toContain('Database configuration required');
+    exitSpy.mockRestore();
+  });
+
+  it('reports no applied migrations and a matching schema', async () => {
+    await createWidgets();
+
+    await dbStatusCommand.handler([], {});
+
+    const out = output();
+    expect(out).toContain('Migration Status');
+    expect(out).toContain('Applied Migrations: None');
+    expect(out).toContain('Live schema matches current manifests');
+    expect(out).toContain('Schema contract passed');
+  });
+
+  it('lists applied migrations in compact form', async () => {
+    await applyMigration();
+
+    await dbStatusCommand.handler([], {});
+
+    const out = output();
+    expect(out).toContain('Applied Migrations: 1');
+    expect(out).toContain('create_widgets');
+  });
+
+  it('renders applied migrations as a verbose table', async () => {
+    await applyMigration();
+
+    await dbStatusCommand.handler([], { verbose: true });
+
+    const out = output();
+    expect(out).toContain('create_widgets');
+    expect(out).toContain('completed');
+  });
+
+  it('flags drift when the live schema is missing a manifest column', async () => {
+    // The live widgets table lacks `price`, which the manifest now declares.
+    await createWidgets();
+    declareSchema({
+      widgets: {
+        tableName: 'widgets',
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          name: { type: 'TEXT' },
+          price: { type: 'REAL' },
+        },
+        indexes: [],
+      },
+    });
+
+    await dbStatusCommand.handler([], { verbose: true });
+
+    const out = output();
+    expect(out).toContain('Drift Detected');
+    expect(out).toContain('widgets.price');
+    expect(out).toContain('missing_column');
+  });
+
+  it('flags a missing table as drift', async () => {
+    declareSchema({
+      gadgets: {
+        tableName: 'gadgets',
+        columns: { id: { type: 'TEXT', primaryKey: true } },
+        indexes: [],
+      },
+    });
+
+    await dbStatusCommand.handler([], {});
+
+    expect(output()).toContain('Drift Detected');
+    expect(output()).toContain('gadgets');
+  });
+
+  it('renders failed migrations still mapping to live drift in verbose mode', async () => {
+    // Live widgets lacks `price`; the manifest declares it (→ add_column drift).
+    // A failed migration whose generated name maps to that change is rendered as
+    // an unresolved failure that still requires action.
+    await createWidgets();
+    const db = await getDatabase({ type: 'sqlite', url: dbUrl });
+    const tracker = new MigrationTracker({ db });
+    await tracker.initialize();
+    await tracker
+      .apply({
+        id: 'add_column_widgets_price',
+        description: 'price',
+        version: '1.0.0',
+        up: ['ALTER TABLE definitely_missing ADD COLUMN price TEXT'],
+        down: [],
+      })
+      .catch(() => undefined);
+    await db.close?.();
+
+    declareSchema({
+      widgets: {
+        tableName: 'widgets',
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          name: { type: 'TEXT' },
+          price: { type: 'REAL' },
+        },
+        indexes: [],
+      },
+    });
+
+    await dbStatusCommand.handler([], { verbose: true });
+
+    const out = output();
+    expect(out).toContain('Failed migration history');
+    expect(out).toContain('add_column_widgets_price');
+  });
+
+  it('formats a recently-applied migration timestamp as "just now"', async () => {
+    await applyMigration();
+
+    await dbStatusCommand.handler([], {});
+
+    // The migration was applied seconds ago, exercising getTimeAgo's recent
+    // branch in the compact applied-migration list.
+    expect(output()).toContain('create_widgets');
+  });
+
+  it('emits a structured JSON status report', async () => {
+    await createWidgets();
+
+    await dbStatusCommand.handler([], { json: true });
+
+    const parsed = JSON.parse(output());
+    expect(parsed.database.engine).toBeDefined();
+    expect(parsed.manifests.objects).toBe(1);
+    expect(parsed.schemaContract.ok).toBe(true);
+    expect(Array.isArray(parsed.drift)).toBe(true);
+  });
+
+  it('reports a failure when the schema source throws', async () => {
+    await createWidgets();
+    getSchemasSpy.mockImplementation(() => {
+      throw new Error('boom reading schema');
+    });
+
+    await dbStatusCommand.handler([], {});
+
+    expect(process.exitCode).toBe(1);
+    expect(errorOutput()).toContain('Failed to get migration status');
+    expect(errorOutput()).toContain('boom reading schema');
+  });
+
+  it('reports a JSON failure when the schema source throws', async () => {
+    await createWidgets();
+    getSchemasSpy.mockImplementation(() => {
+      throw new Error('boom reading schema');
+    });
+
+    await dbStatusCommand.handler([], { json: true });
+
+    expect(process.exitCode).toBe(1);
+    const parsed = JSON.parse(output());
+    expect(parsed.error).toContain('boom reading schema');
+  });
+});

--- a/packages/cli/src/commands/__tests__/dev-knowledge-handlers.test.ts
+++ b/packages/cli/src/commands/__tests__/dev-knowledge-handlers.test.ts
@@ -1,0 +1,249 @@
+/**
+ * dev:knowledge-* handler tests.
+ *
+ * Mocks the deterministic knowledge module (@happyvertical/smrt-dev-mcp/knowledge)
+ * so we can drive every command handler in both markdown and json output modes,
+ * covering renderContextMarkdown and the deprecated --json alias paths.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const knowledgeMocks = vi.hoisted(() => ({
+  buildKnowledgeIndex: vi.fn(),
+  checkKnowledgeFreshness: vi.fn(),
+  diffKnowledgeIndex: vi.fn(),
+  buildReviewContext: vi.fn(),
+  buildArchitectureContext: vi.fn(),
+  renderKnowledgeIndexMarkdown: vi.fn(() => '# Knowledge Index Markdown'),
+  renderFreshnessResult: vi.fn(() => 'Freshness OK'),
+  buildArchitectureContextDefault: vi.fn(),
+}));
+
+vi.mock('@happyvertical/smrt-dev-mcp/knowledge', () => ({
+  buildKnowledgeIndex: knowledgeMocks.buildKnowledgeIndex,
+  checkKnowledgeFreshness: knowledgeMocks.checkKnowledgeFreshness,
+  diffKnowledgeIndex: knowledgeMocks.diffKnowledgeIndex,
+  buildReviewContext: knowledgeMocks.buildReviewContext,
+  buildArchitectureContext: knowledgeMocks.buildArchitectureContext,
+  renderKnowledgeIndexMarkdown: knowledgeMocks.renderKnowledgeIndexMarkdown,
+  renderFreshnessResult: knowledgeMocks.renderFreshnessResult,
+}));
+
+import { devKnowledgeCommands } from '../dev-knowledge.js';
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+const contextResult = {
+  selectedPackages: [{ name: '@happyvertical/smrt-content' }],
+  selectedSdkPackages: [{ name: '@happyvertical/ai' }],
+  deterministicFindings: [
+    {
+      severity: 'warning',
+      code: 'stale-doc',
+      message: 'Doc is stale',
+      file: 'AGENTS.md',
+    },
+    { severity: 'error', code: 'broken', message: 'Reference broke' },
+  ],
+  promptBundle: { contextMarkdown: 'Bundle body' },
+};
+
+describe('dev:knowledge-* handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    knowledgeMocks.buildKnowledgeIndex.mockResolvedValue({ index: true });
+    knowledgeMocks.checkKnowledgeFreshness.mockResolvedValue({ ok: true });
+    knowledgeMocks.diffKnowledgeIndex.mockResolvedValue({
+      base: 'HEAD',
+      changedFiles: ['a.ts', 'b.ts'],
+      changedPackages: ['@happyvertical/smrt-core'],
+    });
+    knowledgeMocks.buildReviewContext.mockResolvedValue(contextResult);
+    knowledgeMocks.buildArchitectureContext.mockResolvedValue(contextResult);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  describe('dev:knowledge-index', () => {
+    it('prints JSON by default', async () => {
+      await devKnowledgeCommands['dev:knowledge-index'].handler([], {
+        format: 'json',
+        scope: 'project',
+      });
+      expect(knowledgeMocks.buildKnowledgeIndex).toHaveBeenCalledWith({
+        scope: 'project',
+        package: undefined,
+      });
+      expect(logSpy).toHaveBeenCalledWith(
+        JSON.stringify({ index: true }, null, 2),
+      );
+    });
+
+    it('renders markdown when format is markdown', async () => {
+      await devKnowledgeCommands['dev:knowledge-index'].handler([], {
+        format: 'markdown',
+      });
+      expect(knowledgeMocks.renderKnowledgeIndexMarkdown).toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledWith('# Knowledge Index Markdown');
+    });
+  });
+
+  describe('dev:knowledge-check', () => {
+    it('prints markdown freshness output by default', async () => {
+      await devKnowledgeCommands['dev:knowledge-check'].handler([], {
+        format: 'markdown',
+        changed: true,
+        strict: true,
+      });
+      expect(knowledgeMocks.checkKnowledgeFreshness).toHaveBeenCalledWith({
+        changed: true,
+        strict: true,
+        scope: undefined,
+        package: undefined,
+      });
+      expect(logSpy).toHaveBeenCalledWith('Freshness OK');
+    });
+
+    it('honors the deprecated --json alias', async () => {
+      await devKnowledgeCommands['dev:knowledge-check'].handler([], {
+        json: true,
+      });
+      expect(logSpy).toHaveBeenCalledWith(
+        JSON.stringify({ ok: true }, null, 2),
+      );
+    });
+
+    it('exits non-zero when freshness fails', async () => {
+      knowledgeMocks.checkKnowledgeFreshness.mockResolvedValue({ ok: false });
+      const exitSpy = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => undefined) as any);
+
+      await devKnowledgeCommands['dev:knowledge-check'].handler([], {
+        format: 'markdown',
+      });
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      exitSpy.mockRestore();
+    });
+  });
+
+  describe('dev:knowledge-diff', () => {
+    it('prints a human-readable diff by default', async () => {
+      await devKnowledgeCommands['dev:knowledge-diff'].handler([], {
+        format: 'markdown',
+        base: 'main',
+      });
+      expect(knowledgeMocks.diffKnowledgeIndex).toHaveBeenCalledWith({
+        base: 'main',
+        scope: undefined,
+        package: undefined,
+      });
+      const printed = logSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(printed).toContain('Base: HEAD');
+      expect(printed).toContain('Changed files: 2');
+      expect(printed).toContain('- a.ts');
+      expect(printed).toContain('Changed packages: 1');
+      expect(printed).toContain('- @happyvertical/smrt-core');
+    });
+
+    it('prints JSON via --json', async () => {
+      await devKnowledgeCommands['dev:knowledge-diff'].handler([], {
+        json: true,
+      });
+      expect(knowledgeMocks.diffKnowledgeIndex).toHaveBeenCalledWith({
+        base: 'HEAD',
+        scope: undefined,
+        package: undefined,
+      });
+      const printed = logSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(printed).toContain('"changedFiles"');
+    });
+  });
+
+  describe('dev:knowledge-review-context', () => {
+    it('renders markdown context including deterministic findings', async () => {
+      await devKnowledgeCommands['dev:knowledge-review-context'].handler(
+        ['focus', 'area'],
+        { format: 'markdown' },
+      );
+      expect(knowledgeMocks.buildReviewContext).toHaveBeenCalledWith({
+        focus: 'focus area',
+        scope: undefined,
+        package: undefined,
+      });
+      const printed = logSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(printed).toContain('# SMRT Domain Context');
+      expect(printed).toContain('@happyvertical/smrt-content');
+      expect(printed).toContain('## Deterministic Findings');
+      expect(printed).toContain(
+        '[WARNING] stale-doc: Doc is stale (AGENTS.md)',
+      );
+      expect(printed).toContain('[ERROR] broken: Reference broke');
+      expect(printed).toContain('Bundle body');
+    });
+
+    it('prints JSON via --json', async () => {
+      await devKnowledgeCommands['dev:knowledge-review-context'].handler([], {
+        json: true,
+        focus: 'opt-focus',
+      });
+      expect(knowledgeMocks.buildReviewContext).toHaveBeenCalledWith({
+        focus: 'opt-focus',
+        scope: undefined,
+        package: undefined,
+      });
+      const printed = logSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(printed).toContain('"promptBundle"');
+    });
+  });
+
+  describe('dev:knowledge-architecture-context', () => {
+    it('renders markdown with the idea joined from args', async () => {
+      await devKnowledgeCommands['dev:knowledge-architecture-context'].handler(
+        ['new', 'feature'],
+        { format: 'markdown', focus: 'extra' },
+      );
+      expect(knowledgeMocks.buildArchitectureContext).toHaveBeenCalledWith({
+        idea: 'new feature',
+        focus: 'extra',
+        scope: undefined,
+        package: undefined,
+      });
+      const printed = logSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(printed).toContain('# SMRT Domain Context');
+    });
+
+    it('prints JSON via --json and falls back to options.idea', async () => {
+      await devKnowledgeCommands['dev:knowledge-architecture-context'].handler(
+        [],
+        { json: true, idea: 'option-idea' },
+      );
+      expect(knowledgeMocks.buildArchitectureContext).toHaveBeenCalledWith({
+        idea: 'option-idea',
+        focus: undefined,
+        scope: undefined,
+        package: undefined,
+      });
+    });
+
+    it('renders markdown without deterministic findings when absent', async () => {
+      knowledgeMocks.buildArchitectureContext.mockResolvedValue({
+        selectedPackages: [],
+        selectedSdkPackages: [],
+        promptBundle: { contextMarkdown: 'Only bundle' },
+      });
+      await devKnowledgeCommands['dev:knowledge-architecture-context'].handler(
+        [],
+        { format: 'markdown' },
+      );
+      const printed = logSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(printed).toContain('(none)');
+      expect(printed).not.toContain('## Deterministic Findings');
+      expect(printed).toContain('Only bundle');
+    });
+  });
+});

--- a/packages/cli/src/commands/__tests__/dispatch.test.ts
+++ b/packages/cli/src/commands/__tests__/dispatch.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Unit tests for dispatch commands
+ *
+ * Exercises the dispatch:list/process/retry/cleanup/subscriptions/subscribe/
+ * unsubscribe command handlers against a real in-memory-on-disk SQLite
+ * DispatchBus. Only the config boundary (getPackageConfig) is mocked so the
+ * handler resolves a real temp-file SQLite database; the DispatchBus, the
+ * _smrt_dispatch tables, and every query run for real (per testing rules:
+ * never mock the database).
+ */
+
+import { randomUUID } from 'node:crypto';
+import { existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getPackageConfigMock } = vi.hoisted(() => ({
+  getPackageConfigMock: vi.fn(),
+}));
+
+vi.mock('@happyvertical/smrt-config', () => ({
+  getPackageConfig: getPackageConfigMock,
+}));
+
+import { createDispatchBus } from '@happyvertical/smrt-core';
+import { getDatabase } from '@happyvertical/sql';
+import { dispatchCommands } from '../dispatch.js';
+
+describe('dispatch commands', () => {
+  let dbPath: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dbPath = join(tmpdir(), `smrt-dispatch-cli-${randomUUID().slice(0, 8)}.db`);
+    getPackageConfigMock.mockReturnValue({
+      database: { type: 'sqlite', url: dbPath },
+    });
+    process.exitCode = undefined;
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
+      _code?: number,
+    ) => {
+      throw new Error('process.exit called');
+    }) as never);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+    process.exitCode = undefined;
+    if (existsSync(dbPath)) {
+      rmSync(dbPath, { force: true });
+    }
+  });
+
+  // Helper: open a real bus against the same temp db to seed/inspect data.
+  async function openBus() {
+    const db = await getDatabase({ type: 'sqlite', url: dbPath });
+    const bus = await createDispatchBus({ db });
+    return { db, bus };
+  }
+
+  const allOutput = () => logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+
+  describe('dispatch:list', () => {
+    it('reports when no dispatches are found', async () => {
+      await dispatchCommands['dispatch:list'].handler([], {});
+      expect(allOutput()).toContain('No dispatches found.');
+    });
+
+    it('renders a table of dispatches', async () => {
+      const { db, bus } = await openBus();
+      await bus.emit('campaign.completed', { x: 1 }, { source: 'suasor' });
+      await bus.emit('order.created', { y: 2 }, { source: 'commerce' });
+      await db.close?.();
+
+      await dispatchCommands['dispatch:list'].handler([], {});
+
+      const out = allOutput();
+      expect(out).toContain('Found 2 dispatch(es)');
+      expect(out).toContain('campaign.completed');
+      expect(out).toContain('order.created');
+    });
+
+    it('supports JSON output and status filtering', async () => {
+      const { db, bus } = await openBus();
+      await bus.emit('a.event', {}, { source: 's1' });
+      await db.close?.();
+
+      await dispatchCommands['dispatch:list'].handler([], {
+        json: true,
+        status: 'pending',
+        limit: 10,
+      });
+
+      const out = allOutput();
+      const parsed = JSON.parse(out);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(1);
+    });
+
+    it('sets exit code on error (bad db config)', async () => {
+      getPackageConfigMock.mockReturnValueOnce({ database: {} });
+      await dispatchCommands['dispatch:list'].handler([], {});
+      expect(process.exitCode).toBe(1);
+      expect(errorSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('dispatch:process', () => {
+    it('exits when subscriber is missing', async () => {
+      await expect(
+        dispatchCommands['dispatch:process'].handler([], {}),
+      ).rejects.toThrow('process.exit called');
+    });
+
+    it('dry-run lists subscriptions and matching dispatches', async () => {
+      const { db, bus } = await openBus();
+      await bus.subscribe({
+        signalType: 'campaign.*',
+        subscriber: 'fiscus',
+        handler: 'handleCampaign',
+      });
+      await bus.emit('campaign.completed', {}, { source: 'suasor' });
+      await db.close?.();
+
+      await dispatchCommands['dispatch:process'].handler([], {
+        subscriber: 'fiscus',
+        dry: true,
+      });
+
+      const out = allOutput();
+      expect(out).toContain('Subscriptions for "fiscus"');
+      expect(out).toContain('campaign.* → handleCampaign()');
+      expect(out).toContain('would be processed');
+    });
+
+    it('processes pending dispatches for a subscriber', async () => {
+      const { db, bus } = await openBus();
+      await bus.subscribe({
+        signalType: 'campaign.completed',
+        subscriber: 'fiscus',
+      });
+      await bus.emit('campaign.completed', {}, { source: 'suasor' });
+      await db.close?.();
+
+      await dispatchCommands['dispatch:process'].handler([], {
+        subscriber: 'fiscus',
+      });
+
+      const out = allOutput();
+      expect(out).toContain('Processing dispatches for "fiscus"');
+      expect(out).toMatch(/Processed \d+ dispatch/);
+    });
+
+    it('sets exit code on error', async () => {
+      getPackageConfigMock.mockReturnValueOnce({ database: {} });
+      await dispatchCommands['dispatch:process'].handler([], {
+        subscriber: 'fiscus',
+      });
+      expect(process.exitCode).toBe(1);
+    });
+  });
+
+  describe('dispatch:retry', () => {
+    it('resets failed dispatches to pending', async () => {
+      await dispatchCommands['dispatch:retry'].handler([], {
+        'max-attempts': 5,
+        type: 'campaign.completed',
+      });
+      expect(allOutput()).toMatch(/Reset \d+ failed dispatch/);
+    });
+
+    it('uses defaults when options omitted', async () => {
+      await dispatchCommands['dispatch:retry'].handler([], {});
+      expect(allOutput()).toMatch(/Reset \d+ failed dispatch/);
+    });
+
+    it('sets exit code on error', async () => {
+      getPackageConfigMock.mockReturnValueOnce({ database: {} });
+      await dispatchCommands['dispatch:retry'].handler([], {});
+      expect(process.exitCode).toBe(1);
+    });
+  });
+
+  describe('dispatch:cleanup', () => {
+    it('dry-run reports current counts', async () => {
+      const { db, bus } = await openBus();
+      await bus.emit('a.event', {}, { source: 's1' });
+      await db.close?.();
+
+      await dispatchCommands['dispatch:cleanup'].handler([], {
+        dry: true,
+        'completed-older-than': 15,
+        'failed-older-than': 7,
+      });
+
+      const out = allOutput();
+      expect(out).toContain('Current counts');
+      expect(out).toContain('Would delete completed older than 15 days');
+      expect(out).toContain('Would delete failed older than 7 days');
+    });
+
+    it('performs cleanup and reports deleted counts', async () => {
+      await dispatchCommands['dispatch:cleanup'].handler([], {});
+      const out = allOutput();
+      expect(out).toContain('Cleanup complete');
+      expect(out).toContain('Completed deleted:');
+      expect(out).toContain('Failed deleted:');
+    });
+
+    it('sets exit code on error', async () => {
+      getPackageConfigMock.mockReturnValueOnce({ database: {} });
+      await dispatchCommands['dispatch:cleanup'].handler([], {});
+      expect(process.exitCode).toBe(1);
+    });
+  });
+
+  describe('dispatch:subscriptions', () => {
+    it('reports when no subscriptions exist', async () => {
+      await dispatchCommands['dispatch:subscriptions'].handler([], {});
+      expect(allOutput()).toContain('No subscriptions found.');
+    });
+
+    it('renders a subscriptions table', async () => {
+      const { db, bus } = await openBus();
+      await bus.subscribe({
+        signalType: 'campaign.*',
+        subscriber: 'fiscus',
+        handler: 'handleCampaign',
+      });
+      await db.close?.();
+
+      await dispatchCommands['dispatch:subscriptions'].handler([], {});
+
+      const out = allOutput();
+      expect(out).toContain('Found 1 subscription(s)');
+      expect(out).toContain('fiscus');
+      expect(out).toContain('campaign.*');
+    });
+
+    it('supports JSON output', async () => {
+      const { db, bus } = await openBus();
+      await bus.subscribe({ signalType: 'x.y', subscriber: 's1' });
+      await db.close?.();
+
+      await dispatchCommands['dispatch:subscriptions'].handler([], {
+        json: true,
+      });
+
+      const parsed = JSON.parse(allOutput());
+      expect(parsed).toHaveLength(1);
+    });
+
+    it('sets exit code on error', async () => {
+      getPackageConfigMock.mockReturnValueOnce({ database: {} });
+      await dispatchCommands['dispatch:subscriptions'].handler([], {});
+      expect(process.exitCode).toBe(1);
+    });
+  });
+
+  describe('dispatch:subscribe', () => {
+    it('exits when args are missing', async () => {
+      await expect(
+        dispatchCommands['dispatch:subscribe'].handler(['only-one'], {}),
+      ).rejects.toThrow('process.exit called');
+    });
+
+    it('creates a subscription', async () => {
+      await dispatchCommands['dispatch:subscribe'].handler(
+        ['campaign.*', 'fiscus'],
+        { handler: 'handleCampaign' },
+      );
+
+      expect(allOutput()).toContain('Created subscription');
+
+      const { db, bus } = await openBus();
+      const subs = await bus.listSubscriptions('fiscus');
+      await db.close?.();
+      expect(subs).toHaveLength(1);
+      expect(subs[0].signalType).toBe('campaign.*');
+      expect(subs[0].handler).toBe('handleCampaign');
+    });
+
+    it('sets exit code on error', async () => {
+      getPackageConfigMock.mockReturnValueOnce({ database: {} });
+      await dispatchCommands['dispatch:subscribe'].handler(
+        ['campaign.*', 'fiscus'],
+        { handler: 'handleDispatch' },
+      );
+      expect(process.exitCode).toBe(1);
+    });
+  });
+
+  describe('dispatch:unsubscribe', () => {
+    it('exits when args are missing', async () => {
+      await expect(
+        dispatchCommands['dispatch:unsubscribe'].handler(['only-one'], {}),
+      ).rejects.toThrow('process.exit called');
+    });
+
+    it('removes a subscription', async () => {
+      const { db, bus } = await openBus();
+      await bus.subscribe({ signalType: 'campaign.*', subscriber: 'fiscus' });
+      await db.close?.();
+
+      await dispatchCommands['dispatch:unsubscribe'].handler(
+        ['campaign.*', 'fiscus'],
+        {},
+      );
+
+      expect(allOutput()).toContain('Removed subscription');
+
+      const probe = await openBus();
+      const subs = await probe.bus.listSubscriptions('fiscus');
+      await probe.db.close?.();
+      expect(subs).toHaveLength(0);
+    });
+
+    it('sets exit code on error', async () => {
+      getPackageConfigMock.mockReturnValueOnce({ database: {} });
+      await dispatchCommands['dispatch:unsubscribe'].handler(
+        ['campaign.*', 'fiscus'],
+        {},
+      );
+      expect(process.exitCode).toBe(1);
+    });
+  });
+});

--- a/packages/cli/src/commands/__tests__/docs-claude-handler.test.ts
+++ b/packages/cli/src/commands/__tests__/docs-claude-handler.test.ts
@@ -1,0 +1,230 @@
+/**
+ * docs:agents / docs:claude handler tests.
+ *
+ * Drives the command handlers against a temp project whose node_modules contains
+ * fake @happyvertical/smrt-* and SDK packages, exercising discoverInstalledPackages,
+ * discoverSdkPackages, loadPackageInfo, loadAgentDoc, and loadRootDocs. Uses
+ * --dry-run to assert generated content, plus a real write to assert file output.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { docsCommands } from '../docs-claude.js';
+
+let tempDir: string;
+let originalCwd: string;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+function makePackage(
+  scope: string,
+  name: string,
+  opts: {
+    version?: string;
+    agents?: string;
+    claude?: string;
+    readme?: string;
+    pkgName?: string;
+  } = {},
+): void {
+  const dir = join(tempDir, 'node_modules', scope, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify({
+      name: opts.pkgName ?? `${scope}/${name}`,
+      version: opts.version ?? '1.0.0',
+    }),
+    'utf-8',
+  );
+  if (opts.agents !== undefined) {
+    writeFileSync(join(dir, 'AGENTS.md'), opts.agents, 'utf-8');
+  }
+  if (opts.claude !== undefined) {
+    writeFileSync(join(dir, 'CLAUDE.md'), opts.claude, 'utf-8');
+  }
+  if (opts.readme !== undefined) {
+    writeFileSync(join(dir, 'README.md'), opts.readme, 'utf-8');
+  }
+}
+
+describe('docs:agents handler', () => {
+  beforeEach(() => {
+    tempDir = realpathSync(mkdtempSync(join(tmpdir(), 'smrt-docs-handler-')));
+    originalCwd = process.cwd();
+    process.chdir(tempDir);
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it('generates markdown from installed SMRT and SDK packages (dry-run)', async () => {
+    makePackage('@happyvertical', 'smrt-content', {
+      version: '2.0.0',
+      agents: '# smrt-content\n\nContent docs here.',
+    });
+    // A package whose CLAUDE.md is just the @AGENTS.md shim -> treated as no doc.
+    makePackage('@happyvertical', 'smrt-core', {
+      claude: '@AGENTS.md',
+    });
+    // SDK (non-smrt) package with a CLAUDE.md fallback doc.
+    makePackage('@happyvertical', 'ai', {
+      claude: '# ai\n\nAI client docs.',
+    });
+
+    await docsCommands['docs:agents'].handler([], { 'dry-run': true });
+
+    const printed = logSpy.mock.calls.map((c) => c[0]).join('\n');
+    expect(printed).toContain('# SMRT Framework Context');
+    expect(printed).toContain('| @happyvertical/smrt-content | 2.0.0 |');
+    expect(printed).toContain('## Installed SDK Packages');
+    expect(printed).toContain('| @happyvertical/ai | 1.0.0 |');
+    expect(printed).toContain('Content docs here.');
+    // smrt-core has only the shim CLAUDE.md, so it reports no AGENTS.md.
+    expect(printed).toContain('*No AGENTS.md found for this package.*');
+  });
+
+  it('writes the output file and reports package counts', async () => {
+    makePackage('@happyvertical', 'smrt-content', {
+      agents: '# smrt-content\n\nDocs.',
+      readme: '## Usage\n\nUse it.',
+    });
+
+    await docsCommands['docs:agents'].handler([], {});
+
+    const outputPath = join(tempDir, '.agents', 'smrt-framework.md');
+    expect(existsSync(outputPath)).toBe(true);
+    const content = readFileSync(outputPath, 'utf-8');
+    expect(content).toContain('@happyvertical/smrt-content');
+    const printed = logSpy.mock.calls.map((c) => c[0]).join('\n');
+    expect(printed).toContain('Generated');
+    expect(printed).toContain('1 with AGENTS.md');
+  });
+
+  it('exits with an error when no @happyvertical packages are found', async () => {
+    mkdirSync(join(tempDir, 'node_modules'), { recursive: true });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called');
+    }) as any);
+
+    await expect(
+      docsCommands['docs:agents'].handler([], { 'dry-run': true }),
+    ).rejects.toThrow('process.exit called');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('docs:claude warns about deprecation and uses the .claude output path', async () => {
+    makePackage('@happyvertical', 'smrt-content', {
+      agents: '# smrt-content\n\nDocs.',
+    });
+
+    await docsCommands['docs:claude'].handler([], {});
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('deprecated'));
+    expect(existsSync(join(tempDir, '.claude', 'smrt-framework.md'))).toBe(
+      true,
+    );
+  });
+
+  it('includes framework root docs when run from a monorepo root', async () => {
+    // Make tempDir look like a monorepo root so detectMonorepoRoot + loadRootDocs run.
+    writeFileSync(
+      join(tempDir, 'pnpm-workspace.yaml'),
+      "packages:\n  - 'packages/*'\n",
+      'utf-8',
+    );
+    mkdirSync(join(tempDir, 'packages'), { recursive: true });
+    writeFileSync(
+      join(tempDir, 'AGENTS.md'),
+      '# Root Agents\n\nFramework overview text.',
+      'utf-8',
+    );
+    writeFileSync(
+      join(tempDir, 'CONTRIBUTING.md'),
+      '# Contributing\n\nHow to contribute.',
+      'utf-8',
+    );
+    makePackage('@happyvertical', 'smrt-content', {
+      agents: '# smrt-content\n\nDocs.',
+    });
+
+    await docsCommands['docs:agents'].handler([], { 'dry-run': true });
+
+    const printed = logSpy.mock.calls.map((c) => c[0]).join('\n');
+    expect(printed).toContain('## Framework Documentation');
+    expect(printed).toContain('Framework overview text.');
+    expect(printed).toContain('*Source: CONTRIBUTING.md*');
+  });
+
+  it('skips a package whose package.json cannot be parsed', async () => {
+    // Valid package alongside one with broken package.json -> the broken one is
+    // skipped via loadPackageInfo's catch, the valid one still documented.
+    makePackage('@happyvertical', 'smrt-content', {
+      agents: '# smrt-content\n\nDocs.',
+    });
+    const brokenDir = join(
+      tempDir,
+      'node_modules',
+      '@happyvertical',
+      'smrt-bad',
+    );
+    mkdirSync(brokenDir, { recursive: true });
+    writeFileSync(join(brokenDir, 'package.json'), '{ broken json', 'utf-8');
+
+    await docsCommands['docs:agents'].handler([], { 'dry-run': true });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Could not read package.json'),
+    );
+    const printed = logSpy.mock.calls.map((c) => c[0]).join('\n');
+    expect(printed).toContain('@happyvertical/smrt-content');
+  });
+
+  it('discovers workspace packages when node_modules has none', async () => {
+    // No node_modules/@happyvertical; provide a pnpm workspace instead.
+    writeFileSync(
+      join(tempDir, 'pnpm-workspace.yaml'),
+      "packages:\n  - 'packages/*'\n",
+      'utf-8',
+    );
+    const pkgDir = join(tempDir, 'packages', 'smrt-widgets');
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({
+        name: '@happyvertical/smrt-widgets',
+        version: '3.0.0',
+      }),
+      'utf-8',
+    );
+    writeFileSync(
+      join(pkgDir, 'AGENTS.md'),
+      '# smrt-widgets\n\nWidget docs.',
+      'utf-8',
+    );
+
+    await docsCommands['docs:agents'].handler([], { 'dry-run': true });
+
+    const printed = logSpy.mock.calls.map((c) => c[0]).join('\n');
+    expect(printed).toContain('@happyvertical/smrt-widgets');
+    expect(printed).toContain('Widget docs.');
+  });
+});

--- a/packages/cli/src/commands/__tests__/export-command.test.ts
+++ b/packages/cli/src/commands/__tests__/export-command.test.ts
@@ -1,0 +1,334 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { exportCommand } from '../export.js';
+
+// ---------------------------------------------------------------------------
+// Dynamic-import mocks for the export command handler.
+// ---------------------------------------------------------------------------
+
+const getConfig = vi.fn();
+const getPackageConfig = vi.fn();
+vi.mock('@happyvertical/smrt-config', () => ({
+  getConfig: (...args: unknown[]) => getConfig(...args),
+  getPackageConfig: (...args: unknown[]) => getPackageConfig(...args),
+}));
+
+vi.mock('../config.js', () => ({
+  DEFAULT_CLI_CONFIG: { database: { type: 'sqlite', url: ':memory:' } },
+}));
+
+const getDatabase = vi.fn();
+const dbQuery = vi.fn();
+vi.mock('@happyvertical/sql', () => ({
+  getDatabase: (...args: unknown[]) => getDatabase(...args),
+}));
+
+// Registry mock: a single STI Article on the `contents` table with a handful of
+// fields, so getCommonFields / queryWithProjection have something to project.
+vi.mock('@happyvertical/smrt-core', () => ({
+  ObjectRegistry: {
+    getTableStrategy: vi.fn(() => 'sti'),
+    getSTIBase: vi.fn((t: string) => t),
+    getTableName: vi.fn((t: string) =>
+      t === 'Article' || t === 'Content' ? 'contents' : null,
+    ),
+    getAllFields: vi.fn(
+      () =>
+        new Map<string, any>([
+          ['id', { type: 'text', _meta: { __smrtSystemField: true } }],
+          ['slug', { type: 'text', _meta: { __smrtSystemField: true } }],
+          ['title', { type: 'string' }],
+          ['body', { type: 'string' }],
+          ['status', { type: 'string' }],
+        ]),
+    ),
+    getSchema: vi.fn(() => ({
+      tableName: 'contents',
+      columns: {
+        id: { type: 'TEXT' },
+        slug: { type: 'TEXT' },
+        _meta_type: { type: 'TEXT' },
+        _meta_data: { type: 'JSON' },
+        title: { type: 'TEXT' },
+        body: { type: 'TEXT' },
+        status: { type: 'TEXT' },
+      },
+    })),
+  },
+}));
+
+describe('export command handler', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  const tempDirs: string[] = [];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = undefined;
+    delete process.env.PUBLIC_SHOW_DRAFTS;
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
+      code?: string | number | null,
+    ) => {
+      throw new Error(`exit:${code ?? ''}`);
+    }) as typeof process.exit);
+
+    getPackageConfig.mockReturnValue({
+      database: { type: 'sqlite', url: './dev.db' },
+    });
+    getDatabase.mockResolvedValue({ query: dbQuery, close: vi.fn() });
+    dbQuery.mockResolvedValue({ rows: [] });
+  });
+
+  afterEach(async () => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    warnSpy.mockRestore();
+    exitSpy.mockRestore();
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+    tempDirs.length = 0;
+    process.exitCode = undefined;
+  });
+
+  const logged = () => logSpy.mock.calls.flat().join('\n');
+  const errored = () => errSpy.mock.calls.flat().join('\n');
+  const warned = () => warnSpy.mock.calls.flat().join('\n');
+
+  async function tmp(prefix: string): Promise<string> {
+    const dir = await mkdtemp(resolve(process.cwd(), prefix));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it('exits when there is no smrt config', async () => {
+    getConfig.mockReturnValue(undefined);
+    await exportCommand.handler([], {});
+    expect(errored()).toContain('No smrt.config.js found');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('emits a JSON error when no smrt config and --json', async () => {
+    getConfig.mockReturnValue(undefined);
+    await exportCommand.handler([], { json: true });
+    expect(logged()).toContain('"error":"No smrt.config.js found"');
+  });
+
+  it('exits when no export configuration is present', async () => {
+    getConfig.mockReturnValue({ export: {} });
+    await exportCommand.handler([], {});
+    expect(errored()).toContain('No export configuration found');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('emits JSON error for missing export config when --json', async () => {
+    getConfig.mockReturnValue({});
+    await exportCommand.handler([], { json: true });
+    expect(logged()).toContain('"error":"No export configuration found"');
+  });
+
+  it('exits when the database is not configured', async () => {
+    getConfig.mockReturnValue({ export: { contents: { types: ['Article'] } } });
+    getPackageConfig.mockReturnValue({ database: { url: ':memory:' } });
+    await exportCommand.handler([], {});
+    expect(errored()).toContain('Database configuration required');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('emits a JSON db error when db missing and --json', async () => {
+    getConfig.mockReturnValue({ export: { contents: { types: ['Article'] } } });
+    getPackageConfig.mockReturnValue({ database: undefined });
+    await exportCommand.handler([], { json: true });
+    expect(logged()).toContain('"error":"Database not configured"');
+  });
+
+  it('writes a JSON export file with projected records', async () => {
+    const dir = await tmp('.tmp-export-json-');
+    getConfig.mockReturnValue({
+      export: {
+        fieldExportDefault: true,
+        contents: { types: ['Article'], filters: { status: ['published'] } },
+      },
+    });
+    dbQuery.mockResolvedValue({
+      rows: [
+        { id: '1', slug: 'a', title: 'Hello', body: 'B', status: 'published' },
+      ],
+    });
+
+    await exportCommand.handler([], { output: dir });
+
+    const written = await readFile(join(dir, 'contents.json'), 'utf-8');
+    const parsed = JSON.parse(written);
+    expect(parsed[0].title).toBe('Hello');
+    expect(logged()).toContain('Export complete');
+    expect(logged()).toContain('contents.json: 1 records');
+  });
+
+  it('honors --dry-run without writing files', async () => {
+    const dir = await tmp('.tmp-export-dry-');
+    getConfig.mockReturnValue({
+      export: { contents: { types: ['Article'] } },
+    });
+    dbQuery.mockResolvedValue({ rows: [{ id: '1', title: 'X' }] });
+
+    await exportCommand.handler([], { output: dir, 'dry-run': true });
+
+    await expect(
+      readFile(join(dir, 'contents.json'), 'utf-8'),
+    ).rejects.toThrow();
+    expect(logged()).toContain('(dry-run)');
+  });
+
+  it('writes ndjson when the file config requests it', async () => {
+    const dir = await tmp('.tmp-export-ndjson-');
+    getConfig.mockReturnValue({
+      export: { contents: { types: ['Article'], format: 'ndjson' } },
+    });
+    dbQuery.mockResolvedValue({
+      rows: [
+        { id: '1', title: 'A' },
+        { id: '2', title: 'B' },
+      ],
+    });
+
+    await exportCommand.handler([], { output: dir });
+
+    const written = await readFile(join(dir, 'contents.ndjson'), 'utf-8');
+    expect(written.split('\n')).toHaveLength(2);
+  });
+
+  it('writes csv with a header row', async () => {
+    const dir = await tmp('.tmp-export-csv-');
+    getConfig.mockReturnValue({
+      export: { format: 'csv', contents: { types: ['Article'] } },
+    });
+    dbQuery.mockResolvedValue({
+      rows: [
+        { id: '1', slug: 's', title: 'A', body: 'b', status: 'published' },
+      ],
+    });
+
+    await exportCommand.handler([], { output: dir });
+
+    const written = await readFile(join(dir, 'contents.csv'), 'utf-8');
+    expect(written.split('\n')[0]).toContain('title');
+  });
+
+  it('skips file configs that specify no types', async () => {
+    const dir = await tmp('.tmp-export-notypes-');
+    getConfig.mockReturnValue({
+      export: { contents: { types: [] } },
+    });
+    await exportCommand.handler([], { output: dir });
+    expect(warned()).toContain('No types specified for contents');
+  });
+
+  it('limits export to a single file via --file', async () => {
+    const dir = await tmp('.tmp-export-onlyfile-');
+    getConfig.mockReturnValue({
+      export: {
+        contents: { types: ['Article'] },
+        events: { types: ['Article'] },
+      },
+    });
+    dbQuery.mockResolvedValue({ rows: [] });
+
+    await exportCommand.handler([], {
+      output: dir,
+      file: 'contents',
+      verbose: true,
+    });
+
+    expect(logged()).toContain('Processing: contents');
+    expect(logged()).not.toContain('Processing: events');
+  });
+
+  it('emits a JSON summary with --json', async () => {
+    const dir = await tmp('.tmp-export-jsonsummary-');
+    getConfig.mockReturnValue({
+      export: { contents: { types: ['Article'] } },
+    });
+    dbQuery.mockResolvedValue({ rows: [{ id: '1', title: 'A' }] });
+
+    await exportCommand.handler([], { output: dir, json: true });
+
+    const out = logged();
+    expect(out).toContain('"contents"');
+    expect(out).toContain('"records": 1');
+  });
+
+  it('reports show-drafts mode when enabled', async () => {
+    const dir = await tmp('.tmp-export-drafts-');
+    getConfig.mockReturnValue({
+      export: { contents: { types: ['Article'] } },
+    });
+    dbQuery.mockResolvedValue({ rows: [] });
+
+    await exportCommand.handler([], { output: dir, 'show-drafts': true });
+    expect(logged()).toContain('Including drafts');
+  });
+
+  it('handles query failures and sets exitCode', async () => {
+    const dir = await tmp('.tmp-export-fail-');
+    getConfig.mockReturnValue({
+      export: { contents: { types: ['Article'] } },
+    });
+    dbQuery.mockRejectedValue(new Error('db blew up'));
+
+    await exportCommand.handler([], { output: dir, verbose: true });
+    expect(errored()).toContain('Export failed');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('handles query failures in JSON mode', async () => {
+    const dir = await tmp('.tmp-export-failjson-');
+    getConfig.mockReturnValue({
+      export: { contents: { types: ['Article'] } },
+    });
+    dbQuery.mockRejectedValue(new Error('db blew up'));
+
+    await exportCommand.handler([], { output: dir, json: true });
+    expect(logged()).toContain('"error"');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('writes an empty csv for a file with no records', async () => {
+    const dir = await tmp('.tmp-export-emptycsv-');
+    getConfig.mockReturnValue({
+      export: { contents: { types: ['Article'], format: 'csv' } },
+    });
+    dbQuery.mockResolvedValue({ rows: [] });
+
+    await exportCommand.handler([], { output: dir });
+
+    const written = await readFile(join(dir, 'contents.csv'), 'utf-8');
+    expect(written).toBe('');
+  });
+
+  it('falls back to the events table for unknown event-like types', async () => {
+    const dir = await tmp('.tmp-export-fallback-');
+    // 'Meeting' is not mapped by the registry getTableName mock, so the handler
+    // exercises the heuristic table-name fallback ('events').
+    getConfig.mockReturnValue({
+      export: { meetings: { types: ['Meeting'] } },
+    });
+    dbQuery.mockResolvedValue({ rows: [{ id: '1', title: 'Town hall' }] });
+
+    await exportCommand.handler([], { output: dir });
+
+    const written = await readFile(join(dir, 'meetings.json'), 'utf-8');
+    expect(JSON.parse(written)).toHaveLength(1);
+    // SQL targeted the heuristic 'events' table.
+    expect(dbQuery).toHaveBeenCalledWith(
+      expect.stringContaining('FROM events'),
+      ...['%:Meeting'],
+    );
+  });
+});

--- a/packages/cli/src/commands/__tests__/generate-handlers.test.ts
+++ b/packages/cli/src/commands/__tests__/generate-handlers.test.ts
@@ -1,0 +1,242 @@
+/**
+ * generate-types / generate-mcp / generate-routes handler tests.
+ *
+ * The generate-register handler is covered by generate-register.test.ts. This
+ * file covers the other three handlers by mocking the smrt-core generator
+ * boundaries (declarations, MCPGenerator, vite-plugin route generator) and the
+ * discovery layer, then asserting on success and error/no-manifest paths.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  generateDeclarationsFromCLI: vi.fn(),
+  generateServer: vi.fn(),
+  getAllClasses: vi.fn(),
+  autoDiscoverAndLoad: vi.fn(),
+  loadManifestFile: vi.fn(),
+  generateSvelteKitRoutes: vi.fn(),
+}));
+
+vi.mock('@happyvertical/smrt-core', () => ({
+  ObjectRegistry: {
+    getAllClasses: mocks.getAllClasses,
+  },
+}));
+
+vi.mock('@happyvertical/smrt-core/generators', () => ({
+  MCPGenerator: class {
+    generateServer = mocks.generateServer;
+  },
+}));
+
+vi.mock('@happyvertical/smrt-core/prebuild', () => ({
+  generateDeclarationsFromCLI: mocks.generateDeclarationsFromCLI,
+}));
+
+vi.mock('@happyvertical/smrt-core/vite-plugin', () => ({
+  generateSvelteKitRoutes: mocks.generateSvelteKitRoutes,
+}));
+
+vi.mock('../../discovery/index.js', () => ({
+  autoDiscoverAndLoad: mocks.autoDiscoverAndLoad,
+  loadManifestFile: mocks.loadManifestFile,
+}));
+
+import { generateCommands } from '../generate.js';
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+describe('generate-* handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  describe('generate-types', () => {
+    it('requires a manifest path', async () => {
+      await expect(
+        generateCommands['generate-types'].handler([], {}),
+      ).rejects.toThrow(/Manifest path is required/);
+    });
+
+    it('forwards the manifest path and output dir', async () => {
+      mocks.generateDeclarationsFromCLI.mockResolvedValue(undefined);
+
+      await generateCommands['generate-types'].handler(['m.json'], {
+        'output-dir': 'out',
+      });
+
+      expect(mocks.generateDeclarationsFromCLI).toHaveBeenCalledWith([
+        'm.json',
+        'out',
+      ]);
+    });
+
+    it('passes a single arg when no output dir', async () => {
+      mocks.generateDeclarationsFromCLI.mockResolvedValue(undefined);
+
+      await generateCommands['generate-types'].handler(['m.json'], {});
+
+      expect(mocks.generateDeclarationsFromCLI).toHaveBeenCalledWith([
+        'm.json',
+      ]);
+    });
+
+    it('wraps generator errors', async () => {
+      mocks.generateDeclarationsFromCLI.mockRejectedValue(new Error('boom'));
+
+      await expect(
+        generateCommands['generate-types'].handler(['m.json'], {}),
+      ).rejects.toThrow(/Failed to generate types: boom/);
+    });
+  });
+
+  describe('generate-mcp', () => {
+    it('warns when there are no registered objects but still generates', async () => {
+      mocks.getAllClasses.mockReturnValue(new Map());
+      mocks.generateServer.mockResolvedValue(undefined);
+
+      await generateCommands['generate-mcp'].handler([], {
+        'output-path': '.smrt/mcp-server/index.js',
+        version: '1.0.0',
+        name: 'my-server',
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('No SMRT objects found'),
+      );
+      expect(mocks.generateServer).toHaveBeenCalledWith(
+        expect.objectContaining({ serverName: 'my-server' }),
+      );
+    });
+
+    it('derives the server name from package.json when not provided', async () => {
+      mocks.getAllClasses.mockReturnValue(new Map([['Widget', {} as never]]));
+      mocks.generateServer.mockResolvedValue(undefined);
+
+      await generateCommands['generate-mcp'].handler([], {
+        'output-path': 'out/index.js',
+        version: '2.0.0',
+      });
+
+      // package.json read may resolve to the cli package's own name or the
+      // default fallback; either way generateServer must run with a name.
+      expect(mocks.generateServer).toHaveBeenCalledWith(
+        expect.objectContaining({ serverVersion: '2.0.0' }),
+      );
+      const call = mocks.generateServer.mock.calls[0][0];
+      expect(typeof call.serverName).toBe('string');
+      expect(call.serverName.length).toBeGreaterThan(0);
+    });
+
+    it('wraps generator errors', async () => {
+      mocks.getAllClasses.mockReturnValue(new Map());
+      mocks.generateServer.mockRejectedValue(new Error('mcp fail'));
+
+      await expect(
+        generateCommands['generate-mcp'].handler([], {
+          'output-path': 'out/index.js',
+          version: '1.0.0',
+          name: 'x',
+        }),
+      ).rejects.toThrow(/Failed to generate MCP server: mcp fail/);
+    });
+  });
+
+  describe('generate-routes', () => {
+    it('exits when no manifests are discovered', async () => {
+      mocks.autoDiscoverAndLoad.mockResolvedValue({
+        discovered: [],
+        totalObjects: 0,
+      });
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as any);
+
+      await expect(
+        generateCommands['generate-routes'].handler([], {}),
+      ).rejects.toThrow();
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      exitSpy.mockRestore();
+    });
+
+    it('exits when manifests have no objects', async () => {
+      mocks.autoDiscoverAndLoad.mockResolvedValue({
+        discovered: [{ path: 'm.json', packageName: 'pkg' }],
+        totalObjects: 0,
+      });
+      mocks.loadManifestFile.mockResolvedValue({ objects: {} });
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('exit');
+      }) as any);
+
+      await expect(
+        generateCommands['generate-routes'].handler([], {}),
+      ).rejects.toThrow();
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      exitSpy.mockRestore();
+    });
+
+    it('generates routes for discovered objects', async () => {
+      mocks.autoDiscoverAndLoad.mockResolvedValue({
+        discovered: [{ path: 'm.json', packageName: '@app/x' }],
+        totalObjects: 1,
+      });
+      mocks.loadManifestFile.mockResolvedValue({
+        objects: {
+          Widget: { collection: 'widgets', packageName: '@app/x' },
+        },
+      });
+      mocks.generateSvelteKitRoutes.mockResolvedValue(undefined);
+
+      await generateCommands['generate-routes'].handler([], {
+        'routes-dir': 'src/routes/api',
+        'objects-dir': 'src/lib/objects',
+        'config-path': 'src/lib/server',
+        'config-file': 'smrt.ts',
+        'kebab-routes': true,
+      });
+
+      expect(mocks.generateSvelteKitRoutes).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          objects: expect.objectContaining({ Widget: expect.any(Object) }),
+        }),
+        expect.objectContaining({
+          kebabRoutes: true,
+          routesDir: 'src/routes/api',
+        }),
+      );
+      const printed = logSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(printed).toContain('Generated routes for 1 object(s)');
+    });
+
+    it('wraps generation errors', async () => {
+      mocks.autoDiscoverAndLoad.mockResolvedValue({
+        discovered: [{ path: 'm.json', packageName: '@app/x' }],
+        totalObjects: 1,
+      });
+      mocks.loadManifestFile.mockResolvedValue({
+        objects: { Widget: { collection: 'widgets' } },
+      });
+      mocks.generateSvelteKitRoutes.mockRejectedValue(new Error('route fail'));
+
+      await expect(
+        generateCommands['generate-routes'].handler([], {}),
+      ).rejects.toThrow(/Failed to generate routes: route fail/);
+    });
+  });
+});

--- a/packages/cli/src/commands/__tests__/git-commands.test.ts
+++ b/packages/cli/src/commands/__tests__/git-commands.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Additional unit tests for git commands.
+ *
+ * The existing git.test.ts thoroughly covers the pure merge functions; this
+ * file targets the two command handlers (git:init, merge-json) and the
+ * remaining merge/sanitize branches. The handlers shell out to git and call
+ * process.exit(), so they run inside a real temp git repository with process.exit
+ * stubbed to throw (so we can assert the exit branch without killing the runner).
+ * No git internals are mocked — the merge driver config is written to a real
+ * `.git`.
+ */
+
+import { execSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mergeObjects } from '../git.js';
+
+describe('mergeObjects additional branches', () => {
+  it('prefers ours wholesale when ours is a non-object', () => {
+    expect(mergeObjects({ a: 1 }, 'scalar', { b: 2 })).toBe('scalar');
+  });
+
+  it('merges nested arrays that lack id/slug by preferring ours', () => {
+    const result = mergeObjects(
+      { items: ['x'] },
+      { items: ['a', 'b'] },
+      { items: ['c'] },
+    );
+    expect(result.items).toEqual(['a', 'b']);
+  });
+
+  it('falls back to theirs array when ours is absent', () => {
+    const result = mergeObjects({}, {}, { tags: ['t1', 't2'] });
+    expect(result.tags).toEqual(['t1', 't2']);
+  });
+
+  it('keeps a key that exists only in base', () => {
+    const result = mergeObjects({ onlyBase: 'kept' }, {}, {});
+    expect(result.onlyBase).toBe('kept');
+  });
+
+  it('sanitizes dangerous keys inside adopted array subtrees', () => {
+    const theirs = JSON.parse(
+      '{"records":[{"id":"a","__proto__":{"polluted":true},"safe":1}]}',
+    );
+    const result = mergeObjects({}, { records: [] }, theirs);
+    expect(result.records).toHaveLength(1);
+    expect(Object.keys(result.records[0])).not.toContain('__proto__');
+    expect(result.records[0].safe).toBe(1);
+  });
+});
+
+describe('git:init handler', () => {
+  let repoDir: string;
+  let originalCwd: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    repoDir = realpathSync(mkdtempSync(join(tmpdir(), 'smrt-git-init-')));
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
+      _code?: number,
+    ) => {
+      throw new Error('process.exit called');
+    }) as never);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  const out = () => logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+
+  function initRepo() {
+    execSync('git init', { cwd: repoDir, stdio: 'ignore' });
+  }
+
+  it('configures the merge driver and writes .gitattributes', async () => {
+    initRepo();
+    process.chdir(repoDir);
+
+    const { gitCommands } = await import('../git.js');
+    await gitCommands['git:init'].handler([], {
+      patterns: 'data/*.json',
+    });
+
+    const gitattributes = readFileSync(
+      join(repoDir, '.gitattributes'),
+      'utf-8',
+    );
+    expect(gitattributes).toContain('# SMRT JSON merge driver');
+    expect(gitattributes).toContain('data/*.json merge=smrt-json');
+
+    const driver = execSync('git config --local merge.smrt-json.driver', {
+      cwd: repoDir,
+      encoding: 'utf-8',
+    });
+    expect(driver).toContain('smrt merge-json');
+    expect(out()).toContain('SMRT JSON merge driver configured');
+  });
+
+  it('reports already-configured patterns on a second run', async () => {
+    initRepo();
+    process.chdir(repoDir);
+
+    const { gitCommands } = await import('../git.js');
+    await gitCommands['git:init'].handler([], { patterns: 'data/*.json' });
+    logSpy.mockClear();
+    await gitCommands['git:init'].handler([], { patterns: 'data/*.json' });
+
+    expect(out()).toContain('already configured');
+  });
+
+  it('appends a new pattern to an existing .gitattributes', async () => {
+    initRepo();
+    writeFileSync(join(repoDir, '.gitattributes'), '*.png binary\n');
+    process.chdir(repoDir);
+
+    const { gitCommands } = await import('../git.js');
+    await gitCommands['git:init'].handler([], { patterns: '*.data.json' });
+
+    const gitattributes = readFileSync(
+      join(repoDir, '.gitattributes'),
+      'utf-8',
+    );
+    expect(gitattributes).toContain('*.png binary');
+    expect(gitattributes).toContain('*.data.json merge=smrt-json');
+  });
+
+  it('exits when not inside a git repository', async () => {
+    process.chdir(repoDir); // no `git init`
+
+    const { gitCommands } = await import('../git.js');
+    await expect(
+      gitCommands['git:init'].handler([], { patterns: 'data/*.json' }),
+    ).rejects.toThrow('process.exit called');
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Not a git repository'),
+    );
+  });
+});
+
+describe('merge-json handler', () => {
+  let workDir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let exitCodes: Array<number | undefined>;
+
+  // The merge-json handler calls process.exit() *inside* its try/catch. A
+  // throwing stub is the only way to halt the handler, but the throw on the
+  // success path (exit 0) is then caught by the handler's catch, which calls
+  // exit(1). So we record every exit code and assert on the FIRST one, which is
+  // the code the real (terminating) process.exit would have used.
+  const firstExit = () => exitCodes[0];
+
+  beforeEach(() => {
+    workDir = realpathSync(mkdtempSync(join(tmpdir(), 'smrt-merge-json-')));
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitCodes = [];
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      exitCodes.push(code);
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  function write(name: string, content: string) {
+    const p = join(workDir, name);
+    writeFileSync(p, content);
+    return p;
+  }
+
+  it('prints usage and exits 1 when arguments are missing', async () => {
+    const { gitCommands } = await import('../git.js');
+    await expect(gitCommands['merge-json'].handler([], {})).rejects.toThrow(
+      'process.exit:1',
+    );
+    expect(firstExit()).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Usage: smrt merge-json'),
+    );
+  });
+
+  it('merges files and writes the result to the ours path (exit 0)', async () => {
+    const base = write('base.json', JSON.stringify([{ id: 'a', n: 1 }]));
+    const ours = write(
+      'ours.json',
+      JSON.stringify([
+        { id: 'a', n: 1 },
+        { id: 'b', n: 2 },
+      ]),
+    );
+    const theirs = write(
+      'theirs.json',
+      JSON.stringify([
+        { id: 'a', n: 1 },
+        { id: 'c', n: 3 },
+      ]),
+    );
+
+    const { gitCommands } = await import('../git.js');
+    await expect(
+      gitCommands['merge-json'].handler([base, ours, theirs], {
+        verbose: true,
+      }),
+    ).rejects.toThrow();
+    expect(firstExit()).toBe(0);
+
+    const merged = JSON.parse(readFileSync(ours, 'utf-8'));
+    expect(merged.map((o: any) => o.id).sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('handles a missing base file (new-file scenario)', async () => {
+    const base = join(workDir, 'missing-base.json');
+    const ours = write('ours.json', JSON.stringify([{ id: 'a' }]));
+    const theirs = write('theirs.json', JSON.stringify([{ id: 'b' }]));
+
+    const { gitCommands } = await import('../git.js');
+    await expect(
+      gitCommands['merge-json'].handler([base, ours, theirs], {}),
+    ).rejects.toThrow();
+    expect(firstExit()).toBe(0);
+    expect(existsSync(base)).toBe(false);
+  });
+
+  it('prints merged output to stdout in dry-run mode', async () => {
+    const base = write('base.json', '[]');
+    const ours = write('ours.json', JSON.stringify([{ id: 'a' }]));
+    const theirs = write('theirs.json', JSON.stringify([{ id: 'b' }]));
+    const oursBefore = readFileSync(ours, 'utf-8');
+
+    const { gitCommands } = await import('../git.js');
+    await expect(
+      gitCommands['merge-json'].handler([base, ours, theirs], {
+        dryRun: true,
+      }),
+    ).rejects.toThrow();
+    expect(firstExit()).toBe(0);
+
+    const printed = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(printed).toContain('"id": "a"');
+    // Dry run must not rewrite ours.
+    expect(readFileSync(ours, 'utf-8')).toBe(oursBefore);
+  });
+
+  it('exits 1 when ours file does not exist', async () => {
+    const base = write('base.json', '[]');
+    const theirs = write('theirs.json', '[]');
+    const missingOurs = join(workDir, 'no-ours.json');
+
+    const { gitCommands } = await import('../git.js');
+    await expect(
+      gitCommands['merge-json'].handler([base, missingOurs, theirs], {}),
+    ).rejects.toThrow('process.exit:1');
+    expect(firstExit()).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"ours" file not found'),
+    );
+  });
+
+  it('exits 1 on invalid JSON and reports the syntax error', async () => {
+    const base = write('base.json', '[]');
+    const ours = write('ours.json', 'not valid json {');
+    const theirs = write('theirs.json', '[]');
+
+    const { gitCommands } = await import('../git.js');
+    await expect(
+      gitCommands['merge-json'].handler([base, ours, theirs], {
+        verbose: true,
+      }),
+    ).rejects.toThrow('process.exit:1');
+    expect(firstExit()).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('invalid JSON'),
+    );
+  });
+});

--- a/packages/cli/src/commands/__tests__/init.test.ts
+++ b/packages/cli/src/commands/__tests__/init.test.ts
@@ -1,0 +1,215 @@
+/**
+ * init command tests.
+ *
+ * Drives initCommands.init.handler against real temp project directories,
+ * asserting on the scaffolded files. Console output is silenced; process.exit
+ * is stubbed so error paths can be asserted without tearing down the worker.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { initCommands } from '../init.js';
+
+let tempDir: string;
+let originalCwd: string;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+function writePackageJson(content: Record<string, unknown> | string): void {
+  writeFileSync(
+    join(tempDir, 'package.json'),
+    typeof content === 'string' ? content : JSON.stringify(content),
+    'utf-8',
+  );
+}
+
+const init = initCommands.init.handler;
+
+describe('init command', () => {
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'smrt-init-'));
+    originalCwd = process.cwd();
+    process.chdir(tempDir);
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('scaffolds SMRT files for a SvelteKit project', async () => {
+    writePackageJson({
+      name: 'demo',
+      devDependencies: { '@sveltejs/kit': '^2.0.0' },
+    });
+
+    await init([], { database: 'sqlite' });
+
+    expect(existsSync(join(tempDir, 'smrt.config.ts'))).toBe(true);
+    expect(existsSync(join(tempDir, 'src/lib/server/smrt.ts'))).toBe(true);
+    expect(existsSync(join(tempDir, 'src/lib/objects/index.ts'))).toBe(true);
+    expect(existsSync(join(tempDir, 'src/lib/objects/Example.ts'))).toBe(true);
+    expect(existsSync(join(tempDir, '.env.example'))).toBe(true);
+    expect(existsSync(join(tempDir, '.gitignore'))).toBe(true);
+    // SQLite default creates a data directory.
+    expect(existsSync(join(tempDir, 'data'))).toBe(true);
+
+    const config = readFileSync(join(tempDir, 'smrt.config.ts'), 'utf-8');
+    expect(config).toContain("type: 'sqlite'");
+    expect(config).toContain('./data/app.db');
+  });
+
+  it('uses the postgres database type and url when requested', async () => {
+    writePackageJson({
+      name: 'demo',
+      dependencies: { '@sveltejs/kit': '^2.0.0' },
+    });
+
+    await init([], { database: 'postgres' });
+
+    const config = readFileSync(join(tempDir, 'smrt.config.ts'), 'utf-8');
+    expect(config).toContain("type: 'postgres'");
+    expect(config).toContain('postgres://localhost/app');
+    // Postgres does not create the SQLite data directory.
+    expect(existsSync(join(tempDir, 'data'))).toBe(false);
+  });
+
+  it('skips the example object when skipExample is set', async () => {
+    writePackageJson({
+      name: 'demo',
+      devDependencies: { '@sveltejs/kit': '^2.0.0' },
+    });
+
+    await init([], { database: 'sqlite', skipExample: true });
+
+    expect(existsSync(join(tempDir, 'src/lib/objects/Example.ts'))).toBe(false);
+    expect(existsSync(join(tempDir, 'src/lib/objects/index.ts'))).toBe(true);
+  });
+
+  it('warns but continues for a non-SvelteKit project', async () => {
+    writePackageJson({ name: 'plain' });
+
+    await init([], { database: 'sqlite' });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('does not appear to be a SvelteKit project'),
+    );
+    expect(existsSync(join(tempDir, 'smrt.config.ts'))).toBe(true);
+  });
+
+  it('appends SMRT patterns to an existing gitignore', async () => {
+    writePackageJson({
+      name: 'demo',
+      devDependencies: { '@sveltejs/kit': '^2.0.0' },
+    });
+    writeFileSync(join(tempDir, '.gitignore'), 'node_modules\n', 'utf-8');
+
+    await init([], { database: 'sqlite' });
+
+    const gitignore = readFileSync(join(tempDir, '.gitignore'), 'utf-8');
+    expect(gitignore).toContain('node_modules');
+    expect(gitignore).toContain('SMRT auto-generated');
+  });
+
+  it('does not duplicate gitignore patterns on re-run', async () => {
+    writePackageJson({
+      name: 'demo',
+      devDependencies: { '@sveltejs/kit': '^2.0.0' },
+    });
+    writeFileSync(
+      join(tempDir, '.gitignore'),
+      'node_modules\n# SMRT auto-generated\n',
+      'utf-8',
+    );
+
+    await init([], { database: 'sqlite' });
+
+    const gitignore = readFileSync(join(tempDir, '.gitignore'), 'utf-8');
+    const matches = gitignore.match(/SMRT auto-generated/g) || [];
+    expect(matches).toHaveLength(1);
+  });
+
+  it('skips existing files unless force is passed', async () => {
+    writePackageJson({
+      name: 'demo',
+      devDependencies: { '@sveltejs/kit': '^2.0.0' },
+    });
+    writeFileSync(join(tempDir, 'smrt.config.ts'), 'EXISTING', 'utf-8');
+
+    await init([], { database: 'sqlite' });
+    expect(readFileSync(join(tempDir, 'smrt.config.ts'), 'utf-8')).toBe(
+      'EXISTING',
+    );
+
+    await init([], { database: 'sqlite', force: true });
+    expect(readFileSync(join(tempDir, 'smrt.config.ts'), 'utf-8')).not.toBe(
+      'EXISTING',
+    );
+  });
+
+  it('exits when no package.json is present', async () => {
+    // Throw from the exit stub so the handler aborts (mirroring real exit)
+    // instead of falling through to the subsequent file reads.
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called');
+    }) as any);
+
+    await expect(init([], { database: 'sqlite' })).rejects.toThrow(
+      'process.exit called',
+    );
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('No package.json found'),
+    );
+    exitSpy.mockRestore();
+  });
+
+  it('exits when package.json is invalid JSON', async () => {
+    writePackageJson('{ not valid json');
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called');
+    }) as any);
+
+    await expect(init([], { database: 'sqlite' })).rejects.toThrow(
+      'process.exit called',
+    );
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to parse package.json'),
+    );
+    exitSpy.mockRestore();
+  });
+
+  it('notes when smrt-core is already installed (no install hint)', async () => {
+    writePackageJson({
+      name: 'demo',
+      devDependencies: {
+        '@sveltejs/kit': '^2.0.0',
+        '@happyvertical/smrt-core': '^1.0.0',
+      },
+    });
+
+    await init([], { database: 'sqlite' });
+
+    const printed = logSpy.mock.calls.map((c) => c[0]).join('\n');
+    expect(printed).not.toContain('npm install @happyvertical/smrt-core');
+  });
+});

--- a/packages/cli/src/commands/__tests__/json-validator-extra.test.ts
+++ b/packages/cli/src/commands/__tests__/json-validator-extra.test.ts
@@ -1,0 +1,547 @@
+/**
+ * Additional unit tests for the JSON database validator.
+ *
+ * Extends db-validate.test.ts to cover the registry-dependent integration
+ * paths: table→class resolution (exact + singular), STI discriminator checks,
+ * field-type validation through the manifest field loop, cross-file foreign-key
+ * validation, applyFixes, and the detailed displayValidationResults output.
+ *
+ * SMRT classes are registered into the real ObjectRegistry via
+ * registerFromManifest (no mocking of the registry for the resolution/type/FK
+ * paths). For the required-field/default paths the validator reads
+ * top-level `required`/`default` on the field def, which the manifest loader
+ * nests under `_meta`; those few tests feed a crafted field map by spying on
+ * ObjectRegistry.getFields so the auto-fix default can be exercised. The
+ * filesystem is real (temp dir); nothing about validation is mocked.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  displayValidationResults,
+  JsonDatabaseValidator,
+} from '../json-validator.js';
+import {
+  ValidationCodes,
+  type ValidationSummary,
+} from '../validation-types.js';
+
+describe('JsonDatabaseValidator integration paths', () => {
+  const testDir = resolve(
+    process.cwd(),
+    `.test-json-validator-${randomUUID()}`,
+  );
+  const dataDir = resolve(testDir, 'data');
+
+  // Unique suffix so registry entries from one run never collide with another.
+  const suffix = randomUUID()
+    .slice(0, 6)
+    .replace(/[^a-z]/gi, 'x');
+  const eventClass = `Evt${suffix}`;
+  const eventTable = `${eventClass.toLowerCase()}s`;
+  const personClass = `Prsn${suffix}`;
+  const personTable = `${personClass.toLowerCase()}s`;
+
+  beforeEach(async () => {
+    await mkdir(dataDir, { recursive: true });
+
+    ObjectRegistry.registerFromManifest(
+      personClass,
+      {
+        className: personClass,
+        decoratorConfig: { tableName: personTable },
+        fields: { name: { type: 'text' } },
+      },
+      '@test/json-validator',
+    );
+
+    ObjectRegistry.registerFromManifest(
+      eventClass,
+      {
+        className: eventClass,
+        decoratorConfig: { tableName: eventTable, tableStrategy: 'sti' },
+        fields: {
+          title: { type: 'text' },
+          attendees: { type: 'integer' },
+          organizerId: { type: 'foreignKey', related: personClass },
+        },
+      },
+      '@test/json-validator',
+    );
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  function newValidator(quickMode = false, verbose = false) {
+    return new JsonDatabaseValidator({ dataPath: dataDir, quickMode, verbose });
+  }
+
+  it('resolves a table to its registered class and validates field types', async () => {
+    await writeFile(
+      resolve(dataDir, `${eventTable}.json`),
+      JSON.stringify([
+        {
+          id: 'e1',
+          _meta_type: eventClass,
+          title: 'Launch',
+          attendees: 'not-a-number',
+        },
+      ]),
+    );
+
+    const validator = newValidator(true);
+    const results = await validator.validate([
+      resolve(dataDir, `${eventTable}.json`),
+    ]);
+
+    const result = results.objectResults[0];
+    expect(result.objectType).toBe(eventClass);
+    const typeErr = result.issues.find(
+      (i) => i.code === ValidationCodes.INVALID_INTEGER,
+    );
+    expect(typeErr).toBeDefined();
+  });
+
+  it('warns on an unknown STI _meta_type and missing discriminator', async () => {
+    await writeFile(
+      resolve(dataDir, `${eventTable}.json`),
+      JSON.stringify([
+        { id: 'e1', title: 'No discriminator' },
+        { id: 'e2', _meta_type: 'TotallyUnknownType', title: 'Bad type' },
+        { id: 'e3', _meta_type: 42, title: 'Numeric type' },
+      ]),
+    );
+
+    const validator = newValidator(true);
+    const results = await validator.validate([
+      resolve(dataDir, `${eventTable}.json`),
+    ]);
+
+    const issues = results.objectResults[0].issues;
+    expect(
+      issues.some((i) => i.code === ValidationCodes.MISSING_META_TYPE),
+    ).toBe(true);
+    expect(
+      issues.some((i) => i.code === ValidationCodes.UNKNOWN_META_TYPE),
+    ).toBe(true);
+    expect(issues.some((i) => i.code === ValidationCodes.INVALID_TYPE)).toBe(
+      true,
+    );
+  });
+
+  it('flags invalid _meta_data that is not an object', async () => {
+    await writeFile(
+      resolve(dataDir, `${eventTable}.json`),
+      JSON.stringify([
+        { id: 'e1', _meta_type: eventClass, _meta_data: ['array', 'bad'] },
+      ]),
+    );
+
+    const validator = newValidator(true);
+    const results = await validator.validate([
+      resolve(dataDir, `${eventTable}.json`),
+    ]);
+
+    expect(
+      results.objectResults[0].issues.some(
+        (i) => i.code === ValidationCodes.INVALID_META_DATA,
+      ),
+    ).toBe(true);
+  });
+
+  it('resolves a plural table name to a singular class name', async () => {
+    // personTable already ends in 's'; the table is registered with that exact
+    // name so the exact-match branch wins. Here we additionally confirm the
+    // singular fallback by querying a table whose registered name is singular.
+    ObjectRegistry.registerFromManifest(
+      `Foo${suffix}`,
+      {
+        className: `Foo${suffix}`,
+        // Registered table name is the singular class name lowercased.
+        decoratorConfig: { tableName: `foo${suffix}`.toLowerCase() },
+        fields: { name: { type: 'text' } },
+      },
+      '@test/json-validator',
+    );
+
+    await writeFile(
+      resolve(dataDir, `foo${suffix}s.json`.toLowerCase()),
+      JSON.stringify([{ id: 'a' }]),
+    );
+
+    const validator = newValidator(true);
+    const results = await validator.validate([
+      resolve(dataDir, `foo${suffix}s.json`.toLowerCase()),
+    ]);
+
+    expect(results.objectResults[0].objectType).toBe(`Foo${suffix}`);
+  });
+
+  it('validates foreign keys across files (full mode)', async () => {
+    await writeFile(
+      resolve(dataDir, `${personTable}.json`),
+      JSON.stringify([{ id: 'p1', name: 'Alice' }]),
+    );
+    await writeFile(
+      resolve(dataDir, `${eventTable}.json`),
+      JSON.stringify([
+        { id: 'e1', _meta_type: eventClass, organizer_id: 'p1' },
+        { id: 'e2', _meta_type: eventClass, organizer_id: 'missing-person' },
+      ]),
+    );
+
+    const validator = newValidator(false); // full mode → FK validation
+    const results = await validator.validate([
+      resolve(dataDir, `${personTable}.json`),
+      resolve(dataDir, `${eventTable}.json`),
+    ]);
+
+    const eventResult = results.objectResults.find(
+      (r) => r.tableName === eventTable,
+    );
+    const fkError = eventResult?.issues.find(
+      (i) => i.code === ValidationCodes.INVALID_FOREIGN_KEY,
+    );
+    expect(fkError).toBeDefined();
+    expect(fkError?.message).toContain('missing-person');
+    // The bad-FK record was downgraded from valid → invalid.
+    expect(eventResult?.invalidCount).toBeGreaterThan(0);
+  });
+
+  it('reports a missing FK table file in full mode', async () => {
+    // Only the event file exists; the related person table file is absent.
+    await writeFile(
+      resolve(dataDir, `${eventTable}.json`),
+      JSON.stringify([
+        { id: 'e1', _meta_type: eventClass, organizer_id: 'p1' },
+      ]),
+    );
+
+    const validator = newValidator(false);
+    const results = await validator.validate([
+      resolve(dataDir, `${eventTable}.json`),
+    ]);
+
+    expect(
+      results.objectResults[0].issues.some(
+        (i) => i.code === ValidationCodes.MISSING_FK_TABLE,
+      ),
+    ).toBe(true);
+  });
+
+  it('logs pre-load failures in verbose mode without throwing', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await writeFile(
+      resolve(dataDir, `${eventTable}.json`),
+      'this is not valid json',
+    );
+
+    const validator = newValidator(false, true); // verbose
+    const results = await validator.validate([
+      resolve(dataDir, `${eventTable}.json`),
+    ]);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[verbose] Failed to pre-load'),
+    );
+    expect(
+      results.objectResults[0].issues.some(
+        (i) => i.code === ValidationCodes.INVALID_JSON,
+      ),
+    ).toBe(true);
+  });
+
+  it('detects records that are not objects', async () => {
+    await writeFile(
+      resolve(dataDir, `${eventTable}.json`),
+      JSON.stringify(['a string', 42, null]),
+    );
+
+    const validator = newValidator(true);
+    const results = await validator.validate([
+      resolve(dataDir, `${eventTable}.json`),
+    ]);
+
+    const emptyObjectIssues = results.objectResults[0].issues.filter(
+      (i) => i.code === ValidationCodes.EMPTY_OBJECT,
+    );
+    expect(emptyObjectIssues.length).toBe(3);
+  });
+
+  it('detects non-string and missing IDs', async () => {
+    await writeFile(
+      resolve(dataDir, `${eventTable}.json`),
+      JSON.stringify([{ id: 123 }, { name: 'no id' }]),
+    );
+
+    const validator = newValidator(true);
+    const results = await validator.validate([
+      resolve(dataDir, `${eventTable}.json`),
+    ]);
+
+    const issues = results.objectResults[0].issues;
+    expect(
+      issues.some((i) => i.code === ValidationCodes.INVALID_ID_FORMAT),
+    ).toBe(true);
+    expect(issues.some((i) => i.code === ValidationCodes.MISSING_ID)).toBe(
+      true,
+    );
+  });
+});
+
+describe('JsonDatabaseValidator required-field auto-fix', () => {
+  const testDir = resolve(process.cwd(), `.test-jv-fix-${randomUUID()}`);
+  const dataDir = resolve(testDir, 'data');
+
+  beforeEach(async () => {
+    await mkdir(dataDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  // The validator reads `required`/`default` at the top level of the field
+  // definition, while the manifest loader nests them under `_meta`. Feed a
+  // crafted field map directly so the required-field + auto-fix branches run.
+  function stubFields(fields: Map<string, unknown>) {
+    vi.spyOn(ObjectRegistry, 'getFields').mockReturnValue(
+      fields as Map<string, any>,
+    );
+    // Resolve any table to a stable class name so getFields is consulted.
+    vi.spyOn(ObjectRegistry, 'getAllClasses').mockReturnValue(
+      new Map([['Fixable', { name: 'Fixable' } as any]]) as any,
+    );
+    vi.spyOn(ObjectRegistry, 'getTableName').mockReturnValue('fixables');
+    vi.spyOn(ObjectRegistry, 'getTableStrategy').mockReturnValue('cti');
+  }
+
+  it('flags a missing required field as fixable during validation', async () => {
+    stubFields(
+      new Map<string, unknown>([
+        ['status', { type: 'text', required: true, default: 'draft' }],
+      ]),
+    );
+
+    const filePath = resolve(dataDir, 'fixables.json');
+    await writeFile(filePath, JSON.stringify([{ id: 'a' }]));
+
+    const validator = new JsonDatabaseValidator({
+      dataPath: dataDir,
+      quickMode: true,
+      verbose: false,
+    });
+
+    const results = await validator.validate([filePath]);
+    const fixable = results.fixableIssues.find(
+      (i) => i.code === ValidationCodes.MISSING_REQUIRED_FIELD,
+    );
+    expect(fixable).toBeDefined();
+    expect(fixable?.fixable).toBe(true);
+  });
+
+  it('applyFixes applies a default value to an id-matched record', async () => {
+    // applyFixes re-reads the field definition by issue.objectType, so the
+    // crafted issue carries objectType + field; getFields is stubbed to expose
+    // the default. (validateField does not set objectType on the issue, so we
+    // construct the fixable issue directly to drive the apply path.)
+    stubFields(
+      new Map<string, unknown>([
+        ['status', { type: 'text', required: true, default: 'draft' }],
+      ]),
+    );
+
+    const filePath = resolve(dataDir, 'fixables.json');
+    await writeFile(filePath, JSON.stringify([{ id: 'a' }]));
+
+    const validator = new JsonDatabaseValidator({
+      dataPath: dataDir,
+      quickMode: true,
+      verbose: false,
+    });
+
+    const fixed = await validator.applyFixes([
+      {
+        severity: 'error',
+        code: ValidationCodes.MISSING_REQUIRED_FIELD,
+        message: 'Missing required field: status',
+        file: filePath,
+        objectId: 'a',
+        objectType: 'Fixable',
+        field: 'status',
+        fixable: true,
+      },
+    ]);
+    expect(fixed).toBe(1);
+
+    const written = JSON.parse(readFileSync(filePath, 'utf-8'));
+    expect(written[0].status).toBe('draft');
+  });
+
+  it('applyFixes resolves an index-only record via the [index:N] objectId', async () => {
+    stubFields(
+      new Map<string, unknown>([
+        ['status', { type: 'text', required: true, default: 'open' }],
+      ]),
+    );
+
+    const filePath = resolve(dataDir, 'fixables.json');
+    await writeFile(filePath, JSON.stringify([{ name: 'no-id' }]));
+
+    const validator = new JsonDatabaseValidator({
+      dataPath: dataDir,
+      quickMode: true,
+      verbose: false,
+    });
+
+    const fixed = await validator.applyFixes([
+      {
+        severity: 'error',
+        code: ValidationCodes.MISSING_REQUIRED_FIELD,
+        message: 'Missing required field: status',
+        file: filePath,
+        objectId: '[index:0]',
+        objectType: 'Fixable',
+        field: 'status',
+        fixable: true,
+      },
+    ]);
+    expect(fixed).toBe(1);
+
+    const written = JSON.parse(readFileSync(filePath, 'utf-8'));
+    expect(written[0].status).toBe('open');
+  });
+
+  it('applyFixes logs and continues when a file cannot be read (verbose)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const validator = new JsonDatabaseValidator({
+      dataPath: dataDir,
+      quickMode: true,
+      verbose: true,
+    });
+
+    const fixed = await validator.applyFixes([
+      {
+        severity: 'error',
+        code: ValidationCodes.MISSING_REQUIRED_FIELD,
+        message: 'Missing required field: status',
+        file: resolve(dataDir, 'does-not-exist.json'),
+        objectId: 'a',
+        objectType: 'Fixable',
+        field: 'status',
+        fixable: true,
+      },
+    ]);
+
+    expect(fixed).toBe(0);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[verbose] Failed to apply fixes'),
+    );
+  });
+});
+
+describe('displayValidationResults detail output', () => {
+  it('renders per-object errors and warnings with truncation note', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const manyErrors = Array.from({ length: 7 }, (_, i) => ({
+      severity: 'error' as const,
+      code: 'DUP',
+      message: `Error ${i}`,
+      objectId: `id-${i}`,
+    }));
+    const manyWarnings = Array.from({ length: 5 }, (_, i) => ({
+      severity: 'warning' as const,
+      code: 'WARN',
+      message: `Warning ${i}`,
+    }));
+
+    const summary: ValidationSummary = {
+      timestamp: new Date().toISOString(),
+      dataPath: '/d',
+      manifestPath: '/manifest.json',
+      duration: 10,
+      totalFiles: 1,
+      totalRecords: 12,
+      validRecords: 5,
+      invalidRecords: 7,
+      issues: { errors: 7, warnings: 5, info: 0 },
+      objectResults: [
+        {
+          objectType: 'Event',
+          tableName: 'events',
+          file: '/d/events.json',
+          recordCount: 12,
+          validCount: 5,
+          invalidCount: 7,
+          issues: [...manyErrors, ...manyWarnings],
+        },
+        {
+          objectType: 'Empty',
+          tableName: 'empty',
+          file: '/d/empty.json',
+          recordCount: 0,
+          validCount: 0,
+          invalidCount: 0,
+          issues: [],
+        },
+      ],
+    };
+
+    displayValidationResults(summary, false);
+
+    const out = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(out).toContain('Manifest:');
+    expect(out).toContain('Issues by Object Type');
+    expect(out).toContain('and 2 more errors'); // 7 errors, 5 shown
+    expect(out).toContain('and 2 more warnings'); // 5 warnings, 3 shown
+
+    logSpy.mockRestore();
+  });
+
+  it('shows all issues in verbose mode (no truncation)', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const summary: ValidationSummary = {
+      timestamp: new Date().toISOString(),
+      dataPath: '/d',
+      manifestPath: null,
+      duration: 10,
+      totalFiles: 1,
+      totalRecords: 6,
+      validRecords: 0,
+      invalidRecords: 6,
+      issues: { errors: 6, warnings: 0, info: 0 },
+      objectResults: [
+        {
+          objectType: 'Event',
+          tableName: 'events',
+          file: '/d/events.json',
+          recordCount: 6,
+          validCount: 0,
+          invalidCount: 6,
+          issues: Array.from({ length: 6 }, (_, i) => ({
+            severity: 'error' as const,
+            code: 'E',
+            message: `Error ${i}`,
+            objectId: `id-${i}`,
+          })),
+        },
+      ],
+    };
+
+    displayValidationResults(summary, true);
+
+    const out = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(out).not.toContain('more errors');
+    logSpy.mockRestore();
+  });
+});

--- a/packages/cli/src/commands/__tests__/playground.test.ts
+++ b/packages/cli/src/commands/__tests__/playground.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Unit tests for playground commands
+ *
+ * Covers the pure scaffolding/arg-handling paths of playground:init and
+ * playground:list (and the dev-server branch selection of playground:dev)
+ * against a real temp-dir filesystem. The only mocked boundaries are:
+ *   - the workspace playground runtime (loaded lazily via importWorkspaceModule),
+ *     because building/importing the full @happyvertical/smrt-playground host is
+ *     out of scope for a unit test and supplies the template/discovery fns; and
+ *   - node:child_process spawn, because playground:dev launches a long-running
+ *     interactive dev server that cannot run inside a unit test.
+ *
+ * INFEASIBLE (flagged, not covered): the actual interactive dev server launched
+ * by playground:dev (runCommand → spawn(..., { stdio: 'inherit' })) and the
+ * real module discovery/import loop inside listDiscoveredPlaygrounds that reads
+ * built playground packages — both require a live workspace build and a running
+ * process, so only their orchestration (branch selection, output) is asserted.
+ */
+
+import {
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { importWorkspaceModuleMock, spawnMock } = vi.hoisted(() => ({
+  importWorkspaceModuleMock: vi.fn(),
+  spawnMock: vi.fn(),
+}));
+
+vi.mock('@happyvertical/smrt-core/utils/import-workspace-module', () => ({
+  importWorkspaceModule: importWorkspaceModuleMock,
+}));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return { ...actual, spawn: spawnMock };
+});
+
+// playground.ts caches the resolved runtime in a module-level promise
+// (playgroundRuntimePromise). Re-import the module fresh per test so each test
+// can supply its own runtime mock without the first call's cache winning.
+async function loadCommands() {
+  const mod = await import('../playground.js');
+  return mod.playgroundCommands;
+}
+
+// Build a fake playground runtime that the lazy loader returns.
+function makeRuntime(overrides: Record<string, unknown> = {}) {
+  return {
+    createPackagePlaygroundTemplate: (name: string) =>
+      `// package playground for ${name}\n`,
+    createAppPlaygroundTemplate: (name: string) =>
+      `// app playground for ${name}\n`,
+    createAppPlaygroundRouteTemplate: () => '<!-- route -->\n',
+    findSmrtWorkspaceRoot: () => null,
+    detectPlaygroundMode: () => 'standalone',
+    discoverPlaygroundTargets: vi.fn(async () => []),
+    describePlaygroundSource: () => 'source-desc',
+    importPlaygroundModule: vi.fn(async () => []),
+    ...overrides,
+  };
+}
+
+describe('playground commands', () => {
+  let projectRoot: string;
+  let originalCwd: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    originalCwd = process.cwd();
+    // realpath via mkdtempSync(tmpdir()) on macOS resolves through /private,
+    // so resolve cwd through the same realpath the handler will see.
+    projectRoot = realpathSync(mkdtempSync(join(tmpdir(), 'smrt-playground-')));
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    importWorkspaceModuleMock.mockResolvedValue(makeRuntime());
+    spawnMock.mockReset();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    importWorkspaceModuleMock.mockReset();
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  const out = () => logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+
+  function writePackageJson(content: Record<string, unknown>) {
+    writeFileSync(
+      join(projectRoot, 'package.json'),
+      `${JSON.stringify(content, null, 2)}\n`,
+    );
+  }
+
+  describe('playground:init', () => {
+    it('throws when no package.json is present', async () => {
+      process.chdir(projectRoot);
+      await expect(
+        (await loadCommands())['playground:init'].handler([], {}),
+      ).rejects.toThrow('No package.json found');
+    });
+
+    it('scaffolds package playground when --target package', async () => {
+      writePackageJson({ name: '@happyvertical/smrt-demo' });
+      process.chdir(projectRoot);
+
+      await (await loadCommands())['playground:init'].handler([], {
+        target: 'package',
+      });
+
+      const o = out();
+      expect(o).toContain('Scaffolded package playground support');
+      expect(o).toContain('src/svelte/playground.ts');
+      const bridge = readFileSync(
+        join(projectRoot, 'src/playground.ts'),
+        'utf-8',
+      );
+      expect(bridge).toContain("from './svelte/playground.js'");
+      const pkgPlayground = readFileSync(
+        join(projectRoot, 'src/svelte/playground.ts'),
+        'utf-8',
+      );
+      expect(pkgPlayground).toContain('package playground');
+    });
+
+    it('reports skipped files when scaffold already exists without --force', async () => {
+      writePackageJson({ name: '@happyvertical/smrt-demo' });
+      process.chdir(projectRoot);
+
+      await (await loadCommands())['playground:init'].handler([], {
+        target: 'package',
+      });
+      logSpy.mockClear();
+      await (await loadCommands())['playground:init'].handler([], {
+        target: 'package',
+      });
+
+      expect(out()).toContain('Skipped:');
+    });
+
+    it('overwrites existing files with --force', async () => {
+      writePackageJson({ name: '@happyvertical/smrt-demo' });
+      process.chdir(projectRoot);
+
+      await (await loadCommands())['playground:init'].handler([], {
+        target: 'package',
+      });
+      logSpy.mockClear();
+      await (await loadCommands())['playground:init'].handler([], {
+        target: 'package',
+        force: true,
+      });
+
+      expect(out()).toContain('Created/updated:');
+    });
+
+    it('scaffolds app playground and warns when no vite config found', async () => {
+      writePackageJson({ name: 'my-app' });
+      process.chdir(projectRoot);
+
+      await (await loadCommands())['playground:init'].handler([], {
+        target: 'app',
+      });
+
+      const o = out();
+      expect(o).toContain('Scaffolded app playground support');
+      expect(o).toContain('src/routes/playground/+page.svelte');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Could not find vite.config'),
+      );
+      // Dependency was added to package.json.
+      const pkg = JSON.parse(
+        readFileSync(join(projectRoot, 'package.json'), 'utf-8'),
+      );
+      expect(pkg.dependencies).toHaveProperty('@happyvertical/smrt-playground');
+    });
+
+    it('patches an existing vite config with the playground plugin', async () => {
+      writePackageJson({ name: 'my-app' });
+      writeFileSync(
+        join(projectRoot, 'vite.config.ts'),
+        "import { sveltekit } from '@sveltejs/kit/vite';\n\nexport default { plugins: [sveltekit()] };\n",
+      );
+      process.chdir(projectRoot);
+
+      await (await loadCommands())['playground:init'].handler([], {
+        target: 'app',
+      });
+
+      const vite = readFileSync(join(projectRoot, 'vite.config.ts'), 'utf-8');
+      expect(vite).toContain('smrtPlaygroundVitePlugin');
+      expect(out()).toContain('Created/updated:');
+    });
+
+    it('auto-detects app target from a non-smrt package name', async () => {
+      writePackageJson({ name: 'plain-project' });
+      process.chdir(projectRoot);
+
+      await (await loadCommands())['playground:init'].handler([], {});
+
+      expect(out()).toContain('Scaffolded app playground support');
+    });
+  });
+
+  describe('playground:list', () => {
+    it('reports when no playground modules are discovered', async () => {
+      process.chdir(projectRoot);
+      await (await loadCommands())['playground:list'].handler([], {});
+      expect(out()).toContain('No playground modules discovered.');
+    });
+
+    it('lists discovered targets with their entries', async () => {
+      importWorkspaceModuleMock.mockResolvedValue(
+        makeRuntime({
+          detectPlaygroundMode: () => 'workspace',
+          discoverPlaygroundTargets: vi.fn(async () => [
+            {
+              packageName: '@happyvertical/smrt-demo',
+              source: 'workspace',
+              sourcePath: '/abs/src/index.ts',
+              runtimePath: '/abs/dist/index.js',
+            },
+          ]),
+          importPlaygroundModule: vi.fn(async () => [
+            {
+              packageName: '@happyvertical/smrt-demo',
+              entries: [
+                {
+                  id: 'demo',
+                  title: 'Demo Entry',
+                  modes: { mock: {}, live: {} },
+                },
+              ],
+            },
+          ]),
+        }),
+      );
+      process.chdir(projectRoot);
+
+      await (await loadCommands())['playground:list'].handler([], {});
+
+      const o = out();
+      expect(o).toContain('Discovered 1 playground target(s)');
+      expect(o).toContain('@happyvertical/smrt-demo');
+      expect(o).toContain('demo: Demo Entry [mock, live]');
+    });
+
+    it('marks a target as unavailable when no modules load', async () => {
+      importWorkspaceModuleMock.mockResolvedValue(
+        makeRuntime({
+          discoverPlaygroundTargets: vi.fn(async () => [
+            {
+              packageName: 'local app',
+              source: 'installed',
+              importSpecifier: 'pkg',
+              runtimePath: '/abs/dist/index.js',
+              sourcePath: '/abs/src/index.ts',
+            },
+          ]),
+          importPlaygroundModule: vi.fn(async () => []),
+        }),
+      );
+      process.chdir(projectRoot);
+
+      await (await loadCommands())['playground:list'].handler([], {});
+
+      expect(out()).toContain('Entries: unavailable');
+    });
+  });
+
+  describe('playground:dev', () => {
+    it('starts the shared host in workspace mode', async () => {
+      // Simulate a successful child process that exits cleanly.
+      spawnMock.mockImplementation(() => {
+        const handlers: Record<string, (code: number) => void> = {};
+        return {
+          on: (event: string, cb: (code: number) => void) => {
+            handlers[event] = cb;
+            if (event === 'exit') setTimeout(() => cb(0), 0);
+          },
+        } as never;
+      });
+
+      importWorkspaceModuleMock.mockResolvedValue(
+        makeRuntime({
+          detectPlaygroundMode: () => 'workspace',
+          findSmrtWorkspaceRoot: () => '/abs/workspace',
+        }),
+      );
+      process.chdir(projectRoot);
+
+      await (await loadCommands())['playground:dev'].handler([], {});
+
+      expect(spawnMock).toHaveBeenCalled();
+      expect(out()).toContain('shared SMRT playground host');
+    });
+
+    it('throws in workspace mode when the workspace root is unknown', async () => {
+      importWorkspaceModuleMock.mockResolvedValue(
+        makeRuntime({
+          detectPlaygroundMode: () => 'workspace',
+          findSmrtWorkspaceRoot: () => null,
+        }),
+      );
+      process.chdir(projectRoot);
+
+      await expect(
+        (await loadCommands())['playground:dev'].handler([], {}),
+      ).rejects.toThrow('Could not determine workspace root');
+    });
+
+    it('runs the local app dev server in standalone mode (npm)', async () => {
+      spawnMock.mockImplementation(
+        () =>
+          ({
+            on: (event: string, cb: (code: number) => void) => {
+              if (event === 'exit') setTimeout(() => cb(0), 0);
+            },
+          }) as never,
+      );
+
+      importWorkspaceModuleMock.mockResolvedValue(
+        makeRuntime({ detectPlaygroundMode: () => 'standalone' }),
+      );
+      // No lockfiles → npm.
+      process.chdir(projectRoot);
+
+      await (await loadCommands())['playground:dev'].handler([], {});
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'npm',
+        ['run', 'dev'],
+        expect.objectContaining({ cwd: projectRoot }),
+      );
+      expect(out()).toContain('app dev server');
+    });
+
+    it('rejects when the dev server exits with a non-zero code', async () => {
+      spawnMock.mockImplementation(
+        () =>
+          ({
+            on: (event: string, cb: (code: number) => void) => {
+              if (event === 'exit') setTimeout(() => cb(1), 0);
+            },
+          }) as never,
+      );
+
+      importWorkspaceModuleMock.mockResolvedValue(
+        makeRuntime({ detectPlaygroundMode: () => 'standalone' }),
+      );
+      process.chdir(projectRoot);
+
+      await expect(
+        (await loadCommands())['playground:dev'].handler([], {}),
+      ).rejects.toThrow(/exited with code 1/);
+    });
+  });
+});

--- a/packages/cli/src/commands/__tests__/schema-contract-extras.test.ts
+++ b/packages/cli/src/commands/__tests__/schema-contract-extras.test.ts
@@ -1,0 +1,200 @@
+/**
+ * schema-contract supplementary tests.
+ *
+ * Covers branches not exercised by schema-contract.test.ts: the formatter ok/
+ * failure rendering, assertSchemaContract / SchemaContractError, short-name and
+ * dotless-field resolution, STI table inference, object-form index checks, and
+ * the "db without getTableSchema" no-op path.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  getClassByQualifiedNameMock,
+  getClassMock,
+  getAllFieldsMock,
+  getTableStrategyMock,
+  getSTIBaseMock,
+  getTableNameMock,
+} = vi.hoisted(() => ({
+  getClassByQualifiedNameMock: vi.fn(),
+  getClassMock: vi.fn(),
+  getAllFieldsMock: vi.fn(),
+  getTableStrategyMock: vi.fn(),
+  getSTIBaseMock: vi.fn(),
+  getTableNameMock: vi.fn(),
+}));
+
+vi.mock('@happyvertical/smrt-core', () => ({
+  ObjectRegistry: {
+    getClassByQualifiedName: getClassByQualifiedNameMock,
+    getClass: getClassMock,
+    getAllFields: getAllFieldsMock,
+    getTableStrategy: getTableStrategyMock,
+    getSTIBase: getSTIBaseMock,
+    getTableName: getTableNameMock,
+  },
+}));
+
+import {
+  assertSchemaContract,
+  evaluateSchemaContract,
+  formatSchemaContractFailures,
+  SchemaContractError,
+} from '../schema-contract.js';
+
+const projectManifest = {
+  path: '/repo/.smrt/manifest.json',
+  source: 'project' as const,
+  packageName: '@app/x',
+  objectCount: 1,
+  objectNames: ['Widget'],
+};
+
+describe('schema-contract extras', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getTableStrategyMock.mockReturnValue('cti');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('formatSchemaContractFailures / assertSchemaContract', () => {
+    it('returns a passing message and does not throw on an ok report', async () => {
+      getClassMock.mockReturnValue({ name: 'Widget' });
+      const report = await evaluateSchemaContract({
+        discovered: [projectManifest],
+      });
+      expect(report.ok).toBe(true);
+      expect(formatSchemaContractFailures(report)).toBe(
+        'SMRT schema contract passed.',
+      );
+      expect(() => assertSchemaContract(report)).not.toThrow();
+    });
+
+    it('renders failures and throws SchemaContractError when not ok', async () => {
+      getClassMock.mockReturnValue(undefined);
+      getClassByQualifiedNameMock.mockReturnValue(undefined);
+      const report = await evaluateSchemaContract({
+        discovered: [projectManifest],
+        schemaContract: { requiredObjects: ['@app/x:Missing'] },
+      });
+
+      const formatted = formatSchemaContractFailures(report);
+      expect(formatted).toContain('SMRT schema contract failed');
+      expect(formatted).toContain('is not registered');
+      expect(() => assertSchemaContract(report)).toThrow(SchemaContractError);
+    });
+  });
+
+  describe('object + field resolution branches', () => {
+    it('resolves a required object by short (non-qualified) name and infers its table', async () => {
+      getClassMock.mockReturnValue({ name: 'Widget' });
+      getTableStrategyMock.mockReturnValue('cti');
+      getTableNameMock.mockReturnValue('widgets');
+
+      const report = await evaluateSchemaContract({
+        discovered: [projectManifest],
+        schemaContract: { requiredObjects: ['Widget'] },
+      });
+
+      expect(report.requiredObjects[0].present).toBe(true);
+      expect(report.inferredDatabaseShape.tables).toContain('widgets');
+    });
+
+    it('infers an STI base table for required objects', async () => {
+      getClassMock.mockReturnValue({ name: 'Article' });
+      getTableStrategyMock.mockReturnValue('sti');
+      getSTIBaseMock.mockReturnValue('Content');
+      getTableNameMock.mockImplementation((name: string) =>
+        name === 'Content' ? 'content' : undefined,
+      );
+
+      const report = await evaluateSchemaContract({
+        discovered: [projectManifest],
+        schemaContract: { requiredObjects: ['@app/x:Article'] },
+      });
+
+      expect(report.inferredDatabaseShape.tables).toContain('content');
+    });
+
+    it('flags a required field that uses a dotless ref (no field name)', async () => {
+      getClassMock.mockReturnValue({ name: 'Widget' });
+      const report = await evaluateSchemaContract({
+        discovered: [projectManifest],
+        // No "." => parseRequiredField yields an empty fieldName, so it is
+        // reported as a missing field.
+        schemaContract: { requiredFields: ['Widget'] },
+      });
+
+      expect(
+        report.failures.some((f) => f.code === 'missing_required_field'),
+      ).toBe(true);
+    });
+
+    it('records inferred column metadata for a present required field', async () => {
+      getClassMock.mockReturnValue({ name: 'Widget' });
+      getTableStrategyMock.mockReturnValue('cti');
+      getTableNameMock.mockReturnValue('widgets');
+      getAllFieldsMock.mockResolvedValue(new Map([['ownerId', {}]]));
+
+      const report = await evaluateSchemaContract({
+        discovered: [projectManifest],
+        schemaContract: { requiredFields: ['Widget.ownerId'] },
+      });
+
+      const field = report.requiredFields[0];
+      expect(field.present).toBe(true);
+      expect(field.table).toBe('widgets');
+      expect(field.column).toBe('owner_id');
+      expect(report.inferredDatabaseShape.columns).toContain(
+        'widgets.owner_id',
+      );
+    });
+  });
+
+  describe('database shape checks', () => {
+    it('is a no-op when the db lacks getTableSchema', async () => {
+      getClassMock.mockReturnValue({ name: 'Widget' });
+      const report = await evaluateSchemaContract({
+        discovered: [projectManifest],
+        schemaContract: {
+          requiredDatabaseShape: { tables: ['widgets'] },
+        },
+        db: {}, // no getTableSchema -> checkTable returns null -> table missing
+      });
+
+      expect(
+        report.failures.some((f) => f.code === 'missing_required_table'),
+      ).toBe(true);
+    });
+
+    it('matches an index provided as an object map and a present column', async () => {
+      getClassMock.mockReturnValue({ name: 'Widget' });
+      const db = {
+        getTableSchema: vi.fn().mockResolvedValue({
+          columns: { name: { type: 'text' } },
+          // object-form indexes (not an array) exercises schemaHasIndex's else.
+          indexes: { idx_widgets_name: { columns: ['name'] } },
+        }),
+      };
+
+      const report = await evaluateSchemaContract({
+        discovered: [projectManifest],
+        schemaContract: {
+          requiredDatabaseShape: {
+            tables: ['widgets'],
+            columns: ['widgets.name'],
+            indexes: ['widgets.idx_widgets_name'],
+          },
+        },
+        db,
+      });
+
+      expect(report.ok).toBe(true);
+      expect(report.failures).toHaveLength(0);
+    });
+  });
+});

--- a/packages/cli/src/commands/__tests__/utilities-handlers.test.ts
+++ b/packages/cli/src/commands/__tests__/utilities-handlers.test.ts
@@ -1,0 +1,1083 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Module mocks. utilities.ts statically imports @happyvertical/smrt-core and
+// ../discovery, then dynamically imports config / sql / json-validator /
+// migrations. We provide controllable stand-ins for all of them.
+// ---------------------------------------------------------------------------
+
+const h = vi.hoisted(() => {
+  const registry = {
+    getAllClasses: vi.fn(() => new Map()),
+    getAllSchemasAsDefinitions: vi.fn(() => [] as unknown[]),
+    getClass: vi.fn(() => undefined as unknown),
+    getFields: vi.fn(() => new Map()),
+    getInheritanceChain: vi.fn((name: string) => [name]),
+    getInitializationOrder: vi.fn(() => [] as string[]),
+    getSTIBase: vi.fn(() => null as unknown),
+    getTableName: vi.fn(() => null as unknown),
+    getTableStrategy: vi.fn(() => 'cti'),
+    getSchema: vi.fn(() => undefined as unknown),
+    findClassesByName: vi.fn(() => [] as Array<{ qualifiedName?: string }>),
+    getConflictColumns: vi.fn(() => [] as string[]),
+  };
+  return {
+    registry,
+    autoDiscoverAndLoad: vi.fn(),
+    getPackageConfig: vi.fn(),
+    getDatabase: vi.fn(),
+    clearConnectionCache: vi.fn(),
+    resolveDataPath: vi.fn(),
+    discoverJsonFiles: vi.fn(),
+    displayValidationResults: vi.fn(),
+    validateFn: vi.fn(),
+    generateSummary: vi.fn(),
+    applyFixes: vi.fn(),
+    trackerInitialize: vi.fn(async () => {}),
+    trackerGetEngine: vi.fn(() => 'sqlite'),
+    trackerApplyAll: vi.fn(async () => []),
+    ensureSchema: vi.fn(async () => {}),
+    generateSchema: vi.fn(async () => 'CREATE TABLE t ()'),
+    schemaCompare: vi.fn(async () => ({ added_tables: [], changes: [] })),
+    manifestGenerate: vi.fn(async () => ({
+      objects: { '@app:Article': {} },
+    })),
+    discoverBaseClasses: vi.fn(async () => ['Base1', 'Base2', 'Base3']),
+    rlQuestion: vi.fn(async () => 'y'),
+    rlClose: vi.fn(),
+    spawn: vi.fn(),
+  };
+});
+
+const {
+  registry,
+  autoDiscoverAndLoad,
+  getPackageConfig,
+  getDatabase,
+  clearConnectionCache,
+  resolveDataPath,
+  discoverJsonFiles,
+  displayValidationResults,
+  validateFn,
+  generateSummary,
+  applyFixes,
+  trackerApplyAll,
+  ensureSchema,
+  generateSchema,
+  schemaCompare,
+  manifestGenerate,
+  discoverBaseClasses,
+  rlQuestion,
+  spawn,
+} = h;
+
+// A migration-capable fake database (has getTableSchema + alterTable).
+function migratableDb(overrides: Record<string, unknown> = {}) {
+  return {
+    getTableSchema: vi.fn(async () => ({ columns: {} })),
+    alterTable: vi.fn(async () => {}),
+    query: vi.fn(async () => ({ rows: [] })),
+    close: vi.fn(),
+    ...overrides,
+  };
+}
+
+vi.mock('@happyvertical/smrt-core', () => ({
+  ObjectRegistry: h.registry,
+  SchemaComparer: class {
+    compare = (...a: unknown[]) => h.schemaCompare(...a);
+  },
+  generateDDLForEngine: vi.fn(() => ({
+    createTable: 'CREATE TABLE x ()',
+    indexes: [],
+    triggers: [],
+  })),
+  isQualifiedName: vi.fn((s: string) => s.includes(':')),
+  getClassName: vi.fn((s: string) => (s.includes(':') ? s.split(':')[1] : s)),
+}));
+
+vi.mock('../../discovery/index.js', () => ({
+  autoDiscoverAndLoad: (...args: unknown[]) => h.autoDiscoverAndLoad(...args),
+}));
+
+vi.mock('@happyvertical/smrt-config', () => ({
+  getPackageConfig: (...args: unknown[]) => h.getPackageConfig(...args),
+}));
+
+vi.mock('../config.js', () => ({
+  DEFAULT_CLI_CONFIG: { database: { type: 'sqlite', url: ':memory:' } },
+}));
+
+vi.mock('@happyvertical/sql', () => ({
+  getDatabase: (...args: unknown[]) => h.getDatabase(...args),
+  clearConnectionCache: (...args: unknown[]) => h.clearConnectionCache(...args),
+}));
+
+// schema-contract guards: make them no-ops so handlers proceed.
+vi.mock('../schema-contract.js', async () => {
+  const actual: any = await vi.importActual('../schema-contract.js');
+  return {
+    ...actual,
+    assertNoUnsupportedMigrationFiles: vi.fn(async () => {}),
+    assertSchemaContract: vi.fn(() => {}),
+    evaluateSchemaContract: vi.fn(async () => ({ ok: true })),
+  };
+});
+
+vi.mock('@happyvertical/smrt-core/migrations', () => ({
+  MigrationTracker: class {
+    initialize = h.trackerInitialize;
+    getEngine = h.trackerGetEngine;
+    applyAll = h.trackerApplyAll;
+  },
+  shortChecksum: (s: string) => (s ? s.slice(0, 8) : 'nochk'),
+}));
+
+vi.mock('@happyvertical/smrt-core/schema/utils', () => ({
+  ensureSchema: (...a: unknown[]) => h.ensureSchema(...a),
+  generateSchema: (...a: unknown[]) => h.generateSchema(...a),
+}));
+
+vi.mock('@happyvertical/smrt-core/manifest', () => ({
+  ManifestBuilder: class {
+    generate = (...a: unknown[]) => h.manifestGenerate(...a);
+  },
+}));
+
+vi.mock('@happyvertical/smrt-core/manifest/discover-base-classes', () => ({
+  discoverBaseClasses: (...a: unknown[]) => h.discoverBaseClasses(...a),
+}));
+
+vi.mock('node:child_process', () => ({
+  spawn: (...a: unknown[]) => h.spawn(...a),
+  spawnSync: vi.fn(() => ({ status: 0, stdout: '', stderr: '' })),
+}));
+
+vi.mock('node:readline/promises', () => ({
+  createInterface: () => ({
+    question: (...a: unknown[]) => h.rlQuestion(...a),
+    close: (...a: unknown[]) => h.rlClose(...a),
+  }),
+}));
+
+// json-validator used by db:validate
+vi.mock('../json-validator.js', () => ({
+  resolveDataPath: (...a: unknown[]) => h.resolveDataPath(...a),
+  discoverJsonFiles: (...a: unknown[]) => h.discoverJsonFiles(...a),
+  displayValidationResults: (...a: unknown[]) =>
+    h.displayValidationResults(...a),
+  JsonDatabaseValidator: class {
+    validate = h.validateFn;
+    applyFixes = h.applyFixes;
+    generateSummary = h.generateSummary;
+  },
+}));
+
+import { utilityCommands } from '../utilities.js';
+
+describe('utility command handlers', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  const tempDirs: string[] = [];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = undefined;
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
+      code?: string | number | null,
+    ) => {
+      throw new Error(`exit:${code ?? ''}`);
+    }) as typeof process.exit);
+
+    // defaults
+    registry.getAllClasses.mockReturnValue(new Map());
+    registry.getInitializationOrder.mockReturnValue([]);
+    registry.getAllSchemasAsDefinitions.mockReturnValue([]);
+    getPackageConfig.mockReturnValue({
+      database: { type: 'sqlite', url: './dev.db' },
+    });
+    getDatabase.mockResolvedValue({ close: vi.fn() });
+    schemaCompare.mockResolvedValue({ added_tables: [], changes: [] });
+    trackerApplyAll.mockResolvedValue([]);
+  });
+
+  afterEach(async () => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    warnSpy.mockRestore();
+    exitSpy.mockRestore();
+    process.exitCode = undefined;
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+    tempDirs.length = 0;
+  });
+
+  const logged = () => logSpy.mock.calls.flat().join('\n');
+  const errored = () => errSpy.mock.calls.flat().join('\n');
+
+  // ----------------------------- introspect -----------------------------
+
+  it('introspect reports when no manifests are discovered', async () => {
+    autoDiscoverAndLoad.mockResolvedValue({ discovered: [], totalObjects: 0 });
+    await utilityCommands.introspect.handler([], {});
+    expect(logged()).toContain('No SMRT manifests found');
+  });
+
+  it('introspect lists manifests and registered objects in verbose mode', async () => {
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [
+        {
+          source: 'project',
+          packageName: '@app/demo',
+          path: '/p/.smrt/manifest.json',
+          objectCount: 2,
+        },
+        {
+          source: 'package',
+          packageName: undefined,
+          path: '/n/manifest.json',
+          objectCount: 1,
+        },
+      ],
+      totalObjects: 3,
+    });
+    registry.getAllClasses.mockReturnValue(
+      new Map([
+        ['@app/demo:Article', { name: 'Article', fields: { title: {} } }],
+      ]),
+    );
+
+    await utilityCommands.introspect.handler([], { verbose: true });
+
+    const out = logged();
+    expect(out).toContain('Discovered 2 manifest(s)');
+    expect(out).toContain('Total objects discovered: 3');
+    expect(out).toContain('Registered Objects');
+    expect(out).toContain('Article');
+  });
+
+  // --------------------------- db:clear-cache ---------------------------
+
+  it('db:clear-cache clears the connection cache', async () => {
+    await utilityCommands['db:clear-cache'].handler([], { verbose: true });
+    expect(clearConnectionCache).toHaveBeenCalled();
+    expect(logged()).toContain('Database connection cache cleared');
+    expect(logged()).toContain('JSON data files have been modified');
+  });
+
+  it('db:clear-cache reports failures', async () => {
+    clearConnectionCache.mockImplementation(() => {
+      throw new Error('cache boom');
+    });
+    await expect(
+      utilityCommands['db:clear-cache'].handler([], {}),
+    ).rejects.toThrow('exit:1');
+    expect(errored()).toContain('Failed to clear cache');
+    expect(errored()).toContain('cache boom');
+  });
+
+  // ------------------------------ db:setup ------------------------------
+
+  it('db:setup exits when the database is not configured', async () => {
+    getPackageConfig.mockReturnValue({ database: { url: ':memory:' } });
+    // process.exit() is invoked inside the try block; the thrown sentinel is
+    // caught by the handler, which sets exitCode and returns.
+    await utilityCommands['db:setup'].handler([], {});
+    expect(errored()).toContain('Database configuration required for db:setup');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('db:setup exits when no manifests are found', async () => {
+    autoDiscoverAndLoad.mockResolvedValue({ discovered: [], totalObjects: 0 });
+    await utilityCommands['db:setup'].handler([], {});
+    expect(errored()).toContain('No SMRT manifests found');
+    expect(process.exitCode).toBe(1);
+  });
+
+  // ----------------------------- db:validate ----------------------------
+
+  it('db:validate exits when the data directory cannot be found', async () => {
+    resolveDataPath.mockResolvedValue(null);
+    await expect(
+      utilityCommands['db:validate'].handler([], {}),
+    ).rejects.toThrow('exit:1');
+    expect(errored()).toContain('Could not find data directory');
+  });
+
+  it('db:validate reports when no JSON files are present', async () => {
+    resolveDataPath.mockResolvedValue('/data');
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [{ path: '/p' }],
+      totalObjects: 1,
+    });
+    discoverJsonFiles.mockResolvedValue([]);
+
+    await utilityCommands['db:validate'].handler([], {});
+    expect(logged()).toContain('No JSON data files found');
+  });
+
+  it('db:validate emits a JSON no-files summary with --json', async () => {
+    resolveDataPath.mockResolvedValue('/data');
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [{ path: '/p' }],
+      totalObjects: 1,
+    });
+    discoverJsonFiles.mockResolvedValue([]);
+
+    await utilityCommands['db:validate'].handler([], { json: true });
+    expect(logged()).toContain('"totalFiles": 0');
+  });
+
+  it('db:validate runs the validator and displays results', async () => {
+    resolveDataPath.mockResolvedValue('/data');
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [{ path: '/p' }],
+      totalObjects: 2,
+    });
+    discoverJsonFiles.mockResolvedValue(['/data/a.json']);
+    validateFn.mockResolvedValue({ fixableIssues: [] });
+    generateSummary.mockReturnValue({ issues: { errors: 0 } });
+
+    await utilityCommands['db:validate'].handler([], {});
+    expect(displayValidationResults).toHaveBeenCalled();
+  });
+
+  it('db:validate exits non-zero when validation has errors', async () => {
+    resolveDataPath.mockResolvedValue('/data');
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [{ path: '/p' }],
+      totalObjects: 1,
+    });
+    discoverJsonFiles.mockResolvedValue(['/data/a.json']);
+    validateFn.mockResolvedValue({ fixableIssues: [] });
+    generateSummary.mockReturnValue({ issues: { errors: 3 } });
+
+    await expect(
+      utilityCommands['db:validate'].handler([], {}),
+    ).rejects.toThrow('exit:1');
+  });
+
+  // ------------------------------ db:migrate ----------------------------
+
+  it('db:migrate exits when the database is not configured', async () => {
+    getPackageConfig.mockReturnValue({ database: { url: ':memory:' } });
+    await utilityCommands['db:migrate'].handler([], {});
+    expect(errored()).toContain(
+      'Database configuration required for db:migrate',
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('db:migrate short-circuits for the JSON adapter', async () => {
+    getPackageConfig.mockReturnValue({
+      database: { type: 'json', url: './data' },
+    });
+    await utilityCommands['db:migrate'].handler([], {});
+    expect(logged()).toContain('JSON adapter has limited migration support');
+  });
+
+  it('db:migrate exits when no manifests are found', async () => {
+    getPackageConfig.mockReturnValue({
+      database: { type: 'sqlite', url: './dev.db' },
+    });
+    autoDiscoverAndLoad.mockResolvedValue({ discovered: [], totalObjects: 0 });
+    await utilityCommands['db:migrate'].handler([], {});
+    expect(errored()).toContain('No SMRT manifests found');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('db:migrate reports adapters lacking migration support', async () => {
+    getPackageConfig.mockReturnValue({
+      database: { type: 'sqlite', url: './dev.db' },
+    });
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [{ path: '/p' }],
+      totalObjects: 1,
+    });
+    registry.getInitializationOrder.mockReturnValue([]);
+    registry.getAllSchemasAsDefinitions.mockReturnValue([]);
+    // a db without getTableSchema/alterTable
+    getDatabase.mockResolvedValue({ close: vi.fn() });
+
+    await utilityCommands['db:migrate'].handler([], {});
+    expect(errored()).toContain('does not support schema migration');
+    expect(process.exitCode).toBe(1);
+  });
+
+  function configureMigrate() {
+    getPackageConfig.mockReturnValue({
+      database: { type: 'sqlite', url: './dev.db' },
+    });
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [{ path: '/p' }],
+      totalObjects: 1,
+    });
+    registry.getInitializationOrder.mockReturnValue(['Article']);
+    registry.getTableName.mockReturnValue('contents');
+    registry.getTableStrategy.mockReturnValue('cti');
+    registry.getClass.mockReturnValue({
+      name: 'Article',
+      qualifiedName: '@app:Article',
+    });
+    registry.getAllSchemasAsDefinitions.mockReturnValue([]);
+    getDatabase.mockResolvedValue(migratableDb());
+  }
+
+  it('db:migrate reports an up-to-date schema when there are no changes', async () => {
+    configureMigrate();
+    schemaCompare.mockResolvedValue({ added_tables: [], changes: [] });
+
+    await utilityCommands['db:migrate'].handler([], { verbose: true });
+    expect(logged()).toContain('Database schema is up to date');
+  });
+
+  it('db:migrate previews changes in --dry-run mode', async () => {
+    configureMigrate();
+    schemaCompare.mockResolvedValue({
+      added_tables: [
+        {
+          tableName: 'widgets',
+          columns: { id: { type: 'TEXT' } },
+          ddl: 'CREATE TABLE widgets (id TEXT)',
+        },
+      ],
+      changes: [
+        {
+          type: 'add_column',
+          table: 'contents',
+          name: 'subtitle',
+          column: { type: 'TEXT' },
+          sql: 'ALTER TABLE contents ADD COLUMN subtitle TEXT',
+        },
+        {
+          type: 'add_index',
+          table: 'contents',
+          index: { name: 'idx_contents_status', columns: ['status'] },
+          sql: 'CREATE INDEX idx_contents_status ON contents (status)',
+        },
+      ],
+    });
+
+    await utilityCommands['db:migrate'].handler([], {
+      'dry-run': true,
+      verbose: true,
+    });
+
+    const out = logged();
+    expect(out).toContain('Migration Preview');
+    expect(out).toContain('Would create table');
+    expect(out).toContain('SQL Statements');
+    // Dry-run never invokes the tracker.
+    expect(trackerApplyAll).not.toHaveBeenCalled();
+  });
+
+  it('db:migrate applies schema changes through the tracker', async () => {
+    configureMigrate();
+    schemaCompare.mockResolvedValue({
+      added_tables: [],
+      changes: [
+        {
+          type: 'add_column',
+          table: 'contents',
+          name: 'subtitle',
+          column: { type: 'TEXT' },
+          sql: 'ALTER TABLE contents ADD COLUMN subtitle TEXT',
+        },
+      ],
+    });
+    trackerApplyAll.mockResolvedValue([
+      {
+        name: 'add_column_contents_subtitle',
+        success: true,
+        skipped: false,
+        applied: true,
+        execution_time_ms: 5,
+        checksum: 'abc123def',
+      },
+    ]);
+
+    await utilityCommands['db:migrate'].handler([], {});
+
+    expect(trackerApplyAll).toHaveBeenCalled();
+    expect(logged()).toContain('Successfully applied');
+  });
+
+  it('db:migrate reports a failed migration batch', async () => {
+    configureMigrate();
+    schemaCompare.mockResolvedValue({
+      added_tables: [],
+      changes: [
+        {
+          type: 'add_column',
+          table: 'contents',
+          name: 'subtitle',
+          column: { type: 'TEXT' },
+          sql: 'ALTER TABLE contents ADD COLUMN subtitle TEXT',
+        },
+      ],
+    });
+    trackerApplyAll.mockResolvedValue([
+      {
+        name: 'add_column_contents_subtitle',
+        success: false,
+        rolled_back: false,
+        error: new Error('disk full'),
+        execution_time_ms: 1,
+        checksum: 'x',
+      },
+    ]);
+
+    await utilityCommands['db:migrate'].handler([], {});
+    expect(errored()).toContain('atomic schema migration failed');
+    expect(process.exitCode).toBe(1);
+  });
+
+  // ------------------------------ db:setup ------------------------------
+
+  it('db:setup previews DDL in --dry-run mode', async () => {
+    getPackageConfig.mockReturnValue({
+      database: { type: 'sqlite', url: './dev.db' },
+    });
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [{ path: '/p' }],
+      totalObjects: 1,
+    });
+    registry.getInitializationOrder.mockReturnValue(['Article']);
+    registry.getClass.mockReturnValue({
+      name: 'Article',
+      qualifiedName: '@app:Article',
+      constructor: class Article {},
+    });
+    registry.getTableStrategy.mockReturnValue('cti');
+    registry.getSTIBase.mockReturnValue(null);
+    registry.getTableName.mockReturnValue('articles');
+    generateSchema.mockResolvedValue('CREATE TABLE articles (id TEXT)');
+
+    await utilityCommands['db:setup'].handler([], {
+      'dry-run': true,
+      verbose: true,
+    });
+
+    const out = logged();
+    expect(out).toContain('SQL Preview');
+    expect(out).toContain('CREATE TABLE articles');
+    expect(out).toContain('Dry-run complete');
+  });
+
+  it('db:setup creates tables and reports a summary', async () => {
+    getPackageConfig.mockReturnValue({
+      database: { type: 'sqlite', url: './dev.db' },
+    });
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [{ path: '/p' }],
+      totalObjects: 1,
+    });
+    registry.getInitializationOrder.mockReturnValue(['Article']);
+    registry.getClass.mockReturnValue({
+      name: 'Article',
+      qualifiedName: '@app:Article',
+      constructor: class Article {},
+    });
+    registry.getTableStrategy.mockReturnValue('cti');
+    registry.getSTIBase.mockReturnValue(null);
+    registry.getTableName.mockReturnValue('articles');
+    registry.getFields.mockReturnValue(new Map([['title', {}]]));
+    ensureSchema.mockResolvedValue(undefined);
+    getDatabase.mockResolvedValue(migratableDb());
+
+    await utilityCommands['db:setup'].handler([], { verbose: true });
+
+    expect(ensureSchema).toHaveBeenCalled();
+    expect(logged()).toContain('Successfully initialized');
+    expect(logged()).toContain('articles');
+  });
+
+  it('db:setup skips the destructive --drop flow in non-interactive mode', async () => {
+    getPackageConfig.mockReturnValue({
+      database: { type: 'sqlite', url: './dev.db' },
+      interactive: false,
+    });
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [{ path: '/p' }],
+      totalObjects: 1,
+    });
+    registry.getInitializationOrder.mockReturnValue(['Article']);
+    registry.getClass.mockReturnValue({ name: 'Article' });
+    registry.getTableStrategy.mockReturnValue('cti');
+    registry.getSTIBase.mockReturnValue(null);
+    registry.getTableName.mockReturnValue('articles');
+    getDatabase.mockResolvedValue(migratableDb());
+
+    await utilityCommands['db:setup'].handler([], { drop: true });
+
+    expect(errored()).toContain('Cannot use --drop in non-interactive mode');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('db:setup drops tables when --drop is confirmed interactively', async () => {
+    getPackageConfig.mockReturnValue({
+      database: { type: 'sqlite', url: './dev.db' },
+      interactive: true,
+    });
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [{ path: '/p' }],
+      totalObjects: 1,
+    });
+    registry.getInitializationOrder.mockReturnValue(['Article']);
+    registry.getClass.mockReturnValue({
+      name: 'Article',
+      qualifiedName: '@app:Article',
+      constructor: class {},
+    });
+    registry.getTableStrategy.mockReturnValue('cti');
+    registry.getSTIBase.mockReturnValue(null);
+    registry.getTableName.mockReturnValue('articles');
+    registry.getFields.mockReturnValue(new Map([['title', {}]]));
+    ensureSchema.mockResolvedValue(undefined);
+    rlQuestion.mockResolvedValue('y');
+    // tagged-template execute used by the drop loop
+    const execute = vi.fn(async () => {});
+    getDatabase.mockResolvedValue(migratableDb({ execute }));
+
+    await utilityCommands['db:setup'].handler([], {
+      drop: true,
+      verbose: true,
+    });
+
+    expect(execute).toHaveBeenCalled();
+    expect(logged()).toContain('Dropping existing tables');
+    expect(logged()).toContain('Successfully initialized');
+  });
+
+  it('db:setup aborts the drop flow when the user declines', async () => {
+    getPackageConfig.mockReturnValue({
+      database: { type: 'sqlite', url: './dev.db' },
+      interactive: true,
+    });
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [{ path: '/p' }],
+      totalObjects: 1,
+    });
+    registry.getInitializationOrder.mockReturnValue(['Article']);
+    registry.getClass.mockReturnValue({ name: 'Article' });
+    registry.getTableStrategy.mockReturnValue('cti');
+    registry.getSTIBase.mockReturnValue(null);
+    registry.getTableName.mockReturnValue('articles');
+    rlQuestion.mockResolvedValue('n');
+    getDatabase.mockResolvedValue(migratableDb({ execute: vi.fn() }));
+
+    await utilityCommands['db:setup'].handler([], { drop: true });
+
+    expect(logged()).toContain('Cancelled by user');
+  });
+
+  it('db:setup skips STI child classes that share a parent table', async () => {
+    getPackageConfig.mockReturnValue({
+      database: { type: 'sqlite', url: './dev.db' },
+    });
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [{ path: '/p' }],
+      totalObjects: 2,
+    });
+    registry.getInitializationOrder.mockReturnValue(['Article', 'Page']);
+    registry.getTableStrategy.mockReturnValue('sti');
+    registry.getClass.mockImplementation((name: string) => ({
+      name,
+      qualifiedName: `@app:${name}`,
+      constructor: class {},
+    }));
+    registry.getSTIBase.mockImplementation((name: string) =>
+      name === 'Page' ? '@app:Article' : '@app:Article',
+    );
+    registry.getTableName.mockReturnValue('contents');
+    registry.getFields.mockReturnValue(new Map([['title', {}]]));
+    ensureSchema.mockResolvedValue(undefined);
+    getDatabase.mockResolvedValue(migratableDb());
+
+    await utilityCommands['db:setup'].handler([], { verbose: true });
+
+    expect(logged()).toContain('shares table with');
+  });
+
+  it('db:setup surfaces ensureSchema failures per class', async () => {
+    getPackageConfig.mockReturnValue({
+      database: { type: 'sqlite', url: './dev.db' },
+    });
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [{ path: '/p' }],
+      totalObjects: 1,
+    });
+    registry.getInitializationOrder.mockReturnValue(['Article']);
+    registry.getClass.mockReturnValue({
+      name: 'Article',
+      qualifiedName: '@app:Article',
+      constructor: class {},
+    });
+    registry.getTableStrategy.mockReturnValue('cti');
+    registry.getSTIBase.mockReturnValue(null);
+    registry.getTableName.mockReturnValue('articles');
+    ensureSchema.mockRejectedValue(new Error('ddl error'));
+    getDatabase.mockResolvedValue(migratableDb());
+
+    await utilityCommands['db:setup'].handler([], { verbose: true });
+
+    expect(errored()).toContain('ddl error');
+  });
+
+  // ------------------------- db:migrate (extended) ----------------------
+
+  it('db:migrate creates new tables atomically', async () => {
+    configureMigrate();
+    schemaCompare.mockResolvedValue({
+      added_tables: [
+        {
+          tableName: 'widgets',
+          columns: { id: { type: 'TEXT' } },
+          ddl: 'CREATE TABLE widgets (id TEXT)',
+        },
+      ],
+      changes: [],
+    });
+    trackerApplyAll.mockResolvedValue([
+      {
+        name: 'create_table_widgets',
+        success: true,
+        skipped: false,
+        applied: true,
+        execution_time_ms: 7,
+        checksum: 'chk12345',
+      },
+    ]);
+
+    await utilityCommands['db:migrate'].handler([], {});
+
+    expect(trackerApplyAll).toHaveBeenCalled();
+    expect(logged()).toContain('Successfully applied');
+  });
+
+  it('db:migrate reports manual-intervention drift', async () => {
+    configureMigrate();
+    schemaCompare.mockResolvedValue({
+      added_tables: [],
+      changes: [
+        {
+          type: 'type_mismatch',
+          table: 'contents',
+          name: 'count',
+          mismatch: { expected: 'BIGINT', actual: 'INTEGER' },
+        },
+      ],
+    });
+
+    await utilityCommands['db:migrate'].handler([], {});
+
+    const out = logged();
+    expect(out).toContain('requires manual intervention');
+    expect(out).toContain('contents.count');
+    // manual intervention should drive a non-zero exit
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('db:migrate verbose lists STI child tables', async () => {
+    configureMigrate();
+    registry.getInitializationOrder.mockReturnValue(['Article', 'Page']);
+    registry.getTableStrategy.mockReturnValue('sti');
+    registry.getTableName.mockImplementation((name: string) =>
+      name === 'Article' ? 'contents' : 'contents',
+    );
+    registry.getSTIBase.mockImplementation((name: string) =>
+      name === 'Page' ? '@app:Article' : null,
+    );
+    registry.getClass.mockImplementation((name: string) => ({
+      name,
+      qualifiedName: `@app:${name}`,
+    }));
+
+    await utilityCommands['db:migrate'].handler([], { verbose: true });
+
+    expect(logged()).toContain('Tables to check');
+  });
+
+  it('db:migrate runs the STI discriminator repair with --repair-data', async () => {
+    configureMigrate();
+    registry.getInitializationOrder.mockReturnValue(['Article']);
+    registry.getTableName.mockReturnValue('contents');
+    schemaCompare.mockResolvedValue({ added_tables: [], changes: [] });
+    // A db whose STI table reports a _meta_type column plus rows to inspect.
+    getDatabase.mockResolvedValue(
+      migratableDb({
+        getTableSchema: vi.fn(async () => ({
+          columns: { _meta_type: { type: 'TEXT' } },
+        })),
+        query: vi.fn(async () => ({ rows: [] })),
+      }),
+    );
+
+    await utilityCommands['db:migrate'].handler([], { 'repair-data': true });
+
+    expect(logged()).toContain('Repairing STI discriminators');
+  });
+
+  it('db:migrate builds migration defs for index and type-upgrade changes', async () => {
+    configureMigrate();
+    schemaCompare.mockResolvedValue({
+      added_tables: [],
+      changes: [
+        {
+          type: 'add_index',
+          table: 'contents',
+          index: { name: 'idx_status', columns: ['status'] },
+          sql: 'CREATE INDEX idx_status ON contents (status)',
+        },
+        {
+          type: 'type_upgrade',
+          table: 'contents',
+          name: 'count',
+          column: { type: 'BIGINT' },
+          mismatch: { expected: 'BIGINT', actual: 'INTEGER' },
+          sql: 'ALTER TABLE contents ALTER COLUMN count TYPE BIGINT',
+        },
+      ],
+    });
+    trackerApplyAll.mockResolvedValue([
+      {
+        name: 'add_index_idx_status_abc',
+        success: true,
+        applied: true,
+        execution_time_ms: 2,
+        checksum: 'c1',
+      },
+      {
+        name: 'type_upgrade_contents_count',
+        success: true,
+        applied: true,
+        execution_time_ms: 3,
+        checksum: 'c2',
+      },
+    ]);
+
+    await utilityCommands['db:migrate'].handler([], { verbose: true });
+    expect(trackerApplyAll).toHaveBeenCalled();
+    expect(logged()).toContain('Successfully applied');
+  });
+
+  it('db:migrate dry-run reports the STI repair preview with --repair-data', async () => {
+    configureMigrate();
+    registry.getInitializationOrder.mockReturnValue(['Article']);
+    registry.getTableName.mockReturnValue('contents');
+    registry.findClassesByName.mockReturnValue([
+      { qualifiedName: '@app:Article' },
+    ]);
+    registry.getConflictColumns.mockReturnValue(['slug']);
+    schemaCompare.mockResolvedValue({ added_tables: [], changes: [] });
+
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ _meta_type: 'Article' }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'r1', slug: 'x' }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    getDatabase.mockResolvedValue(
+      migratableDb({
+        getTableSchema: vi.fn(async () => ({
+          columns: { _meta_type: { type: 'TEXT' } },
+        })),
+        query,
+      }),
+    );
+
+    await utilityCommands['db:migrate'].handler([], {
+      'dry-run': true,
+      'repair-data': true,
+    });
+
+    expect(logged()).toContain('Repairing STI discriminators');
+    expect(logged()).toContain('DRY RUN');
+  });
+
+  it('db:migrate upgrades legacy STI discriminators with --repair-data', async () => {
+    configureMigrate();
+    registry.getInitializationOrder.mockReturnValue(['Article']);
+    registry.getTableName.mockReturnValue('contents');
+    registry.findClassesByName.mockReturnValue([
+      { qualifiedName: '@app:Article' },
+    ]);
+    registry.getConflictColumns.mockReturnValue(['slug']);
+    schemaCompare.mockResolvedValue({ added_tables: [], changes: [] });
+
+    // Drive the query stack: DISTINCT _meta_type -> legacy unqualified name;
+    // legacy-row SELECT -> one row; duplicate-check -> none; UPDATE -> rowCount.
+    const query = vi
+      .fn()
+      // SELECT DISTINCT _meta_type ...
+      .mockResolvedValueOnce({ rows: [{ _meta_type: 'Article' }] })
+      // SELECT id, slug ... WHERE _meta_type = legacy
+      .mockResolvedValueOnce({ rows: [{ id: 'r1', slug: 'hello' }] })
+      // duplicate check -> none
+      .mockResolvedValueOnce({ rows: [] })
+      // UPDATE -> rowCount
+      .mockResolvedValueOnce({ rowCount: 1 });
+
+    getDatabase.mockResolvedValue(
+      migratableDb({
+        getTableSchema: vi.fn(async () => ({
+          columns: { _meta_type: { type: 'TEXT' } },
+        })),
+        query,
+      }),
+    );
+
+    await utilityCommands['db:migrate'].handler([], { 'repair-data': true });
+
+    const out = logged();
+    expect(out).toContain('Repairing STI discriminators');
+    expect(out).toContain('Successfully repaired');
+  });
+
+  it('db:migrate warns that --upgrade-sti is deprecated', async () => {
+    configureMigrate();
+    registry.getInitializationOrder.mockReturnValue(['Article']);
+    registry.getTableName.mockReturnValue('contents');
+    getDatabase.mockResolvedValue(
+      migratableDb({
+        getTableSchema: vi.fn(async () => ({ columns: {} })),
+      }),
+    );
+
+    await utilityCommands['db:migrate'].handler([], { 'upgrade-sti': true });
+
+    expect(warnSpy.mock.calls.flat().join('\n')).toContain(
+      '--upgrade-sti is deprecated',
+    );
+  });
+
+  // ------------------------------- test ---------------------------------
+
+  it('test command generates a manifest with --manifest-only', async () => {
+    const dir = await mkdtemp(resolve(process.cwd(), '.tmp-test-cmd-'));
+    tempDirs.push(dir);
+    const originalCwd = process.cwd();
+    process.chdir(dir);
+    try {
+      manifestGenerate.mockResolvedValue({ objects: { '@app:Article': {} } });
+      discoverBaseClasses.mockResolvedValue(['B1', 'B2', 'B3', 'B4']);
+
+      await utilityCommands.test.handler([], { manifestOnly: true });
+
+      const out = logged();
+      expect(out).toContain('DEPRECATED');
+      expect(out).toContain('Generated test manifest');
+      expect(manifestGenerate).toHaveBeenCalled();
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('test command runs vitest after generating the manifest', async () => {
+    const dir = await mkdtemp(resolve(process.cwd(), '.tmp-test-run-'));
+    tempDirs.push(dir);
+    const originalCwd = process.cwd();
+    process.chdir(dir);
+    try {
+      manifestGenerate.mockResolvedValue({ objects: { '@app:Article': {} } });
+      discoverBaseClasses.mockResolvedValue(['B1', 'B2', 'B3']);
+      // a fake child process that immediately closes with success
+      spawn.mockReturnValue({
+        on: (event: string, cb: (code?: number) => void) => {
+          if (event === 'close') cb(0);
+        },
+      });
+
+      await utilityCommands.test.handler([], {});
+
+      expect(spawn).toHaveBeenCalled();
+      expect(logged()).toContain('Running tests');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('test command reports manifest generation failures', async () => {
+    const dir = await mkdtemp(resolve(process.cwd(), '.tmp-test-cmd-fail-'));
+    tempDirs.push(dir);
+    const originalCwd = process.cwd();
+    process.chdir(dir);
+    try {
+      discoverBaseClasses.mockResolvedValue(['B1', 'B2', 'B3']);
+      manifestGenerate.mockRejectedValue(new Error('scan failed'));
+
+      await expect(
+        utilityCommands.test.handler([], { manifestOnly: true }),
+      ).rejects.toThrow('exit:1');
+      expect(errored()).toContain('Failed to generate test manifest');
+      expect(errored()).toContain('scan failed');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  // --------------------------- db:validate fix --------------------------
+
+  it('db:validate applies fixes when --fix is set', async () => {
+    resolveDataPath.mockResolvedValue('/data');
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [{ path: '/p' }],
+      totalObjects: 1,
+    });
+    discoverJsonFiles.mockResolvedValue(['/data/a.json']);
+    validateFn.mockResolvedValue({ fixableIssues: [{ id: 'x' }] });
+    applyFixes.mockResolvedValue(1);
+    generateSummary.mockReturnValue({ issues: { errors: 0 } });
+
+    await utilityCommands['db:validate'].handler([], { fix: true });
+
+    expect(applyFixes).toHaveBeenCalledWith([{ id: 'x' }]);
+    expect(logged()).toContain('Fixed 1 issue');
+  });
+
+  it('db:validate emits a JSON summary with --json', async () => {
+    resolveDataPath.mockResolvedValue('/data');
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [{ path: '/p' }],
+      totalObjects: 1,
+    });
+    discoverJsonFiles.mockResolvedValue(['/data/a.json']);
+    validateFn.mockResolvedValue({ fixableIssues: [] });
+    generateSummary.mockReturnValue({ issues: { errors: 0 }, totalFiles: 1 });
+
+    await utilityCommands['db:validate'].handler([], { json: true });
+    expect(logged()).toContain('"totalFiles": 1');
+    expect(displayValidationResults).not.toHaveBeenCalled();
+  });
+
+  it('db:validate generates a manifest on the fly when none are found', async () => {
+    resolveDataPath.mockResolvedValue('/data');
+    autoDiscoverAndLoad.mockResolvedValue({ discovered: [], totalObjects: 0 });
+    discoverJsonFiles.mockResolvedValue(['/data/a.json']);
+    manifestGenerate.mockResolvedValue({ objects: {} });
+    discoverBaseClasses.mockResolvedValue(['B1', 'B2', 'B3']);
+    validateFn.mockResolvedValue({ fixableIssues: [] });
+    generateSummary.mockReturnValue({ issues: { errors: 0 } });
+
+    await utilityCommands['db:validate'].handler([], {});
+
+    expect(manifestGenerate).toHaveBeenCalled();
+    expect(logged()).toContain('Generated manifest from source files');
+  });
+
+  it('db:validate reports failures and exits', async () => {
+    resolveDataPath.mockRejectedValue(new Error('fs boom'));
+    await expect(
+      utilityCommands['db:validate'].handler([], {}),
+    ).rejects.toThrow('exit:1');
+    expect(errored()).toContain('Validation failed');
+  });
+});

--- a/packages/cli/src/commands/__tests__/utilities.test.ts
+++ b/packages/cli/src/commands/__tests__/utilities.test.ts
@@ -292,4 +292,143 @@ describe('utilities', () => {
     logSpy.mockRestore();
     process.chdir(originalCwd);
   });
+
+  it('doctor reports a healthy project with all checks passing', async () => {
+    const projectDir = await mkdtemp(
+      resolve(process.cwd(), '.tmp-smrt-doctor-ok-'),
+    );
+    tempDirs.push(projectDir);
+
+    await mkdir(resolve(projectDir, 'src/lib/objects'), { recursive: true });
+    await mkdir(resolve(projectDir, 'src/lib/server'), { recursive: true });
+    await mkdir(resolve(projectDir, '.smrt'), { recursive: true });
+
+    // Private package => no publish-surface verification path.
+    await writeFile(
+      resolve(projectDir, 'package.json'),
+      JSON.stringify({
+        name: 'healthy-fixture',
+        private: true,
+        dependencies: {
+          '@happyvertical/smrt-core': '0.0.0-test',
+          '@sveltejs/kit': '0.0.0-test',
+        },
+      }),
+    );
+    await writeFile(
+      resolve(projectDir, 'smrt.config.ts'),
+      'export default {};\n',
+    );
+    await writeFile(
+      resolve(projectDir, 'vite.config.ts'),
+      [
+        "import { smrtPlugin } from '@happyvertical/smrt-core/vite-plugin';",
+        'export default { plugins: [smrtPlugin()] };',
+        '',
+      ].join('\n'),
+    );
+    await writeFile(
+      resolve(projectDir, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { experimentalDecorators: true } }),
+    );
+    await writeFile(
+      resolve(projectDir, 'src/lib/objects/index.ts'),
+      'export {};\n',
+    );
+    await writeFile(
+      resolve(projectDir, 'src/lib/server/smrt.ts'),
+      'export {};\n',
+    );
+    await writeFile(resolve(projectDir, '.env'), '\n');
+    await writeFile(
+      resolve(projectDir, '.smrt/manifest.json'),
+      JSON.stringify({
+        version: '1.0.0',
+        timestamp: Date.now(),
+        packageName: 'healthy-fixture',
+        objects: {},
+      }),
+    );
+
+    const originalCwd = process.cwd();
+    process.chdir(projectDir);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await utilityCommands.doctor.handler([], {});
+
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('SMRT Doctor');
+    expect(output).toContain('package.json exists');
+    expect(output).toContain('SvelteKit detected');
+    expect(output).toContain('smrtPlugin in vite.config');
+    expect(output).toContain('experimentalDecorators enabled');
+    expect(output).toContain('.env file exists');
+    expect(output).toContain('Summary');
+
+    logSpy.mockRestore();
+    process.chdir(originalCwd);
+  });
+
+  it('doctor surfaces warnings for a bare project lacking optional config', async () => {
+    const projectDir = await mkdtemp(
+      resolve(process.cwd(), '.tmp-smrt-doctor-bare-'),
+    );
+    tempDirs.push(projectDir);
+
+    // Missing smrt-core dependency, no vite/tsconfig, no objects dir, no .env.
+    await writeFile(
+      resolve(projectDir, 'package.json'),
+      JSON.stringify({ name: 'bare-fixture', private: true }),
+    );
+    await writeFile(resolve(projectDir, '.env.example'), 'DATABASE_URL=\n');
+
+    const originalCwd = process.cwd();
+    process.chdir(projectDir);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
+      code?: string | number | null,
+    ) => {
+      throw new Error(`exit:${code ?? ''}`);
+    }) as typeof process.exit);
+
+    // Issues present (missing smrt-core, missing config) => exits 1.
+    await expect(
+      utilityCommands.doctor.handler([], { fix: true }),
+    ).rejects.toThrow('exit:1');
+
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('@happyvertical/smrt-core installed');
+    expect(output).toContain('Not a SvelteKit project');
+    expect(output).toContain('.env.example exists');
+    expect(output).toContain('Auto-fix is not yet implemented');
+    expect(output).toContain('Issues to fix');
+
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+    process.chdir(originalCwd);
+  });
+
+  it('introspect surfaces a guidance message when no manifests exist', async () => {
+    const projectDir = await mkdtemp(
+      resolve(process.cwd(), '.tmp-smrt-introspect-'),
+    );
+    tempDirs.push(projectDir);
+    await writeFile(
+      resolve(projectDir, 'package.json'),
+      JSON.stringify({ name: 'introspect-fixture', private: true }),
+    );
+
+    const originalCwd = process.cwd();
+    process.chdir(projectDir);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await utilityCommands.introspect.handler([], {});
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('Introspecting SMRT project');
+
+    logSpy.mockRestore();
+    process.chdir(originalCwd);
+  });
 });

--- a/packages/cli/src/loaders/git-loader.test.ts
+++ b/packages/cli/src/loaders/git-loader.test.ts
@@ -1,0 +1,410 @@
+/**
+ * Git Loader — download, redirect, extraction, and config-validation tests.
+ *
+ * Complements git-loader.spec.ts (which only drives the network-error path) by
+ * exercising the success path, HTTP redirect handling (including SSRF redirect
+ * rejection), HTTP error statuses, oversized-tarball rejection, and template
+ * config loading/validation. We mock node:https and tar at the boundary, and
+ * let the real filesystem hold the extracted template.config.js.
+ */
+
+import { EventEmitter, Readable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockHttpsGet, mockExtract, extractState } = vi.hoisted(() => {
+  const state: { cwd?: string; onFinish?: () => void } = {};
+  return {
+    mockHttpsGet: vi.fn(),
+    mockExtract: vi.fn(),
+    extractState: state,
+  };
+});
+
+vi.mock('node:https', () => ({
+  default: { get: mockHttpsGet },
+}));
+
+vi.mock('tar', () => ({
+  extract: mockExtract,
+}));
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  cleanupGitTemplate,
+  getGitTemplateDir,
+  loadGitTemplate,
+} from './git-loader.js';
+
+/**
+ * Build a fake https.get that immediately returns a successful (200) response
+ * with no body bytes; extraction completion is driven by the tar mock.
+ */
+function fakeSuccessfulGet() {
+  return (_url: string, callback: any) => {
+    const req = new EventEmitter() as any;
+    req.setTimeout = vi.fn();
+    req.destroy = vi.fn();
+
+    const response = new Readable({ read() {} }) as any;
+    response.statusCode = 200;
+    response.headers = {};
+    setImmediate(() => {
+      callback(response);
+      // No data emitted; just end so the pipe completes.
+      response.push(null);
+    });
+    return req;
+  };
+}
+
+/**
+ * Build a fake https.get that issues a redirect to the provided location.
+ */
+function fakeRedirectGet(location: string | undefined, status = 302) {
+  return (_url: string, callback: any) => {
+    const req = new EventEmitter() as any;
+    req.setTimeout = vi.fn();
+    req.destroy = vi.fn();
+    const response = new Readable({ read() {} }) as any;
+    response.statusCode = status;
+    response.headers = location ? { location } : {};
+    setImmediate(() => callback(response));
+    return req;
+  };
+}
+
+/**
+ * Build a fake https.get that returns an error status.
+ */
+function fakeErrorStatusGet(status: number) {
+  return (_url: string, callback: any) => {
+    const req = new EventEmitter() as any;
+    req.setTimeout = vi.fn();
+    req.destroy = vi.fn();
+    const response = new Readable({ read() {} }) as any;
+    response.statusCode = status;
+    response.headers = {};
+    setImmediate(() => callback(response));
+    return req;
+  };
+}
+
+let tempRoot: string;
+
+describe('git-loader (download + extraction)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    extractState.cwd = undefined;
+    extractState.onFinish = undefined;
+    tempRoot = mkdtempSync(join(tmpdir(), 'smrt-git-loader-'));
+
+    // The tar mock records the cwd it was asked to extract into and returns a
+    // writable-ish stream we can drive to completion.
+    mockExtract.mockImplementation((opts: any) => {
+      extractState.cwd = opts.cwd;
+      const stream = new EventEmitter() as any;
+      stream.write = vi.fn();
+      stream.end = vi.fn();
+      stream.on = stream.on.bind(stream);
+      // Emit finish on next tick after the response pipes into it.
+      setImmediate(() => stream.emit('finish'));
+      return stream;
+    });
+  });
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('throws when no template.config file exists after extraction', async () => {
+    mockHttpsGet.mockImplementation(fakeSuccessfulGet());
+
+    await expect(loadGitTemplate('github:user/repo')).rejects.toThrow(
+      /No template\.config\.js or template\.config\.ts found/,
+    );
+  });
+
+  it('loads a template.config.js produced by extraction', async () => {
+    // When tar.extract runs, drop a valid config into the extraction cwd so the
+    // subsequent dynamic import succeeds.
+    mockExtract.mockImplementation((opts: any) => {
+      extractState.cwd = opts.cwd;
+      const stream = new EventEmitter() as any;
+      stream.write = vi.fn();
+      stream.end = vi.fn();
+      setImmediate(() => {
+        mkdirSync(opts.cwd, { recursive: true });
+        writeFileSync(
+          join(opts.cwd, 'template.config.js'),
+          `export default ${JSON.stringify({
+            name: 'Git Template',
+            description: 'From git',
+            dependencies: { dep: '1.0.0' },
+          })};`,
+          'utf-8',
+        );
+        stream.emit('finish');
+      });
+      return stream;
+    });
+    mockHttpsGet.mockImplementation(fakeSuccessfulGet());
+
+    const config = await loadGitTemplate('github:user/repo');
+    expect(config.name).toBe('Git Template');
+    // getGitTemplateDir returns the temp dir stamped on the config.
+    expect(getGitTemplateDir(config)).toContain('smrt-template-user-repo');
+
+    // cleanup removes the temp dir without throwing.
+    await expect(cleanupGitTemplate(config)).resolves.toBeUndefined();
+  });
+
+  // When the extracted .js config loads but fails validation, loadGitTemplate's
+  // outer try/catch swallows the validation error and falls through to the .ts
+  // attempt, which then fails to import — surfacing as a "no config" error.
+  it('surfaces an error when an extracted config fails validation', async () => {
+    mockExtract.mockImplementation((opts: any) => {
+      extractState.cwd = opts.cwd;
+      const stream = new EventEmitter() as any;
+      stream.write = vi.fn();
+      stream.end = vi.fn();
+      setImmediate(() => {
+        mkdirSync(opts.cwd, { recursive: true });
+        writeFileSync(
+          join(opts.cwd, 'template.config.js'),
+          `export default ${JSON.stringify({
+            name: 'Incomplete',
+            description: 'no deps',
+          })};`,
+          'utf-8',
+        );
+        stream.emit('finish');
+      });
+      return stream;
+    });
+    mockHttpsGet.mockImplementation(fakeSuccessfulGet());
+
+    await expect(loadGitTemplate('github:user/repo')).rejects.toThrow(
+      /No template\.config/,
+    );
+  });
+
+  it('follows a redirect to a trusted host', async () => {
+    let call = 0;
+    mockHttpsGet.mockImplementation((url: string, callback: any) => {
+      call += 1;
+      if (call === 1) {
+        return fakeRedirectGet('https://codeload.github.com/user/repo/tar.gz')(
+          url,
+          callback,
+        );
+      }
+      return fakeSuccessfulGet()(url, callback);
+    });
+
+    // First (redirect) then success but no config -> ends at config-missing,
+    // proving the redirect was followed to a second request.
+    await expect(loadGitTemplate('github:user/repo')).rejects.toThrow(
+      /No template\.config/,
+    );
+    expect(mockHttpsGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects a redirect to an untrusted host (SSRF guard)', async () => {
+    mockHttpsGet.mockImplementation(
+      fakeRedirectGet('https://evil.example.com/payload.tar.gz'),
+    );
+
+    await expect(loadGitTemplate('github:user/repo')).rejects.toThrow(
+      /untrusted host/,
+    );
+  });
+
+  it('rejects a redirect to an internal address (SSRF guard)', async () => {
+    mockHttpsGet.mockImplementation(
+      // 127.0.0.1 is not in the trusted-host allowlist, so it is rejected as an
+      // untrusted host before the internal-address check.
+      fakeRedirectGet('https://127.0.0.1/payload.tar.gz'),
+    );
+
+    await expect(loadGitTemplate('github:user/repo')).rejects.toThrow(
+      /untrusted host|internal/,
+    );
+  });
+
+  it('rejects a non-https redirect protocol', async () => {
+    mockHttpsGet.mockImplementation(
+      fakeRedirectGet('http://github.com/user/repo.tar.gz'),
+    );
+
+    await expect(loadGitTemplate('github:user/repo')).rejects.toThrow(
+      /Invalid redirect protocol/,
+    );
+  });
+
+  it('rejects a malformed redirect URL', async () => {
+    mockHttpsGet.mockImplementation(fakeRedirectGet('::::not a url::::'));
+
+    await expect(loadGitTemplate('github:user/repo')).rejects.toThrow(
+      /Invalid redirect URL format|Invalid redirect protocol/,
+    );
+  });
+
+  it('rejects a redirect without a location header', async () => {
+    mockHttpsGet.mockImplementation(fakeRedirectGet(undefined));
+
+    await expect(loadGitTemplate('github:user/repo')).rejects.toThrow(
+      /Redirect without location header/,
+    );
+  });
+
+  it('rejects a non-200/redirect HTTP status', async () => {
+    mockHttpsGet.mockImplementation(fakeErrorStatusGet(404));
+
+    await expect(loadGitTemplate('github:user/repo')).rejects.toThrow(
+      /Failed to download tarball: HTTP 404/,
+    );
+  });
+
+  it('constructs gitlab and bitbucket tarball URLs without parse errors', async () => {
+    mockHttpsGet.mockImplementation(fakeSuccessfulGet());
+
+    await expect(loadGitTemplate('gitlab:user/repo#main')).rejects.toThrow(
+      /No template\.config/,
+    );
+    await expect(loadGitTemplate('bitbucket:user/repo#main')).rejects.toThrow(
+      /No template\.config/,
+    );
+  });
+
+  it('parses gitlab and bitbucket shorthand with subdirectories', async () => {
+    mockHttpsGet.mockImplementation(fakeSuccessfulGet());
+
+    await expect(
+      loadGitTemplate('gitlab:user/repo/templates/sub#main'),
+    ).rejects.toThrow(/No template\.config/);
+    await expect(
+      loadGitTemplate('bitbucket:user/repo/templates/sub#main'),
+    ).rejects.toThrow(/No template\.config/);
+  });
+
+  it('parses gitlab and bitbucket HTTPS URLs with ref:subdir', async () => {
+    mockHttpsGet.mockImplementation(fakeSuccessfulGet());
+
+    await expect(
+      loadGitTemplate('https://gitlab.com/user/repo.git#main:templates'),
+    ).rejects.toThrow(/No template\.config/);
+    await expect(
+      loadGitTemplate('https://bitbucket.org/user/repo.git#main:templates'),
+    ).rejects.toThrow(/No template\.config/);
+  });
+
+  it('rejects invalid GitLab and Bitbucket HTTPS URLs', async () => {
+    await expect(loadGitTemplate('https://gitlab.com/')).rejects.toThrow(
+      /Invalid GitLab URL/,
+    );
+    await expect(loadGitTemplate('https://bitbucket.org/')).rejects.toThrow(
+      /Invalid Bitbucket URL/,
+    );
+  });
+
+  it('rejects a tarball that exceeds the size limit', async () => {
+    // The size monitor calls response.destroy(err); we mirror real stream
+    // behavior by forwarding that error to the (mocked) extract stream, which
+    // the loader listens to for rejection.
+    let extractStream: any;
+    mockExtract.mockImplementation(() => {
+      extractStream = new EventEmitter() as any;
+      extractStream.write = vi.fn();
+      extractStream.end = vi.fn();
+      return extractStream;
+    });
+    mockHttpsGet.mockImplementation((_url: string, callback: any) => {
+      const req = new EventEmitter() as any;
+      req.setTimeout = vi.fn();
+      req.destroy = vi.fn();
+      const response = new EventEmitter() as any;
+      response.statusCode = 200;
+      response.headers = {};
+      response.pipe = vi.fn();
+      response.destroy = vi.fn((err?: Error) => {
+        // Real readable.destroy(err) surfaces via the piped extract stream.
+        if (err && extractStream) extractStream.emit('error', err);
+      });
+      setImmediate(() => {
+        callback(response);
+        // Emit a chunk larger than the 100 MB limit to trip the monitor.
+        response.emit('data', Buffer.alloc(101 * 1024 * 1024));
+      });
+      return req;
+    });
+
+    await expect(loadGitTemplate('github:user/repo')).rejects.toThrow(
+      /size exceeds limit/,
+    );
+  });
+
+  it('rejects when tar extraction emits an error', async () => {
+    mockExtract.mockImplementation(() => {
+      const stream = new EventEmitter() as any;
+      stream.write = vi.fn();
+      stream.end = vi.fn();
+      setImmediate(() => stream.emit('error', new Error('corrupt tarball')));
+      return stream;
+    });
+    mockHttpsGet.mockImplementation(fakeSuccessfulGet());
+
+    await expect(loadGitTemplate('github:user/repo')).rejects.toThrow(
+      /corrupt tarball/,
+    );
+  });
+
+  it('rejects a request timeout', async () => {
+    mockHttpsGet.mockImplementation((_url: string, _callback: any) => {
+      const req = new EventEmitter() as any;
+      req.destroy = vi.fn((err?: Error) => {
+        if (err) req.emit('error', err);
+      });
+      // Invoke the timeout handler synchronously to simulate a stalled request.
+      req.setTimeout = vi.fn((_ms: number, handler: () => void) => {
+        setImmediate(handler);
+      });
+      return req;
+    });
+
+    await expect(loadGitTemplate('github:user/repo')).rejects.toThrow(
+      /timed out/,
+    );
+  });
+
+  it('falls back to template.config.ts when only a .ts config is extracted', async () => {
+    // The .js import fails (file absent), then the .ts import succeeds because
+    // we write a .js-syntax module under the .ts name and the loader imports it.
+    mockExtract.mockImplementation((opts: any) => {
+      const stream = new EventEmitter() as any;
+      stream.write = vi.fn();
+      stream.end = vi.fn();
+      setImmediate(() => {
+        mkdirSync(opts.cwd, { recursive: true });
+        writeFileSync(
+          join(opts.cwd, 'template.config.ts'),
+          `export default ${JSON.stringify({
+            name: 'TS Template',
+            description: 'from ts',
+            dependencies: { dep: '1.0.0' },
+            devDependencies: { devdep: '1.0.0' },
+          })};`,
+          'utf-8',
+        );
+        stream.emit('finish');
+      });
+      return stream;
+    });
+    mockHttpsGet.mockImplementation(fakeSuccessfulGet());
+
+    const config = await loadGitTemplate('github:user/repo');
+    expect(config.name).toBe('TS Template');
+    await cleanupGitTemplate(config);
+  });
+});

--- a/packages/cli/src/loaders/npm-loader.test.ts
+++ b/packages/cli/src/loaders/npm-loader.test.ts
@@ -1,0 +1,220 @@
+/**
+ * NPM Loader — config-loading and discovery tests.
+ *
+ * Complements npm-loader.spec.ts (which mocks fs/fast-glob) by driving the real
+ * dynamic-import + validation paths against on-disk template.config.js files in
+ * a temp directory. We chdir into the temp project so resolveNpmPackage,
+ * findTemplateInPackages, and discoverInstalledTemplates resolve real paths.
+ */
+
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  discoverInstalledTemplates,
+  findTemplateInPackages,
+  loadNpmTemplate,
+  resolveNpmPackage,
+} from './npm-loader.js';
+
+let tempDir: string;
+let originalCwd: string;
+
+function writeConfigModule(
+  dir: string,
+  config: Record<string, unknown> | string,
+): string {
+  mkdirSync(dir, { recursive: true });
+  const configPath = join(dir, 'template.config.js');
+  const body =
+    typeof config === 'string'
+      ? config
+      : `export default ${JSON.stringify(config)};`;
+  writeFileSync(configPath, body, 'utf-8');
+  return configPath;
+}
+
+const validConfig = {
+  name: 'Sample Template',
+  description: 'A sample template',
+  dependencies: { '@happyvertical/smrt-core': '^1.0.0' },
+};
+
+describe('npm-loader (real filesystem)', () => {
+  beforeEach(() => {
+    // realpathSync resolves macOS's /var -> /private/var symlink so paths
+    // returned by fast-glob (which canonicalizes) match our expectations.
+    tempDir = realpathSync(mkdtempSync(join(tmpdir(), 'smrt-npm-loader-')));
+    originalCwd = process.cwd();
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('loadNpmTemplate', () => {
+    it('loads a valid template.config.js from a directory', async () => {
+      const dir = join(tempDir, 'pkg');
+      writeConfigModule(dir, validConfig);
+
+      const config = await loadNpmTemplate(dir);
+
+      expect(config.name).toBe('Sample Template');
+      expect(config.dependencies).toEqual({
+        '@happyvertical/smrt-core': '^1.0.0',
+      });
+    });
+
+    it('accepts a direct path to a template.config.js file', async () => {
+      const dir = join(tempDir, 'pkg');
+      const configPath = writeConfigModule(dir, validConfig);
+
+      const config = await loadNpmTemplate(configPath);
+
+      expect(config.description).toBe('A sample template');
+    });
+
+    it('throws when no template.config file is found in the directory', async () => {
+      const dir = join(tempDir, 'empty');
+      mkdirSync(dir, { recursive: true });
+
+      await expect(loadNpmTemplate(dir)).rejects.toThrow(
+        /No template\.config\.js or template\.config\.ts found/,
+      );
+    });
+
+    it('throws when the config is missing a required field', async () => {
+      const dir = join(tempDir, 'bad');
+      writeConfigModule(dir, {
+        name: 'Missing deps',
+        description: 'No dependencies field',
+      });
+
+      await expect(loadNpmTemplate(dir)).rejects.toThrow(
+        /missing required field 'dependencies'/,
+      );
+    });
+
+    it('throws when dependencies is not an object', async () => {
+      const dir = join(tempDir, 'baddeps');
+      writeConfigModule(dir, {
+        name: 'Bad deps type',
+        description: 'deps is a string',
+        dependencies: 'not-an-object',
+      });
+
+      await expect(loadNpmTemplate(dir)).rejects.toThrow(
+        /'dependencies' must be an object/,
+      );
+    });
+
+    it('throws when devDependencies is present but not an object', async () => {
+      const dir = join(tempDir, 'baddev');
+      writeConfigModule(dir, {
+        ...validConfig,
+        devDependencies: 'nope',
+      });
+
+      await expect(loadNpmTemplate(dir)).rejects.toThrow(
+        /'devDependencies' must be an object/,
+      );
+    });
+  });
+
+  describe('resolveNpmPackage', () => {
+    it('throws a helpful error for a non-existent package', async () => {
+      await expect(
+        resolveNpmPackage('definitely-not-installed-zzz'),
+      ).rejects.toThrow(/not found\. Install with: npm install/);
+    });
+
+    it('resolves a package present in node_modules by directory access', async () => {
+      const pkgDir = join(tempDir, 'node_modules', 'local-template-pkg');
+      mkdirSync(pkgDir, { recursive: true });
+      writeFileSync(
+        join(pkgDir, 'package.json'),
+        JSON.stringify({ name: 'local-template-pkg', version: '1.0.0' }),
+        'utf-8',
+      );
+
+      const resolved = await resolveNpmPackage('local-template-pkg');
+      expect(resolved).toContain('local-template-pkg');
+    });
+  });
+
+  describe('findTemplateInPackages', () => {
+    it('finds a template under a scoped templates directory', async () => {
+      const dir = join(
+        tempDir,
+        'node_modules',
+        '@org',
+        'templates',
+        'my-template',
+      );
+      writeConfigModule(dir, validConfig);
+
+      const result = await findTemplateInPackages('my-template');
+      expect(result).toBe(dir);
+    });
+
+    it('returns null when no matching template exists', async () => {
+      mkdirSync(join(tempDir, 'node_modules'), { recursive: true });
+      const result = await findTemplateInPackages('nonexistent-template');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('discoverInstalledTemplates', () => {
+    it('discovers templates and extracts their package source', async () => {
+      writeConfigModule(
+        join(tempDir, 'node_modules', '@org', 'templates', 'alpha'),
+        { ...validConfig, name: 'Alpha' },
+      );
+      writeConfigModule(join(tempDir, 'node_modules', 'beta-template'), {
+        ...validConfig,
+        name: 'Beta',
+      });
+
+      const templates = await discoverInstalledTemplates();
+      const names = templates.map((template) => template.name).sort();
+
+      expect(names).toContain('Alpha');
+      expect(names).toContain('Beta');
+      const alpha = templates.find((template) => template.name === 'Alpha');
+      expect(alpha?.source).toBe('@org/templates/alpha');
+    });
+
+    it('skips templates that fail to load and returns the rest', async () => {
+      writeConfigModule(join(tempDir, 'node_modules', 'good-template'), {
+        ...validConfig,
+        name: 'Good',
+      });
+      // A config module that throws on import.
+      writeConfigModule(
+        join(tempDir, 'node_modules', 'broken-template'),
+        'throw new Error("boom");',
+      );
+
+      const templates = await discoverInstalledTemplates();
+      const names = templates.map((template) => template.name);
+
+      expect(names).toContain('Good');
+      expect(names).not.toContain('broken-template');
+    });
+
+    it('returns an empty list when node_modules has no templates', async () => {
+      mkdirSync(join(tempDir, 'node_modules'), { recursive: true });
+      const templates = await discoverInstalledTemplates();
+      expect(templates).toEqual([]);
+    });
+  });
+});

--- a/packages/cli/src/runtime-check.test.ts
+++ b/packages/cli/src/runtime-check.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Runtime check tests
+ *
+ * Exercises runRuntimeCheck end-to-end against temp-dir manifest fixtures and
+ * the formatRuntimeCheckReport renderer. We never mock the filesystem or the
+ * ObjectRegistry: each test writes a real `.smrt/manifest.json` into a fresh
+ * temp project and drives the public API.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { formatRuntimeCheckReport, runRuntimeCheck } from './runtime-check.js';
+
+let tempDir: string;
+
+function writeManifest(root: string, manifest: Record<string, unknown>): void {
+  const smrtDir = join(root, '.smrt');
+  mkdirSync(smrtDir, { recursive: true });
+  writeFileSync(
+    join(smrtDir, 'manifest.json'),
+    JSON.stringify(manifest, null, 2),
+    'utf-8',
+  );
+}
+
+function findCodes(findings: Array<{ code: string }>): string[] {
+  return findings.map((finding) => finding.code);
+}
+
+describe('runRuntimeCheck', () => {
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'smrt-runtime-check-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('reports a missing project manifest when none is discovered', async () => {
+    const result = await runRuntimeCheck(tempDir);
+
+    expect(result.discoveredManifestCount).toBe(0);
+    expect(findCodes(result.findings)).toContain('missing-project-manifest');
+    expect(result.projectManifestPath).toBeUndefined();
+  });
+
+  it('passes for a simple single-class project manifest', async () => {
+    writeManifest(tempDir, {
+      version: '1.0.0',
+      packageName: '@app/example',
+      objects: {
+        '@app/example:Widget': {
+          className: 'Widget',
+          qualifiedName: '@app/example:Widget',
+          fields: {
+            id: { type: 'text' },
+            name: { type: 'text' },
+          },
+        },
+      },
+    });
+
+    const result = await runRuntimeCheck(tempDir);
+
+    expect(result.projectPackageName).toBe('@app/example');
+    expect(result.projectManifestPath).toBeDefined();
+    const codes = findCodes(result.findings);
+    expect(codes).not.toContain('missing-project-manifest');
+  });
+
+  it('flags a qualified-name mismatch in manifest identity checks', async () => {
+    writeManifest(tempDir, {
+      version: '1.0.0',
+      packageName: '@app/example',
+      objects: {
+        Widget: {
+          className: 'Widget',
+          // qualifiedName intentionally disagrees with packageName:className
+          qualifiedName: '@other/pkg:Widget',
+          fields: { id: { type: 'text' } },
+        },
+      },
+    });
+
+    const result = await runRuntimeCheck(tempDir);
+
+    expect(findCodes(result.findings)).toContain('qualified-name-mismatch');
+  });
+
+  it('flags a manifest-key mismatch when the key disagrees with identity', async () => {
+    writeManifest(tempDir, {
+      version: '1.0.0',
+      packageName: '@app/example',
+      objects: {
+        // Qualified key whose className part does not match the definition.
+        '@app/example:Renamed': {
+          className: 'Widget',
+          fields: { id: { type: 'text' } },
+        },
+      },
+    });
+
+    const result = await runRuntimeCheck(tempDir);
+
+    expect(findCodes(result.findings)).toContain('manifest-key-mismatch');
+  });
+
+  it('warns when a class is missing package identity', async () => {
+    writeManifest(tempDir, {
+      version: '1.0.0',
+      // No top-level packageName, and the entry has no qualified key.
+      objects: {
+        Widget: {
+          className: 'Widget',
+          fields: { id: { type: 'text' } },
+        },
+      },
+    });
+
+    const result = await runRuntimeCheck(tempDir);
+
+    expect(findCodes(result.findings)).toContain(
+      'missing-manifest-package-name',
+    );
+  });
+
+  it('loads a dependency manifest, hydrates fields, and reports consumer-register + shadow findings', async () => {
+    // Create a real dependency package under node_modules with a manifest so
+    // loadDependencyManifest / resolvePackageJsonPath / findPackageJsonForResolvedEntry
+    // all run against a genuine on-disk package.
+    const depName = '@acme/widgets';
+    const depDir = join(tempDir, 'node_modules', '@acme', 'widgets');
+    mkdirSync(join(depDir, 'dist'), { recursive: true });
+    writeFileSync(
+      join(depDir, 'package.json'),
+      JSON.stringify({
+        name: depName,
+        version: '1.0.0',
+        main: 'dist/index.js',
+        dependencies: { '@happyvertical/smrt-core': '*' },
+        exports: { '.': './dist/index.js' },
+      }),
+      'utf-8',
+    );
+    writeFileSync(join(depDir, 'dist', 'index.js'), 'module.exports = {};');
+    const depManifest = {
+      version: '1.0.0',
+      packageName: depName,
+      objects: {
+        '@acme/widgets:Gadget': {
+          className: 'Gadget',
+          qualifiedName: '@acme/widgets:Gadget',
+          fields: {
+            id: { type: 'text' },
+            color: { type: 'text' },
+            weight: { type: 'integer' },
+            size: { type: 'integer' },
+          },
+        },
+      },
+    };
+    writeFileSync(
+      join(depDir, 'dist', 'manifest.json'),
+      JSON.stringify(depManifest),
+      'utf-8',
+    );
+
+    // Project manifest declares the dependency and defines a thin "Gadget"
+    // shadow (only one non-system field) so the shadow-class heuristic trips.
+    writeManifest(tempDir, {
+      version: '1.0.0',
+      packageName: '@app/example',
+      smrtDependencies: [depName],
+      objects: {
+        '@app/example:Gadget': {
+          className: 'Gadget',
+          qualifiedName: '@app/example:Gadget',
+          fields: {
+            id: { type: 'text' },
+            label: { type: 'text' },
+          },
+        },
+      },
+    });
+
+    const result = await runRuntimeCheck(tempDir);
+
+    const codes = findCodes(result.findings);
+    // A consumer with external object deps but no register.js must be flagged.
+    expect(codes).toContain('missing-consumer-register');
+    // The dependency manifest resolved (no missing-dependency-manifest finding).
+    expect(codes).not.toContain('missing-dependency-manifest');
+    expect(result.discoveredManifestCount).toBeGreaterThan(0);
+  });
+
+  it('does not flag consumer-register when a register.js exists', async () => {
+    const depName = '@acme/things';
+    const depDir = join(tempDir, 'node_modules', '@acme', 'things');
+    mkdirSync(join(depDir, 'dist'), { recursive: true });
+    writeFileSync(
+      join(depDir, 'package.json'),
+      JSON.stringify({
+        name: depName,
+        version: '1.0.0',
+        main: 'dist/index.js',
+        dependencies: { '@happyvertical/smrt-core': '*' },
+        exports: { '.': './dist/index.js' },
+      }),
+      'utf-8',
+    );
+    writeFileSync(join(depDir, 'dist', 'index.js'), 'module.exports = {};');
+    writeFileSync(
+      join(depDir, 'dist', 'manifest.json'),
+      JSON.stringify({
+        version: '1.0.0',
+        packageName: depName,
+        objects: {
+          '@acme/things:Thing': {
+            className: 'Thing',
+            qualifiedName: '@acme/things:Thing',
+            fields: { id: { type: 'text' }, name: { type: 'text' } },
+          },
+        },
+      }),
+      'utf-8',
+    );
+
+    writeManifest(tempDir, {
+      version: '1.0.0',
+      packageName: '@app/example',
+      smrtDependencies: [depName],
+      objects: {
+        '@app/example:Local': {
+          className: 'Local',
+          qualifiedName: '@app/example:Local',
+          fields: { id: { type: 'text' } },
+        },
+      },
+    });
+    // Provide the register.js (in the now-created .smrt dir) that satisfies the
+    // consumer-registration check.
+    writeFileSync(join(tempDir, '.smrt', 'register.js'), '// registered');
+
+    const result = await runRuntimeCheck(tempDir);
+
+    expect(findCodes(result.findings)).not.toContain(
+      'missing-consumer-register',
+    );
+  });
+
+  it('hydrates an extends chain and resolves a manifest exposed via package exports', async () => {
+    // Dependency package that exposes its manifest only through package.json
+    // "exports": { "./manifest.json": ... } — exercising resolveExportedManifestPath.
+    const depName = '@acme/base';
+    const depDir = join(tempDir, 'node_modules', '@acme', 'base');
+    mkdirSync(join(depDir, 'dist'), { recursive: true });
+    writeFileSync(
+      join(depDir, 'package.json'),
+      JSON.stringify({
+        name: depName,
+        version: '1.0.0',
+        main: 'dist/index.js',
+        dependencies: { '@happyvertical/smrt-core': '*' },
+        exports: {
+          '.': './dist/index.js',
+          './manifest.json': './custom-manifest.json',
+        },
+      }),
+      'utf-8',
+    );
+    writeFileSync(join(depDir, 'dist', 'index.js'), 'module.exports = {};');
+    // Note: NOT placed at any of the default candidate paths so the exports
+    // fallback branch runs.
+    writeFileSync(
+      join(depDir, 'custom-manifest.json'),
+      JSON.stringify({
+        version: '1.0.0',
+        packageName: depName,
+        objects: {
+          '@acme/base:Animal': {
+            className: 'Animal',
+            qualifiedName: '@acme/base:Animal',
+            fields: { id: { type: 'text' }, species: { type: 'text' } },
+          },
+        },
+      }),
+      'utf-8',
+    );
+
+    writeManifest(tempDir, {
+      version: '1.0.0',
+      packageName: '@app/example',
+      smrtDependencies: [depName],
+      objects: {
+        '@app/example:Dog': {
+          className: 'Dog',
+          qualifiedName: '@app/example:Dog',
+          extends: '@acme/base:Animal',
+          fields: { id: { type: 'text' }, breed: { type: 'text' } },
+        },
+      },
+    });
+    writeFileSync(join(tempDir, '.smrt', 'register.js'), '// registered');
+
+    const result = await runRuntimeCheck(tempDir);
+
+    // The custom-exports manifest must have resolved (no missing finding).
+    expect(findCodes(result.findings)).not.toContain(
+      'missing-dependency-manifest',
+    );
+    expect(result.projectPackageName).toBe('@app/example');
+  });
+
+  it('reports a missing dependency manifest for an undeclared SMRT dependency', async () => {
+    writeManifest(tempDir, {
+      version: '1.0.0',
+      packageName: '@app/example',
+      smrtDependencies: ['@happyvertical/does-not-exist-xyz'],
+      objects: {
+        '@app/example:Widget': {
+          className: 'Widget',
+          qualifiedName: '@app/example:Widget',
+          fields: { id: { type: 'text' } },
+        },
+      },
+    });
+
+    const result = await runRuntimeCheck(tempDir);
+
+    expect(findCodes(result.findings)).toContain('missing-dependency-manifest');
+  });
+});
+
+describe('formatRuntimeCheckReport', () => {
+  it('renders heading, manifest details, and a summary by default', () => {
+    const report = formatRuntimeCheckReport({
+      projectRoot: '/tmp/project',
+      projectManifestPath: '/tmp/project/.smrt/manifest.json',
+      projectPackageName: '@app/example',
+      discoveredManifestCount: 3,
+      findings: [
+        { severity: 'error', code: 'boom', message: 'It broke' },
+        { severity: 'warning', code: 'careful', message: 'Watch out' },
+        { severity: 'pass', code: 'ok', message: 'All good' },
+      ],
+    });
+
+    expect(report).toContain('🧪 SMRT Runtime Check');
+    expect(report).toContain(
+      'Project manifest: /tmp/project/.smrt/manifest.json',
+    );
+    expect(report).toContain('Project package: @app/example');
+    expect(report).toContain('Discovered manifests: 3');
+    expect(report).toContain('❌ It broke');
+    expect(report).toContain('⚠️  Watch out');
+    expect(report).toContain('✅ All good');
+    expect(report).toContain('Summary: 1 passed, 1 warning(s), 1 error(s)');
+  });
+
+  it('omits the heading when heading:false is passed', () => {
+    const report = formatRuntimeCheckReport(
+      {
+        projectRoot: '/tmp/project',
+        discoveredManifestCount: 0,
+        findings: [],
+      },
+      { heading: false },
+    );
+
+    expect(report).not.toContain('🧪 SMRT Runtime Check');
+    expect(report).toContain('Discovered manifests: 0');
+    expect(report).toContain('Summary: 0 passed, 0 warning(s), 0 error(s)');
+  });
+
+  it('handles a report with no optional manifest fields', () => {
+    const report = formatRuntimeCheckReport({
+      projectRoot: '/tmp/project',
+      discoveredManifestCount: 1,
+      findings: [{ severity: 'pass', code: 'ok', message: 'Fine' }],
+    });
+
+    expect(report).not.toContain('Project manifest:');
+    expect(report).not.toContain('Project package:');
+    expect(report).toContain('✅ Fine');
+  });
+});

--- a/packages/cli/src/utils/generator.test.ts
+++ b/packages/cli/src/utils/generator.test.ts
@@ -1,0 +1,504 @@
+/**
+ * Tests for the template generator utility (utils/generator.ts).
+ *
+ * These exercise the exported `generate()` entry point end-to-end against real
+ * temporary directories (no DB, no network). The internal helpers
+ * (overlayTemplate, mergePackageJson, processPlaceholders, validateBaseGenerator)
+ * are covered through `generate()` using a `local` template source so no base
+ * generator is spawned.
+ */
+
+import { EventEmitter } from 'node:events';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TemplateConfig, TemplateSource } from '../loaders/index.js';
+import { generate } from './generator.js';
+
+// Mock child_process so runBaseGenerator() can be driven deterministically
+// without depending on installed tooling. `node:child_process` cannot be
+// `vi.spyOn`'d in ESM (non-configurable namespace), so we mock the module and
+// capture the spawned EventEmitter via a shared handle.
+const spawnHandle: {
+  proc: EventEmitter | null;
+  calls: Array<[string, string[], unknown]>;
+} = { proc: null, calls: [] };
+
+vi.mock('node:child_process', () => ({
+  spawn: (command: string, args: string[], opts: unknown) => {
+    const proc = new EventEmitter();
+    spawnHandle.proc = proc;
+    spawnHandle.calls.push([command, args, opts]);
+    return proc;
+  },
+}));
+
+describe('utils/generator generate()', () => {
+  let workDir: string;
+  let templateDir: string;
+  let outputDir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'smrt-gen-'));
+    templateDir = join(workDir, 'tpl');
+    outputDir = join(workDir, 'out');
+    // Silence the generator's progress logging.
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    logSpy.mockRestore();
+    await rm(workDir, { recursive: true, force: true });
+  });
+
+  /** Build a `local` template source with a `template/` directory of files. */
+  function makeLocalTemplate(files: Record<string, string>): TemplateSource {
+    const tplFilesDir = join(templateDir, 'template');
+    mkdirSync(tplFilesDir, { recursive: true });
+    for (const [rel, content] of Object.entries(files)) {
+      const full = join(tplFilesDir, rel);
+      mkdirSync(join(full, '..'), { recursive: true });
+      writeFileSync(full, content);
+    }
+    return { type: 'local', location: templateDir, resolved: templateDir };
+  }
+
+  function baseConfig(overrides: Partial<TemplateConfig> = {}): TemplateConfig {
+    return {
+      name: 'test-template',
+      description: 'A test template',
+      framework: 'sveltekit',
+      dependencies: { '@happyvertical/smrt-core': '^1.0.0' },
+      devDependencies: { vitest: '^1.0.0' },
+      ...overrides,
+    };
+  }
+
+  it('copies template files and creates a package.json from scratch', async () => {
+    const source = makeLocalTemplate({
+      'src/index.ts': 'export const x = 1;\n',
+      'README.md': '# Hello\n',
+    });
+    const config = baseConfig();
+
+    await generate(source, config, {
+      template: 'test',
+      name: 'my-site',
+      outputDir,
+    });
+
+    const copied = await readFile(join(outputDir, 'src/index.ts'), 'utf-8');
+    expect(copied).toContain('export const x = 1;');
+
+    const pkg = JSON.parse(
+      await readFile(join(outputDir, 'package.json'), 'utf-8'),
+    );
+    expect(pkg.name).toBe('my-site');
+    // Dependencies are merged in.
+    expect(pkg.dependencies['@happyvertical/smrt-core']).toBe('^1.0.0');
+    expect(pkg.devDependencies.vitest).toBe('^1.0.0');
+    // Gnode workflow scripts are injected when missing.
+    expect(pkg.scripts['workflow:research']).toContain('research.ts');
+    expect(pkg.scripts['workflow:report']).toContain('report.ts');
+  });
+
+  it('merges into an existing package.json without clobbering existing scripts', async () => {
+    const source = makeLocalTemplate({
+      'package.json': JSON.stringify({
+        name: 'original',
+        version: '9.9.9',
+        scripts: { 'workflow:research': 'echo existing', build: 'tsc' },
+        dependencies: { existing: '1.0.0' },
+      }),
+    });
+
+    await generate(source, baseConfig(), {
+      template: 'test',
+      name: 'renamed-site',
+      outputDir,
+    });
+
+    const pkg = JSON.parse(
+      await readFile(join(outputDir, 'package.json'), 'utf-8'),
+    );
+    // Name overwritten with project name.
+    expect(pkg.name).toBe('renamed-site');
+    // Existing scripts preserved; workflow scripts NOT re-added because the
+    // key already exists.
+    expect(pkg.scripts.build).toBe('tsc');
+    expect(pkg.scripts['workflow:research']).toBe('echo existing');
+    expect(pkg.scripts['workflow:report']).toBeUndefined();
+    // Existing + template deps both present.
+    expect(pkg.dependencies.existing).toBe('1.0.0');
+    expect(pkg.dependencies['@happyvertical/smrt-core']).toBe('^1.0.0');
+  });
+
+  it('processes function and string placeholders across text files', async () => {
+    const source = makeLocalTemplate({
+      'site.config.ts':
+        'export const site = "{{SITE_NAME}}"; export const lat = {{LATITUDE}};\n',
+      'README.md': '# {{SITE_NAME}} in {{LOCATION}}\n',
+      'binary.png': 'not-processed-because-extension',
+    });
+    const config = baseConfig({
+      placeholders: {
+        '{{SITE_NAME}}': (ctx) => ctx.siteName,
+        '{{LATITUDE}}': (ctx) => String(ctx.latitude),
+        '{{LOCATION}}': 'Static City',
+      },
+    });
+
+    await generate(source, config, {
+      template: 'test',
+      name: 'my-town-site',
+      outputDir,
+      site: { location: 'Bentley, AB', latitude: 52.07, longitude: -114.1 },
+    });
+
+    const cfg = await readFile(join(outputDir, 'site.config.ts'), 'utf-8');
+    // siteName is derived from the project name: "My Town Site".
+    expect(cfg).toContain('"My Town Site"');
+    expect(cfg).toContain('lat = 52.07');
+
+    const readme = await readFile(join(outputDir, 'README.md'), 'utf-8');
+    expect(readme).toContain('My Town Site in Static City');
+
+    // The .png file is not in the processed extensions list and is untouched.
+    const png = await readFile(join(outputDir, 'binary.png'), 'utf-8');
+    expect(png).toBe('not-processed-because-extension');
+  });
+
+  it('derives siteName and defaults for site options when not provided', async () => {
+    const source = makeLocalTemplate({
+      'meta.txt': '{{NAME}}|{{TZ}}|{{LON}}',
+    });
+    const config = baseConfig({
+      placeholders: {
+        '{{NAME}}': (ctx) => ctx.siteName,
+        '{{TZ}}': (ctx) => ctx.timezone,
+        '{{LON}}': (ctx) => String(ctx.longitude),
+      },
+    });
+
+    await generate(source, config, {
+      template: 'test',
+      name: 'hello_world',
+      outputDir,
+    });
+
+    const meta = await readFile(join(outputDir, 'meta.txt'), 'utf-8');
+    // hello_world -> Hello World; defaults: timezone America/Edmonton, lon 0.
+    expect(meta).toBe('Hello World|America/Edmonton|0');
+  });
+
+  it('skips placeholder processing when the map is empty', async () => {
+    const source = makeLocalTemplate({ 'a.txt': '{{UNTOUCHED}}' });
+    const config = baseConfig({ placeholders: {} });
+
+    await generate(source, config, {
+      template: 'test',
+      name: 'site',
+      outputDir,
+    });
+
+    const a = await readFile(join(outputDir, 'a.txt'), 'utf-8');
+    expect(a).toBe('{{UNTOUCHED}}');
+  });
+
+  it('honors a custom templateDir from config', async () => {
+    // Place files in a custom subdirectory instead of the default template/.
+    const customDir = join(templateDir, 'custom-files');
+    mkdirSync(customDir, { recursive: true });
+    writeFileSync(join(customDir, 'custom.txt'), 'from-custom-dir');
+    const source: TemplateSource = {
+      type: 'local',
+      location: templateDir,
+      resolved: templateDir,
+    };
+    const config = baseConfig();
+    (config as Record<string, unknown>).templateDir = 'custom-files';
+
+    await generate(source, config, {
+      template: 'test',
+      name: 'site',
+      outputDir,
+    });
+
+    const out = await readFile(join(outputDir, 'custom.txt'), 'utf-8');
+    expect(out).toBe('from-custom-dir');
+  });
+
+  it('falls back to the overlay/ directory when no template/ exists', async () => {
+    const overlayDir = join(templateDir, 'overlay');
+    mkdirSync(overlayDir, { recursive: true });
+    writeFileSync(join(overlayDir, 'overlaid.txt'), 'overlay-content');
+    const source: TemplateSource = {
+      type: 'local',
+      location: templateDir,
+      resolved: templateDir,
+    };
+
+    await generate(source, baseConfig(), {
+      template: 'test',
+      name: 'site',
+      outputDir,
+    });
+
+    const out = await readFile(join(outputDir, 'overlaid.txt'), 'utf-8');
+    expect(out).toBe('overlay-content');
+  });
+
+  it('throws when no template files are found and no base generator', async () => {
+    mkdirSync(templateDir, { recursive: true });
+    const source: TemplateSource = {
+      type: 'local',
+      location: templateDir,
+      resolved: templateDir,
+    };
+
+    await expect(
+      generate(source, baseConfig(), {
+        template: 'test',
+        name: 'site',
+        outputDir,
+      }),
+    ).rejects.toThrow(/No template files found/);
+  });
+
+  it('resolves npm template source relative to the resolved file dirname', async () => {
+    // For npm sources, baseDir is dirname(source.resolved). Put a template/
+    // dir next to a fake resolved entry file.
+    const pkgDir = join(workDir, 'npm-pkg');
+    const tplFilesDir = join(pkgDir, 'template');
+    mkdirSync(tplFilesDir, { recursive: true });
+    writeFileSync(join(tplFilesDir, 'npm.txt'), 'npm-template');
+    const source: TemplateSource = {
+      type: 'npm',
+      location: '@scope/pkg',
+      resolved: join(pkgDir, 'index.js'),
+    };
+
+    await generate(source, baseConfig(), {
+      template: 'test',
+      name: 'site',
+      outputDir,
+    });
+
+    const out = await readFile(join(outputDir, 'npm.txt'), 'utf-8');
+    expect(out).toBe('npm-template');
+  });
+
+  it('throws for git template source when __tempDir is missing', async () => {
+    const source: TemplateSource = {
+      type: 'git',
+      location: 'github:user/repo',
+      resolved: '',
+    };
+
+    await expect(
+      generate(source, baseConfig(), {
+        template: 'test',
+        name: 'site',
+        outputDir,
+      }),
+    ).rejects.toThrow(/Git template temp directory not found/);
+  });
+
+  it('uses the __tempDir for git template sources', async () => {
+    const gitTemp = join(workDir, 'git-temp');
+    const tplFilesDir = join(gitTemp, 'template');
+    mkdirSync(tplFilesDir, { recursive: true });
+    writeFileSync(join(tplFilesDir, 'git.txt'), 'git-template');
+    const source: TemplateSource = {
+      type: 'git',
+      location: 'github:user/repo',
+      resolved: '',
+    };
+    const config = baseConfig();
+    (config as Record<string, unknown>).__tempDir = gitTemp;
+
+    await generate(source, config, {
+      template: 'test',
+      name: 'site',
+      outputDir,
+    });
+
+    const out = await readFile(join(outputDir, 'git.txt'), 'utf-8');
+    expect(out).toBe('git-template');
+  });
+
+  it('throws on an unknown source type', async () => {
+    const source = {
+      type: 'ftp',
+      location: 'x',
+      resolved: 'y',
+    } as unknown as TemplateSource;
+
+    await expect(
+      generate(source, baseConfig(), {
+        template: 'test',
+        name: 'site',
+        outputDir,
+      }),
+    ).rejects.toThrow(/Unknown source type: ftp/);
+  });
+
+  describe('base generator validation (security)', () => {
+    beforeEach(() => {
+      spawnHandle.proc = null;
+      spawnHandle.calls = [];
+    });
+
+    function configWithBaseGen(
+      baseGenerator: NonNullable<TemplateConfig['baseGenerator']>,
+    ): TemplateConfig {
+      return baseConfig({ baseGenerator });
+    }
+
+    it('rejects a non-whitelisted base generator command', async () => {
+      const source: TemplateSource = {
+        type: 'local',
+        location: templateDir,
+        resolved: templateDir,
+      };
+      const config = configWithBaseGen({ command: 'rm', args: ['-rf', '/'] });
+
+      await expect(
+        generate(source, config, {
+          template: 'test',
+          name: 'site',
+          outputDir,
+        }),
+      ).rejects.toThrow(/not allowed/);
+    });
+
+    it('rejects an output directory containing shell metacharacters', async () => {
+      const source: TemplateSource = {
+        type: 'local',
+        location: templateDir,
+        resolved: templateDir,
+      };
+      const config = configWithBaseGen({ command: 'npx', args: ['{DIR}'] });
+
+      await expect(
+        generate(source, config, {
+          template: 'test',
+          name: 'site',
+          outputDir: join(outputDir, 'evil; rm -rf'),
+        }),
+      ).rejects.toThrow(/dangerous characters/);
+    });
+
+    it('rejects a base generator argument with dangerous characters after replacement', async () => {
+      const source: TemplateSource = {
+        type: 'local',
+        location: templateDir,
+        resolved: templateDir,
+      };
+      const config = configWithBaseGen({
+        command: 'npx',
+        args: ['--flag=$(whoami)'],
+      });
+
+      await expect(
+        generate(source, config, {
+          template: 'test',
+          name: 'site',
+          outputDir,
+        }),
+      ).rejects.toThrow(/dangerous characters/);
+    });
+
+    /** Wait for spawn() to be invoked, then run an action against the proc. */
+    async function withSpawnedProc(act: (proc: EventEmitter) => void) {
+      // Allow the spawn call to register close/error listeners.
+      for (let i = 0; i < 50 && !spawnHandle.proc; i++) {
+        await new Promise((r) => setImmediate(r));
+      }
+      if (!spawnHandle.proc) throw new Error('spawn was never called');
+      act(spawnHandle.proc);
+    }
+
+    it('runs a whitelisted base generator and resolves on exit code 0', async () => {
+      const source = makeLocalTemplate({ 'a.txt': 'hi' });
+      const config = configWithBaseGen({
+        command: 'npx',
+        args: ['create-thing', '{DIR}'],
+      });
+
+      const promise = generate(source, config, {
+        template: 'test',
+        name: 'site',
+        outputDir,
+      });
+      await withSpawnedProc((proc) => proc.emit('close', 0));
+      await promise;
+
+      // {DIR} placeholder is replaced with the outputDir and shell is disabled.
+      expect(spawnHandle.calls[0][0]).toBe('npx');
+      expect(spawnHandle.calls[0][1]).toEqual(['create-thing', outputDir]);
+      expect(spawnHandle.calls[0][2]).toMatchObject({ shell: false });
+    });
+
+    it('rejects when the base generator exits with a non-zero code', async () => {
+      const source = makeLocalTemplate({ 'a.txt': 'hi' });
+      const config = configWithBaseGen({ command: 'pnpm', args: ['x'] });
+
+      const promise = generate(source, config, {
+        template: 'test',
+        name: 'site',
+        outputDir,
+      });
+      await withSpawnedProc((proc) => proc.emit('close', 1));
+
+      await expect(promise).rejects.toThrow(/exited with code 1/);
+    });
+
+    it('rejects when the base generator process emits an error', async () => {
+      const source = makeLocalTemplate({ 'a.txt': 'hi' });
+      const config = configWithBaseGen({ command: 'yarn', args: ['x'] });
+
+      const promise = generate(source, config, {
+        template: 'test',
+        name: 'site',
+        outputDir,
+      });
+      await withSpawnedProc((proc) =>
+        proc.emit('error', new Error('spawn failed')),
+      );
+
+      await expect(promise).rejects.toThrow(/spawn failed/);
+    });
+
+    it('returns without copying when base generator runs but no template dir exists', async () => {
+      // baseGenerator present + no template/overlay dir => overlayTemplate
+      // returns early (no throw). The base generator is responsible for
+      // creating outputDir, so create it here to mirror that contract.
+      mkdirSync(templateDir, { recursive: true });
+      mkdirSync(outputDir, { recursive: true });
+      const source: TemplateSource = {
+        type: 'local',
+        location: templateDir,
+        resolved: templateDir,
+      };
+      const config = configWithBaseGen({ command: 'npm', args: ['x'] });
+
+      const promise = generate(source, config, {
+        template: 'test',
+        name: 'site',
+        outputDir,
+      });
+      await withSpawnedProc((proc) => proc.emit('close', 0));
+      await promise;
+
+      // package.json is created since mergePackageJson always runs.
+      const pkg = JSON.parse(
+        await readFile(join(outputDir, 'package.json'), 'utf-8'),
+      );
+      expect(pkg.name).toBe('site');
+    });
+  });
+});

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -26,6 +26,19 @@ export default defineConfig({
       : process.env.CI
         ? 2
         : 0,
+    // Coverage scope: cli does not use smrtVitestPlugin (which supplies this for
+    // other packages), and its tests self-import the built `@happyvertical/smrt-cli`
+    // (→ dist/), so without an explicit scope the v8 provider counted the dist
+    // bundle and reported a misleadingly low package coverage. Restrict to source.
+    coverage: {
+      include: ['src/**/*.ts'],
+      exclude: [
+        '**/*.test.ts',
+        '**/*.spec.ts',
+        '**/__tests__/**',
+        '**/*.d.ts',
+      ],
+    },
   },
   resolve: {
     alias: [


### PR DESCRIPTION
Raises @happyvertical/smrt-cli line coverage from a real **40.4%** to **88.46%**, clearing the T1 80% floor (epic #1354 coverage-debt; sibling to core #1500). +5 conventional commits, ~9.1k lines of tests, **757 tests passing**, no source modified.

## Two parts
1. **Measurement fix** (`test(cli): scope coverage to src`): cli doesn't use `smrtVitestPlugin` and its tests self-import the built `@happyvertical/smrt-cli` (→ `dist/`), so the v8 provider was counting the dist bundle — the gate read **23.81%** when real source coverage was 40.4%. Added a `coverage` block scoping to `src/**` (excluding tests/d.ts). dist files in report: 0.
2. **Test uplift** (5 parallel agents, real in-memory SQLite per .claude/rules/testing.md — DB never mocked, only external/process/fs boundaries):

| Area | Notable before→after |
|------|----------------------|
| cli-generator.ts | 29%→82% · utils/generator.ts 0%→100% |
| utilities/export/config-export | 31/38/1% → 80/83/100% |
| db-* (rollback/diff/status/history/migrate-actions) | up to 1%→95% |
| dispatch/git/json-validator/playground | ~0/39/55/0% → 99/92/95/92% |
| docs/generate/init/dev-knowledge/loaders/runtime-check | up to 4%→100% |

**Package total: 88.46% lines / 91.66% funcs / 87.94% stmts.**

## Honest ceilings (flagged, not padded)
- `db-migrate-uuid.ts` 59% — ~40% is the Postgres-only TEXT→native-uuid conversion engine (unreachable on SQLite; covered by the existing `DATABASE_URL`-gated suite).
- `cli-generator.ts` residual — `main()` bin entry + dynamic import of a *consumer's* on-disk classes (don't exist inside the cli package).
- `playground:dev` interactive dev-server (spawn stdio:inherit); various process.exit glue.
- Found **dead code** in `utilities.ts` (~130 lines: `parseExpectedColumns`/`parseExpectedIndexes`/`normalizeType` are unreferenced) — left in place (test-only PR); worth a follow-up removal.

Relates to #1386 (cli audit). Does not change runtime behavior.