### PR TITLE
test(core): raise package coverage to T1 80% floor (67.78%→83.79%)

### DIFF
--- a/packages/core/src/__tests__/class-ai-usage-query.test.ts
+++ b/packages/core/src/__tests__/class-ai-usage-query.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Coverage tests for SmrtClass AI-usage query/reporting paths in class.ts:
+ *   - listAiUsage: WHERE-clause builder (every filter branch), LIMIT/OFFSET,
+ *     orderBy ASC/DESC, and row → record mapping (null/undefined coalescing,
+ *     tag parsing, token hydration, timestamp normalization)
+ *   - summarizeAiUsage: every `groupBy` bucket expression + stat aggregation
+ *   - error paths when no database is configured
+ *   - getAiUsageSnapshot / resetAiUsage / signalBus / destroy on a no-AI instance
+ *
+ * Uses a real in-memory SQLite database (SmrtClass.initialize() creates the
+ * `_smrt_ai_usage` system table) and inserts rows directly, then drives the
+ * public query methods. No mocking — these are pure SQL/data-shaping paths.
+ *
+ * @see src/class.ts (issue #1500 coverage, ORM group)
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SmrtClass } from '../class';
+
+/** A row matching the `_smrt_ai_usage` schema (id TEXT PK, ...). */
+interface UsageRow {
+  id: string;
+  provider: string;
+  model: string;
+  operation: string;
+  promptTokens: number | null;
+  completionTokens: number | null;
+  totalTokens: number | null;
+  estimatedCost: number | null;
+  duration: number;
+  className: string | null;
+  tenantId: string | null;
+  tags: string | null;
+  createdAt: string;
+}
+
+async function insertUsage(db: any, row: UsageRow): Promise<void> {
+  await db.query(
+    `INSERT INTO _smrt_ai_usage
+       (id, provider, model, operation, prompt_tokens, completion_tokens,
+        total_tokens, estimated_cost, duration, class_name, tenant_id, tags, created_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
+    row.id,
+    row.provider,
+    row.model,
+    row.operation,
+    row.promptTokens,
+    row.completionTokens,
+    row.totalTokens,
+    row.estimatedCost,
+    row.duration,
+    row.className,
+    row.tenantId,
+    row.tags,
+    row.createdAt,
+  );
+}
+
+let instance: SmrtClass;
+let db: any;
+
+beforeEach(async () => {
+  instance = new SmrtClass({ db: ':memory:' });
+  await (instance as any).initialize();
+  db = (instance as any)._db;
+
+  // Seed a representative spread of rows.
+  await insertUsage(db, {
+    id: 'u1',
+    provider: 'openai',
+    model: 'gpt-4',
+    operation: 'chat',
+    promptTokens: 100,
+    completionTokens: 50,
+    totalTokens: 150,
+    estimatedCost: 0.01,
+    duration: 1200,
+    className: 'Widget',
+    tenantId: 'tenant-a',
+    tags: JSON.stringify({ env: 'prod', team: 'core' }),
+    createdAt: '2026-01-01T00:00:00.000Z',
+  });
+  await insertUsage(db, {
+    id: 'u2',
+    provider: 'anthropic',
+    model: 'claude-3',
+    operation: 'embed',
+    promptTokens: null, // exercise null coalescing in hydration/mapping
+    completionTokens: null,
+    totalTokens: null,
+    estimatedCost: null, // estimated_cost null → undefined in record
+    duration: 800,
+    className: null, // class_name null → undefined
+    tenantId: null, // tenant_id null
+    tags: 'not-valid-json{', // exercise parseAiUsageTags catch → undefined
+    createdAt: '2026-01-02T00:00:00.000Z',
+  });
+  await insertUsage(db, {
+    id: 'u3',
+    provider: 'openai',
+    model: 'gpt-4',
+    operation: 'chat',
+    promptTokens: 200,
+    completionTokens: 100,
+    totalTokens: 300,
+    estimatedCost: 0.02,
+    duration: 1500,
+    className: 'Widget',
+    tenantId: 'tenant-b',
+    tags: null, // tags null → undefined
+    createdAt: '2026-01-03T00:00:00.000Z',
+  });
+});
+
+afterEach(() => {
+  instance?.destroy?.();
+});
+
+describe('SmrtClass.listAiUsage', () => {
+  it('lists all rows newest-first by default and maps fields', async () => {
+    const rows = await (instance as any).listAiUsage();
+    expect(rows).toHaveLength(3);
+    // DESC by created_at → u3 first
+    expect(rows[0].id).toBe('u3');
+    expect(rows[2].id).toBe('u1');
+
+    const u1 = rows.find((r: any) => r.id === 'u1');
+    expect(u1.provider).toBe('openai');
+    expect(u1.estimatedCost).toBe(0.01);
+    expect(u1.className).toBe('Widget');
+    expect(u1.tags).toEqual({ env: 'prod', team: 'core' });
+    expect(u1.timestamp).toBeInstanceOf(Date);
+
+    const u2 = rows.find((r: any) => r.id === 'u2');
+    // null DB columns coalesce to undefined in the record
+    expect(u2.estimatedCost).toBeUndefined();
+    expect(u2.className).toBeUndefined();
+    // invalid-JSON tags → undefined
+    expect(u2.tags).toBeUndefined();
+  });
+
+  it('orders ascending when orderBy is "timestamp ASC"', async () => {
+    const rows = await (instance as any).listAiUsage({
+      orderBy: 'timestamp ASC',
+    });
+    expect(rows[0].id).toBe('u1');
+    expect(rows[2].id).toBe('u3');
+  });
+
+  it('applies LIMIT and OFFSET', async () => {
+    const limited = await (instance as any).listAiUsage({ limit: 1 });
+    expect(limited).toHaveLength(1);
+    expect(limited[0].id).toBe('u3'); // newest
+
+    const offset = await (instance as any).listAiUsage({
+      limit: 1,
+      offset: 1,
+    });
+    expect(offset[0].id).toBe('u2');
+  });
+
+  it('filters by provider, model, and operation', async () => {
+    const byProvider = await (instance as any).listAiUsage({
+      provider: 'openai',
+    });
+    expect(byProvider.map((r: any) => r.id).sort()).toEqual(['u1', 'u3']);
+
+    const byModel = await (instance as any).listAiUsage({ model: 'claude-3' });
+    expect(byModel.map((r: any) => r.id)).toEqual(['u2']);
+
+    const byOp = await (instance as any).listAiUsage({ operation: 'embed' });
+    expect(byOp.map((r: any) => r.id)).toEqual(['u2']);
+  });
+
+  it('filters by className and by date window (since/until)', async () => {
+    const byClass = await (instance as any).listAiUsage({
+      className: 'Widget',
+    });
+    expect(byClass.map((r: any) => r.id).sort()).toEqual(['u1', 'u3']);
+
+    const window = await (instance as any).listAiUsage({
+      since: new Date('2026-01-02T00:00:00.000Z'),
+      until: new Date('2026-01-02T23:59:59.000Z'),
+    });
+    expect(window.map((r: any) => r.id)).toEqual(['u2']);
+  });
+
+  it('filters by tenantId value and by tenantId === null', async () => {
+    const byTenant = await (instance as any).listAiUsage({
+      tenantId: 'tenant-a',
+    });
+    expect(byTenant.map((r: any) => r.id)).toEqual(['u1']);
+
+    const nullTenant = await (instance as any).listAiUsage({
+      tenantId: null,
+    });
+    expect(nullTenant.map((r: any) => r.id)).toEqual(['u2']);
+  });
+});
+
+describe('SmrtClass.summarizeAiUsage', () => {
+  it('groups by model by default and aggregates stats', async () => {
+    const summary = await (instance as any).summarizeAiUsage();
+    // model bucket = provider:model
+    const gpt = summary['openai:gpt-4'];
+    expect(gpt).toBeDefined();
+    expect(gpt.callCount).toBe(2);
+    expect(gpt.promptTokens).toBe(300); // 100 + 200
+    expect(gpt.totalTokens).toBe(450);
+    expect(gpt.estimatedCost).toBeCloseTo(0.03, 5);
+    expect(gpt.lastUsed).toBeGreaterThan(0);
+  });
+
+  it('groups by provider', async () => {
+    const summary = await (instance as any).summarizeAiUsage({
+      groupBy: 'provider',
+    });
+    expect(summary.openai.callCount).toBe(2);
+    expect(summary.anthropic.callCount).toBe(1);
+  });
+
+  it('groups by operation', async () => {
+    const summary = await (instance as any).summarizeAiUsage({
+      groupBy: 'operation',
+    });
+    expect(summary.chat.callCount).toBe(2);
+    expect(summary.embed.callCount).toBe(1);
+  });
+
+  it('groups by class, bucketing nulls as "unknown"', async () => {
+    const summary = await (instance as any).summarizeAiUsage({
+      groupBy: 'class',
+    });
+    expect(summary.Widget.callCount).toBe(2);
+    expect(summary.unknown.callCount).toBe(1); // u2 has null class_name
+  });
+
+  it('groups by tenant, bucketing nulls as "global"', async () => {
+    const summary = await (instance as any).summarizeAiUsage({
+      groupBy: 'tenant',
+    });
+    expect(summary['tenant-a'].callCount).toBe(1);
+    expect(summary['tenant-b'].callCount).toBe(1);
+    expect(summary.global.callCount).toBe(1); // u2 null tenant
+  });
+
+  it('groups by day (date bucket via created_at prefix)', async () => {
+    const summary = await (instance as any).summarizeAiUsage({
+      groupBy: 'day',
+    });
+    // three distinct dates → three buckets
+    expect(Object.keys(summary)).toHaveLength(3);
+    expect(summary['2026-01-01'].callCount).toBe(1);
+  });
+
+  it('honors filter options alongside grouping', async () => {
+    const summary = await (instance as any).summarizeAiUsage({
+      groupBy: 'provider',
+      provider: 'openai',
+    });
+    expect(Object.keys(summary)).toEqual(['openai']);
+    expect(summary.openai.callCount).toBe(2);
+  });
+});
+
+describe('SmrtClass AI-usage without a database', () => {
+  it('listAiUsage throws a clear error when no db is configured', async () => {
+    const noDb = new SmrtClass({});
+    await (noDb as any).initialize();
+    await expect((noDb as any).listAiUsage()).rejects.toThrow(
+      /AI usage requires a database configuration/,
+    );
+  });
+
+  it('summarizeAiUsage throws a clear error when no db is configured', async () => {
+    const noDb = new SmrtClass({});
+    await (noDb as any).initialize();
+    await expect((noDb as any).summarizeAiUsage()).rejects.toThrow(
+      /AI usage requires a database configuration/,
+    );
+  });
+});
+
+describe('SmrtClass misc accessors', () => {
+  it('getAiUsageSnapshot returns undefined when no collector is active', () => {
+    const base = new SmrtClass({});
+    expect(base.getAiUsageSnapshot()).toBeUndefined();
+  });
+
+  it('resetAiUsage is a no-op (does not throw) with no collector', () => {
+    const base = new SmrtClass({});
+    expect(() => base.resetAiUsage()).not.toThrow();
+  });
+
+  it('signalBus is undefined when signals are not enabled', () => {
+    const base = new SmrtClass({});
+    expect(base.signalBus).toBeUndefined();
+  });
+
+  it('destroy is safe to call when nothing was registered', () => {
+    const base = new SmrtClass({});
+    expect(() => base.destroy()).not.toThrow();
+  });
+});

--- a/packages/core/src/__tests__/class-ai-usage-query.test.ts
+++ b/packages/core/src/__tests__/class-ai-usage-query.test.ts
@@ -61,8 +61,11 @@ let db: any;
 
 beforeEach(async () => {
   instance = new SmrtClass({ db: ':memory:' });
+  // initialize() is protected on the bare base class (no public factory exists
+  // for SmrtClass itself), so it stays cast; the db handle and AI-usage methods
+  // below are read through their public API (db getter / public methods).
   await (instance as any).initialize();
-  db = (instance as any)._db;
+  db = instance.db;
 
   // Seed a representative spread of rows.
   await insertUsage(db, {
@@ -118,7 +121,7 @@ afterEach(() => {
 
 describe('SmrtClass.listAiUsage', () => {
   it('lists all rows newest-first by default and maps fields', async () => {
-    const rows = await (instance as any).listAiUsage();
+    const rows = await instance.listAiUsage();
     expect(rows).toHaveLength(3);
     // DESC by created_at → u3 first
     expect(rows[0].id).toBe('u3');
@@ -140,7 +143,7 @@ describe('SmrtClass.listAiUsage', () => {
   });
 
   it('orders ascending when orderBy is "timestamp ASC"', async () => {
-    const rows = await (instance as any).listAiUsage({
+    const rows = await instance.listAiUsage({
       orderBy: 'timestamp ASC',
     });
     expect(rows[0].id).toBe('u1');
@@ -148,11 +151,11 @@ describe('SmrtClass.listAiUsage', () => {
   });
 
   it('applies LIMIT and OFFSET', async () => {
-    const limited = await (instance as any).listAiUsage({ limit: 1 });
+    const limited = await instance.listAiUsage({ limit: 1 });
     expect(limited).toHaveLength(1);
     expect(limited[0].id).toBe('u3'); // newest
 
-    const offset = await (instance as any).listAiUsage({
+    const offset = await instance.listAiUsage({
       limit: 1,
       offset: 1,
     });
@@ -160,25 +163,25 @@ describe('SmrtClass.listAiUsage', () => {
   });
 
   it('filters by provider, model, and operation', async () => {
-    const byProvider = await (instance as any).listAiUsage({
+    const byProvider = await instance.listAiUsage({
       provider: 'openai',
     });
     expect(byProvider.map((r: any) => r.id).sort()).toEqual(['u1', 'u3']);
 
-    const byModel = await (instance as any).listAiUsage({ model: 'claude-3' });
+    const byModel = await instance.listAiUsage({ model: 'claude-3' });
     expect(byModel.map((r: any) => r.id)).toEqual(['u2']);
 
-    const byOp = await (instance as any).listAiUsage({ operation: 'embed' });
+    const byOp = await instance.listAiUsage({ operation: 'embed' });
     expect(byOp.map((r: any) => r.id)).toEqual(['u2']);
   });
 
   it('filters by className and by date window (since/until)', async () => {
-    const byClass = await (instance as any).listAiUsage({
+    const byClass = await instance.listAiUsage({
       className: 'Widget',
     });
     expect(byClass.map((r: any) => r.id).sort()).toEqual(['u1', 'u3']);
 
-    const window = await (instance as any).listAiUsage({
+    const window = await instance.listAiUsage({
       since: new Date('2026-01-02T00:00:00.000Z'),
       until: new Date('2026-01-02T23:59:59.000Z'),
     });
@@ -186,12 +189,12 @@ describe('SmrtClass.listAiUsage', () => {
   });
 
   it('filters by tenantId value and by tenantId === null', async () => {
-    const byTenant = await (instance as any).listAiUsage({
+    const byTenant = await instance.listAiUsage({
       tenantId: 'tenant-a',
     });
     expect(byTenant.map((r: any) => r.id)).toEqual(['u1']);
 
-    const nullTenant = await (instance as any).listAiUsage({
+    const nullTenant = await instance.listAiUsage({
       tenantId: null,
     });
     expect(nullTenant.map((r: any) => r.id)).toEqual(['u2']);
@@ -200,7 +203,7 @@ describe('SmrtClass.listAiUsage', () => {
 
 describe('SmrtClass.summarizeAiUsage', () => {
   it('groups by model by default and aggregates stats', async () => {
-    const summary = await (instance as any).summarizeAiUsage();
+    const summary = await instance.summarizeAiUsage();
     // model bucket = provider:model
     const gpt = summary['openai:gpt-4'];
     expect(gpt).toBeDefined();
@@ -212,7 +215,7 @@ describe('SmrtClass.summarizeAiUsage', () => {
   });
 
   it('groups by provider', async () => {
-    const summary = await (instance as any).summarizeAiUsage({
+    const summary = await instance.summarizeAiUsage({
       groupBy: 'provider',
     });
     expect(summary.openai.callCount).toBe(2);
@@ -220,7 +223,7 @@ describe('SmrtClass.summarizeAiUsage', () => {
   });
 
   it('groups by operation', async () => {
-    const summary = await (instance as any).summarizeAiUsage({
+    const summary = await instance.summarizeAiUsage({
       groupBy: 'operation',
     });
     expect(summary.chat.callCount).toBe(2);
@@ -228,7 +231,7 @@ describe('SmrtClass.summarizeAiUsage', () => {
   });
 
   it('groups by class, bucketing nulls as "unknown"', async () => {
-    const summary = await (instance as any).summarizeAiUsage({
+    const summary = await instance.summarizeAiUsage({
       groupBy: 'class',
     });
     expect(summary.Widget.callCount).toBe(2);
@@ -236,7 +239,7 @@ describe('SmrtClass.summarizeAiUsage', () => {
   });
 
   it('groups by tenant, bucketing nulls as "global"', async () => {
-    const summary = await (instance as any).summarizeAiUsage({
+    const summary = await instance.summarizeAiUsage({
       groupBy: 'tenant',
     });
     expect(summary['tenant-a'].callCount).toBe(1);
@@ -245,7 +248,7 @@ describe('SmrtClass.summarizeAiUsage', () => {
   });
 
   it('groups by day (date bucket via created_at prefix)', async () => {
-    const summary = await (instance as any).summarizeAiUsage({
+    const summary = await instance.summarizeAiUsage({
       groupBy: 'day',
     });
     // three distinct dates → three buckets
@@ -254,7 +257,7 @@ describe('SmrtClass.summarizeAiUsage', () => {
   });
 
   it('honors filter options alongside grouping', async () => {
-    const summary = await (instance as any).summarizeAiUsage({
+    const summary = await instance.summarizeAiUsage({
       groupBy: 'provider',
       provider: 'openai',
     });
@@ -267,7 +270,7 @@ describe('SmrtClass AI-usage without a database', () => {
   it('listAiUsage throws a clear error when no db is configured', async () => {
     const noDb = new SmrtClass({});
     await (noDb as any).initialize();
-    await expect((noDb as any).listAiUsage()).rejects.toThrow(
+    await expect(noDb.listAiUsage()).rejects.toThrow(
       /AI usage requires a database configuration/,
     );
   });
@@ -275,7 +278,7 @@ describe('SmrtClass AI-usage without a database', () => {
   it('summarizeAiUsage throws a clear error when no db is configured', async () => {
     const noDb = new SmrtClass({});
     await (noDb as any).initialize();
-    await expect((noDb as any).summarizeAiUsage()).rejects.toThrow(
+    await expect(noDb.summarizeAiUsage()).rejects.toThrow(
       /AI usage requires a database configuration/,
     );
   });

--- a/packages/core/src/__tests__/collection-coverage.test.ts
+++ b/packages/core/src/__tests__/collection-coverage.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Coverage tests for SmrtCollection convenience + reporting methods:
+ *   - findById / findOne / findAll (delegators) and listByIds (incl. the
+ *     empty-array short-circuit)
+ *   - count(): no filter, with a where filter
+ *   - getDiff(): changed-subset diff, and null when nothing changed
+ *   - getOrUpsert(): create path, update-by-slug path, no-op-when-unchanged path
+ *   - collection-scoped memory: remember/recall/recallAll/forget/forgetScope and
+ *     the "not initialized" throws
+ *
+ * Real in-memory SQLite via getTestDatabase(); no mocking.
+ *
+ * @see src/collection.ts (issue #1500 coverage, ORM group)
+ */
+
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getTestDatabase } from '../testing/database';
+import {
+  CovWidget,
+  CovWidgetCollection,
+} from './fixtures/collection-coverage-fixtures.js';
+
+let db: DatabaseInterface;
+let widgets: CovWidgetCollection;
+
+beforeEach(async () => {
+  db = await getTestDatabase({ classes: ['CovWidget'], url: ':memory:' });
+  widgets = await CovWidgetCollection.create({ db });
+});
+
+afterEach(async () => {
+  if (db && typeof db.close === 'function') {
+    try {
+      await db.close();
+    } catch {
+      // ignore
+    }
+  }
+});
+
+describe('SmrtCollection convenience finders', () => {
+  it('findById delegates to get() and returns the row or null', async () => {
+    const created = await widgets.create({ name: 'Alpha', price: 1.5 });
+    const found = await widgets.findById(created.id as string);
+    expect(found?.name).toBe('Alpha');
+
+    const missing = await widgets.findById('does-not-exist');
+    expect(missing).toBeNull();
+  });
+
+  it('findOne delegates to get() with a where clause', async () => {
+    await widgets.create({ name: 'Beta', category: 'tools' });
+    const found = await widgets.findOne({ where: { name: 'Beta' } });
+    expect(found?.category).toBe('tools');
+  });
+
+  it('findAll delegates to list() with options', async () => {
+    await widgets.create({ name: 'A', category: 'x' });
+    await widgets.create({ name: 'B', category: 'x' });
+    await widgets.create({ name: 'C', category: 'y' });
+
+    const xs = await widgets.findAll({ where: { category: 'x' } });
+    expect(xs).toHaveLength(2);
+  });
+
+  it('listByIds returns [] for an empty id list (no query)', async () => {
+    const result = await widgets.listByIds([]);
+    expect(result).toEqual([]);
+  });
+
+  it('listByIds fetches multiple rows by id', async () => {
+    const a = await widgets.create({ name: 'one' });
+    const b = await widgets.create({ name: 'two' });
+    const c = await widgets.create({ name: 'three' });
+
+    const some = await widgets.listByIds([a.id as string, c.id as string]);
+    expect(some.map((w) => w.name).sort()).toEqual(['one', 'three']);
+    // 'two' (b) intentionally excluded
+    expect(some.find((w) => w.id === b.id)).toBeUndefined();
+  });
+});
+
+describe('SmrtCollection.count', () => {
+  it('counts all rows when no filter is supplied', async () => {
+    await widgets.create({ name: 'a' });
+    await widgets.create({ name: 'b' });
+    expect(await widgets.count()).toBe(2);
+  });
+
+  it('counts rows matching a where filter', async () => {
+    await widgets.create({ name: 'a', category: 'keep' });
+    await widgets.create({ name: 'b', category: 'keep' });
+    await widgets.create({ name: 'c', category: 'drop' });
+    expect(await widgets.count({ where: { category: 'keep' } })).toBe(2);
+  });
+});
+
+describe('SmrtCollection.getDiff', () => {
+  it('returns only the changed fields', async () => {
+    const existing = { name: 'old', price: 1, category: 'x' };
+    const diff = await widgets.getDiff(existing, { name: 'new', price: 1 });
+    expect(diff).toEqual({ name: 'new' });
+  });
+
+  it('returns null when nothing changed', async () => {
+    const existing = { name: 'same', price: 5 };
+    const diff = await widgets.getDiff(existing, { name: 'same', price: 5 });
+    expect(diff).toBeNull();
+  });
+
+  it('ignores keys that are not valid fields', async () => {
+    const existing = { name: 'n' };
+    const diff = await widgets.getDiff(existing, {
+      bogusField: 'whatever',
+    });
+    expect(diff).toBeNull();
+  });
+});
+
+describe('SmrtCollection.getOrUpsert', () => {
+  it('creates a new row when none matches', async () => {
+    const created = await widgets.getOrUpsert(
+      { slug: 'gadget-1' },
+      { name: 'Gadget One', price: 9.99 },
+    );
+    expect(created.id).toBeTruthy();
+    expect(created.name).toBe('Gadget One');
+    expect(await widgets.count()).toBe(1);
+  });
+
+  it('updates an existing row identified by slug', async () => {
+    await widgets.getOrUpsert({ slug: 'gadget-2' }, { name: 'First' });
+    const updated = await widgets.getOrUpsert({
+      slug: 'gadget-2',
+      name: 'Second',
+    });
+    expect(updated.name).toBe('Second');
+    // Still a single row — upsert, not insert
+    expect(await widgets.count()).toBe(1);
+  });
+
+  it('returns the existing row unchanged when the diff is empty', async () => {
+    const first = await widgets.getOrUpsert(
+      { slug: 'gadget-3' },
+      { name: 'Stable' },
+    );
+    const again = await widgets.getOrUpsert({
+      slug: 'gadget-3',
+      name: 'Stable',
+    });
+    expect(again.id).toBe(first.id);
+    expect(again.name).toBe('Stable');
+  });
+});
+
+describe('SmrtCollection memory (collection-scoped)', () => {
+  it('remembers and recalls a collection-scoped value', async () => {
+    await widgets.remember({
+      scope: 'crawl/site',
+      key: 'k1',
+      value: { seen: true },
+      confidence: 0.8,
+    });
+    const recalled = await widgets.recall({ scope: 'crawl/site', key: 'k1' });
+    expect(recalled).toEqual({ seen: true });
+  });
+
+  it('recall returns null when no entry matches', async () => {
+    expect(await widgets.recall({ scope: 'none', key: 'x' })).toBeNull();
+  });
+
+  it('recallAll returns a Map of entries in a scope', async () => {
+    await widgets.remember({ scope: 's', key: 'a', value: 1 });
+    await widgets.remember({ scope: 's', key: 'b', value: 2 });
+    const all = await widgets.recallAll({ scope: 's' });
+    expect(all.size).toBe(2);
+    expect(all.get('a')).toBe(1);
+  });
+
+  it('forget removes a single entry', async () => {
+    await widgets.remember({ scope: 's', key: 'gone', value: 1 });
+    await widgets.forget({ scope: 's', key: 'gone' });
+    expect(await widgets.recall({ scope: 's', key: 'gone' })).toBeNull();
+  });
+
+  it('forgetScope clears entries in a scope', async () => {
+    await widgets.remember({ scope: 'wipe', key: 'a', value: 1 });
+    await widgets.remember({ scope: 'wipe', key: 'b', value: 2 });
+    await widgets.forgetScope({ scope: 'wipe' });
+    expect(await widgets.recall({ scope: 'wipe', key: 'a' })).toBeNull();
+    expect(await widgets.recall({ scope: 'wipe', key: 'b' })).toBeNull();
+  });
+});
+
+describe('SmrtCollection memory requires initialization', () => {
+  it('throws from memory methods when systemDb is not initialized', async () => {
+    const bare = new CovWidgetCollection({});
+    await expect(
+      bare.remember({ scope: 's', key: 'k', value: 'v' }),
+    ).rejects.toThrow(/Database not initialized/);
+    await expect(bare.recall({ scope: 's', key: 'k' })).rejects.toThrow(
+      /Database not initialized/,
+    );
+    await expect(bare.recallAll()).rejects.toThrow(/Database not initialized/);
+    await expect(bare.forget({ scope: 's', key: 'k' })).rejects.toThrow(
+      /Database not initialized/,
+    );
+    await expect(bare.forgetScope({ scope: 's' })).rejects.toThrow(
+      /Database not initialized/,
+    );
+    // Reference the item class so the import is load-bearing.
+    expect(CovWidget.name).toBe('CovWidget');
+  });
+});

--- a/packages/core/src/__tests__/fixtures/advisor-test-classes.ts
+++ b/packages/core/src/__tests__/fixtures/advisor-test-classes.ts
@@ -1,0 +1,77 @@
+/**
+ * Fixtures for the mcp-advisor registry-backed tool tests.
+ *
+ * Importing this module triggers the `@smrt()` decorators, which register the
+ * classes (with config) into the global ObjectRegistry. Field metadata is
+ * populated from the generated test manifest at decoration time, so these
+ * classes expose real fields via `ObjectRegistry.getFields(...)`.
+ *
+ * Each class deliberately exercises a different decorator-config shape so the
+ * advisor handlers' branching (boolean vs object api/mcp, exclude lists,
+ * hooks, custom methods, constraints) is covered.
+ */
+
+import { field } from '../../decorators/index.js';
+import { SmrtObject } from '../../object.js';
+import { smrt } from '../../registry.js';
+
+/**
+ * Rich object: object-form api/mcp with include lists, cli enabled, hooks,
+ * a custom method, and fields carrying constraints (min/max/maxLength).
+ */
+@smrt({
+  api: { include: ['list', 'get', 'create', 'update', 'archive'] },
+  mcp: { include: ['list', 'get'] },
+  cli: true,
+  hooks: {
+    beforeSave: 'validateAdvisor',
+    afterSave: 'indexAdvisor',
+  },
+})
+export class AdvisorRichProduct extends SmrtObject {
+  @field({
+    required: true,
+    maxLength: 120,
+    description: 'Product display name',
+  })
+  title: string = '';
+
+  @field({ min: 0, max: 1000 })
+  quantity: number = 0;
+
+  @field({ default: 0.0 })
+  rate: number = 0.0;
+
+  /** A custom domain method that should surface in get-object-config. */
+  async recalculate(): Promise<number> {
+    return this.quantity * this.rate;
+  }
+}
+
+/**
+ * Boolean-config object: api/mcp enabled via `true`, cli disabled. Exercises
+ * the boolean branches in list-registered-objects and get-object-config.
+ */
+@smrt({
+  api: true,
+  mcp: true,
+  cli: false,
+})
+export class AdvisorBooleanWidget extends SmrtObject {
+  @field({ required: true })
+  label: string = '';
+}
+
+/**
+ * Exclude-config object: api/mcp use `exclude` lists. Exercises the
+ * preview-api-endpoints exclusion path and the `exclude !== undefined`
+ * enabled-detection branch.
+ */
+@smrt({
+  api: { exclude: ['delete'] },
+  mcp: { exclude: ['delete'] },
+})
+export class AdvisorExcludeNote extends SmrtObject {
+  @field({ required: true })
+  body: string = '';
+}

--- a/packages/core/src/__tests__/fixtures/collection-coverage-fixtures.ts
+++ b/packages/core/src/__tests__/fixtures/collection-coverage-fixtures.ts
@@ -1,0 +1,24 @@
+/**
+ * Fixtures for collection.ts coverage tests (convenience finders, count,
+ * getDiff, getOrUpsert, and collection-scoped memory).
+ *
+ * Separate file so the @smrt() classes land in the test manifest.
+ *
+ * @see src/collection.ts (issue #1500 coverage, ORM group)
+ */
+
+import { SmrtCollection } from '../../collection.js';
+import { SmrtObject } from '../../object.js';
+import { smrt } from '../../registry.js';
+
+@smrt()
+export class CovWidget extends SmrtObject {
+  name: string = '';
+  price: number = 0.0;
+  category: string = '';
+  inStock: boolean = true;
+}
+
+export class CovWidgetCollection extends SmrtCollection<CovWidget> {
+  static readonly _itemClass = CovWidget;
+}

--- a/packages/core/src/__tests__/fixtures/inheritance-resolver-fixtures.ts
+++ b/packages/core/src/__tests__/fixtures/inheritance-resolver-fixtures.ts
@@ -1,0 +1,71 @@
+/**
+ * Fixture classes for inheritance-resolver coverage tests.
+ *
+ * Kept in a separate file (not the test file) so they are picked up by
+ * test-manifest generation. Mirrors the convention used by
+ * inheritance-test-classes.ts.
+ *
+ * @see src/registry/inheritance-resolver.ts (issue #1500 coverage, ORM group)
+ */
+
+import { field } from '../../decorators/index.js';
+import { SmrtHierarchical } from '../../hierarchical.js';
+import { SmrtObject } from '../../object.js';
+import { smrt } from '../../registry.js';
+
+// ── A 3-level chain dedicated to the module-function tests ──────────────
+@smrt()
+export class IRBase extends SmrtObject {
+  baseTitle: string = '';
+  shared: string = '';
+
+  async baseMethod(): Promise<string> {
+    return 'IRBase.baseMethod';
+  }
+}
+
+@smrt()
+export class IRMiddle extends IRBase {
+  middleField: string = '';
+
+  async middleMethod(): Promise<string> {
+    return 'IRMiddle.middleMethod';
+  }
+}
+
+@smrt()
+export class IRLeaf extends IRMiddle {
+  leafField: string = '';
+
+  // Override an inherited method (last-one-wins behavior in getAllMethods)
+  async baseMethod(): Promise<string> {
+    return 'IRLeaf.baseMethod';
+  }
+}
+
+// ── Numeric-constraint parent/child for mergeFieldConfigs ───────────────
+@smrt()
+export class IRConstraintParent extends SmrtObject {
+  @field({ min: 0, max: 100 })
+  amount: number = 0;
+}
+
+@smrt()
+export class IRConstraintChild extends IRConstraintParent {
+  @field({ min: 10, max: 80 })
+  amount: number = 0;
+}
+
+// ── Hierarchical subclass to exercise normalizeFrameworkInheritedField ──
+// SmrtHierarchical contributes a `parentId` field that the resolver rewrites
+// into a self-referential foreignKey for the child class.
+@smrt({ tableName: 'ir_tree_nodes' })
+export class IRTreeNode extends SmrtHierarchical {
+  label: string = '';
+}
+
+// ── A lone class with no parent (extends SmrtObject) ────────────────────
+@smrt()
+export class IRSolo extends SmrtObject {
+  soloField: string = '';
+}

--- a/packages/core/src/__tests__/fixtures/object-ai-memory-fixtures.ts
+++ b/packages/core/src/__tests__/fixtures/object-ai-memory-fixtures.ts
@@ -1,0 +1,46 @@
+/**
+ * Fixtures for object.ts AI + memory coverage tests.
+ *
+ * Separate file so the @smrt() classes are picked up by test-manifest
+ * generation. The AI client is injectable so is()/do()/describe() can run
+ * against a stub without a real provider (mocking AI is the only mocking
+ * allowed by the testing rules).
+ *
+ * @see src/object.ts (issue #1500 coverage, ORM group)
+ */
+
+import { SmrtObject } from '../../object.js';
+import { smrt } from '../../registry.js';
+
+/** Minimal stub matching the slice of AIClient that is()/do()/describe() use. */
+export interface StubAi {
+  message: (prompt: string, options?: any) => Promise<string>;
+}
+
+@smrt({ tableName: 'object_ai_memory_nodes' })
+export class ObjectAiMemoryNode extends SmrtObject {
+  name: string = '';
+
+  /** Test seam: set this to control what the AI returns. */
+  stubAi?: StubAi;
+
+  /** Capture the last prompt/options passed to the stub for assertions. */
+  lastPrompt?: string;
+  lastOptions?: any;
+
+  // Override the protected AI accessor to return our injectable stub instead
+  // of resolving a real provider. This is the sanctioned "mock only AI" seam.
+  protected async getAiClient(): Promise<any> {
+    if (!this.stubAi) {
+      throw new Error('stubAi not configured for ObjectAiMemoryNode');
+    }
+    const stub = this.stubAi;
+    return {
+      message: async (prompt: string, options?: any) => {
+        this.lastPrompt = prompt;
+        this.lastOptions = options;
+        return stub.message(prompt, options);
+      },
+    };
+  }
+}

--- a/packages/core/src/__tests__/object-ai-memory.test.ts
+++ b/packages/core/src/__tests__/object-ai-memory.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Coverage tests for SmrtObject AI + memory (`_smrt_contexts`) methods:
+ *   - is(): JSON result true/false, and the "Unexpected answer" throw on
+ *     unparseable AI output
+ *   - do() / describe(): pass-through of the AI message result
+ *   - remember/recall/recallAll/forget/forgetScope: upsert, single lookup,
+ *     minConfidence filtering, ancestor scope walking, descendants LIKE,
+ *     deletion + affected count, and the "not initialized" throws
+ *
+ * Real in-memory SQLite (initialize() creates `_smrt_contexts`). AI is the
+ * only mocked dependency, injected via the fixture's overridden getAiClient().
+ *
+ * @see src/object.ts (issue #1500 coverage, ORM group)
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ObjectAiMemoryNode } from './fixtures/object-ai-memory-fixtures.js';
+
+async function makeNode(stub?: {
+  message: (p: string, o?: any) => Promise<string>;
+}): Promise<ObjectAiMemoryNode> {
+  const node = new ObjectAiMemoryNode({
+    name: 'mem-node',
+    db: { type: 'sqlite', url: ':memory:' },
+  });
+  await node.initialize();
+  if (stub) node.stubAi = stub;
+  return node;
+}
+
+let node: ObjectAiMemoryNode;
+
+afterEach(() => {
+  node?.destroy?.();
+});
+
+describe('SmrtObject.is / do / describe (AI)', () => {
+  it('returns true when the AI replies with {"result": true}', async () => {
+    node = await makeNode({
+      message: async () => JSON.stringify({ result: true }),
+    });
+    expect(await node.is('is it good?')).toBe(true);
+    // prompt carries the criteria block and requests json
+    expect(node.lastPrompt).toContain('Beginning of criteria');
+    expect(node.lastOptions.responseFormat).toEqual({ type: 'json_object' });
+  });
+
+  it('returns false when the AI replies with {"result": false}', async () => {
+    node = await makeNode({
+      message: async () => JSON.stringify({ result: false }),
+    });
+    expect(await node.is('is it bad?')).toBe(false);
+  });
+
+  it('returns undefined when result is present but not boolean', async () => {
+    node = await makeNode({
+      message: async () => JSON.stringify({ result: 'maybe' }),
+    });
+    expect(await node.is('ambiguous?')).toBeUndefined();
+  });
+
+  it('throws "Unexpected answer" when the AI reply is not valid JSON', async () => {
+    node = await makeNode({
+      message: async () => 'totally not json',
+    });
+    await expect(node.is('check')).rejects.toThrow(/Unexpected answer/);
+  });
+
+  it('do() returns the raw AI message', async () => {
+    node = await makeNode({
+      message: async () => 'a freeform answer',
+    });
+    const result = await node.do('summarize');
+    expect(result).toBe('a freeform answer');
+    expect(node.lastPrompt).toContain('Beginning of instructions');
+  });
+
+  it('describe() returns the raw AI message', async () => {
+    node = await makeNode({
+      message: async () => 'a concise description',
+    });
+    const result = await node.describe();
+    expect(result).toBe('a concise description');
+    expect(node.lastPrompt).toContain('concise');
+  });
+});
+
+describe('SmrtObject memory: remember / recall', () => {
+  it('remembers and recalls a value by scope + key', async () => {
+    node = await makeNode();
+    await node.remember({
+      scope: 'parser/example.com',
+      key: 'url-1',
+      value: { patterns: ['a', 'b'] },
+      confidence: 0.9,
+    });
+
+    const recalled = await node.recall({
+      scope: 'parser/example.com',
+      key: 'url-1',
+    });
+    expect(recalled).toEqual({ patterns: ['a', 'b'] });
+  });
+
+  it('returns null when nothing matches', async () => {
+    node = await makeNode();
+    const recalled = await node.recall({ scope: 'nope', key: 'missing' });
+    expect(recalled).toBeNull();
+  });
+
+  it('filters by minConfidence', async () => {
+    node = await makeNode();
+    await node.remember({
+      scope: 's',
+      key: 'lowconf',
+      value: 'v',
+      confidence: 0.3,
+    });
+
+    // Above threshold → excluded → null
+    expect(
+      await node.recall({ scope: 's', key: 'lowconf', minConfidence: 0.8 }),
+    ).toBeNull();
+    // At/below threshold → found
+    expect(
+      await node.recall({ scope: 's', key: 'lowconf', minConfidence: 0.2 }),
+    ).toBe('v');
+  });
+
+  it('walks ancestor scopes when includeAncestors is set', async () => {
+    node = await makeNode();
+    // Store at a parent scope only
+    await node.remember({ scope: 'a', key: 'shared', value: 'from-parent' });
+
+    // Look up at a deeper scope with ancestor fallback
+    const recalled = await node.recall({
+      scope: 'a/b/c',
+      key: 'shared',
+      includeAncestors: true,
+    });
+    expect(recalled).toBe('from-parent');
+  });
+
+  it('falls back to the global scope during ancestor walk', async () => {
+    node = await makeNode();
+    await node.remember({ scope: 'global', key: 'g', value: 'global-value' });
+
+    const recalled = await node.recall({
+      scope: 'x/y',
+      key: 'g',
+      includeAncestors: true,
+    });
+    expect(recalled).toBe('global-value');
+  });
+
+  it('overwrites an existing value on repeated remember (same scope+key+version)', async () => {
+    node = await makeNode();
+    await node.remember({ scope: 's', key: 'k', value: 'first' });
+    await node.remember({ scope: 's', key: 'k', value: 'second' });
+    expect(await node.recall({ scope: 's', key: 'k' })).toBe('second');
+  });
+});
+
+describe('SmrtObject memory: recallAll', () => {
+  beforeEach(async () => {
+    node = await makeNode();
+    await node.remember({
+      scope: 'cfg/site',
+      key: 'a',
+      value: 1,
+      confidence: 0.9,
+    });
+    await node.remember({
+      scope: 'cfg/site',
+      key: 'b',
+      value: 2,
+      confidence: 0.4,
+    });
+    await node.remember({
+      scope: 'cfg/site/child',
+      key: 'c',
+      value: 3,
+      confidence: 1.0,
+    });
+  });
+
+  it('returns all entries in an exact scope as a Map', async () => {
+    const all = await node.recallAll({ scope: 'cfg/site' });
+    expect(all.size).toBe(2);
+    expect(all.get('a')).toBe(1);
+    expect(all.get('b')).toBe(2);
+  });
+
+  it('includes descendant scopes with includeDescendants', async () => {
+    const all = await node.recallAll({
+      scope: 'cfg/site',
+      includeDescendants: true,
+    });
+    // a, b (cfg/site) + c (cfg/site/child)
+    expect(all.size).toBe(3);
+    expect(all.get('c')).toBe(3);
+  });
+
+  it('applies minConfidence filtering', async () => {
+    const all = await node.recallAll({
+      scope: 'cfg/site',
+      minConfidence: 0.5,
+    });
+    // only key 'a' (0.9) passes; 'b' (0.4) is filtered out
+    expect(all.size).toBe(1);
+    expect(all.get('a')).toBe(1);
+  });
+
+  it('returns every entry when no scope is supplied', async () => {
+    const all = await node.recallAll();
+    expect(all.size).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('SmrtObject memory: forget / forgetScope', () => {
+  it('forgets a single entry by scope + key', async () => {
+    node = await makeNode();
+    await node.remember({ scope: 's', key: 'k', value: 'v' });
+    await node.forget({ scope: 's', key: 'k' });
+    expect(await node.recall({ scope: 's', key: 'k' })).toBeNull();
+  });
+
+  it('forgetScope deletes only the exact scope, leaving descendants', async () => {
+    node = await makeNode();
+    await node.remember({ scope: 'z', key: 'a', value: 1 });
+    await node.remember({ scope: 'z', key: 'b', value: 2 });
+    await node.remember({ scope: 'z/child', key: 'c', value: 3 });
+
+    // Returns the adapter-reported affected count (>= 0). The reliable signal
+    // is the observable state: exact-scope rows gone, descendant retained.
+    const count = await node.forgetScope({ scope: 'z' });
+    expect(count).toBeGreaterThanOrEqual(0);
+    expect(await node.recall({ scope: 'z', key: 'a' })).toBeNull();
+    expect(await node.recall({ scope: 'z', key: 'b' })).toBeNull();
+    // descendant survived (exact-scope match only)
+    expect(await node.recall({ scope: 'z/child', key: 'c' })).toBe(3);
+  });
+
+  it('forgetScope with includeDescendants clears child scopes too', async () => {
+    node = await makeNode();
+    await node.remember({ scope: 'z', key: 'a', value: 1 });
+    await node.remember({ scope: 'z/child', key: 'c', value: 3 });
+
+    await node.forgetScope({
+      scope: 'z',
+      includeDescendants: true,
+    });
+    // Both the exact scope and its descendant are cleared.
+    expect(await node.recall({ scope: 'z', key: 'a' })).toBeNull();
+    expect(await node.recall({ scope: 'z/child', key: 'c' })).toBeNull();
+  });
+});
+
+describe('SmrtObject memory: requires initialization', () => {
+  it('remember throws when systemDb is not initialized', async () => {
+    const bare = new ObjectAiMemoryNode({ name: 'bare' });
+    await expect(
+      bare.remember({ scope: 's', key: 'k', value: 'v' }),
+    ).rejects.toThrow(/Database not initialized/);
+  });
+
+  it('recall throws when systemDb is not initialized', async () => {
+    const bare = new ObjectAiMemoryNode({ name: 'bare' });
+    await expect(bare.recall({ scope: 's', key: 'k' })).rejects.toThrow(
+      /Database not initialized/,
+    );
+  });
+
+  it('recallAll / forget / forgetScope throw when not initialized', async () => {
+    const bare = new ObjectAiMemoryNode({ name: 'bare' });
+    await expect(bare.recallAll()).rejects.toThrow(/Database not initialized/);
+    await expect(bare.forget({ scope: 's', key: 'k' })).rejects.toThrow(
+      /Database not initialized/,
+    );
+    await expect(bare.forgetScope({ scope: 's' })).rejects.toThrow(
+      /Database not initialized/,
+    );
+  });
+});

--- a/packages/core/src/consumer-plugin/load-resolve.test.ts
+++ b/packages/core/src/consumer-plugin/load-resolve.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Tests for the smrtConsumer Vite plugin's pure hooks (src/consumer-plugin/index.ts).
+ *
+ * The existing index.test.ts covers register.js generation; this file covers
+ * the resolveId / load virtual-module hooks and the package-discovery and
+ * manifest-aggregation paths in buildStart. We invoke the plugin hook functions
+ * directly with synthetic ids / project roots (no Vite dev server, no real
+ * build) and assert their pure outputs and on-disk side effects. Temp dirs are
+ * removed in afterEach.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { smrtConsumer } from './index.js';
+
+let projectRoot: string;
+
+beforeEach(() => {
+  projectRoot = mkdtempSync(join(tmpdir(), 'smrt-consumer-'));
+});
+
+afterEach(() => {
+  if (existsSync(projectRoot)) {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+function writePackageJson(dir: string, json: Record<string, unknown>) {
+  writeFileSync(join(dir, 'package.json'), JSON.stringify(json));
+}
+
+// resolveId / load are objects-or-functions on the plugin; normalize to a
+// callable so we can invoke them with a minimal `this`.
+function getHook(plugin: any, name: 'resolveId' | 'load') {
+  const hook = plugin[name];
+  return typeof hook === 'function' ? hook : hook.handler;
+}
+
+describe('smrtConsumer resolveId', () => {
+  it('resolves a known virtual module to the \\0 virtual id when no .d.ts exists', () => {
+    const plugin = smrtConsumer({
+      packages: [],
+      projectRoot,
+      disableScanning: true,
+    });
+    const resolveId = getHook(plugin, 'resolveId');
+
+    const resolved = resolveId.call({}, '@smrt/routes', undefined);
+    expect(resolved).toBe('\0smrt:routes');
+  });
+
+  it('resolves a virtual module to the physical .d.ts file when it exists', () => {
+    const typesDir = 'src/types/smrt-generated';
+    mkdirSync(join(projectRoot, typesDir), { recursive: true });
+    const declPath = join(projectRoot, typesDir, 'smrt-client.d.ts');
+    writeFileSync(declPath, '// types');
+
+    const plugin = smrtConsumer({
+      packages: [],
+      typesDir,
+      projectRoot,
+      disableScanning: true,
+    });
+    const resolveId = getHook(plugin, 'resolveId');
+
+    const resolved = resolveId.call({}, '@smrt/client', undefined);
+    expect(resolved).toBe(declPath);
+  });
+
+  it('returns null for unknown ids', () => {
+    const plugin = smrtConsumer({ projectRoot, disableScanning: true });
+    const resolveId = getHook(plugin, 'resolveId');
+    expect(resolveId.call({}, 'some-other-module', undefined)).toBeNull();
+  });
+});
+
+describe('smrtConsumer load fallback modules', () => {
+  function makePlugin() {
+    return smrtConsumer({ projectRoot, disableScanning: true });
+  }
+
+  it('returns a fallback routes module', async () => {
+    const load = getHook(makePlugin(), 'load');
+    const code = await load.call({}, '\0smrt:routes');
+    expect(code).toContain('export function setupRoutes');
+    expect(code).toContain('export default setupRoutes');
+  });
+
+  it('returns an empty-client fallback when the manifest has no objects', async () => {
+    const load = getHook(makePlugin(), 'load');
+    const code = await load.call({}, '\0smrt:client');
+    expect(code).toContain('export function createClient');
+    expect(code).toContain('No API client available');
+  });
+
+  it('returns a fallback mcp module', async () => {
+    const load = getHook(makePlugin(), 'load');
+    const code = await load.call({}, '\0smrt:mcp');
+    expect(code).toContain('export function createMCPServer');
+    expect(code).toContain('tools: []');
+  });
+
+  it('returns a no-types message when the manifest has no objects', async () => {
+    const load = getHook(makePlugin(), 'load');
+    const code = await load.call({}, '\0smrt:types');
+    expect(code).toContain('No types available');
+  });
+
+  it('returns a manifest module embedding the manifest JSON', async () => {
+    const load = getHook(makePlugin(), 'load');
+    const code = await load.call({}, '\0smrt:manifest');
+    expect(code).toContain('export const manifest =');
+    expect(code).toContain('export default manifest');
+  });
+
+  it('returns null for an unknown virtual id', async () => {
+    const load = getHook(makePlugin(), 'load');
+    expect(await load.call({}, '\0smrt:nope')).toBeNull();
+  });
+});
+
+describe('smrtConsumer load with a populated manifest', () => {
+  // After buildStart aggregates a manifest, the client/types fallbacks should
+  // generate real per-object code instead of the empty placeholder.
+  async function pluginWithObjects() {
+    mkdirSync(join(projectRoot, 'node_modules', '@acme', 'widgets', 'dist'), {
+      recursive: true,
+    });
+    writePackageJson(projectRoot, {
+      name: 'consumer-app',
+      version: '1.0.0',
+    });
+    writePackageJson(join(projectRoot, 'node_modules', '@acme', 'widgets'), {
+      name: '@acme/widgets',
+      version: '2.0.0',
+      exports: { '.': './dist/index.js' },
+    });
+    const widgetsDist = join(
+      projectRoot,
+      'node_modules',
+      '@acme',
+      'widgets',
+      'dist',
+    );
+    writeFileSync(
+      join(widgetsDist, 'manifest.json'),
+      JSON.stringify({
+        packageName: '@acme/widgets',
+        objects: {
+          Widget: {
+            className: 'Widget',
+            collection: 'widgets',
+            fields: {},
+            methods: {},
+            decoratorConfig: {},
+          },
+        },
+      }),
+    );
+
+    const plugin = smrtConsumer({
+      packages: ['@acme/widgets'],
+      generateTypes: false,
+      projectRoot,
+      disableScanning: true,
+    });
+    await plugin.buildStart?.call({} as any);
+    return plugin;
+  }
+
+  it('generates a per-object client and typed interfaces', async () => {
+    const plugin = await pluginWithObjects();
+    const load = getHook(plugin, 'load');
+
+    const client = await load.call({}, '\0smrt:client');
+    expect(client).toContain('Widget:');
+    expect(client).toContain("'/widgets'");
+
+    const types = await load.call({}, '\0smrt:types');
+    expect(types).toContain('export interface WidgetData');
+  });
+});
+
+describe('smrtConsumer buildStart package discovery', () => {
+  it('writes an aggregated manifest and discovers packages from package.json', async () => {
+    // Auto-discovery (packages: []) scans dependencies whose names include "smrt".
+    mkdirSync(
+      join(projectRoot, 'node_modules', '@scope', 'smrt-things', 'dist'),
+      { recursive: true },
+    );
+    writePackageJson(projectRoot, {
+      name: 'consumer-app',
+      version: '1.0.0',
+      dependencies: { '@scope/smrt-things': '^1.0.0' },
+    });
+    writePackageJson(
+      join(projectRoot, 'node_modules', '@scope', 'smrt-things'),
+      { name: '@scope/smrt-things', version: '1.0.0', main: 'dist/index.js' },
+    );
+    writeFileSync(
+      join(
+        projectRoot,
+        'node_modules',
+        '@scope',
+        'smrt-things',
+        'dist',
+        'manifest.json',
+      ),
+      JSON.stringify({
+        packageName: '@scope/smrt-things',
+        objects: {
+          Thing: {
+            className: 'Thing',
+            collection: 'things',
+            fields: {},
+            methods: {},
+            decoratorConfig: {},
+          },
+        },
+      }),
+    );
+
+    const plugin = smrtConsumer({
+      // packages omitted -> triggers discoverSmrtPackages
+      generateTypes: false,
+      projectRoot,
+      disableScanning: false,
+    });
+    await plugin.buildStart?.call({} as any);
+
+    const aggregatedPath = join(projectRoot, '.smrt', 'manifest.json');
+    expect(existsSync(aggregatedPath)).toBe(true);
+    const aggregated = JSON.parse(readFileSync(aggregatedPath, 'utf-8'));
+    expect(aggregated.objects.Thing).toBeDefined();
+    expect(aggregated.objects.Thing.packageName).toBe('@scope/smrt-things');
+    // determineImportPath fell back to the package name (main field present).
+    expect(aggregated.objects.Thing.importPath).toBe('@scope/smrt-things');
+  });
+
+  it('produces an empty manifest when no SMRT packages are found', async () => {
+    writePackageJson(projectRoot, { name: 'consumer-app', version: '1.0.0' });
+
+    const plugin = smrtConsumer({
+      generateTypes: false,
+      projectRoot,
+      disableScanning: false,
+    });
+    await plugin.buildStart?.call({} as any);
+
+    // No packages -> no aggregated manifest written, and no register.js.
+    expect(existsSync(join(projectRoot, '.smrt', 'register.js'))).toBe(false);
+  });
+
+  it('uses the objects export path when package.json exposes ./objects', async () => {
+    mkdirSync(join(projectRoot, 'node_modules', 'plain-pkg', 'dist'), {
+      recursive: true,
+    });
+    writePackageJson(projectRoot, { name: 'consumer-app', version: '1.0.0' });
+    writePackageJson(join(projectRoot, 'node_modules', 'plain-pkg'), {
+      name: 'plain-pkg',
+      version: '1.0.0',
+      exports: {
+        '.': './dist/index.js',
+        './objects': './dist/objects.js',
+      },
+    });
+    writeFileSync(
+      join(projectRoot, 'node_modules', 'plain-pkg', 'dist', 'manifest.json'),
+      JSON.stringify({
+        objects: {
+          Gadget: {
+            className: 'Gadget',
+            collection: 'gadgets',
+            packageName: 'plain-pkg',
+            hasCollection: false,
+            fields: {},
+            methods: {},
+            decoratorConfig: {},
+          },
+        },
+      }),
+    );
+
+    const plugin = smrtConsumer({
+      packages: ['plain-pkg'],
+      generateTypes: false,
+      projectRoot,
+      disableScanning: true,
+    });
+    await plugin.buildStart?.call({} as any);
+
+    const registerPath = join(projectRoot, '.smrt', 'register.js');
+    expect(existsSync(registerPath)).toBe(true);
+    const register = readFileSync(registerPath, 'utf-8');
+    // determineImportPath chose the "./objects" subpath export.
+    expect(register).toContain("from 'plain-pkg/objects'");
+  });
+
+  it('tolerates a package whose package.json is unreadable', async () => {
+    // The package dir exists but has no package.json: aggregation should warn
+    // and continue without throwing.
+    mkdirSync(join(projectRoot, 'node_modules', 'broken-pkg'), {
+      recursive: true,
+    });
+    writePackageJson(projectRoot, { name: 'consumer-app', version: '1.0.0' });
+
+    const plugin = smrtConsumer({
+      packages: ['broken-pkg'],
+      generateTypes: false,
+      projectRoot,
+      disableScanning: true,
+    });
+
+    await expect(plugin.buildStart?.call({} as any)).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/errors-branches.spec.ts
+++ b/packages/core/src/errors-branches.spec.ts
@@ -1,0 +1,651 @@
+/**
+ * Branch coverage for the SMRT error system.
+ *
+ * errors.spec.ts already covers the common DatabaseError/ValidationError/AIError
+ * factories, retry skip logic, sanitize, and JSON serialization. This file
+ * targets the remaining surface:
+ * - getPrimaryCauseMessage / collectErrorMessages cause-chain traversal
+ *   (queryFailed deep-cause message folding, context.originalError, depth cap)
+ * - the rarely-used static factories on every error class
+ * - ConfigurationError / RuntimeError / FilesystemError / NetworkError families
+ * - ValidationReport collection behavior
+ * - ValidationUtils field/range/length/pattern helpers (incl. async + custom)
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  AIError,
+  ConfigurationError,
+  DatabaseError,
+  ErrorUtils,
+  FilesystemError,
+  NetworkError,
+  RuntimeError,
+  SmrtError,
+  TenantIsolationError,
+  ValidationError,
+  ValidationReport,
+  ValidationUtils,
+} from './errors';
+
+describe('DatabaseError deep-cause message folding (queryFailed)', () => {
+  it('appends the deepest actionable cause message and records the chain', () => {
+    const root = new Error('UNIQUE constraint failed: users.email');
+    const wrapper = new Error('insert failed') as Error & { cause?: Error };
+    wrapper.cause = root;
+
+    const error = DatabaseError.queryFailed(
+      'INSERT INTO users (email) VALUES (?)',
+      wrapper,
+    );
+
+    // Message shows the last (deepest) collected message.
+    expect(error.message).toContain(
+      'Cause: UNIQUE constraint failed: users.email',
+    );
+    expect(error.details?.causeMessage).toBe(
+      'UNIQUE constraint failed: users.email',
+    );
+    expect(error.details?.causeMessages).toEqual([
+      'insert failed',
+      'UNIQUE constraint failed: users.email',
+    ]);
+  });
+
+  it('truncates queries longer than 100 chars with an ellipsis', () => {
+    const longQuery = `SELECT ${'col, '.repeat(40)}1`;
+    const error = DatabaseError.queryFailed(longQuery);
+
+    expect(error.message).toContain('...');
+    // No cause -> no "Cause:" suffix.
+    expect(error.message).not.toContain('Cause:');
+    expect(error.details?.causeMessage).toBeUndefined();
+  });
+
+  it('follows context.originalError and dedupes repeated messages', () => {
+    const original = new Error('connection reset');
+    const outer = new Error('connection reset') as Error & {
+      context?: { originalError?: unknown };
+    };
+    outer.context = { originalError: original };
+
+    const error = DatabaseError.queryFailed('SELECT 1', outer);
+
+    // Both the outer message and the originalError message are identical, so
+    // the deduped list collapses to a single entry.
+    expect(error.details?.causeMessages).toEqual(['connection reset']);
+  });
+
+  it('returns no cause info when the cause chain has only blank messages', () => {
+    const blank = new Error('   ');
+    const error = DatabaseError.queryFailed('SELECT 1', blank);
+
+    expect(error.details?.causeMessage).toBeUndefined();
+    expect(error.message).not.toContain('Cause:');
+  });
+
+  it('stops traversing the cause chain beyond the depth cap', () => {
+    // Build a chain deeper than the depth>10 guard; the deepest messages
+    // beyond the cap must not appear in the collected list.
+    let current = new Error('depth-0') as Error & { cause?: Error };
+    const head = current;
+    for (let i = 1; i <= 15; i++) {
+      const next = new Error(`depth-${i}`) as Error & { cause?: Error };
+      current.cause = next;
+      current = next;
+    }
+
+    const error = DatabaseError.queryFailed('SELECT 1', head);
+    const messages = error.details?.causeMessages as string[];
+
+    expect(messages).toContain('depth-0');
+    // The traversal halts once depth exceeds 10, so very deep nodes are absent.
+    expect(messages).not.toContain('depth-15');
+  });
+});
+
+describe('DatabaseError schema/STI factories', () => {
+  it('builds a schemaError with table and operation', () => {
+    const error = DatabaseError.schemaError('users', 'ADD COLUMN');
+    expect(error.code).toBe('DB_SCHEMA_ERROR');
+    expect(error.message).toContain("table 'users'");
+    expect(error.message).toContain('ADD COLUMN');
+    expect(error.details).toEqual({
+      tableName: 'users',
+      operation: 'ADD COLUMN',
+    });
+  });
+
+  it('builds a corruptedData error', () => {
+    const error = DatabaseError.corruptedData('metadata', 'Product');
+    expect(error.code).toBe('DB_CORRUPTED_DATA');
+    expect(error.message).toContain("field 'metadata'");
+    expect(error.message).toContain('Product');
+  });
+
+  it('builds a missingDiscriminator error, with and without a row id', () => {
+    const withRow = DatabaseError.missingDiscriminator('Article', 'row-7');
+    expect(withRow.code).toBe('DB_MISSING_DISCRIMINATOR');
+    expect(withRow.message).toContain('row id: row-7');
+    expect(withRow.details).toEqual({ className: 'Article', rowId: 'row-7' });
+
+    const withoutRow = DatabaseError.missingDiscriminator('Article');
+    expect(withoutRow.message).not.toContain('row id:');
+  });
+
+  it('builds an stiDiscriminatorConflict error with formatted identity', () => {
+    const error = DatabaseError.stiDiscriminatorConflict({
+      className: 'Article',
+      tableName: 'content',
+      id: 'id-1',
+      slug: 'hello',
+      context: 'blog',
+      conflictIdentity: { slug: 'hello', context: 'blog' },
+      legacyMetaType: 'Article',
+      qualifiedMetaType: '@happyvertical/smrt-content:Article',
+      duplicateId: 'id-2',
+    });
+
+    expect(error.code).toBe('DB_STI_DISCRIMINATOR_CONFLICT');
+    expect(error.message).toContain("slug 'hello'");
+    expect(error.message).toContain("context 'blog'");
+    expect(error.message).toContain("Row 'id-1'");
+    expect(error.message).toContain("row 'id-2'");
+  });
+
+  it('builds an stiDiscriminatorConflict with an empty conflict identity', () => {
+    const error = DatabaseError.stiDiscriminatorConflict({
+      className: 'Article',
+      tableName: 'content',
+      id: 'id-1',
+      slug: 'hello',
+      context: 'blog',
+      conflictIdentity: {},
+      legacyMetaType: 'Article',
+      qualifiedMetaType: 'pkg:Article',
+      duplicateId: 'id-2',
+    });
+
+    expect(error.message).toContain('the same conflict identity');
+  });
+
+  it('builds a schemaMissing error', () => {
+    const error = DatabaseError.schemaMissing('widgets', 'Widget');
+    expect(error.code).toBe('DB_SCHEMA_MISSING');
+    expect(error.message).toContain("Table 'widgets'");
+    expect(error.message).toContain('smrt db:migrate');
+  });
+});
+
+describe('AIError factories', () => {
+  it('builds an invalidResponse error capturing the response', () => {
+    const error = AIError.invalidResponse('anthropic', { foo: 'bar' });
+    expect(error.code).toBe('AI_INVALID_RESPONSE');
+    expect(error.category).toBe('ai');
+    expect(error.details?.response).toEqual({ foo: 'bar' });
+  });
+
+  it('builds an authenticationFailed error', () => {
+    const error = AIError.authenticationFailed('openai');
+    expect(error.code).toBe('AI_AUTH_FAILED');
+    expect(error.details?.provider).toBe('openai');
+  });
+
+  it('marks AI errors as retryable', () => {
+    expect(ErrorUtils.isRetryable(AIError.authenticationFailed('openai'))).toBe(
+      true,
+    );
+  });
+});
+
+describe('FilesystemError factories', () => {
+  it('builds fileNotFound, permissionDenied, and diskSpaceExceeded', () => {
+    const notFound = FilesystemError.fileNotFound('/tmp/x');
+    expect(notFound.code).toBe('FS_FILE_NOT_FOUND');
+    expect(notFound.category).toBe('filesystem');
+
+    const denied = FilesystemError.permissionDenied('/etc/secret', 'read');
+    expect(denied.code).toBe('FS_PERMISSION_DENIED');
+    expect(denied.message).toContain('read');
+
+    const space = FilesystemError.diskSpaceExceeded('/data', 1024);
+    expect(space.code).toBe('FS_DISK_SPACE_EXCEEDED');
+    expect(space.details?.requiredBytes).toBe(1024);
+  });
+});
+
+describe('ValidationError factories', () => {
+  it('builds invalidValue reporting the runtime type', () => {
+    const error = ValidationError.invalidValue('age', 'twelve', 'number');
+    expect(error.code).toBe('VALIDATION_INVALID_VALUE');
+    expect(error.message).toContain('expected number');
+    expect(error.message).toContain('got string');
+  });
+
+  it('builds uniqueConstraint', () => {
+    const error = ValidationError.uniqueConstraint('email', 'a@b.com');
+    expect(error.code).toBe('VALIDATION_UNIQUE_CONSTRAINT');
+    expect(error.details?.value).toBe('a@b.com');
+  });
+
+  it('renders rangeError for min-only and max-only bounds', () => {
+    const minOnly = ValidationError.rangeError('n', -1, 0);
+    expect(minOnly.message).toContain('>= 0');
+
+    const maxOnly = ValidationError.rangeError('n', 11, undefined, 10);
+    expect(maxOnly.message).toContain('<= 10');
+  });
+});
+
+describe('NetworkError factories', () => {
+  it('includes status and truncates response body strings', () => {
+    const body = 'x'.repeat(500);
+    const error = NetworkError.requestFailed('https://api/x', 502, body);
+    expect(error.code).toBe('NETWORK_REQUEST_FAILED');
+    expect(error.message).toContain('Status: 502');
+    expect(error.details?.responseBody?.length).toBe(500);
+    // Only the first 200 chars are inlined into the message.
+    expect(error.message).toContain('x'.repeat(200));
+    expect(error.cause).toBeUndefined();
+  });
+
+  it('captures an Error response body as the cause', () => {
+    const cause = new Error('socket hang up');
+    const error = NetworkError.requestFailed('https://api/x', undefined, cause);
+    expect(error.cause).toBe(cause);
+    expect(error.message).not.toContain('Status:');
+    expect(error.details?.responseBody).toBeUndefined();
+  });
+
+  it('builds timeout and serviceUnavailable (with and without reason)', () => {
+    const timeout = NetworkError.timeout('https://api/x', 5000);
+    expect(timeout.code).toBe('NETWORK_TIMEOUT');
+    expect(timeout.message).toContain('5000ms');
+
+    const withReason = NetworkError.serviceUnavailable(
+      'billing',
+      'maintenance',
+    );
+    expect(withReason.message).toContain('billing - maintenance');
+
+    const withoutReason = NetworkError.serviceUnavailable('billing');
+    expect(withoutReason.message).toBe('External service unavailable: billing');
+  });
+
+  it('marks network errors as retryable', () => {
+    expect(ErrorUtils.isRetryable(NetworkError.timeout('u', 1))).toBe(true);
+  });
+});
+
+describe('ConfigurationError factories', () => {
+  it('builds missingConfiguration with and without context', () => {
+    const withCtx = ConfigurationError.missingConfiguration(
+      'apiKey',
+      'AIClient',
+    );
+    expect(withCtx.code).toBe('CONFIG_MISSING');
+    expect(withCtx.message).toContain('in AIClient');
+
+    const withoutCtx = ConfigurationError.missingConfiguration('apiKey');
+    expect(withoutCtx.message).toBe('Missing required configuration: apiKey');
+  });
+
+  it('builds invalidConfiguration, initializationFailed', () => {
+    const invalid = ConfigurationError.invalidConfiguration(
+      'port',
+      '80',
+      'number',
+    );
+    expect(invalid.code).toBe('CONFIG_INVALID');
+    expect(invalid.message).toContain('expected number');
+
+    const cause = new Error('boom');
+    const init = ConfigurationError.initializationFailed('Cache', cause);
+    expect(init.code).toBe('CONFIG_INIT_FAILED');
+    expect(init.cause).toBe(cause);
+  });
+
+  it('builds circularInheritance and incompatibleStrategy', () => {
+    const circular = ConfigurationError.circularInheritance('A', ['A', 'B']);
+    expect(circular.code).toBe('CONFIG_CIRCULAR_INHERITANCE');
+    expect(circular.message).toContain('A → B → A');
+
+    const incompatible = ConfigurationError.incompatibleStrategy(
+      'Child',
+      'cti',
+      'Parent',
+      'sti',
+    );
+    expect(incompatible.code).toBe('CONFIG_INCOMPATIBLE_STRATEGY');
+    expect(incompatible.message).toContain('Parent');
+  });
+
+  it('builds unregisteredBaseClass', () => {
+    const error = ConfigurationError.unregisteredBaseClass('Meeting', 'Event');
+    expect(error.code).toBe('CONFIG_UNREGISTERED_BASE');
+    expect(error.message).toContain('Event');
+    expect(error.message).toContain('Meeting');
+  });
+
+  it('does not retry configuration errors', async () => {
+    let attempts = 0;
+    await expect(
+      ErrorUtils.withRetry(
+        async () => {
+          attempts++;
+          throw ConfigurationError.missingConfiguration('apiKey');
+        },
+        3,
+        1,
+      ),
+    ).rejects.toThrow(ConfigurationError);
+    expect(attempts).toBe(1);
+  });
+});
+
+describe('RuntimeError factories', () => {
+  it('builds operationFailed with and without context', () => {
+    const withCtx = RuntimeError.operationFailed('save', 'Product');
+    expect(withCtx.code).toBe('RUNTIME_OPERATION_FAILED');
+    expect(withCtx.message).toContain('in Product');
+
+    const withoutCtx = RuntimeError.operationFailed('save');
+    expect(withoutCtx.message).toBe('Operation failed: save');
+  });
+
+  it('builds invalidState carrying structured context as details', () => {
+    const error = RuntimeError.invalidState('bad state', { phase: 'init' });
+    expect(error.code).toBe('RUNTIME_INVALID_STATE');
+    expect(error.message).toBe('bad state');
+    expect(error.details).toEqual({ phase: 'init' });
+  });
+
+  it('builds resourceExhausted', () => {
+    const error = RuntimeError.resourceExhausted('connections', 10);
+    expect(error.code).toBe('RUNTIME_RESOURCE_EXHAUSTED');
+    expect(error.message).toContain('limit of 10');
+  });
+
+  it('is retryable only via message patterns, not category', () => {
+    expect(ErrorUtils.isRetryable(RuntimeError.operationFailed('x'))).toBe(
+      false,
+    );
+  });
+});
+
+describe('TenantIsolationError', () => {
+  it('exposes tenantId/attemptedTenantId via crossTenantReference', () => {
+    const error = TenantIsolationError.crossTenantReference({
+      sourceClass: 'Order',
+      fieldName: 'customerId',
+      sourceTenantId: 'tenant-a',
+      targetClass: 'Customer',
+      targetTenantId: 'tenant-b',
+    });
+
+    expect(error.code).toBe('TENANT_ISOLATION_VIOLATION');
+    expect(error.category).toBe('validation');
+    expect(error.tenantId).toBe('tenant-a');
+    expect(error.attemptedTenantId).toBe('tenant-b');
+    expect(error.message).toContain('Customer');
+  });
+
+  it('omits the target class label when targetClass is absent', () => {
+    const error = TenantIsolationError.crossTenantReference({
+      sourceClass: 'Order',
+      fieldName: 'customerId',
+      sourceTenantId: 'tenant-a',
+      targetTenantId: 'tenant-b',
+    });
+
+    expect(error.message).toContain("tenant 'tenant-b'");
+    expect(error.message).not.toContain('Customer');
+  });
+});
+
+describe('ErrorUtils.sanitizeError on a plain Error', () => {
+  it('returns only name/message/stack for non-SmrtError', () => {
+    const sanitized = ErrorUtils.sanitizeError(new Error('plain'));
+    expect(sanitized.name).toBe('Error');
+    expect(sanitized.code).toBeUndefined();
+    expect(sanitized.category).toBeUndefined();
+  });
+
+  it('leaves details untouched when an SmrtError has no sensitive fields', () => {
+    const error = AIError.providerError('openai', 'embed');
+    const sanitized = ErrorUtils.sanitizeError(error);
+    expect(sanitized.details).toEqual({
+      provider: 'openai',
+      operation: 'embed',
+    });
+  });
+});
+
+describe('ErrorUtils.withRetry', () => {
+  it('coerces a thrown non-Error to an Error and rethrows after retries', async () => {
+    await expect(
+      ErrorUtils.withRetry(
+        async () => {
+          throw 'string failure';
+        },
+        1,
+        1,
+      ),
+    ).rejects.toThrow('string failure');
+  });
+
+  it('retries then succeeds for a non-skipped error', async () => {
+    let attempts = 0;
+    const result = await ErrorUtils.withRetry(
+      async () => {
+        attempts++;
+        if (attempts < 2) throw new Error('transient');
+        return 'ok';
+      },
+      3,
+      1,
+    );
+    expect(result).toBe('ok');
+    expect(attempts).toBe(2);
+  });
+});
+
+describe('SmrtError subclassing contract', () => {
+  it('sets name to the concrete subclass constructor name', () => {
+    expect(AIError.providerError('p', 'o').name).toBe('AIError');
+    expect(NetworkError.timeout('u', 1).name).toBe('NetworkError');
+    expect(RuntimeError.operationFailed('o').name).toBe('RuntimeError');
+    expect(ConfigurationError.missingConfiguration('k').name).toBe(
+      'ConfigurationError',
+    );
+    expect(FilesystemError.fileNotFound('p')).toBeInstanceOf(SmrtError);
+  });
+});
+
+describe('ValidationReport', () => {
+  it('starts empty and reports the passing string', () => {
+    const report = new ValidationReport('Product');
+    expect(report.hasErrors()).toBe(false);
+    expect(report.getErrorCount()).toBe(0);
+    expect(report.getErrors()).toEqual([]);
+    expect(report.toString()).toBe('Validation passed for Product');
+    // throwIfErrors is a no-op when empty.
+    expect(() => report.throwIfErrors()).not.toThrow();
+  });
+
+  it('collects errors and renders a numbered failure summary', () => {
+    const report = new ValidationReport('Product');
+    report.addError(ValidationError.requiredField('name', 'Product'));
+    report.addError(ValidationError.rangeError('price', -1, 0));
+
+    expect(report.hasErrors()).toBe(true);
+    expect(report.getErrorCount()).toBe(2);
+
+    const str = report.toString();
+    expect(str).toContain('Validation failed for Product with 2 error(s)');
+    expect(str).toContain('1. ');
+    expect(str).toContain('2. ');
+  });
+
+  it('serializes to JSON with per-error toJSON()', () => {
+    const report = new ValidationReport('Product');
+    report.addError(ValidationError.requiredField('name', 'Product'));
+
+    const json = report.toJSON() as {
+      objectType: string;
+      errorCount: number;
+      errors: Array<{ code: string }>;
+    };
+    expect(json.objectType).toBe('Product');
+    expect(json.errorCount).toBe(1);
+    expect(json.errors[0].code).toBe('VALIDATION_REQUIRED_FIELD');
+  });
+
+  it('throwIfErrors throws the first collected error', () => {
+    const report = new ValidationReport('Product');
+    report.addError(ValidationError.requiredField('name', 'Product'));
+    report.addError(ValidationError.uniqueConstraint('slug', 'x'));
+
+    expect(() => report.throwIfErrors()).toThrow(ValidationError);
+    try {
+      report.throwIfErrors();
+    } catch (err) {
+      expect((err as ValidationError).code).toBe('VALIDATION_REQUIRED_FIELD');
+    }
+  });
+
+  it('clear() empties the report and returns a defensive copy from getErrors()', () => {
+    const report = new ValidationReport('Product');
+    report.addError(ValidationError.requiredField('name', 'Product'));
+
+    const snapshot = report.getErrors();
+    snapshot.push(ValidationError.uniqueConstraint('slug', 'x'));
+    // Mutating the returned array must not affect internal state.
+    expect(report.getErrorCount()).toBe(1);
+
+    report.clear();
+    expect(report.hasErrors()).toBe(false);
+  });
+});
+
+describe('ValidationUtils.validateField', () => {
+  it('flags a missing required value', async () => {
+    const error = await ValidationUtils.validateField('name', '', {
+      required: true,
+    });
+    expect(error?.code).toBe('VALIDATION_REQUIRED_FIELD');
+  });
+
+  it('returns null for a null value that is not required', async () => {
+    expect(await ValidationUtils.validateField('name', null, {})).toBeNull();
+  });
+
+  it('flags numbers below min and above max', async () => {
+    expect(
+      (await ValidationUtils.validateField('n', -1, { min: 0, max: 10 }))?.code,
+    ).toBe('VALIDATION_RANGE_ERROR');
+    expect(
+      (await ValidationUtils.validateField('n', 11, { min: 0, max: 10 }))?.code,
+    ).toBe('VALIDATION_RANGE_ERROR');
+    expect(
+      await ValidationUtils.validateField('n', 5, { min: 0, max: 10 }),
+    ).toBeNull();
+  });
+
+  it('flags strings outside the configured length bounds', async () => {
+    expect(
+      (await ValidationUtils.validateField('s', 'a', { minLength: 2 }))
+        ?.message,
+    ).toContain('minimum length 2');
+    expect(
+      (await ValidationUtils.validateField('s', 'abcd', { maxLength: 3 }))
+        ?.message,
+    ).toContain('maximum length 3');
+  });
+
+  it('validates string patterns from both string and RegExp options', async () => {
+    expect(
+      await ValidationUtils.validateField('hex', 'abc', {
+        pattern: '^[a-f]+$',
+      }),
+    ).toBeNull();
+    expect(
+      (
+        await ValidationUtils.validateField('hex', 'xyz', {
+          pattern: /^[a-f]+$/,
+        })
+      )?.code,
+    ).toBe('VALIDATION_INVALID_VALUE');
+  });
+
+  it('runs a custom validator and reports its failure message', async () => {
+    const ok = await ValidationUtils.validateField('v', 5, {
+      customValidator: (value) => value === 5,
+    });
+    expect(ok).toBeNull();
+
+    const failed = await ValidationUtils.validateField('v', 4, {
+      customValidator: (value) => value === 5,
+      customMessage: 'must equal 5',
+    });
+    expect(failed?.message).toContain('must equal 5');
+  });
+
+  it('catches a throwing custom validator and surfaces the error message', async () => {
+    const error = await ValidationUtils.validateField('v', 4, {
+      customValidator: async () => {
+        throw new Error('validator exploded');
+      },
+    });
+    expect(error?.code).toBe('VALIDATION_INVALID_VALUE');
+    expect(error?.message).toContain('validator exploded');
+  });
+
+  it('catches a custom validator throwing a non-Error', async () => {
+    const error = await ValidationUtils.validateField('v', 4, {
+      customValidator: async () => {
+        throw 'nope';
+      },
+    });
+    expect(error?.message).toContain('nope');
+  });
+});
+
+describe('ValidationUtils synchronous helpers', () => {
+  it('validateRequired flags empty/null/undefined', () => {
+    expect(ValidationUtils.validateRequired('f', '')?.code).toBe(
+      'VALIDATION_REQUIRED_FIELD',
+    );
+    expect(ValidationUtils.validateRequired('f', null)?.code).toBe(
+      'VALIDATION_REQUIRED_FIELD',
+    );
+    expect(ValidationUtils.validateRequired('f', 'value')).toBeNull();
+  });
+
+  it('validateRange enforces both bounds', () => {
+    expect(ValidationUtils.validateRange('n', -1, 0, 10)?.code).toBe(
+      'VALIDATION_RANGE_ERROR',
+    );
+    expect(ValidationUtils.validateRange('n', 11, 0, 10)?.code).toBe(
+      'VALIDATION_RANGE_ERROR',
+    );
+    expect(ValidationUtils.validateRange('n', 5, 0, 10)).toBeNull();
+  });
+
+  it('validateLength enforces min and max', () => {
+    expect(ValidationUtils.validateLength('s', 'a', 2)?.message).toContain(
+      'minimum length 2',
+    );
+    expect(
+      ValidationUtils.validateLength('s', 'abcd', undefined, 3)?.message,
+    ).toContain('maximum length 3');
+    expect(ValidationUtils.validateLength('s', 'ab', 1, 3)).toBeNull();
+  });
+
+  it('validatePattern accepts string and RegExp patterns', () => {
+    expect(ValidationUtils.validatePattern('s', 'abc', '^[a-c]+$')).toBeNull();
+    expect(ValidationUtils.validatePattern('s', 'zzz', /^[a-c]+$/)?.code).toBe(
+      'VALIDATION_INVALID_VALUE',
+    );
+  });
+});

--- a/packages/core/src/generators/cli-commands.spec.ts
+++ b/packages/core/src/generators/cli-commands.spec.ts
@@ -1,0 +1,307 @@
+/**
+ * Coverage for the CLI generator parsing + dispatch surface (#1500).
+ *
+ * cli-hardening.spec covers the security policy (exhaustive include, writable
+ * guard, sensitive redaction, tenancy pass-through). This file fills the
+ * remaining branches: argv parsing forms, help output, the full CRUD verb
+ * dispatch with list flags, custom-action routing (instance + collection),
+ * value coercion, and the `setupCLI` / `getCLIHandler` wrappers.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { SmrtCollection } from '../collection';
+import { field } from '../decorators';
+import { SmrtObject } from '../object';
+import { ObjectRegistry, smrt } from '../registry';
+import { getTestDatabase } from '../testing/database';
+import { CLIGenerator, getCLIHandler, setupCLI } from './cli';
+
+@smrt({ cli: true })
+class CliCmdWidget extends SmrtObject {
+  @field({ type: 'text' })
+  name = '';
+
+  @field({ type: 'integer' })
+  qty = 0;
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+    if (options.qty !== undefined) this.qty = options.qty;
+  }
+
+  // Instance custom action — echoes the options it receives.
+  async describe(options: any = {}): Promise<any> {
+    return { kind: 'instance', name: this.name, options };
+  }
+
+  // Public on the object too (so command exposure passes), but when invoked
+  // without an id the collection's same-named method runs instead.
+  async tally(options: any = {}): Promise<any> {
+    return { kind: 'instance-tally', options };
+  }
+}
+
+class CliCmdWidgetCollection extends SmrtCollection<CliCmdWidget> {
+  static readonly _itemClass = CliCmdWidget;
+
+  // Collection-level custom action (invoked when no id is provided). The CLI
+  // exposure gate validates against the object's methods, so `tally` is also
+  // declared on the object above.
+  async tally(options: any = {}): Promise<any> {
+    return { kind: 'collection', options };
+  }
+}
+
+function captureLog<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; out: string }> {
+  const logs: string[] = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => {
+    logs.push(args.map(String).join(' '));
+  };
+  return fn()
+    .then((result) => ({ result, out: logs.join('\n') }))
+    .finally(() => {
+      console.log = original;
+    });
+}
+
+describe('CLI generator parsing + dispatch (#1500)', () => {
+  ObjectRegistry.registerCollection('CliCmdWidget', CliCmdWidgetCollection);
+
+  let db: any;
+
+  beforeAll(async () => {
+    db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['CliCmdWidget'],
+    });
+  });
+
+  afterAll(async () => {
+    await db?.close?.();
+  });
+
+  describe('help + empty input', () => {
+    it('prints help for no args', async () => {
+      const gen = new CLIGenerator();
+      const { out } = await captureLog(() => gen.run([]));
+      expect(out).toContain('Usage:');
+      expect(out).toContain('Commands:');
+      // Generated default name/version appear in the header.
+      expect(out).toContain('smrt-cli');
+    });
+
+    it('prints help for the --help flag', async () => {
+      const gen = new CLIGenerator();
+      const { out } = await captureLog(() => gen.run(['--help']));
+      expect(out).toContain('Global flags:');
+    });
+
+    it('prints help when the command starts with a dash', async () => {
+      const gen = new CLIGenerator();
+      const { out } = await captureLog(() => gen.run(['--limit', '5']));
+      expect(out).toContain('Usage:');
+    });
+
+    it('prints help for a bare object name with no action', async () => {
+      const gen = new CLIGenerator();
+      const { out } = await captureLog(() => gen.run(['clicmdwidget']));
+      expect(out).toContain('Usage:');
+    });
+
+    it('lists the generated CRUD commands for the object', async () => {
+      const gen = new CLIGenerator();
+      const commands = await gen.listCommands();
+      expect(commands).toContain('clicmdwidget:list');
+      expect(commands).toContain('clicmdwidget:create');
+      expect(commands).toContain('clicmdwidget:describe');
+    });
+  });
+
+  describe('unknown commands', () => {
+    it('throws for an unknown object type', async () => {
+      const gen = new CLIGenerator();
+      await expect(gen.run(['nosuchobject:list'])).rejects.toThrow(
+        /not found/i,
+      );
+    });
+
+    it('throws for an unknown custom method', async () => {
+      const gen = new CLIGenerator({}, { db });
+      await expect(
+        gen.run(['clicmdwidget:noSuchMethod', 'id1']),
+      ).rejects.toThrow(/unknown command/i);
+    });
+  });
+
+  describe('CRUD dispatch', () => {
+    it('creates via the name:action form and parses --key=value', async () => {
+      const collection = await CliCmdWidgetCollection.create({ db });
+      const gen = new CLIGenerator({}, { db });
+
+      // `name action` (space) command form + `--key=value` flag form.
+      await gen.run(['clicmdwidget', 'create', '--name=Spaced', '--qty=7']);
+
+      const rows = await collection.list({ where: { name: 'Spaced' } });
+      expect(rows).toHaveLength(1);
+      expect((rows[0] as CliCmdWidget).qty).toBe(7);
+    });
+
+    it('gets an object by positional id and prints it', async () => {
+      const collection = await CliCmdWidgetCollection.create({ db });
+      const created = await collection.create({ name: 'Gettable', qty: 1 });
+      await created.save();
+      const gen = new CLIGenerator({}, { db });
+
+      const { out } = await captureLog(() =>
+        gen.run(['clicmdwidget:get', created.id as string]),
+      );
+      expect(out).toContain('Gettable');
+    });
+
+    it('throws when get is missing an id', async () => {
+      const gen = new CLIGenerator({}, { db });
+      await expect(gen.run(['clicmdwidget:get'])).rejects.toThrow(
+        /id is required/i,
+      );
+    });
+
+    it('throws a not-found for get on a missing id', async () => {
+      const gen = new CLIGenerator({}, { db });
+      await expect(gen.run(['clicmdwidget:get', 'missing-id'])).rejects.toThrow(
+        /not found/i,
+      );
+    });
+
+    it('updates an object and merges new field values', async () => {
+      const collection = await CliCmdWidgetCollection.create({ db });
+      const created = await collection.create({ name: 'Updatable', qty: 1 });
+      await created.save();
+      const gen = new CLIGenerator({}, { db });
+
+      await gen.run([
+        'clicmdwidget:update',
+        created.id as string,
+        '--qty',
+        '99',
+      ]);
+
+      const reread = await collection.get(created.id as string);
+      expect((reread as CliCmdWidget).qty).toBe(99);
+    });
+
+    it('throws when update is missing an id', async () => {
+      const gen = new CLIGenerator({}, { db });
+      await expect(
+        gen.run(['clicmdwidget:update', '--qty', '1']),
+      ).rejects.toThrow(/id is required/i);
+    });
+
+    it('deletes an object and returns a success payload', async () => {
+      const collection = await CliCmdWidgetCollection.create({ db });
+      const created = await collection.create({ name: 'Deletable', qty: 1 });
+      await created.save();
+      const gen = new CLIGenerator({}, { db });
+
+      const { out } = await captureLog(() =>
+        gen.run(['clicmdwidget:delete', created.id as string]),
+      );
+      expect(out).toContain('deleted');
+      expect(await collection.get(created.id as string)).toBeNull();
+    });
+
+    it('throws when delete is missing an id', async () => {
+      const gen = new CLIGenerator({}, { db });
+      await expect(gen.run(['clicmdwidget:delete'])).rejects.toThrow(
+        /id is required/i,
+      );
+    });
+
+    it('lists with --where, --limit, --offset, and --order-by', async () => {
+      const collection = await CliCmdWidgetCollection.create({ db });
+      for (const [name, qty] of [
+        ['List-A', 1],
+        ['List-B', 2],
+      ] as const) {
+        const o = await collection.create({ name, qty });
+        await o.save();
+      }
+      const gen = new CLIGenerator({}, { db });
+
+      const { out } = await captureLog(() =>
+        gen.run([
+          'clicmdwidget:list',
+          '--where',
+          JSON.stringify({ name: 'List-B' }),
+          '--limit',
+          '10',
+          '--offset',
+          '0',
+          '--order-by',
+          'qty DESC',
+        ]),
+      );
+      expect(out).toContain('List-B');
+      expect(out).not.toContain('List-A');
+    });
+  });
+
+  describe('custom action dispatch', () => {
+    it('runs an instance custom action with coerced options', async () => {
+      const collection = await CliCmdWidgetCollection.create({ db });
+      const created = await collection.create({ name: 'ActionTarget', qty: 1 });
+      await created.save();
+      const gen = new CLIGenerator({}, { db });
+
+      // Coercion: --count 3 → number, --flag → boolean true, JSON object value.
+      const { out } = await captureLog(() =>
+        gen.run([
+          'clicmdwidget:describe',
+          created.id as string,
+          '--count',
+          '3',
+          '--flag',
+          '--payload',
+          '{"a":1}',
+        ]),
+      );
+      expect(out).toContain('"kind": "instance"');
+      expect(out).toContain('"count": 3');
+      expect(out).toContain('"flag": true');
+      // JSON-object flag value was parsed into an object, not left a string.
+      expect(out).toContain('"a": 1');
+    });
+
+    it('runs a collection-level custom action when no id is given', async () => {
+      const gen = new CLIGenerator({}, { db });
+      const { out } = await captureLog(() =>
+        gen.run(['clicmdwidget:tally', '--scope', 'all']),
+      );
+      expect(out).toContain('"kind": "collection"');
+      expect(out).toContain('"scope": "all"');
+    });
+  });
+
+  describe('setupCLI / getCLIHandler wrappers', () => {
+    it('setupCLI().run strips the leading node + script argv entries', async () => {
+      const { run, generator } = setupCLI({}, { db });
+      expect(generator).toBeInstanceOf(CLIGenerator);
+      const { out } = await captureLog(() =>
+        run(['node', 'script.js', 'clicmdwidget:list', '--limit', '1']),
+      );
+      // Runs without throwing and prints a JSON array result.
+      expect(out.startsWith('[') || out === '').toBe(true);
+    });
+
+    it('getCLIHandler returns a runnable argv handler', async () => {
+      const handler = getCLIHandler({}, { db });
+      const { out } = await captureLog(() => handler(['--help']));
+      expect(out).toContain('Usage:');
+    });
+  });
+});

--- a/packages/core/src/generators/mcp-schemas.spec.ts
+++ b/packages/core/src/generators/mcp-schemas.spec.ts
@@ -1,0 +1,285 @@
+/**
+ * Coverage for MCP generator tool input-schemas and metadata (#1500).
+ *
+ * The existing mcp-protocol/integration/examples suites cover tool dispatch and
+ * server-code generation. This file asserts the produced tool *input schemas*
+ * for every field type (the fieldToMCPSchema branches), the create/update tool
+ * shapes (properties + required), the server-info/getter accessors, and the
+ * `public` / `public: 'read'` tool-auth branches that let unauthenticated reads
+ * and writes through.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { SmrtCollection } from '../collection';
+import { field } from '../decorators';
+import { SmrtObject } from '../object';
+import { ObjectRegistry, smrt } from '../registry';
+import { getTestDatabase } from '../testing/database';
+import { MCPGenerator } from './mcp';
+
+// One field of each supported type so every fieldToMCPSchema branch is hit.
+@smrt({ mcp: { include: ['list', 'get', 'create', 'update', 'delete'] } })
+class McpSchemaWidget extends SmrtObject {
+  @field({ type: 'text', required: true, maxLength: 50, minLength: 3 })
+  title = '';
+
+  @field({ type: 'integer', min: 0, max: 10, default: 1 })
+  count = 0;
+
+  @field({ type: 'decimal', min: 0.5, max: 99.5 })
+  rating = 0.0;
+
+  @field({ type: 'boolean' })
+  active = false;
+
+  @field({ type: 'datetime', nullable: true })
+  startsAt: string | null = null;
+
+  @field({ type: 'json' })
+  payload: Record<string, any> = {};
+
+  constructor(options: any = {}) {
+    super(options);
+    const { db, ai, fs, ...safe } = options;
+    Object.assign(this, safe);
+  }
+}
+
+class McpSchemaWidgetCollection extends SmrtCollection<McpSchemaWidget> {
+  static readonly _itemClass = McpSchemaWidget;
+}
+
+describe('MCP tool input schemas (#1500)', () => {
+  ObjectRegistry.registerCollection(
+    'McpSchemaWidget',
+    McpSchemaWidgetCollection,
+  );
+
+  let tools: Awaited<ReturnType<MCPGenerator['generateTools']>>;
+
+  beforeAll(async () => {
+    const generator = new MCPGenerator();
+    tools = await generator.generateTools();
+  });
+
+  const tool = (name: string) => tools.find((t) => t.name === name);
+
+  it('emits the five CRUD tools for the object', () => {
+    for (const verb of ['list', 'get', 'create', 'update', 'delete']) {
+      expect(tool(`mcpschemawidget_${verb}`)).toBeDefined();
+    }
+  });
+
+  it('builds the list tool with pagination + where properties', () => {
+    const list = tool('mcpschemawidget_list');
+    const props = list?.inputSchema.properties as Record<string, any>;
+    expect(props.limit.type).toBe('integer');
+    expect(props.limit.default).toBe(50);
+    expect(props.offset.type).toBe('integer');
+    expect(props.orderBy.type).toBe('string');
+    expect(props.where.additionalProperties).toBe(true);
+  });
+
+  it('marks id (not slug) as required on the get tool', () => {
+    const get = tool('mcpschemawidget_get');
+    expect(get?.inputSchema.required).toEqual(['id']);
+    const props = get?.inputSchema.properties as Record<string, any>;
+    expect(props.id.type).toBe('string');
+    expect(props.slug.type).toBe('string');
+  });
+
+  it('maps every field type in the create tool schema', () => {
+    const create = tool('mcpschemawidget_create');
+    const props = create?.inputSchema.properties as Record<string, any>;
+
+    // text with length constraints
+    expect(props.title.type).toBe('string');
+    expect(props.title.maxLength).toBe(50);
+    expect(props.title.minLength).toBe(3);
+
+    // integer with min/max + default
+    expect(props.count.type).toBe('integer');
+    expect(props.count.minimum).toBe(0);
+    expect(props.count.maximum).toBe(10);
+    expect(props.count.default).toBe(1);
+
+    // decimal → number with min/max
+    expect(props.rating.type).toBe('number');
+    expect(props.rating.minimum).toBe(0.5);
+    expect(props.rating.maximum).toBe(99.5);
+
+    // boolean
+    expect(props.active.type).toBe('boolean');
+
+    // datetime → string/date-time
+    expect(props.startsAt.type).toBe('string');
+    expect(props.startsAt.format).toBe('date-time');
+
+    // json → object
+    expect(props.payload.type).toBe('object');
+
+    // required-field propagation onto the create schema.
+    expect(create?.inputSchema.required).toContain('title');
+  });
+
+  it('includes id plus all fields on the update tool, requiring id', () => {
+    const update = tool('mcpschemawidget_update');
+    const props = update?.inputSchema.properties as Record<string, any>;
+    expect(props.id.type).toBe('string');
+    expect(props.title).toBeDefined();
+    expect(props.count).toBeDefined();
+    expect(update?.inputSchema.required).toEqual(['id']);
+  });
+
+  it('requires id on the delete tool', () => {
+    const del = tool('mcpschemawidget_delete');
+    expect(del?.inputSchema.required).toEqual(['id']);
+  });
+});
+
+// foreignKey field is split out so its `ID of related ...` description renders.
+@smrt({ mcp: { include: ['create'] } })
+class McpFkWidget extends SmrtObject {
+  @field({ type: 'foreignKey', related: 'Author' })
+  authorId = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    const { db, ai, fs, ...safe } = options;
+    Object.assign(this, safe);
+  }
+}
+
+describe('MCP foreignKey field schema (#1500)', () => {
+  it('renders a foreignKey field as a string with a related-id description', async () => {
+    const generator = new MCPGenerator();
+    const tools = await generator.generateTools();
+    const create = tools.find((t) => t.name === 'mcpfkwidget_create');
+    const props = create?.inputSchema.properties as Record<string, any>;
+    expect(props.authorId.type).toBe('string');
+    expect(props.authorId.description).toContain('ID of related');
+  });
+});
+
+describe('MCP generator metadata accessors (#1500)', () => {
+  it('exposes name/version getters and a default server info', () => {
+    const generator = new MCPGenerator({
+      name: 'meta-server',
+      version: '2.3.4',
+      description: 'a description',
+    });
+    expect(generator.name).toBe('meta-server');
+    expect(generator.version).toBe('2.3.4');
+
+    const info = generator.getServerInfo();
+    // server.* defaults are filled in by the constructor.
+    expect(info.name).toBe('smrt-mcp');
+    expect(info.version).toBe('1.0.0');
+    expect(info.description).toBe('a description');
+  });
+
+  it('uses the configured server.name/version in server info', () => {
+    const generator = new MCPGenerator({
+      server: { name: 'custom-srv', version: '7.0.0' },
+    });
+    const info = generator.getServerInfo();
+    expect(info.name).toBe('custom-srv');
+    expect(info.version).toBe('7.0.0');
+  });
+});
+
+// public:true and public:'read' objects to cover requireToolAuth allow-paths
+// without an authenticated context.
+@smrt({ mcp: { include: ['list', 'get', 'create'] }, api: { public: true } })
+class McpPublicWidget extends SmrtObject {
+  @field({ type: 'text' })
+  name = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+  }
+}
+
+class McpPublicWidgetCollection extends SmrtCollection<McpPublicWidget> {
+  static readonly _itemClass = McpPublicWidget;
+}
+
+@smrt({
+  mcp: { include: ['list', 'get', 'create'] },
+  api: { public: 'read' },
+})
+class McpReadPublicWidget extends SmrtObject {
+  @field({ type: 'text' })
+  name = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+  }
+}
+
+class McpReadPublicWidgetCollection extends SmrtCollection<McpReadPublicWidget> {
+  static readonly _itemClass = McpReadPublicWidget;
+}
+
+describe('MCP tool-auth public branches (#1540)', () => {
+  ObjectRegistry.registerCollection(
+    'McpPublicWidget',
+    McpPublicWidgetCollection,
+  );
+  ObjectRegistry.registerCollection(
+    'McpReadPublicWidget',
+    McpReadPublicWidgetCollection,
+  );
+
+  let db: any;
+
+  beforeAll(async () => {
+    db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['McpPublicWidget', 'McpReadPublicWidget'],
+    });
+  });
+
+  afterAll(async () => {
+    await db?.close?.();
+  });
+
+  it('public:true lets an unauthenticated create through', async () => {
+    // No context.user — requireToolAuth must allow because public === true.
+    const generator = new MCPGenerator({}, { db });
+    const res = await generator.handleToolCall({
+      method: 'tools/call',
+      params: {
+        name: 'mcppublicwidget_create',
+        arguments: { name: 'PublicCreated' },
+      },
+    });
+    const payload = JSON.parse(res.content[0].text);
+    expect(payload.name).toBe('PublicCreated');
+  });
+
+  it("public:'read' allows an unauthenticated list but blocks create", async () => {
+    const generator = new MCPGenerator({}, { db });
+
+    const listRes = await generator.handleToolCall({
+      method: 'tools/call',
+      params: { name: 'mcpreadpublicwidget_list', arguments: {} },
+    });
+    // A successful list returns a data/meta envelope, not an error string.
+    expect(listRes.content[0].text).toContain('"data"');
+
+    const createRes = await generator.handleToolCall({
+      method: 'tools/call',
+      params: {
+        name: 'mcpreadpublicwidget_create',
+        arguments: { name: 'nope' },
+      },
+    });
+    // Mutating tool with no principal on a read-only-public object fails closed.
+    expect(createRes.content[0].text).toContain('Authentication required');
+  });
+});

--- a/packages/core/src/generators/rest-routes.spec.ts
+++ b/packages/core/src/generators/rest-routes.spec.ts
@@ -1,0 +1,704 @@
+/**
+ * Coverage for the REST API generator route map and request handling (#1500).
+ *
+ * These tests drive `APIGenerator.generateHandler()` with `Request` objects and
+ * assert the produced `Response` artifacts — CRUD routing, include/exclude
+ * action gating, REST query-operator translation, the count endpoint, the
+ * mass-assignment writable policy, auth middleware, the fail-closed posture, and
+ * the explicit-allowlist CORS behavior (#1540). No real HTTP server is bound;
+ * the handler is exercised directly, mirroring `issue-1540-rest-writable.spec`.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { SmrtCollection } from '../collection';
+import { field } from '../decorators';
+import { SmrtObject } from '../object';
+import { ObjectRegistry, smrt } from '../registry';
+import { getTestDatabase } from '../testing/database';
+import { APIGenerator } from './rest';
+
+// Full-CRUD, public object so route dispatch is isolated from the auth gate.
+@smrt({ api: { public: true } })
+class RestRouteWidget extends SmrtObject {
+  @field({ type: 'text' })
+  name: string = '';
+
+  @field({ type: 'integer' })
+  price: number = 0;
+
+  @field({ type: 'text', readonly: true })
+  internalCode: string = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+    if (options.price !== undefined) this.price = options.price;
+    if (options.internalCode !== undefined)
+      this.internalCode = options.internalCode;
+  }
+}
+
+class RestRouteWidgetCollection extends SmrtCollection<RestRouteWidget> {
+  static readonly _itemClass = RestRouteWidget;
+}
+
+// Object exposing only list/get — create/update/delete must be 405.
+@smrt({ api: { include: ['list', 'get'], public: true } })
+class RestReadOnlyWidget extends SmrtObject {
+  @field({ type: 'text' })
+  name: string = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+  }
+}
+
+class RestReadOnlyWidgetCollection extends SmrtCollection<RestReadOnlyWidget> {
+  static readonly _itemClass = RestReadOnlyWidget;
+}
+
+// Object with an explicit exclude list — delete must be blocked (405).
+@smrt({ api: { exclude: ['delete'], public: true } })
+class RestExcludeWidget extends SmrtObject {
+  @field({ type: 'text' })
+  name: string = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+  }
+}
+
+class RestExcludeWidgetCollection extends SmrtCollection<RestExcludeWidget> {
+  static readonly _itemClass = RestExcludeWidget;
+}
+
+describe('REST generator route map (#1500)', () => {
+  ObjectRegistry.registerCollection(
+    'RestRouteWidget',
+    RestRouteWidgetCollection,
+  );
+  ObjectRegistry.registerCollection(
+    'RestReadOnlyWidget',
+    RestReadOnlyWidgetCollection,
+  );
+  ObjectRegistry.registerCollection(
+    'RestExcludeWidget',
+    RestExcludeWidgetCollection,
+  );
+
+  let db: any;
+  let handler: (req: Request) => Promise<Response>;
+  let collection: RestRouteWidgetCollection;
+
+  beforeAll(async () => {
+    db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['RestRouteWidget', 'RestReadOnlyWidget', 'RestExcludeWidget'],
+    });
+    collection = await RestRouteWidgetCollection.create({ db });
+
+    const api = new APIGenerator({ basePath: '/api/v1' });
+    api.registerCollection('restroutewidgets', collection);
+    handler = api.generateHandler();
+  });
+
+  afterAll(async () => {
+    await db?.close?.();
+  });
+
+  const post = (body: Record<string, any>) =>
+    handler(
+      new Request('http://local/api/v1/restroutewidgets', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      }),
+    );
+
+  describe('full CRUD lifecycle', () => {
+    let createdId: string;
+
+    it('POST creates and returns 201 with the public payload', async () => {
+      const res = await post({ name: 'Alpha', price: 10, internalCode: 'X' });
+      expect(res.status).toBe(201);
+      const json = (await res.json()) as any;
+      expect(json.name).toBe('Alpha');
+      // readonly field stripped by the writable policy.
+      expect(json.internalCode).toBe('');
+      createdId = json.id;
+      expect(createdId).toBeTruthy();
+    });
+
+    it('GET /:id returns the object', async () => {
+      const res = await handler(
+        new Request(`http://local/api/v1/restroutewidgets/${createdId}`),
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as any;
+      expect(json.id).toBe(createdId);
+      expect(json.name).toBe('Alpha');
+    });
+
+    it('GET /:id returns 404 for a missing id', async () => {
+      const res = await handler(
+        new Request('http://local/api/v1/restroutewidgets/does-not-exist'),
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it('GET list returns an array', async () => {
+      const res = await handler(
+        new Request('http://local/api/v1/restroutewidgets'),
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as any[];
+      expect(Array.isArray(json)).toBe(true);
+      expect(json.some((o) => o.id === createdId)).toBe(true);
+    });
+
+    it('PUT /:id updates the object', async () => {
+      const res = await handler(
+        new Request(`http://local/api/v1/restroutewidgets/${createdId}`, {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ name: 'Alpha-2' }),
+        }),
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as any;
+      expect(json.name).toBe('Alpha-2');
+    });
+
+    it('PATCH /:id updates the object', async () => {
+      const res = await handler(
+        new Request(`http://local/api/v1/restroutewidgets/${createdId}`, {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ price: 42 }),
+        }),
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as any;
+      expect(json.price).toBe(42);
+    });
+
+    it('PUT without an id returns 400', async () => {
+      const res = await handler(
+        new Request('http://local/api/v1/restroutewidgets', {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ name: 'no-id' }),
+        }),
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('PUT /:id returns 404 for a missing object', async () => {
+      const res = await handler(
+        new Request('http://local/api/v1/restroutewidgets/missing', {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ name: 'nope' }),
+        }),
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it('DELETE /:id removes the object and returns 204', async () => {
+      const res = await handler(
+        new Request(`http://local/api/v1/restroutewidgets/${createdId}`, {
+          method: 'DELETE',
+        }),
+      );
+      expect(res.status).toBe(204);
+
+      const after = await handler(
+        new Request(`http://local/api/v1/restroutewidgets/${createdId}`),
+      );
+      expect(after.status).toBe(404);
+    });
+
+    it('DELETE without an id returns 400', async () => {
+      const res = await handler(
+        new Request('http://local/api/v1/restroutewidgets', {
+          method: 'DELETE',
+        }),
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('DELETE /:id returns 404 for a missing object', async () => {
+      const res = await handler(
+        new Request('http://local/api/v1/restroutewidgets/missing', {
+          method: 'DELETE',
+        }),
+      );
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('list filtering and count', () => {
+    beforeAll(async () => {
+      for (const [name, price] of [
+        ['Filter-A', 5],
+        ['Filter-B', 15],
+        ['Filter-C', 25],
+      ] as const) {
+        const r = await post({ name, price });
+        expect(r.status).toBe(201);
+      }
+    });
+
+    it('translates the gt REST operator into a SQL filter', async () => {
+      const res = await handler(
+        new Request(
+          'http://local/api/v1/restroutewidgets?price[gt]=10&orderBy=price ASC',
+        ),
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as any[];
+      const names = json.map((o) => o.name);
+      expect(names).toContain('Filter-B');
+      expect(names).toContain('Filter-C');
+      expect(names).not.toContain('Filter-A');
+    });
+
+    it('translates the in REST operator into an array filter', async () => {
+      const res = await handler(
+        new Request(
+          'http://local/api/v1/restroutewidgets?name[in]=Filter-A,Filter-C',
+        ),
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as any[];
+      const names = json.map((o) => o.name).sort();
+      expect(names).toEqual(['Filter-A', 'Filter-C']);
+    });
+
+    it('honors limit + offset on list', async () => {
+      const res = await handler(
+        new Request('http://local/api/v1/restroutewidgets?limit=2&offset=0'),
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as any[];
+      expect(json.length).toBeLessThanOrEqual(2);
+    });
+
+    it('GET /count returns a count, honoring REST operators', async () => {
+      const all = await handler(
+        new Request('http://local/api/v1/restroutewidgets/count'),
+      );
+      expect(all.status).toBe(200);
+      const allJson = (await all.json()) as { count: number };
+      expect(typeof allJson.count).toBe('number');
+
+      const filtered = await handler(
+        new Request('http://local/api/v1/restroutewidgets/count?price[gte]=15'),
+      );
+      const filteredJson = (await filtered.json()) as { count: number };
+      expect(filteredJson.count).toBeGreaterThanOrEqual(2);
+      expect(filteredJson.count).toBeLessThan(allJson.count);
+    });
+  });
+
+  describe('action gating via @smrt({ api })', () => {
+    let readOnlyHandler: (req: Request) => Promise<Response>;
+    let excludeHandler: (req: Request) => Promise<Response>;
+
+    beforeAll(async () => {
+      const roCollection = await RestReadOnlyWidgetCollection.create({ db });
+      const roApi = new APIGenerator({ basePath: '/api/v1' });
+      roApi.registerCollection('restreadonlywidgets', roCollection);
+      readOnlyHandler = roApi.generateHandler();
+
+      const exCollection = await RestExcludeWidgetCollection.create({ db });
+      const exApi = new APIGenerator({ basePath: '/api/v1' });
+      exApi.registerCollection('restexcludewidgets', exCollection);
+      excludeHandler = exApi.generateHandler();
+    });
+
+    it('returns 405 for create when include omits it', async () => {
+      const res = await readOnlyHandler(
+        new Request('http://local/api/v1/restreadonlywidgets', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ name: 'blocked' }),
+        }),
+      );
+      expect(res.status).toBe(405);
+    });
+
+    it('allows list when include names it', async () => {
+      const res = await readOnlyHandler(
+        new Request('http://local/api/v1/restreadonlywidgets'),
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 405 for delete when exclude lists it', async () => {
+      const res = await excludeHandler(
+        new Request('http://local/api/v1/restexcludewidgets/some-id', {
+          method: 'DELETE',
+        }),
+      );
+      expect(res.status).toBe(405);
+    });
+  });
+
+  describe('routing edge cases', () => {
+    it('returns 400 when no object type is given', async () => {
+      const res = await handler(new Request('http://local/api/v1/'));
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 404 for an out-of-basePath path', async () => {
+      const res = await handler(new Request('http://local/totally/elsewhere'));
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 404 for an unknown object type', async () => {
+      const res = await handler(
+        new Request('http://local/api/v1/nonexistentthings'),
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 405 for an unsupported HTTP method', async () => {
+      const res = await handler(
+        new Request('http://local/api/v1/restroutewidgets', {
+          method: 'OPTIONS',
+        }),
+      );
+      // CORS is disabled by default, so OPTIONS falls through to the object
+      // router, which has no handler for it → 405.
+      expect(res.status).toBe(405);
+    });
+  });
+});
+
+// Object whose URL is resolved through auto-discovery (no explicit
+// api.registerCollection) — exercises the ObjectRegistry fallback + pluralize.
+@smrt({ api: { public: true } })
+class RestDiscoveryWidget extends SmrtObject {
+  @field({ type: 'text' })
+  name: string = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+  }
+}
+
+class RestDiscoveryWidgetCollection extends SmrtCollection<RestDiscoveryWidget> {
+  static readonly _itemClass = RestDiscoveryWidget;
+}
+
+// Non-public object resolved via auto-discovery — with no auth middleware the
+// fail-closed gate must 401 (covers the discovery-path isRoutePublic branch).
+@smrt({ api: { include: ['list', 'get'] } })
+class RestDiscoveryPrivate extends SmrtObject {
+  @field({ type: 'text' })
+  name: string = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+  }
+}
+
+class RestDiscoveryPrivateCollection extends SmrtCollection<RestDiscoveryPrivate> {
+  static readonly _itemClass = RestDiscoveryPrivate;
+}
+
+describe('REST generator auto-discovery (#1500)', () => {
+  ObjectRegistry.registerCollection(
+    'RestDiscoveryWidget',
+    RestDiscoveryWidgetCollection,
+  );
+  ObjectRegistry.registerCollection(
+    'RestDiscoveryPrivate',
+    RestDiscoveryPrivateCollection,
+  );
+
+  let db: any;
+  let handler: (req: Request) => Promise<Response>;
+
+  beforeAll(async () => {
+    db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['RestDiscoveryWidget', 'RestDiscoveryPrivate'],
+    });
+    // No api.registerCollection — the generator must resolve the class from the
+    // ObjectRegistry by pluralized name and build the collection itself.
+    const api = new APIGenerator({ basePath: '/api/v1' }, { db });
+    handler = api.generateHandler();
+  });
+
+  afterAll(async () => {
+    await db?.close?.();
+  });
+
+  it('resolves a registered class through the registry fallback (no 404)', async () => {
+    // The discovery matcher pluralizes BOTH sides, so the registered simple
+    // name `RestDiscoveryWidget` is matched by its singular URL segment. This
+    // exercises the whole ObjectRegistry fallback path (class lookup + auth gate
+    // + getCollection factory). The generator builds the auto-discovered
+    // collection but does not call initialize() on it, so list() surfaces a 500
+    // rather than a 200 — the resolution branch is what we assert here (it is
+    // NOT a 404 "object type not found").
+    const res = await handler(
+      new Request('http://local/api/v1/restdiscoverywidget'),
+    );
+    expect(res.status).not.toBe(404);
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 404 through the discovery path for an unknown type', async () => {
+    const res = await handler(
+      new Request('http://local/api/v1/unknowndiscoverywidgets'),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('fail-closes a non-public discovered object with no auth middleware', async () => {
+    // public is not set → isRoutePublic returns false → 401 on the discovery
+    // path (no api.registerCollection, no authMiddleware).
+    const api = new APIGenerator({ basePath: '/api/v1' }, { db });
+    const h = api.generateHandler();
+    const res = await h(
+      new Request('http://local/api/v1/restdiscoveryprivate'),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('applies auth middleware on the auto-discovery path', async () => {
+    // No api.registerCollection → discovery path; the middleware short-circuits
+    // with a Response before any collection work, covering lines 271-285.
+    const api = new APIGenerator(
+      {
+        basePath: '/api/v1',
+        authMiddleware: () => async () =>
+          new Response('denied', { status: 401 }),
+      },
+      { db },
+    );
+    const denyHandler = api.generateHandler();
+    const res = await denyHandler(
+      new Request('http://local/api/v1/restdiscoverywidget'),
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+// Auth-middleware + CORS behavior. Uses a non-public object so the middleware
+// is the only thing standing between the request and the handler.
+@smrt({ api: { include: ['list', 'get', 'create'] } })
+class RestAuthWidget extends SmrtObject {
+  @field({ type: 'text' })
+  name: string = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+  }
+}
+
+class RestAuthWidgetCollection extends SmrtCollection<RestAuthWidget> {
+  static readonly _itemClass = RestAuthWidget;
+}
+
+// api:false — every action is disabled by isApiActionEnabled (405).
+@smrt({ api: false })
+class RestApiFalseWidget extends SmrtObject {
+  @field({ type: 'text' })
+  name: string = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+  }
+}
+
+class RestApiFalseWidgetCollection extends SmrtCollection<RestApiFalseWidget> {
+  static readonly _itemClass = RestApiFalseWidget;
+}
+
+describe('REST generator auth middleware + CORS (#1500/#1540)', () => {
+  ObjectRegistry.registerCollection('RestAuthWidget', RestAuthWidgetCollection);
+  ObjectRegistry.registerCollection(
+    'RestApiFalseWidget',
+    RestApiFalseWidgetCollection,
+  );
+
+  let db: any;
+
+  beforeAll(async () => {
+    db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['RestAuthWidget', 'RestApiFalseWidget'],
+    });
+  });
+
+  afterAll(async () => {
+    await db?.close?.();
+  });
+
+  it('rejects the request when auth middleware returns a Response', async () => {
+    const collection = await RestAuthWidgetCollection.create({ db });
+    const api = new APIGenerator({
+      basePath: '/api/v1',
+      authMiddleware: () => async () =>
+        new Response('forbidden', { status: 403 }),
+    });
+    api.registerCollection('restauthwidgets', collection);
+    const handler = api.generateHandler();
+
+    const res = await handler(
+      new Request('http://local/api/v1/restauthwidgets'),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('passes through when auth middleware returns the request', async () => {
+    const collection = await RestAuthWidgetCollection.create({ db });
+    const api = new APIGenerator({
+      basePath: '/api/v1',
+      authMiddleware: () => async (req) => req,
+    });
+    api.registerCollection('restauthwidgets', collection);
+    const handler = api.generateHandler();
+
+    const res = await handler(
+      new Request('http://local/api/v1/restauthwidgets'),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('echoes an allowlisted Origin on a CORS preflight and on responses', async () => {
+    const collection = await RestAuthWidgetCollection.create({ db });
+    const api = new APIGenerator({
+      basePath: '/api/v1',
+      enableCors: true,
+      allowedOrigins: ['https://allowed.example'],
+      authMiddleware: () => async (req) => req,
+    });
+    api.registerCollection('restauthwidgets', collection);
+    const handler = api.generateHandler();
+
+    // Preflight from an allowed origin echoes that origin (never `*`).
+    const preflight = await handler(
+      new Request('http://local/api/v1/restauthwidgets', {
+        method: 'OPTIONS',
+        headers: { origin: 'https://allowed.example' },
+      }),
+    );
+    expect(preflight.status).toBe(200);
+    expect(preflight.headers.get('access-control-allow-origin')).toBe(
+      'https://allowed.example',
+    );
+    expect(preflight.headers.get('vary')).toBe('Origin');
+
+    // Actual GET response also carries the echoed origin.
+    const res = await handler(
+      new Request('http://local/api/v1/restauthwidgets', {
+        headers: { origin: 'https://allowed.example' },
+      }),
+    );
+    expect(res.headers.get('access-control-allow-origin')).toBe(
+      'https://allowed.example',
+    );
+  });
+
+  it('omits CORS headers for a non-allowlisted Origin', async () => {
+    const collection = await RestAuthWidgetCollection.create({ db });
+    const api = new APIGenerator({
+      basePath: '/api/v1',
+      enableCors: true,
+      allowedOrigins: ['https://allowed.example'],
+      authMiddleware: () => async (req) => req,
+    });
+    api.registerCollection('restauthwidgets', collection);
+    const handler = api.generateHandler();
+
+    const preflight = await handler(
+      new Request('http://local/api/v1/restauthwidgets', {
+        method: 'OPTIONS',
+        headers: { origin: 'https://evil.example' },
+      }),
+    );
+    expect(preflight.status).toBe(200);
+    expect(preflight.headers.get('access-control-allow-origin')).toBeNull();
+
+    const res = await handler(
+      new Request('http://local/api/v1/restauthwidgets', {
+        headers: { origin: 'https://evil.example' },
+      }),
+    );
+    expect(res.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
+  it('returns 405 for an api:false object that passes auth middleware', async () => {
+    // api:false makes isApiActionEnabled() return false → 405, but only once the
+    // request is past the auth gate (covers the isApiActionEnabled false branch).
+    const collection = await RestApiFalseWidgetCollection.create({ db });
+    const api = new APIGenerator({
+      basePath: '/api/v1',
+      authMiddleware: () => async (req) => req,
+    });
+    api.registerCollection('restapifalsewidgets', collection);
+    const handler = api.generateHandler();
+
+    const res = await handler(
+      new Request('http://local/api/v1/restapifalsewidgets'),
+    );
+    expect(res.status).toBe(405);
+  });
+
+  it('treats a non-object JSON create body as empty (no fields set)', async () => {
+    const collection = await RestAuthWidgetCollection.create({ db });
+    const api = new APIGenerator({
+      basePath: '/api/v1',
+      authMiddleware: () => async (req) => req,
+    });
+    api.registerCollection('restauthwidgets', collection);
+    const handler = api.generateHandler();
+
+    // A JSON primitive (not an object) → applyWritablePolicy returns {}.
+    const res = await handler(
+      new Request('http://local/api/v1/restauthwidgets', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify('just-a-string'),
+      }),
+    );
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as any;
+    expect(json.name).toBe('');
+  });
+
+  it('dispatches a configured custom route', async () => {
+    const collection = await RestAuthWidgetCollection.create({ db });
+    const api = new APIGenerator({
+      basePath: '/api/v1',
+      customRoutes: {
+        '/ping': async () =>
+          new Response(JSON.stringify({ pong: true }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+      },
+    });
+    api.registerCollection('restauthwidgets', collection);
+    const handler = api.generateHandler();
+
+    const res = await handler(new Request('http://local/api/v1/ping'));
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { pong: boolean };
+    expect(json.pong).toBe(true);
+  });
+});

--- a/packages/core/src/generators/swagger-spec.spec.ts
+++ b/packages/core/src/generators/swagger-spec.spec.ts
@@ -1,0 +1,304 @@
+/**
+ * Coverage for the OpenAPI/Swagger spec generator output (#1500).
+ *
+ * generator-surface-hardening.spec asserts the `api: false` skip. This file
+ * asserts the produced spec artifact in detail: config overrides, the
+ * per-verb include/exclude path gating, the component schema shape (base
+ * fields, required, the `*List` wrapper), every field-type → OpenAPI mapping,
+ * pluralization branches, and the optional Swagger UI setup fallback.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { field } from '../decorators';
+import { SmrtObject } from '../object';
+import { ObjectRegistry } from '../registry';
+import { generateOpenAPISpec, setupSwaggerUI } from './swagger';
+
+function smrt(config?: any) {
+  return (target: any) => {
+    ObjectRegistry.register(target, config);
+    return target;
+  };
+}
+
+// Exercises every fieldToOpenAPISchema branch + required propagation.
+@smrt()
+class SwaggerFieldWidget extends SmrtObject {
+  @field({ type: 'text', required: true, maxLength: 120, minLength: 2 })
+  title = '';
+
+  @field({ type: 'integer', min: 0, max: 100 })
+  count = 0;
+
+  @field({ type: 'decimal', min: 1, max: 9.5 })
+  rating = 0.0;
+
+  @field({ type: 'boolean' })
+  active = false;
+
+  @field({ type: 'datetime', nullable: true })
+  publishedAt: string | null = null;
+
+  @field({ type: 'json' })
+  meta: Record<string, any> = {};
+
+  @field({ type: 'text', default: 'draft' })
+  status = 'draft';
+
+  constructor(options: any = {}) {
+    super(options);
+    const { db, ai, fs, ...safe } = options;
+    Object.assign(this, safe);
+  }
+}
+
+// include list — only list+get paths should be emitted.
+@smrt({ api: { include: ['list', 'get'] } })
+class SwaggerReadOnly extends SmrtObject {
+  @field({ type: 'text' })
+  name = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    const { db, ai, fs, ...safe } = options;
+    Object.assign(this, safe);
+  }
+}
+
+// exclude list — delete path must be omitted; others present.
+@smrt({ api: { exclude: ['delete'] } })
+class SwaggerNoDelete extends SmrtObject {
+  @field({ type: 'text' })
+  name = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    const { db, ai, fs, ...safe } = options;
+    Object.assign(this, safe);
+  }
+}
+
+describe('OpenAPI spec generation (#1500)', () => {
+  describe('top-level config', () => {
+    it('uses defaults when no config is given', () => {
+      const spec = generateOpenAPISpec();
+      expect(spec.openapi).toBe('3.0.3');
+      expect(spec.info.title).toBe('smrt API');
+      expect(spec.info.version).toBe('1.0.0');
+      expect(spec.servers[0].url).toBe('http://localhost:3000');
+      // Bearer auth security scheme is always declared.
+      expect(spec.components.securitySchemes.bearerAuth.scheme).toBe('bearer');
+      expect(spec.security).toEqual([{ bearerAuth: [] }]);
+      // Shared responses are present.
+      expect(spec.components.responses.ValidationError).toBeDefined();
+      expect(spec.components.responses.NotFound).toBeDefined();
+    });
+
+    it('honors title / version / description / serverUrl / basePath overrides', () => {
+      const spec = generateOpenAPISpec({
+        title: 'My API',
+        version: '9.9.9',
+        description: 'custom',
+        serverUrl: 'https://api.example.com',
+        basePath: '/v2',
+      });
+      expect(spec.info.title).toBe('My API');
+      expect(spec.info.version).toBe('9.9.9');
+      expect(spec.info.description).toBe('custom');
+      expect(spec.servers[0].url).toBe('https://api.example.com');
+      // Paths reflect the custom basePath.
+      const keys = Object.keys(spec.paths);
+      expect(keys.some((k) => k.startsWith('/v2/'))).toBe(true);
+    });
+  });
+
+  describe('component schemas', () => {
+    it('emits a base schema and a *List wrapper for a registered object', () => {
+      const spec = generateOpenAPISpec();
+      const schema = spec.components.schemas.SwaggerFieldWidget;
+      expect(schema).toBeDefined();
+      expect(schema.type).toBe('object');
+
+      // Base framework fields are always present.
+      expect(schema.properties.id).toEqual({ type: 'string', format: 'uuid' });
+      expect(schema.properties.slug).toEqual({ type: 'string' });
+      expect(schema.properties.created_at.format).toBe('date-time');
+      expect(schema.properties.updated_at.format).toBe('date-time');
+
+      // id is always required; a `required: true` field is added to required.
+      expect(schema.required).toContain('id');
+      expect(schema.required).toContain('title');
+
+      // List wrapper shape.
+      const list = spec.components.schemas.SwaggerFieldWidgetList;
+      expect(list.properties.data.type).toBe('array');
+      expect(list.properties.data.items.$ref).toBe(
+        '#/components/schemas/SwaggerFieldWidget',
+      );
+      expect(list.properties.meta.properties.total.type).toBe('integer');
+    });
+
+    it('maps every field type to the right OpenAPI schema', () => {
+      const spec = generateOpenAPISpec();
+      const props = spec.components.schemas.SwaggerFieldWidget.properties;
+
+      // text with length constraints
+      expect(props.title.type).toBe('string');
+      expect(props.title.maxLength).toBe(120);
+      expect(props.title.minLength).toBe(2);
+
+      // integer with min/max
+      expect(props.count.type).toBe('integer');
+      expect(props.count.minimum).toBe(0);
+      expect(props.count.maximum).toBe(100);
+
+      // decimal → number with float format + min/max
+      expect(props.rating.type).toBe('number');
+      expect(props.rating.format).toBe('float');
+      expect(props.rating.minimum).toBe(1);
+      expect(props.rating.maximum).toBe(9.5);
+
+      // boolean
+      expect(props.active.type).toBe('boolean');
+
+      // datetime → string/date-time
+      expect(props.publishedAt.type).toBe('string');
+      expect(props.publishedAt.format).toBe('date-time');
+
+      // json → object + additionalProperties
+      expect(props.meta.type).toBe('object');
+      expect(props.meta.additionalProperties).toBe(true);
+
+      // default value carried through
+      expect(props.status.default).toBe('draft');
+    });
+  });
+
+  describe('path generation per verb', () => {
+    it('emits collection + item CRUD paths with the expected operations', () => {
+      const spec = generateOpenAPISpec();
+      const base = '/api/v1/swaggerfieldwidgets';
+      expect(spec.paths[base].get.summary).toContain('List');
+      expect(spec.paths[base].post.summary).toContain('Create');
+      expect(spec.paths[base].post.responses['201']).toBeDefined();
+      expect(spec.paths[`${base}/{id}`].get).toBeDefined();
+      expect(spec.paths[`${base}/{id}`].put).toBeDefined();
+      expect(spec.paths[`${base}/{id}`].delete).toBeDefined();
+      // List parameters include limit/offset.
+      const paramNames = spec.paths[base].get.parameters.map(
+        (p: any) => p.name,
+      );
+      expect(paramNames).toEqual(['limit', 'offset']);
+    });
+
+    it('include: [list, get] emits only those operations', () => {
+      const spec = generateOpenAPISpec();
+      const base = '/api/v1/swaggerreadonlies';
+      expect(spec.paths[base].get).toBeDefined();
+      // create not in include → no POST.
+      expect(spec.paths[base].post).toBeUndefined();
+      expect(spec.paths[`${base}/{id}`].get).toBeDefined();
+      // update/delete not in include.
+      expect(spec.paths[`${base}/{id}`].put).toBeUndefined();
+      expect(spec.paths[`${base}/{id}`].delete).toBeUndefined();
+    });
+
+    it('exclude: [delete] omits the DELETE operation only', () => {
+      const spec = generateOpenAPISpec();
+      const base = '/api/v1/swaggernodeletes';
+      expect(spec.paths[base].get).toBeDefined();
+      expect(spec.paths[base].post).toBeDefined();
+      expect(spec.paths[`${base}/{id}`].get).toBeDefined();
+      expect(spec.paths[`${base}/{id}`].put).toBeDefined();
+      // delete excluded.
+      expect(spec.paths[`${base}/{id}`].delete).toBeUndefined();
+    });
+  });
+
+  describe('setupSwaggerUI fallback', () => {
+    it('warns instead of throwing when swagger-ui-express is unavailable', () => {
+      const original = console.warn;
+      const warnings: string[] = [];
+      console.warn = (...args: unknown[]) => {
+        warnings.push(args.map(String).join(' '));
+      };
+      try {
+        // `app` is never used because the require() of the optional peer dep
+        // throws first and is caught. Must not throw.
+        expect(() => setupSwaggerUI({}, generateOpenAPISpec())).not.toThrow();
+      } finally {
+        console.warn = original;
+      }
+      expect(warnings.some((w) => w.includes('Swagger UI not available'))).toBe(
+        true,
+      );
+    });
+  });
+});
+
+// Pluralization branch coverage: names ending in y / x / z / ch / sh / default.
+@smrt()
+class SwaggerCategory extends SmrtObject {
+  // ends in 'y' → categories
+  @field({ type: 'text' })
+  name = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    const { db, ai, fs, ...safe } = options;
+    Object.assign(this, safe);
+  }
+}
+
+@smrt()
+class SwaggerBox extends SmrtObject {
+  // ends in 'x' → boxes
+  @field({ type: 'text' })
+  name = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    const { db, ai, fs, ...safe } = options;
+    Object.assign(this, safe);
+  }
+}
+
+@smrt()
+class SwaggerBuzz extends SmrtObject {
+  // ends in 'z' → buzzes
+  @field({ type: 'text' })
+  name = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    const { db, ai, fs, ...safe } = options;
+    Object.assign(this, safe);
+  }
+}
+
+@smrt()
+class SwaggerDish extends SmrtObject {
+  // ends in 'sh' → dishes
+  @field({ type: 'text' })
+  name = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    const { db, ai, fs, ...safe } = options;
+    Object.assign(this, safe);
+  }
+}
+
+describe('OpenAPI pluralization branches (#1500)', () => {
+  it('pluralizes y/x/z/sh/default endings in the path keys', () => {
+    const spec = generateOpenAPISpec();
+    const keys = Object.keys(spec.paths);
+    expect(keys).toContain('/api/v1/swaggercategories'); // y → ies
+    expect(keys).toContain('/api/v1/swaggerboxes'); // x → xes
+    expect(keys).toContain('/api/v1/swaggerbuzzes'); // z → zes
+    expect(keys).toContain('/api/v1/swaggerdishes'); // sh → shes
+    // default 's' suffix is exercised by SwaggerFieldWidget → ...widgets.
+    expect(keys).toContain('/api/v1/swaggerfieldwidgets');
+  });
+});

--- a/packages/core/src/manifest/__tests__/discover-smrt-packages-coverage.test.ts
+++ b/packages/core/src/manifest/__tests__/discover-smrt-packages-coverage.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Coverage-focused tests for discover-smrt-packages.ts (issue #1500).
+ *
+ * The existing discover-smrt-packages.test.ts covers outermost-root resolution
+ * and two cache-invalidation scenarios. This file targets the remaining
+ * branches of the discovery pipeline:
+ *
+ * - Cache write-then-reuse on a second call (the cache hit path)
+ * - noCache option forcing fresh discovery (skips the cache entirely)
+ * - Cache version mismatch invalidation
+ * - Timing data capture via getDiscoveryTiming
+ * - moduleType !== 'smrt' manifests being rejected
+ * - node_modules scanning that picks up an undeclared but manifest-bearing pkg
+ * - Empty result when node_modules is absent
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  discoverSmrtPackages,
+  getDiscoveryTiming,
+} from '../discover-smrt-packages.js';
+
+const SMRT_PKG = '@happyvertical/smrt-example';
+
+function writeSmrtPackage(
+  baseDir: string,
+  packageName: string,
+  opts: { moduleType?: string } = {},
+): void {
+  const pkgDir = join(
+    baseDir,
+    'node_modules',
+    ...packageName
+      .replace('@', '')
+      .split('/')
+      .map((p, i) => (i === 0 ? `@${p}` : p)),
+  );
+  mkdirSync(join(pkgDir, 'dist'), { recursive: true });
+  writeFileSync(
+    join(pkgDir, 'package.json'),
+    JSON.stringify({
+      name: packageName,
+      type: 'module',
+      exports: {
+        '.': './dist/index.js',
+        './manifest.json': './dist/manifest.json',
+      },
+    }),
+  );
+  writeFileSync(join(pkgDir, 'dist', 'index.js'), 'export {};\n');
+  writeFileSync(
+    join(pkgDir, 'dist', 'manifest.json'),
+    JSON.stringify({
+      moduleType: opts.moduleType ?? 'smrt',
+      version: '1.0.0',
+      packageName,
+      objects: {},
+    }),
+  );
+}
+
+describe('discoverSmrtPackages coverage', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'smrt-discover-cov-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes a discovery cache then reuses it on the next call', () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({
+        name: 'consumer',
+        type: 'module',
+        dependencies: { [SMRT_PKG]: '1.0.0' },
+      }),
+    );
+    writeSmrtPackage(dir, SMRT_PKG);
+
+    // First call performs discovery and saves the cache.
+    const first = discoverSmrtPackages({ baseDir: dir });
+    expect(first).toContain(SMRT_PKG);
+
+    // Second call should hit the cache (no inputs changed). The result is
+    // identical; the cache-hit branch is exercised.
+    const second = discoverSmrtPackages({ baseDir: dir });
+    expect(second).toEqual(first);
+  });
+
+  it('performs fresh discovery and skips the cache when noCache is set', () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({
+        name: 'consumer',
+        type: 'module',
+        dependencies: { [SMRT_PKG]: '1.0.0' },
+      }),
+    );
+    writeSmrtPackage(dir, SMRT_PKG);
+
+    const packages = discoverSmrtPackages({ baseDir: dir, noCache: true });
+    expect(packages).toContain(SMRT_PKG);
+  });
+
+  it('captures timing data when the timing option is enabled', () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ name: 'consumer', type: 'module' }),
+    );
+
+    discoverSmrtPackages({ baseDir: dir, noCache: true, timing: true });
+    const timing = getDiscoveryTiming();
+    expect(timing.total).toBeTypeOf('number');
+    expect(timing.discovery).toBeTypeOf('number');
+  });
+
+  it('captures cache-check timing on a cached run', () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({
+        name: 'consumer',
+        type: 'module',
+        dependencies: { [SMRT_PKG]: '1.0.0' },
+      }),
+    );
+    writeSmrtPackage(dir, SMRT_PKG);
+
+    // Prime the cache.
+    discoverSmrtPackages({ baseDir: dir });
+    // Cached run with timing -> cacheCheck + total recorded.
+    discoverSmrtPackages({ baseDir: dir, timing: true });
+    const timing = getDiscoveryTiming();
+    expect(timing.cacheCheck).toBeTypeOf('number');
+    expect(timing.total).toBeTypeOf('number');
+  });
+
+  it('rejects manifests whose moduleType is not "smrt"', () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({
+        name: 'consumer',
+        type: 'module',
+        dependencies: { [SMRT_PKG]: '1.0.0' },
+      }),
+    );
+    // moduleType: 'other' -> not a SMRT package, must be excluded.
+    writeSmrtPackage(dir, SMRT_PKG, { moduleType: 'other' });
+
+    const packages = discoverSmrtPackages({ baseDir: dir, noCache: true });
+    expect(packages).not.toContain(SMRT_PKG);
+  });
+
+  it('discovers an undeclared package found by scanning node_modules', () => {
+    // No dependency entry in package.json — discovery must still find it via
+    // the node_modules scan (scanNodeModules + hasManifestExport).
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ name: 'consumer', type: 'module' }),
+    );
+    writeSmrtPackage(dir, SMRT_PKG);
+
+    const packages = discoverSmrtPackages({ baseDir: dir, noCache: true });
+    expect(packages).toContain(SMRT_PKG);
+  });
+
+  it('returns an empty list when node_modules and dependencies are absent', () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ name: 'consumer', type: 'module' }),
+    );
+    expect(discoverSmrtPackages({ baseDir: dir, noCache: true })).toEqual([]);
+  });
+
+  it('invalidates the cache when the cache version is stale', () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({
+        name: 'consumer',
+        type: 'module',
+        dependencies: { [SMRT_PKG]: '1.0.0' },
+      }),
+    );
+    writeSmrtPackage(dir, SMRT_PKG);
+
+    // Prime the cache, then corrupt its version field.
+    discoverSmrtPackages({ baseDir: dir });
+    const cachePath = join(dir, '.smrt', 'discovery-cache.json');
+    writeFileSync(
+      cachePath,
+      JSON.stringify({
+        version: 0, // stale version -> cache must be rejected
+        lockfileHash: null,
+        packageJsonHash: null,
+        manifestsHash: '',
+        timestamp: Date.now(),
+        packages: [],
+      }),
+    );
+
+    // With a stale cache version, discovery re-runs and still finds the package.
+    const packages = discoverSmrtPackages({ baseDir: dir });
+    expect(packages).toContain(SMRT_PKG);
+  });
+
+  it('honors the verbose option without throwing', () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ name: 'consumer', type: 'module' }),
+    );
+    // verbose:true drives the console.log branches; just assert it completes.
+    expect(() =>
+      discoverSmrtPackages({ baseDir: dir, noCache: true, verbose: true }),
+    ).not.toThrow();
+  });
+
+  it('logs declared SMRT packages under verbose discovery', () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({
+        name: 'consumer',
+        type: 'module',
+        // devDependencies path of the declared-dependency merge.
+        devDependencies: { [SMRT_PKG]: '1.0.0' },
+      }),
+    );
+    writeSmrtPackage(dir, SMRT_PKG);
+
+    const packages = discoverSmrtPackages({
+      baseDir: dir,
+      noCache: true,
+      verbose: true,
+    });
+    expect(packages).toContain(SMRT_PKG);
+  });
+
+  it('tolerates a malformed package.json while reading declared dependencies', () => {
+    // Discovery still runs via node_modules scanning; the declared-dependency
+    // read hits its catch branch on the malformed JSON without throwing.
+    writeFileSync(join(dir, 'package.json'), '{ broken json');
+    writeSmrtPackage(dir, SMRT_PKG);
+
+    const packages = discoverSmrtPackages({
+      baseDir: dir,
+      noCache: true,
+      verbose: true,
+    });
+    // The package is still found through the node_modules scan.
+    expect(packages).toContain(SMRT_PKG);
+  });
+});

--- a/packages/core/src/manifest/__tests__/generator-coverage.test.ts
+++ b/packages/core/src/manifest/__tests__/generator-coverage.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Coverage-focused tests for ManifestBuilder (manifest/generator.ts, #1500).
+ *
+ * The existing generator.test.ts covers file discovery, scanner config, output
+ * generation, and empty-manifest handling. This file targets the remaining
+ * uncovered orchestration branches:
+ *
+ * - loadViteConfig: the "vite.config.ts not found" path, and a real config that
+ *   exposes a smrt-auto-service plugin with baseClasses
+ * - includeExternalBaseClasses: loadExternalBaseClasses reading a fixture
+ *   package's dist/manifest.json (success + missing-manifest paths)
+ * - injectPackageInfo with an unreadable package.json (warning branch)
+ * - normalizeFilePaths rewriting absolute file paths to workspace-relative
+ *
+ * ManifestBuilder resolves everything relative to process.cwd(), so each test
+ * chdir's into an isolated fixture dir and restores cwd in a finally block.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ManifestBuilder } from '../generator.js';
+
+const LOCAL_CLASS_SRC = `import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+@smrt()
+class Local extends SmrtObject {
+  name: string = '';
+}
+`;
+
+describe('ManifestBuilder coverage', () => {
+  let dir: string;
+  let prev: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'smrt-builder-cov-'));
+    prev = process.cwd();
+    mkdirSync(join(dir, 'src'), { recursive: true });
+  });
+
+  afterEach(() => {
+    process.chdir(prev);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('continues with default baseClasses when loadViteConfig finds no vite.config.ts', async () => {
+    writeFileSync(join(dir, 'src', 'thing.ts'), LOCAL_CLASS_SRC);
+
+    const builder = new ManifestBuilder();
+    process.chdir(dir);
+    const manifest = await builder.generate({
+      include: ['src/**/*.ts'],
+      loadViteConfig: true, // no vite.config.ts present -> returns null, defaults used
+      outputDir: join(dir, 'out'),
+      generateTypeStub: false,
+    });
+
+    expect(manifest.objects).toBeDefined();
+  });
+
+  it('loads baseClasses from a vite.config.ts smrt-auto-service plugin', async () => {
+    writeFileSync(join(dir, 'src', 'widget.ts'), LOCAL_CLASS_SRC);
+    // Minimal vite config exposing a plugin named 'smrt-auto-service' with
+    // options.baseClasses readable via the `.api.options` accessor.
+    writeFileSync(
+      join(dir, 'vite.config.ts'),
+      `export default {
+  plugins: [
+    {
+      name: 'smrt-auto-service',
+      api: {
+        options: {
+          baseClasses: ['SmrtObject', 'SmrtClass', 'SmrtCollection'],
+          followImports: false,
+        },
+      },
+    },
+  ],
+};
+`,
+    );
+
+    const builder = new ManifestBuilder();
+    process.chdir(dir);
+    const manifest = await builder.generate({
+      include: ['src/**/*.ts'],
+      loadViteConfig: true,
+      outputDir: join(dir, 'out'),
+      generateTypeStub: false,
+    });
+
+    expect(manifest.objects).toBeDefined();
+  });
+
+  it('adds external base classes from a fixture package manifest', async () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({
+        name: '@acme/consumer',
+        type: 'module',
+        dependencies: { '@happyvertical/smrt-fixture-ext': '1.0.0' },
+      }),
+    );
+    writeFileSync(join(dir, 'src', 'local.ts'), LOCAL_CLASS_SRC);
+
+    // Fixture external SMRT package with a dist/manifest.json the builder reads
+    // both for discovery and for loadExternalBaseClasses.
+    const extDir = join(
+      dir,
+      'node_modules',
+      '@happyvertical',
+      'smrt-fixture-ext',
+    );
+    mkdirSync(join(extDir, 'dist'), { recursive: true });
+    writeFileSync(
+      join(extDir, 'package.json'),
+      JSON.stringify({
+        name: '@happyvertical/smrt-fixture-ext',
+        type: 'module',
+        exports: {
+          '.': './dist/index.js',
+          './manifest.json': './dist/manifest.json',
+        },
+      }),
+    );
+    writeFileSync(join(extDir, 'dist', 'index.js'), 'export {};\n');
+    writeFileSync(
+      join(extDir, 'dist', 'manifest.json'),
+      JSON.stringify({
+        moduleType: 'smrt',
+        version: '1.0.0',
+        packageName: '@happyvertical/smrt-fixture-ext',
+        objects: {
+          '@happyvertical/smrt-fixture-ext:ExternalBase': {
+            className: 'ExternalBase',
+            fields: {},
+          },
+        },
+      }),
+    );
+
+    const builder = new ManifestBuilder();
+    process.chdir(dir);
+    const manifest = await builder.generate({
+      include: ['src/**/*.ts'],
+      discoverExternalPackages: true,
+      includeExternalBaseClasses: true,
+      outputDir: join(dir, 'out'),
+      generateTypeStub: false,
+    });
+
+    // The external package is recorded as a dependency reference.
+    expect(manifest.smrtDependencies).toContain(
+      '@happyvertical/smrt-fixture-ext',
+    );
+  });
+
+  it('tolerates a missing external manifest during loadExternalBaseClasses', async () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({
+        name: '@acme/consumer',
+        type: 'module',
+        dependencies: { '@happyvertical/smrt-broken-ext': '1.0.0' },
+      }),
+    );
+    writeFileSync(join(dir, 'src', 'local.ts'), LOCAL_CLASS_SRC);
+
+    // Package resolves for discovery (has a manifest export) but the dist/
+    // manifest.json that loadExternalBaseClasses expects is intentionally
+    // absent in the path it reads, so the catch branch runs.
+    const extDir = join(
+      dir,
+      'node_modules',
+      '@happyvertical',
+      'smrt-broken-ext',
+    );
+    mkdirSync(join(extDir, '.smrt'), { recursive: true });
+    writeFileSync(
+      join(extDir, 'package.json'),
+      JSON.stringify({
+        name: '@happyvertical/smrt-broken-ext',
+        type: 'module',
+        exports: { './manifest.json': './.smrt/manifest.json' },
+      }),
+    );
+    writeFileSync(
+      join(extDir, '.smrt', 'manifest.json'),
+      JSON.stringify({
+        moduleType: 'smrt',
+        version: '1.0.0',
+        packageName: '@happyvertical/smrt-broken-ext',
+        objects: {},
+      }),
+    );
+
+    const builder = new ManifestBuilder();
+    process.chdir(dir);
+    // Should not throw even though dist/manifest.json is missing for the
+    // external-base-class read.
+    await expect(
+      builder.generate({
+        include: ['src/**/*.ts'],
+        discoverExternalPackages: true,
+        includeExternalBaseClasses: true,
+        outputDir: join(dir, 'out'),
+        generateTypeStub: false,
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it('warns and leaves packageName unset when package.json is unreadable', async () => {
+    // Malformed package.json -> readPackageJson catch -> {} -> no packageName.
+    writeFileSync(join(dir, 'package.json'), '{ not valid json');
+    writeFileSync(join(dir, 'src', 'thing.ts'), LOCAL_CLASS_SRC);
+
+    const builder = new ManifestBuilder();
+    process.chdir(dir);
+    const manifest = await builder.generate({
+      include: ['src/**/*.ts'],
+      injectPackageInfo: true,
+      outputDir: join(dir, 'out'),
+      generateTypeStub: false,
+    });
+
+    expect(manifest.packageName).toBeUndefined();
+  });
+
+  it('normalizes absolute object filePaths to workspace-relative paths', async () => {
+    // Mark this temp dir as a workspace root so findWorkspaceRoot stops here.
+    writeFileSync(join(dir, 'pnpm-workspace.yaml'), 'packages: []\n');
+    writeFileSync(join(dir, 'src', 'rel.ts'), LOCAL_CLASS_SRC);
+
+    const builder = new ManifestBuilder();
+    process.chdir(dir);
+    const manifest = await builder.generate({
+      include: ['src/**/*.ts'],
+      outputDir: join(dir, 'out'),
+      generateTypeStub: false,
+    });
+
+    const obj = Object.values(manifest.objects)[0];
+    if (obj?.filePath) {
+      // Rewritten to a relative path (no leading slash, no Windows backslashes).
+      expect(obj.filePath.startsWith('/')).toBe(false);
+      expect(obj.filePath).not.toContain('\\');
+    }
+  });
+});

--- a/packages/core/src/manifest/__tests__/manifest-loader-coverage.test.ts
+++ b/packages/core/src/manifest/__tests__/manifest-loader-coverage.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Coverage-focused tests for manifest-loader.ts (issue #1500).
+ *
+ * The existing manifest-loader-contract.test.ts covers external discovery via
+ * declared smrtDependencies and clearManifestCache. This file targets the
+ * remaining exported surface and its branches:
+ *
+ * - lookupInManifest: direct key, qualified-name, constructed-qualified, and
+ *   case-insensitive className-index lookups (incl. the STI child-wins index)
+ * - findManifestEntryByQualifiedName: cache hit, static-manifest, miss
+ * - loadExternalManifestSync: cache reuse, invalid structure, read failure,
+ *   packageName enrichment
+ * - loadManifestFromPathSync: success, invalid structure, missing file
+ * - discoverSTISiblingsSync: collection grouping, case-insensitive dedup,
+ *   result caching
+ * - getLoadedManifests / getManifestCollisions snapshots
+ * - getPackageName: ObjectRegistry hit, __package__ metadata, null fallback
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ObjectRegistry } from '../../registry.js';
+import type { SmartObjectManifest } from '../../scanner/types.js';
+import {
+  clearManifestCache,
+  discoverSTISiblingsSync,
+  findManifestEntryByQualifiedName,
+  getLoadedManifests,
+  getManifestCollisions,
+  getPackageName,
+  loadExternalManifestSync,
+  loadManifestFromPathSync,
+  lookupInManifest,
+} from '../manifest-loader.js';
+import { getManifestCache } from '../store.js';
+
+function makeManifest(
+  packageName: string,
+  objects: Record<string, any>,
+  extra: Partial<SmartObjectManifest> = {},
+): SmartObjectManifest {
+  return {
+    version: '1.0.0',
+    timestamp: 0,
+    packageName,
+    objects,
+    ...extra,
+  } as SmartObjectManifest;
+}
+
+describe('manifest-loader coverage', () => {
+  beforeEach(() => {
+    clearManifestCache();
+    ObjectRegistry.clear();
+  });
+
+  afterEach(() => {
+    clearManifestCache();
+    ObjectRegistry.clear();
+  });
+
+  describe('lookupInManifest', () => {
+    const manifest = makeManifest('@acme/pkg', {
+      '@acme/pkg:Widget': {
+        className: 'Widget',
+        fields: { a: { type: 'text' } },
+      },
+      // Un-keyed-by-qualified-name entry to exercise the className index.
+      RawGizmo: { className: 'Gizmo', fields: {} },
+    });
+
+    it('returns a direct key match (qualified name)', () => {
+      expect(lookupInManifest(manifest, '@acme/pkg:Widget')?.className).toBe(
+        'Widget',
+      );
+    });
+
+    it('resolves a simple class name via constructed qualified key', () => {
+      expect(lookupInManifest(manifest, 'Widget')?.className).toBe('Widget');
+    });
+
+    it('resolves a qualified name through the className index when not a direct key', () => {
+      // '@acme/pkg:Gizmo' is not a literal object key, but the index maps it.
+      expect(lookupInManifest(manifest, '@acme/pkg:Gizmo')?.className).toBe(
+        'Gizmo',
+      );
+    });
+
+    it('falls back to a case-insensitive className lookup', () => {
+      expect(lookupInManifest(manifest, 'gizmo')?.className).toBe('Gizmo');
+    });
+
+    it('returns undefined for an unknown class', () => {
+      expect(lookupInManifest(manifest, 'Nope')).toBeUndefined();
+    });
+
+    it('prefers an STI child over its parent when both map to one simple name', () => {
+      // Two entries collapse to the same lowercase className via the index;
+      // the child (extends the parent) must win (#950).
+      const collide = makeManifest('@acme/pkg', {
+        Parent: { className: 'Thing', fields: { base: { type: 'text' } } },
+        Child: {
+          className: 'Thing',
+          extends: 'Thing',
+          fields: { extra: { type: 'text' } },
+        },
+      });
+      const hit = lookupInManifest(collide, 'thing');
+      expect(hit?.fields.extra).toBeDefined();
+    });
+  });
+
+  describe('findManifestEntryByQualifiedName', () => {
+    it('returns undefined for a non-qualified name', () => {
+      expect(findManifestEntryByQualifiedName('PlainName')).toBeUndefined();
+    });
+
+    it('finds an entry in a cached external manifest', () => {
+      getManifestCache().set(
+        '@acme/pkg',
+        makeManifest('@acme/pkg', {
+          '@acme/pkg:Widget': { className: 'Widget', fields: {} },
+        }),
+      );
+      expect(
+        findManifestEntryByQualifiedName('@acme/pkg:Widget')?.className,
+      ).toBe('Widget');
+    });
+
+    it('returns undefined when the package is not loaded anywhere', () => {
+      expect(
+        findManifestEntryByQualifiedName('@unknown/pkg:Ghost'),
+      ).toBeUndefined();
+    });
+
+    it('finds an entry in the static manifest by package name', () => {
+      globalThis.__smrtManifestStatic = makeManifest(
+        '@happyvertical/smrt-core',
+        {
+          '@happyvertical/smrt-core:CoreThing': {
+            className: 'CoreThing',
+            fields: {},
+          },
+        },
+      );
+      globalThis.__smrtManifestStaticLoadAttempted = true;
+      try {
+        expect(
+          findManifestEntryByQualifiedName('@happyvertical/smrt-core:CoreThing')
+            ?.className,
+        ).toBe('CoreThing');
+      } finally {
+        globalThis.__smrtManifestStatic = undefined;
+        globalThis.__smrtManifestStaticLoadAttempted = false;
+      }
+    });
+  });
+
+  describe('loadExternalManifestSync', () => {
+    let dir: string | null = null;
+    afterEach(() => {
+      if (dir) {
+        rmSync(dir, { recursive: true, force: true });
+        dir = null;
+      }
+    });
+
+    it('returns a cached manifest without re-reading disk', () => {
+      const cached = makeManifest('@acme/cached', {
+        '@acme/cached:X': { className: 'X', fields: {} },
+      });
+      getManifestCache().set('@acme/cached', cached);
+      expect(loadExternalManifestSync('@acme/cached')).toBe(cached);
+    });
+
+    it('returns null for a package that exposes no manifest export', () => {
+      dir = mkdtempSync(join(tmpdir(), 'smrt-loader-noexport-'));
+      const prev = process.cwd();
+      process.chdir(dir);
+      try {
+        writeFileSync(
+          join(dir, 'package.json'),
+          JSON.stringify({ name: 'consumer' }),
+        );
+        expect(
+          loadExternalManifestSync('@happyvertical/smrt-missing', {
+            warn: false,
+          }),
+        ).toBeNull();
+      } finally {
+        process.chdir(prev);
+      }
+    });
+  });
+
+  describe('loadManifestFromPathSync', () => {
+    let dir: string | null = null;
+    afterEach(() => {
+      if (dir) {
+        rmSync(dir, { recursive: true, force: true });
+        dir = null;
+      }
+    });
+
+    it('loads a manifest from an explicit path and caches it by package name', () => {
+      dir = mkdtempSync(join(tmpdir(), 'smrt-loader-path-'));
+      const file = join(dir, 'manifest.json');
+      writeFileSync(
+        file,
+        JSON.stringify(
+          makeManifest('@acme/from-path', {
+            '@acme/from-path:Y': { className: 'Y', fields: {} },
+          }),
+        ),
+      );
+      const loaded = loadManifestFromPathSync(file);
+      expect(loaded?.objects['@acme/from-path:Y'].className).toBe('Y');
+      // Cached under the manifest's packageName.
+      expect(getManifestCache().get('@acme/from-path')).toBe(loaded);
+    });
+
+    it('returns null for a manifest with an invalid structure', () => {
+      dir = mkdtempSync(join(tmpdir(), 'smrt-loader-bad-'));
+      const file = join(dir, 'manifest.json');
+      writeFileSync(file, JSON.stringify({ version: '1.0.0' })); // no objects
+      expect(loadManifestFromPathSync(file)).toBeNull();
+    });
+
+    it('returns null when the file cannot be read', () => {
+      expect(
+        loadManifestFromPathSync(join(tmpdir(), 'definitely-missing-xyz.json')),
+      ).toBeNull();
+    });
+  });
+
+  describe('discoverSTISiblingsSync', () => {
+    it('groups entries sharing a collection and dedups case-insensitively, then caches', () => {
+      getManifestCache().set(
+        '@acme/pkg',
+        makeManifest('@acme/pkg', {
+          A: { className: 'Article', collection: 'contents', fields: {} },
+          B: { className: 'Mirror', collection: 'contents', fields: {} },
+          // Duplicate simple name (different case) — must not be added twice.
+          C: { className: 'article', collection: 'contents', fields: {} },
+          D: { className: 'Other', collection: 'others', fields: {} },
+        }),
+      );
+
+      const siblings = discoverSTISiblingsSync('contents');
+      const names = siblings.map((s) => s.className.toLowerCase()).sort();
+      expect(names).toEqual(['article', 'mirror']);
+
+      // Second call returns the cached array reference (no rescan).
+      const again = discoverSTISiblingsSync('contents');
+      expect(again).toBe(siblings);
+    });
+
+    it('returns an empty list when no entry uses the collection', () => {
+      getManifestCache().set(
+        '@acme/empty',
+        makeManifest('@acme/empty', {
+          A: { className: 'Solo', collection: 'solos', fields: {} },
+        }),
+      );
+      expect(discoverSTISiblingsSync('nonexistent_table')).toEqual([]);
+    });
+  });
+
+  describe('getLoadedManifests / getManifestCollisions', () => {
+    it('returns a snapshot of cached manifests', () => {
+      getManifestCache().set(
+        '@acme/snap',
+        makeManifest('@acme/snap', {
+          '@acme/snap:Z': { className: 'Z', fields: {} },
+        }),
+      );
+      const loaded = getLoadedManifests();
+      expect(loaded.map(([name]) => name)).toContain('@acme/snap');
+    });
+
+    it('returns a defensive copy of the collisions map', () => {
+      const collisions = getManifestCollisions();
+      expect(collisions).toBeInstanceOf(Map);
+      // Mutating the returned copy must not affect internal state.
+      collisions.set('Fake', [{ packageName: '@x', manifestSource: 's' }]);
+      expect(getManifestCollisions().has('Fake')).toBe(false);
+    });
+  });
+
+  describe('getPackageName', () => {
+    it('returns the package name registered in ObjectRegistry', () => {
+      class RegisteredThing {}
+      ObjectRegistry.register(RegisteredThing as any, {
+        packageName: '@acme/registered',
+      });
+      expect(getPackageName(RegisteredThing as any)).toBe('@acme/registered');
+    });
+
+    it('reads __package__ metadata when registry lookup is skipped', () => {
+      class Tagged {}
+      (Tagged as any).__package__ = '@acme/tagged';
+      expect(getPackageName(Tagged as any, true)).toBe('@acme/tagged');
+    });
+
+    it('prefers the registry over __package__ metadata', () => {
+      class Both {}
+      (Both as any).__package__ = '@acme/from-meta';
+      ObjectRegistry.register(Both as any, {
+        packageName: '@acme/from-registry',
+      });
+      // skipRegistry=false -> registry wins over the metadata fallback.
+      expect(getPackageName(Both as any)).toBe('@acme/from-registry');
+    });
+  });
+});

--- a/packages/core/src/manifest/__tests__/store-coverage.test.ts
+++ b/packages/core/src/manifest/__tests__/store-coverage.test.ts
@@ -1,0 +1,428 @@
+/**
+ * Coverage-focused tests for manifest/store.ts (issue #1500).
+ *
+ * store.ts is the leaf module owning the globalThis manifest caches and the
+ * pure fs/path helpers. The ManifestSource tests exercise it indirectly; this
+ * file targets the store's own exported primitives and their branches:
+ *
+ * - lookupCachedManifestEntry: qualified key, simple name, lowercase, and the
+ *   iterate-and-compare fallback; null/empty manifest guard
+ * - cloneManifestSchemaColumns: default backfill + foreignKey deep copy
+ * - createEmptyStaticManifest shape
+ * - getCurrentPackageName via npm_package_name + cwd walk
+ * - findWorkspaceRootSync (found / not-found)
+ * - resolveInstalledPackageJsonPathSync / resolveWorkspacePackageJsonPathSync
+ * - resolveManifestExportPathSync: valid, non-json, missing-file, no-export
+ * - loadExternalManifestSyncWithNode: cache reuse, invalid structure
+ * - loadManifestFromPathSyncWithNode: success, invalid, missing
+ * - discoverCachedManifestSync across the cache priority chain
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { SmartObjectManifest } from '../../scanner/types.js';
+import {
+  cloneManifestSchemaColumns,
+  createEmptyStaticManifest,
+  discoverCachedManifestSync,
+  findWorkspaceRootSync,
+  getCurrentPackageName,
+  getManifestCache,
+  loadExternalManifestSyncWithNode,
+  loadManifestFromPathSyncWithNode,
+  lookupCachedManifestEntry,
+  resolveInstalledPackageJsonPathSync,
+  resolveManifestExportPathSync,
+  resolveWorkspacePackageJsonPathSync,
+} from '../store.js';
+
+type ManifestGlobals = typeof globalThis & {
+  __smrtManifestCache?: Map<string, SmartObjectManifest>;
+  __smrtManifestStatic?: SmartObjectManifest | null;
+  __smrtManifestStaticLoadAttempted?: boolean;
+  __smrtManifestTest?: SmartObjectManifest | null;
+  __smrtManifestLocalTest?: SmartObjectManifest | null;
+};
+
+function manifest(
+  packageName: string,
+  objects: Record<string, any>,
+): SmartObjectManifest {
+  return { version: '1.0.0', timestamp: 0, packageName, objects } as any;
+}
+
+describe('manifest/store coverage', () => {
+  let snapshot: {
+    cache?: Map<string, SmartObjectManifest>;
+    staticM?: SmartObjectManifest | null;
+    staticAttempted?: boolean;
+    test?: SmartObjectManifest | null;
+    localTest?: SmartObjectManifest | null;
+    npmPkg?: string;
+  };
+
+  beforeEach(() => {
+    const g = globalThis as ManifestGlobals;
+    snapshot = {
+      cache: g.__smrtManifestCache ? new Map(g.__smrtManifestCache) : undefined,
+      staticM: g.__smrtManifestStatic,
+      staticAttempted: g.__smrtManifestStaticLoadAttempted,
+      test: g.__smrtManifestTest,
+      localTest: g.__smrtManifestLocalTest,
+      npmPkg: process.env.npm_package_name,
+    };
+    g.__smrtManifestCache = new Map();
+    g.__smrtManifestStatic = null;
+    g.__smrtManifestStaticLoadAttempted = false;
+    g.__smrtManifestTest = null;
+    g.__smrtManifestLocalTest = null;
+  });
+
+  afterEach(() => {
+    const g = globalThis as ManifestGlobals;
+    g.__smrtManifestCache = snapshot.cache ?? new Map();
+    g.__smrtManifestStatic = snapshot.staticM;
+    g.__smrtManifestStaticLoadAttempted = snapshot.staticAttempted;
+    g.__smrtManifestTest = snapshot.test;
+    g.__smrtManifestLocalTest = snapshot.localTest;
+    if (snapshot.npmPkg === undefined) {
+      delete process.env.npm_package_name;
+    } else {
+      process.env.npm_package_name = snapshot.npmPkg;
+    }
+  });
+
+  describe('lookupCachedManifestEntry', () => {
+    const m = manifest('@acme/pkg', {
+      '@acme/pkg:Widget': { className: 'Widget', fields: {} },
+      gizmo: { className: 'Gizmo', fields: {} },
+    });
+
+    it('returns undefined for a null/empty manifest', () => {
+      expect(lookupCachedManifestEntry(null, 'Widget')).toBeUndefined();
+      expect(
+        lookupCachedManifestEntry({ objects: undefined } as any, 'Widget'),
+      ).toBeUndefined();
+    });
+
+    it('matches via the constructed qualified key', () => {
+      expect(lookupCachedManifestEntry(m, 'Widget')?.className).toBe('Widget');
+    });
+
+    it('matches a lowercase object key directly', () => {
+      expect(lookupCachedManifestEntry(m, 'gizmo')?.className).toBe('Gizmo');
+    });
+
+    it('matches by iterating className when no key matches', () => {
+      // 'Gizmo' is not a literal key, but the value's className matches.
+      expect(lookupCachedManifestEntry(m, 'Gizmo')?.className).toBe('Gizmo');
+    });
+
+    it('resolves an explicit qualified name input', () => {
+      expect(lookupCachedManifestEntry(m, '@acme/pkg:Widget')?.className).toBe(
+        'Widget',
+      );
+    });
+
+    it('returns undefined when nothing matches', () => {
+      expect(lookupCachedManifestEntry(m, 'Missing')).toBeUndefined();
+    });
+  });
+
+  describe('cloneManifestSchemaColumns', () => {
+    it('deep-copies columns, backfills defaultValue, and clones foreignKey', () => {
+      const fk = { table: 'authors', column: 'id' };
+      const cloned = cloneManifestSchemaColumns({
+        id: { type: 'TEXT', primaryKey: true },
+        status: { type: 'TEXT', default: 'draft' } as any,
+        author_id: { type: 'TEXT', foreignKey: fk } as any,
+      });
+
+      // default -> defaultValue backfill.
+      expect((cloned.status as any).defaultValue).toBe('draft');
+      // foreignKey object is a distinct copy, not the same reference.
+      expect((cloned.author_id as any).foreignKey).toEqual(fk);
+      expect((cloned.author_id as any).foreignKey).not.toBe(fk);
+    });
+
+    it('handles an undefined column map', () => {
+      expect(cloneManifestSchemaColumns(undefined)).toEqual({});
+    });
+  });
+
+  describe('createEmptyStaticManifest', () => {
+    it('produces an empty smrt-core manifest shell', () => {
+      const empty = createEmptyStaticManifest();
+      expect(empty.packageName).toBe('@happyvertical/smrt-core');
+      expect(empty.objects).toEqual({});
+      expect(empty.timestamp).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getCurrentPackageName', () => {
+    it('returns npm_package_name when set', () => {
+      process.env.npm_package_name = '@acme/explicit';
+      expect(getCurrentPackageName()).toBe('@acme/explicit');
+    });
+
+    it('walks up to the nearest package.json when env is unset', () => {
+      delete process.env.npm_package_name;
+      const dir = mkdtempSync(join(tmpdir(), 'smrt-store-pkg-'));
+      const nested = join(dir, 'a', 'b');
+      mkdirSync(nested, { recursive: true });
+      writeFileSync(
+        join(dir, 'package.json'),
+        JSON.stringify({ name: '@acme/walked' }),
+      );
+      const prev = process.cwd();
+      process.chdir(nested);
+      try {
+        expect(getCurrentPackageName()).toBe('@acme/walked');
+      } finally {
+        process.chdir(prev);
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('filesystem resolution helpers', () => {
+    let dir: string;
+    let prev: string;
+    let strictPrev: string | undefined;
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), 'smrt-store-fs-'));
+      prev = process.cwd();
+      // resolveManifestExportPathSync records registry diagnostics, which throw
+      // under the default strict mode. Relax it so the not-found/not-json paths
+      // exercise their `return null` branch instead of throwing.
+      strictPrev = process.env.SMRT_STRICT_REGISTRY;
+      process.env.SMRT_STRICT_REGISTRY = 'false';
+    });
+    afterEach(() => {
+      process.chdir(prev);
+      if (strictPrev === undefined) {
+        delete process.env.SMRT_STRICT_REGISTRY;
+      } else {
+        process.env.SMRT_STRICT_REGISTRY = strictPrev;
+      }
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('findWorkspaceRootSync locates a pnpm-workspace.yaml ancestor', () => {
+      writeFileSync(join(dir, 'pnpm-workspace.yaml'), 'packages: []\n');
+      const nested = join(dir, 'packages', 'core');
+      mkdirSync(nested, { recursive: true });
+      expect(findWorkspaceRootSync(nested)).toBe(dir);
+    });
+
+    it('findWorkspaceRootSync returns null when no workspace marker exists', () => {
+      // A freshly-created temp dir under tmpdir has no pnpm-workspace.yaml chain
+      // up to the filesystem root.
+      const isolated = mkdtempSync(join(tmpdir(), 'smrt-no-ws-'));
+      try {
+        expect(findWorkspaceRootSync(isolated)).toBeNull();
+      } finally {
+        rmSync(isolated, { recursive: true, force: true });
+      }
+    });
+
+    it('resolveInstalledPackageJsonPathSync finds an installed package', () => {
+      const pkgDir = join(dir, 'node_modules', '@acme', 'inst');
+      mkdirSync(pkgDir, { recursive: true });
+      writeFileSync(
+        join(pkgDir, 'package.json'),
+        JSON.stringify({ name: '@acme/inst' }),
+      );
+      process.chdir(dir);
+      // Use a suffix match: macOS resolves tmpdir() through a /private symlink,
+      // so the absolute prefix differs from the raw mkdtemp path.
+      expect(resolveInstalledPackageJsonPathSync('@acme/inst')).toMatch(
+        /node_modules\/@acme\/inst\/package\.json$/,
+      );
+    });
+
+    it('resolveWorkspacePackageJsonPathSync finds a workspace package by name', () => {
+      writeFileSync(join(dir, 'pnpm-workspace.yaml'), 'packages: []\n');
+      const pkgDir = join(dir, 'packages', 'thing');
+      mkdirSync(pkgDir, { recursive: true });
+      writeFileSync(
+        join(pkgDir, 'package.json'),
+        JSON.stringify({ name: '@acme/workspace-thing' }),
+      );
+      process.chdir(dir);
+      expect(
+        resolveWorkspacePackageJsonPathSync('@acme/workspace-thing'),
+      ).toMatch(/packages\/thing\/package\.json$/);
+    });
+
+    it('resolveManifestExportPathSync resolves a declared JSON manifest export', () => {
+      const pkgDir = join(dir, 'node_modules', '@acme', 'exp');
+      mkdirSync(join(pkgDir, 'dist'), { recursive: true });
+      writeFileSync(
+        join(pkgDir, 'package.json'),
+        JSON.stringify({
+          name: '@acme/exp',
+          exports: { './manifest.json': './dist/manifest.json' },
+        }),
+      );
+      writeFileSync(
+        join(pkgDir, 'dist', 'manifest.json'),
+        JSON.stringify(manifest('@acme/exp', {})),
+      );
+      process.chdir(dir);
+      expect(resolveManifestExportPathSync('@acme/exp')).toMatch(
+        /node_modules\/@acme\/exp\/dist\/manifest\.json$/,
+      );
+    });
+
+    it('resolveManifestExportPathSync rejects a non-JSON manifest export', () => {
+      const pkgDir = join(dir, 'node_modules', '@acme', 'notjson');
+      mkdirSync(pkgDir, { recursive: true });
+      writeFileSync(
+        join(pkgDir, 'package.json'),
+        JSON.stringify({
+          name: '@acme/notjson',
+          exports: { './manifest': './dist/manifest.js' },
+        }),
+      );
+      process.chdir(dir);
+      expect(
+        resolveManifestExportPathSync('@acme/notjson', { warn: false }),
+      ).toBeNull();
+    });
+
+    it('resolveManifestExportPathSync returns null when no package.json resolves', () => {
+      process.chdir(dir);
+      expect(
+        resolveManifestExportPathSync('@acme/absent', { warn: false }),
+      ).toBeNull();
+    });
+  });
+
+  describe('loadExternalManifestSyncWithNode', () => {
+    let dir: string;
+    let prev: string;
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), 'smrt-store-load-'));
+      prev = process.cwd();
+    });
+    afterEach(() => {
+      process.chdir(prev);
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('returns a cached manifest without touching disk', () => {
+      const cached = manifest('@acme/cached2', {
+        '@acme/cached2:Q': { className: 'Q', fields: {} },
+      });
+      getManifestCache().set('@acme/cached2', cached);
+      expect(loadExternalManifestSyncWithNode('@acme/cached2')).toBe(cached);
+    });
+
+    it('returns null for a manifest with an invalid structure', () => {
+      const pkgDir = join(dir, 'node_modules', '@acme', 'badstruct');
+      mkdirSync(join(pkgDir, 'dist'), { recursive: true });
+      writeFileSync(
+        join(pkgDir, 'package.json'),
+        JSON.stringify({
+          name: '@acme/badstruct',
+          exports: { './manifest.json': './dist/manifest.json' },
+        }),
+      );
+      writeFileSync(
+        join(pkgDir, 'dist', 'manifest.json'),
+        JSON.stringify({ version: '1.0.0' }), // missing objects
+      );
+      process.chdir(dir);
+      expect(
+        loadExternalManifestSyncWithNode('@acme/badstruct', { warn: false }),
+      ).toBeNull();
+    });
+
+    it('enriches a manifest lacking packageName with the requested name', () => {
+      const pkgDir = join(dir, 'node_modules', '@acme', 'noname');
+      mkdirSync(join(pkgDir, 'dist'), { recursive: true });
+      writeFileSync(
+        join(pkgDir, 'package.json'),
+        JSON.stringify({
+          name: '@acme/noname',
+          exports: { './manifest.json': './dist/manifest.json' },
+        }),
+      );
+      writeFileSync(
+        join(pkgDir, 'dist', 'manifest.json'),
+        JSON.stringify({
+          version: '1.0.0',
+          timestamp: 0,
+          objects: { X: { className: 'X', fields: {} } },
+        }),
+      );
+      process.chdir(dir);
+      const loaded = loadExternalManifestSyncWithNode('@acme/noname');
+      expect(loaded?.packageName).toBe('@acme/noname');
+    });
+  });
+
+  describe('loadManifestFromPathSyncWithNode', () => {
+    let dir: string;
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), 'smrt-store-path-'));
+    });
+    afterEach(() => {
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('loads and caches a manifest from an explicit path', () => {
+      const file = join(dir, 'manifest.json');
+      writeFileSync(
+        file,
+        JSON.stringify(
+          manifest('@acme/path2', { '@acme/path2:W': { className: 'W' } }),
+        ),
+      );
+      const loaded = loadManifestFromPathSyncWithNode(file);
+      expect(loaded?.objects['@acme/path2:W'].className).toBe('W');
+      expect(getManifestCache().get('@acme/path2')).toBe(loaded);
+    });
+
+    it('returns null for an invalid manifest structure', () => {
+      const file = join(dir, 'bad.json');
+      writeFileSync(file, JSON.stringify({ version: '1.0.0' }));
+      expect(loadManifestFromPathSyncWithNode(file)).toBeNull();
+    });
+
+    it('returns null when the file does not exist', () => {
+      expect(
+        loadManifestFromPathSyncWithNode(join(dir, 'missing.json')),
+      ).toBeNull();
+    });
+  });
+
+  describe('discoverCachedManifestSync', () => {
+    it('finds an entry from the embedded cache via the priority chain', () => {
+      getManifestCache().set(
+        '@acme/disc',
+        manifest('@acme/disc', {
+          '@acme/disc:Found': { className: 'Found', fields: {} },
+        }),
+      );
+      expect(discoverCachedManifestSync('Found')?.className).toBe('Found');
+    });
+
+    it('finds an entry from the local-test cache before the embedded cache', () => {
+      (globalThis as ManifestGlobals).__smrtManifestLocalTest = manifest(
+        '@local/test',
+        { '@local/test:LocalFound': { className: 'LocalFound', fields: {} } },
+      );
+      expect(discoverCachedManifestSync('LocalFound')?.className).toBe(
+        'LocalFound',
+      );
+    });
+
+    it('returns undefined when no cache holds the class', () => {
+      expect(discoverCachedManifestSync('NeverEverThere')).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/src/mcp-advisor/index.spec.ts
+++ b/packages/core/src/mcp-advisor/index.spec.ts
@@ -1,11 +1,13 @@
 /**
  * Integration test for the mcp-advisor stdio server (src/mcp-advisor/index.ts).
  *
- * The advisor entrypoint auto-starts an MCP server over stdio when imported, so
- * it cannot be unit-tested by import. Following the established pattern in
+ * The advisor's main() only runs when the module is the process entrypoint
+ * (guarded by isEntrypoint()), so the stdio transport can only be exercised by
+ * launching it as a subprocess. Following the established pattern in
  * packages/smrt-dev-mcp/src/mcp-stdio.test.ts we spawn it via `tsx` and drive it
  * with a real MCP Client. This exercises the ListTools handler, the CallTool
  * routing switch, the success-response formatter, and the error-response path.
+ * The in-process unit tests for TOOLS and handleToolCall live in index.test.ts.
  */
 
 import { existsSync } from 'node:fs';

--- a/packages/core/src/mcp-advisor/index.spec.ts
+++ b/packages/core/src/mcp-advisor/index.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * Integration test for the mcp-advisor stdio server (src/mcp-advisor/index.ts).
+ *
+ * The advisor entrypoint auto-starts an MCP server over stdio when imported, so
+ * it cannot be unit-tested by import. Following the established pattern in
+ * packages/smrt-dev-mcp/src/mcp-stdio.test.ts we spawn it via `tsx` and drive it
+ * with a real MCP Client. This exercises the ListTools handler, the CallTool
+ * routing switch, the success-response formatter, and the error-response path.
+ */
+
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(__dirname, '..', '..');
+const repoRoot = resolve(packageRoot, '..', '..');
+const tsxBin = join(repoRoot, 'node_modules', '.bin', 'tsx');
+
+let activeClient: Client | undefined;
+let activeTransport: StdioClientTransport | undefined;
+
+async function createMcpClient() {
+  expect(existsSync(tsxBin)).toBe(true);
+
+  const transport = new StdioClientTransport({
+    command: tsxBin,
+    args: ['src/mcp-advisor/index.ts'],
+    cwd: packageRoot,
+    stderr: 'pipe',
+  });
+  const client = new Client(
+    { name: 'smrt-advisor-smoke-test', version: '1.0.0' },
+    { capabilities: {} },
+  );
+
+  activeClient = client;
+  activeTransport = transport;
+  await client.connect(transport);
+  return client;
+}
+
+function textContent(result: Awaited<ReturnType<Client['callTool']>>): string {
+  if (!('content' in result) || !Array.isArray(result.content)) {
+    return JSON.stringify(result);
+  }
+  const first = result.content[0];
+  if (!first || first.type !== 'text') {
+    throw new Error('Expected text MCP response');
+  }
+  return first.text;
+}
+
+afterEach(async () => {
+  await activeClient?.close();
+  await activeTransport?.close();
+  activeClient = undefined;
+  activeTransport = undefined;
+});
+
+describe('mcp-advisor stdio server', () => {
+  it('lists all advisor tools, routes calls, and surfaces handler errors', async () => {
+    const client = await createMcpClient();
+
+    // ── ListTools ────────────────────────────────────────────────────────
+    const listResult = await client.listTools();
+    const toolNames = listResult.tools.map((t) => t.name);
+    expect(toolNames).toEqual(
+      expect.arrayContaining([
+        'generate-smrt-class',
+        'add-ai-methods',
+        'generate-field-definitions',
+        'generate-collection',
+        'configure-decorators',
+        'validate-smrt-object',
+        'preview-api-endpoints',
+        'preview-mcp-tools',
+        'list-registered-objects',
+        'get-object-schema',
+        'get-object-config',
+      ]),
+    );
+    // Each tool carries an input schema.
+    for (const tool of listResult.tools) {
+      expect(tool.inputSchema).toBeTruthy();
+    }
+
+    // ── CallTool: pure generator route (object result → JSON.stringify) ───
+    const genResult = await client.callTool({
+      name: 'generate-smrt-class',
+      arguments: {
+        className: 'Widget',
+        properties: [{ name: 'name', type: 'text', required: true }],
+      },
+    });
+    const gen = JSON.parse(textContent(genResult));
+    expect(gen.success).toBe(true);
+    expect(gen.data).toContain('export class Widget extends SmrtObject');
+
+    // ── CallTool: configure-decorators route ─────────────────────────────
+    const cfgResult = await client.callTool({
+      name: 'configure-decorators',
+      arguments: { className: 'Widget', cli: true },
+    });
+    const cfg = JSON.parse(textContent(cfgResult));
+    expect(cfg.success).toBe(true);
+    expect(cfg.data).toContain('cli: true');
+
+    // ── CallTool: registry route (empty/whatever-is-registered) ──────────
+    const listObjsResult = await client.callTool({
+      name: 'list-registered-objects',
+      arguments: {},
+    });
+    const listObjs = JSON.parse(textContent(listObjsResult));
+    expect(listObjs).toHaveProperty('objects');
+    expect(listObjs).toHaveProperty('total');
+    expect(Array.isArray(listObjs.objects)).toBe(true);
+
+    // ── CallTool: handler validation error → success:false response ───────
+    const badGenResult = await client.callTool({
+      name: 'generate-smrt-class',
+      arguments: { className: 'lowercase', properties: [] },
+    });
+    const badGen = JSON.parse(textContent(badGenResult));
+    expect(badGen.success).toBe(false);
+    expect(badGen.error).toMatch(/PascalCase|property/);
+
+    // ── CallTool: unknown tool → isError text response ───────────────────
+    const unknownResult = await client.callTool({
+      name: 'does-not-exist',
+      arguments: {},
+    });
+    expect(unknownResult.isError).toBe(true);
+    expect(textContent(unknownResult)).toMatch(
+      /Error executing does-not-exist: Unknown tool/,
+    );
+
+    // ── CallTool: registry handler that throws → isError text response ────
+    const previewErr = await client.callTool({
+      name: 'preview-mcp-tools',
+      arguments: { className: 'DefinitelyNotRegistered' },
+    });
+    expect(previewErr.isError).toBe(true);
+    expect(textContent(previewErr)).toMatch(/not found in ObjectRegistry/);
+  }, 60_000);
+});

--- a/packages/core/src/mcp-advisor/index.test.ts
+++ b/packages/core/src/mcp-advisor/index.test.ts
@@ -1,0 +1,141 @@
+/**
+ * In-process unit tests for the mcp-advisor server module (index.ts).
+ *
+ * The module's `main()` only runs when it is the process entrypoint (guarded by
+ * isEntrypoint()), so importing it here is side-effect free — no stdio server is
+ * started. We test the exported `TOOLS` surface and the `handleToolCall` routing
+ * switch directly. The end-to-end stdio transport is covered separately by
+ * index.spec.ts.
+ */
+
+import { describe, expect, it } from 'vitest';
+// Importing a fixture registers a real @smrt() class so registry-backed routes
+// return data instead of throwing.
+import { AdvisorRichProduct } from '../__tests__/fixtures/advisor-test-classes.js';
+import { handleToolCall, TOOLS } from './index.js';
+
+void AdvisorRichProduct;
+
+describe('mcp-advisor index: TOOLS surface', () => {
+  it('declares every advisor tool with a name, description and input schema', () => {
+    const names = TOOLS.map((t) => t.name);
+    expect(names).toEqual([
+      'generate-smrt-class',
+      'add-ai-methods',
+      'generate-field-definitions',
+      'generate-collection',
+      'configure-decorators',
+      'validate-smrt-object',
+      'preview-api-endpoints',
+      'preview-mcp-tools',
+      'list-registered-objects',
+      'get-object-schema',
+      'get-object-config',
+    ]);
+
+    for (const tool of TOOLS) {
+      expect(tool.description.length).toBeGreaterThan(0);
+      expect(tool.inputSchema.type).toBe('object');
+      expect(tool.inputSchema.properties).toBeTypeOf('object');
+    }
+  });
+});
+
+describe('mcp-advisor index: handleToolCall routing', () => {
+  it('routes generate-smrt-class', async () => {
+    const result = await handleToolCall('generate-smrt-class', {
+      className: 'Widget',
+      properties: [{ name: 'name', type: 'text' }],
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).toContain('export class Widget extends SmrtObject');
+  });
+
+  it('routes add-ai-methods', async () => {
+    const result = await handleToolCall('add-ai-methods', {
+      className: 'Widget',
+      methods: ['is'],
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).toContain('async is(');
+  });
+
+  it('routes generate-field-definitions', async () => {
+    const result = await handleToolCall('generate-field-definitions', {
+      fields: [{ name: 'title', type: 'text' }],
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).toContain("title: string = '';");
+  });
+
+  it('routes generate-collection', async () => {
+    const result = await handleToolCall('generate-collection', {
+      collectionName: 'WidgetCollection',
+      itemClassName: 'Widget',
+      itemClassPath: './widget.js',
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).toContain('static readonly _itemClass = Widget;');
+  });
+
+  it('routes configure-decorators', async () => {
+    const result = await handleToolCall('configure-decorators', {
+      className: 'Widget',
+      cli: true,
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).toContain('cli: true');
+  });
+
+  it('routes validate-smrt-object (read failure path)', async () => {
+    const result = await handleToolCall('validate-smrt-object', {
+      filePath: '/no/such/advisor/file.ts',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('routes preview-api-endpoints', async () => {
+    const result = await handleToolCall('preview-api-endpoints', {
+      className: 'AdvisorRichProduct',
+    });
+    expect(result.basePath).toBe('/api/v1');
+    expect(result.endpoints.length).toBeGreaterThan(0);
+  });
+
+  it('routes preview-mcp-tools', async () => {
+    const result = await handleToolCall('preview-mcp-tools', {
+      className: 'AdvisorRichProduct',
+    });
+    expect(result.className).toBe('AdvisorRichProduct');
+    expect(Array.isArray(result.tools)).toBe(true);
+  });
+
+  it('routes list-registered-objects', async () => {
+    const result = await handleToolCall('list-registered-objects', {});
+    expect(Array.isArray(result.objects)).toBe(true);
+    expect(result.total).toBe(result.objects.length);
+  });
+
+  it('routes get-object-schema', async () => {
+    const result = await handleToolCall('get-object-schema', {
+      className: 'AdvisorRichProduct',
+    });
+    expect(result.className).toBe('AdvisorRichProduct');
+    expect(result.fields.length).toBe(3);
+  });
+
+  it('routes get-object-config', async () => {
+    const result = await handleToolCall('get-object-config', {
+      className: 'AdvisorRichProduct',
+    });
+    expect(result.className).toBe('AdvisorRichProduct');
+    expect(result.decorator.cli).toBe(true);
+  });
+
+  it('throws for an unknown tool name', async () => {
+    await expect(handleToolCall('no-such-tool', {})).rejects.toThrow(
+      'Unknown tool: no-such-tool',
+    );
+  });
+});

--- a/packages/core/src/mcp-advisor/index.ts
+++ b/packages/core/src/mcp-advisor/index.ts
@@ -8,6 +8,8 @@
  * This server integrates with Claude Code to help developers write correct SMRT code.
  */
 
+import { realpathSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
@@ -36,8 +38,11 @@ const DEBUG = process.env.DEBUG === 'true';
 
 /**
  * MCP tool definitions with JSON schemas
+ *
+ * Exported so tests can assert the advertised tool surface without spawning the
+ * stdio server.
  */
-const TOOLS = [
+export const TOOLS = [
   {
     name: 'generate-smrt-class',
     description:
@@ -366,8 +371,11 @@ const TOOLS = [
 
 /**
  * Route tool calls to appropriate handler functions
+ *
+ * Exported so the routing switch can be unit-tested in-process (the stdio
+ * entrypoint guard below keeps importing this module side-effect free).
  */
-async function handleToolCall(name: string, args: any): Promise<any> {
+export async function handleToolCall(name: string, args: any): Promise<any> {
   switch (name) {
     case 'generate-smrt-class':
       return generateSmrtClass(args);
@@ -524,8 +532,25 @@ async function main() {
   }
 }
 
-// Start the server
-main().catch((error) => {
-  console.error('[SMRT Advisor] Unhandled error:', error);
-  process.exit(1);
-});
+/**
+ * True only when this module is the process entrypoint (e.g. launched directly
+ * via `node`/`tsx`). Mirrors the guard in packages/smrt-dev-mcp/src/index.ts so
+ * importing this module for testing does not auto-start the stdio server.
+ */
+function isEntrypoint(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(entry);
+  } catch {
+    return import.meta.url === pathToFileURL(entry).href;
+  }
+}
+
+// Start the server only when run as the entrypoint.
+if (isEntrypoint()) {
+  main().catch((error) => {
+    console.error('[SMRT Advisor] Unhandled error:', error);
+    process.exit(1);
+  });
+}

--- a/packages/core/src/mcp-advisor/tools/add-ai-methods.test.ts
+++ b/packages/core/src/mcp-advisor/tools/add-ai-methods.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for the mcp-advisor add-ai-methods tool.
+ *
+ * Pure generator: returns a `ToolResponse` whose `data` is the source for the
+ * requested AI methods (is/do/tool). We assert each generated method body and
+ * the error path for unknown / empty method lists.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { addAiMethods } from './add-ai-methods.js';
+
+describe('mcp-advisor: addAiMethods', () => {
+  it('generates the is() method', async () => {
+    const result = await addAiMethods({
+      className: 'Product',
+      methods: ['is'],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toEqual([]);
+    const code = result.data as string;
+    expect(code).toContain(
+      'async is(criteria: string, options?: any): Promise<boolean> {',
+    );
+    expect(code).toContain('if (!this.ai) {');
+    expect(code).toContain("return response.toLowerCase().includes('true');");
+  });
+
+  it('generates the do() method', async () => {
+    const result = await addAiMethods({
+      className: 'Product',
+      methods: ['do'],
+    });
+
+    expect(result.success).toBe(true);
+    const code = result.data as string;
+    expect(code).toContain(
+      'async do(instructions: string, options?: any): Promise<string> {',
+    );
+    expect(code).toContain(
+      'const response = await this.ai.message(prompt, options);',
+    );
+  });
+
+  it('generates the tool/analyze method embedding the class name', async () => {
+    const result = await addAiMethods({
+      className: 'Invoice',
+      methods: ['tool'],
+    });
+
+    expect(result.success).toBe(true);
+    const code = result.data as string;
+    expect(code).toContain(
+      "async analyze(options: { depth?: 'shallow' | 'deep' } = {}):",
+    );
+    // The generated prompt interpolates the class name into the analyze body.
+    expect(code).toContain('Analyze this Invoice with ');
+    expect(code).toContain("action: 'analyze',");
+  });
+
+  it('generates and concatenates multiple methods', async () => {
+    const result = await addAiMethods({
+      className: 'Product',
+      methods: ['is', 'do', 'tool'],
+    });
+
+    expect(result.success).toBe(true);
+    const code = result.data as string;
+    expect(code).toContain('async is(');
+    expect(code).toContain('async do(');
+    expect(code).toContain('async analyze(');
+    // Methods are joined with a blank-line separator
+    expect(code.split('async ').length).toBe(4);
+  });
+
+  it('returns an error for an empty method list', async () => {
+    const result = await addAiMethods({ className: 'Product', methods: [] });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('At least one method is required');
+  });
+
+  it('returns an error for an unknown method type', async () => {
+    const result = await addAiMethods({
+      className: 'Product',
+      // Deliberately invalid input to exercise the default-case error branch.
+      methods: ['frobnicate' as unknown as 'is'],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Unknown method type: frobnicate');
+  });
+});

--- a/packages/core/src/mcp-advisor/tools/configure-decorators.test.ts
+++ b/packages/core/src/mcp-advisor/tools/configure-decorators.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for the mcp-advisor configure-decorators tool.
+ *
+ * Pure generator: assembles a `@smrt({...})` decorator string from the supplied
+ * api/mcp/cli/hooks config. Covers each config branch plus the empty-config
+ * fallback to a bare `@smrt()`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { configureDecorators } from './configure-decorators.js';
+
+describe('mcp-advisor: configureDecorators', () => {
+  it('renders api include/exclude lists', async () => {
+    const result = await configureDecorators({
+      className: 'Product',
+      api: { include: ['list', 'get'], exclude: ['delete'] },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toEqual([]);
+    const code = result.data as string;
+    expect(code).toContain('@smrt({');
+    expect(code).toContain('api: {');
+    expect(code).toContain("include: ['list', 'get']");
+    expect(code).toContain("exclude: ['delete']");
+    expect(code).toContain('export class Product extends SmrtObject {');
+  });
+
+  it('renders mcp include/exclude lists', async () => {
+    const result = await configureDecorators({
+      className: 'Product',
+      mcp: { include: ['list'], exclude: ['create'] },
+    });
+
+    expect(result.success).toBe(true);
+    const code = result.data as string;
+    expect(code).toContain('mcp: {');
+    expect(code).toContain("include: ['list']");
+    expect(code).toContain("exclude: ['create']");
+  });
+
+  it('renders cli boolean (including false)', async () => {
+    const enabled = await configureDecorators({ className: 'A', cli: true });
+    expect(enabled.data as string).toContain('cli: true');
+
+    const disabled = await configureDecorators({ className: 'A', cli: false });
+    expect(disabled.data as string).toContain('cli: false');
+  });
+
+  it('renders lifecycle hooks', async () => {
+    const result = await configureDecorators({
+      className: 'Product',
+      hooks: { beforeSave: 'validate', afterSave: 'index' },
+    });
+
+    expect(result.success).toBe(true);
+    const code = result.data as string;
+    expect(code).toContain('hooks: {');
+    expect(code).toContain("beforeSave: 'validate'");
+    expect(code).toContain("afterSave: 'index'");
+  });
+
+  it('combines all config sections', async () => {
+    const result = await configureDecorators({
+      className: 'Combined',
+      api: { include: ['list'] },
+      mcp: { exclude: ['delete'] },
+      cli: true,
+      hooks: { beforeDelete: 'guard' },
+    });
+
+    expect(result.success).toBe(true);
+    const code = result.data as string;
+    expect(code).toContain('api: {');
+    expect(code).toContain('mcp: {');
+    expect(code).toContain('cli: true');
+    expect(code).toContain('hooks: {');
+  });
+
+  it('falls back to a bare @smrt() when no config is supplied', async () => {
+    const result = await configureDecorators({ className: 'Bare' });
+
+    expect(result.success).toBe(true);
+    const code = result.data as string;
+    expect(code).toContain('@smrt()');
+    expect(code).not.toContain('@smrt({');
+  });
+
+  it('ignores empty include/exclude arrays', async () => {
+    const result = await configureDecorators({
+      className: 'EmptyArrays',
+      api: { include: [], exclude: [] },
+      mcp: { include: [], exclude: [] },
+      hooks: {},
+    });
+
+    expect(result.success).toBe(true);
+    const code = result.data as string;
+    // All sections empty → bare decorator
+    expect(code).toContain('@smrt()');
+    expect(code).not.toContain('@smrt({');
+  });
+});

--- a/packages/core/src/mcp-advisor/tools/generate-collection.test.ts
+++ b/packages/core/src/mcp-advisor/tools/generate-collection.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for the mcp-advisor generate-collection tool.
+ *
+ * Pure generator: returns a `ToolResponse` whose `data` is a SmrtCollection
+ * subclass. Covers imports, the required `_itemClass`, optional custom methods,
+ * and PascalCase validation errors for both class names.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { generateCollection } from './generate-collection.js';
+
+describe('mcp-advisor: generateCollection', () => {
+  it('generates a minimal collection with imports and _itemClass', async () => {
+    const result = await generateCollection({
+      collectionName: 'ProductCollection',
+      itemClassName: 'Product',
+      itemClassPath: './product.js',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toEqual([]);
+    const code = result.data as string;
+    expect(code).toContain(
+      "import { SmrtCollection } from '@happyvertical/smrt-core';",
+    );
+    expect(code).toContain("import { Product } from './product.js';");
+    expect(code).toContain(
+      'export class ProductCollection extends SmrtCollection<Product> {',
+    );
+    expect(code).toContain('static readonly _itemClass = Product;');
+    // No custom methods by default
+    expect(code).not.toContain('findByCriteria');
+    expect(code).not.toContain('getOrCreate');
+  });
+
+  it('includes placeholder custom methods when requested', async () => {
+    const result = await generateCollection({
+      collectionName: 'OrderCollection',
+      itemClassName: 'Order',
+      itemClassPath: './order.js',
+      includeCustomMethods: true,
+    });
+
+    expect(result.success).toBe(true);
+    const code = result.data as string;
+    expect(code).toContain(
+      'async findByCriteria(criteria: any): Promise<Order[]> {',
+    );
+    expect(code).toContain(
+      'async getOrCreate(data: any, defaults: any = {}): Promise<Order> {',
+    );
+    expect(code).toContain('return this.getOrUpsert(data, defaults);');
+  });
+
+  it('rejects a non-PascalCase collectionName', async () => {
+    const result = await generateCollection({
+      collectionName: 'productCollection',
+      itemClassName: 'Product',
+      itemClassPath: './product.js',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/collectionName must be in PascalCase/);
+  });
+
+  it('rejects a non-PascalCase itemClassName', async () => {
+    const result = await generateCollection({
+      collectionName: 'ProductCollection',
+      itemClassName: 'product',
+      itemClassPath: './product.js',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/itemClassName must be in PascalCase/);
+  });
+});

--- a/packages/core/src/mcp-advisor/tools/generate-field-definitions.test.ts
+++ b/packages/core/src/mcp-advisor/tools/generate-field-definitions.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for the mcp-advisor generate-field-definitions tool.
+ *
+ * Pure generator: returns a `ToolResponse` whose `data` is field-definition
+ * source (decorators + typed properties with defaults). Covers the decorator /
+ * no-decorator branches, the full type→TS map, and the empty-input error.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { generateFieldDefinitions } from './generate-field-definitions.js';
+
+describe('mcp-advisor: generateFieldDefinitions', () => {
+  it('generates plain field definitions without a @field decorator when no _meta', async () => {
+    const result = await generateFieldDefinitions({
+      fields: [{ name: 'title', type: 'text' }],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toEqual([]);
+    const code = result.data as string;
+    expect(code).toContain("import { field } from '@happyvertical/smrt-core';");
+    expect(code).toContain("title: string = '';");
+    expect(code).not.toContain('@field(');
+  });
+
+  it('emits a @field decorator with serialized _meta options', async () => {
+    const result = await generateFieldDefinitions({
+      fields: [
+        {
+          name: 'name',
+          type: 'text',
+          _meta: { required: true, maxLength: 50 },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    const code = result.data as string;
+    expect(code).toContain('@field({"required":true,"maxLength":50})');
+    expect(code).toContain("name: string = '';");
+  });
+
+  it('treats an empty _meta object as no decorator', async () => {
+    const result = await generateFieldDefinitions({
+      fields: [{ name: 'x', type: 'integer', _meta: {} }],
+    });
+
+    expect(result.success).toBe(true);
+    const code = result.data as string;
+    expect(code).not.toContain('@field(');
+    expect(code).toContain('x: number = 0;');
+  });
+
+  it('maps each field type to the correct TS type and default value', async () => {
+    const result = await generateFieldDefinitions({
+      fields: [
+        { name: 'a', type: 'text' },
+        { name: 'b', type: 'integer' },
+        { name: 'c', type: 'decimal' },
+        { name: 'd', type: 'boolean' },
+        { name: 'e', type: 'datetime' },
+        { name: 'f', type: 'json' },
+        { name: 'g', type: 'foreignKey' },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    const code = result.data as string;
+    expect(code).toContain("a: string = '';");
+    expect(code).toContain('b: number = 0;');
+    expect(code).toContain('c: number = 0.0;');
+    expect(code).toContain('d: boolean = false;');
+    expect(code).toContain('e: Date = new Date();');
+    expect(code).toContain('f: Record<string, any> = {};');
+    // foreignKey is not in the local type map → falls through to `any`/`undefined`
+    expect(code).toContain('g: any = undefined;');
+  });
+
+  it('returns an error for an empty field list', async () => {
+    const result = await generateFieldDefinitions({ fields: [] });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('At least one field is required');
+  });
+});

--- a/packages/core/src/mcp-advisor/tools/generate-smrt-class.test.ts
+++ b/packages/core/src/mcp-advisor/tools/generate-smrt-class.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for the mcp-advisor generate-smrt-class tool.
+ *
+ * These are pure code-generation handlers: given a class spec they return a
+ * `ToolResponse` whose `data` is generated TypeScript source. We assert the
+ * generated source contains the right decorator/interface/constructor shapes
+ * and that input validation produces structured error responses.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { generateSmrtClass } from './generate-smrt-class.js';
+
+describe('mcp-advisor: generateSmrtClass', () => {
+  it('generates a complete SmrtObject class with interface, decorator and constructor', async () => {
+    const result = await generateSmrtClass({
+      className: 'Product',
+      properties: [
+        { name: 'name', type: 'text', required: true },
+        { name: 'price', type: 'decimal' },
+        { name: 'stock', type: 'integer' },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toEqual([]);
+    const code = result.data as string;
+
+    // Imports + base class
+    expect(code).toContain(
+      "import { SmrtObject, type SmrtObjectOptions, smrt, field } from '@happyvertical/smrt-core';",
+    );
+    // Options interface
+    expect(code).toContain(
+      'export interface ProductOptions extends SmrtObjectOptions {',
+    );
+    expect(code).toContain('name?: string;');
+    expect(code).toContain('price?: number;');
+    // Default decorator config (api/mcp/cli all on by default)
+    expect(code).toContain('@smrt({');
+    expect(code).toContain('api: {');
+    expect(code).toContain('mcp: {');
+    expect(code).toContain('cli: true');
+    expect(code).toContain('export class Product extends SmrtObject {');
+    // Required field gets a @field decorator; integer default 0, decimal 0.0
+    expect(code).toContain('@field({ required: true })');
+    expect(code).toContain("name: string = '';");
+    expect(code).toContain('price: number = 0.0;');
+    expect(code).toContain('stock: number = 0;');
+    // Constructor + super + assignments (required uses truthy, optional uses !== undefined)
+    expect(code).toContain('constructor(options: ProductOptions = {}) {');
+    expect(code).toContain('super(options);');
+    expect(code).toContain('if (options.name) this.name = options.name;');
+    expect(code).toContain(
+      'if (options.price !== undefined) this.price = options.price;',
+    );
+  });
+
+  it('honours the SmrtCollection base class', async () => {
+    const result = await generateSmrtClass({
+      className: 'WidgetCollection',
+      baseClass: 'SmrtCollection',
+      properties: [{ name: 'label', type: 'text' }],
+    });
+
+    expect(result.success).toBe(true);
+    const code = result.data as string;
+    expect(code).toContain(
+      'export class WidgetCollection extends SmrtCollection {',
+    );
+    expect(code).toContain(
+      "import { SmrtCollection, type SmrtObjectOptions, smrt, field } from '@happyvertical/smrt-core';",
+    );
+  });
+
+  it('emits a bare @smrt() decorator when all config flags are disabled', async () => {
+    const result = await generateSmrtClass({
+      className: 'Plain',
+      properties: [{ name: 'value', type: 'text' }],
+      includeApiConfig: false,
+      includeMcpConfig: false,
+      includeCliConfig: false,
+    });
+
+    expect(result.success).toBe(true);
+    const code = result.data as string;
+    expect(code).toContain('@smrt()');
+    expect(code).not.toContain('@smrt({');
+  });
+
+  it('maps every supported field type to its TS type and default', async () => {
+    const result = await generateSmrtClass({
+      className: 'AllTypes',
+      properties: [
+        { name: 'a', type: 'text' },
+        { name: 'b', type: 'integer' },
+        { name: 'c', type: 'decimal' },
+        { name: 'd', type: 'boolean' },
+        { name: 'e', type: 'datetime' },
+        { name: 'f', type: 'json' },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    const code = result.data as string;
+    expect(code).toContain("a: string = '';");
+    expect(code).toContain('b: number = 0;');
+    expect(code).toContain('c: number = 0.0;');
+    expect(code).toContain('d: boolean = false;');
+    expect(code).toContain('e: Date = new Date();');
+    expect(code).toContain('f: Record<string, any> = {};');
+  });
+
+  it('rejects a non-PascalCase className with a structured error', async () => {
+    const result = await generateSmrtClass({
+      className: 'product',
+      properties: [{ name: 'name', type: 'text' }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/PascalCase/);
+    expect(result.data).toBeUndefined();
+  });
+
+  it('rejects an empty className', async () => {
+    const result = await generateSmrtClass({
+      className: '',
+      properties: [{ name: 'name', type: 'text' }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/PascalCase/);
+  });
+
+  it('rejects an empty property list', async () => {
+    const result = await generateSmrtClass({
+      className: 'Empty',
+      properties: [],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('At least one property is required');
+  });
+});

--- a/packages/core/src/mcp-advisor/tools/get-object-config.test.ts
+++ b/packages/core/src/mcp-advisor/tools/get-object-config.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for the mcp-advisor get-object-config tool.
+ *
+ * Registry-backed: imported @smrt() fixtures supply runtime decorator config,
+ * manifest-hydrated fields, and prototype custom methods. Asserts the assembled
+ * ObjectConfig (decorator/api/mcp/cli/hooks, fields, customMethods) and the
+ * yaml format branch.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  AdvisorBooleanWidget,
+  AdvisorExcludeNote,
+  AdvisorRichProduct,
+} from '../../__tests__/fixtures/advisor-test-classes.js';
+import { getObjectConfig } from './get-object-config.js';
+
+void AdvisorBooleanWidget;
+void AdvisorExcludeNote;
+void AdvisorRichProduct;
+
+describe('mcp-advisor: getObjectConfig', () => {
+  it('assembles decorator config, fields and custom methods (object-form config)', async () => {
+    const result = await getObjectConfig({ className: 'AdvisorRichProduct' });
+
+    expect(result.className).toBe('AdvisorRichProduct');
+
+    // Object-form api/mcp include lists round-trip through the registry config.
+    expect(result.decorator.api).toMatchObject({
+      include: ['list', 'get', 'create', 'update', 'archive'],
+    });
+    expect(result.decorator.mcp).toMatchObject({ include: ['list', 'get'] });
+    expect(result.decorator.cli).toBe(true);
+    expect(result.decorator.hooks).toMatchObject({
+      beforeSave: 'validateAdvisor',
+      afterSave: 'indexAdvisor',
+    });
+
+    // Fields come from the manifest.
+    expect(result.fields).toHaveLength(3);
+    expect(result.fields.map((f) => f.name).sort()).toEqual([
+      'quantity',
+      'rate',
+      'title',
+    ]);
+
+    // The custom `recalculate` method is discovered from the prototype and the
+    // standard CRUD/AI methods are filtered out.
+    expect(result.customMethods).toContain('recalculate');
+    expect(result.customMethods).not.toContain('save');
+    expect(result.customMethods).not.toContain('is');
+    expect(result.customMethods).not.toContain('do');
+  });
+
+  it('reports boolean api/mcp config and cli=false', async () => {
+    const result = await getObjectConfig({ className: 'AdvisorBooleanWidget' });
+    expect(result.decorator.api).toBe(true);
+    expect(result.decorator.mcp).toBe(true);
+    expect(result.decorator.cli).toBe(false);
+    expect(result.decorator.hooks).toBeUndefined();
+  });
+
+  it('renders the yaml format branch without error', async () => {
+    const result = await getObjectConfig({
+      className: 'AdvisorRichProduct',
+      format: 'yaml',
+    });
+    // The handler still returns the structured config regardless of format.
+    expect(result.className).toBe('AdvisorRichProduct');
+    expect(result.fields.length).toBeGreaterThan(0);
+  });
+
+  it('renders yaml for exclude-form config (covers exclude yaml branch)', async () => {
+    const result = await getObjectConfig({
+      className: 'AdvisorExcludeNote',
+      format: 'yaml',
+    });
+    expect(result.decorator.api).toMatchObject({ exclude: ['delete'] });
+    expect(result.decorator.mcp).toMatchObject({ exclude: ['delete'] });
+  });
+
+  it('returns an empty config for an unregistered class', async () => {
+    // getConfig() returns {} (truthy) for unknown classes, so the handler
+    // resolves with an empty decorator and zero fields rather than throwing.
+    const result = await getObjectConfig({ className: 'TotallyUnknownClass' });
+    expect(result.className).toBe('TotallyUnknownClass');
+    expect(result.decorator).toEqual({});
+    expect(result.fields).toEqual([]);
+    expect(result.customMethods).toEqual([]);
+  });
+});

--- a/packages/core/src/mcp-advisor/tools/get-object-schema.test.ts
+++ b/packages/core/src/mcp-advisor/tools/get-object-schema.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for the mcp-advisor get-object-schema tool.
+ *
+ * Registry-backed: relies on imported @smrt() fixtures whose fields (and field
+ * constraints) are hydrated from the test manifest. Asserts the returned
+ * FieldDefinition array, constraint extraction, and each format branch.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  AdvisorBooleanWidget,
+  AdvisorRichProduct,
+} from '../../__tests__/fixtures/advisor-test-classes.js';
+import { getObjectSchema } from './get-object-schema.js';
+
+void AdvisorBooleanWidget;
+void AdvisorRichProduct;
+
+describe('mcp-advisor: getObjectSchema', () => {
+  it('returns field definitions with types, required flags and constraints', async () => {
+    const result = await getObjectSchema({ className: 'AdvisorRichProduct' });
+
+    expect(result.className).toBe('AdvisorRichProduct');
+    expect(result.format).toBe('json');
+    expect(result.fields).toHaveLength(3);
+
+    const title = result.fields.find((f) => f.name === 'title');
+    expect(title).toMatchObject({
+      name: 'title',
+      type: 'text',
+      required: true,
+      description: 'Product display name',
+    });
+    // maxLength is a recognised constraint
+    expect(title?.constraints).toMatchObject({ maxLength: 120 });
+
+    const quantity = result.fields.find((f) => f.name === 'quantity');
+    expect(quantity?.type).toBe('integer');
+    expect(quantity?.required).toBe(false);
+    expect(quantity?.constraints).toMatchObject({ min: 0, max: 1000 });
+  });
+
+  it('reports fields with no constraints as an empty constraints object', async () => {
+    const result = await getObjectSchema({ className: 'AdvisorBooleanWidget' });
+    const label = result.fields.find((f) => f.name === 'label');
+    expect(label?.required).toBe(true);
+    expect(label?.constraints).toEqual({});
+  });
+
+  it('accepts the typescript format', async () => {
+    const result = await getObjectSchema({
+      className: 'AdvisorRichProduct',
+      format: 'typescript',
+    });
+    expect(result.format).toBe('typescript');
+    expect(result.fields).toHaveLength(3);
+  });
+
+  it('accepts the table format', async () => {
+    const result = await getObjectSchema({
+      className: 'AdvisorRichProduct',
+      format: 'table',
+    });
+    expect(result.format).toBe('table');
+    expect(result.fields.length).toBeGreaterThan(0);
+  });
+
+  it('returns an empty field list for an unregistered class', async () => {
+    // getFields() returns an empty Map (not undefined) for unknown classes, so
+    // the handler resolves with zero fields rather than throwing.
+    const result = await getObjectSchema({ className: 'TotallyUnknownClass' });
+    expect(result.className).toBe('TotallyUnknownClass');
+    expect(result.fields).toEqual([]);
+  });
+});

--- a/packages/core/src/mcp-advisor/tools/list-registered-objects.test.ts
+++ b/packages/core/src/mcp-advisor/tools/list-registered-objects.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for the mcp-advisor list-registered-objects tool.
+ *
+ * Registry-backed: importing the fixture modules registers real @smrt() classes
+ * (with fields from the test manifest) into the global ObjectRegistry. We do NOT
+ * clear the registry here — clearing would drop the manifest-hydrated field
+ * metadata. Instead we assert on the specific fixtures we registered.
+ */
+
+import { describe, expect, it } from 'vitest';
+// Importing the fixtures triggers @smrt() registration as a side effect.
+import {
+  AdvisorBooleanWidget,
+  AdvisorExcludeNote,
+  AdvisorRichProduct,
+} from '../../__tests__/fixtures/advisor-test-classes.js';
+import { listRegisteredObjects } from './list-registered-objects.js';
+
+// Reference the imported classes so tree-shaking / lint keeps the import.
+void AdvisorBooleanWidget;
+void AdvisorExcludeNote;
+void AdvisorRichProduct;
+
+describe('mcp-advisor: listRegisteredObjects', () => {
+  it('lists registered objects with metadata derived from the registry', async () => {
+    const result = await listRegisteredObjects({ filter: 'all' });
+
+    expect(result.total).toBe(result.objects.length);
+    expect(result.total).toBeGreaterThan(0);
+
+    const rich = result.objects.find((o) => o.name === 'AdvisorRichProduct');
+    expect(rich).toBeDefined();
+    expect(rich?.type).toBe('object');
+    expect(rich?.hasDecorator).toBe(true);
+    expect(rich?.fieldCount).toBe(3);
+    expect(rich?.apiEnabled).toBe(true);
+    expect(rich?.mcpEnabled).toBe(true);
+    expect(rich?.cliEnabled).toBe(true);
+  });
+
+  it('detects boolean api/mcp config and disabled cli', async () => {
+    const result = await listRegisteredObjects();
+
+    const widget = result.objects.find(
+      (o) => o.name === 'AdvisorBooleanWidget',
+    );
+    expect(widget).toBeDefined();
+    expect(widget?.apiEnabled).toBe(true);
+    expect(widget?.mcpEnabled).toBe(true);
+    expect(widget?.cliEnabled).toBe(false);
+    expect(widget?.fieldCount).toBe(1);
+  });
+
+  it('treats exclude-only config as enabled (exclude !== undefined)', async () => {
+    const result = await listRegisteredObjects();
+
+    const note = result.objects.find((o) => o.name === 'AdvisorExcludeNote');
+    expect(note).toBeDefined();
+    expect(note?.apiEnabled).toBe(true);
+    expect(note?.mcpEnabled).toBe(true);
+    // No cli configured → disabled
+    expect(note?.cliEnabled).toBe(false);
+  });
+
+  it('defaults filter to "all" when called with no arguments', async () => {
+    const result = await listRegisteredObjects();
+    expect(result.objects.length).toBe(result.total);
+    expect(result.objects.some((o) => o.name === 'AdvisorRichProduct')).toBe(
+      true,
+    );
+  });
+
+  it('filters to objects only', async () => {
+    const result = await listRegisteredObjects({ filter: 'objects' });
+    expect(result.objects.every((o) => o.type === 'object')).toBe(true);
+    expect(result.objects.some((o) => o.name === 'AdvisorRichProduct')).toBe(
+      true,
+    );
+  });
+
+  it('filters to collections only', async () => {
+    const result = await listRegisteredObjects({ filter: 'collections' });
+    // Every returned entry must be a collection; our object fixtures excluded.
+    expect(result.objects.every((o) => o.type === 'collection')).toBe(true);
+    expect(result.objects.some((o) => o.name === 'AdvisorRichProduct')).toBe(
+      false,
+    );
+  });
+});

--- a/packages/core/src/mcp-advisor/tools/preview-api-endpoints.test.ts
+++ b/packages/core/src/mcp-advisor/tools/preview-api-endpoints.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for the mcp-advisor preview-api-endpoints tool.
+ *
+ * Registry-backed: imported @smrt() fixtures supply api config and fields. Covers
+ * include lists (with a custom action), exclude lists, the default base path,
+ * a custom base path, and field-derived body parameters.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  AdvisorExcludeNote,
+  AdvisorRichProduct,
+} from '../../__tests__/fixtures/advisor-test-classes.js';
+import { previewApiEndpoints } from './preview-api-endpoints.js';
+
+void AdvisorExcludeNote;
+void AdvisorRichProduct;
+
+describe('mcp-advisor: previewApiEndpoints', () => {
+  it('generates endpoints honouring an include list plus custom actions', async () => {
+    const result = await previewApiEndpoints({
+      className: 'AdvisorRichProduct',
+    });
+
+    expect(result.basePath).toBe('/api/v1');
+    const byKey = result.endpoints.map((e) => `${e.method} ${e.path}`);
+
+    // Standard CRUD from the include list.
+    expect(byKey).toContain('GET /api/v1/advisorrichproducts');
+    expect(byKey).toContain('GET /api/v1/advisorrichproducts/:id');
+    expect(byKey).toContain('POST /api/v1/advisorrichproducts');
+    expect(byKey).toContain('PUT /api/v1/advisorrichproducts/:id');
+    // 'delete' was not in the include list → no DELETE endpoint.
+    expect(byKey).not.toContain('DELETE /api/v1/advisorrichproducts/:id');
+    // The custom 'archive' action becomes a POST sub-resource endpoint.
+    expect(byKey).toContain('POST /api/v1/advisorrichproducts/:id/archive');
+
+    // CREATE endpoint body params are derived from the registered fields.
+    const create = result.endpoints.find(
+      (e) => e.method === 'POST' && e.path === '/api/v1/advisorrichproducts',
+    );
+    const titleParam = create?.parameters?.find((p) => p.name === 'title');
+    expect(titleParam).toMatchObject({
+      location: 'body',
+      required: true,
+      type: 'text',
+    });
+  });
+
+  it('honours an exclude list (delete removed)', async () => {
+    const result = await previewApiEndpoints({
+      className: 'AdvisorExcludeNote',
+    });
+    const byKey = result.endpoints.map((e) => `${e.method} ${e.path}`);
+
+    // No include list → all standard endpoints except the excluded delete.
+    expect(byKey).toContain('GET /api/v1/advisorexcludenotes');
+    expect(byKey).toContain('POST /api/v1/advisorexcludenotes');
+    expect(byKey).toContain('PUT /api/v1/advisorexcludenotes/:id');
+    expect(byKey).not.toContain('DELETE /api/v1/advisorexcludenotes/:id');
+  });
+
+  it('respects a custom base path', async () => {
+    const result = await previewApiEndpoints({
+      className: 'AdvisorExcludeNote',
+      basePath: '/v2',
+    });
+    expect(result.basePath).toBe('/v2');
+    expect(result.endpoints.every((e) => e.path.startsWith('/v2/'))).toBe(true);
+  });
+
+  it('returns the full default endpoint set for an unregistered class', async () => {
+    // getConfig() yields {} for unknown classes, so every standard endpoint is
+    // included (no include/exclude filtering) rather than throwing.
+    const result = await previewApiEndpoints({ className: 'UnknownApiClass' });
+    const methods = result.endpoints.map((e) => e.method).sort();
+    expect(methods).toEqual(['DELETE', 'GET', 'GET', 'POST', 'PUT']);
+  });
+});

--- a/packages/core/src/mcp-advisor/tools/preview-mcp-tools.test.ts
+++ b/packages/core/src/mcp-advisor/tools/preview-mcp-tools.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for the mcp-advisor preview-mcp-tools tool.
+ *
+ * Registry-backed: delegates to the real MCPGenerator and filters its output to
+ * the requested class. Covers the happy path (tools prefixed with the lowercased
+ * class name) and the genuine error path for an unregistered class.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { AdvisorRichProduct } from '../../__tests__/fixtures/advisor-test-classes.js';
+import { McpIntegrationTestProduct } from '../../__tests__/fixtures/mcp-integration-test-classes.js';
+import { previewMcpTools } from './preview-mcp-tools.js';
+
+void McpIntegrationTestProduct;
+void AdvisorRichProduct;
+
+describe('mcp-advisor: previewMcpTools', () => {
+  it('returns the MCP tools generated for a registered class', async () => {
+    const result = await previewMcpTools({
+      className: 'McpIntegrationTestProduct',
+    });
+
+    expect(result.className).toBe('McpIntegrationTestProduct');
+    expect(result.tools.length).toBeGreaterThan(0);
+    // All returned tools are namespaced to the lowercased class name.
+    expect(
+      result.tools.every((t) =>
+        t.name.startsWith('mcpintegrationtestproduct_'),
+      ),
+    ).toBe(true);
+    // The fixture's mcp include list exposes list + get.
+    const names = result.tools.map((t) => t.name);
+    expect(names).toContain('mcpintegrationtestproduct_list');
+    expect(names).toContain('mcpintegrationtestproduct_get');
+    // Each tool carries a JSON-schema input shape.
+    for (const tool of result.tools) {
+      expect(tool.inputSchema.type).toBe('object');
+      expect(tool.inputSchema.properties).toBeTypeOf('object');
+    }
+  });
+
+  it('filters tools to the requested class only', async () => {
+    const result = await previewMcpTools({ className: 'AdvisorRichProduct' });
+    expect(
+      result.tools.every((t) => t.name.startsWith('advisorrichproduct_')),
+    ).toBe(true);
+    // Should not bleed in tools from other registered classes.
+    expect(
+      result.tools.some((t) => t.name.startsWith('mcpintegrationtestproduct_')),
+    ).toBe(false);
+  });
+
+  it('throws for an unregistered class', async () => {
+    await expect(
+      previewMcpTools({ className: 'NoSuchMcpClass' }),
+    ).rejects.toThrow(/not found in ObjectRegistry/);
+  });
+});

--- a/packages/core/src/mcp-advisor/tools/validate-smrt-object.test.ts
+++ b/packages/core/src/mcp-advisor/tools/validate-smrt-object.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for the mcp-advisor validate-smrt-object tool.
+ *
+ * This handler reads a source file from disk and runs regex-based structural
+ * checks. We write representative source files to a temp dir and assert the
+ * ValidationResult (errors, className, hasDecorator, fieldCount, strict-mode
+ * warnings) plus the read-failure error path.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { validateSmrtObject } from './validate-smrt-object.js';
+
+describe('mcp-advisor: validateSmrtObject', () => {
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'advisor-validate-'));
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  async function write(name: string, content: string): Promise<string> {
+    const filePath = join(dir, name);
+    await writeFile(filePath, content, 'utf-8');
+    return filePath;
+  }
+
+  it('validates a well-formed SmrtObject as valid', async () => {
+    const filePath = await write(
+      'good.ts',
+      `import { SmrtObject, smrt } from '@have/smrt';
+
+@smrt()
+export class Product extends SmrtObject {
+  name = field({ required: true });
+
+  constructor(options = {}) {
+    super(options);
+  }
+}
+`,
+    );
+
+    const result = await validateSmrtObject({ filePath });
+    expect(result.valid).toBe(true);
+    expect(result.errors.filter((e) => e.type === 'error')).toHaveLength(0);
+    expect(result.className).toBe('Product');
+    expect(result.hasDecorator).toBe(true);
+    expect(result.hasRequiredMethods).toBe(true);
+    expect(result.fieldCount).toBeGreaterThan(0);
+  });
+
+  it('flags a missing decorator, missing base class and missing import', async () => {
+    const filePath = await write(
+      'bad.ts',
+      `export class Orphan {
+  someMethod() {}
+}
+`,
+    );
+
+    const result = await validateSmrtObject({ filePath });
+    expect(result.valid).toBe(false);
+    const messages = result.errors.map((e) => e.message);
+    expect(messages).toContain('Missing @smrt() decorator');
+    expect(messages).toContain(
+      'Class must extend SmrtObject or SmrtCollection',
+    );
+    expect(messages).toContain('Missing import from @smrt/core');
+    expect(result.hasDecorator).toBe(false);
+  });
+
+  it('errors when a constructor omits super()', async () => {
+    const filePath = await write(
+      'no-super.ts',
+      `import { SmrtObject, smrt } from '@have/smrt';
+
+@smrt()
+export class Thing extends SmrtObject {
+  value = field();
+  constructor(options = {}) {
+    this.value = options.value;
+  }
+}
+`,
+    );
+
+    const result = await validateSmrtObject({ filePath });
+    const messages = result.errors.map((e) => e.message);
+    expect(messages).toContain('Constructor must call super()');
+    expect(result.valid).toBe(false);
+  });
+
+  it('requires _itemClass on a SmrtCollection', async () => {
+    const filePath = await write(
+      'collection-missing-itemclass.ts',
+      `import { SmrtCollection, smrt } from '@have/smrt';
+
+@smrt()
+export class ThingCollection extends SmrtCollection {
+}
+`,
+    );
+
+    const result = await validateSmrtObject({ filePath });
+    const messages = result.errors.map((e) => e.message);
+    expect(messages).toContain(
+      'SmrtCollection must define static readonly _itemClass',
+    );
+  });
+
+  it('accepts a SmrtCollection that declares _itemClass', async () => {
+    const filePath = await write(
+      'collection-good.ts',
+      `import { SmrtCollection, smrt } from '@have/smrt';
+
+@smrt()
+export class ThingCollection extends SmrtCollection {
+  static readonly _itemClass = Thing;
+}
+`,
+    );
+
+    const result = await validateSmrtObject({ filePath });
+    expect(result.valid).toBe(true);
+    expect(
+      result.errors.some(
+        (e) =>
+          e.message === 'SmrtCollection must define static readonly _itemClass',
+      ),
+    ).toBe(false);
+  });
+
+  it('warns about a missing constructor and no fields (non-strict)', async () => {
+    const filePath = await write(
+      'sparse.ts',
+      `import { SmrtObject, smrt } from '@have/smrt';
+
+@smrt()
+export class Sparse extends SmrtObject {
+}
+`,
+    );
+
+    const result = await validateSmrtObject({ filePath });
+    const warnings = result.errors.filter((e) => e.type === 'warning');
+    const warningMessages = warnings.map((w) => w.message);
+    expect(warningMessages).toContain('No constructor found');
+    expect(warningMessages).toContain('No field definitions found');
+    // Warnings alone do not make it invalid.
+    expect(result.valid).toBe(true);
+  });
+
+  it('adds JSDoc and typing warnings in strict mode', async () => {
+    const filePath = await write(
+      'strict.ts',
+      `import { SmrtObject, smrt } from '@have/smrt';
+
+@smrt()
+export class StrictTarget extends SmrtObject {
+  name = field({ required: true });
+  constructor(options = {}) {
+    super(options);
+  }
+}
+`,
+    );
+
+    const result = await validateSmrtObject({ filePath, strictMode: true });
+    const warningMessages = result.errors
+      .filter((e) => e.type === 'warning')
+      .map((w) => w.message);
+    expect(warningMessages).toContain('Missing JSDoc documentation');
+    expect(warningMessages).toContain(
+      'Properties should have explicit TypeScript types',
+    );
+  });
+
+  it('returns a structured error when the file cannot be read', async () => {
+    const result = await validateSmrtObject({
+      filePath: join(dir, 'does-not-exist.ts'),
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].type).toBe('error');
+    expect(result.errors[0].message).toMatch(/ENOENT|no such file/i);
+  });
+});

--- a/packages/core/src/migrations/__tests__/generator-branches.test.ts
+++ b/packages/core/src/migrations/__tests__/generator-branches.test.ts
@@ -1,0 +1,387 @@
+/**
+ * MigrationGenerator branch coverage
+ *
+ * Targets branches not exercised by generator.test.ts:
+ * - generateCreateTable building DDL from columns (no pre-supplied `ddl`),
+ *   including primaryKey / notNull / unique / defaultValue parts and FK
+ *   constraints with ON DELETE / ON UPDATE actions.
+ * - generateChangeSQL fallbacks that synthesize SQL from a column/index
+ *   definition (rather than `sqlStatements`/`sql`), plus drop_column,
+ *   drop_index, and type_mismatch warning emission.
+ * - formatDefaultValue across null / string / boolean / number.
+ * - SQL file header `-- @package:` line.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { SchemaDefinition, SchemaDiff } from '../../schema/types.js';
+import { MigrationGenerator } from '../generator.js';
+
+describe('MigrationGenerator branch coverage', () => {
+  describe('generateCreateTable from columns (no pre-supplied ddl)', () => {
+    it('builds CREATE TABLE with all column modifiers and FK constraints', () => {
+      const diff: SchemaDiff = {
+        has_changes: true,
+        added_tables: [
+          {
+            tableName: 'orders',
+            // No `ddl` field — forces the column-by-column build path.
+            columns: {
+              id: { type: 'TEXT', primaryKey: true, notNull: true },
+              code: { type: 'TEXT', unique: true, notNull: true },
+              quantity: { type: 'INTEGER', notNull: true, defaultValue: 0 },
+              note: { type: 'TEXT', defaultValue: "O'Brien" },
+              customer_id: {
+                type: 'TEXT',
+                foreignKey: {
+                  table: 'customers',
+                  column: 'id',
+                  onDelete: 'CASCADE',
+                  onUpdate: 'RESTRICT',
+                },
+              },
+            },
+            indexes: [],
+            triggers: [],
+            foreignKeys: [
+              {
+                column: 'customer_id',
+                referencesTable: 'customers',
+                referencesColumn: 'id',
+                onDelete: 'CASCADE',
+                onUpdate: 'RESTRICT',
+              },
+            ],
+            dependencies: [],
+            version: '1.0.0',
+          } as SchemaDefinition,
+        ],
+        dropped_tables: [],
+        changes: [],
+      };
+
+      const generator = new MigrationGenerator({
+        engine: 'sqlite',
+        format: 'sql',
+        includeDown: true,
+      });
+
+      const migration = generator.generateFromDiff(diff, {
+        name: '0001_create_orders',
+      });
+
+      const up = migration.up.join('\n');
+      expect(up).toContain('CREATE TABLE IF NOT EXISTS "orders"');
+      expect(up).toContain('"id" TEXT PRIMARY KEY NOT NULL');
+      expect(up).toContain('"code" TEXT NOT NULL UNIQUE');
+      expect(up).toContain('"quantity" INTEGER NOT NULL DEFAULT 0');
+      // String default escapes single quotes.
+      expect(up).toContain(`"note" TEXT DEFAULT 'O''Brien'`);
+      // FK constraint with both actions.
+      expect(up).toContain(
+        'FOREIGN KEY ("customer_id") REFERENCES "customers"("id") ON DELETE CASCADE ON UPDATE RESTRICT',
+      );
+      // DOWN drops the table.
+      expect(migration.down.join('\n')).toContain(
+        'DROP TABLE IF EXISTS "orders"',
+      );
+    });
+
+    it('omits ON DELETE/ON UPDATE when the FK declares no actions', () => {
+      const diff: SchemaDiff = {
+        has_changes: true,
+        added_tables: [
+          {
+            tableName: 'links',
+            columns: { id: { type: 'TEXT', primaryKey: true } },
+            indexes: [],
+            triggers: [],
+            foreignKeys: [
+              {
+                column: 'target_id',
+                referencesTable: 'targets',
+                referencesColumn: 'id',
+              },
+            ],
+            dependencies: [],
+            version: '1.0.0',
+          } as SchemaDefinition,
+        ],
+        dropped_tables: [],
+        changes: [],
+      };
+
+      const generator = new MigrationGenerator({ engine: 'sqlite' });
+      const migration = generator.generateFromDiff(diff, {
+        name: '0001_links',
+      });
+
+      const up = migration.up.join('\n');
+      expect(up).toContain(
+        'FOREIGN KEY ("target_id") REFERENCES "targets"("id")',
+      );
+      expect(up).not.toContain('ON DELETE');
+      expect(up).not.toContain('ON UPDATE');
+    });
+  });
+
+  describe('generateChangeSQL synthesis fallbacks', () => {
+    it('synthesizes ADD COLUMN SQL from a column definition with modifiers', () => {
+      const diff: SchemaDiff = {
+        has_changes: true,
+        added_tables: [],
+        dropped_tables: [],
+        changes: [
+          {
+            type: 'add_column',
+            table: 'users',
+            name: 'nickname',
+            // No sqlStatements/sql -> generateAddColumn path.
+            column: {
+              type: 'TEXT',
+              notNull: true,
+              unique: true,
+              defaultValue: 'anon',
+            },
+          },
+        ],
+      };
+
+      const generator = new MigrationGenerator({ engine: 'sqlite' });
+      const migration = generator.generateFromDiff(diff, {
+        name: '0001_add_nickname',
+      });
+
+      const up = migration.up.join('\n');
+      expect(up).toContain(
+        `ALTER TABLE "users" ADD COLUMN "nickname" TEXT NOT NULL UNIQUE DEFAULT 'anon'`,
+      );
+      // DOWN drops the column.
+      expect(migration.down.join('\n')).toContain(
+        'ALTER TABLE "users" DROP COLUMN "nickname"',
+      );
+    });
+
+    it('synthesizes DROP COLUMN SQL when no explicit SQL provided', () => {
+      const diff: SchemaDiff = {
+        has_changes: true,
+        added_tables: [],
+        dropped_tables: [],
+        changes: [{ type: 'drop_column', table: 'users', name: 'legacy' }],
+      };
+
+      const generator = new MigrationGenerator({ engine: 'sqlite' });
+      const migration = generator.generateFromDiff(diff, {
+        name: '0001_drop_legacy',
+      });
+
+      expect(migration.up.join('\n')).toContain(
+        'ALTER TABLE "users" DROP COLUMN "legacy"',
+      );
+      // Drops have no automatic DOWN.
+      expect(migration.down).toHaveLength(0);
+    });
+
+    it('synthesizes ADD INDEX SQL from an index definition (sqlite, non-concurrent)', () => {
+      const diff: SchemaDiff = {
+        has_changes: true,
+        added_tables: [],
+        dropped_tables: [],
+        changes: [
+          {
+            type: 'add_index',
+            table: 'users',
+            name: 'idx_users_handle',
+            index: {
+              name: 'idx_users_handle',
+              columns: ['handle'],
+              unique: true,
+            },
+          },
+        ],
+      };
+
+      const generator = new MigrationGenerator({ engine: 'sqlite' });
+      const migration = generator.generateFromDiff(diff, {
+        name: '0001_add_handle_idx',
+      });
+
+      const up = migration.up.join('\n');
+      expect(up).toContain(
+        'CREATE UNIQUE INDEX IF NOT EXISTS "idx_users_handle" ON "users" ("handle")',
+      );
+      expect(up).not.toContain('CONCURRENTLY');
+      expect(migration.down.join('\n')).toContain(
+        'DROP INDEX IF EXISTS "idx_users_handle"',
+      );
+    });
+
+    it('emits DROP INDEX with no automatic DOWN', () => {
+      const diff: SchemaDiff = {
+        has_changes: true,
+        added_tables: [],
+        dropped_tables: [],
+        changes: [
+          { type: 'drop_index', table: 'users', name: 'idx_users_old' },
+        ],
+      };
+
+      const generator = new MigrationGenerator({ engine: 'sqlite' });
+      const migration = generator.generateFromDiff(diff, {
+        name: '0001_drop_old_idx',
+      });
+
+      expect(migration.up.join('\n')).toContain(
+        'DROP INDEX IF EXISTS "idx_users_old"',
+      );
+      expect(migration.down).toHaveLength(0);
+    });
+
+    it('emits warning comments for type_mismatch changes', () => {
+      const diff: SchemaDiff = {
+        has_changes: true,
+        added_tables: [],
+        dropped_tables: [],
+        changes: [
+          {
+            type: 'type_mismatch',
+            table: 'products',
+            name: 'price',
+            mismatch: { expected: 'REAL', actual: 'TEXT' },
+          },
+        ],
+      };
+
+      const generator = new MigrationGenerator({ engine: 'sqlite' });
+      const migration = generator.generateFromDiff(diff, {
+        name: '0001_price_mismatch',
+      });
+
+      const up = migration.up.join('\n');
+      expect(up).toContain('-- WARNING: Type mismatch for products.price');
+      expect(up).toContain('-- Expected: REAL, Actual: TEXT');
+      expect(up).toContain('-- Manual migration required');
+      expect(migration.down).toHaveLength(0);
+    });
+
+    it('ignores unknown change types without emitting SQL', () => {
+      const diff: SchemaDiff = {
+        has_changes: true,
+        added_tables: [],
+        dropped_tables: [],
+        changes: [
+          // `add_table` is not handled by generateChangeSQL's switch.
+          { type: 'add_table', table: 'ghost' },
+        ],
+      };
+
+      const generator = new MigrationGenerator({ engine: 'sqlite' });
+      const migration = generator.generateFromDiff(diff, {
+        name: '0001_unknown',
+      });
+
+      expect(migration.up).toHaveLength(0);
+      expect(migration.down).toHaveLength(0);
+    });
+
+    it('drops a table named in dropped_tables', () => {
+      const diff: SchemaDiff = {
+        has_changes: true,
+        added_tables: [],
+        dropped_tables: ['obsolete'],
+        changes: [],
+      };
+
+      const generator = new MigrationGenerator({ engine: 'sqlite' });
+      const migration = generator.generateFromDiff(diff, {
+        name: '0001_drop_obsolete',
+      });
+
+      expect(migration.up.join('\n')).toContain(
+        'DROP TABLE IF EXISTS "obsolete"',
+      );
+    });
+  });
+
+  describe('formatDefaultValue branches', () => {
+    it('renders NULL, boolean, and numeric defaults correctly in ADD COLUMN', () => {
+      const generator = new MigrationGenerator({ engine: 'sqlite' });
+
+      const nullDiff: SchemaDiff = {
+        has_changes: true,
+        added_tables: [],
+        dropped_tables: [],
+        changes: [
+          {
+            type: 'add_column',
+            table: 't',
+            name: 'maybe',
+            column: { type: 'TEXT', defaultValue: null },
+          },
+        ],
+      };
+      expect(
+        generator
+          .generateFromDiff(nullDiff, { name: '0001_null' })
+          .up.join('\n'),
+      ).toContain('DEFAULT NULL');
+
+      const boolDiff: SchemaDiff = {
+        has_changes: true,
+        added_tables: [],
+        dropped_tables: [],
+        changes: [
+          {
+            type: 'add_column',
+            table: 't',
+            name: 'active',
+            column: { type: 'BOOLEAN', defaultValue: true },
+          },
+          {
+            type: 'add_column',
+            table: 't',
+            name: 'archived',
+            column: { type: 'BOOLEAN', defaultValue: false },
+          },
+        ],
+      };
+      const boolUp = generator
+        .generateFromDiff(boolDiff, { name: '0001_bool' })
+        .up.join('\n');
+      expect(boolUp).toContain('"active" BOOLEAN DEFAULT 1');
+      expect(boolUp).toContain('"archived" BOOLEAN DEFAULT 0');
+
+      const numDiff: SchemaDiff = {
+        has_changes: true,
+        added_tables: [],
+        dropped_tables: [],
+        changes: [
+          {
+            type: 'add_column',
+            table: 't',
+            name: 'score',
+            column: { type: 'REAL', defaultValue: 4.5 },
+          },
+        ],
+      };
+      expect(
+        generator.generateFromDiff(numDiff, { name: '0001_num' }).up.join('\n'),
+      ).toContain('DEFAULT 4.5');
+    });
+  });
+
+  describe('SQL file header', () => {
+    it('includes the @package line when packageName is configured', () => {
+      const generator = new MigrationGenerator({
+        engine: 'sqlite',
+        format: 'sql',
+        packageName: '@happyvertical/smrt-core',
+      });
+
+      const migration = generator.generateEmpty({ name: '0001_pkg' });
+
+      expect(migration.content).toContain(
+        '-- @package: @happyvertical/smrt-core',
+      );
+    });
+  });
+});

--- a/packages/core/src/migrations/__tests__/tracker-branches.test.ts
+++ b/packages/core/src/migrations/__tests__/tracker-branches.test.ts
@@ -1,0 +1,355 @@
+/**
+ * MigrationTracker branch coverage.
+ *
+ * tracker.test.ts covers initialize/apply/applyAll(atomic)/rollback/getHistory
+ * happy paths. This file targets the gaps:
+ * - getEngine / detectDbEngine via config.url + engineHint
+ * - getPendingMigrations filtering
+ * - detectDrift: unknown_in_db, file_modified, and db_modified reports
+ * - getNextBatch incrementing from existing rows
+ * - rollback: not-found, not-completed, and dry-run early returns
+ * - executeStatements fallbacks: no-transaction sequential, postgres safe mode
+ *   (regular-in-transaction + CONCURRENTLY outside), and postgres no-transaction.
+ */
+
+import type { DatabaseProvider } from '@happyvertical/sql';
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { MigrationDefinition } from '../../schema/types.js';
+import { computeChecksum } from '../checksum.js';
+import { MigrationTracker } from '../tracker.js';
+
+describe('MigrationTracker engine detection', () => {
+  it('reads the URL from db.config when db.url is empty', () => {
+    const tracker = new MigrationTracker({
+      db: {
+        url: '',
+        config: { url: 'postgres://localhost/test' },
+        query: async () => ({ rows: [] }),
+      } as any,
+    });
+    expect(tracker.getEngine()).toBe('postgres');
+  });
+
+  it('honors an explicit engineHint over URL parsing', () => {
+    const tracker = new MigrationTracker({
+      db: { url: '', query: async () => ({ rows: [] }) } as any,
+      engineHint: 'postgres',
+    });
+    expect(tracker.getEngine()).toBe('postgres');
+  });
+});
+
+describe('MigrationTracker on real SQLite', () => {
+  let db: DatabaseProvider;
+  let tracker: MigrationTracker;
+
+  beforeEach(async () => {
+    db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+    tracker = new MigrationTracker({ db });
+    await tracker.initialize();
+  });
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') {
+      try {
+        await db.close();
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  it('getPendingMigrations returns only unapplied definitions', async () => {
+    const applied: MigrationDefinition = {
+      id: '0001_applied',
+      description: 'a',
+      version: '1.0.0',
+      up: ['CREATE TABLE applied_t (id TEXT);'],
+      down: [],
+    };
+    const pending: MigrationDefinition = {
+      id: '0002_pending',
+      description: 'b',
+      version: '1.0.0',
+      up: ['CREATE TABLE pending_t (id TEXT);'],
+      down: [],
+    };
+
+    await tracker.apply(applied);
+    const result = await tracker.getPendingMigrations([applied, pending]);
+
+    expect(result.map((d) => d.id)).toEqual(['0002_pending']);
+  });
+
+  it('getNextBatch increments from the highest existing batch', async () => {
+    await db.query(
+      `INSERT INTO _smrt_schema_migrations (id, name, version, checksum, status, batch)
+       VALUES ('x', '0001_x', '1.0.0', 'c', 'completed', 7)`,
+    );
+    expect(await tracker.getNextBatch()).toBe(8);
+  });
+
+  it('getMigration returns null for an unknown migration', async () => {
+    expect(await tracker.getMigration('nope')).toBeNull();
+  });
+
+  describe('detectDrift', () => {
+    it('reports unknown_in_db when an applied migration has no definition', async () => {
+      await db.query(
+        `INSERT INTO _smrt_schema_migrations (id, name, version, checksum, status, applied_at, batch)
+         VALUES ('id-1', '0001_orphan', '1.0.0', 'abc', 'completed', datetime('now'), 1)`,
+      );
+
+      const reports = await tracker.detectDrift([]);
+      expect(reports).toHaveLength(1);
+      expect(reports[0].drift_type).toBe('unknown_in_db');
+      expect(reports[0].migration_name).toBe('0001_orphan');
+    });
+
+    it('reports file_modified when the definition checksum no longer matches', async () => {
+      const original = ['CREATE TABLE drift_t (id TEXT);'];
+      const recordedChecksum = computeChecksum(original);
+      // applied_checksum equal to recorded -> DB untouched, so a definition
+      // change classifies as file_modified.
+      await db.query(
+        `INSERT INTO _smrt_schema_migrations (id, name, version, checksum, applied_checksum, status, applied_at, batch)
+         VALUES ('id-1', '0001_drift', '1.0.0', ?, ?, 'completed', datetime('now'), 1)`,
+        recordedChecksum,
+        recordedChecksum,
+      );
+
+      const reports = await tracker.detectDrift([
+        {
+          id: '0001_drift',
+          description: 'changed',
+          version: '1.0.0',
+          up: ['CREATE TABLE drift_t (id TEXT, extra TEXT);'], // changed!
+          down: [],
+        },
+      ]);
+
+      expect(reports).toHaveLength(1);
+      expect(reports[0].drift_type).toBe('file_modified');
+      expect(reports[0].recommendation).toContain('Create a new migration');
+    });
+
+    it('reports db_modified when the applied checksum diverges from the recorded one', async () => {
+      const def: MigrationDefinition = {
+        id: '0001_dbdrift',
+        description: 'x',
+        version: '1.0.0',
+        up: ['CREATE TABLE dbdrift_t (id TEXT);'],
+        down: [],
+      };
+      const defChecksum = computeChecksum(def.up);
+
+      // checksum matches the definition, but applied_checksum differs ->
+      // the database was modified outside migrations.
+      await db.query(
+        `INSERT INTO _smrt_schema_migrations (id, name, version, checksum, applied_checksum, status, applied_at, batch)
+         VALUES ('id-1', '0001_dbdrift', '1.0.0', ?, 'different-applied', 'completed', datetime('now'), 1)`,
+        defChecksum,
+      );
+
+      const reports = await tracker.detectDrift([def]);
+      expect(reports).toHaveLength(1);
+      expect(reports[0].drift_type).toBe('db_modified');
+      expect(reports[0].recommendation).toContain('reconcile manually');
+    });
+
+    it('returns no reports when checksums all match', async () => {
+      const def: MigrationDefinition = {
+        id: '0001_clean',
+        description: 'x',
+        version: '1.0.0',
+        up: ['CREATE TABLE clean_t (id TEXT);'],
+        down: [],
+      };
+      await tracker.apply(def);
+      expect(await tracker.detectDrift([def])).toHaveLength(0);
+    });
+  });
+
+  describe('rollback early returns', () => {
+    it('fails when the migration is not in the database', async () => {
+      const result = await tracker.rollback('0001_ghost', {
+        id: '0001_ghost',
+        description: 'x',
+        version: '1.0.0',
+        up: ['SELECT 1;'],
+        down: ['SELECT 1;'],
+      });
+      expect(result.success).toBe(false);
+      expect(String(result.error)).toContain('not found in database');
+    });
+
+    it('fails when the migration is not in completed state', async () => {
+      await db.query(
+        `INSERT INTO _smrt_schema_migrations (id, name, version, checksum, status, batch)
+         VALUES ('id-1', '0001_failed', '1.0.0', 'c', 'failed', 1)`,
+      );
+      const result = await tracker.rollback('0001_failed', {
+        id: '0001_failed',
+        description: 'x',
+        version: '1.0.0',
+        up: ['SELECT 1;'],
+        down: ['SELECT 1;'],
+      });
+      expect(result.success).toBe(false);
+      expect(String(result.error)).toContain('not in completed state');
+    });
+
+    it('returns success without executing during a dry-run rollback', async () => {
+      const def: MigrationDefinition = {
+        id: '0001_dryroll',
+        description: 'x',
+        version: '1.0.0',
+        up: ['CREATE TABLE dryroll_t (id TEXT);'],
+        down: ['DROP TABLE dryroll_t;'],
+      };
+      await tracker.apply(def);
+
+      const result = await tracker.rollback('0001_dryroll', def, {
+        dryRun: true,
+      });
+      expect(result.success).toBe(true);
+      expect(result.rolled_back).toBe(true);
+
+      // Table still exists; status unchanged.
+      expect(await db.tableExists('dryroll_t')).toBe(true);
+      const [record] = await tracker.getHistory();
+      expect(record.status).toBe('completed');
+    });
+
+    it('reports a failed rollback when a DOWN statement errors', async () => {
+      const def: MigrationDefinition = {
+        id: '0001_badroll',
+        description: 'x',
+        version: '1.0.0',
+        up: ['CREATE TABLE badroll_t (id TEXT);'],
+        down: ['DROP TABLE does_not_exist_xyz;'],
+      };
+      await tracker.apply(def);
+
+      const result = await tracker.rollback('0001_badroll', def);
+      expect(result.success).toBe(false);
+      expect(result.rolled_back).toBe(false);
+      expect(result.error).toBeInstanceOf(Error);
+    });
+  });
+});
+
+describe('MigrationTracker statement execution fallbacks', () => {
+  it('executes sequentially when the adapter has no transaction support', async () => {
+    const executed: string[] = [];
+    const db = {
+      url: 'sqlite::memory:',
+      // No `transaction` method -> sequential fallback.
+      query: async (sql: string) => {
+        executed.push(sql);
+        return { rows: [] };
+      },
+    } as any;
+
+    const tracker = new MigrationTracker({ db });
+    const result = await tracker.apply({
+      id: '0001_seq',
+      description: 'x',
+      version: '1.0.0',
+      up: [
+        'CREATE TABLE seq_t (id TEXT);',
+        'CREATE INDEX idx_seq ON seq_t(id);',
+      ],
+      down: [],
+    });
+
+    expect(result.success).toBe(true);
+    // Both migration statements ran via direct query (no transaction wrapper).
+    expect(executed).toContain('CREATE TABLE seq_t (id TEXT);');
+    expect(executed).toContain('CREATE INDEX idx_seq ON seq_t(id);');
+  });
+
+  it('routes CONCURRENTLY index DDL outside the transaction in postgres safe mode', async () => {
+    const insideTx: string[] = [];
+    const outsideTx: string[] = [];
+    let txCalls = 0;
+
+    // Records which statements run inside db.transaction() vs direct db.query().
+    const db: any = {
+      url: 'postgres://localhost/test',
+      query: async (sql: string) => {
+        outsideTx.push(sql);
+        return { rows: [] };
+      },
+      transaction: async (cb: (tx: any) => Promise<unknown>) => {
+        txCalls++;
+        const tx = {
+          query: async (sql: string) => {
+            insideTx.push(sql);
+            return { rows: [] };
+          },
+        };
+        return cb(tx);
+      },
+    };
+    // getMigration / status writes go through db.query too; filter them out
+    // by tagging migration DDL distinctly below.
+
+    const tracker = new MigrationTracker({ db, useConcurrentIndexes: true });
+
+    const result = await tracker.apply(
+      {
+        id: '0001_pg_safe',
+        description: 'x',
+        version: '1.0.0',
+        up: ['ALTER TABLE t ADD COLUMN c TEXT', 'CREATE INDEX idx_pg ON t (c)'],
+        down: [],
+      },
+      { postgresSafe: true },
+    );
+
+    expect(result.success).toBe(true);
+    // Transaction was used for the regular ALTER plus SET LOCAL timeouts.
+    expect(txCalls).toBeGreaterThan(0);
+    expect(insideTx.some((s) => s.includes('ALTER TABLE t ADD COLUMN c'))).toBe(
+      true,
+    );
+    expect(insideTx.some((s) => s.startsWith('SET LOCAL lock_timeout'))).toBe(
+      true,
+    );
+    // The plain CREATE INDEX was rewritten to CONCURRENTLY and run outside tx.
+    expect(
+      outsideTx.some((s) => s.includes('CREATE INDEX CONCURRENTLY idx_pg')),
+    ).toBe(true);
+  });
+
+  it('runs regular postgres statements directly when no transaction is available', async () => {
+    const ran: string[] = [];
+    const db: any = {
+      url: 'postgres://localhost/test',
+      // No `transaction` method -> regular statements run via db.query loop.
+      query: async (sql: string) => {
+        ran.push(sql);
+        return { rows: [] };
+      },
+    };
+
+    const tracker = new MigrationTracker({ db, useConcurrentIndexes: false });
+    const result = await tracker.apply(
+      {
+        id: '0001_pg_notx',
+        description: 'x',
+        version: '1.0.0',
+        up: ['ALTER TABLE t ADD COLUMN d TEXT'],
+        down: [],
+      },
+      { postgresSafe: true },
+    );
+
+    expect(result.success).toBe(true);
+    expect(ran.some((s) => s.includes('ALTER TABLE t ADD COLUMN d'))).toBe(
+      true,
+    );
+  });
+});

--- a/packages/core/src/prebuild/index.test.ts
+++ b/packages/core/src/prebuild/index.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for the pre-build TypeScript declaration generator (src/prebuild/index.ts).
+ *
+ * generateDeclarations() is a pure function that reads a SMRT manifest (object
+ * or JSON-file path) and writes .d.ts files to a directory. These tests run it
+ * against real temp directories and assert on the emitted file contents — in
+ * particular the SMRT-field-type -> TypeScript-type mapping and the virtual
+ * module declarations. No fs mocking; temp dirs are removed in afterEach.
+ */
+
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SmartObjectManifest } from '../scanner/types.js';
+import { generateDeclarations, generateDeclarationsFromCLI } from './index.js';
+
+function buildManifest(): SmartObjectManifest {
+  return {
+    version: '1.0.0',
+    timestamp: 1,
+    objects: {
+      Article: {
+        className: 'Article',
+        collection: 'articles',
+        // Every supported field type so mapFieldTypeToTypeScript is fully exercised.
+        fields: {
+          title: { type: 'text', required: true },
+          body: { type: 'text' },
+          views: { type: 'integer' },
+          rating: { type: 'decimal' },
+          published: { type: 'boolean' },
+          publishedAt: { type: 'datetime' },
+          metadata: { type: 'json' },
+          authorId: { type: 'foreignKey' },
+          weird: { type: 'somethingUnknown' as any },
+        },
+        methods: {},
+        decoratorConfig: {},
+      } as any,
+      Author: {
+        className: 'Author',
+        collection: 'authors',
+        fields: {
+          name: { type: 'text', required: true },
+        },
+        methods: {},
+        decoratorConfig: {},
+      } as any,
+    },
+  };
+}
+
+let outDir: string;
+
+beforeEach(() => {
+  outDir = mkdtempSync(join(tmpdir(), 'smrt-prebuild-'));
+});
+
+afterEach(() => {
+  if (existsSync(outDir)) {
+    rmSync(outDir, { recursive: true, force: true });
+  }
+  vi.restoreAllMocks();
+});
+
+describe('generateDeclarations', () => {
+  it('writes object-type declarations mapping field types to TS types', async () => {
+    await generateDeclarations({
+      manifest: buildManifest(),
+      outDir,
+      includeVirtualModules: false,
+      includeObjectTypes: true,
+    });
+
+    const objectsPath = join(outDir, 'smrt-objects.d.ts');
+    expect(existsSync(objectsPath)).toBe(true);
+    const content = readFileSync(objectsPath, 'utf-8');
+
+    expect(content).toContain('export interface ArticleData {');
+    expect(content).toContain('export interface AuthorData {');
+    // Standard SmrtObject properties.
+    expect(content).toContain('id?: string;');
+    expect(content).toContain('created_at?: string;');
+    expect(content).toContain('updated_at?: string;');
+    // Field type mapping.
+    expect(content).toContain('title: string;'); // text + required -> no ?
+    expect(content).toContain('body?: string;'); // text optional
+    expect(content).toContain('views?: number;'); // integer
+    expect(content).toContain('rating?: number;'); // decimal
+    expect(content).toContain('published?: boolean;'); // boolean
+    expect(content).toContain('publishedAt?: string | Date;'); // datetime
+    expect(content).toContain('metadata?: any;'); // json
+    expect(content).toContain('authorId?: string;'); // foreignKey
+    expect(content).toContain('weird?: any;'); // unknown -> any
+  });
+
+  it('writes virtual module declarations for every @smrt virtual module', async () => {
+    await generateDeclarations({
+      manifest: buildManifest(),
+      outDir,
+      includeVirtualModules: true,
+      includeObjectTypes: false,
+    });
+
+    const files = [
+      'smrt-manifest.d.ts',
+      'smrt-client.d.ts',
+      'smrt-routes.d.ts',
+      'smrt-mcp.d.ts',
+      'smrt-types.d.ts',
+    ];
+    for (const file of files) {
+      expect(existsSync(join(outDir, file))).toBe(true);
+    }
+
+    const manifestDecl = readFileSync(
+      join(outDir, 'smrt-manifest.d.ts'),
+      'utf-8',
+    );
+    expect(manifestDecl).toContain("declare module '@smrt/manifest'");
+
+    const clientDecl = readFileSync(join(outDir, 'smrt-client.d.ts'), 'utf-8');
+    expect(clientDecl).toContain("declare module '@smrt/client'");
+    // Client interface derives CRUD operations keyed by unique collection name.
+    expect(clientDecl).toContain('articles: CrudOperations<ArticleData>;');
+    expect(clientDecl).toContain('authors: CrudOperations<AuthorData>;');
+
+    const typesDecl = readFileSync(join(outDir, 'smrt-types.d.ts'), 'utf-8');
+    expect(typesDecl).toContain("declare module '@smrt/types'");
+    // Object imports re-export the generated object data types.
+    expect(typesDecl).toContain(
+      "export type ArticleData = import('./smrt-objects').ArticleData;",
+    );
+  });
+
+  it('generates both object and virtual declarations by default', async () => {
+    await generateDeclarations({ manifest: buildManifest(), outDir });
+    expect(existsSync(join(outDir, 'smrt-objects.d.ts'))).toBe(true);
+    expect(existsSync(join(outDir, 'smrt-manifest.d.ts'))).toBe(true);
+  });
+
+  it('reads the manifest from a JSON file path when given a string', async () => {
+    const manifestFile = join(outDir, 'manifest.json');
+    writeFileSync(manifestFile, JSON.stringify(buildManifest()), 'utf-8');
+
+    const typesOut = join(outDir, 'types');
+    await generateDeclarations({
+      manifest: manifestFile,
+      outDir: typesOut,
+      includeVirtualModules: false,
+    });
+
+    expect(existsSync(join(typesOut, 'smrt-objects.d.ts'))).toBe(true);
+  });
+
+  it('resolves a relative outDir against projectRoot', async () => {
+    await generateDeclarations({
+      manifest: buildManifest(),
+      outDir: 'generated/types',
+      projectRoot: outDir,
+      includeVirtualModules: false,
+    });
+    expect(
+      existsSync(join(outDir, 'generated', 'types', 'smrt-objects.d.ts')),
+    ).toBe(true);
+  });
+
+  it('handles an empty manifest without throwing', async () => {
+    await generateDeclarations({
+      manifest: { version: '1.0.0', timestamp: 1, objects: {} },
+      outDir,
+    });
+    // Object declaration file is still written (with no interfaces).
+    expect(existsSync(join(outDir, 'smrt-objects.d.ts'))).toBe(true);
+  });
+});
+
+describe('generateDeclarationsFromCLI', () => {
+  it('generates declarations from a manifest path argument', async () => {
+    const manifestFile = join(outDir, 'manifest.json');
+    writeFileSync(manifestFile, JSON.stringify(buildManifest()), 'utf-8');
+    const typesOut = join(outDir, 'cli-out');
+
+    await generateDeclarationsFromCLI([manifestFile, typesOut]);
+
+    expect(existsSync(join(typesOut, 'smrt-objects.d.ts'))).toBe(true);
+    expect(existsSync(join(typesOut, 'smrt-manifest.d.ts'))).toBe(true);
+  });
+
+  it('exits with an error when no manifest path is provided', async () => {
+    // Real process.exit halts execution; emulate that by throwing so the guard
+    // short-circuits exactly as it would at runtime.
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called');
+    }) as never);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(generateDeclarationsFromCLI([])).rejects.toThrow(
+      'process.exit called',
+    );
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Usage:'));
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('exits with an error when the manifest file does not exist', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called');
+    }) as never);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      generateDeclarationsFromCLI([join(outDir, 'missing.json')]),
+    ).rejects.toThrow('process.exit called');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Manifest file not found'),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/core/src/registry/__tests__/inheritance-resolver.test.ts
+++ b/packages/core/src/registry/__tests__/inheritance-resolver.test.ts
@@ -1,0 +1,406 @@
+/**
+ * Coverage tests for registry/inheritance-resolver.ts.
+ *
+ * IMPORTANT: ObjectRegistry.getInheritanceChain / getAllFields / getAllMethods
+ * are INLINE re-implementations in registry.ts — they do NOT call the
+ * inheritance-resolver module. So inheritance.test.ts (which goes through
+ * ObjectRegistry) leaves this module at ~26%. These tests import the module
+ * functions DIRECTLY to cover their real branches.
+ *
+ * The module functions read/write the same globalThis registry + caches the
+ * decorator populates, so we register real `@smrt()` fixtures and, for the
+ * synthetic edge cases (circular chains, missing parents), splice fake
+ * RegisteredClass entries into the shared `classes` map and clean them up.
+ *
+ * @see src/registry/inheritance-resolver.ts (issue #1500 coverage, ORM group)
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  IRConstraintChild,
+  IRLeaf,
+  IRSolo,
+} from '../../__tests__/fixtures/inheritance-resolver-fixtures.js';
+import { ConfigurationError } from '../../errors';
+import { SmrtObject } from '../../object';
+import { ObjectRegistry } from '../../registry';
+import {
+  buildInheritanceChain,
+  getAllFields,
+  getAllMethods,
+  getInheritanceChain,
+  mergeFieldConfigs,
+} from '../inheritance-resolver';
+import { getClasses, getInheritanceCache } from '../shared-state';
+
+/** Track synthetic registry keys we add so afterEach can remove them. */
+const syntheticKeys = new Set<string>();
+
+function addSyntheticClass(key: string, registered: any): void {
+  getClasses().set(key, registered);
+  syntheticKeys.add(key);
+}
+
+beforeEach(() => {
+  ObjectRegistry.invalidateAllInheritanceCaches();
+  getInheritanceCache().clear();
+});
+
+afterEach(() => {
+  for (const key of syntheticKeys) {
+    getClasses().delete(key);
+  }
+  syntheticKeys.clear();
+  ObjectRegistry.invalidateAllInheritanceCaches();
+  getInheritanceCache().clear();
+  vi.restoreAllMocks();
+});
+
+describe('inheritance-resolver: buildInheritanceChain', () => {
+  it('walks the prototype chain base→child, stopping at SmrtObject', () => {
+    const chain = buildInheritanceChain(IRLeaf as unknown as typeof SmrtObject);
+    expect(chain).toEqual(['IRBase', 'IRMiddle', 'IRLeaf']);
+  });
+
+  it('returns a single-element chain for a direct SmrtObject subclass', () => {
+    const chain = buildInheritanceChain(IRSolo as unknown as typeof SmrtObject);
+    expect(chain).toEqual(['IRSolo']);
+  });
+
+  it('throws circularInheritance when the walk revisits a constructor', () => {
+    // Real JS prototype chains cannot contain a cycle (the engine rejects
+    // `__proto__` loops), so drive the visited-set guard by stubbing
+    // Object.getPrototypeOf to return an already-seen node on the 2nd hop.
+    const nodeA: any = { name: 'CycleA' };
+    const nodeB: any = { name: 'CycleB' };
+    const realGetProto = Object.getPrototypeOf;
+    const spy = vi
+      .spyOn(Object, 'getPrototypeOf')
+      .mockImplementation((obj: any) => {
+        if (obj === nodeA) return nodeB; // A -> B
+        if (obj === nodeB) return nodeA; // B -> A (revisits A => cycle)
+        return realGetProto(obj);
+      });
+    try {
+      expect(() => buildInheritanceChain(nodeA)).toThrow(ConfigurationError);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe('inheritance-resolver: getInheritanceChain (module)', () => {
+  it('returns [] for an unregistered class', () => {
+    expect(getInheritanceChain('TotallyUnregisteredXYZ')).toEqual([]);
+  });
+
+  it('builds a qualified chain for a registered 3-level hierarchy', () => {
+    const chain = getInheritanceChain('IRLeaf');
+    expect(chain).toEqual([
+      '@happyvertical/smrt-core:IRBase',
+      '@happyvertical/smrt-core:IRMiddle',
+      '@happyvertical/smrt-core:IRLeaf',
+    ]);
+  });
+
+  it('serves a cached chain on the second call (same reference)', () => {
+    const first = getInheritanceChain('IRMiddle');
+    const second = getInheritanceChain('IRMiddle');
+    expect(second).toBe(first);
+  });
+
+  it('returns a pre-stored inheritanceChain and seeds the cache from it', () => {
+    const registered = ObjectRegistry.getClass('IRSolo');
+    expect(registered).toBeDefined();
+    getInheritanceCache().clear();
+    const sentinel = ['pre', 'computed', 'IRSolo'];
+    (registered as any).inheritanceChain = sentinel;
+    try {
+      const chain = getInheritanceChain('IRSolo');
+      expect(chain).toBe(sentinel);
+      // cache now holds the same reference
+      expect(getInheritanceCache().get('IRSolo')).toBe(sentinel);
+    } finally {
+      (registered as any).inheritanceChain = undefined;
+    }
+  });
+
+  it('stops at a framework base class named in `extends`', () => {
+    // Synthetic class whose extends points straight at SmrtClass (framework base)
+    addSyntheticClass('@test/ir:FrameworkExtender', {
+      name: 'FrameworkExtender',
+      qualifiedName: '@test/ir:FrameworkExtender',
+      constructor: SmrtObject,
+      config: {},
+      fields: new Map(),
+      methods: new Map(),
+      packageName: '@test/ir',
+      extends: 'SmrtClass',
+    });
+
+    const chain = getInheritanceChain('@test/ir:FrameworkExtender');
+    expect(chain).toEqual(['@test/ir:FrameworkExtender']);
+  });
+
+  it('gracefully ends the chain when a named parent is not registered', () => {
+    addSyntheticClass('@test/ir:OrphanLeaf', {
+      name: 'OrphanLeaf',
+      qualifiedName: '@test/ir:OrphanLeaf',
+      constructor: SmrtObject,
+      config: {},
+      fields: new Map(),
+      methods: new Map(),
+      packageName: '@test/ir',
+      extends: 'GhostParentNeverRegistered',
+    });
+
+    const chain = getInheritanceChain('@test/ir:OrphanLeaf');
+    // Chain still includes the leaf; missing parent just terminates the walk.
+    expect(chain).toEqual(['@test/ir:OrphanLeaf']);
+  });
+
+  it('detects a multi-node cycle, warns, and does NOT cache the broken chain', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Two distinct registrations that point at each other by qualified extends.
+    const cycleA: any = {
+      name: 'CycleNodeA',
+      qualifiedName: '@test/ir:CycleNodeA',
+      constructor: SmrtObject,
+      config: {},
+      fields: new Map(),
+      methods: new Map(),
+      packageName: '@test/ir',
+      extends: '@test/ir:CycleNodeB',
+    };
+    const cycleB: any = {
+      name: 'CycleNodeB',
+      qualifiedName: '@test/ir:CycleNodeB',
+      constructor: SmrtObject,
+      config: {},
+      fields: new Map(),
+      methods: new Map(),
+      packageName: '@test/ir',
+      extends: '@test/ir:CycleNodeA',
+    };
+    addSyntheticClass('@test/ir:CycleNodeA', cycleA);
+    addSyntheticClass('@test/ir:CycleNodeB', cycleB);
+
+    const chain = getInheritanceChain('@test/ir:CycleNodeA');
+    expect(chain.length).toBeGreaterThan(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Circular inheritance detected'),
+    );
+    // Broken (circular) chains must not be cached.
+    expect(getInheritanceCache().get('@test/ir:CycleNodeA')).toBeUndefined();
+  });
+
+  it('treats a self-referential single node as expected (no warn, cached)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // A class whose extends resolves back to itself (same package + name).
+    const selfRef: any = {
+      name: 'SelfRef',
+      qualifiedName: '@test/ir:SelfRef',
+      constructor: SmrtObject,
+      config: {},
+      fields: new Map(),
+      methods: new Map(),
+      packageName: '@test/ir',
+      extends: 'SelfRef',
+    };
+    addSyntheticClass('@test/ir:SelfRef', selfRef);
+
+    const chain = getInheritanceChain('@test/ir:SelfRef');
+    expect(chain).toEqual(['@test/ir:SelfRef']);
+    // chain.length === 1 → not treated as a misconfigured cycle
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Circular inheritance detected'),
+    );
+  });
+});
+
+describe('inheritance-resolver: getAllFields (module)', () => {
+  it('returns an empty map for an unregistered class that cannot be loaded', async () => {
+    const fields = await getAllFields('NoSuchClassForFieldsXYZ');
+    expect(fields.size).toBe(0);
+  });
+
+  it('merges fields across the full inheritance chain and prepends system fields', async () => {
+    const fields = await getAllFields('IRLeaf');
+
+    // Own + inherited declared fields
+    expect(fields.has('baseTitle')).toBe(true); // IRBase
+    expect(fields.has('shared')).toBe(true); // IRBase
+    expect(fields.has('middleField')).toBe(true); // IRMiddle
+    expect(fields.has('leafField')).toBe(true); // IRLeaf
+
+    // System fields prepended
+    expect(fields.has('id')).toBe(true);
+    expect(fields.has('slug')).toBe(true);
+    expect(fields.has('created_at')).toBe(true);
+  });
+
+  it('returns the cached inheritedFields when already populated (with system fields)', async () => {
+    const registered = ObjectRegistry.getClass('IRSolo');
+    expect(registered).toBeDefined();
+    (registered as any).inheritedFields = new Map([
+      ['cachedOnly', { type: 'text', _meta: {} }],
+    ]);
+    try {
+      const fields = await getAllFields('IRSolo');
+      expect(fields.has('cachedOnly')).toBe(true);
+      // prependSmrtSystemFields still runs on the cached map
+      expect(fields.has('id')).toBe(true);
+    } finally {
+      (registered as any).inheritedFields = undefined;
+    }
+  });
+
+  it('rewrites SmrtHierarchical parentId into a self-referential foreignKey', async () => {
+    const fields = await getAllFields('IRTreeNode');
+    const parentId = fields.get('parentId');
+    expect(parentId).toBeDefined();
+    // normalizeFrameworkInheritedField turns it into a nullable FK back to the child
+    expect(parentId.type).toBe('foreignKey');
+    expect(parentId.related).toBe('IRTreeNode');
+    expect(parentId.required).toBe(false);
+    expect(parentId._meta?.nullable).toBe(true);
+  });
+});
+
+describe('inheritance-resolver: getAllMethods (module)', () => {
+  it('returns an empty map for an unregistered class', async () => {
+    const methods = await getAllMethods('NoSuchClassForMethodsXYZ');
+    expect(methods.size).toBe(0);
+  });
+
+  it('merges methods across the chain with child overriding parent', async () => {
+    const methods = await getAllMethods('IRLeaf');
+    expect(methods.has('baseMethod')).toBe(true); // declared on IRBase, overridden on IRLeaf
+    expect(methods.has('middleMethod')).toBe(true); // IRMiddle
+  });
+
+  it('serves cached inheritedMethods on the second call', async () => {
+    const registered = ObjectRegistry.getClass('IRMiddle');
+    expect(registered).toBeDefined();
+    (registered as any).inheritedMethods = undefined;
+
+    const first = await getAllMethods('IRMiddle');
+    // populate cache and re-call
+    const second = await getAllMethods('IRMiddle');
+    expect(Array.from(second.keys()).sort()).toEqual(
+      Array.from(first.keys()).sort(),
+    );
+    expect((registered as any).inheritedMethods).toBeDefined();
+  });
+});
+
+describe('inheritance-resolver: mergeFieldConfigs', () => {
+  it('child type wins and warns on a genuine type mismatch', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const merged = mergeFieldConfigs(
+      { type: 'text', _meta: {} },
+      { type: 'integer', _meta: {} },
+      'someField',
+    );
+    expect(merged.type).toBe('integer');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Field type mismatch'),
+    );
+  });
+
+  it('suppresses the warning for a tenantId field type conflict', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const merged = mergeFieldConfigs(
+      { type: 'foreignKey', __tenancy: { isTenantIdField: true }, _meta: {} },
+      { type: 'text', _meta: {} },
+      'tenantId',
+    );
+    // child type still wins...
+    expect(merged.type).toBe('text');
+    // ...but no warning for the known decorator/AST tenantId mismatch
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Field type mismatch'),
+    );
+  });
+
+  it('takes the strictest numeric min/max from parent and child _meta', () => {
+    const merged = mergeFieldConfigs(
+      { type: 'integer', _meta: { min: 0, max: 100 } },
+      { type: 'integer', _meta: { min: 10, max: 80 } },
+      'amount',
+    );
+    expect(merged._meta.min).toBe(10); // larger min = stricter lower bound
+    expect(merged._meta.max).toBe(80); // smaller max = stricter upper bound
+  });
+
+  it('combines parent and child validators (both must pass)', async () => {
+    const parentValidate = vi.fn(async (v: number) => v > 0);
+    const childValidate = vi.fn(async (v: number) => v < 100);
+    const merged = mergeFieldConfigs(
+      { type: 'integer', _meta: { validate: parentValidate } },
+      { type: 'integer', _meta: { validate: childValidate } },
+      'amount',
+    );
+
+    expect(await merged._meta.validate(50)).toBe(true); // both pass
+    expect(await merged._meta.validate(-1)).toBe(false); // parent fails
+    expect(await merged._meta.validate(150)).toBe(false); // child fails
+    expect(parentValidate).toHaveBeenCalled();
+    expect(childValidate).toHaveBeenCalled();
+  });
+
+  it('ORs the unique flag (unique if either parent or child says so)', () => {
+    const merged = mergeFieldConfigs(
+      { type: 'text', _meta: { unique: false } },
+      { type: 'text', _meta: { unique: true } },
+      'email',
+    );
+    expect(merged._meta.unique).toBe(true);
+  });
+
+  it('preserves __tenancy with parent (decorator) precedence', () => {
+    const merged = mergeFieldConfigs(
+      {
+        type: 'foreignKey',
+        __tenancy: { isTenantIdField: true, src: 'parent' },
+      },
+      { type: 'text', __tenancy: { isTenantIdField: false, src: 'child' } },
+      'tenantId',
+    );
+    // parent (decorator) wins on the overlapping keys
+    expect(merged.__tenancy.isTenantIdField).toBe(true);
+    expect(merged.__tenancy.src).toBe('parent');
+  });
+
+  it('lets the child override the default value', () => {
+    const merged = mergeFieldConfigs(
+      { type: 'text', value: 'parentDefault' },
+      { type: 'text', value: 'childDefault' },
+      'label',
+    );
+    expect(merged.value).toBe('childDefault');
+  });
+
+  it('keeps the parent value when the child does not define one', () => {
+    const merged = mergeFieldConfigs(
+      { type: 'text', value: 'parentDefault' },
+      { type: 'text' },
+      'label',
+    );
+    expect(merged.value).toBe('parentDefault');
+  });
+});
+
+describe('inheritance-resolver: end-to-end constraint merge via getAllFields', () => {
+  it('applies the strictest numeric constraints from the chain', async () => {
+    const fields = await getAllFields('IRConstraintChild');
+    const amount = fields.get('amount');
+    expect(amount).toBeDefined();
+    expect(amount._meta.min).toBe(10);
+    expect(amount._meta.max).toBe(80);
+    // Reference the parent fixture so the import is load-bearing.
+    expect(typeof IRConstraintChild).toBe('function');
+  });
+});

--- a/packages/core/src/registry/__tests__/schema-builder-helpers.test.ts
+++ b/packages/core/src/registry/__tests__/schema-builder-helpers.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Coverage tests for the pure exported helpers in registry/schema-builder.ts:
+ *   - formatDefaultValue (NULL, SQL-keyword/function passthrough, per-type
+ *     quoting, JSON edge cases)
+ *   - mapFieldTypeToSQL (every field-type → SQL-type mapping + default)
+ *   - generateDDLFromColumns (primaryKey/notNull/unique/default, STI vs non-STI
+ *     UNIQUE constraint, empty)
+ *   - fieldsToColumns (system-field skip, transient skip, relationship skip,
+ *     meta skip, foreignKey expansion, crossPackageRef text idType, sqlType
+ *     override, nullable/unique flags)
+ *
+ * These are pure functions over plain column/field maps — no DB or registry
+ * state needed, so we import them straight from the module.
+ *
+ * @see src/registry/schema-builder.ts (issue #1500 coverage, ORM group)
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { FieldDefinition } from '../../scanner/types.js';
+import type { ColumnDefinition } from '../../schema/types.js';
+import {
+  fieldsToColumns,
+  formatDefaultValue,
+  generateDDLFromColumns,
+  mapFieldTypeToSQL,
+} from '../schema-builder';
+
+describe('schema-builder: formatDefaultValue', () => {
+  it('renders NULL for null/undefined', () => {
+    expect(formatDefaultValue(null, 'TEXT')).toBe('NULL');
+    expect(formatDefaultValue(undefined, 'TEXT')).toBe('NULL');
+  });
+
+  it('passes through SQL function calls (anything containing "(")', () => {
+    expect(formatDefaultValue('uuid_generate_v4()', 'UUID')).toBe(
+      'uuid_generate_v4()',
+    );
+    expect(formatDefaultValue('coalesce(a, b)', 'TEXT')).toBe('coalesce(a, b)');
+  });
+
+  it('passes through recognized SQL keywords case-insensitively', () => {
+    expect(formatDefaultValue('CURRENT_TIMESTAMP', 'TIMESTAMP')).toBe(
+      'CURRENT_TIMESTAMP',
+    );
+    expect(formatDefaultValue('current_date', 'TIMESTAMP')).toBe(
+      'current_date',
+    );
+    expect(formatDefaultValue('NULL', 'TEXT')).toBe('NULL');
+  });
+
+  it('single-quotes and escapes TEXT/VARCHAR values', () => {
+    expect(formatDefaultValue('hello', 'TEXT')).toBe("'hello'");
+    expect(formatDefaultValue("O'Brien", 'VARCHAR')).toBe("'O''Brien'");
+  });
+
+  it('renders INTEGER/REAL numerics unquoted', () => {
+    expect(formatDefaultValue(42, 'INTEGER')).toBe('42');
+    expect(formatDefaultValue(3.14, 'REAL')).toBe('3.14');
+  });
+
+  it('renders BOOLEAN as TRUE/FALSE', () => {
+    expect(formatDefaultValue(true, 'BOOLEAN')).toBe('TRUE');
+    expect(formatDefaultValue(false, 'BOOLEAN')).toBe('FALSE');
+  });
+
+  describe('JSON type', () => {
+    it('renders empty string as JSON null', () => {
+      expect(formatDefaultValue('', 'JSON')).toBe("'null'");
+    });
+
+    it('renders the stringified-object sentinel as empty object', () => {
+      expect(formatDefaultValue('[object Object]', 'JSON')).toBe("'{}'");
+    });
+
+    it('passes through already-valid JSON strings (escaping quotes)', () => {
+      expect(formatDefaultValue('{"k":"v"}', 'JSON')).toBe(`'{"k":"v"}'`);
+    });
+
+    it('JSON-encodes a non-JSON string', () => {
+      // 'hello world' is not valid JSON → gets JSON.stringify'd into a quoted string
+      expect(formatDefaultValue('hello world', 'JSON')).toBe(`'"hello world"'`);
+    });
+
+    it('JSON-encodes a non-string value (object)', () => {
+      expect(formatDefaultValue({ a: 1 }, 'JSON')).toBe(`'{"a":1}'`);
+    });
+  });
+
+  it('falls back to quoted string for unknown types', () => {
+    expect(formatDefaultValue('x', 'SOMETHING_ELSE')).toBe("'x'");
+  });
+});
+
+describe('schema-builder: mapFieldTypeToSQL', () => {
+  it('maps each known field type to its SQL type', () => {
+    expect(mapFieldTypeToSQL('text')).toBe('TEXT');
+    expect(mapFieldTypeToSQL('integer')).toBe('INTEGER');
+    expect(mapFieldTypeToSQL('decimal')).toBe('REAL');
+    expect(mapFieldTypeToSQL('boolean')).toBe('BOOLEAN');
+    expect(mapFieldTypeToSQL('datetime')).toBe('TIMESTAMP');
+    expect(mapFieldTypeToSQL('json')).toBe('JSON');
+    expect(mapFieldTypeToSQL('foreignKey')).toBe('UUID');
+    expect(mapFieldTypeToSQL('crossPackageRef')).toBe('UUID');
+  });
+
+  it('defaults unknown types to TEXT', () => {
+    expect(mapFieldTypeToSQL('mysteryType' as FieldDefinition['type'])).toBe(
+      'TEXT',
+    );
+  });
+});
+
+describe('schema-builder: generateDDLFromColumns', () => {
+  it('emits PRIMARY KEY, NOT NULL, UNIQUE, and DEFAULT clauses', () => {
+    const columns: Record<string, ColumnDefinition> = {
+      id: { type: 'UUID', primaryKey: true },
+      name: { type: 'TEXT', notNull: true, unique: true },
+      count: { type: 'INTEGER', defaultValue: 0 },
+    };
+    const ddl = generateDDLFromColumns('widgets', columns);
+    expect(ddl).toContain('CREATE TABLE IF NOT EXISTS "widgets"');
+    expect(ddl).toContain('"id" UUID PRIMARY KEY');
+    expect(ddl).toContain('"name" TEXT NOT NULL UNIQUE');
+    expect(ddl).toContain('"count" INTEGER DEFAULT 0');
+  });
+
+  it('omits UNIQUE on a primary-key column even when unique is set', () => {
+    const columns: Record<string, ColumnDefinition> = {
+      id: { type: 'UUID', primaryKey: true, unique: true },
+    };
+    const ddl = generateDDLFromColumns('t', columns);
+    // primaryKey already implies uniqueness → no standalone UNIQUE token
+    expect(ddl).toContain('"id" UUID PRIMARY KEY');
+    expect(ddl).not.toMatch(/"id" UUID PRIMARY KEY UNIQUE/);
+  });
+
+  it('adds UNIQUE(slug, context) for non-STI tables with slug+context', () => {
+    const columns: Record<string, ColumnDefinition> = {
+      slug: { type: 'TEXT', notNull: true },
+      context: { type: 'TEXT' },
+    };
+    const ddl = generateDDLFromColumns('articles', columns, false);
+    expect(ddl).toContain('UNIQUE(slug, context)');
+    expect(ddl).not.toContain('_meta_type');
+  });
+
+  it('adds UNIQUE(slug, context, _meta_type) for STI tables', () => {
+    const columns: Record<string, ColumnDefinition> = {
+      slug: { type: 'TEXT', notNull: true },
+      context: { type: 'TEXT' },
+      _meta_type: { type: 'TEXT', notNull: true },
+    };
+    const ddl = generateDDLFromColumns('contents', columns, true);
+    expect(ddl).toContain('UNIQUE(slug, context, _meta_type)');
+  });
+});
+
+describe('schema-builder: fieldsToColumns', () => {
+  function fieldMap(
+    entries: Record<string, any>,
+  ): Map<string, FieldDefinition> {
+    return new Map(Object.entries(entries)) as Map<string, FieldDefinition>;
+  }
+
+  it('skips system fields (id, slug, context, timestamps)', () => {
+    const columns = fieldsToColumns(
+      fieldMap({
+        id: { type: 'text' },
+        slug: { type: 'text' },
+        context: { type: 'text' },
+        created_at: { type: 'datetime' },
+        updated_at: { type: 'datetime' },
+        realField: { type: 'text' },
+      }),
+    );
+    expect(Object.keys(columns)).toEqual(['real_field']);
+  });
+
+  it('skips transient fields (top-level and _meta)', () => {
+    const columns = fieldsToColumns(
+      fieldMap({
+        a: { type: 'text', transient: true },
+        b: { type: 'text', _meta: { transient: true } },
+        c: { type: 'text' },
+      }),
+    );
+    expect(Object.keys(columns)).toEqual(['c']);
+  });
+
+  it('skips oneToMany / manyToMany relationship fields', () => {
+    const columns = fieldsToColumns(
+      fieldMap({
+        children: { type: 'oneToMany' },
+        tags: { type: 'manyToMany' },
+        keep: { type: 'text' },
+      }),
+    );
+    expect(Object.keys(columns)).toEqual(['keep']);
+  });
+
+  it('skips meta fields (stored in _meta_data)', () => {
+    const columns = fieldsToColumns(
+      fieldMap({
+        extra: { type: 'meta' },
+        keep: { type: 'integer' },
+      }),
+    );
+    expect(Object.keys(columns)).toEqual(['keep']);
+  });
+
+  it('expands a foreignKey field into a column with FK metadata + snake_case', () => {
+    const columns = fieldsToColumns(
+      fieldMap({
+        authorId: {
+          type: 'foreignKey',
+          related: 'Author',
+          required: true,
+          _meta: { onDelete: 'SET NULL' },
+        },
+      }),
+    );
+    const col = columns.author_id;
+    expect(col).toBeDefined();
+    expect(col.type).toBe('UUID');
+    expect(col.referenceKind).toBe('foreignKey');
+    expect(col.notNull).toBe(true);
+    expect(col.foreignKey?.table).toBe('authors');
+    expect(col.foreignKey?.column).toBe('id');
+    expect(col.foreignKey?.onDelete).toBe('SET NULL');
+    expect(col.foreignKey?.onUpdate).toBe('CASCADE'); // defaulted
+  });
+
+  it('honors an explicit related column in "Table.col" form', () => {
+    const columns = fieldsToColumns(
+      fieldMap({
+        ownerRef: { type: 'foreignKey', related: 'Owner.code' },
+      }),
+    );
+    expect(columns.owner_ref.foreignKey?.column).toBe('code');
+  });
+
+  it('maps crossPackageRef with text idType to TEXT', () => {
+    const columns = fieldsToColumns(
+      fieldMap({
+        remoteId: { type: 'crossPackageRef', _meta: { idType: 'text' } },
+      }),
+    );
+    expect(columns.remote_id.type).toBe('TEXT');
+    expect(columns.remote_id.referenceKind).toBe('crossPackageRef');
+  });
+
+  it('applies an explicit _meta.sqlType override (uppercased)', () => {
+    const columns = fieldsToColumns(
+      fieldMap({
+        amount: { type: 'integer', _meta: { sqlType: 'numeric' } },
+      }),
+    );
+    expect(columns.amount.type).toBe('NUMERIC');
+  });
+
+  it('marks nullable fields as notNull:false and carries unique flag', () => {
+    const columns = fieldsToColumns(
+      fieldMap({
+        optional: { type: 'text', required: true, _meta: { nullable: true } },
+        handle: { type: 'text', _meta: { unique: true } },
+      }),
+    );
+    // nullable wins over required → notNull false
+    expect(columns.optional.notNull).toBe(false);
+    expect(columns.handle.unique).toBe(true);
+  });
+
+  it('emits a default value when one is set', () => {
+    const columns = fieldsToColumns(
+      fieldMap({
+        status: { type: 'text', default: 'active' },
+      }),
+    );
+    expect(columns.status.defaultValue).toBe('active');
+  });
+});

--- a/packages/core/src/registry/__tests__/validator-compile.test.ts
+++ b/packages/core/src/registry/__tests__/validator-compile.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Coverage tests for registry/validator.ts (compileValidators).
+ *
+ * Drives ObjectRegistry.compileValidators() directly with field-definition
+ * maps, then executes each compiled validator against mock instances to
+ * exercise every branch: required, numeric min/max, string min/max length,
+ * regex pattern, custom validator (pass/fail/throw), transient skip, and the
+ * pass-through (returns null) paths.
+ *
+ * No database needed — compileValidators is a pure function over field
+ * metadata; the validators it returns are plain async closures we call by hand.
+ *
+ * @see src/registry/validator.ts (issue #1500 coverage push, ORM group)
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ObjectRegistry } from '../../registry';
+
+/**
+ * Field definition shape matching what the AST scanner / decorators produce:
+ * a `type` discriminator, optional top-level `transient`, and an `_meta`
+ * options bag carrying required/min/max/minLength/maxLength/pattern/validate.
+ */
+function field(
+  type: string,
+  meta: Record<string, any> = {},
+  extra: Record<string, any> = {},
+): any {
+  return { type, _meta: meta, ...extra };
+}
+
+function compile(fields: Record<string, any>) {
+  const map = new Map<string, any>(Object.entries(fields));
+  return ObjectRegistry.compileValidators('CompileValidatorFixture', map);
+}
+
+/** Run every validator and collect the non-null results (validation errors). */
+async function runAll(validators: any[], instance: any): Promise<any[]> {
+  const results = await Promise.all(validators.map((v) => v(instance)));
+  return results.filter((r) => r !== null && r !== undefined);
+}
+
+describe('compileValidators', () => {
+  describe('transient fields', () => {
+    it('skips fields flagged transient via _meta.transient', () => {
+      const validators = compile({
+        ghost: field('text', { transient: true, required: true }),
+      });
+      expect(validators).toHaveLength(0);
+    });
+
+    it('skips fields flagged transient via top-level field.transient', () => {
+      const validators = compile({
+        ghost: field('text', { required: true }, { transient: true }),
+      });
+      expect(validators).toHaveLength(0);
+    });
+  });
+
+  describe('required validator', () => {
+    it('returns a requiredField error when value is null/undefined/empty', async () => {
+      const validators = compile({
+        name: field('text', { required: true }),
+      });
+      expect(validators).toHaveLength(1);
+
+      const nullErr = await validators[0]({ name: null });
+      const undefErr = await validators[0]({ name: undefined });
+      const emptyErr = await validators[0]({ name: '' });
+
+      for (const err of [nullErr, undefErr, emptyErr]) {
+        expect(err).not.toBeNull();
+        expect(err.code).toBe('VALIDATION_REQUIRED_FIELD');
+        expect(err.details.fieldName).toBe('name');
+      }
+    });
+
+    it('returns null when the required value is present', async () => {
+      const validators = compile({
+        name: field('text', { required: true }),
+      });
+      expect(await validators[0]({ name: 'present' })).toBeNull();
+      // 0 is a present value for a required field (only '' counts as empty).
+      expect(await validators[0]({ name: 0 })).toBeNull();
+    });
+  });
+
+  describe('numeric range validators', () => {
+    it('produces min and max validators for integer/decimal/number types', () => {
+      for (const type of ['integer', 'decimal', 'number']) {
+        const validators = compile({ a: field(type, { min: 1, max: 10 }) });
+        expect(validators).toHaveLength(2);
+      }
+    });
+
+    it('flags values below min and passes values at/above min', async () => {
+      const [minValidator] = compile({ qty: field('integer', { min: 5 }) });
+      const below = await minValidator({ qty: 4 });
+      expect(below.code).toBe('VALIDATION_RANGE_ERROR');
+      expect(below.details.min).toBe(5);
+
+      expect(await minValidator({ qty: 5 })).toBeNull();
+      expect(await minValidator({ qty: 99 })).toBeNull();
+      // null/undefined skip the range check (only checked when value present)
+      expect(await minValidator({ qty: null })).toBeNull();
+      expect(await minValidator({ qty: undefined })).toBeNull();
+    });
+
+    it('flags values above max and passes values at/below max', async () => {
+      const [maxValidator] = compile({ qty: field('decimal', { max: 100 }) });
+      const above = await maxValidator({ qty: 101 });
+      expect(above.code).toBe('VALIDATION_RANGE_ERROR');
+      expect(above.details.max).toBe(100);
+
+      expect(await maxValidator({ qty: 100 })).toBeNull();
+      expect(await maxValidator({ qty: 0 })).toBeNull();
+      expect(await maxValidator({ qty: null })).toBeNull();
+    });
+
+    it('does not emit numeric validators for non-numeric types', () => {
+      // text type with min/max should not generate range validators here
+      const validators = compile({ a: field('text', { min: 1, max: 10 }) });
+      expect(validators).toHaveLength(0);
+    });
+  });
+
+  describe('string length validators', () => {
+    it('flags strings shorter than minLength and passes longer ones', async () => {
+      const [minLen] = compile({ bio: field('text', { minLength: 3 }) });
+      const tooShort = await minLen({ bio: 'ab' });
+      expect(tooShort.code).toBe('VALIDATION_INVALID_VALUE');
+      expect(tooShort.details.fieldName).toBe('bio');
+
+      expect(await minLen({ bio: 'abc' })).toBeNull();
+      // empty string is falsy → guard short-circuits, returns null
+      expect(await minLen({ bio: '' })).toBeNull();
+      // non-string value → typeof guard short-circuits
+      expect(await minLen({ bio: 12345 })).toBeNull();
+    });
+
+    it('flags strings longer than maxLength and passes shorter ones', async () => {
+      const [maxLen] = compile({ code: field('text', { maxLength: 4 }) });
+      const tooLong = await maxLen({ code: 'abcde' });
+      expect(tooLong.code).toBe('VALIDATION_INVALID_VALUE');
+
+      expect(await maxLen({ code: 'abcd' })).toBeNull();
+      expect(await maxLen({ code: '' })).toBeNull();
+      expect(await maxLen({ code: { not: 'a string' } })).toBeNull();
+    });
+  });
+
+  describe('pattern validator', () => {
+    it('flags strings that do not match the pattern and passes matches', async () => {
+      const [pat] = compile({
+        slug: field('text', { pattern: '^[a-z]+$' }),
+      });
+      const bad = await pat({ slug: 'Has-Caps-123' });
+      expect(bad.code).toBe('VALIDATION_INVALID_VALUE');
+
+      expect(await pat({ slug: 'lowercase' })).toBeNull();
+      // empty / non-string short-circuit
+      expect(await pat({ slug: '' })).toBeNull();
+      expect(await pat({ slug: 42 })).toBeNull();
+    });
+  });
+
+  describe('custom validator', () => {
+    it('returns null when the custom validator resolves truthy', async () => {
+      const [custom] = compile({
+        even: field('integer', {
+          validate: (v: number) => v % 2 === 0,
+        }),
+      });
+      expect(await custom({ even: 4 })).toBeNull();
+    });
+
+    it('returns invalidValue with default message when validator resolves falsy', async () => {
+      const [custom] = compile({
+        even: field('integer', {
+          validate: (v: number) => v % 2 === 0,
+        }),
+      });
+      const err = await custom({ even: 3 });
+      expect(err.code).toBe('VALIDATION_INVALID_VALUE');
+      expect(err.details.expectedType).toContain('failed custom validation');
+    });
+
+    it('uses customMessage when provided and validator fails', async () => {
+      const [custom] = compile({
+        even: field('integer', {
+          validate: (v: number) => v % 2 === 0,
+          customMessage: 'must be even',
+        }),
+      });
+      const err = await custom({ even: 7 });
+      expect(err.details.expectedType).toBe('must be even');
+    });
+
+    it('catches a throwing custom validator and reports the error message', async () => {
+      const [custom] = compile({
+        x: field('text', {
+          validate: () => {
+            throw new Error('boom in validator');
+          },
+        }),
+      });
+      const err = await custom({ x: 'anything' });
+      expect(err.code).toBe('VALIDATION_INVALID_VALUE');
+      expect(err.details.expectedType).toContain('boom in validator');
+    });
+
+    it('catches a thrown non-Error value (String(error) branch)', async () => {
+      const [custom] = compile({
+        x: field('text', {
+          validate: () => {
+            // Intentionally throw a non-Error to hit the String(error) branch.
+            return Promise.reject('string failure');
+          },
+        }),
+      });
+      const err = await custom({ x: 'anything' });
+      expect(err.code).toBe('VALIDATION_INVALID_VALUE');
+      expect(err.details.expectedType).toContain('string failure');
+    });
+
+    it('ignores a non-function validate option', () => {
+      // validate present but not a function → no custom validator pushed
+      const validators = compile({
+        x: field('text', { validate: 'not-a-function' }),
+      });
+      expect(validators).toHaveLength(0);
+    });
+  });
+
+  describe('combined fields', () => {
+    it('compiles independent validators across many fields', async () => {
+      const validators = compile({
+        name: field('text', { required: true, maxLength: 10 }),
+        age: field('integer', { min: 0, max: 120 }),
+        nickname: field('text', { minLength: 2 }),
+      });
+      // required(name) + maxLength(name) + min(age) + max(age) + minLength(nickname)
+      expect(validators).toHaveLength(5);
+
+      const errors = await runAll(validators, {
+        name: '',
+        age: 200,
+        nickname: 'x',
+      });
+      // missing name (required), age over max, nickname too short
+      expect(errors.length).toBe(3);
+    });
+  });
+});

--- a/packages/core/src/runtime/server.test.ts
+++ b/packages/core/src/runtime/server.test.ts
@@ -17,12 +17,11 @@ import { createSmrtServer } from './index.js';
 import type { SmrtServerOptions } from './types.js';
 
 // SmrtServer is not re-exported from runtime/index, so build it via the factory.
-// handleRequest is private; we reach it through a typed cast — a test-only seam,
-// since there is no public in-process dispatch entry point.
+// dispatch() is the supported public in-process entry point (no socket bound).
 function makeServer(options?: SmrtServerOptions) {
   const server = createSmrtServer(options);
   const dispatch = (request: Request): Promise<Response> =>
-    (server as any).handleRequest(request);
+    server.dispatch(request);
   return { server, dispatch };
 }
 

--- a/packages/core/src/runtime/server.test.ts
+++ b/packages/core/src/runtime/server.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Tests for the SMRT runtime HTTP server (src/runtime/server.ts).
+ *
+ * The bulk of SmrtServer is request-routing logic that does not require a live
+ * socket: route registration, :param matching, the Express-style response
+ * adapter, CORS handling, and bearer/basic/custom auth. We drive these through
+ * the server's request handler with synthetic Web `Request` objects so no port
+ * is ever opened.
+ *
+ * The genuinely server-bound surface — start(), nodeRequestToWebRequest(),
+ * webResponseToNodeResponse(), streamToString() — is NOT exercised here; it
+ * requires spawning an http.Server and is flagged as infeasible for unit tests.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createSmrtServer } from './index.js';
+import type { SmrtServerOptions } from './types.js';
+
+// SmrtServer is not re-exported from runtime/index, so build it via the factory.
+// handleRequest is private; we reach it through a typed cast — a test-only seam,
+// since there is no public in-process dispatch entry point.
+function makeServer(options?: SmrtServerOptions) {
+  const server = createSmrtServer(options);
+  const dispatch = (request: Request): Promise<Response> =>
+    (server as any).handleRequest(request);
+  return { server, dispatch };
+}
+
+const BASE = 'http://localhost:3000';
+
+describe('createSmrtServer', () => {
+  it('returns a server instance', () => {
+    const server = createSmrtServer();
+    expect(server).toBeDefined();
+    expect(typeof server.addRoute).toBe('function');
+  });
+});
+
+describe('route dispatch', () => {
+  it('returns 404 when no route matches', async () => {
+    const { dispatch } = makeServer({ cors: false });
+    const res = await dispatch(new Request(`${BASE}/api/v1/unknown`));
+    expect(res.status).toBe(404);
+  });
+
+  it('dispatches an exact-match route', async () => {
+    const { server, dispatch } = makeServer({ cors: false });
+    server.addRoute('GET', '/ping', async () => new Response('pong'));
+
+    const res = await dispatch(new Request(`${BASE}/api/v1/ping`));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('pong');
+  });
+
+  it('extracts :params from a parameterized route', async () => {
+    const { server, dispatch } = makeServer({ cors: false });
+    server.addRoute(
+      'GET',
+      '/users/:id',
+      async (req) => new Response(req.params.id),
+    );
+
+    const res = await dispatch(new Request(`${BASE}/api/v1/users/42`));
+    expect(await res.text()).toBe('42');
+  });
+
+  it('does not match when segment counts differ', async () => {
+    const { server, dispatch } = makeServer({ cors: false });
+    server.addRoute('GET', '/users/:id', async () => new Response('ok'));
+
+    const res = await dispatch(new Request(`${BASE}/api/v1/users/42/extra`));
+    expect(res.status).toBe(404);
+  });
+
+  it('does not match when a literal segment differs', async () => {
+    const { server, dispatch } = makeServer({ cors: false });
+    server.addRoute('GET', '/users/:id', async () => new Response('ok'));
+
+    // Method matches but the literal prefix "users" is "teams" here.
+    const res = await dispatch(new Request(`${BASE}/api/v1/teams/42`));
+    expect(res.status).toBe(404);
+  });
+
+  it('parses JSON bodies for POST requests', async () => {
+    const { server, dispatch } = makeServer({ cors: false });
+    server.addRoute('POST', '/echo', async (req) => {
+      const data = await req.json();
+      return new Response(JSON.stringify(data));
+    });
+
+    const res = await dispatch(
+      new Request(`${BASE}/api/v1/echo`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ hello: 'world' }),
+      }),
+    );
+    expect(await res.json()).toEqual({ hello: 'world' });
+  });
+
+  it('parses query parameters', async () => {
+    const { server, dispatch } = makeServer({ cors: false });
+    server.addRoute('GET', '/search', async (req) => new Response(req.query.q));
+
+    const res = await dispatch(new Request(`${BASE}/api/v1/search?q=term`));
+    expect(await res.text()).toBe('term');
+  });
+
+  it('returns 500 when a handler throws', async () => {
+    const { server, dispatch } = makeServer({ cors: false });
+    server.addRoute('GET', '/boom', async () => {
+      throw new Error('kaboom');
+    });
+
+    const res = await dispatch(new Request(`${BASE}/api/v1/boom`));
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('Express-style route adapters', () => {
+  it('adapts res.status().json() into a Response', async () => {
+    const { server, dispatch } = makeServer({ cors: false });
+    server.get('/widget', (_req, res) => {
+      res.status(201).json({ created: true });
+    });
+
+    const res = await dispatch(new Request(`${BASE}/api/v1/widget`));
+    expect(res.status).toBe(201);
+    expect(res.headers.get('content-type')).toBe('application/json');
+    expect(await res.json()).toEqual({ created: true });
+  });
+
+  it('adapts res.send() with a string to text/plain', async () => {
+    const { server, dispatch } = makeServer({ cors: false });
+    server.post('/note', (_req, res) => {
+      res.send('plain body');
+    });
+
+    const res = await dispatch(
+      new Request(`${BASE}/api/v1/note`, { method: 'POST' }),
+    );
+    expect(res.headers.get('content-type')).toBe('text/plain');
+    expect(await res.text()).toBe('plain body');
+  });
+
+  it('adapts res.send() with an object to application/json', async () => {
+    const { server, dispatch } = makeServer({ cors: false });
+    server.put('/note', (_req, res) => {
+      res.send({ ok: 1 });
+    });
+
+    const res = await dispatch(
+      new Request(`${BASE}/api/v1/note`, { method: 'PUT' }),
+    );
+    expect(res.headers.get('content-type')).toBe('application/json');
+    expect(await res.json()).toEqual({ ok: 1 });
+  });
+
+  it('adapts res.setHeader() and res.end()', async () => {
+    const { server, dispatch } = makeServer({ cors: false });
+    server.delete('/note', (_req, res) => {
+      res.setHeader('X-Custom', 'yes');
+      res.end('done');
+    });
+
+    const res = await dispatch(
+      new Request(`${BASE}/api/v1/note`, { method: 'DELETE' }),
+    );
+    expect(res.headers.get('x-custom')).toBe('yes');
+    expect(await res.text()).toBe('done');
+  });
+
+  it('propagates a synchronous throw from an Express handler as 500', async () => {
+    const { server, dispatch } = makeServer({ cors: false });
+    server.get('/fail', () => {
+      throw new Error('sync fail');
+    });
+
+    const res = await dispatch(new Request(`${BASE}/api/v1/fail`));
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('CORS handling', () => {
+  it('answers OPTIONS preflight with 204 and default headers', async () => {
+    const { dispatch } = makeServer({ cors: true });
+    const res = await dispatch(
+      new Request(`${BASE}/api/v1/anything`, { method: 'OPTIONS' }),
+    );
+    expect(res.status).toBe(204);
+    expect(res.headers.get('access-control-allow-origin')).toBe('*');
+    expect(res.headers.get('access-control-allow-methods')).toContain('GET');
+  });
+
+  it('adds default CORS headers to handled responses', async () => {
+    const { server, dispatch } = makeServer({ cors: true });
+    server.addRoute('GET', '/ping', async () => new Response('pong'));
+
+    const res = await dispatch(new Request(`${BASE}/api/v1/ping`));
+    expect(res.headers.get('access-control-allow-origin')).toBe('*');
+  });
+
+  it('honors a custom CORS origin/methods/headers config', async () => {
+    const { server, dispatch } = makeServer({
+      cors: {
+        origin: ['https://a.test', 'https://b.test'],
+        methods: ['GET', 'POST'],
+        headers: ['X-Token'],
+      },
+    });
+    server.addRoute('GET', '/ping', async () => new Response('pong'));
+
+    const res = await dispatch(new Request(`${BASE}/api/v1/ping`));
+    expect(res.headers.get('access-control-allow-origin')).toBe(
+      'https://a.test, https://b.test',
+    );
+    expect(res.headers.get('access-control-allow-methods')).toBe('GET, POST');
+    expect(res.headers.get('access-control-allow-headers')).toBe('X-Token');
+  });
+});
+
+describe('authentication', () => {
+  it('rejects requests with no Authorization header as 401', async () => {
+    const { server, dispatch } = makeServer({
+      cors: false,
+      auth: { type: 'bearer' },
+    });
+    server.addRoute('GET', '/secure', async () => new Response('secret'));
+
+    const res = await dispatch(new Request(`${BASE}/api/v1/secure`));
+    expect(res.status).toBe(401);
+  });
+
+  it('accepts a bearer token verified by the verify callback', async () => {
+    const { server, dispatch } = makeServer({
+      cors: false,
+      auth: {
+        type: 'bearer',
+        verify: async (token) => token === 'good-token',
+      },
+    });
+    server.addRoute('GET', '/secure', async () => new Response('secret'));
+
+    const ok = await dispatch(
+      new Request(`${BASE}/api/v1/secure`, {
+        headers: { authorization: 'Bearer good-token' },
+      }),
+    );
+    expect(ok.status).toBe(200);
+
+    const bad = await dispatch(
+      new Request(`${BASE}/api/v1/secure`, {
+        headers: { authorization: 'Bearer wrong' },
+      }),
+    );
+    expect(bad.status).toBe(401);
+  });
+
+  it('accepts a bearer token when no verify callback is configured', async () => {
+    const { server, dispatch } = makeServer({
+      cors: false,
+      auth: { type: 'bearer' },
+    });
+    server.addRoute('GET', '/secure', async () => new Response('secret'));
+
+    const res = await dispatch(
+      new Request(`${BASE}/api/v1/secure`, {
+        headers: { authorization: 'Bearer anything' },
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('verifies basic credentials via the verify callback', async () => {
+    const { server, dispatch } = makeServer({
+      cors: false,
+      auth: {
+        type: 'basic',
+        verify: async (creds) => creds === 'dXNlcjpwYXNz',
+      },
+    });
+    server.addRoute('GET', '/secure', async () => new Response('secret'));
+
+    const res = await dispatch(
+      new Request(`${BASE}/api/v1/secure`, {
+        headers: { authorization: 'Basic dXNlcjpwYXNz' },
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('verifies a custom auth header via the verify callback', async () => {
+    const { server, dispatch } = makeServer({
+      cors: false,
+      auth: {
+        type: 'custom',
+        verify: async (header) => header === 'magic',
+      },
+    });
+    server.addRoute('GET', '/secure', async () => new Response('secret'));
+
+    const res = await dispatch(
+      new Request(`${BASE}/api/v1/secure`, {
+        headers: { authorization: 'magic' },
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('basePath handling', () => {
+  it('strips a custom basePath before route matching', async () => {
+    const { server, dispatch } = makeServer({
+      cors: false,
+      basePath: '/custom',
+    });
+    server.addRoute('GET', '/ping', async () => new Response('pong'));
+
+    const res = await dispatch(new Request(`${BASE}/custom/ping`));
+    expect(await res.text()).toBe('pong');
+  });
+});

--- a/packages/core/src/runtime/server.ts
+++ b/packages/core/src/runtime/server.ts
@@ -157,6 +157,15 @@ export class SmrtServer {
   }
 
   /**
+   * Dispatch a request in-process and return the Response, without binding a
+   * socket. Supported public entry point for embedding the router and for
+   * tests that exercise routing/auth/CORS without spawning an HTTP server.
+   */
+  async dispatch(request: Request): Promise<Response> {
+    return this.handleRequest(request);
+  }
+
+  /**
    * Convert stream to string
    */
   private async streamToString(stream: http.IncomingMessage): Promise<string> {

--- a/packages/core/src/scanner/__tests__/manifest-generator-coverage.test.ts
+++ b/packages/core/src/scanner/__tests__/manifest-generator-coverage.test.ts
@@ -1,0 +1,796 @@
+/**
+ * Coverage-focused tests for ManifestGenerator (issue #1500).
+ *
+ * The existing manifest-generator.test.ts covers collision detection, agent
+ * signalSubscriptions, REST endpoint routing, and the tenant-scoped schema
+ * contract. This file targets the remaining uncovered branches:
+ *
+ * - STI base / STI child (local + external) / CTI schema generation paths
+ * - Inherited-field merging through framework abstract bases (SmrtHierarchical)
+ *   and collection item-class inheritance
+ * - Same-package foreign-key column-type reconciliation
+ * - Visibility inference + filtering, import-path determination
+ * - Code generators: type definitions, REST endpoint code, MCP tools/code
+ * - Agent manifests with uiSlots/components/adminRoutes
+ * - saveManifest / loadManifest round-trip
+ *
+ * Everything is exercised through hand-built ScanResult inputs so the tests
+ * stay deterministic and never touch oxc-parser or the filesystem — except the
+ * save/load round-trip and the external-STI block, which use isolated temp
+ * dirs with throwaway node_modules packages.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearManifestCache } from '../../manifest/manifest-loader.js';
+import {
+  generateManifest as generateManifestFn,
+  ManifestGenerator,
+} from '../manifest-generator';
+import type {
+  ScanResult,
+  SmartObjectDefinition,
+  SmartObjectManifest,
+} from '../types';
+
+/**
+ * Build a minimal valid SmartObjectDefinition. Only `className` is required;
+ * everything else is derived so individual tests stay focused.
+ */
+function def(
+  className: string,
+  overrides: Partial<SmartObjectDefinition> = {},
+): SmartObjectDefinition {
+  const name = className.toLowerCase();
+  return {
+    name,
+    className,
+    collection: `${name}s`,
+    filePath: `/src/${name}.ts`,
+    fields: {},
+    methods: {},
+    decoratorConfig: {},
+    exportName: className,
+    collectionExportName: `${className}Collection`,
+    ...overrides,
+  } as SmartObjectDefinition;
+}
+
+function scan(objects: SmartObjectDefinition[]): ScanResult {
+  return {
+    filePath: objects[0]?.filePath ?? '/src/unknown.ts',
+    objects,
+    imports: [],
+    exports: [],
+  };
+}
+
+describe('ManifestGenerator coverage', () => {
+  describe('schema generation strategies', () => {
+    it('generates a CTI table schema for a plain SmrtObject subclass', () => {
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest([
+        scan([
+          def('Widget', {
+            fields: {
+              name: { type: 'text', required: true },
+              count: { type: 'integer' },
+            },
+          }),
+        ]),
+      ]);
+
+      const widget = manifest.objects.widget;
+      expect(widget.schema?.tableName).toBe('widgets');
+      expect(widget.schema?.columns.name).toBeDefined();
+      expect(widget.schema?.ddl).toContain('CREATE TABLE');
+    });
+
+    it('generates an STI schema on the base class and skips local STI children', () => {
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest([
+        scan([
+          def('Content', {
+            decoratorConfig: { tableStrategy: 'sti' },
+            fields: { title: { type: 'text' } },
+          }),
+          def('Article', {
+            extends: 'Content',
+            fields: { body: { type: 'text' } },
+          }),
+        ]),
+      ]);
+
+      // Base owns the shared table schema.
+      expect(manifest.objects.content.schema?.tableName).toBe('contents');
+      // The child inherited the base table name + strategy during merge, so it
+      // resolves to the shared `contents` table (not its own `articles` table).
+      expect(manifest.objects.article.decoratorConfig.tableName).toBe(
+        'contents',
+      );
+      expect(manifest.objects.article.decoratorConfig.tableStrategy).toBe(
+        'sti',
+      );
+      expect(manifest.objects.article.schema?.tableName).toBe('contents');
+      // STI child has the base's title field merged in.
+      expect(manifest.objects.article.fields.title).toBeDefined();
+    });
+
+    it('honors an explicit tableName on the STI base', () => {
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest([
+        scan([
+          def('Content', {
+            decoratorConfig: { tableStrategy: 'sti', tableName: 'content' },
+            fields: { title: { type: 'text' } },
+          }),
+          def('Article', { extends: 'Content' }),
+        ]),
+      ]);
+
+      expect(manifest.objects.content.schema?.tableName).toBe('content');
+      expect(manifest.objects.article.decoratorConfig.tableName).toBe(
+        'content',
+      );
+    });
+  });
+
+  describe('framework abstract base inheritance (CTI through SmrtHierarchical)', () => {
+    it('merges parentId from SmrtHierarchical into a CTI subclass and rewrites it as a self-FK', () => {
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest([
+        scan([
+          // Framework base declared inline (no @smrt table of its own).
+          def('SmrtHierarchical', {
+            collection: '',
+            decoratorConfig: {},
+            fields: {
+              parentId: { type: 'text', _meta: {} },
+            },
+          }),
+          def('Account', {
+            extends: 'SmrtHierarchical',
+            fields: { name: { type: 'text' } },
+          }),
+        ]),
+      ]);
+
+      const account = manifest.objects.account;
+      // parentId propagated into the CTI subclass...
+      expect(account.fields.parentId).toBeDefined();
+      // ...and normalized to a nullable self-referencing foreignKey.
+      expect(account.fields.parentId.type).toBe('foreignKey');
+      expect(account.fields.parentId.related).toBe('Account');
+      expect(account.fields.parentId.required).toBe(false);
+    });
+  });
+
+  describe('collection item-class inheritance', () => {
+    it('inherits tableName/collection from the item class via extendsTypeArg', () => {
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest([
+        scan([
+          def('Event', {
+            decoratorConfig: { tableStrategy: 'sti', tableName: 'events' },
+            fields: { title: { type: 'text' } },
+          }),
+          def('Meeting', { extends: 'Event' }),
+          def('Meetings', {
+            collection: 'meetings_collection',
+            extends: 'SmrtCollection',
+            extendsTypeArg: 'Meeting',
+          }),
+        ]),
+      ]);
+
+      // Meeting inherited the STI base table.
+      expect(manifest.objects.meeting.decoratorConfig.tableName).toBe('events');
+      // The collection class inherits the item class's table + collection.
+      expect(manifest.objects.meetings.decoratorConfig.tableName).toBe(
+        'events',
+      );
+      expect(manifest.objects.meetings.collection).toBe(
+        manifest.objects.meeting.collection,
+      );
+    });
+
+    it('falls back to name-based singularization when extendsTypeArg is absent', () => {
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest([
+        scan([
+          def('Category', {
+            decoratorConfig: { tableName: 'categories' },
+            fields: { label: { type: 'text' } },
+          }),
+          // "Categories" -> "Category" via the 'ies' -> 'y' candidate.
+          def('Categories', {
+            collection: 'categories_collection',
+            extends: 'SmrtCollection',
+          }),
+        ]),
+      ]);
+
+      expect(manifest.objects.categories.decoratorConfig?.tableName).toBe(
+        'categories',
+      );
+    });
+  });
+
+  describe('same-package foreign-key column-type reconciliation', () => {
+    it('rewrites a foreign-key column type to match the target id column type', () => {
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest([
+        scan([
+          def('Author', { fields: { name: { type: 'text' } } }),
+          def('Book', {
+            fields: {
+              title: { type: 'text' },
+              authorId: { type: 'foreignKey', related: 'Author' },
+            },
+          }),
+        ]),
+      ]);
+
+      const book = manifest.objects.book;
+      const author = manifest.objects.author;
+      // The FK column carries the foreignKey referenceKind marker.
+      expect(book.schema?.columns.author_id?.referenceKind).toBe('foreignKey');
+      // And its SQL type matches the target table's id column type.
+      expect(book.schema?.columns.author_id?.type).toBe(
+        author.schema?.columns.id?.type,
+      );
+    });
+
+    it('marks crossPackageRef columns with the crossPackageRef referenceKind', () => {
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest([
+        scan([
+          def('Order', {
+            fields: {
+              ref: {
+                type: 'crossPackageRef',
+                related: '@happyvertical/smrt-users:User',
+              },
+            },
+          }),
+        ]),
+      ]);
+
+      expect(manifest.objects.order.schema?.columns.ref?.referenceKind).toBe(
+        'crossPackageRef',
+      );
+    });
+  });
+
+  describe('visibility inference and filtering', () => {
+    it('infers test visibility from test file paths', () => {
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest([
+        scan([
+          def('TestThing', { filePath: '/src/thing.test.ts' }),
+          def('RealThing', { filePath: '/src/thing.ts' }),
+        ]),
+      ]);
+
+      expect(manifest.objects.testthing.visibility).toBe('test');
+      expect(manifest.objects.realthing.visibility).toBe('public');
+    });
+
+    it('respects explicit visibility from the decorator config', () => {
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest([
+        scan([
+          def('InternalThing', {
+            decoratorConfig: { visibility: 'internal' as any },
+          }),
+        ]),
+      ]);
+
+      expect(manifest.objects.internalthing.visibility).toBe('internal');
+    });
+
+    it('filters out objects whose visibility is not in includeVisibility', () => {
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest(
+        [
+          scan([
+            def('PublicThing', { filePath: '/src/public.ts' }),
+            def('TestThing', { filePath: '/src/thing.test.ts' }),
+          ]),
+        ],
+        { includeVisibility: ['public'] },
+      );
+
+      expect(manifest.objects.publicthing).toBeDefined();
+      expect(manifest.objects.testthing).toBeUndefined();
+    });
+  });
+
+  describe('package metadata and import paths', () => {
+    it('sets qualified names and import paths from package.json exports', () => {
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest(
+        [scan([def('Product', { fields: { sku: { type: 'text' } } })])],
+        {
+          packageName: '@acme/catalog',
+          packageVersion: '2.1.0',
+          packageJson: {
+            name: '@acme/catalog',
+            exports: { './objects': './dist/objects.js' },
+          },
+        },
+      );
+
+      expect(manifest.packageName).toBe('@acme/catalog');
+      expect(manifest.packageVersion).toBe('2.1.0');
+      const key = '@acme/catalog:Product';
+      expect(manifest.objects[key]).toBeDefined();
+      expect(manifest.objects[key].importPath).toBe('@acme/catalog/objects');
+      expect(manifest.objects[key].qualifiedName).toBe(key);
+    });
+
+    it('falls back to the package name when only a main export exists', () => {
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest([scan([def('Thing')])], {
+        packageName: '@acme/pkg',
+        packageJson: {
+          name: '@acme/pkg',
+          exports: { '.': { import: './dist/index.js' } },
+        },
+      });
+      expect(manifest.objects['@acme/pkg:Thing'].importPath).toBe('@acme/pkg');
+    });
+
+    it('falls back to the package name when only a legacy main field exists', () => {
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest([scan([def('Thing')])], {
+        packageName: '@acme/pkg',
+        packageJson: { name: '@acme/pkg', main: './dist/index.js' },
+      });
+      expect(manifest.objects['@acme/pkg:Thing'].importPath).toBe('@acme/pkg');
+    });
+  });
+
+  describe('validation rules', () => {
+    it('derives required/min/max/length/pattern rules and skips transient fields', () => {
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest([
+        scan([
+          def('Profile', {
+            fields: {
+              name: {
+                type: 'text',
+                required: true,
+                minLength: 2,
+                maxLength: 50,
+                _meta: { pattern: '^[a-z]+$' },
+              },
+              age: { type: 'integer', _meta: { min: 0, max: 120 } },
+              computed: { type: 'text', transient: true, required: true },
+            },
+          }),
+        ]),
+      ]);
+
+      const rules = manifest.objects.profile.validationRules ?? [];
+      const byField = (f: string) => rules.filter((r) => r.field === f);
+      expect(
+        byField('name')
+          .map((r) => r.rule)
+          .sort(),
+      ).toEqual(['maxLength', 'minLength', 'pattern', 'required']);
+      expect(
+        byField('age')
+          .map((r) => r.rule)
+          .sort(),
+      ).toEqual(['max', 'min']);
+      // Transient field contributes no rules even though it is required.
+      expect(byField('computed')).toHaveLength(0);
+    });
+
+    it('supports RegExp pattern objects by serializing their source', () => {
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest([
+        scan([
+          def('Coded', {
+            fields: {
+              code: { type: 'text', _meta: { pattern: /^[A-Z]{3}$/ } },
+            },
+          }),
+        ]),
+      ]);
+      const patternRule = manifest.objects.coded.validationRules?.find(
+        (r) => r.rule === 'pattern',
+      );
+      expect(patternRule?.value).toBe('^[A-Z]{3}$');
+    });
+  });
+
+  describe('code generators', () => {
+    const baseManifest = (): SmartObjectManifest => ({
+      version: '1.0.0',
+      timestamp: 0,
+      objects: {
+        Note: def('Note', {
+          fields: {
+            title: { type: 'text', required: true, description: 'The title' },
+            length: { type: 'integer', min: 0, max: 99 },
+            ratio: { type: 'decimal' },
+            ok: { type: 'boolean' },
+            at: { type: 'datetime' },
+            data: { type: 'json' },
+            link: { type: 'foreignKey', related: 'Other' },
+          },
+          methods: {
+            summarize: {
+              name: 'summarize',
+              async: true,
+              parameters: [],
+              returnType: 'string',
+              isStatic: false,
+              isPublic: true,
+            },
+          },
+          decoratorConfig: { api: true, mcp: true },
+        }),
+      },
+    });
+
+    it('generates TypeScript interfaces mapping every field type', () => {
+      const gen = new ManifestGenerator();
+      const ts = gen.generateTypeDefinitions(baseManifest());
+      expect(ts).toContain('export interface NoteData');
+      expect(ts).toContain('title: string;'); // required -> no '?'
+      expect(ts).toContain('length?: number;'); // integer
+      expect(ts).toContain('ratio?: number;'); // decimal
+      expect(ts).toContain('ok?: boolean;');
+      expect(ts).toContain('at?: Date | string;');
+      expect(ts).toContain('data?: any;');
+      expect(ts).toContain('link?: string;'); // foreignKey
+    });
+
+    it('generates REST endpoint code and respects api: false', () => {
+      const gen = new ManifestGenerator();
+      const code = gen.generateRestEndpointCode(baseManifest());
+      expect(code).toContain("app.get('/notes'");
+      expect(code).toContain("app.post('/notes'");
+      expect(code).toContain("app.put('/notes/:id'");
+      expect(code).toContain("app.delete('/notes/:id'");
+
+      const disabled = baseManifest();
+      disabled.objects.Note.decoratorConfig.api = false;
+      expect(gen.generateRestEndpointCode(disabled)).toBe('');
+    });
+
+    it('honors include/exclude operation filters in REST code', () => {
+      const gen = new ManifestGenerator();
+      const m = baseManifest();
+      m.objects.Note.decoratorConfig.api = { include: ['list', 'get'] };
+      const code = gen.generateRestEndpointCode(m);
+      expect(code).toContain("app.get('/notes'");
+      expect(code).toContain("app.get('/notes/:id'");
+      expect(code).not.toContain("app.post('/notes'");
+      expect(code).not.toContain("app.delete('/notes/:id'");
+    });
+
+    it('generates MCP tool names and JSON tool definitions', () => {
+      const gen = new ManifestGenerator();
+      const names = gen.generateMCPTools(baseManifest());
+      expect(names.split('\n')).toEqual([
+        'list_notes',
+        'get_notes',
+        'create_notes',
+        'update_notes',
+        'delete_notes',
+      ]);
+
+      const code = gen.generateMCPToolsCode(baseManifest());
+      expect(code).toContain('"list_notes"');
+      expect(code).toContain('"get_note"');
+      expect(code).toContain('"create_note"');
+      // JSON schema properties carry numeric/length constraints from fields.
+      expect(code).toContain('"minimum": 0');
+      expect(code).toContain('"maximum": 99');
+    });
+
+    it('omits MCP tools entirely when mcp is false', () => {
+      const gen = new ManifestGenerator();
+      const m = baseManifest();
+      m.objects.Note.decoratorConfig.mcp = false;
+      expect(gen.generateMCPTools(m)).toBe('');
+    });
+
+    it('exposes simple endpoints for collection-class static methods', () => {
+      const gen = new ManifestGenerator();
+      const m: SmartObjectManifest = {
+        version: '1.0.0',
+        timestamp: 0,
+        objects: {
+          Things: def('Things', {
+            collection: 'things',
+            extends: 'SmrtCollection',
+            extendsTypeArg: 'Thing',
+            methods: {
+              bulkImport: {
+                name: 'bulkImport',
+                async: true,
+                parameters: [],
+                returnType: 'void',
+                isStatic: true,
+                isPublic: true,
+              },
+            },
+            decoratorConfig: { api: true },
+          }),
+        },
+      };
+      const endpoints = gen.generateRestEndpoints(m);
+      // Collection class: no item CRUD, just the collection-scope method.
+      expect(endpoints).toBe('POST /things/bulkImport');
+    });
+  });
+
+  describe('agent manifests', () => {
+    it('derives permissions, features, menu items, and components from uiSlots + exports', () => {
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest(
+        [
+          scan([
+            def('TownAgent', {
+              decoratorConfig: {
+                agent: { icon: 'town', tier: 'pro', description: 'Town agent' },
+                cli: { include: ['runReport'] },
+                mcp: { include: ['runReport', 'sync'] },
+              },
+              staticProperties: {
+                uiSlots: {
+                  dashboard: { label: 'Dashboard', icon: 'gauge', order: 1 },
+                  settings: { label: 'Settings', order: 2 },
+                },
+                adminRoutes: [{ path: '/admin/town', label: 'Town admin' }],
+              },
+            }),
+          ]),
+        ],
+        {
+          packageName: '@acme/town',
+          packageJson: {
+            name: '@acme/town',
+            exports: {
+              '.': './dist/index.js',
+              './admin': { svelte: './admin.svelte' },
+              './town': { import: { svelte: './town.svelte' } },
+            },
+          },
+        },
+      );
+
+      const agent = manifest.objects['@acme/town:TownAgent'].agent;
+      expect(agent).toBeDefined();
+      expect(agent?.tier).toBe('pro');
+      // manage:<slot> permission per uiSlot + execute:<method> per exposed method.
+      const permIds = agent?.permissions.map((p) => p.id) ?? [];
+      expect(permIds).toContain('manage:dashboard');
+      expect(permIds).toContain('manage:settings');
+      expect(permIds).toContain('execute:runReport');
+      expect(permIds).toContain('execute:sync');
+      // Menu items sorted by order and routed under the agent slug.
+      expect(agent?.menuItems.map((m) => m.id)).toEqual([
+        'dashboard',
+        'settings',
+      ]);
+      expect(agent?.menuItems[0].path).toBe('/agents/townagent/dashboard');
+      // Component declarations derived from svelte-conditioned exports.
+      const componentTypes = agent?.components.map((c) => c.type).sort();
+      expect(componentTypes).toEqual(['admin', 'town']);
+      // adminRoutes captured from the static property.
+      expect(agent?.adminRoutes).toHaveLength(1);
+    });
+
+    it('defaults tier to free and omits adminRoutes when none are declared', () => {
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest([
+        scan([
+          def('BareAgent', {
+            decoratorConfig: { agent: { icon: 'bot' } },
+          }),
+        ]),
+      ]);
+      const agent = manifest.objects.bareagent.agent;
+      expect(agent?.tier).toBe('free');
+      expect(agent?.adminRoutes).toBeUndefined();
+      expect(agent?.permissions).toEqual([]);
+    });
+  });
+
+  describe('saveManifest / loadManifest round-trip', () => {
+    let dir: string | null = null;
+    afterEach(() => {
+      if (dir) {
+        rmSync(dir, { recursive: true, force: true });
+        dir = null;
+      }
+    });
+
+    it('writes a manifest to disk and reads it back identically', () => {
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest([
+        scan([def('Saved', { fields: { x: { type: 'text' } } })]),
+      ]);
+
+      dir = mkdtempSync(join(tmpdir(), 'smrt-mg-save-'));
+      const file = join(dir, 'manifest.json');
+      gen.saveManifest(manifest, file);
+
+      const loaded = gen.loadManifest(file);
+      expect(loaded.objects.saved.className).toBe('Saved');
+      expect(loaded.version).toBe(manifest.version);
+    });
+  });
+
+  describe('generateManifest convenience function', () => {
+    it('delegates to a fresh ManifestGenerator instance', () => {
+      const manifest = generateManifestFn([
+        scan([def('Convenience', { fields: { a: { type: 'text' } } })]),
+      ]);
+      expect(manifest.objects.convenience).toBeDefined();
+      expect(manifest.objects.convenience.schema?.tableName).toBe(
+        'conveniences',
+      );
+    });
+  });
+
+  describe('AI tool generation', () => {
+    it('attaches generated tools when the decorator declares an ai config', () => {
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest([
+        scan([
+          def('Assistant', {
+            decoratorConfig: { ai: { include: ['draft'] } as any },
+            methods: {
+              draft: {
+                name: 'draft',
+                async: true,
+                parameters: [
+                  { name: 'topic', type: 'string', optional: false },
+                ],
+                returnType: 'string',
+                isStatic: false,
+                isPublic: true,
+                description: 'Draft something',
+              } as any,
+            },
+          }),
+        ]),
+      ]);
+      // The ai config drives generateToolManifest; whether tools are produced
+      // depends on method shape, but the object must still be emitted intact.
+      expect(manifest.objects.assistant).toBeDefined();
+    });
+  });
+
+  // These tests exercise the external-package resolution paths
+  // (loadParentFromExternalPackage, the external-STI-base branch of
+  // generateSchemas, createAggregatedManifest's external merge, and the
+  // external loop in extendsFrameworkAbstractBase). They require a real
+  // manifest on disk that loadExternalManifestSync can resolve via package
+  // exports, so each test writes a throwaway node_modules package.
+  describe('external SMRT package resolution', () => {
+    let dir: string;
+    let prev: string;
+    const EXT_PKG = '@happyvertical/smrt-ext-fixture';
+
+    beforeEach(() => {
+      clearManifestCache();
+      dir = mkdtempSync(join(tmpdir(), 'smrt-mg-ext-'));
+      prev = process.cwd();
+    });
+
+    afterEach(() => {
+      process.chdir(prev);
+      clearManifestCache();
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    /** Write an external SMRT package exposing the given manifest objects. */
+    function writeExternalPackage(objects: Record<string, any>): void {
+      const pkgDir = join(
+        dir,
+        'node_modules',
+        '@happyvertical',
+        'smrt-ext-fixture',
+      );
+      mkdirSync(join(pkgDir, 'dist'), { recursive: true });
+      writeFileSync(
+        join(pkgDir, 'package.json'),
+        JSON.stringify({
+          name: EXT_PKG,
+          type: 'module',
+          exports: { './manifest.json': './dist/manifest.json' },
+        }),
+      );
+      writeFileSync(
+        join(pkgDir, 'dist', 'manifest.json'),
+        JSON.stringify({
+          version: '1.0.0',
+          timestamp: 0,
+          moduleType: 'smrt',
+          packageName: EXT_PKG,
+          objects,
+        }),
+      );
+      writeFileSync(
+        join(dir, 'package.json'),
+        JSON.stringify({ name: '@acme/consumer', type: 'module' }),
+      );
+    }
+
+    it('generates an STI schema for a child whose STI base lives in an external package', () => {
+      // External STI base "Content" with the shared table.
+      writeExternalPackage({
+        [`${EXT_PKG}:Content`]: {
+          className: 'Content',
+          collection: 'contents',
+          fields: { title: { type: 'text' } },
+          decoratorConfig: { tableStrategy: 'sti', tableName: 'contents' },
+        },
+      });
+
+      process.chdir(dir);
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest(
+        [
+          scan([
+            // Local child extends the EXTERNAL base — base not in this manifest.
+            def('Memo', {
+              extends: 'Content',
+              fields: { body: { type: 'text' } },
+            }),
+          ]),
+        ],
+        { smrtDependencies: [EXT_PKG] },
+      );
+
+      const memo = manifest.objects.memo;
+      // Child resolved the external STI base and generated a schema against the
+      // base's shared table name, not its own derived 'memos' table.
+      expect(memo.schema?.tableName).toBe('contents');
+      // The external base's title field was merged into the child.
+      expect(memo.fields.title).toBeDefined();
+    });
+
+    it('merges parentId from an external SmrtHierarchical base into a CTI child', () => {
+      // External framework abstract base contributing a parentId field.
+      writeExternalPackage({
+        [`${EXT_PKG}:SmrtHierarchical`]: {
+          className: 'SmrtHierarchical',
+          collection: '',
+          fields: { parentId: { type: 'text', _meta: {} } },
+          decoratorConfig: {},
+        },
+      });
+
+      process.chdir(dir);
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest(
+        [
+          scan([
+            def('Node', {
+              extends: 'SmrtHierarchical',
+              fields: { label: { type: 'text' } },
+            }),
+          ]),
+        ],
+        { smrtDependencies: [EXT_PKG] },
+      );
+
+      const node = manifest.objects.node;
+      // parentId pulled from the external framework base and normalized.
+      expect(node.fields.parentId).toBeDefined();
+      expect(node.fields.parentId.type).toBe('foreignKey');
+      expect(node.fields.parentId.related).toBe('Node');
+    });
+  });
+});

--- a/packages/core/src/schema/generator-branches.test.ts
+++ b/packages/core/src/schema/generator-branches.test.ts
@@ -1,0 +1,566 @@
+/**
+ * SchemaGenerator branch coverage.
+ *
+ * uuid-schema-generator.test.ts and schema-generation.test.ts cover the
+ * runtime/CTI manifest paths and UUID reconciliation. This file targets the
+ * remaining branches:
+ * - generateSchema(objectDef): the build-time AST path (columns, FK column +
+ *   index + dependency extraction, triggers, slug/email unique, transient and
+ *   relationship-field skipping, version hashing, package extraction).
+ * - generateSchemaFromRegistry: custom-PK handling, explicit timestamp fields,
+ *   indexed regular columns, multi-column conflictColumns truncation.
+ * - generateSTISchemaFromRegistry with an injected fake registry (descendants,
+ *   FK partial indexes, meta-field JSON-path indexes, indexed columns).
+ * - generateSTISchemaFromManifest descendant aggregation + self-reference guard.
+ * - generateSQL / formatDefaultValue across TEXT/INTEGER/BOOLEAN/TIMESTAMP/JSON.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type {
+  FieldDefinition,
+  SmartObjectDefinition,
+  SmartObjectManifest,
+} from '../scanner/types.js';
+import { SchemaGenerator } from './generator.js';
+import type { SchemaDefinition } from './types.js';
+
+function objectDef(
+  className: string,
+  fields: Record<string, FieldDefinition> = {},
+  decoratorConfig: Record<string, unknown> = {},
+  extendsName?: string,
+  filePath = `packages/test/src/${className}.ts`,
+): SmartObjectDefinition {
+  return {
+    name: className.toLowerCase(),
+    className,
+    collection: `${className.toLowerCase()}s`,
+    filePath,
+    packageName: '@happyvertical/smrt-test',
+    packageVersion: '0.0.0',
+    fields,
+    methods: {},
+    decoratorConfig:
+      decoratorConfig as SmartObjectDefinition['decoratorConfig'],
+    extends: extendsName,
+  } as SmartObjectDefinition;
+}
+
+describe('SchemaGenerator.generateSchema (build-time AST path)', () => {
+  it('maps field types, emits FK column/index/dependency, and slug/email unique', () => {
+    const generator = new SchemaGenerator();
+    const schema = generator.generateSchema(
+      objectDef('Comment', {
+        body: { type: 'text' },
+        score: { type: 'integer' },
+        rating: { type: 'decimal' },
+        active: { type: 'boolean' },
+        publishedAt: { type: 'datetime' },
+        payload: { type: 'json' },
+        authorId: { type: 'foreignKey', related: 'users.id' },
+        slug: { type: 'text' },
+        email: { type: 'text' },
+        // Relationship + transient + meta fields must be skipped.
+        replies: { type: 'oneToMany', related: 'Comment' },
+        tags: { type: 'manyToMany', related: 'Tag' },
+        computed: { type: 'text', transient: true },
+        extra: { type: 'meta' },
+      }),
+    );
+
+    // SQL type mapping.
+    expect(schema.columns.body.type).toBe('TEXT');
+    expect(schema.columns.score.type).toBe('INTEGER');
+    expect(schema.columns.rating.type).toBe('REAL');
+    expect(schema.columns.active.type).toBe('BOOLEAN');
+    expect(schema.columns.publishedAt.type).toBe('TIMESTAMP');
+    expect(schema.columns.payload.type).toBe('JSON');
+    expect(schema.columns.authorId.type).toBe('UUID');
+
+    // FK column carries a foreignKey + the table-level FK list + dependency.
+    expect(schema.columns.authorId.foreignKey).toEqual({
+      table: 'users',
+      column: 'id',
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+    });
+    expect(schema.foreignKeys).toEqual([
+      expect.objectContaining({ column: 'authorId', referencesTable: 'users' }),
+    ]);
+    expect(schema.dependencies).toContain('users');
+
+    // FK index + updated_at index + slug/email unique indexes are generated.
+    const indexNames = schema.indexes.map((i) => i.name);
+    expect(indexNames).toContain('idx_comments_authorId');
+    expect(indexNames).toContain('idx_comments_updated_at');
+    expect(
+      schema.indexes.some((i) => i.unique && i.columns[0] === 'slug'),
+    ).toBe(true);
+    expect(
+      schema.indexes.some((i) => i.unique && i.columns[0] === 'email'),
+    ).toBe(true);
+
+    // slug/email are forced unique.
+    expect(schema.columns.slug.unique).toBe(true);
+    expect(schema.columns.email.unique).toBe(true);
+
+    // Skipped fields produce no columns.
+    expect(schema.columns.replies).toBeUndefined();
+    expect(schema.columns.tags).toBeUndefined();
+    expect(schema.columns.computed).toBeUndefined();
+    expect(schema.columns.extra).toBeUndefined();
+
+    // A trigger is emitted for updated_at.
+    expect(schema.triggers).toHaveLength(1);
+    expect(schema.triggers[0].event).toBe('UPDATE');
+
+    // Version is an 8-char hash, package extracted from the path.
+    expect(schema.version).toMatch(/^[a-f0-9]{8}$/);
+    expect(schema.packageName).toBe('test');
+  });
+
+  it('falls back to "unknown" package when the path has no packages/ segment', () => {
+    const generator = new SchemaGenerator();
+    const schema = generator.generateSchema(
+      objectDef(
+        'Loose',
+        { name: { type: 'text' } },
+        {},
+        undefined,
+        '/tmp/Loose.ts',
+      ),
+    );
+    expect(schema.packageName).toBe('unknown');
+  });
+
+  it('records a base-class dependency for inheriting classes', () => {
+    const generator = new SchemaGenerator();
+    const schema = generator.generateSchema(
+      objectDef('Meeting', { topic: { type: 'text' } }, {}, 'Event'),
+    );
+    // extends Event -> events table dependency; SmrtObject/SmrtCollection excluded.
+    expect(schema.dependencies).toContain('events');
+    expect(schema.baseClass).toBe('Event');
+  });
+
+  it('honors a field-level default value', () => {
+    const generator = new SchemaGenerator();
+    const schema = generator.generateSchema(
+      objectDef('Defaulted', {
+        status: { type: 'text', default: 'draft' },
+      }),
+    );
+    expect(schema.columns.status.defaultValue).toBe('draft');
+  });
+});
+
+describe('SchemaGenerator.generateSchemaFromRegistry', () => {
+  const generator = new SchemaGenerator();
+
+  it('emits default id/slug/context plus conflict index for a standard class', () => {
+    const fields = new Map<string, any>([
+      ['title', { type: 'text', _meta: { required: true } }],
+    ]);
+    const schema = generator.generateSchemaFromRegistry(
+      'Post',
+      'posts',
+      fields,
+    );
+
+    expect(schema.columns.id.primaryKey).toBe(true);
+    expect(schema.columns.slug).toBeDefined();
+    expect(schema.columns.context).toBeDefined();
+    expect(schema.columns.title.notNull).toBe(true);
+
+    const conflict = schema.indexes.find((i) => i.unique);
+    expect(conflict?.columns).toEqual(['slug', 'context']);
+  });
+
+  it('respects a custom primary key and skips synthetic slug/context', () => {
+    const fields = new Map<string, any>([
+      [
+        'externalId',
+        { type: 'text', _meta: { primaryKey: true, required: true } },
+      ],
+      ['label', { type: 'text' }],
+    ]);
+    const schema = generator.generateSchemaFromRegistry(
+      'External',
+      'externals',
+      fields,
+    );
+
+    expect(schema.columns.external_id.primaryKey).toBe(true);
+    // No synthetic defaults when a custom PK is present.
+    expect(schema.columns.slug).toBeUndefined();
+    expect(schema.columns.context).toBeUndefined();
+    // PK index points at the custom column.
+    expect(schema.indexes.some((i) => i.columns[0] === 'external_id')).toBe(
+      true,
+    );
+    // No unique conflict index in custom-PK mode.
+    expect(schema.indexes.some((i) => i.unique)).toBe(false);
+  });
+
+  it('uses explicit timestamp fields and dedupes them', () => {
+    const fields = new Map<string, any>([
+      ['createdAt', { type: 'datetime' }],
+      ['created_at', { type: 'datetime' }],
+      ['updatedAt', { type: 'datetime' }],
+    ]);
+    const schema = generator.generateSchemaFromRegistry('T', 'ts', fields);
+    expect(schema.columns.created_at).toBeDefined();
+    expect(schema.columns.updated_at).toBeDefined();
+  });
+
+  it('emits a plain column index for fields tagged indexed:true', () => {
+    const fields = new Map<string, any>([
+      ['lookupKey', { type: 'text', _meta: { indexed: true } }],
+    ]);
+    const schema = generator.generateSchemaFromRegistry('L', 'lk', fields);
+    expect(schema.indexes.some((i) => i.columns[0] === 'lookup_key')).toBe(
+      true,
+    );
+  });
+
+  it('truncates multi-column conflict index names beyond two columns', () => {
+    const fields = new Map<string, any>([['a', { type: 'text' }]]);
+    const schema = generator.generateSchemaFromRegistry(
+      'Multi',
+      'multi',
+      fields,
+      {
+        conflictColumns: ['one', 'two', 'three'],
+      },
+    );
+    const conflict = schema.indexes.find((i) => i.unique);
+    // Index name uses only the first two columns, but indexes all three.
+    expect(conflict?.name).toBe('multi_one_two_idx');
+    expect(conflict?.columns).toEqual(['one', 'two', 'three']);
+  });
+
+  it('skips transient, relationship, and meta fields', () => {
+    const fields = new Map<string, any>([
+      ['gone', { type: 'text', transient: true }],
+      ['many', { type: 'oneToMany', related: 'X' }],
+      ['m2m', { type: 'manyToMany', related: 'Y' }],
+      ['flex', { type: 'meta' }],
+      ['kept', { type: 'text' }],
+    ]);
+    const schema = generator.generateSchemaFromRegistry('S', 's', fields);
+    expect(schema.columns.gone).toBeUndefined();
+    expect(schema.columns.many).toBeUndefined();
+    expect(schema.columns.m2m).toBeUndefined();
+    expect(schema.columns.flex).toBeUndefined();
+    expect(schema.columns.kept).toBeDefined();
+  });
+
+  it('emits a foreign key column + index from a registry foreignKey field', () => {
+    const fields = new Map<string, any>([
+      [
+        'ownerId',
+        {
+          type: 'foreignKey',
+          related: 'User',
+          _meta: { onDelete: 'SET NULL' },
+        },
+      ],
+    ]);
+    const schema = generator.generateSchemaFromRegistry('Doc', 'docs', fields);
+    expect(schema.columns.owner_id.foreignKey).toEqual({
+      table: 'users',
+      column: 'id',
+      onDelete: 'SET NULL',
+      onUpdate: 'CASCADE',
+    });
+    expect(schema.indexes.some((i) => i.name === 'idx_docs_owner_id')).toBe(
+      true,
+    );
+  });
+});
+
+describe('SchemaGenerator.generateSTISchemaFromRegistry (injected registry)', () => {
+  const generator = new SchemaGenerator();
+
+  function fakeRegistry(
+    fieldsByClass: Record<string, Map<string, any>>,
+    descendants: string[],
+  ) {
+    return {
+      getDescendants: () => descendants,
+      getAllFields: async (className: string) =>
+        fieldsByClass[className] ?? new Map(),
+    };
+  }
+
+  it('aggregates descendant FK columns, meta indexes, and plain indexes', async () => {
+    const baseFields = new Map<string, any>([
+      ['title', { type: 'text' }],
+      // meta field opted into JSON-path indexing
+      ['priority', { type: 'meta', indexed: true }],
+    ]);
+    const childFields = new Map<string, any>([
+      ['title', { type: 'text' }], // duplicate -> inherited skip
+      ['roomId', { type: 'foreignKey', related: 'Room' }],
+      ['searchKey', { type: 'text', _meta: { indexed: true } }],
+    ]);
+
+    const registry = fakeRegistry({ Event: baseFields, Meeting: childFields }, [
+      'Meeting',
+    ]);
+
+    const schema = await generator.generateSTISchemaFromRegistry(
+      'Event',
+      'events',
+      new Map(),
+      { registry: registry as any },
+    );
+
+    // STI discriminator + meta columns.
+    expect(schema.columns._meta_type).toBeDefined();
+    expect(schema.columns._meta_data).toBeDefined();
+    // All aggregated columns are nullable.
+    expect(schema.columns.title.notNull).toBe(false);
+    expect(schema.columns.room_id.notNull).toBe(false);
+
+    const indexNames = schema.indexes.map((i) => i.name);
+    // Base STI indexes.
+    expect(indexNames).toContain('events_id_idx');
+    expect(indexNames).toContain('events_slug_context_meta_type_idx');
+    expect(indexNames).toContain('events_meta_type_idx');
+    // Partial FK index filtered by discriminator.
+    const partial = schema.indexes.find((i) => i.where?.includes('Meeting'));
+    expect(partial?.columns).toEqual(['room_id']);
+    // JSON-path index for the @meta indexed field.
+    const jsonIdx = schema.indexes.find((i) => i.jsonPath);
+    expect(jsonIdx?.jsonPath).toEqual({
+      column: '_meta_data',
+      path: 'priority',
+    });
+    // Plain column index for the indexed regular field.
+    expect(indexNames).toContain('events_search_key_idx');
+  });
+
+  it('loads ObjectRegistry from config when none is injected (default branch covered elsewhere)', async () => {
+    // Provide a registry to avoid importing the real one, but with no
+    // descendants and only the base — exercises the empty-descendants path
+    // and the timestamp-fallback branch.
+    const registry = {
+      getDescendants: () => [],
+      getAllFields: async () => new Map(),
+    };
+    const schema = await generator.generateSTISchemaFromRegistry(
+      'Solo',
+      'solos',
+      new Map(),
+      { registry: registry as any },
+    );
+    expect(schema.columns.created_at).toBeDefined();
+    expect(schema.columns.updated_at).toBeDefined();
+    expect(schema.tableName).toBe('solos');
+  });
+});
+
+describe('SchemaGenerator.generateSTISchemaFromManifest', () => {
+  const generator = new SchemaGenerator();
+
+  function manifest(
+    objects: Record<string, SmartObjectDefinition>,
+  ): SmartObjectManifest {
+    return {
+      version: '1.0.0',
+      timestamp: 0,
+      packageName: '@happyvertical/smrt-test',
+      objects,
+    };
+  }
+
+  it('aggregates base + descendant fields and emits STI structure', () => {
+    const m = manifest({
+      Animal: objectDef('Animal', { name: { type: 'text' } }),
+      Dog: objectDef(
+        'Dog',
+        {
+          breed: { type: 'text' },
+          ownerId: { type: 'foreignKey', related: 'Owner' },
+        },
+        {},
+        'Animal',
+      ),
+    });
+
+    const schema = generator.generateSTISchemaFromManifest(
+      'Animal',
+      'animals',
+      m.objects.Animal.fields,
+      m,
+    );
+
+    expect(schema.columns._meta_type).toBeDefined();
+    expect(schema.columns.name).toBeDefined();
+    expect(schema.columns.breed).toBeDefined();
+    expect(schema.columns.owner_id).toBeDefined();
+    // DDL is generated and the version is hashed.
+    expect(schema.ddl).toContain('CREATE TABLE');
+    expect(schema.version).toMatch(/^[a-f0-9]{8}$/);
+    // STI unique index present.
+    expect(
+      schema.indexes.some(
+        (i) => i.name === 'animals_slug_context_meta_type_idx',
+      ),
+    ).toBe(true);
+  });
+
+  it('skips a self-referential descendant (same name extends same name)', () => {
+    const m = manifest({
+      PolyEvent: objectDef('PolyEvent', { title: { type: 'text' } }),
+      // A class whose className == extends (cross-package same-name) is skipped.
+      Self: {
+        ...objectDef('PolyEvent', { dup: { type: 'text' } }, {}, 'PolyEvent'),
+      },
+    });
+
+    const schema = generator.generateSTISchemaFromManifest(
+      'PolyEvent',
+      'poly_events',
+      m.objects.PolyEvent.fields,
+      m,
+    );
+
+    // The self-referential entry's `dup` field must not be aggregated.
+    expect(schema.columns.dup).toBeUndefined();
+    expect(schema.columns.title).toBeDefined();
+  });
+
+  it('captures indexed meta fields and indexed regular columns from the manifest', () => {
+    const m = manifest({
+      Note: objectDef('Note', {
+        tag: { type: 'meta', indexed: true } as FieldDefinition,
+        lookup: { type: 'text', indexed: true } as FieldDefinition,
+      }),
+    });
+
+    const schema = generator.generateSTISchemaFromManifest(
+      'Note',
+      'notes',
+      m.objects.Note.fields,
+      m,
+    );
+
+    expect(schema.indexes.some((i) => i.jsonPath?.path === 'tag')).toBe(true);
+    expect(schema.indexes.some((i) => i.name === 'notes_lookup_idx')).toBe(
+      true,
+    );
+  });
+});
+
+describe('SchemaGenerator.generateSQL / formatDefaultValue', () => {
+  const generator = new SchemaGenerator();
+
+  function schemaWith(columns: SchemaDefinition['columns']): SchemaDefinition {
+    return {
+      tableName: 'defaults',
+      columns,
+      indexes: [],
+      triggers: [],
+      foreignKeys: [],
+      version: '',
+      dependencies: [],
+    };
+  }
+
+  it('renders SQL keyword and function defaults verbatim', () => {
+    const sql = generator.generateSQL(
+      schemaWith({
+        a: { type: 'TIMESTAMP', defaultValue: 'current_timestamp' },
+        b: { type: 'TEXT', defaultValue: "datetime('now')" },
+        c: { type: 'TEXT', defaultValue: 'uuid_generate_v4()' },
+      }),
+    );
+    expect(sql).toContain('DEFAULT current_timestamp');
+    expect(sql).toContain("DEFAULT datetime('now')");
+    expect(sql).toContain('DEFAULT uuid_generate_v4()');
+  });
+
+  it('quotes/escapes TEXT, formats INTEGER/REAL, NULL, and BOOLEAN defaults', () => {
+    const sql = generator.generateSQL(
+      schemaWith({
+        t: { type: 'TEXT', defaultValue: "O'Hara" },
+        i: { type: 'INTEGER', defaultValue: 42 },
+        r: { type: 'REAL', defaultValue: null },
+        bTrue: { type: 'BOOLEAN', defaultValue: true },
+        bFalse: { type: 'BOOLEAN', defaultValue: false },
+      }),
+    );
+    expect(sql).toContain(`DEFAULT 'O''Hara'`);
+    expect(sql).toContain('DEFAULT 42');
+    expect(sql).toContain('DEFAULT NULL');
+    expect(sql).toContain('DEFAULT TRUE');
+    expect(sql).toContain('DEFAULT FALSE');
+  });
+
+  it('formats TIMESTAMP string vs non-string defaults', () => {
+    const sql = generator.generateSQL(
+      schemaWith({
+        s: { type: 'TIMESTAMP', defaultValue: '2024-01-01T00:00:00Z' },
+        n: { type: 'TIMESTAMP', defaultValue: 12345 },
+      }),
+    );
+    expect(sql).toContain(`DEFAULT '2024-01-01T00:00:00Z'`);
+    // Non-string timestamp falls back to current_timestamp.
+    expect(sql).toContain('DEFAULT current_timestamp');
+  });
+
+  it('handles JSON defaults: null, empty string, [object Object], valid + invalid JSON, objects', () => {
+    const nullSql = generator.generateSQL(
+      schemaWith({ a: { type: 'JSON', defaultValue: null } }),
+    );
+    expect(nullSql).toContain(`DEFAULT 'null'`);
+
+    const emptySql = generator.generateSQL(
+      schemaWith({ a: { type: 'JSON', defaultValue: '' } }),
+    );
+    expect(emptySql).toContain(`DEFAULT 'null'`);
+
+    const objStrSql = generator.generateSQL(
+      schemaWith({ a: { type: 'JSON', defaultValue: '[object Object]' } }),
+    );
+    expect(objStrSql).toContain(`DEFAULT '{}'`);
+
+    const validSql = generator.generateSQL(
+      schemaWith({ a: { type: 'JSON', defaultValue: '{"k":1}' } }),
+    );
+    expect(validSql).toContain(`DEFAULT '{"k":1}'`);
+
+    const invalidSql = generator.generateSQL(
+      schemaWith({ a: { type: 'JSON', defaultValue: 'not json' } }),
+    );
+    // Non-JSON string is encoded as a JSON string literal.
+    expect(invalidSql).toContain(`DEFAULT '"not json"'`);
+
+    const objSql = generator.generateSQL(
+      schemaWith({ a: { type: 'JSON', defaultValue: { k: 2 } } }),
+    );
+    expect(objSql).toContain(`DEFAULT '{"k":2}'`);
+  });
+
+  it('delegates to the engine strategy when an engine is supplied', () => {
+    const sql = generator.generateSQL(
+      schemaWith({ id: { type: 'UUID', primaryKey: true, notNull: true } }),
+      'sqlite',
+    );
+    // SQLite maps UUID -> TEXT.
+    expect(sql).toContain('"id" TEXT');
+  });
+
+  it('emits PRIMARY KEY, NOT NULL, and UNIQUE column constraints', () => {
+    const sql = generator.generateSQL(
+      schemaWith({
+        id: { type: 'TEXT', primaryKey: true, notNull: true },
+        email: { type: 'TEXT', unique: true, notNull: true },
+      }),
+    );
+    expect(sql).toContain('"id" TEXT PRIMARY KEY NOT NULL');
+    expect(sql).toContain('"email" TEXT NOT NULL UNIQUE');
+  });
+});

--- a/packages/core/src/schema/schema-manager-branches.test.ts
+++ b/packages/core/src/schema/schema-manager-branches.test.ts
@@ -1,0 +1,496 @@
+/**
+ * SchemaManager branch coverage.
+ *
+ * schema-manager.test.ts covers the addMissingColumns introspection path with
+ * a mocked DB. This file exercises the table-CREATION paths end-to-end on a
+ * real in-memory SQLite database (per testing rules: real SQLite, never mock
+ * the DB for SmrtObject/schema work), plus the adapter-specific branches
+ * (syncSchema present, exportTable JSON detection, postgres introspection)
+ * that SQLite doesn't structurally expose — those use minimal stub adapters.
+ *
+ * @happyvertical/logger is mocked so debug traces can be asserted; createLogger
+ * is a spy to verify the per-instance level follows the `debug` option.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockLogger, createLoggerMock } = vi.hoisted(() => {
+  const mockLogger = {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  };
+  return { mockLogger, createLoggerMock: vi.fn(() => mockLogger) };
+});
+vi.mock('@happyvertical/logger', () => ({
+  createLogger: createLoggerMock,
+}));
+
+import type { DatabaseProvider } from '@happyvertical/sql';
+import { getDatabase } from '@happyvertical/sql';
+import { createSchemaManager, SchemaManager } from './schema-manager';
+import type { SchemaDefinition } from './types';
+
+function fullSchema(tableName: string): SchemaDefinition {
+  return {
+    tableName,
+    columns: {
+      id: {
+        type: 'TEXT',
+        primaryKey: true,
+        notNull: true,
+        referenceKind: 'id',
+      },
+      slug: { type: 'TEXT', notNull: true },
+      title: { type: 'TEXT' },
+      // notNull without default and not a PK -> exercises ADD COLUMN relaxation
+      // (only when added to an existing table) and CREATE-time NOT NULL.
+      count: { type: 'INTEGER', notNull: true, defaultValue: 0 },
+      // updated_at must exist for the no-op trigger body below to be valid DDL.
+      updated_at: {
+        type: 'TIMESTAMP',
+        notNull: true,
+        defaultValue: 'current_timestamp',
+      },
+    },
+    indexes: [
+      { name: `idx_${tableName}_slug`, columns: ['slug'] },
+      {
+        name: `idx_${tableName}_title_unique`,
+        columns: ['title'],
+        unique: true,
+      },
+    ],
+    triggers: [
+      {
+        name: `trg_${tableName}_updated`,
+        when: 'AFTER',
+        event: 'UPDATE',
+        // Complete no-op UPDATE so SQLite accepts the trigger DDL.
+        body: `UPDATE "${tableName}" SET "updated_at" = "updated_at" WHERE 0;`,
+        description: 'noop',
+      },
+    ],
+    foreignKeys: [],
+    version: 'v1',
+    dependencies: [],
+  };
+}
+
+describe('SchemaManager table creation on real SQLite', () => {
+  let db: DatabaseProvider;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+  });
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') {
+      try {
+        await db.close();
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  it('creates a table with indexes and triggers end-to-end on real SQLite', async () => {
+    // The SDK sqlite provider exposes syncSchema, so ensureTable feeds it the
+    // combined DDL first; on this in-memory connection the post-sync existence
+    // check drives a direct-DDL fallback that ultimately creates everything.
+    // Either way the table, indexes, and trigger must all exist afterwards.
+    const manager = new SchemaManager(db, { engine: 'sqlite', debug: true });
+    const schema = fullSchema('widgets');
+
+    await manager.ensureTable(schema);
+
+    expect(await db.tableExists('widgets')).toBe(true);
+
+    const indexes = await db.query<{ name: string }>(
+      `SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='widgets'`,
+    );
+    const indexNames = indexes.rows.map((r) => r.name);
+    expect(indexNames).toContain('idx_widgets_slug');
+    expect(indexNames).toContain('idx_widgets_title_unique');
+
+    const triggers = await db.query<{ name: string }>(
+      `SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name='widgets'`,
+    );
+    expect(triggers.rows.map((r) => r.name)).toContain('trg_widgets_updated');
+
+    // Debug option raises the logger level so traces emit.
+    expect(createLoggerMock).toHaveBeenCalledWith({ level: 'debug' });
+    expect(mockLogger.debug).toHaveBeenCalled();
+  });
+
+  it('skips triggers when skipTriggers is set', async () => {
+    const manager = new SchemaManager(db, {
+      engine: 'sqlite',
+      skipTriggers: true,
+    });
+
+    await manager.ensureTable(fullSchema('gadgets'));
+
+    const triggers = await db.query<{ name: string }>(
+      `SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name='gadgets'`,
+    );
+    expect(triggers.rows).toHaveLength(0);
+  });
+
+  it('adds missing columns when the table already exists with a partial schema', async () => {
+    // Pre-create a partial table; ensureTable should ALTER in the missing cols.
+    await db.query(`CREATE TABLE parts ("id" TEXT PRIMARY KEY, "slug" TEXT)`);
+
+    const manager = new SchemaManager(db, { engine: 'sqlite' });
+    await manager.ensureTable(fullSchema('parts'));
+
+    const cols = await db.query<{ name: string }>(`PRAGMA table_info(parts)`);
+    const colNames = cols.rows.map((r) => r.name);
+    expect(colNames).toContain('title');
+    // `count` was NOT NULL with a default; it should still be added.
+    expect(colNames).toContain('count');
+  });
+
+  it('ensureTables creates multiple tables ordered by dependencies', async () => {
+    const parent = fullSchema('parents');
+    const child: SchemaDefinition = {
+      ...fullSchema('children'),
+      dependencies: ['parents'],
+    };
+
+    const manager = new SchemaManager(db, { engine: 'sqlite' });
+    // Pass child first; topological sort must create parent first regardless.
+    await manager.ensureTables([child, parent]);
+
+    expect(await db.tableExists('parents')).toBe(true);
+    expect(await db.tableExists('children')).toBe(true);
+  });
+});
+
+describe('SchemaManager engine resolution', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('detects the JSON adapter structurally via exportTable', () => {
+    const db = {
+      url: 'duckdb://:memory:',
+      exportTable: () => undefined,
+      query: vi.fn(),
+      tableExists: vi.fn(),
+    } as any;
+
+    const manager = new SchemaManager(db);
+    expect(manager.getEngine()).toBe('json');
+  });
+
+  it('falls back to URL-based detection when no engine or adapter hint', () => {
+    const db = {
+      url: 'postgres://localhost/test',
+      query: vi.fn(),
+      tableExists: vi.fn(),
+    } as any;
+
+    const manager = new SchemaManager(db);
+    expect(manager.getEngine()).toBe('postgres');
+  });
+
+  it('honors an explicitly provided engine over detection', () => {
+    const db = { url: 'postgres://localhost/test' } as any;
+    const manager = createSchemaManager(db, { engine: 'duckdb' });
+    expect(manager.getEngine()).toBe('duckdb');
+  });
+
+  it('generateDDL returns engine-specific DDL without executing', () => {
+    const db = { url: 'sqlite::memory:' } as any;
+    const manager = createSchemaManager(db, { engine: 'sqlite' });
+
+    const ddl = manager.generateDDL(fullSchema('preview'));
+    expect(ddl.createTable).toContain('preview');
+    expect(Array.isArray(ddl.indexes)).toBe(true);
+    expect(Array.isArray(ddl.triggers)).toBe(true);
+  });
+});
+
+describe('SchemaManager adapter syncSchema path', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('uses adapter syncSchema and returns when the table is verified created', async () => {
+    let tableCreated = false;
+    const syncSchema = vi.fn(async () => {
+      tableCreated = true;
+    });
+    const db = {
+      url: 'duckdb://:memory:',
+      query: vi.fn(),
+      tableExists: vi.fn(async () => tableCreated),
+      syncSchema,
+    } as any;
+
+    const manager = new SchemaManager(db, { engine: 'duckdb', debug: true });
+    await manager.ensureTable(fullSchema('via_sync'));
+
+    expect(syncSchema).toHaveBeenCalledTimes(1);
+    // The combined schema string should contain CREATE TABLE plus indexes.
+    const passed = syncSchema.mock.calls[0][0] as string;
+    expect(passed).toContain('CREATE TABLE');
+    expect(passed).toContain('idx_via_sync_slug');
+    // Direct DDL must NOT run (query never called for DDL).
+    expect(db.query).not.toHaveBeenCalled();
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      '[SchemaManager] Table "via_sync" created via adapter syncSchema',
+    );
+  });
+
+  it('omits triggers from the syncSchema string when skipTriggers is set', async () => {
+    const syncSchema = vi.fn(async () => {});
+    const tableExists = vi
+      .fn()
+      // initial existence check -> false (create path)
+      .mockResolvedValueOnce(false)
+      // post-syncSchema verification -> true (success)
+      .mockResolvedValueOnce(true);
+    const db = {
+      url: 'duckdb://:memory:',
+      query: vi.fn(),
+      tableExists,
+      syncSchema,
+    } as any;
+
+    const manager = new SchemaManager(db, {
+      engine: 'duckdb',
+      skipTriggers: true,
+    });
+    await manager.ensureTable(fullSchema('no_trig'));
+
+    const passed = syncSchema.mock.calls[0][0] as string;
+    expect(passed).not.toContain('trg_no_trig_updated');
+  });
+
+  it('falls back to direct DDL when syncSchema returns but the table is absent', async () => {
+    const syncSchema = vi.fn(async () => {});
+    const tableExists = vi
+      .fn()
+      // 1) initial existence check -> false (create path)
+      .mockResolvedValueOnce(false)
+      // 2) post-syncSchema verification -> false (triggers fallback)
+      .mockResolvedValueOnce(false);
+    const query = vi.fn(async () => ({ rows: [] }));
+    const db = {
+      url: 'duckdb://:memory:',
+      query,
+      tableExists,
+      syncSchema,
+    } as any;
+
+    const manager = new SchemaManager(db, { engine: 'duckdb' });
+    await manager.ensureTable(fullSchema('fallback'));
+
+    expect(syncSchema).toHaveBeenCalledTimes(1);
+    // Direct DDL fallback ran -> query executed createTable + indexes + triggers.
+    expect(query).toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `syncSchema returned but table "fallback" doesn't exist`,
+      ),
+    );
+  });
+
+  it('falls back to direct DDL when syncSchema throws', async () => {
+    const syncSchema = vi.fn(async () => {
+      throw new Error('adapter refused');
+    });
+    const query = vi.fn(async () => ({ rows: [] }));
+    const db = {
+      url: 'duckdb://:memory:',
+      query,
+      tableExists: vi.fn(async () => false),
+      syncSchema,
+    } as any;
+
+    const manager = new SchemaManager(db, { engine: 'duckdb' });
+    await manager.ensureTable(fullSchema('throwing'));
+
+    expect(query).toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(`syncSchema failed for "throwing"`),
+      expect.objectContaining({ error: expect.any(Error) }),
+    );
+  });
+});
+
+describe('SchemaManager addMissingColumns edge cases', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns early when the schema declares no columns', async () => {
+    const query = vi.fn();
+    const db = {
+      url: 'sqlite::memory:',
+      query,
+      tableExists: vi.fn(async () => true),
+    } as any;
+
+    const manager = new SchemaManager(db, { engine: 'sqlite' });
+    await manager.ensureTable({
+      tableName: 'empty_cols',
+      columns: {},
+      indexes: [],
+      triggers: [],
+      foreignKeys: [],
+      version: 'v',
+      dependencies: [],
+    });
+
+    // tableExists short-circuits; with no columns, no PRAGMA/ALTER queries run.
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('skips column additions when introspection returns no columns', async () => {
+    const query = vi
+      .fn()
+      // PRAGMA table_info -> empty (introspection yields nothing)
+      .mockResolvedValueOnce([]);
+    const db = {
+      url: 'sqlite::memory:',
+      query,
+      tableExists: vi.fn(async () => true),
+    } as any;
+
+    const manager = new SchemaManager(db, { engine: 'sqlite' });
+    await manager.ensureTable(fullSchema('introspect_empty'));
+
+    // Only the introspection PRAGMA ran; no ALTER statements followed.
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0][0]).toContain('PRAGMA table_info');
+  });
+
+  it('does not attempt to ALTER in primary-key columns', async () => {
+    // Existing table missing the PK column "id"; ensureTable must skip it
+    // (cannot ADD a PRIMARY KEY via ALTER) but still add "title"/"count".
+    const query = vi
+      .fn()
+      // introspection: only slug present
+      .mockResolvedValueOnce([{ name: 'slug' }])
+      // subsequent ALTERs resolve
+      .mockResolvedValue([]);
+    const db = {
+      url: 'sqlite::memory:',
+      query,
+      tableExists: vi.fn(async () => true),
+    } as any;
+
+    const manager = new SchemaManager(db, { engine: 'sqlite' });
+    await manager.ensureTable(fullSchema('pk_skip'));
+
+    const alterStatements = query.mock.calls
+      .map((c) => c[0] as string)
+      .filter((sql) => sql.startsWith('ALTER TABLE'));
+    // id is the PK -> never altered in.
+    expect(alterStatements.some((s) => s.includes('"id"'))).toBe(false);
+    expect(alterStatements.some((s) => s.includes('"title"'))).toBe(true);
+  });
+
+  it('continues past a failing ALTER without aborting the whole operation', async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.startsWith('ALTER TABLE') && sql.includes('"title"')) {
+        throw new Error('duplicate column title');
+      }
+      if (sql.includes('PRAGMA table_info')) {
+        return [{ name: 'id' }, { name: 'slug' }];
+      }
+      return [];
+    });
+    const db = {
+      url: 'sqlite::memory:',
+      query,
+      tableExists: vi.fn(async () => true),
+    } as any;
+
+    const manager = new SchemaManager(db, { engine: 'sqlite', debug: true });
+    // Must not throw despite the failing ALTER.
+    await expect(
+      manager.ensureTable(fullSchema('resilient')),
+    ).resolves.toBeUndefined();
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to add column "title"'),
+      expect.objectContaining({ error: expect.any(Error) }),
+    );
+  });
+
+  it('uses information_schema introspection for postgres and logs on failure', async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('information_schema.columns')) {
+        throw new Error('permission denied');
+      }
+      return { rows: [] };
+    });
+    const db = {
+      url: 'postgres://localhost/test',
+      query,
+      tableExists: vi.fn(async () => true),
+    } as any;
+
+    const manager = new SchemaManager(db, { engine: 'postgres', debug: true });
+    await manager.ensureTable(fullSchema('pg_introspect'));
+
+    // Introspection failure is swallowed (empty set) -> no columns added.
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to introspect columns'),
+      expect.objectContaining({ error: expect.any(Error) }),
+    );
+  });
+});
+
+describe('SchemaManager dependency sorting', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('warns and proceeds when a circular dependency is detected', async () => {
+    const created: string[] = [];
+    const db = {
+      url: 'sqlite::memory:',
+      query: vi.fn(async () => ({ rows: [] })),
+      tableExists: vi.fn(async (name: string) => {
+        // Report not-exists so each schema goes through the create path.
+        created.push(name);
+        return false;
+      }),
+    } as any;
+
+    const a: SchemaDefinition = {
+      ...fullSchema('a'),
+      dependencies: ['b'],
+    };
+    const b: SchemaDefinition = {
+      ...fullSchema('b'),
+      dependencies: ['a'],
+    };
+
+    const manager = new SchemaManager(db, { engine: 'sqlite' });
+    await manager.ensureTables([a, b]);
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Circular dependency detected involving'),
+    );
+    // Both tables still get created despite the cycle.
+    expect(created).toContain('a');
+    expect(created).toContain('b');
+  });
+
+  it('ignores external (unknown) dependencies during sorting', async () => {
+    const db = {
+      url: 'sqlite::memory:',
+      query: vi.fn(async () => ({ rows: [] })),
+      tableExists: vi.fn(async () => false),
+    } as any;
+
+    const schema: SchemaDefinition = {
+      ...fullSchema('local'),
+      // 'external' is not among the provided schemas -> skipped, no throw.
+      dependencies: ['external'],
+    };
+
+    const manager = new SchemaManager(db, { engine: 'sqlite' });
+    await expect(manager.ensureTables([schema])).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/test-utils.test.ts
+++ b/packages/core/src/test-utils.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Tests for the framework test-utilities (src/test-utils.ts).
+ *
+ * These cover the pure mock factories and the ObjectRegistry snapshot/restore
+ * helper. They exercise real logic — the mock collection's where/orderBy/
+ * pagination engine, the data factories, and a genuine snapshot/restore cycle
+ * against the live ObjectRegistry — without mocking any framework internals.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { SmrtObject } from './object.js';
+import { ObjectRegistry } from './registry.js';
+import {
+  MockCollectionFactory,
+  MockContextFactory,
+  type MockObject,
+  mockCollectionFactory,
+  mockContextFactory,
+  snapshotObjectRegistryState,
+  TestDataFactory,
+  TestSetup,
+  testDataFactory,
+  testSetup,
+} from './test-utils.js';
+
+describe('TestDataFactory', () => {
+  it('generates monotonically increasing unique ids', () => {
+    const a = TestDataFactory.generateId();
+    const b = TestDataFactory.generateId();
+    expect(a).not.toBe(b);
+    expect(a.startsWith('test-')).toBe(true);
+    expect(b.startsWith('test-')).toBe(true);
+  });
+
+  it('builds a test user with lifecycle methods and overridable fields', () => {
+    const user = TestDataFactory.generateTestUser({ username: 'custom' });
+    expect(user.username).toBe('custom');
+    expect(user.email).toContain('@example.com');
+    expect(user.active).toBe(true);
+    expect(typeof user.save).toBe('function');
+    expect(typeof user.delete).toBe('function');
+    expect(typeof user.initialize).toBe('function');
+  });
+
+  it('builds a test product with default price and overridable fields', () => {
+    const product = TestDataFactory.generateTestProduct({ price: 5 });
+    expect(product.price).toBe(5);
+    expect(product.inStock).toBe(true);
+    expect(product.slug).toContain('product-');
+  });
+
+  it('generates multiple objects with distinct ids', () => {
+    const products = TestDataFactory.generateMultiple<MockObject>(
+      TestDataFactory.generateTestProduct,
+      4,
+    );
+    expect(products).toHaveLength(4);
+    const ids = new Set(products.map((p) => p.id));
+    expect(ids.size).toBe(4);
+  });
+
+  it('is also exported as the testDataFactory alias', () => {
+    expect(testDataFactory).toBe(TestDataFactory);
+  });
+});
+
+describe('MockCollectionFactory', () => {
+  it('pre-populates a collection with three records and lists them', async () => {
+    const factory = new MockCollectionFactory();
+    const collection = factory.createMockCollection('user');
+    const all = await collection.list();
+    expect(all).toHaveLength(3);
+  });
+
+  it('applies equality where filters', async () => {
+    const factory = new MockCollectionFactory();
+    const collection = factory.createMockCollection('user');
+    await collection.create({ username: 'needle', age: 99 });
+    const found = await collection.list({ where: { username: 'needle' } });
+    expect(found).toHaveLength(1);
+    expect(found[0].username).toBe('needle');
+  });
+
+  it('supports comparison, like, and in operators in where', async () => {
+    const factory = new MockCollectionFactory();
+    const collection = factory.createMockCollection('product');
+    factory.clear();
+    await collection.create({ productName: 'Alpha', price: 10 });
+    await collection.create({ productName: 'Beta', price: 200 });
+    await collection.create({ productName: 'Gamma', price: 300 });
+
+    const expensive = await collection.list({ where: { 'price >': 100 } });
+    expect(expensive.every((p) => p.price > 100)).toBe(true);
+
+    const cheap = await collection.list({ where: { 'price <': 100 } });
+    expect(cheap.every((p) => p.price < 100)).toBe(true);
+
+    const liked = await collection.list({
+      where: { 'productName like': '%lph%' },
+    });
+    expect(liked.some((p) => p.productName === 'Alpha')).toBe(true);
+
+    const inList = await collection.list({
+      where: { 'productName in': ['Beta', 'Gamma'] },
+    });
+    expect(inList).toHaveLength(2);
+  });
+
+  it('orders results ascending and descending', async () => {
+    const factory = new MockCollectionFactory();
+    const collection = factory.createMockCollection('product');
+    factory.clear();
+    await collection.create({ productName: 'A', price: 3 });
+    await collection.create({ productName: 'B', price: 1 });
+    await collection.create({ productName: 'C', price: 2 });
+
+    const asc = await collection.list({ orderBy: 'price ASC' });
+    expect(asc.map((p) => p.price)).toEqual([1, 2, 3]);
+
+    const desc = await collection.list({ orderBy: 'price DESC' });
+    expect(desc.map((p) => p.price)).toEqual([3, 2, 1]);
+  });
+
+  it('paginates with offset and limit', async () => {
+    const factory = new MockCollectionFactory();
+    const collection = factory.createMockCollection('user');
+    factory.clear();
+    for (let i = 0; i < 5; i++) {
+      await collection.create({ username: `u${i}` });
+    }
+    const page = await collection.list({ offset: 1, limit: 2 });
+    expect(page).toHaveLength(2);
+  });
+
+  it('gets by id and returns null for unknown ids', async () => {
+    const factory = new MockCollectionFactory();
+    const collection = factory.createMockCollection('user');
+    const created = await collection.create({ username: 'getme' });
+    expect(await collection.get(created.id)).toMatchObject({
+      username: 'getme',
+    });
+    expect(await collection.get('does-not-exist')).toBeNull();
+  });
+
+  it('updates an existing record and stamps updated_at', async () => {
+    const factory = new MockCollectionFactory();
+    const collection = factory.createMockCollection('user');
+    const created = await collection.create({ username: 'before' });
+    const updated = await collection.update(created.id, { username: 'after' });
+    expect(updated.username).toBe('after');
+    expect(updated.updated_at).toBeDefined();
+  });
+
+  it('throws when updating or deleting a missing record', async () => {
+    const factory = new MockCollectionFactory();
+    const collection = factory.createMockCollection('user');
+    await expect(collection.update('nope', {})).rejects.toThrow(/not found/);
+    await expect(collection.delete('nope')).rejects.toThrow(/not found/);
+  });
+
+  it('deletes a record so it no longer lists', async () => {
+    const factory = new MockCollectionFactory();
+    const collection = factory.createMockCollection('user');
+    const created = await collection.create({ username: 'goner' });
+    await collection.delete(created.id);
+    expect(await collection.get(created.id)).toBeNull();
+  });
+
+  it('saves an object directly into storage', async () => {
+    const factory = new MockCollectionFactory();
+    const collection = factory.createMockCollection('user');
+    const obj = TestDataFactory.generateTestUser({ id: 'saved-1' });
+    await collection.save(obj);
+    expect(await collection.get('saved-1')).toMatchObject({ id: 'saved-1' });
+  });
+
+  it('exposes a defensive copy of storage and clears it', async () => {
+    const factory = new MockCollectionFactory();
+    factory.createMockCollection('user');
+    const snapshot = factory.getStorage();
+    expect(snapshot.size).toBe(3);
+    // Mutating the returned copy must not affect internal storage.
+    snapshot.clear();
+    expect(factory.getStorage().size).toBe(3);
+    factory.clear();
+    expect(factory.getStorage().size).toBe(0);
+  });
+
+  it('exposes a shared mockCollectionFactory singleton', () => {
+    expect(mockCollectionFactory).toBeInstanceOf(MockCollectionFactory);
+  });
+});
+
+describe('MockContextFactory', () => {
+  it('creates a context with db/ai/user defaults', () => {
+    const factory = new MockContextFactory();
+    const ctx = factory.createMockContext();
+    expect(ctx.db.type).toBe('sqlite');
+    expect(ctx.user.roles).toContain('admin');
+    expect(typeof ctx.ai.message).toBe('function');
+  });
+
+  it('applies db/ai/user overrides', () => {
+    const factory = new MockContextFactory();
+    const ctx = factory.createMockContext({
+      db: { type: 'postgres' },
+      user: { id: 'override-id' },
+    });
+    expect(ctx.db.type).toBe('postgres');
+    expect(ctx.user.id).toBe('override-id');
+  });
+
+  it('creates named mock collections and clears them', () => {
+    const factory = new MockContextFactory();
+    const collections = factory.createMockCollections();
+    expect(collections.TestUser).toBeDefined();
+    expect(collections.TestProduct).toBeDefined();
+    // Should not throw.
+    factory.clear();
+  });
+
+  it('exposes a shared mockContextFactory singleton', () => {
+    expect(mockContextFactory).toBeInstanceOf(MockContextFactory);
+  });
+});
+
+describe('TestSetup', () => {
+  it('sets up a full test environment and forces NODE_ENV=test', () => {
+    const env = TestSetup.setupTestEnvironment();
+    expect(process.env.NODE_ENV).toBe('test');
+    expect(env.mockContext).toBeDefined();
+    expect(env.mockCollections.TestUser).toBeDefined();
+    expect(typeof env.cleanup).toBe('function');
+    env.cleanup();
+  });
+
+  it('builds a constructor mock that returns a configured collection', () => {
+    const collections = new MockContextFactory().createMockCollections();
+    const Ctor = TestSetup.mockCollectionConstructors(collections);
+    const instance = Ctor({ tenantId: 't1' });
+    expect(instance).toBeDefined();
+    // Options were merged into the returned mock collection.
+    expect((instance as any).tenantId).toBe('t1');
+  });
+
+  it('creates realistic database query responses for users and products', () => {
+    const userResponses = TestSetup.createDatabaseResponses('user');
+    expect(userResponses.list.rows).toHaveLength(3);
+    expect(userResponses.get.rows).toHaveLength(1);
+    expect(userResponses.empty.rows).toHaveLength(0);
+
+    const productResponses = TestSetup.createDatabaseResponses('product');
+    expect(productResponses.create.rows[0].slug).toContain('product-');
+  });
+
+  it('is exported as the testSetup alias', () => {
+    expect(testSetup).toBe(TestSetup);
+  });
+});
+
+describe('snapshotObjectRegistryState', () => {
+  // Always restore the registry after each test so we never leak a fixture
+  // class into sibling suites.
+  let restore: (() => void) | undefined;
+
+  afterEach(() => {
+    if (restore) {
+      restore();
+      restore = undefined;
+    }
+  });
+
+  it('restores the registry to its captured state after mutation', () => {
+    restore = snapshotObjectRegistryState();
+
+    class SnapshotProbe extends SmrtObject {
+      label = '';
+    }
+    ObjectRegistry.register(SnapshotProbe, { name: 'SnapshotProbe' });
+    expect(ObjectRegistry.getClass('SnapshotProbe')).toBeDefined();
+
+    // Restore should remove the class registered after the snapshot.
+    restore();
+    restore = undefined;
+    expect(ObjectRegistry.getClass('SnapshotProbe')).toBeUndefined();
+  });
+
+  it('returns an independent restore function each call', () => {
+    const first = snapshotObjectRegistryState();
+    const second = snapshotObjectRegistryState();
+    expect(first).not.toBe(second);
+    // Calling both restores is harmless (idempotent enough for cleanup).
+    first();
+    second();
+  });
+});

--- a/packages/core/src/vite-plugin/load-hooks.test.ts
+++ b/packages/core/src/vite-plugin/load-hooks.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for the smrtPlugin Vite hooks that generate virtual modules
+ * (src/vite-plugin/index.ts).
+ *
+ * The per-virtual-module code generators (generateClientModule,
+ * generateManifestModule, generateRoutesModule, generateMCPModule,
+ * generateTypesModule, generateCLIModule, generateSchemaModule, the default-UI
+ * loaders) are module-private. We reach them the way Vite does: through the
+ * plugin's `resolveId` and `load` hooks. A small real project (two @smrt
+ * classes) is scanned once via `configResolved` to seed a genuine manifest, and
+ * then every `load` branch is invoked and its emitted source asserted. No dev
+ * server is started and no Vite build runs.
+ *
+ * Hooks that require a live ViteDevServer / file watcher (configureServer,
+ * transformIndexHtml) and the closeBundle library-build path are exercised only
+ * where they have a pure, server-independent branch; the rest is flagged
+ * infeasible in the report.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { smrtPlugin } from './index.js';
+
+function getHook(plugin: any, name: string) {
+  const hook = plugin[name];
+  return typeof hook === 'function' ? hook : hook.handler;
+}
+
+describe('smrtPlugin resolveId', () => {
+  it('resolves each known virtual module to its \\0-prefixed id', () => {
+    const plugin: any = smrtPlugin();
+    const resolveId = getHook(plugin, 'resolveId');
+
+    expect(resolveId.call(plugin, '@happyvertical/smrt-virt-routes')).toBe(
+      '\0smrt:routes',
+    );
+    expect(resolveId.call(plugin, '@happyvertical/smrt-virt-client')).toBe(
+      '\0smrt:client',
+    );
+    expect(resolveId.call(plugin, '@happyvertical/smrt-virt-manifest')).toBe(
+      '\0smrt:manifest',
+    );
+    expect(resolveId.call(plugin, '@happyvertical/smrt-virt-schema')).toBe(
+      '\0smrt:schema',
+    );
+    expect(resolveId.call(plugin, '@happyvertical/smrt-virt-cli')).toBe(
+      '\0smrt:cli',
+    );
+  });
+
+  it('returns null for /index.html when no dev server is attached', () => {
+    const plugin: any = smrtPlugin();
+    const resolveId = getHook(plugin, 'resolveId');
+    expect(resolveId.call(plugin, '/index.html')).toBeNull();
+  });
+
+  it('returns null for unknown ids', () => {
+    const plugin: any = smrtPlugin();
+    const resolveId = getHook(plugin, 'resolveId');
+    expect(resolveId.call(plugin, './local-module.ts')).toBeNull();
+  });
+});
+
+describe('smrtPlugin api.options', () => {
+  it('exposes the resolved scan options for external manifest generation', () => {
+    const plugin: any = smrtPlugin({
+      include: ['lib/**/*.ts'],
+      exclude: ['**/*.spec.ts'],
+      baseClasses: ['SmrtObject', 'CustomBase'],
+      followImports: false,
+    });
+    expect(plugin.api.options).toEqual({
+      include: ['lib/**/*.ts'],
+      exclude: ['**/*.spec.ts'],
+      baseClasses: ['SmrtObject', 'CustomBase'],
+      followImports: false,
+    });
+  });
+});
+
+describe('smrtPlugin load (virtual module generation)', () => {
+  let projectRoot: string;
+  let plugin: any;
+  let load: (id: string) => Promise<string | null>;
+
+  beforeAll(async () => {
+    // Real mini-project with two @smrt classes that share no collisions plus a
+    // custom method, so the generators exercise CRUD + custom-method emission.
+    projectRoot = mkdtempSync(join(tmpdir(), 'smrt-vite-load-'));
+    mkdirSync(join(projectRoot, 'src'), { recursive: true });
+    writeFileSync(
+      join(projectRoot, 'package.json'),
+      JSON.stringify({ name: 'mini-app', version: '0.0.1', type: 'module' }),
+    );
+    writeFileSync(
+      join(projectRoot, 'src', 'objects.ts'),
+      `import { SmrtObject } from '@happyvertical/smrt-core';
+
+@smrt({ cli: true, api: true })
+export class Widget extends SmrtObject {
+  name: string = '';
+  price: number = 0.0;
+
+  async refresh(): Promise<void> {}
+}
+
+@smrt({ cli: { exclude: ['delete'] } })
+export class Gizmo extends SmrtObject {
+  label: string = '';
+}
+`,
+    );
+
+    plugin = smrtPlugin({
+      // Keep type-declaration writing off (it only runs with a dev server).
+      generateTypes: false,
+      include: ['src/**/*.ts'],
+    });
+
+    // Drive configResolved with a minimal resolved-config stand-in. This scans
+    // the project and seeds the closure manifest used by the load hook.
+    await plugin.configResolved?.call(plugin, {
+      root: projectRoot,
+      mode: 'production',
+      plugins: [],
+      build: {},
+    } as any);
+
+    load = getHook(plugin, 'load').bind(plugin);
+  }, 60_000);
+
+  afterAll(() => {
+    if (existsSync(projectRoot)) {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('seeds a manifest containing the scanned objects', () => {
+    // configResolved writes the local manifest to .smrt/manifest.json.
+    expect(existsSync(join(projectRoot, '.smrt', 'manifest.json'))).toBe(true);
+  });
+
+  it('generates the routes module', async () => {
+    const code = await load('\0smrt:routes');
+    expect(code).toContain('export function setupRoutes');
+    expect(code).toContain('export { setupRoutes as default }');
+  });
+
+  it('generates a client module with per-object CRUD methods', async () => {
+    const code = await load('\0smrt:client');
+    expect(code).toContain('export function createClient');
+    // CRUD verbs are emitted for the scanned collections.
+    expect(code).toContain('list:');
+    expect(code).toContain('create:');
+    expect(code).toContain('delete:');
+    expect(code).toContain('search:');
+  });
+
+  it('generates the MCP module wired to SmrtMCPServer', async () => {
+    const code = await load('\0smrt:mcp');
+    expect(code).toContain('SmrtMCPServer');
+    expect(code).toContain('export function createMCPServer');
+  });
+
+  it('generates the types module with Request/Response interfaces', async () => {
+    const code = await load('\0smrt:types');
+    expect(code).toContain('export interface Request');
+    expect(code).toContain('export interface Response');
+  });
+
+  it('generates the manifest module embedding the manifest JSON', async () => {
+    const code = await load('\0smrt:manifest');
+    expect(code).toContain('export const manifest =');
+    expect(code).toContain('export { manifest as default }');
+    expect(code).toContain('Widget');
+  });
+
+  it('generates the schema module with a schema registry', async () => {
+    const code = await load('\0smrt:schema');
+    expect(code).toContain('export const schemaManifest =');
+    expect(code).toContain('export function getSchema');
+    expect(code).toContain('export const schemas =');
+  });
+
+  it('generates the CLI module honoring cli include/exclude config', async () => {
+    const code = await load('\0smrt:cli');
+    expect(code).toContain('export const cliCommands');
+    expect(code).toContain('export function setupCLI');
+    // Widget enables cli + has a custom method -> a widget command group exists.
+    expect(code).toContain('widget:list');
+    // Gizmo excludes delete -> no gizmo:delete command emitted.
+    expect(code).not.toContain('gizmo:delete');
+  });
+
+  it('loads the default UI module source', async () => {
+    const code = await load('\0smrt:ui');
+    expect(typeof code).toBe('string');
+    expect((code as string).length).toBeGreaterThan(0);
+  });
+
+  it('loads the default index.html', async () => {
+    const html = await load('\0smrt:index-html');
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('SMRT Development UI');
+  });
+
+  it('returns null for an unknown virtual id', async () => {
+    expect(await load('\0smrt:does-not-exist')).toBeNull();
+  });
+});

--- a/scripts/check-coverage.mjs
+++ b/scripts/check-coverage.mjs
@@ -111,10 +111,10 @@ const GATE_EXEMPT = new Set(['smrt-svelte', 'vitest']);
 // work item. Ratchet upward as uplift lands; delete the entry once the package
 // measures at its tier floor.
 const INTERIM_FLOORS = {
-  // core measured ~66% (CI/local) on 2026-06-11, the first time a core-touching
-  // PR hit the gate (#1499). Floor set just below baseline to absorb run-to-run
-  // measurement noise. Uplift to the T1 80% floor is #1500.
-  core: 65,
+  // core: interim floor removed — the #1500 coverage uplift took core from
+  // ~66% to 83.79% lines (2026-06-21), clearing the ratified T1 80% floor. The
+  // gate now enforces the real tier floor for core. Add new entries here only
+  // for packages still measuring below their tier floor.
 };
 
 function flagValue(name) {


### PR DESCRIPTION
Raises `@happyvertical/smrt-core` line coverage from a measured **67.78%** to **83.79%**, clearing the T1 80% floor with margin (epic #1354 coverage-debt; closes #1500). 6 conventional commits (one per area, fanned out across 6 parallel agents), **+586 tests** (2558 passing / 0 failing, 29 pre-existing `.optional`/integration skips). Real in-memory SQLite per `.claude/rules/testing.md` — the DB is never mocked; only external/network/process boundaries are.

Unlike the cli uplift (#1566) there is **no measurement-scope fix** — core measures cleanly (no dist pollution). This is a pure test uplift plus the gate flip.

## Per-area line coverage (before → after, full-suite run)

| File | Before | After |
|------|--------|-------|
| **mcp-advisor** cluster (12 files) | **0%** | tools 85–100%; `index.ts` 33%* |
| registry/validator.ts | 25.4% | **100%** |
| registry/inheritance-resolver.ts | 26.4% | **91.5%** |
| registry/schema-builder.ts · class.ts · collection.ts | 78.6 / 81.6 / 79.9% | 85.5 / 89.8 / 86.5% |
| object.ts | 73.4% | 79.0%* |
| errors.ts · schema/schema-manager.ts | 51.5 / 49.1% | **98.8 / 99.1%** |
| schema/generator.ts | 74.6% | **96.8%** |
| migrations/tracker.ts · migrations/generator.ts | 76.7 / 69.4% | 95.6 / 97.2% |
| generators/cli.ts · swagger.ts · mcp.ts | 62.4 / 64.8 / 70.7% | 95.1 / 94.5 / 83.7% |
| generators/rest.ts | 34.0% | 77.7%* |
| scanner/manifest-generator.ts (biggest file) | 53.5% | **85.4%** |
| manifest/generator · loader · store · discover | 64.8 / 75 / 62.4 / 70.4% | 92 / 83 / 80.1 / 77.9%* |
| test-utils.ts · prebuild/index.ts | 21.6 / 0% | **92.8 / 100%** |
| consumer-plugin/index.ts · runtime/server.ts | 55.6 / 0.7% | 86.2 / 73.9%* |
| vite-plugin/index.ts | 34.3% | 58.4%* |

`*` = honest ceiling, see below.

**Package total: 83.79% lines / 87.83% funcs / 82.99% stmts / 75.15% branch.**

## One source change (the rest is test-only)
- **`mcp-advisor/index.ts`** — a small, deliberate testability seam: export `TOOLS` and `handleToolCall` so the routing/tool-surface can be asserted in-process, and guard `main()` behind an `isEntrypoint()` check so importing the module for tests no longer auto-starts the stdio MCP server. Mirrors the existing pattern in `packages/smrt-dev-mcp/src/index.ts`. No behavior change when run as the entrypoint.
- **`scripts/check-coverage.mjs`** — removes core's interim ratchet floor (was 65, a freeze-avoidance stopgap from #1499) so the gate now enforces the real T1 80% floor for core.

## Honest ceilings (flagged, not padded)
- **`vite-plugin/templates/default-ui.ts` (0%)** — browser-only DOM module (`document`/`window`/`fetch`/click listeners); only runs in a real browser via `<script type=module>`. Not meaningfully unit-testable; repo rules say "test generators, not generated output."
- **`runtime/server.ts` ~74%** and **`generators/rest.ts` ~78%** — the residual is live-socket HTTP plumbing (`server.listen()`, Node↔Web stream conversion, SIGTERM handlers). The request-handling logic (routing/CRUD/auth/CORS/query-ops) is covered in-process without binding a port; covering the rest needs an integration server.
- **`vite-plugin/index.ts` ~58%** — remainder is the dev-server lifecycle (`configureServer` middleware + file-watcher, `transformIndexHtml`, `closeBundle` lib-build path) that needs a live `ViteDevServer`.
- **`mcp-advisor/index.ts` ~33%** — the `TOOLS` surface + `handleToolCall` routing are unit-covered; the `main()`/stdio bootstrap is exercised by an integration spec that **spawns** the server via `tsx`, so v8 can't instrument it across the process boundary (the in-process coverage undercounts it).
- **`object.ts` ~79%**, **`manifest/discover-smrt-packages.ts` ~78%** — residual paths need real installed external packages / pnpm symlink layouts (external-manifest discovery, direct-CLI entry). Left honest rather than padded; package total already clears 80%.

Does not change runtime behavior. Relates to #1354.

Closes #1500.
