### PR TITLE
fix(stabilization): smrt-vitest DOM lib build + remove cli dead code

### DIFF
--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -60,17 +60,6 @@ import {
   type StiDiscriminatorRepairConflict,
 } from './sti-upgrade.js';
 
-/**
- * Column definition type for migration comparison
- */
-interface ColumnDef {
-  type: string;
-  notNull?: boolean;
-  defaultValue?: any;
-  unique?: boolean;
-  primaryKey?: boolean;
-}
-
 function formatSchemaCommandFailureHeader(
   error: unknown,
   fallback: string,
@@ -123,15 +112,6 @@ function migrationResultError(result: MigrationResult): Error {
   });
 }
 
-/**
- * Index definition type for migration comparison
- */
-interface IndexDef {
-  name: string;
-  columns: string[];
-  unique?: boolean;
-}
-
 type DDLPreviewEngine = 'sqlite' | 'duckdb' | 'json' | 'postgres';
 
 export function resolveVitestEntrypoint(fromDir = process.cwd()): string {
@@ -153,137 +133,6 @@ function resolveDDLPreviewEngine(dbType: string): DDLPreviewEngine {
     default:
       return 'sqlite';
   }
-}
-
-/**
- * Parse expected columns from a schema definition
- * Handles both DDL string parsing and columns object format
- */
-function parseExpectedColumns(schema: {
-  ddl: string;
-  tableName: string;
-  indexes?: string[];
-}): Record<string, ColumnDef> {
-  const columns: Record<string, ColumnDef> = {};
-
-  // Try to extract columns from DDL using regex
-  // Match: CREATE TABLE ... ( column definitions )
-  const createTableMatch = schema.ddl.match(
-    /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?["']?(\w+)["']?\s*\(([\s\S]+?)\)(?:\s*;)?$/im,
-  );
-
-  if (!createTableMatch) {
-    return columns;
-  }
-
-  const columnSection = createTableMatch[2];
-
-  // Split by comma, but not commas inside parentheses (for CHECK constraints)
-  const parts: string[] = [];
-  let depth = 0;
-  let current = '';
-
-  for (const char of columnSection) {
-    if (char === '(') depth++;
-    else if (char === ')') depth--;
-
-    if (char === ',' && depth === 0) {
-      parts.push(current.trim());
-      current = '';
-    } else {
-      current += char;
-    }
-  }
-  if (current.trim()) {
-    parts.push(current.trim());
-  }
-
-  for (const part of parts) {
-    // Skip foreign key constraints, primary key constraints, etc.
-    if (
-      /^\s*(FOREIGN\s+KEY|PRIMARY\s+KEY|UNIQUE|CHECK|CONSTRAINT)/i.test(part)
-    ) {
-      continue;
-    }
-
-    // Parse column definition: "column_name" TYPE [constraints]
-    // Handle both quoted and unquoted column names
-    const colMatch = part.match(
-      /^["']?(\w+)["']?\s+(\w+(?:\s*\([^)]+\))?)\s*(.*)?$/i,
-    );
-
-    if (colMatch) {
-      const colName = colMatch[1];
-      const colType = colMatch[2].toUpperCase();
-      const constraints = colMatch[3] || '';
-
-      columns[colName] = {
-        type: colType,
-        notNull:
-          /NOT\s+NULL/i.test(constraints) || /PRIMARY\s+KEY/i.test(constraints),
-        unique: /UNIQUE/i.test(constraints),
-        primaryKey: /PRIMARY\s+KEY/i.test(constraints),
-      };
-
-      // Extract default value - handle SQL escaped quotes ('' -> ')
-      const defaultMatch = constraints.match(
-        /DEFAULT\s+(?:'((?:[^']|'{2})*)'|(\d+(?:\.\d+)?)|(\w+))/i,
-      );
-      if (defaultMatch) {
-        const rawDefault =
-          defaultMatch[1] ?? defaultMatch[2] ?? defaultMatch[3];
-        // Unescape SQL single-quoted strings: '' -> '
-        columns[colName].defaultValue =
-          defaultMatch[1] !== undefined
-            ? rawDefault.replace(/''/g, "'")
-            : rawDefault;
-      }
-    }
-  }
-
-  return columns;
-}
-
-/**
- * Parse expected indexes from a schema definition
- * Handles index SQL strings in the indexes array
- */
-function parseExpectedIndexes(schema: {
-  ddl: string;
-  tableName: string;
-  indexes?: string[];
-}): IndexDef[] {
-  const indexes: IndexDef[] = [];
-
-  if (!schema.indexes || schema.indexes.length === 0) {
-    return indexes;
-  }
-
-  for (const indexSQL of schema.indexes) {
-    // Parse: CREATE [UNIQUE] INDEX index_name ON table_name (columns)
-    // Support both quoted and unquoted identifiers
-    const match = indexSQL.match(
-      /CREATE\s+(UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:"([^"]+)"|'([^']+)'|(\w+))\s+ON\s+(?:"[^"]+"|'[^']+'|\w+)\s*\(([^)]+)\)/i,
-    );
-
-    if (match) {
-      const isUnique = !!match[1];
-      // Index name can be in group 2 (double-quoted), 3 (single-quoted), or 4 (unquoted)
-      const indexName = match[2] ?? match[3] ?? match[4];
-      const columnsStr = match[5];
-      const columns = columnsStr
-        .split(',')
-        .map((c) => c.trim().replace(/["']/g, ''));
-
-      indexes.push({
-        name: indexName,
-        columns,
-        unique: isUnique,
-      });
-    }
-  }
-
-  return indexes;
 }
 
 /**
@@ -311,67 +160,6 @@ function formatStiConflictIdentity(
       : '';
 
   return `${identity}${ids}`;
-}
-
-/**
- * Normalize SQL types for comparison
- * Different databases use different type names for the same logical type.
- * Preserves size distinctions (BIGINT vs INTEGER, VARCHAR(50) vs TEXT) to avoid
- * hiding important schema differences.
- */
-function normalizeType(type: string): string {
-  const upper = type.toUpperCase().trim();
-
-  // Normalize integer types - preserve size distinctions
-  if (/^(INTEGER|INT)$/i.test(upper)) {
-    return 'INTEGER';
-  }
-  if (/^BIGINT$/i.test(upper)) {
-    return 'BIGINT';
-  }
-  if (/^SMALLINT$/i.test(upper)) {
-    return 'SMALLINT';
-  }
-  if (/^TINYINT$/i.test(upper)) {
-    return 'TINYINT';
-  }
-
-  // Normalize text types - preserve length-limited types
-  // Only normalize truly unbounded text types to TEXT
-  if (/^(TEXT|CLOB|STRING)$/i.test(upper)) {
-    return 'TEXT';
-  }
-  // Keep VARCHAR and CHAR with their size specs (e.g., VARCHAR(50))
-  if (/^(VARCHAR|CHAR)/i.test(upper)) {
-    return upper; // Preserve as-is to detect size mismatches
-  }
-
-  // Normalize decimal/float types
-  if (/^(REAL|FLOAT|DOUBLE|DECIMAL|NUMERIC|NUMBER)/i.test(upper)) {
-    return 'REAL';
-  }
-
-  // Normalize boolean types
-  if (/^(BOOLEAN|BOOL)/i.test(upper)) {
-    return 'BOOLEAN';
-  }
-
-  // Normalize date/time types
-  if (/^(DATETIME|TIMESTAMP|DATE|TIME)/i.test(upper)) {
-    return 'TIMESTAMP';
-  }
-
-  // Normalize blob types
-  if (/^(BLOB|BINARY|BYTEA)/i.test(upper)) {
-    return 'BLOB';
-  }
-
-  // Normalize JSON types
-  if (/^(JSON|JSONB)/i.test(upper)) {
-    return 'JSON';
-  }
-
-  return upper;
 }
 
 /**

--- a/packages/vitest/tsconfig.json
+++ b/packages/vitest/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2023",
-    "lib": ["ES2023"],
+    "lib": ["ES2023", "DOM"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "outDir": "./dist",


### PR DESCRIPTION
## Summary

Two small stabilization follow-ups from epic #1354 (companion cleanup to the security-audit + coverage tracks).

### #1568 — smrt-vitest `tsc` build fails (DOM lib missing)
`src/a11y.ts` and `src/svelte-setup.ts` (added with the S11 UI test harness, #1416) use DOM globals (`HTMLElement`, `document`, `HTMLDialogElement`), but `packages/vitest/tsconfig.json` had `lib: ["ES2023"]` with no DOM. So `pnpm --filter @happyvertical/smrt-vitest build` (tsc) failed in a clean tree, and `turbo build --continue` flagged it as a failed task.

**Fix:** add `"DOM"` to `lib`.

### #1569 — dead code in cli `utilities.ts`
`parseExpectedColumns`, `parseExpectedIndexes`, and `normalizeType` (plus the local `ColumnDef`/`IndexDef` interfaces used only by them) were unreferenced anywhere outside their own definitions — ~130 lines of unreachable code that capped `utilities.ts` coverage near ~85%.

Verified each appears exactly once (its definition) via repo-wide grep. The `this.normalizeType` in `packages/core/src/migrations/differ.ts` is an unrelated private class method and is untouched. `quoteIdentifier` (genuinely used by `db:migrate`'s STI repair) is kept.

**Fix:** delete the three functions and two interfaces.

## Verification
- `pnpm --filter @happyvertical/smrt-vitest build` → exit 0 (was failing)
- `npx turbo build --continue` → 50/50 tasks pass (no failed smrt-vitest task)
- `pnpm --filter @happyvertical/smrt-cli typecheck` → clean
- `pnpm --filter @happyvertical/smrt-cli test` → 757 passed, 4 skipped (53 files) — no test exercised the removed code, confirming it was dead

Closes #1568
Closes #1569