### PR TITLE
[codex] Reuse request-scoped auth and entitlement work

### DIFF
--- a/packages/subscriptions/AGENTS.md
+++ b/packages/subscriptions/AGENTS.md
@@ -16,6 +16,7 @@ pnpm --filter @happyvertical/smrt-subscriptions build
 - Keep Stripe-specific fields as provider binding metadata. Runtime Stripe API
   calls belong in the HappyVertical SDK accounting provider.
 - Thresholds are evaluated from tenant usage metrics and optional AI usage
-  summaries. Do not bypass tenant context in application code.
+  summaries. Resolve multiple thresholds with the batch usage path where
+  available; do not bypass tenant context in application code.
 - Subscription UI components should stay provider-neutral and receive actions
   from the host app.

--- a/packages/subscriptions/AGENTS.md
+++ b/packages/subscriptions/AGENTS.md
@@ -18,5 +18,9 @@ pnpm --filter @happyvertical/smrt-subscriptions build
 - Thresholds are evaluated from tenant usage metrics and optional AI usage
   summaries. Resolve multiple thresholds with the batch usage path where
   available; do not bypass tenant context in application code.
+- Use `SubscriptionResolver.create()` or an explicitly injected
+  `SubscriptionResolver` once per request when resolving entitlements multiple
+  times. Load and pass `EntitlementResolutionContext` to avoid re-reading the
+  current subscription and plan.
 - Subscription UI components should stay provider-neutral and receive actions
   from the host app.

--- a/packages/subscriptions/src/__tests__/subscription-resolver.test.ts
+++ b/packages/subscriptions/src/__tests__/subscription-resolver.test.ts
@@ -345,6 +345,48 @@ describe('smrt-subscriptions', () => {
     expect(getPlan).toHaveBeenCalledTimes(1);
   });
 
+  it('rejects unverifiable context plans instead of trusting stale entitlements', async () => {
+    const plan = new SubscriptionPlan({
+      planKey: 'wrong',
+      name: 'Wrong',
+      status: 'active',
+    });
+    plan.setFeatureGrants(['smrt:wrong']);
+
+    const subscription = new TenantSubscription({
+      tenantId: 'tenant-1',
+      planId: 'plan-team',
+      status: 'active',
+      currentPeriodEnd: new Date('2026-07-01T00:00:00Z'),
+    });
+    Object.assign(subscription, { id: 'sub-team' });
+
+    const resolver = new SubscriptionResolver({
+      plans: {
+        async get() {
+          throw new Error('plan reader should not run with provided context');
+        },
+      },
+      subscriptions: {
+        async findCurrentForTenant() {
+          return subscription;
+        },
+      },
+      usage: {
+        async summarize() {
+          throw new Error('usage should not be read with invalid context');
+        },
+      },
+    });
+
+    await expect(
+      resolver.resolveTenantEntitlements('tenant-1', {
+        context: { plan, subscription },
+        now: new Date('2026-06-15T00:00:00Z'),
+      }),
+    ).rejects.toThrow(/context plan/);
+  });
+
   it('creates a resolver with reusable default readers', async () => {
     const plan = new SubscriptionPlan({
       planKey: 'factory',

--- a/packages/subscriptions/src/__tests__/subscription-resolver.test.ts
+++ b/packages/subscriptions/src/__tests__/subscription-resolver.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { SubscriptionPlan } from '../models/SubscriptionPlan.js';
 import { TenantSubscription } from '../models/TenantSubscription.js';
 import { SubscriptionResolver } from '../services/subscription-resolver.js';
@@ -195,6 +195,100 @@ describe('smrt-subscriptions', () => {
         now: new Date('2026-06-15T00:00:00Z'),
       }),
     ).rejects.toThrow('ai.tokens.total');
+  });
+
+  it('batches threshold usage summaries by usage window', async () => {
+    const plan = new SubscriptionPlan({
+      planKey: 'scale',
+      name: 'Scale',
+      status: 'active',
+    });
+    Object.assign(plan, { id: 'plan-scale' });
+    plan.setThresholds([
+      {
+        metricKey: 'messages.sent',
+        limit: 100,
+        window: 'month',
+        enforcement: 'warn',
+      },
+      {
+        metricKey: 'ai.tokens.total',
+        limit: 1000,
+        window: 'month',
+        enforcement: 'block',
+      },
+      {
+        metricKey: 'messages.sent',
+        limit: 200,
+        window: 'month',
+        enforcement: 'block',
+      },
+    ]);
+
+    const subscription = new TenantSubscription({
+      tenantId: 'tenant-1',
+      planId: 'plan-scale',
+      status: 'active',
+      currentPeriodEnd: new Date('2026-07-01T00:00:00Z'),
+    });
+    Object.assign(subscription, { id: 'sub-scale' });
+
+    const summarize = vi.fn(async () => {
+      throw new Error('single-metric usage reader should not be called');
+    });
+    const summarizeBatch = vi.fn(async () => [
+      {
+        tenantId: 'tenant-1',
+        metricKey: 'messages.sent',
+        quantity: 150,
+        windowStart: new Date('2026-06-01T00:00:00Z'),
+        windowEnd: new Date('2026-07-01T00:00:00Z'),
+      },
+      {
+        tenantId: 'tenant-1',
+        metricKey: 'ai.tokens.total',
+        quantity: 750,
+        windowStart: new Date('2026-06-01T00:00:00Z'),
+        windowEnd: new Date('2026-07-01T00:00:00Z'),
+      },
+    ]);
+
+    const resolver = new SubscriptionResolver({
+      plans: {
+        async get() {
+          return plan;
+        },
+      },
+      subscriptions: {
+        async findCurrentForTenant() {
+          return subscription;
+        },
+      },
+      usage: {
+        summarize,
+        summarizeBatch,
+      },
+    });
+
+    const resolution = await resolver.resolveTenantEntitlements('tenant-1', {
+      now: new Date('2026-06-15T00:00:00Z'),
+    });
+
+    expect(summarize).not.toHaveBeenCalled();
+    expect(summarizeBatch).toHaveBeenCalledTimes(1);
+    expect(summarizeBatch).toHaveBeenCalledWith({
+      tenantId: 'tenant-1',
+      subscriberKind: 'tenant',
+      subscriberExternalId: undefined,
+      metricKeys: ['messages.sent', 'ai.tokens.total'],
+      window: {
+        start: new Date('2026-06-01T00:00:00Z'),
+        end: new Date('2026-07-01T00:00:00Z'),
+      },
+    });
+    expect(
+      resolution.thresholdEvaluations.map((evaluation) => evaluation.state),
+    ).toEqual(['warn', 'ok', 'ok']);
   });
 
   it('returns a closed resolution without a subscription', async () => {

--- a/packages/subscriptions/src/__tests__/subscription-resolver.test.ts
+++ b/packages/subscriptions/src/__tests__/subscription-resolver.test.ts
@@ -1,10 +1,17 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SubscriptionPlanCollection } from '../collections/SubscriptionPlanCollection.js';
+import { TenantSubscriptionCollection } from '../collections/TenantSubscriptionCollection.js';
 import { SubscriptionPlan } from '../models/SubscriptionPlan.js';
 import { TenantSubscription } from '../models/TenantSubscription.js';
 import { SubscriptionResolver } from '../services/subscription-resolver.js';
 import { evaluateThreshold } from '../services/threshold-evaluator.js';
+import { TenantUsageMeter } from '../services/usage-meter.js';
 import type { PlanThreshold, UsageSummary } from '../types.js';
 import { isValidThreshold } from '../utils.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('smrt-subscriptions', () => {
   it('stores plan feature grants and thresholds as typed accessors', () => {
@@ -289,6 +296,113 @@ describe('smrt-subscriptions', () => {
     expect(
       resolution.thresholdEvaluations.map((evaluation) => evaluation.state),
     ).toEqual(['warn', 'ok', 'ok']);
+  });
+
+  it('loads entitlement context once and reuses it across resolution', async () => {
+    const plan = new SubscriptionPlan({
+      planKey: 'team',
+      name: 'Team',
+      status: 'active',
+    });
+    Object.assign(plan, { id: 'plan-team' });
+    plan.setFeatureGrants(['smrt:billing']);
+
+    const subscription = new TenantSubscription({
+      tenantId: 'tenant-1',
+      planId: 'plan-team',
+      status: 'active',
+      currentPeriodEnd: new Date('2026-07-01T00:00:00Z'),
+    });
+    Object.assign(subscription, { id: 'sub-team' });
+
+    const getPlan = vi.fn(async () => plan);
+    const findCurrentForTenant = vi.fn(async () => subscription);
+    const resolver = new SubscriptionResolver({
+      plans: { get: getPlan },
+      subscriptions: { findCurrentForTenant },
+      usage: {
+        async summarize() {
+          throw new Error('usage should not be read without thresholds');
+        },
+      },
+    });
+
+    const now = new Date('2026-06-15T00:00:00Z');
+    const context = await resolver.loadEntitlementContext('tenant-1', { now });
+    const resolution = await resolver.resolveTenantEntitlements('tenant-1', {
+      context,
+      now,
+    });
+
+    expect(context).toEqual({ subscription, plan });
+    expect(resolution).toMatchObject({
+      tenantId: 'tenant-1',
+      planKey: 'team',
+      featureKeys: ['smrt:billing'],
+      allowed: true,
+    });
+    expect(findCurrentForTenant).toHaveBeenCalledTimes(1);
+    expect(getPlan).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates a resolver with reusable default readers', async () => {
+    const plan = new SubscriptionPlan({
+      planKey: 'factory',
+      name: 'Factory',
+      status: 'active',
+    });
+    Object.assign(plan, { id: 'plan-factory' });
+
+    const subscription = new TenantSubscription({
+      tenantId: 'tenant-1',
+      planId: 'plan-factory',
+      status: 'active',
+      currentPeriodEnd: new Date('2026-07-01T00:00:00Z'),
+    });
+    Object.assign(subscription, { id: 'sub-factory' });
+
+    const plans = {
+      async get() {
+        throw new Error('plan reader should not run with provided context');
+      },
+    } as unknown as SubscriptionPlanCollection;
+    const subscriptions = {
+      async findCurrentForTenant() {
+        throw new Error(
+          'subscription reader should not run with provided context',
+        );
+      },
+    } as unknown as TenantSubscriptionCollection;
+    const usage = {
+      async summarize() {
+        throw new Error('usage should not be read without thresholds');
+      },
+    } as unknown as TenantUsageMeter;
+
+    const createPlans = vi
+      .spyOn(SubscriptionPlanCollection, 'create')
+      .mockResolvedValue(plans);
+    const createSubscriptions = vi
+      .spyOn(TenantSubscriptionCollection, 'create')
+      .mockResolvedValue(subscriptions);
+    const createUsage = vi
+      .spyOn(TenantUsageMeter, 'create')
+      .mockResolvedValue(usage);
+
+    const resolver = await SubscriptionResolver.create();
+    const resolution = await resolver.resolveTenantEntitlements('tenant-1', {
+      context: { subscription, plan },
+      now: new Date('2026-06-15T00:00:00Z'),
+    });
+
+    expect(createPlans).toHaveBeenCalledTimes(1);
+    expect(createSubscriptions).toHaveBeenCalledTimes(1);
+    expect(createUsage).toHaveBeenCalledTimes(1);
+    expect(resolution).toMatchObject({
+      tenantId: 'tenant-1',
+      planKey: 'factory',
+      allowed: true,
+    });
   });
 
   it('returns a closed resolution without a subscription', async () => {

--- a/packages/subscriptions/src/__tests__/subscription-resolver.test.ts
+++ b/packages/subscriptions/src/__tests__/subscription-resolver.test.ts
@@ -345,6 +345,50 @@ describe('smrt-subscriptions', () => {
     expect(getPlan).toHaveBeenCalledTimes(1);
   });
 
+  it('treats undefined context values as absent and falls back to readers', async () => {
+    const plan = new SubscriptionPlan({
+      planKey: 'team',
+      name: 'Team',
+      status: 'active',
+    });
+    Object.assign(plan, { id: 'plan-team' });
+    plan.setFeatureGrants(['smrt:billing']);
+
+    const subscription = new TenantSubscription({
+      tenantId: 'tenant-1',
+      planId: 'plan-team',
+      status: 'active',
+      currentPeriodEnd: new Date('2026-07-01T00:00:00Z'),
+    });
+    Object.assign(subscription, { id: 'sub-team' });
+
+    const getPlan = vi.fn(async () => plan);
+    const findCurrentForTenant = vi.fn(async () => subscription);
+    const resolver = new SubscriptionResolver({
+      plans: { get: getPlan },
+      subscriptions: { findCurrentForTenant },
+      usage: {
+        async summarize() {
+          throw new Error('usage should not be read without thresholds');
+        },
+      },
+    });
+
+    const resolution = await resolver.resolveTenantEntitlements('tenant-1', {
+      context: { plan: undefined, subscription: undefined },
+      now: new Date('2026-06-15T00:00:00Z'),
+    });
+
+    expect(resolution).toMatchObject({
+      tenantId: 'tenant-1',
+      planKey: 'team',
+      featureKeys: ['smrt:billing'],
+      allowed: true,
+    });
+    expect(findCurrentForTenant).toHaveBeenCalledTimes(1);
+    expect(getPlan).toHaveBeenCalledTimes(1);
+  });
+
   it('rejects unverifiable context plans instead of trusting stale entitlements', async () => {
     const plan = new SubscriptionPlan({
       planKey: 'wrong',

--- a/packages/subscriptions/src/__tests__/usage-meter.test.ts
+++ b/packages/subscriptions/src/__tests__/usage-meter.test.ts
@@ -162,6 +162,53 @@ describe('TenantUsageMeter AI usage summaries', () => {
     expect(requests.quantity).toBe(1);
   });
 
+  it('summarizes mixed AI and persisted metrics in one batch call', async () => {
+    await seedAiUsage(metrics, [
+      {
+        tenantId: 'tenant-1',
+        promptTokens: 30,
+        completionTokens: 10,
+        totalTokens: 40,
+        estimatedCost: 0.2,
+        createdAt: '2026-06-10T12:00:00.000Z',
+      },
+    ]);
+
+    const meter = new TenantUsageMeter(metrics);
+    const window = {
+      start: new Date('2026-06-01T00:00:00.000Z'),
+      end: new Date('2026-07-01T00:00:00.000Z'),
+    };
+
+    await meter.record({
+      tenantId: 'tenant-1',
+      metricKey: 'storage.bytes',
+      quantity: 1024,
+      windowStart: new Date('2026-06-12T00:00:00.000Z'),
+      windowEnd: new Date('2026-06-12T01:00:00.000Z'),
+    });
+    await meter.record({
+      tenantId: 'tenant-1',
+      metricKey: 'storage.bytes',
+      quantity: 2048,
+      windowStart: new Date('2026-06-13T00:00:00.000Z'),
+      windowEnd: new Date('2026-06-13T01:00:00.000Z'),
+    });
+
+    const summaries = await meter.summarizeBatch({
+      tenantId: 'tenant-1',
+      metricKeys: ['ai.tokens.total', 'ai.requests', 'storage.bytes'],
+      window,
+    });
+    const quantityByMetric = new Map(
+      summaries.map((summary) => [summary.metricKey, summary.quantity]),
+    );
+
+    expect(quantityByMetric.get('ai.tokens.total')).toBe(40);
+    expect(quantityByMetric.get('ai.requests')).toBe(1);
+    expect(quantityByMetric.get('storage.bytes')).toBe(3072);
+  });
+
   it('returns zeroed totals when no usage matches', async () => {
     const meter = new TenantUsageMeter(metrics);
     const summary = await meter.summarizeAiUsage({

--- a/packages/subscriptions/src/collections/TenantUsageMetricCollection.ts
+++ b/packages/subscriptions/src/collections/TenantUsageMetricCollection.ts
@@ -4,6 +4,7 @@ import type {
   AiUsageSummary,
   RecordUsageOptions,
   SummarizeAiUsageOptions,
+  SummarizeUsageBatchOptions,
   SummarizeUsageOptions,
   UsageSummary,
 } from '../types.js';
@@ -90,6 +91,77 @@ export class TenantUsageMetricCollection extends SmrtCollection<TenantUsageMetri
     return baseSummary;
   }
 
+  async summarizeUsageBatch(
+    options: SummarizeUsageBatchOptions,
+  ): Promise<UsageSummary[]> {
+    const metricKeys = Array.from(new Set(options.metricKeys));
+    if (metricKeys.length === 0) {
+      return [];
+    }
+
+    const subscriber = normalizeSubscriber({
+      tenantId: options.tenantId,
+      subscriberKind: options.subscriberKind,
+      subscriberExternalId: options.subscriberExternalId,
+    });
+    const columns = subscriberToColumns(subscriber);
+
+    const metricPlaceholders = metricKeys.map(() => '?').join(', ');
+    const params: unknown[] = [
+      columns.tenantId,
+      columns.subscriberKind,
+      ...metricKeys,
+      options.window.end.toISOString(),
+      options.window.start.toISOString(),
+    ];
+    let subscriberSql = '';
+    if (subscriber.kind === 'external') {
+      subscriberSql = 'AND subscriber_external_id = ?';
+      params.splice(2, 0, columns.subscriberExternalId);
+    }
+
+    const result = await this.db.query(
+      `SELECT
+          metric_key,
+          COALESCE(SUM(quantity), 0) AS quantity
+        FROM _smrt_tenant_usage_metrics
+        WHERE tenant_id = ?
+          AND subscriber_kind = ?
+          ${subscriberSql}
+          AND metric_key IN (${metricPlaceholders})
+          AND window_start < ?
+          AND window_end > ?
+        GROUP BY metric_key`,
+      ...params,
+    );
+
+    const quantityByMetric = new Map<string, number>();
+    for (const row of resultRows(result)) {
+      const metricKey = String(row.metric_key ?? row.metricKey ?? '');
+      if (metricKey) {
+        quantityByMetric.set(metricKey, numberFromRow(row, 'quantity'));
+      }
+    }
+
+    return metricKeys.map((metricKey) => {
+      const baseSummary: UsageSummary = {
+        tenantId: columns.tenantId,
+        metricKey,
+        quantity: quantityByMetric.get(metricKey) ?? 0,
+        windowStart: options.window.start,
+        windowEnd: options.window.end,
+      };
+      if (subscriber.kind === 'external') {
+        return {
+          ...baseSummary,
+          subscriberKind: 'external',
+          subscriberExternalId: subscriber.externalId,
+        };
+      }
+      return baseSummary;
+    });
+  }
+
   /**
    * Summarize persisted AI usage for a tenant within a window.
    *
@@ -136,10 +208,14 @@ export class TenantUsageMetricCollection extends SmrtCollection<TenantUsageMetri
 }
 
 function firstRow(result: unknown): Record<string, unknown> {
-  const rows = Array.isArray(result)
+  const rows = resultRows(result);
+  return (rows[0] ?? {}) as Record<string, unknown>;
+}
+
+function resultRows(result: unknown): Record<string, unknown>[] {
+  return Array.isArray(result)
     ? (result as Record<string, unknown>[])
     : ((result as { rows?: Record<string, unknown>[] })?.rows ?? []);
-  return (rows[0] ?? {}) as Record<string, unknown>;
 }
 
 function numberFromRow(row: Record<string, unknown>, key: string): number {

--- a/packages/subscriptions/src/index.ts
+++ b/packages/subscriptions/src/index.ts
@@ -33,6 +33,7 @@ export type {
   AiUsageSummary,
   BillingInterval,
   EntitlementResolution,
+  EntitlementResolutionContext,
   JsonObject,
   PlanFeatureGrant,
   PlanThreshold,

--- a/packages/subscriptions/src/index.ts
+++ b/packages/subscriptions/src/index.ts
@@ -43,6 +43,7 @@ export type {
   SubscriptionResolverOptions,
   SubscriptionStatus,
   SummarizeAiUsageOptions,
+  SummarizeUsageBatchOptions,
   SummarizeUsageOptions,
   ThresholdEnforcement,
   ThresholdEvaluation,

--- a/packages/subscriptions/src/services/index.ts
+++ b/packages/subscriptions/src/services/index.ts
@@ -1,3 +1,4 @@
+export type { EntitlementResolutionContext } from '../types.js';
 export {
   type SubscriptionPlanReader,
   SubscriptionResolver,

--- a/packages/subscriptions/src/services/subscription-resolver.ts
+++ b/packages/subscriptions/src/services/subscription-resolver.ts
@@ -1,8 +1,12 @@
+import { SubscriptionPlanCollection } from '../collections/SubscriptionPlanCollection.js';
+import { TenantSubscriptionCollection } from '../collections/TenantSubscriptionCollection.js';
 import type { SubscriptionPlan } from '../models/SubscriptionPlan.js';
 import type { TenantSubscription } from '../models/TenantSubscription.js';
 import type {
   EntitlementResolution,
+  EntitlementResolutionContext,
   PlanThreshold,
+  SmrtClassOptions,
   Subscriber,
   SubscriptionResolverOptions,
   ThresholdEvaluation,
@@ -15,6 +19,7 @@ import {
   isValidThreshold,
 } from '../utils.js';
 import { evaluateThreshold } from './threshold-evaluator.js';
+import { TenantUsageMeter } from './usage-meter.js';
 
 export interface SubscriptionPlanReader {
   get(criteria: { id: string }): Promise<SubscriptionPlan | null>;
@@ -77,6 +82,41 @@ export class SubscriptionResolver {
   constructor(private readonly readers: SubscriptionResolverReaders) {}
 
   /**
+   * Build the default resolver readers once for a request or app lifecycle and
+   * reuse the returned resolver across entitlement checks.
+   */
+  static async create(
+    classOptions: SmrtClassOptions = {},
+  ): Promise<SubscriptionResolver> {
+    const [plans, subscriptions, usage] = await Promise.all([
+      SubscriptionPlanCollection.create(classOptions),
+      TenantSubscriptionCollection.create(classOptions),
+      TenantUsageMeter.create(classOptions),
+    ]);
+    return new SubscriptionResolver({ plans, subscriptions, usage });
+  }
+
+  /**
+   * Load the subscription/plan pair used by entitlement resolution. Callers
+   * that need both the entitlement snapshot and the backing records can load
+   * this once, then pass it back via `options.context`.
+   */
+  async loadEntitlementContext(
+    subscriberOrTenantId: Subscriber | string,
+    options: SubscriptionResolverOptions = {},
+  ): Promise<EntitlementResolutionContext> {
+    const subscriber = toSubscriber(subscriberOrTenantId);
+    const now = options.now ?? new Date();
+    const subscription = await this.resolveSubscription(
+      subscriber,
+      now,
+      options.context,
+    );
+    const plan = await this.resolvePlan(subscription, options.context);
+    return { subscription, plan };
+  }
+
+  /**
    * Polymorphic entitlement resolution. Works for both `'tenant'`-kind and
    * `'external'`-kind subscribers and is the preferred surface — the
    * `resolveTenantEntitlements(tenantId)` method below is a thin wrapper.
@@ -86,15 +126,14 @@ export class SubscriptionResolver {
     options: SubscriptionResolverOptions = {},
   ): Promise<EntitlementResolution> {
     const now = options.now ?? new Date();
-    const subscription = await this.findCurrentSubscription(subscriber, now);
+    const { subscription, plan } = await this.loadEntitlementContext(
+      subscriber,
+      { ...options, now },
+    );
 
     if (!subscription) {
       return emptyResolution(subscriber);
     }
-
-    const plan = subscription.planId
-      ? await this.readers.plans.get({ id: subscription.planId })
-      : null;
 
     if (!plan || !plan.isActive() || !subscription.isEntitled(now)) {
       return {
@@ -170,6 +209,34 @@ export class SubscriptionResolver {
         `${subject} exceeded subscription threshold ${blocked.threshold.metricKey}`,
       );
     }
+  }
+
+  private async resolveSubscription(
+    subscriber: Subscriber,
+    now: Date,
+    context?: EntitlementResolutionContext,
+  ): Promise<TenantSubscription | null> {
+    if (hasContextValue(context, 'subscription')) {
+      const subscription = context?.subscription ?? null;
+      assertSubscriptionMatchesSubscriber(subscription, subscriber);
+      return subscription;
+    }
+    return this.findCurrentSubscription(subscriber, now);
+  }
+
+  private async resolvePlan(
+    subscription: TenantSubscription | null,
+    context?: EntitlementResolutionContext,
+  ): Promise<SubscriptionPlan | null> {
+    if (!subscription?.planId) {
+      return null;
+    }
+    if (hasContextValue(context, 'plan')) {
+      const plan = context?.plan ?? null;
+      assertPlanMatchesSubscription(plan, subscription);
+      return plan;
+    }
+    return this.readers.plans.get({ id: subscription.planId });
   }
 
   /**
@@ -302,6 +369,55 @@ function emptyResolution(subscriber: Subscriber): EntitlementResolution {
     thresholdEvaluations: [],
     allowed: false,
   };
+}
+
+function hasContextValue<K extends keyof EntitlementResolutionContext>(
+  context: EntitlementResolutionContext | undefined,
+  key: K,
+): boolean {
+  return context !== undefined && Object.hasOwn(context, key);
+}
+
+function assertSubscriptionMatchesSubscriber(
+  subscription: TenantSubscription | null,
+  subscriber: Subscriber,
+): void {
+  if (!subscription) {
+    return;
+  }
+  const subscriptionSubscriber = subscription.getSubscriber();
+  if (
+    !subscriptionSubscriber ||
+    !sameSubscriber(subscriptionSubscriber, subscriber)
+  ) {
+    throw new Error(
+      'Provided entitlement context subscription does not match requested subscriber',
+    );
+  }
+}
+
+function assertPlanMatchesSubscription(
+  plan: SubscriptionPlan | null,
+  subscription: TenantSubscription,
+): void {
+  if (!plan?.id || !subscription.planId) {
+    return;
+  }
+  if (plan.id !== subscription.planId) {
+    throw new Error(
+      'Provided entitlement context plan does not match subscription.planId',
+    );
+  }
+}
+
+function sameSubscriber(left: Subscriber, right: Subscriber): boolean {
+  if (left.kind !== right.kind || left.tenantId !== right.tenantId) {
+    return false;
+  }
+  if (left.kind === 'tenant') {
+    return true;
+  }
+  return right.kind === 'external' && left.externalId === right.externalId;
 }
 
 function uniqueMetricKeys(metricKeys: string[]): string[] {

--- a/packages/subscriptions/src/services/subscription-resolver.ts
+++ b/packages/subscriptions/src/services/subscription-resolver.ts
@@ -375,7 +375,7 @@ function hasContextValue<K extends keyof EntitlementResolutionContext>(
   context: EntitlementResolutionContext | undefined,
   key: K,
 ): boolean {
-  return context !== undefined && Object.hasOwn(context, key);
+  return context?.[key] !== undefined;
 }
 
 function assertSubscriptionMatchesSubscriber(

--- a/packages/subscriptions/src/services/subscription-resolver.ts
+++ b/packages/subscriptions/src/services/subscription-resolver.ts
@@ -9,7 +9,11 @@ import type {
   UsageSummary,
   UsageWindow,
 } from '../types.js';
-import { getWindowForThreshold, isValidThreshold } from '../utils.js';
+import {
+  getWindowForThreshold,
+  getWindowKey,
+  isValidThreshold,
+} from '../utils.js';
 import { evaluateThreshold } from './threshold-evaluator.js';
 
 export interface SubscriptionPlanReader {
@@ -54,6 +58,13 @@ export interface UsageSummaryReader {
     metricKey: string;
     window: UsageWindow;
   }): Promise<UsageSummary>;
+  summarizeBatch?(options: {
+    tenantId: string;
+    subscriberKind?: Subscriber['kind'];
+    subscriberExternalId?: string;
+    metricKeys: string[];
+    window: UsageWindow;
+  }): Promise<UsageSummary[]>;
 }
 
 export interface SubscriptionResolverReaders {
@@ -96,22 +107,12 @@ export class SubscriptionResolver {
     }
 
     const thresholds = plan.getThresholds().filter(isValidThreshold);
-    const thresholdEvaluations: ThresholdEvaluation[] = [];
-
-    for (const threshold of thresholds) {
-      const window =
-        options.usageWindows?.[threshold.window] ??
-        getWindowForThreshold(threshold.window, now);
-      const usage = await this.readers.usage.summarize({
-        tenantId: subscriber.tenantId,
-        subscriberKind: subscriber.kind,
-        subscriberExternalId:
-          subscriber.kind === 'external' ? subscriber.externalId : undefined,
-        metricKey: threshold.metricKey,
-        window,
-      });
-      thresholdEvaluations.push(evaluateThreshold(threshold, usage));
-    }
+    const thresholdEvaluations = await this.resolveThresholdEvaluations(
+      subscriber,
+      thresholds,
+      now,
+      options,
+    );
 
     return {
       tenantId: subscriber.tenantId,
@@ -202,6 +203,83 @@ export class SubscriptionResolver {
         'that implements findCurrentForSubscriber()',
     );
   }
+
+  private async resolveThresholdEvaluations(
+    subscriber: Subscriber,
+    thresholds: PlanThreshold[],
+    now: Date,
+    options: SubscriptionResolverOptions,
+  ): Promise<ThresholdEvaluation[]> {
+    if (thresholds.length === 0) {
+      return [];
+    }
+
+    if (!this.readers.usage.summarizeBatch) {
+      const evaluations: ThresholdEvaluation[] = [];
+      for (const threshold of thresholds) {
+        const window =
+          options.usageWindows?.[threshold.window] ??
+          getWindowForThreshold(threshold.window, now);
+        const usage = await this.readers.usage.summarize({
+          tenantId: subscriber.tenantId,
+          subscriberKind: subscriber.kind,
+          subscriberExternalId:
+            subscriber.kind === 'external' ? subscriber.externalId : undefined,
+          metricKey: threshold.metricKey,
+          window,
+        });
+        evaluations.push(evaluateThreshold(threshold, usage));
+      }
+      return evaluations;
+    }
+
+    const groups = new Map<
+      string,
+      {
+        window: UsageWindow;
+        entries: Array<{ index: number; threshold: PlanThreshold }>;
+      }
+    >();
+
+    thresholds.forEach((threshold, index) => {
+      const window =
+        options.usageWindows?.[threshold.window] ??
+        getWindowForThreshold(threshold.window, now);
+      const key = getWindowKey(window);
+      const group = groups.get(key) ?? { window, entries: [] };
+      group.entries.push({ index, threshold });
+      groups.set(key, group);
+    });
+
+    const evaluations: ThresholdEvaluation[] = new Array(thresholds.length);
+    await Promise.all(
+      Array.from(groups.values()).map(async ({ window, entries }) => {
+        const metricKeys = uniqueMetricKeys(
+          entries.map((entry) => entry.threshold.metricKey),
+        );
+        const summaries = await this.readers.usage.summarizeBatch?.({
+          tenantId: subscriber.tenantId,
+          subscriberKind: subscriber.kind,
+          subscriberExternalId:
+            subscriber.kind === 'external' ? subscriber.externalId : undefined,
+          metricKeys,
+          window,
+        });
+        const summaryByMetric = new Map(
+          (summaries ?? []).map((summary) => [summary.metricKey, summary]),
+        );
+
+        for (const { index, threshold } of entries) {
+          const usage =
+            summaryByMetric.get(threshold.metricKey) ??
+            emptyUsageSummary(subscriber, threshold.metricKey, window);
+          evaluations[index] = evaluateThreshold(threshold, usage);
+        }
+      }),
+    );
+
+    return evaluations;
+  }
 }
 
 function toSubscriber(input: Subscriber | string): Subscriber {
@@ -224,6 +302,32 @@ function emptyResolution(subscriber: Subscriber): EntitlementResolution {
     thresholdEvaluations: [],
     allowed: false,
   };
+}
+
+function uniqueMetricKeys(metricKeys: string[]): string[] {
+  return Array.from(new Set(metricKeys));
+}
+
+function emptyUsageSummary(
+  subscriber: Subscriber,
+  metricKey: string,
+  window: UsageWindow,
+): UsageSummary {
+  const summary: UsageSummary = {
+    tenantId: subscriber.tenantId,
+    metricKey,
+    quantity: 0,
+    windowStart: window.start,
+    windowEnd: window.end,
+  };
+  if (subscriber.kind === 'external') {
+    return {
+      ...summary,
+      subscriberKind: 'external',
+      subscriberExternalId: subscriber.externalId,
+    };
+  }
+  return summary;
 }
 
 export type { PlanThreshold };

--- a/packages/subscriptions/src/services/subscription-resolver.ts
+++ b/packages/subscriptions/src/services/subscription-resolver.ts
@@ -400,10 +400,10 @@ function assertPlanMatchesSubscription(
   plan: SubscriptionPlan | null,
   subscription: TenantSubscription,
 ): void {
-  if (!plan?.id || !subscription.planId) {
+  if (!plan) {
     return;
   }
-  if (plan.id !== subscription.planId) {
+  if (!plan.id || plan.id !== subscription.planId) {
     throw new Error(
       'Provided entitlement context plan does not match subscription.planId',
     );

--- a/packages/subscriptions/src/services/usage-meter.ts
+++ b/packages/subscriptions/src/services/usage-meter.ts
@@ -4,6 +4,7 @@ import type {
   AiUsageSummary,
   RecordUsageOptions,
   SummarizeAiUsageOptions,
+  SummarizeUsageBatchOptions,
   SummarizeUsageOptions,
   UsageSummary,
 } from '../types.js';
@@ -62,6 +63,60 @@ export class TenantUsageMeter {
     return this.metrics.summarizeUsage(options);
   }
 
+  async summarizeBatch(
+    options: SummarizeUsageBatchOptions,
+  ): Promise<UsageSummary[]> {
+    const subscriber = normalizeSubscriber({
+      tenantId: options.tenantId,
+      subscriberKind: options.subscriberKind,
+      subscriberExternalId: options.subscriberExternalId,
+    });
+    const metricKeys = Array.from(new Set(options.metricKeys));
+    if (metricKeys.length === 0) {
+      return [];
+    }
+
+    const useTenantAiSummary = subscriber.kind === 'tenant';
+    const aiMetricKeys = useTenantAiSummary
+      ? metricKeys.filter((metricKey) => metricKey.startsWith('ai.'))
+      : [];
+    const persistedMetricKeys = useTenantAiSummary
+      ? metricKeys.filter((metricKey) => !metricKey.startsWith('ai.'))
+      : metricKeys;
+
+    const summaries = new Map<string, UsageSummary>();
+    if (aiMetricKeys.length > 0) {
+      const aiSummary = await this.summarizeAiUsage({
+        tenantId: options.tenantId,
+        window: options.window,
+      });
+      const quantityByMetric = aiQuantityByMetric(aiSummary);
+      for (const metricKey of aiMetricKeys) {
+        summaries.set(metricKey, {
+          tenantId: options.tenantId,
+          metricKey,
+          quantity: quantityByMetric[metricKey] ?? 0,
+          windowStart: options.window.start,
+          windowEnd: options.window.end,
+        });
+      }
+    }
+
+    const persistedSummaries = await this.metrics.summarizeUsageBatch({
+      ...options,
+      metricKeys: persistedMetricKeys,
+    });
+    for (const summary of persistedSummaries) {
+      summaries.set(summary.metricKey, summary);
+    }
+
+    return metricKeys.map(
+      (metricKey) =>
+        summaries.get(metricKey) ??
+        emptyUsageSummary(subscriber, metricKey, options.window),
+    );
+  }
+
   async summarizeAiUsage(
     options: SummarizeAiUsageOptions,
   ): Promise<AiUsageSummary> {
@@ -92,11 +147,7 @@ export class TenantUsageMeter {
     });
 
     const quantityByMetric: Record<string, number> = {
-      'ai.tokens.prompt': summary.promptTokens,
-      'ai.tokens.completion': summary.completionTokens,
-      'ai.tokens.total': summary.totalTokens,
-      'ai.cost.estimated': summary.estimatedCost,
-      'ai.requests': summary.requestCount,
+      ...aiQuantityByMetric(summary),
     };
 
     return {
@@ -107,4 +158,36 @@ export class TenantUsageMeter {
       windowEnd: options.window.end,
     };
   }
+}
+
+function aiQuantityByMetric(summary: AiUsageSummary): Record<string, number> {
+  return {
+    'ai.tokens.prompt': summary.promptTokens,
+    'ai.tokens.completion': summary.completionTokens,
+    'ai.tokens.total': summary.totalTokens,
+    'ai.cost.estimated': summary.estimatedCost,
+    'ai.requests': summary.requestCount,
+  };
+}
+
+function emptyUsageSummary(
+  subscriber: ReturnType<typeof normalizeSubscriber>,
+  metricKey: string,
+  window: SummarizeUsageBatchOptions['window'],
+): UsageSummary {
+  const summary: UsageSummary = {
+    tenantId: subscriber.tenantId,
+    metricKey,
+    quantity: 0,
+    windowStart: window.start,
+    windowEnd: window.end,
+  };
+  if (subscriber.kind === 'external') {
+    return {
+      ...summary,
+      subscriberKind: 'external',
+      subscriberExternalId: subscriber.externalId,
+    };
+  }
+  return summary;
 }

--- a/packages/subscriptions/src/types.ts
+++ b/packages/subscriptions/src/types.ts
@@ -157,6 +157,17 @@ export interface SummarizeUsageOptions {
   window: UsageWindow;
 }
 
+export interface SummarizeUsageBatchOptions {
+  /** Owning/issuing tenant scope. */
+  tenantId: string;
+  /** Defaults to `'tenant'`. */
+  subscriberKind?: SubscriberKind;
+  /** Required when `subscriberKind === 'external'`. */
+  subscriberExternalId?: string;
+  metricKeys: string[];
+  window: UsageWindow;
+}
+
 export interface SummarizeAiUsageOptions {
   tenantId: string;
   window: UsageWindow;

--- a/packages/subscriptions/src/types.ts
+++ b/packages/subscriptions/src/types.ts
@@ -1,4 +1,6 @@
 import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+import type { SubscriptionPlan } from './models/SubscriptionPlan.js';
+import type { TenantSubscription } from './models/TenantSubscription.js';
 
 export type SubscriptionStatus =
   | 'active'
@@ -135,9 +137,27 @@ export interface EntitlementResolution {
   allowed: boolean;
 }
 
+export interface EntitlementResolutionContext {
+  /**
+   * Current subscription for the requested subscriber. Set to `null` when a
+   * caller has already resolved that no current subscription exists.
+   */
+  subscription?: TenantSubscription | null;
+  /**
+   * Plan for `subscription.planId`. Set to `null` when the caller has already
+   * resolved the plan as absent or inactive.
+   */
+  plan?: SubscriptionPlan | null;
+}
+
 export interface SubscriptionResolverOptions {
   now?: Date;
   usageWindows?: Partial<Record<ThresholdWindow, UsageWindow>>;
+  /**
+   * Request-scoped context that lets repeated entitlement checks reuse an
+   * already-loaded subscription and plan instead of re-querying readers.
+   */
+  context?: EntitlementResolutionContext;
 }
 
 export interface UsageMeterOptions {

--- a/packages/users/AGENTS.md
+++ b/packages/users/AGENTS.md
@@ -41,7 +41,7 @@ PermissionResolver evaluates in order (each level can add/remove permissions):
 ```typescript
 // hooks.server.ts
 export const handle = createSessionHandler({ db, ttl: 604800, skipPaths: ['/api/public'] });
-// Populates event.locals: { user, permissions: string[], tenantId, sessionId }
+// Populates event.locals: { user, membership, permissions: string[], tenantId, sessionId }
 
 // +page.server.ts
 await createSessionCookie(event, userId, tenantId, { db });

--- a/packages/users/src/__tests__/permission-resolver.test.ts
+++ b/packages/users/src/__tests__/permission-resolver.test.ts
@@ -12,7 +12,7 @@
 import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GroupCollection } from '../collections/GroupCollection.js';
 import { GroupMemberCollection } from '../collections/GroupMemberCollection.js';
 import { GroupRoleCollection } from '../collections/GroupRoleCollection.js';
@@ -39,6 +39,7 @@ describe('User', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     if (existsSync(dbPath)) {
       try {
         rmSync(dbPath, { force: true });
@@ -412,6 +413,7 @@ describe('PermissionResolver', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     if (existsSync(dbPath)) {
       try {
         rmSync(dbPath, { force: true });
@@ -465,6 +467,56 @@ describe('PermissionResolver', () => {
     expect(result.permissions.has('articles.create')).toBe(true);
     expect(result.permissions.has('articles.update')).toBe(true);
     expect(result.permissions.has('articles.delete')).toBe(false);
+  });
+
+  it('should reuse a provided membership instead of querying it again', async () => {
+    const user = await users.create({ email: 'cached-member@example.com' });
+    await user.save();
+
+    const tenant = await tenants.create({ name: 'Cached Member Org' });
+    await tenant.save();
+
+    const role = await roles.create({ name: 'Cached Editor' });
+    await role.save();
+
+    const permission = await permissions.create({
+      slug: 'articles.cache-read',
+      name: 'Read Cached Articles',
+    });
+    await permission.save();
+
+    const userId = user.id;
+    const tenantId = tenant.id;
+    const roleId = role.id;
+    const permissionId = permission.id;
+    if (!userId || !tenantId || !roleId || !permissionId) {
+      throw new Error('Expected persisted test records to have ids.');
+    }
+
+    await rolePermissions.addPermission(roleId, permissionId);
+
+    const membership = await memberships.create({
+      userId,
+      tenantId,
+      roleId,
+    });
+    await membership.save();
+
+    const resolver = await PermissionResolver.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+    const lookupSpy = vi.spyOn(
+      MembershipCollection.prototype,
+      'findByUserAndTenant',
+    );
+
+    const result = await resolver.resolvePermissions(userId, tenantId, {
+      membership,
+    });
+
+    expect(lookupSpy).not.toHaveBeenCalled();
+    expect(result.membershipId).toBe(membership.id);
+    expect(result.permissions.has('articles.cache-read')).toBe(true);
   });
 
   it('should inherit permissions from group roles', async () => {

--- a/packages/users/src/__tests__/session-handler.integration.test.ts
+++ b/packages/users/src/__tests__/session-handler.integration.test.ts
@@ -158,6 +158,11 @@ describe('createSessionHandler integration', () => {
           email: 'handler.integration@example.com',
           id: user.id,
         });
+        expect(requestEvent.locals.membership).toMatchObject({
+          id: membership.id,
+          tenantId: tenant.id,
+          userId: user.id,
+        });
         expect(requestEvent.locals.permissions).toEqual(
           expect.arrayContaining(['request_scoped_documents.read']),
         );
@@ -187,6 +192,11 @@ describe('createSessionHandler integration', () => {
     expect(event.locals.user).toMatchObject({
       email: 'handler.integration@example.com',
       id: user.id,
+    });
+    expect(event.locals.membership).toMatchObject({
+      id: membership.id,
+      tenantId: tenant.id,
+      userId: user.id,
     });
     expect(event.locals.permissions).toEqual(
       expect.arrayContaining(['request_scoped_documents.read']),

--- a/packages/users/src/index.ts
+++ b/packages/users/src/index.ts
@@ -151,6 +151,7 @@ export {
   type PermissionCatalogSource,
   type PermissionCatalogSyncResult,
   type PermissionDefinition,
+  type PermissionResolutionOptions,
   type PermissionResolutionResult,
   PermissionResolver,
   type PostgresPermissionAction,

--- a/packages/users/src/services/PermissionResolver.ts
+++ b/packages/users/src/services/PermissionResolver.ts
@@ -12,6 +12,7 @@ import { PermissionCollection } from '../collections/PermissionCollection.js';
 import { RolePermissionCollection } from '../collections/RolePermissionCollection.js';
 import { TenantCollection } from '../collections/TenantCollection.js';
 import { TenantPermissionOverrideCollection } from '../collections/TenantPermissionOverrideCollection.js';
+import type { Membership } from '../models/Membership.js';
 import type { Tenant } from '../models/Tenant.js';
 
 /**
@@ -28,6 +29,15 @@ export interface PermissionResolutionResult {
   groupIds: string[];
   /** Permission IDs explicitly denied */
   deniedPermissionIds: string[];
+}
+
+export interface PermissionResolutionOptions {
+  /**
+   * Active membership already resolved by the caller for this user/tenant.
+   * Passing this lets request-scoped session loaders avoid re-querying the
+   * same membership row before resolving permissions.
+   */
+  membership?: Membership | null;
 }
 
 /**
@@ -315,6 +325,7 @@ export class PermissionResolver {
   async resolvePermissions(
     userId: string,
     tenantId: string,
+    options: PermissionResolutionOptions = {},
   ): Promise<PermissionResolutionResult> {
     const result: PermissionResolutionResult = {
       permissions: new Set<string>(),
@@ -324,12 +335,16 @@ export class PermissionResolver {
       deniedPermissionIds: [],
     };
 
-    // 1. Get membership
-    const membership = await this.membershipCollection.findByUserAndTenant(
-      userId,
-      tenantId,
-    );
+    // 1. Get membership, reusing a request-scoped row when the caller already
+    // resolved it for this exact user/tenant.
+    const membership =
+      options.membership === undefined
+        ? await this.membershipCollection.findByUserAndTenant(userId, tenantId)
+        : options.membership;
     if (!membership || !membership.isActive()) {
+      return result;
+    }
+    if (membership.userId !== userId || membership.tenantId !== tenantId) {
       return result;
     }
 
@@ -459,8 +474,9 @@ export class PermissionResolver {
     userId: string,
     tenantId: string,
     permissionSlug: string,
+    options: PermissionResolutionOptions = {},
   ): Promise<boolean> {
-    const result = await this.resolvePermissions(userId, tenantId);
+    const result = await this.resolvePermissions(userId, tenantId, options);
     return result.permissions.has(permissionSlug);
   }
 
@@ -471,8 +487,9 @@ export class PermissionResolver {
     userId: string,
     tenantId: string,
     permissionSlugs: string[],
+    options: PermissionResolutionOptions = {},
   ): Promise<boolean> {
-    const result = await this.resolvePermissions(userId, tenantId);
+    const result = await this.resolvePermissions(userId, tenantId, options);
     return permissionSlugs.every((slug) => result.permissions.has(slug));
   }
 
@@ -483,8 +500,9 @@ export class PermissionResolver {
     userId: string,
     tenantId: string,
     permissionSlugs: string[],
+    options: PermissionResolutionOptions = {},
   ): Promise<boolean> {
-    const result = await this.resolvePermissions(userId, tenantId);
+    const result = await this.resolvePermissions(userId, tenantId, options);
     return permissionSlugs.some((slug) => result.permissions.has(slug));
   }
 

--- a/packages/users/src/services/SessionPermissionContext.ts
+++ b/packages/users/src/services/SessionPermissionContext.ts
@@ -28,6 +28,7 @@ export interface SessionPermissionRuntimeContext {
   database?: QueryableDatabase;
   permissions: string[];
   permissionSet: Set<string>;
+  membership: SessionContext['membership'];
   postgresRls: boolean;
   session: SessionContext | null;
   sessionId: string | null;
@@ -225,6 +226,7 @@ export async function withSessionPermissionContext<T>(
     database: transaction ?? baseDatabase,
     permissions: session?.permissions ?? [],
     permissionSet,
+    membership: session?.membership ?? null,
     postgresRls: usePostgresRls,
     session,
     sessionId: session?.sessionId ?? null,

--- a/packages/users/src/services/SessionService.ts
+++ b/packages/users/src/services/SessionService.ts
@@ -22,7 +22,7 @@ export interface SessionContext {
   /** The User record */
   user: User;
   /** Active membership for the current tenant, if one was resolved */
-  membership: Membership | null;
+  membership?: Membership | null;
   /** Resolved permission slugs */
   permissions: string[];
   /** Tenant ID from session (if any) */

--- a/packages/users/src/services/SessionService.ts
+++ b/packages/users/src/services/SessionService.ts
@@ -10,6 +10,7 @@ import {
   SessionCollection,
 } from '../collections/SessionCollection.js';
 import { UserCollection } from '../collections/UserCollection.js';
+import type { Membership } from '../models/Membership.js';
 import { DEFAULT_SESSION_TTL } from '../models/Session.js';
 import type { User } from '../models/User.js';
 import { PermissionResolver } from './PermissionResolver.js';
@@ -20,6 +21,8 @@ import { PermissionResolver } from './PermissionResolver.js';
 export interface SessionContext {
   /** The User record */
   user: User;
+  /** Active membership for the current tenant, if one was resolved */
+  membership: Membership | null;
   /** Resolved permission slugs */
   permissions: string[];
   /** Tenant ID from session (if any) */
@@ -137,10 +140,19 @@ export class SessionService {
 
     // Resolve permissions (only if tenant context exists)
     let permissions: string[] = [];
+    let membership: Membership | null = null;
     if (session.tenantId) {
+      const resolvedMembership =
+        await this.membershipCollection.findByUserAndTenant(
+          session.userId,
+          session.tenantId,
+        );
+      membership = resolvedMembership?.isActive() ? resolvedMembership : null;
+
       const result = await this.permissionResolver.resolvePermissions(
         session.userId,
         session.tenantId,
+        { membership },
       );
       permissions = Array.from(result.permissions);
     }
@@ -155,6 +167,7 @@ export class SessionService {
 
     return {
       user,
+      membership,
       permissions,
       tenantId: session.tenantId,
       sessionId: session.id as string,

--- a/packages/users/src/services/index.ts
+++ b/packages/users/src/services/index.ts
@@ -45,6 +45,7 @@ export {
   type UsersConfig,
 } from './PermissionCatalogService.js';
 export {
+  type PermissionResolutionOptions,
   type PermissionResolutionResult,
   PermissionResolver,
   type TenantPermissionInheritanceResult,

--- a/packages/users/src/sveltekit/index.ts
+++ b/packages/users/src/sveltekit/index.ts
@@ -240,6 +240,7 @@ export function createSessionHandler(options: SessionHandlerOptions): Handle {
   return async ({ event, resolve }) => {
     // Initialize locals with defaults (use property assignment for type safety)
     event.locals.user = null;
+    event.locals.membership = null;
     event.locals.permissions = [];
     event.locals.tenantId = null;
     event.locals.sessionId = null;
@@ -268,6 +269,7 @@ export function createSessionHandler(options: SessionHandlerOptions): Handle {
         async (context) => {
           if (context.session) {
             event.locals.user = context.user;
+            event.locals.membership = context.membership ?? null;
             event.locals.permissions = context.permissions;
             event.locals.tenantId = context.tenantId;
             event.locals.sessionId = context.sessionId;

--- a/packages/users/src/sveltekit/resource-list-handler.ts
+++ b/packages/users/src/sveltekit/resource-list-handler.ts
@@ -117,7 +117,7 @@ export interface CliResource {
 
 export interface ResolvedSession {
   user: SessionLocals['user'];
-  membership: SessionLocals['membership'];
+  membership?: SessionLocals['membership'];
   permissions: string[];
   tenantId: string | null;
   sessionId: string | null;

--- a/packages/users/src/sveltekit/resource-list-handler.ts
+++ b/packages/users/src/sveltekit/resource-list-handler.ts
@@ -117,6 +117,7 @@ export interface CliResource {
 
 export interface ResolvedSession {
   user: SessionLocals['user'];
+  membership: SessionLocals['membership'];
   permissions: string[];
   tenantId: string | null;
   sessionId: string | null;
@@ -897,6 +898,7 @@ async function defaultResolveSession(
   if (locals.user) {
     return {
       user: locals.user,
+      membership: locals.membership ?? null,
       permissions: locals.permissions ?? [],
       tenantId: locals.tenantId ?? null,
       sessionId: locals.sessionId ?? null,
@@ -913,6 +915,7 @@ async function defaultResolveSession(
     }
     return {
       user: ctx.user,
+      membership: ctx.membership ?? null,
       permissions: ctx.permissions,
       tenantId: ctx.tenantId,
       sessionId: ctx.sessionId,
@@ -922,6 +925,7 @@ async function defaultResolveSession(
   // 3. Truly anonymous.
   return {
     user: null,
+    membership: null,
     permissions: [],
     tenantId: null,
     sessionId: null,

--- a/packages/users/src/sveltekit/types.ts
+++ b/packages/users/src/sveltekit/types.ts
@@ -3,6 +3,7 @@
  * @packageDocumentation
  */
 
+import type { Membership } from '../models/Membership.js';
 import type { User } from '../models/User.js';
 
 /**
@@ -20,6 +21,8 @@ import type { User } from '../models/User.js';
 export interface SessionLocals {
   /** The authenticated user (null if not authenticated) */
   user: User | null;
+  /** Active membership for the current tenant (null if none) */
+  membership: Membership | null;
   /** User's resolved permissions */
   permissions: string[];
   /** Current tenant context (null if no tenant selected) */
@@ -33,6 +36,7 @@ export interface SessionLocals {
  */
 export const defaultSessionLocals: SessionLocals = {
   user: null,
+  membership: null,
   permissions: [],
   tenantId: null,
   sessionId: null,

--- a/packages/users/src/sveltekit/types.ts
+++ b/packages/users/src/sveltekit/types.ts
@@ -22,7 +22,7 @@ export interface SessionLocals {
   /** The authenticated user (null if not authenticated) */
   user: User | null;
   /** Active membership for the current tenant (null if none) */
-  membership: Membership | null;
+  membership?: Membership | null;
   /** User's resolved permissions */
   permissions: string[];
   /** Current tenant context (null if no tenant selected) */


### PR DESCRIPTION
## Summary

Fixes #1570.
Fixes #1573.

- Reuse the active `Membership` already loaded for a request/session when resolving user permissions.
- Carry `membership` through `SessionContext`, SvelteKit locals, request permission context, and resource-list session resolution.
- Batch subscription threshold usage summaries by usage window, with a back-compatible single-metric fallback.
- Add `SubscriptionResolver.create()` and `EntitlementResolutionContext` so request-scoped callers can reuse default readers plus preloaded subscription/plan state.
- Add collection-level and meter-level batch usage APIs for persisted tenant metrics and tenant-scoped `ai.*` metrics.

## Root Cause

The default SaaS request path repeatedly re-resolved the same tenant membership and subscription entitlement state. Subscription threshold evaluation also fanned out to one usage summary call per threshold, which scaled with threshold count even when all thresholds shared the same usage window.

## Review Notes

I did a manual pass over request-context propagation, tenancy boundaries, public exports, generated SQL columns, and the reusable entitlement context API. One defect was found during review: a caller-provided context plan without an `id` could be trusted without proving it matched `subscription.planId`. That now fails closed and has regression coverage.

SMRT deterministic review context raised only routing warnings for public entrypoint/docs/generated-surface changes; those were checked manually.

## Validation

- `pnpm --filter @happyvertical/smrt-users test`
- `pnpm --filter @happyvertical/smrt-users typecheck`
- `pnpm --filter @happyvertical/smrt-users build`
- `pnpm --filter @happyvertical/smrt-subscriptions test`
- `pnpm --filter @happyvertical/smrt-subscriptions typecheck`
- `pnpm --filter @happyvertical/smrt-subscriptions build`
- `pnpm exec biome check --max-diagnostics 200 <changed files>`
- `pnpm knowledge:check --changed --strict --format markdown`
- `git diff --check`
- pre-commit and pre-push hooks

Biome reports existing non-null assertion warnings in older users tests and resolver code; no blocking errors were introduced. Pre-push workflow validation also reports an existing line-length warning in `.github/workflows/test-suite.yml`, while still passing.