### PR TITLE
feat(core): inject object field data into is()/do()/describe() prompts

### DIFF
--- a/packages/analytics/src/models/AnalyticsProperty.ts
+++ b/packages/analytics/src/models/AnalyticsProperty.ts
@@ -260,7 +260,8 @@ export class AnalyticsProperty extends SmrtObject {
    * AI-powered: Check if property is performing well
    */
   async isPerformingWell(): Promise<boolean> {
-    return await this.is(`
+    return await this.is(
+      `
       Based on the property configuration and metadata:
       - Property: ${this.displayName}
       - Provider: ${this.provider}
@@ -268,7 +269,10 @@ export class AnalyticsProperty extends SmrtObject {
       - Last sync: ${this.lastSyncAt}
 
       Is this property properly configured and likely performing well?
-    `);
+    `,
+      // Property fields hand-rolled above; skip is()'s object-data injection.
+      { includeData: false },
+    );
   }
 }
 

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -18,7 +18,7 @@ ORM, code generation, AI integration, and the DispatchBus. Everything else build
 
 - `initialize()`: loads field initializers, applies option values (options override initializers), loads from DB if id/slug provided
 - `save()`: upsert with STI validation, interceptor execution, auto-embeddings. Persisted objects (`isPersisted` — set by DB hydration and successful saves) upsert on `['id']` so natural-key edits (e.g. slug renames) update in place; new objects upsert on the natural-key conflict columns for ingestion-style dedup (#1472)
-- `is(criteria)` / `do(instructions)`: AI operations via function calling
+- `is(criteria)` / `do(instructions)` / `describe()`: AI operations via function calling. They inject the object's own `toPublicJSON()` (sensitive fields stripped) as a "content body" so the model reasons over the instance. Options: `includeData: false` skips injection (for callers that already curate the relevant fields into the instruction); `maxDataLength` overrides the truncation budget. Neither key is forwarded to `ai.message()`. (#1567)
 - `getSlug()`: auto-generates from name → title → label → id
 - `loadRelated(fieldName)`: lazy-loads relationships (cached in `_loadedRelationships` Map)
 

--- a/packages/core/src/__tests__/issue-1567-ai-methods-include-object-data.test.ts
+++ b/packages/core/src/__tests__/issue-1567-ai-methods-include-object-data.test.ts
@@ -135,6 +135,13 @@ describe('Issue #1567: AI methods include the object field data', () => {
     // The huge value is cut off, not sent whole.
     expect(prompt).not.toContain('X'.repeat(2000));
 
+    // The budget is a hard ceiling: the injected content body (marker included)
+    // never exceeds maxDataLength.
+    const contentBody = prompt
+      .split('--- Beginning of content ---\n')[1]
+      ?.split('\n--- End of content ---')[0] as string;
+    expect(contentBody.length).toBeLessThanOrEqual(100);
+
     // The control option is stripped; real AI options still pass through.
     const opts = message.mock.calls[0]?.[1] as Record<string, unknown>;
     expect(opts).not.toHaveProperty('maxDataLength');

--- a/packages/core/src/__tests__/issue-1567-ai-methods-include-object-data.test.ts
+++ b/packages/core/src/__tests__/issue-1567-ai-methods-include-object-data.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Test for issue #1567: `is()`, `do()`, and `describe()` must reason over the
+ * object's own field data — not just the caller's instruction/criteria string.
+ * https://github.com/happyvertical/smrt/issues/1567
+ *
+ * Before this fix the prompt template referenced "the content body" but only
+ * the instruction was interpolated, so `product.is('costs more than $10')` and
+ * `product.do('write a marketing description')` were evaluated with no
+ * knowledge of the product's actual fields.
+ *
+ * The object is now injected as the "content body" via `toPublicJSON()`, so:
+ * - non-sensitive field values appear in the prompt the model receives;
+ * - `@field({ sensitive: true })` values are NEVER sent to the model;
+ * - oversized payloads are truncated by a coarse token-budget guard (default
+ *   and explicit `maxDataLength`);
+ * - callers that already curate their own fields can opt out with
+ *   `includeData: false`;
+ * - the `maxDataLength` / `includeData` control keys are not forwarded to
+ *   `ai.message()`.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { field } from '../decorators';
+import { SmrtObject } from '../object';
+import { smrt } from '../registry';
+
+// Unique class name to avoid AST-scanner collisions (issue #543).
+@smrt()
+class Issue1567Product extends SmrtObject {
+  @field({ type: 'text' })
+  name: string = '';
+
+  @field({ type: 'decimal' })
+  price: number = 0.0;
+
+  @field({ type: 'text', sensitive: true })
+  supplierApiKey: string = '';
+}
+
+/**
+ * Build an explicit mock AI client. The `embed` function + absence of a
+ * `provider` key is what marks it as a pre-built client in SmrtClass runtime
+ * init, so it is used verbatim instead of constructing a real provider.
+ */
+function makeAiClient(reply: string) {
+  const message = vi.fn(async () => reply);
+  return {
+    client: { embed: vi.fn(), message } as any,
+    message,
+  };
+}
+
+function makeProduct(reply: string) {
+  const { client, message } = makeAiClient(reply);
+  const product = new Issue1567Product({ ai: client });
+  product.name = 'Acme Widget';
+  product.price = 19.99;
+  product.supplierApiKey = 'sk-secret-supplier-key';
+  return { product, message };
+}
+
+describe('Issue #1567: AI methods include the object field data', () => {
+  it('do() injects the object public data as the content body', async () => {
+    const { product, message } = makeProduct('A short marketing blurb');
+
+    const result = await product.do('write a marketing description');
+
+    expect(result).toBe('A short marketing blurb');
+    expect(message).toHaveBeenCalledTimes(1);
+
+    const prompt = message.mock.calls[0]?.[0] as string;
+    expect(prompt).toContain('--- Beginning of content ---');
+    expect(prompt).toContain('Acme Widget');
+    expect(prompt).toContain('19.99');
+    expect(prompt).toContain('write a marketing description');
+    // The instruction-only prompt is gone; the data is genuinely present.
+    expect(prompt).not.toContain('[truncated');
+  });
+
+  it('do() never sends @field({ sensitive: true }) values to the model', async () => {
+    const { product, message } = makeProduct('ok');
+
+    await product.do('summarize this product');
+
+    const prompt = message.mock.calls[0]?.[0] as string;
+    expect(prompt).toContain('Acme Widget');
+    expect(prompt).not.toContain('sk-secret-supplier-key');
+    expect(prompt).not.toContain('supplierApiKey');
+  });
+
+  it('is() injects the object data alongside the criteria and returns a boolean', async () => {
+    const { product, message } = makeProduct('{"result": true}');
+
+    const result = await product.is('costs more than ten dollars');
+
+    expect(result).toBe(true);
+
+    const prompt = message.mock.calls[0]?.[0] as string;
+    expect(prompt).toContain('--- Beginning of content ---');
+    expect(prompt).toContain('Acme Widget');
+    expect(prompt).toContain('19.99');
+    expect(prompt).toContain('costs more than ten dollars');
+    // Still excludes secrets.
+    expect(prompt).not.toContain('sk-secret-supplier-key');
+
+    // json_object response format is preserved (it follows the spread).
+    const opts = message.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(opts.responseFormat).toEqual({ type: 'json_object' });
+  });
+
+  it('describe() injects the object data as the content body', async () => {
+    const { product, message } = makeProduct('A premium widget.');
+
+    const result = await product.describe();
+
+    expect(result).toBe('A premium widget.');
+
+    const prompt = message.mock.calls[0]?.[0] as string;
+    expect(prompt).toContain('--- Beginning of content ---');
+    expect(prompt).toContain('Acme Widget');
+    expect(prompt).not.toContain('sk-secret-supplier-key');
+  });
+
+  it('truncates oversized object data and does not forward maxDataLength to ai.message()', async () => {
+    const { client, message } = makeAiClient('ok');
+    const product = new Issue1567Product({ ai: client });
+    product.name = 'X'.repeat(2000);
+
+    await product.do('summarize', { maxDataLength: 100, model: 'gpt-4o-mini' });
+
+    const prompt = message.mock.calls[0]?.[0] as string;
+    expect(prompt).toContain(
+      '[truncated: object data exceeded 100 characters]',
+    );
+    // The huge value is cut off, not sent whole.
+    expect(prompt).not.toContain('X'.repeat(2000));
+
+    // The control option is stripped; real AI options still pass through.
+    const opts = message.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(opts).not.toHaveProperty('maxDataLength');
+    expect(opts.model).toBe('gpt-4o-mini');
+  });
+
+  it('truncates at the default budget when no maxDataLength is given', async () => {
+    const { client, message } = makeAiClient('ok');
+    const product = new Issue1567Product({ ai: client });
+    // Comfortably larger than the 100_000-char default guard.
+    product.name = 'Y'.repeat(120_000);
+
+    await product.do('summarize');
+
+    const prompt = message.mock.calls[0]?.[0] as string;
+    expect(prompt).toContain(
+      '[truncated: object data exceeded 100000 characters]',
+    );
+    expect(prompt).not.toContain('Y'.repeat(120_000));
+  });
+
+  it('omits the content body entirely when includeData is false', async () => {
+    const { product, message } = makeProduct('ok');
+
+    await product.do('summarize this product', {
+      includeData: false,
+      model: 'gpt-4o-mini',
+    });
+
+    const prompt = message.mock.calls[0]?.[0] as string;
+    // No content section, and none of the object's field values are injected.
+    expect(prompt).not.toContain('--- Beginning of content ---');
+    expect(prompt).not.toContain('Acme Widget');
+    expect(prompt).not.toContain('19.99');
+    // The caller's own instruction is still present.
+    expect(prompt).toContain('summarize this product');
+
+    // The control option is stripped; real AI options still pass through.
+    const opts = message.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(opts).not.toHaveProperty('includeData');
+    expect(opts.model).toBe('gpt-4o-mini');
+  });
+
+  it('honors includeData:false for is() (criteria-only prompt, boolean result)', async () => {
+    const { product, message } = makeProduct('{"result": false}');
+
+    const result = await product.is('costs more than ten dollars', {
+      includeData: false,
+    });
+
+    expect(result).toBe(false);
+    const prompt = message.mock.calls[0]?.[0] as string;
+    expect(prompt).not.toContain('--- Beginning of content ---');
+    expect(prompt).not.toContain('Acme Widget');
+    expect(prompt).toContain('costs more than ten dollars');
+    // responseFormat is still forced even with the data omitted.
+    const opts = message.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(opts.responseFormat).toEqual({ type: 'json_object' });
+  });
+
+  it('honors includeData:false for describe()', async () => {
+    const { product, message } = makeProduct('A premium widget.');
+
+    await product.describe({ includeData: false });
+
+    const prompt = message.mock.calls[0]?.[0] as string;
+    expect(prompt).not.toContain('--- Beginning of content ---');
+    expect(prompt).not.toContain('Acme Widget');
+    expect(prompt).toContain('Generate a concise, professional description');
+  });
+});

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -2063,7 +2063,13 @@ export class SmrtObject extends SmrtClass {
       maxLength > 0 &&
       serialized.length > maxLength
     ) {
-      serialized = `${serialized.slice(0, maxLength)}\n… [truncated: object data exceeded ${maxLength} characters]`;
+      const marker = `\n… [truncated: object data exceeded ${maxLength} characters]`;
+      // Reserve room for the marker so the returned string never exceeds
+      // maxLength — the budget is a hard ceiling, not "data + marker". For a
+      // budget smaller than the marker itself, emit just the marker (an
+      // unusably small budget still yields a clear truncation signal).
+      const keep = Math.max(0, maxLength - marker.length);
+      serialized = `${serialized.slice(0, keep)}${marker}`;
     }
 
     return serialized;

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -39,6 +39,18 @@ const logger = createLogger({
 });
 
 /**
+ * Default maximum number of characters of serialized object data injected into
+ * the AI prompts built by `is()`, `do()`, and `describe()`.
+ *
+ * Acts as a coarse token-budget guard so a very large instance (e.g. a long
+ * document body) cannot blow past model context limits or inflate request
+ * costs. At roughly four characters per token this is ~25k tokens of object
+ * data — generous enough for typical records, while still capping pathological
+ * cases. Override per call with the `maxDataLength` option.
+ */
+const AI_PROMPT_DATA_MAX_LENGTH = 100_000;
+
+/**
  * Validate that _meta_type matches the expected class (Issue #713)
  *
  * Accepts both simple class name (e.g., 'Product') and qualified name
@@ -2013,14 +2025,96 @@ export class SmrtObject extends SmrtClass {
   }
 
   /**
+   * Serializes this instance into the "content body" injected into the AI
+   * prompts used by {@link is}, {@link do}, and {@link describe} so those
+   * methods reason over the object's own field data, not just the caller's
+   * instruction string.
+   *
+   * Uses {@link toPublicJSON} (never {@link toJSON}) so that
+   * `@field({ sensitive: true })` values — API secrets, credentials, tax IDs —
+   * are never sent to the model. The serialized payload is truncated to
+   * `maxLength` characters as a coarse token-budget guard for large instances;
+   * truncation appends a clear marker so the model knows the data was cut.
+   *
+   * @param maxLength - Maximum characters of object data to include
+   *   (defaults to {@link AI_PROMPT_DATA_MAX_LENGTH}). A non-positive value
+   *   disables truncation.
+   * @returns A JSON string of the object's public (sensitive-stripped) fields
+   */
+  private serializeForAiPrompt(
+    maxLength: number = AI_PROMPT_DATA_MAX_LENGTH,
+  ): string {
+    let serialized: string;
+    try {
+      serialized = JSON.stringify(this.toPublicJSON(), null, 2);
+    } catch (error) {
+      // Defensive: never let a serialization edge case break an AI call.
+      // The instruction-only prompt still works; we just lose the data context.
+      logger.warn(
+        `Failed to serialize ${this.constructor.name} for AI prompt: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      serialized = '{}';
+    }
+
+    if (
+      Number.isFinite(maxLength) &&
+      maxLength > 0 &&
+      serialized.length > maxLength
+    ) {
+      serialized = `${serialized.slice(0, maxLength)}\n… [truncated: object data exceeded ${maxLength} characters]`;
+    }
+
+    return serialized;
+  }
+
+  /**
+   * Builds the optional "content body" section prepended to the AI prompts in
+   * {@link is}, {@link do}, and {@link describe}.
+   *
+   * Returns an empty string when the caller opts out with `includeData: false`
+   * — used by callers that already curate the object's relevant fields into
+   * their own instruction/criteria string (so the data is not duplicated, and
+   * the prompt stays exactly as the caller authored it). Otherwise it wraps
+   * {@link serializeForAiPrompt} in `--- Beginning/End of content ---`
+   * delimiters so the methods reason over the instance's own data by default.
+   *
+   * @param includeData - `false` to omit the section; any other value (incl.
+   *   `undefined`) injects it
+   * @param maxLength - Forwarded to {@link serializeForAiPrompt} as the
+   *   truncation budget
+   * @returns The content-body section (with a trailing newline) or `''`
+   */
+  private buildAiContentSection(
+    includeData: boolean | undefined,
+    maxLength?: number,
+  ): string {
+    if (includeData === false) {
+      return '';
+    }
+    const contentBody = this.serializeForAiPrompt(maxLength);
+    return `--- Beginning of content ---\n${contentBody}\n--- End of content ---\n`;
+  }
+
+  /**
    * Evaluates whether this object satisfies the given natural-language criteria using AI.
    *
-   * Sends the object's JSON representation to the AI with the criteria prompt and
-   * asks for a `{ result: boolean }` JSON response. Uses any AI-callable tools
-   * registered on this class (via `@smrt({ ai })`) as part of the function-calling context.
+   * Injects the object's own public field data (via {@link toPublicJSON}, so
+   * `@field({ sensitive: true })` values are excluded) into the prompt as the
+   * "content body", then asks the AI whether that data meets the criteria and
+   * to reply with a `{ result: boolean }` JSON response. Uses any AI-callable
+   * tools registered on this class (via `@smrt({ ai })`) as part of the
+   * function-calling context.
    *
    * @param criteria - Natural-language description of the condition to evaluate
-   * @param options - AI message options passed to `ai.message()` (e.g. model override)
+   * @param options - AI message options passed to `ai.message()` (e.g. model
+   *   override). Two non-standard control keys are consumed here and not
+   *   forwarded to `ai.message()`:
+   *   - `includeData: false` — omit the injected object "content body" (for
+   *     callers that already curate the relevant fields into `criteria`).
+   *   - `maxDataLength` (number of characters) — override the injected
+   *     object-data truncation limit.
    * @returns `true` if the object meets the criteria, `false` otherwise
    * @throws Error if the AI returns a non-boolean or malformed JSON response
    *
@@ -2035,13 +2129,18 @@ export class SmrtObject extends SmrtClass {
    */
   public async is(criteria: string, options: any = {}) {
     const ai = await this.getAiClient();
-    const prompt = `--- Beginning of criteria ---\n${criteria}\n--- End of criteria ---\nDoes the content meet all the given criteria? Reply with a json object with a single boolean 'result' property`;
+    const { maxDataLength, includeData, ...aiOptions } = options ?? {};
+    const contentSection = this.buildAiContentSection(
+      includeData,
+      maxDataLength,
+    );
+    const prompt = `${contentSection}--- Beginning of criteria ---\n${criteria}\n--- End of criteria ---\nDoes the content meet all the given criteria? Reply with a json object with a single boolean 'result' property`;
 
     // Get available tools for AI function calling
     const tools = this.getAvailableTools();
 
     const message = await ai.message(prompt, {
-      ...(options as any),
+      ...(aiOptions as any),
       responseFormat: { type: 'json_object' },
       tools: tools.length > 0 ? tools : undefined,
     });
@@ -2059,16 +2158,24 @@ export class SmrtObject extends SmrtClass {
   /**
    * Performs a freeform operation on this object using AI instructions.
    *
-   * Sends the object's JSON representation to the AI together with the given
-   * instructions and returns the raw text response. Unlike `is()`, this method
-   * does not constrain the response format — use it for transformations,
-   * summaries, extractions, or any open-ended AI task.
+   * Injects the object's own public field data (via {@link toPublicJSON}, so
+   * `@field({ sensitive: true })` values are excluded) into the prompt as the
+   * "content body" the instructions operate on, then returns the raw text
+   * response. Unlike `is()`, this method does not constrain the response
+   * format — use it for transformations, summaries, extractions, or any
+   * open-ended AI task.
    *
    * Uses any AI-callable tools registered on this class (via `@smrt({ ai })`)
    * as part of the function-calling context.
    *
    * @param instructions - Natural-language instructions for the AI to follow
-   * @param options - AI message options passed to `ai.message()` (e.g. model override)
+   * @param options - AI message options passed to `ai.message()` (e.g. model
+   *   override). Two non-standard control keys are consumed here and not
+   *   forwarded to `ai.message()`:
+   *   - `includeData: false` — omit the injected object "content body" (for
+   *     callers that already curate the relevant fields into `instructions`).
+   *   - `maxDataLength` (number of characters) — override the injected
+   *     object-data truncation limit.
    * @returns The raw AI response string
    *
    * @example
@@ -2082,13 +2189,18 @@ export class SmrtObject extends SmrtClass {
    */
   public async do(instructions: string, options: any = {}) {
     const ai = await this.getAiClient();
-    const prompt = `--- Beginning of instructions ---\n${instructions}\n--- End of instructions ---\nBased on the content body, please follow the instructions and provide a response. Never make use of codeblocks.`;
+    const { maxDataLength, includeData, ...aiOptions } = options ?? {};
+    const contentSection = this.buildAiContentSection(
+      includeData,
+      maxDataLength,
+    );
+    const prompt = `${contentSection}--- Beginning of instructions ---\n${instructions}\n--- End of instructions ---\nBased on the content body, please follow the instructions and provide a response. Never make use of codeblocks.`;
 
     // Get available tools for AI function calling
     const tools = this.getAvailableTools();
 
     const result = await ai.message(prompt, {
-      ...options,
+      ...aiOptions,
       tools: tools.length > 0 ? tools : undefined,
     });
 
@@ -2099,9 +2211,17 @@ export class SmrtObject extends SmrtClass {
    * Generates a description of this object using AI (Issue #52)
    *
    * Creates a concise, human-readable description based on the object's content
-   * and properties. Useful for summaries, previews, and documentation.
+   * and properties. The object's own public field data (via
+   * {@link toPublicJSON}, so `@field({ sensitive: true })` values are excluded)
+   * is injected into the prompt as the "content body" the description is built
+   * from. Useful for summaries, previews, and documentation.
    *
-   * @param options - AI message options (can include style, length, focus, etc.)
+   * @param options - AI message options (can include style, length, focus,
+   *   etc.). Two non-standard control keys are consumed here and not forwarded
+   *   to `ai.message()`:
+   *   - `includeData: false` — omit the injected object "content body".
+   *   - `maxDataLength` (number of characters) — override the injected
+   *     object-data truncation limit.
    * @returns Promise resolving to the AI-generated description
    *
    * @example
@@ -2117,13 +2237,18 @@ export class SmrtObject extends SmrtClass {
    */
   public async describe(options: any = {}) {
     const ai = await this.getAiClient();
-    const prompt = `Generate a concise, professional description of this object based on its content and properties. The description should be clear, informative, and suitable for display to end users. Focus on the most important and distinctive characteristics.`;
+    const { maxDataLength, includeData, ...aiOptions } = options ?? {};
+    const contentSection = this.buildAiContentSection(
+      includeData,
+      maxDataLength,
+    );
+    const prompt = `${contentSection}Generate a concise, professional description of this object based on its content and properties. The description should be clear, informative, and suitable for display to end users. Focus on the most important and distinctive characteristics.`;
 
     // Get available tools for AI function calling
     const tools = this.getAvailableTools();
 
     const result = await ai.message(prompt, {
-      ...options,
+      ...aiOptions,
       tools: tools.length > 0 ? tools : undefined,
     });
 

--- a/packages/projects/src/issue-prompt-integration.test.ts
+++ b/packages/projects/src/issue-prompt-integration.test.ts
@@ -159,4 +159,52 @@ describe('Issue prompt integration', () => {
     expect(explicitMessage).toHaveBeenCalledTimes(1);
     expect(getAI).not.toHaveBeenCalled();
   });
+
+  it('keeps incorporateFeedback curated (no object-dump injection) so the body is not duplicated (#1567)', async () => {
+    // No `template` override → the default feedback template is used, which
+    // interpolates only {body} and {comments}. Setting `profile: 'deep'`
+    // resolves a provider so the synthesis routes through sendPromptMessage().
+    await overrides.create({
+      key: issueIncorporateFeedbackPrompt.key,
+      tenantId: null,
+      profile: 'deep',
+    });
+
+    const issue = new Issue({
+      db,
+      tenantId: null,
+      title: 'Quarterly Analytics Rollout',
+      body: 'Current specification body',
+      state: 'open',
+    });
+
+    vi.spyOn(issue, 'getComments').mockResolvedValue([
+      {
+        author: 'alice',
+        body: 'Please add analytics instrumentation.',
+        createdAt: new Date('2026-01-02T00:00:00.000Z'),
+      },
+    ] as any);
+
+    const messageSpy = vi.fn(async () => 'Updated spec body');
+    vi.mocked(getAI).mockResolvedValue({ message: messageSpy } as any);
+
+    await issue.incorporateFeedback();
+
+    expect(messageSpy).toHaveBeenCalledTimes(1);
+    const promptText = messageSpy.mock.calls[0]?.[0] as string;
+
+    // The curated template (body once + comments) is present...
+    expect(promptText).toContain('Current specification body');
+    expect(promptText).toContain(
+      '- alice: Please add analytics instrumentation.',
+    );
+    // ...but the object is NOT dumped on top. The template already curates the
+    // relevant fields, so there is no `toPublicJSON()` content body (which would
+    // duplicate the body and leak unrelated fields like `title`).
+    expect(promptText).not.toContain('--- Beginning of content ---');
+    expect(promptText).not.toContain('Quarterly Analytics Rollout');
+    // The body appears exactly once (no duplication from a content-body dump).
+    expect(promptText.split('Current specification body')).toHaveLength(2);
+  });
 });

--- a/packages/projects/src/models/Comment.ts
+++ b/packages/projects/src/models/Comment.ts
@@ -128,6 +128,8 @@ export class Comment extends SmrtObject {
       Only return the JSON array, nothing else.
 
       Comment: ${this.body}`,
+      // Body is hand-rolled above; skip do()'s object-data injection (no dup).
+      { includeData: false },
     );
 
     try {
@@ -150,6 +152,8 @@ export class Comment extends SmrtObject {
     return await this.do(
       `Summarize this comment in one sentence.
       Comment by ${this.author}: ${this.body}`,
+      // Author + body hand-rolled above; skip do()'s object-data injection.
+      { includeData: false },
     );
   }
 
@@ -163,6 +167,8 @@ export class Comment extends SmrtObject {
       `Classify the sentiment of this comment as exactly one of: positive, negative, neutral
       Only return one word.
       Comment: ${this.body}`,
+      // Body is hand-rolled above; skip do()'s object-data injection (no dup).
+      { includeData: false },
     );
 
     const normalized = result.toLowerCase().trim();

--- a/packages/projects/src/models/Issue.ts
+++ b/packages/projects/src/models/Issue.ts
@@ -362,7 +362,12 @@ export class Issue extends SmrtObject {
         aiOptions,
       );
     } else {
-      synthesized = await this.do(resolvedPrompt.text, aiOptions);
+      // The resolved prompt template already curates the issue body + comments,
+      // so opt out of do()'s object-data injection to avoid duplicating the body.
+      synthesized = await this.do(resolvedPrompt.text, {
+        ...aiOptions,
+        includeData: false,
+      });
     }
 
     const result: IncorporateFeedbackResult = {
@@ -449,6 +454,15 @@ export class Issue extends SmrtObject {
     return this.sendPromptMessage(ai, instructions, options);
   }
 
+  /**
+   * Sends a fully-resolved instruction string to the given AI client.
+   *
+   * `incorporateFeedback()` curates the entire prompt (issue body + comments)
+   * via the resolved prompt template, so this path deliberately does NOT inject
+   * the object's own field data — that would duplicate the body. The `this.do()`
+   * fallback path passes `includeData: false` for the same reason, keeping both
+   * `incorporateFeedback()` paths consistent (#1567).
+   */
   private async sendPromptMessage(
     ai: { message: (prompt: string, options?: any) => Promise<string> },
     instructions: string,

--- a/packages/projects/src/models/Project.ts
+++ b/packages/projects/src/models/Project.ts
@@ -408,6 +408,9 @@ export class Project extends SmrtObject {
       1. Overall health assessment
       2. Potential bottlenecks
       3. Suggestions for improvement`,
+      // Title/description/status counts hand-rolled above; skip do()'s
+      // object-data injection so the board context is not duplicated.
+      { includeData: false },
     );
   }
 

--- a/packages/projects/src/models/PullRequest.ts
+++ b/packages/projects/src/models/PullRequest.ts
@@ -155,6 +155,8 @@ export class PullRequest extends Issue {
       1. What the PR does
       2. Why it matters
       3. Any notable implementation details`,
+      // Title/body/stats hand-rolled above; skip do()'s object-data injection.
+      { includeData: false },
     );
   }
 
@@ -289,6 +291,8 @@ export class PullRequest extends Issue {
 
       Return only a comma-separated list of GitHub usernames, nothing else.
       If you cannot determine reviewers, return an empty string.`,
+      // Title/description hand-rolled above; skip do()'s object-data injection.
+      { includeData: false },
     );
 
     return suggestion


### PR DESCRIPTION
## Summary

Closes #1567.

`SmrtObject.is()`, `do()`, and `describe()` built prompts that referenced *"the content body"* but only interpolated the caller's instruction/criteria — the object's **own field data was never included**. So `product.do('write a marketing description')` and `issue.needsReview()` were evaluated with no knowledge of the instance.

This injects the object's `toPublicJSON()` (sensitive fields stripped) as a **content body** so the methods reason over the instance by default, with a coarse truncation guard and an opt-out for callers that already curate their own context.

## What changed

**Core ([`packages/core/src/object.ts`](https://github.com/happyvertical/smrt/blob/claude/zen-bouman-e90bb0/packages/core/src/object.ts))**
- `is()` / `do()` / `describe()` prepend a `--- Beginning of content ---` block built from `toPublicJSON()` — never `toJSON()`, so `@field({ sensitive: true })` values (API secrets, credentials) are **never** sent to the model (stripped at both top level and the STI `_meta_data` nesting).
- Char-count truncation guard: default `AI_PROMPT_DATA_MAX_LENGTH = 100_000`, override per call via `maxDataLength`. Serialization is wrapped defensively so a circular/edge-case object can never break an AI call.
- New `includeData: false` opt-out for callers that already hand-roll the relevant fields. Both `includeData` and `maxDataLength` are stripped before reaching `ai.message()`.

**Opt-out applied to curated callers** (they already interpolate their own fields, so this avoids duplicating content and preserves their exact prior prompts):
- projects: `Comment.{extractActionItems,summarize,getSentiment}`, `PullRequest.{summarize,suggestReviewers}`, `Project.analyzeHealth`
- analytics: `AnalyticsProperty.isPerformingWell`
- `Issue.incorporateFeedback` curates body + comments via its prompt template, so **both** synthesis paths (resolved-provider `sendPromptMessage` and the `this.do()` fallback) now stay curated-only — the body is no longer duplicated.

**Naive callers left injecting** (they interpolated *no* fields and were silently evaluating against empty context before this fix): `Comment.is{Question,Approval,…}`, `Issue.{needsReview,isBugReport,isFeatureRequest,suggestLabels}`, `PullRequest.isReadyToMerge`, `Profile.matches`. These are now actually data-aware.

## Why the opt-out (not opt-in)

Several existing methods were *silently broken* — asking the model to judge an object it couldn't see. Injection must therefore default **on** (to fix them), with curated callers opting **out**. This was surfaced by review: the first blanket implementation duplicated content in callers that already embed `${this.body}`/`${this.title}`.

## Testing

- New core regression suite (9 tests): default injection, sensitive-field exclusion, `is()`/`describe()` injection, explicit + default-budget truncation, control-key stripping, and `includeData:false` for all three methods.
- Updated projects integration test asserts `incorporateFeedback` stays curated (body appears exactly once, no content-body dump).
- ✅ core suite (1981 passed) · projects (31) · analytics (287) · typecheck (core/projects/analytics) · Biome — all green.

## Review

Two independent review passes (Claude reviewers): round 1 caught the duplication, round 2 verified the remediation as *"correct and complete, no blocker or major findings"*, including the caller categorization and the `incorporateFeedback` dual-path consistency.
