### PR TITLE
fix(core,cli,config,scanner,types): T1 deep-review remediation (#1354)

### DIFF
--- a/packages/cli/src/__tests__/cli-generator-coverage.test.ts
+++ b/packages/cli/src/__tests__/cli-generator-coverage.test.ts
@@ -21,6 +21,7 @@
  */
 
 import { ObjectRegistry } from '@happyvertical/smrt-core';
+import { parseCliArgs } from '@happyvertical/utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CLIGenerator } from '../cli-generator.js';
 
@@ -758,6 +759,128 @@ describe('CLIGenerator - handlers (in-memory collection)', () => {
     await expect(
       (cli as any).handleDelete('Widget', 'nope', { force: true }),
     ).rejects.toThrow(/not found/);
+  });
+});
+
+/**
+ * Regression for the kebab-vs-camel CRUD option bugs (#1385). The list/create/
+ * update commands declare `'order-by'` and `'from-file'`, and `parseCliArgs`
+ * returns keys verbatim — so the handlers must read the kebab keys. The
+ * handler-direct tests above pass `{ orderBy }` / `{ fromFile }`, the camelCase
+ * keys the real CLI never produces, which masked the bug. These route the real
+ * argv through `parseCliArgs` and the generated command's own handler.
+ */
+describe('CLIGenerator - CRUD options via parseCliArgs (regression #1385)', () => {
+  let cli: CLIGenerator;
+  beforeEach(() => {
+    cli = new CLIGenerator({ prompt: false, colors: false });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  async function commandFor(objectName: string, suffix: string): Promise<any> {
+    const commands = await (cli as any).generateObjectCommands(objectName, {});
+    const lower = objectName.toLowerCase();
+    const cmd = commands.find((c: any) => c.name === `${lower}:${suffix}`);
+    if (!cmd) throw new Error(`command ${lower}:${suffix} not generated`);
+    return cmd;
+  }
+
+  it('honors --order-by routed through parseCliArgs', async () => {
+    // No fields needed for list; getFields is only consulted by create/update.
+    const listCmd = await commandFor('Widget', 'list');
+    const listSpy = vi.fn().mockResolvedValue([]);
+    vi.spyOn(cli as any, 'getCollection').mockResolvedValue({
+      list: listSpy,
+    } as any);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const parsed = parseCliArgs(
+      ['widget:list', '--order-by', 'name'],
+      [listCmd],
+      {},
+    );
+    // Premise: the kebab key is produced, not a camelCase one.
+    expect(parsed.options['order-by']).toBe('name');
+    expect((parsed.options as any).orderBy).toBeUndefined();
+
+    await listCmd.handler(parsed.args, parsed.options);
+
+    expect(listSpy).toHaveBeenCalledTimes(1);
+    expect(listSpy.mock.calls[0][0]).toMatchObject({ orderBy: 'name' });
+  });
+
+  it('honors --from-file on create routed through parseCliArgs', async () => {
+    vi.spyOn(ObjectRegistry, 'getFields').mockReturnValue(new Map());
+    const createCmd = await commandFor('Widget', 'create');
+
+    const { mkdtemp, writeFile } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const dir = await mkdtemp(join(tmpdir(), 'smrt-cli-ff-'));
+    const filePath = join(dir, 'data.json');
+    await writeFile(filePath, JSON.stringify({ title: 'FromKebabFile' }));
+
+    const created: any[] = [];
+    vi.spyOn(cli as any, 'getCollection').mockResolvedValue({
+      create: async (data: any) => ({
+        ...data,
+        id: 'x1',
+        async save() {
+          created.push(this);
+        },
+      }),
+    } as any);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const parsed = parseCliArgs(
+      ['widget:create', '--from-file', filePath],
+      [createCmd],
+      {},
+    );
+    expect(parsed.options['from-file']).toBe(filePath);
+    expect((parsed.options as any).fromFile).toBeUndefined();
+
+    await createCmd.handler(parsed.args, parsed.options);
+
+    expect(created).toHaveLength(1);
+    expect(created[0].title).toBe('FromKebabFile');
+  });
+
+  it('honors --from-file on update routed through parseCliArgs', async () => {
+    vi.spyOn(ObjectRegistry, 'getFields').mockReturnValue(new Map());
+    const updateCmd = await commandFor('Widget', 'update');
+
+    const { mkdtemp, writeFile } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const dir = await mkdtemp(join(tmpdir(), 'smrt-cli-ffu-'));
+    const filePath = join(dir, 'data.json');
+    await writeFile(filePath, JSON.stringify({ title: 'UpdatedFromFile' }));
+
+    const saved: any[] = [];
+    const existing: any = {
+      id: '1',
+      title: 'Old',
+      async save() {
+        saved.push(this);
+      },
+    };
+    vi.spyOn(cli as any, 'getCollection').mockResolvedValue({
+      get: async () => existing,
+    } as any);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const parsed = parseCliArgs(
+      ['widget:update', '1', '--from-file', filePath],
+      [updateCmd],
+      {},
+    );
+    expect(parsed.options['from-file']).toBe(filePath);
+
+    await updateCmd.handler(parsed.args, parsed.options);
+
+    expect(saved).toHaveLength(1);
+    expect(existing.title).toBe('UpdatedFromFile');
   });
 });
 

--- a/packages/cli/src/cli-generator.ts
+++ b/packages/cli/src/cli-generator.ts
@@ -1616,8 +1616,11 @@ export class CLIGenerator {
         offset: Number.parseInt(options.offset, 10),
       };
 
-      if (options.orderBy) {
-        listOptions.orderBy = options.orderBy;
+      // `parseCliArgs` returns the declared kebab key verbatim ('order-by'),
+      // so read that first; keep the camel fallback for handler-direct callers.
+      const orderBy = options['order-by'] ?? options.orderBy;
+      if (orderBy) {
+        listOptions.orderBy = orderBy;
       }
 
       if (options.where) {
@@ -1684,10 +1687,13 @@ export class CLIGenerator {
     try {
       let data: any = {};
 
-      if (options.fromFile) {
+      // Declared kebab option ('from-file') arrives verbatim from parseCliArgs;
+      // keep the camel fallback for handler-direct callers.
+      const fromFile = options['from-file'] ?? options.fromFile;
+      if (fromFile) {
         // Load from file
         const fs = await import('node:fs/promises');
-        const content = await fs.readFile(options.fromFile, 'utf-8');
+        const content = await fs.readFile(fromFile, 'utf-8');
         data = JSON.parse(content);
       } else if (options.interactive && this.config.prompt) {
         // Interactive mode
@@ -1740,10 +1746,13 @@ export class CLIGenerator {
 
       let data: any = {};
 
-      if (options.fromFile) {
+      // Declared kebab option ('from-file') arrives verbatim from parseCliArgs;
+      // keep the camel fallback for handler-direct callers.
+      const fromFile = options['from-file'] ?? options.fromFile;
+      if (fromFile) {
         // Load from file
         const fs = await import('node:fs/promises');
-        const content = await fs.readFile(options.fromFile, 'utf-8');
+        const content = await fs.readFile(fromFile, 'utf-8');
         data = JSON.parse(content);
       } else if (options.interactive && this.config.prompt) {
         // Interactive mode with current values

--- a/packages/cli/src/commands/__tests__/db-rollback.test.ts
+++ b/packages/cli/src/commands/__tests__/db-rollback.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { clearCache, setConfig } from '@happyvertical/smrt-config';
 import { MigrationTracker } from '@happyvertical/smrt-core/migrations';
 import { getDatabase } from '@happyvertical/sql';
+import { parseCliArgs } from '@happyvertical/utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { dbRollbackCommand } from '../db-rollback.js';
 
@@ -367,5 +368,79 @@ describe('db:rollback (real SQLite)', () => {
     const history = await readHistory();
     expect(history[0].status).toBe('rolled_back');
     expect(questionMock).toHaveBeenCalled();
+  });
+
+  /**
+   * Regression for the data-loss BLOCKER (#1385): the `'dry-run'` option is
+   * declared kebab-cased, and `parseCliArgs` returns keys verbatim, so the real
+   * CLI produces `options['dry-run']`. The handler previously read
+   * `options.dryRun` (always undefined on the CLI path), so `--dry-run` fell
+   * through and executed real rollbacks. The handler-direct tests above passed a
+   * `{ dryRun: true }` key the real CLI never produces, masking the hole — these
+   * tests route through `parseCliArgs` like the actual command dispatcher.
+   */
+  describe('--dry-run via parseCliArgs (regression #1385)', () => {
+    function route(argv: string[]) {
+      const parsed = parseCliArgs(
+        ['db:rollback', ...argv],
+        [dbRollbackCommand as any],
+        {},
+      );
+      return dbRollbackCommand.handler(parsed.args, parsed.options);
+    }
+
+    it('produces the kebab option key, not a camelCase one', () => {
+      const parsed = parseCliArgs(
+        ['db:rollback', '--dry-run', '--force'],
+        [dbRollbackCommand as any],
+        {},
+      );
+      // Proves the premise: the real CLI never yields `dryRun`.
+      expect(parsed.options['dry-run']).toBe(true);
+      expect((parsed.options as any).dryRun).toBeUndefined();
+    });
+
+    it('does NOT execute any rollback when --dry-run is passed (data-loss guard)', async () => {
+      await seedMigrations([
+        nonReversibleDef('dry_one'),
+        nonReversibleDef('dry_two'),
+      ]);
+
+      // Stub the destructive boundaries: the reversible path goes through
+      // MigrationTracker.rollback; the non-reversible path issues a raw UPDATE
+      // via db.query. Neither must fire under --dry-run.
+      const rollbackSpy = vi.spyOn(MigrationTracker.prototype, 'rollback');
+
+      await route(['--dry-run', '--force']);
+
+      expect(rollbackSpy).not.toHaveBeenCalled();
+      expect(output()).toContain('Dry-run');
+
+      // Real DB state is the ground truth: nothing was marked rolled_back.
+      const history = await readHistory();
+      expect(history.every((m) => m.status === 'completed')).toBe(true);
+
+      rollbackSpy.mockRestore();
+    });
+
+    it('emits structured dry-run JSON without mutating history via the CLI path', async () => {
+      await seedMigrations([nonReversibleDef('dry_json')]);
+
+      await route(['--dry-run', '--json', '--force']);
+
+      const parsed = lastJson();
+      expect(parsed.dryRun).toBe(true);
+      const history = await readHistory();
+      expect(history.every((m) => m.status === 'completed')).toBe(true);
+    });
+
+    it('still executes the rollback when --dry-run is absent (CLI path)', async () => {
+      await seedMigrations([nonReversibleDef('wet_one')]);
+
+      await route(['--force']);
+
+      const history = await readHistory();
+      expect(history[0].status).toBe('rolled_back');
+    });
   });
 });

--- a/packages/cli/src/commands/__tests__/git-commands.test.ts
+++ b/packages/cli/src/commands/__tests__/git-commands.test.ts
@@ -21,6 +21,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { parseCliArgs } from '@happyvertical/utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mergeObjects } from '../git.js';
 
@@ -265,6 +266,41 @@ describe('merge-json handler', () => {
     const printed = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
     expect(printed).toContain('"id": "a"');
     // Dry run must not rewrite ours.
+    expect(readFileSync(ours, 'utf-8')).toBe(oursBefore);
+  });
+
+  // Regression for #1385: the `'dry-run'` option is declared kebab-cased and
+  // `parseCliArgs` returns keys verbatim, so the real CLI yields
+  // `options['dry-run']`. The handler previously read `options.dryRun`, so the
+  // real `--dry-run` flag was ignored and the merge OVERWROTE the "ours" file
+  // instead of printing a preview. The handler-direct test above passed
+  // `{ dryRun: true }`, the camel key the CLI never produces, masking the bug.
+  it('does NOT overwrite ours when --dry-run is routed through parseCliArgs', async () => {
+    const base = write('base.json', '[]');
+    const ours = write('ours.json', JSON.stringify([{ id: 'a' }]));
+    const theirs = write('theirs.json', JSON.stringify([{ id: 'b' }]));
+    const oursBefore = readFileSync(ours, 'utf-8');
+
+    const { gitCommands } = await import('../git.js');
+    const mergeJson = gitCommands['merge-json'];
+
+    const parsed = parseCliArgs(
+      ['merge-json', base, ours, theirs, '--dry-run'],
+      [mergeJson as any],
+      {},
+    );
+    // Premise: the kebab key is produced, not a camelCase one.
+    expect(parsed.options['dry-run']).toBe(true);
+    expect((parsed.options as any).dryRun).toBeUndefined();
+
+    await expect(
+      mergeJson.handler(parsed.args, parsed.options),
+    ).rejects.toThrow();
+    expect(firstExit()).toBe(0);
+
+    const printed = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(printed).toContain('"id": "a"');
+    // The whole point: the dry run preview must not have rewritten ours.
     expect(readFileSync(ours, 'utf-8')).toBe(oursBefore);
   });
 

--- a/packages/cli/src/commands/db-command-utils.ts
+++ b/packages/cli/src/commands/db-command-utils.ts
@@ -46,6 +46,16 @@ export function redactConnectionString(value: string): string {
   );
 }
 
+/**
+ * Quote a SQL identifier (table name, column name, etc.).
+ *
+ * Uses double quotes, the ANSI SQL standard understood by SQLite, PostgreSQL,
+ * and DuckDB, and escapes embedded double quotes by doubling them.
+ */
+export function quoteIdentifier(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
 export function formatDatabaseDisplayUrl(
   dbType: string,
   dbUrl: string,

--- a/packages/cli/src/commands/db-migrate-uuid.ts
+++ b/packages/cli/src/commands/db-migrate-uuid.ts
@@ -71,6 +71,7 @@ import { autoDiscoverAndLoad } from '../discovery/index.js';
 import {
   closeDatabaseConnection,
   formatDatabaseDisplayUrl,
+  quoteIdentifier,
 } from './db-command-utils.js';
 
 const UUID_RE =
@@ -178,10 +179,6 @@ export function planUuidConversions(
   }
 
   return { convert, skipDirtyData, skipNotDeclared };
-}
-
-function quoteIdent(value: string): string {
-  return `"${value.replaceAll('"', '""')}"`;
 }
 
 interface RenameSpec {
@@ -386,8 +383,8 @@ export const dbMigrateUuidCommand: CLICommand = {
           );
           let nonUuid = 0;
           if (declared) {
-            const t = quoteIdent(row.table_name);
-            const c = quoteIdent(row.column_name);
+            const t = quoteIdentifier(row.table_name);
+            const c = quoteIdentifier(row.column_name);
             const { rows } = await db.query(
               `SELECT count(*)::text AS n
                  FROM ${t}
@@ -451,8 +448,8 @@ export const dbMigrateUuidCommand: CLICommand = {
         }
 
         for (const { table, column, hasDefault } of convert) {
-          const t = quoteIdent(table);
-          const c = quoteIdent(column);
+          const t = quoteIdentifier(table);
+          const c = quoteIdentifier(column);
           if (hasDefault) {
             const dropDefault = `ALTER TABLE ${t} ALTER COLUMN ${c} DROP DEFAULT`;
             console.log(`  ${dropDefault};`);
@@ -528,9 +525,9 @@ async function applyRenameBackfills(
   if (useOwnTxn) await db.query('BEGIN');
   try {
     for (const spec of renameSpecs) {
-      const t = quoteIdent(spec.table);
-      const from = quoteIdent(spec.from);
-      const to = quoteIdent(spec.to);
+      const t = quoteIdentifier(spec.table);
+      const from = quoteIdentifier(spec.from);
+      const to = quoteIdentifier(spec.to);
 
       // Skip if the old column is already gone (idempotent re-run).
       const fromExists = await columnExists(
@@ -647,7 +644,9 @@ async function columnExists(
   }
   // SQLite / DuckDB: PRAGMA-style introspection.
   try {
-    const { rows } = await db.query(`PRAGMA table_info(${quoteIdent(table)})`);
+    const { rows } = await db.query(
+      `PRAGMA table_info(${quoteIdentifier(table)})`,
+    );
     return (rows as any[]).some((r) => r.name === column);
   } catch {
     return false;

--- a/packages/cli/src/commands/db-rollback.ts
+++ b/packages/cli/src/commands/db-rollback.ts
@@ -51,6 +51,12 @@ export const dbRollbackCommand: CLICommand = {
   handler: async (_args: string[], options: any) => {
     let db: any;
 
+    // `parseCliArgs` returns option keys verbatim, so the declared `'dry-run'`
+    // arrives as the kebab key `options['dry-run']` — not `options.dryRun`.
+    // Read the kebab key first (real CLI path) and keep the camel fallback so
+    // handler-direct callers/tests passing `{ dryRun: true }` still work.
+    const dryRun = options['dry-run'] ?? options.dryRun;
+
     try {
       // 1. Load CLI config
       const { getPackageConfig } = await import('@happyvertical/smrt-config');
@@ -176,7 +182,7 @@ export const dbRollbackCommand: CLICommand = {
       }
 
       // 9. Confirm rollback (unless --force or --dry-run)
-      if (!options.force && !options.dryRun && !options.json) {
+      if (!options.force && !dryRun && !options.json) {
         console.log('⚠️  WARNING: This will revert database changes!');
 
         const readline = await import('node:readline/promises');
@@ -196,7 +202,7 @@ export const dbRollbackCommand: CLICommand = {
       }
 
       // 10. Dry-run mode
-      if (options.dryRun) {
+      if (dryRun) {
         if (options.json) {
           console.log(
             JSON.stringify({

--- a/packages/cli/src/commands/git.ts
+++ b/packages/cli/src/commands/git.ts
@@ -545,7 +545,12 @@ export const gitCommands: Record<string, CLICommand> = {
         // Format output (preserve pretty-printing)
         const output = JSON.stringify(merged, null, 2);
 
-        if (options.dryRun) {
+        // Declared kebab option ('dry-run') arrives verbatim from parseCliArgs;
+        // reading `options.dryRun` here previously caused --dry-run to overwrite
+        // the "ours" file instead of printing a preview. Keep the camel fallback
+        // for handler-direct callers/tests.
+        const dryRun = options['dry-run'] ?? options.dryRun;
+        if (dryRun) {
           // Dry run - output to stdout
           console.log(output);
         } else {

--- a/packages/cli/src/commands/sti-upgrade.ts
+++ b/packages/cli/src/commands/sti-upgrade.ts
@@ -3,6 +3,7 @@ import {
   isQualifiedName,
   ObjectRegistry,
 } from '@happyvertical/smrt-core';
+import { quoteIdentifier } from './db-command-utils.js';
 
 type QueryableDb = {
   query(sql: string, ...params: any[]): Promise<any>;
@@ -72,10 +73,6 @@ export function resolveStiDiscriminatorUpgrade(
     currentQualifiedName,
     sourceKind: isQualifiedName(metaType) ? 'stale-qualified' : 'simple',
   };
-}
-
-function quoteIdentifier(name: string): string {
-  return `"${name.replace(/"/g, '""')}"`;
 }
 
 function rowsFromResult(result: any): any[] {

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -25,6 +25,7 @@ import { configExportCommand } from './config-export.js';
 import {
   closeDatabaseConnection,
   formatDatabaseDisplayUrl,
+  quoteIdentifier,
 } from './db-command-utils.js';
 import { dbDiffCommand } from './db-diff.js';
 import { dbGenerateCommand } from './db-generate.js';
@@ -133,15 +134,6 @@ function resolveDDLPreviewEngine(dbType: string): DDLPreviewEngine {
     default:
       return 'sqlite';
   }
-}
-
-/**
- * Quote a SQL identifier (table name, column name, etc.)
- * Uses double quotes which is ANSI SQL standard and works across SQLite, PostgreSQL, and DuckDB
- */
-function quoteIdentifier(name: string): string {
-  // Escape any double quotes in the identifier by doubling them
-  return `"${name.replace(/"/g, '""')}"`;
 }
 
 function formatStiConflictIdentity(

--- a/packages/cli/src/loaders/git-loader.test.ts
+++ b/packages/cli/src/loaders/git-loader.test.ts
@@ -160,6 +160,50 @@ describe('git-loader (download + extraction)', () => {
     await expect(cleanupGitTemplate(config)).resolves.toBeUndefined();
   });
 
+  // Regression for #1385: a subdirectory template (github:user/repo/subdir)
+  // resolves its config under <tempDir>/subdir, but the overlay base used to be
+  // stored as the repo-root tempDir, so overlayTemplate copied from the wrong
+  // place and subdir templates were effectively broken. The fix records the
+  // subdir-resolved dir as __templateRoot; getGitTemplateDir must return it.
+  it('uses the subdirectory as the overlay base for subdir templates', async () => {
+    mockExtract.mockImplementation((opts: any) => {
+      extractState.cwd = opts.cwd;
+      const stream = new EventEmitter() as any;
+      stream.write = vi.fn();
+      stream.end = vi.fn();
+      setImmediate(() => {
+        // The real tar extraction lays out the whole repo; the template lives
+        // in a subdirectory. Write the config under <tempDir>/templates/site.
+        const subdir = join(opts.cwd, 'templates', 'site');
+        mkdirSync(subdir, { recursive: true });
+        writeFileSync(
+          join(subdir, 'template.config.js'),
+          `export default ${JSON.stringify({
+            name: 'Subdir Template',
+            description: 'lives in a subdir',
+            dependencies: { dep: '1.0.0' },
+          })};`,
+          'utf-8',
+        );
+        stream.emit('finish');
+      });
+      return stream;
+    });
+    mockHttpsGet.mockImplementation(fakeSuccessfulGet());
+
+    const config = await loadGitTemplate('github:user/repo/templates/site');
+    expect(config.name).toBe('Subdir Template');
+
+    // The overlay base must point at the subdir, not the repo-root temp dir.
+    const overlayBase = getGitTemplateDir(config);
+    expect(overlayBase.endsWith(join('templates', 'site'))).toBe(true);
+    // __tempDir remains the repo root so cleanup removes the whole tree.
+    expect((config as any).__tempDir).not.toBe(overlayBase);
+    expect(overlayBase.startsWith((config as any).__tempDir)).toBe(true);
+
+    await cleanupGitTemplate(config);
+  });
+
   // When the extracted .js config loads but fails validation, loadGitTemplate's
   // outer try/catch swallows the validation error and falls through to the .ts
   // attempt, which then fails to import — surfacing as a "no config" error.

--- a/packages/cli/src/loaders/git-loader.ts
+++ b/packages/cli/src/loaders/git-loader.ts
@@ -371,8 +371,12 @@ export async function loadGitTemplate(gitUrl: string): Promise<TemplateConfig> {
       // Validate
       validateTemplateConfig(config, configPath);
 
-      // Store temp directory in config for later cleanup
+      // Store the repo-root temp dir for cleanup and the subdir-resolved dir
+      // (`templateDir`) for overlay. For non-subdir templates these are equal;
+      // for `github:user/repo/subdir` the overlay must read from the subdir,
+      // not the repo root (regression #1385).
       (config as any).__tempDir = tempDir;
+      (config as any).__templateRoot = templateDir;
 
       return config;
     } catch (_error) {
@@ -385,6 +389,7 @@ export async function loadGitTemplate(gitUrl: string): Promise<TemplateConfig> {
 
         validateTemplateConfig(config, tsConfigPath);
         (config as any).__tempDir = tempDir;
+        (config as any).__templateRoot = templateDir;
 
         return config;
       } catch {
@@ -402,13 +407,18 @@ export async function loadGitTemplate(gitUrl: string): Promise<TemplateConfig> {
 
 /**
  * Get the template directory path (for copying overlay files)
+ *
+ * Prefers the subdir-resolved `__templateRoot` so that subdirectory templates
+ * (`github:user/repo/subdir`) overlay from the subdir rather than the repo root.
+ * Falls back to `__tempDir` for configs loaded before the field existed.
  */
 export function getGitTemplateDir(config: TemplateConfig): string {
-  const tempDir = (config as any).__tempDir;
-  if (!tempDir) {
+  const templateRoot =
+    (config as any).__templateRoot ?? (config as any).__tempDir;
+  if (!templateRoot) {
     throw new Error('Template was not loaded from git repository');
   }
-  return tempDir;
+  return templateRoot;
 }
 
 /**

--- a/packages/cli/src/loaders/npm-loader.test.ts
+++ b/packages/cli/src/loaders/npm-loader.test.ts
@@ -149,6 +149,23 @@ describe('npm-loader (real filesystem)', () => {
       const resolved = await resolveNpmPackage('local-template-pkg');
       expect(resolved).toContain('local-template-pkg');
     });
+
+    // Regression for the ESM crash (#1385): the loader used bare `require`/
+    // `module` in a "type":"module" package. The fix recreates `require` via
+    // createRequire and uses `require.resolve.paths(...)`. cwd is the empty
+    // temp dir, so a successful resolve here must have gone through the
+    // module-resolution paths (where the dependency is actually installed),
+    // exercising the new `require.resolve.paths` code path rather than the
+    // node_modules/<cwd> access fallback.
+    it('resolves an installed dependency via require.resolve (not cwd access)', async () => {
+      // `fast-glob` is a real dependency of this package but is NOT under the
+      // temp project cwd, so the access() fallback cannot find it.
+      const resolved = await resolveNpmPackage('fast-glob');
+      expect(resolved).toContain('fast-glob');
+      // The access() fallback would return `${cwd}/node_modules/...`; the
+      // require.resolve path points at the real install location instead.
+      expect(resolved).not.toContain(join(tempDir, 'node_modules'));
+    });
   });
 
   describe('findTemplateInPackages', () => {
@@ -217,4 +234,39 @@ describe('npm-loader (real filesystem)', () => {
       expect(templates).toEqual([]);
     });
   });
+});
+
+/**
+ * Regression guard for the ESM `require`/`module` crash (#1385).
+ *
+ * Both npm-loader and template-loader live in a pure-ESM ("type":"module")
+ * package, where the CommonJS `require`/`module` globals are undefined. The
+ * shipped dist had no shim, so `smrt gnode create --template <npm-pkg>` threw
+ * `ReferenceError` against the built artifact (the test suite ran through
+ * Vite's transform, which silently shims `require`/`module`).
+ *
+ * The in-process tests above run under Vite's shim and therefore cannot observe
+ * the native-ESM failure. This static check asserts the source uses
+ * `createRequire(import.meta.url)` and has eliminated the bare `module.paths`
+ * ESM-global reference — it fails on the exact pre-fix code.
+ */
+describe('loader ESM require safety (regression #1385)', () => {
+  const loaderFiles = ['npm-loader.ts', 'template-loader.ts'];
+
+  for (const file of loaderFiles) {
+    it(`${file} recreates require via createRequire and avoids the bare module global`, async () => {
+      const { readFileSync } = await import('node:fs');
+      const { fileURLToPath } = await import('node:url');
+      const { dirname, join: joinPath } = await import('node:path');
+      const here = dirname(fileURLToPath(import.meta.url));
+      const src = readFileSync(joinPath(here, file), 'utf-8');
+
+      // The fix: import createRequire and bind a real `require`.
+      expect(src).toContain("import { createRequire } from 'node:module'");
+      expect(src).toContain('createRequire(import.meta.url)');
+
+      // The bug: spreading the undefined ESM `module` global's `.paths`.
+      expect(src).not.toMatch(/\.\.\.module\.paths/);
+    });
+  }
 });

--- a/packages/cli/src/loaders/npm-loader.ts
+++ b/packages/cli/src/loaders/npm-loader.ts
@@ -6,11 +6,17 @@
  */
 
 import { access } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { createLogger } from '@happyvertical/logger';
 import glob from 'fast-glob';
 import type { TemplateConfig } from './template-loader.js';
+
+// This package is pure ESM ("type":"module"), where `require`/`module` are not
+// defined. Recreate `require` so `require.resolve` works in the built artifact;
+// the dev test path used to be papered over by Vite's CJS interop shim.
+const require = createRequire(import.meta.url);
 
 const logger = createLogger({ level: 'info' });
 
@@ -26,7 +32,7 @@ export async function resolveNpmPackage(packagePath: string): Promise<string> {
   // Try to resolve as module
   try {
     const resolved = require.resolve(packagePath, {
-      paths: [process.cwd(), ...module.paths],
+      paths: [process.cwd(), ...(require.resolve.paths(packagePath) ?? [])],
     });
     return resolved;
   } catch {

--- a/packages/cli/src/loaders/template-loader.ts
+++ b/packages/cli/src/loaders/template-loader.ts
@@ -7,6 +7,7 @@
  * - Local filesystem paths (../path/to/template, /absolute/path)
  */
 
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadGitTemplate } from './git-loader.js';
@@ -18,6 +19,10 @@ import {
 } from './npm-loader.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// This package is pure ESM ("type":"module"), where `require`/`module` are not
+// defined. Recreate `require` so `require.resolve` works in the built artifact.
+const require = createRequire(import.meta.url);
 
 /**
  * Context passed to placeholder functions
@@ -183,8 +188,9 @@ async function findBundledTemplate(name: string): Promise<string | null> {
   // Try resolving as npm package (@happyvertical/smrt-template-sveltekit)
   try {
     const npmPackage = `@happyvertical/smrt-${packageDir}`;
-    const resolved = require.resolve(`${npmPackage}/template.config.js`, {
-      paths: [process.cwd(), ...module.paths],
+    const specifier = `${npmPackage}/template.config.js`;
+    const resolved = require.resolve(specifier, {
+      paths: [process.cwd(), ...(require.resolve.paths(specifier) ?? [])],
     });
     return dirname(resolved);
   } catch {

--- a/packages/cli/src/utils/generator.test.ts
+++ b/packages/cli/src/utils/generator.test.ts
@@ -330,6 +330,44 @@ describe('utils/generator generate()', () => {
     expect(out).toBe('git-template');
   });
 
+  // Regression for #1385: for subdir git templates the overlay base must be the
+  // subdir (stored as __templateRoot), not the repo-root __tempDir. The repo
+  // root holds an unrelated `template/` that must NOT be copied.
+  it('overlays from __templateRoot (subdir), not the repo-root __tempDir', async () => {
+    const repoRoot = join(workDir, 'git-repo-root');
+    // A decoy template at the repo root that must be ignored.
+    const rootTpl = join(repoRoot, 'template');
+    mkdirSync(rootTpl, { recursive: true });
+    writeFileSync(join(rootTpl, 'root.txt'), 'should-not-copy');
+    // The real template lives in a subdir.
+    const subdir = join(repoRoot, 'templates', 'site');
+    const subTpl = join(subdir, 'template');
+    mkdirSync(subTpl, { recursive: true });
+    writeFileSync(join(subTpl, 'sub.txt'), 'subdir-template');
+
+    const source: TemplateSource = {
+      type: 'git',
+      location: 'github:user/repo/templates/site',
+      resolved: '',
+    };
+    const config = baseConfig();
+    (config as Record<string, unknown>).__tempDir = repoRoot;
+    (config as Record<string, unknown>).__templateRoot = subdir;
+
+    await generate(source, config, {
+      template: 'test',
+      name: 'site',
+      outputDir,
+    });
+
+    const out = await readFile(join(outputDir, 'sub.txt'), 'utf-8');
+    expect(out).toBe('subdir-template');
+    // The repo-root decoy template must not have been copied.
+    await expect(
+      readFile(join(outputDir, 'root.txt'), 'utf-8'),
+    ).rejects.toThrow();
+  });
+
   it('throws on an unknown source type', async () => {
     const source = {
       type: 'ftp',

--- a/packages/cli/src/utils/generator.ts
+++ b/packages/cli/src/utils/generator.ts
@@ -166,12 +166,16 @@ async function overlayTemplate(
       baseDir = dirname(source.resolved);
       break;
     case 'git': {
-      // For git templates, the temp directory is stored in config
-      const tempDir = (config as any).__tempDir;
-      if (!tempDir) {
+      // For git templates the temp directory is stored on the config. Prefer
+      // the subdir-resolved `__templateRoot` so `github:user/repo/subdir`
+      // overlays from the subdir, not the repo root (#1385); fall back to
+      // `__tempDir` for the non-subdir case / older configs.
+      const baseGitDir =
+        (config as any).__templateRoot ?? (config as any).__tempDir;
+      if (!baseGitDir) {
         throw new Error('Git template temp directory not found');
       }
-      baseDir = tempDir;
+      baseDir = baseGitDir;
       break;
     }
     case 'local':

--- a/packages/config/AGENTS.md
+++ b/packages/config/AGENTS.md
@@ -5,7 +5,7 @@ Configuration management with cosmiconfig, secret sanitization, and SSG export.
 ## How It Works
 
 1. **cosmiconfig loader** searches for `smrt.config.{js,ts,json}` (via `loadConfig()`)
-2. **Priority**: runtime (highest) > file config > env vars > defaults
+2. **Priority**: runtime (highest) > file config > defaults
 3. **globalThis caching**: `globalThis.__smrtConfigCache` — all modules share one config instance
 
 ## Key Functions

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -116,9 +116,9 @@ const sanitized = sanitizeConfig(config);
 | `setConfig(overrides)` | Runtime overrides (highest priority) |
 | `clearCache()` | Reset cached config (global — affects all modules) |
 | `defineConfig(config)` | Type-safe config file helper |
-| `exportConfig(options?)` | SSG-safe export (defaults to no secrets) |
+| `exportConfig(config, options?)` | SSG-safe export (defaults to no secrets) |
 | `sanitizeConfig(config)` | Strip secret-matching keys |
-| `mergeExportedConfig(configs)` | Merge multiple exported configs |
+| `mergeExportedConfig(baseConfig, exportedConfig)` | Merge an exported config over a base |
 | `parseExportedConfig(raw)` | Parse an exported config string |
 
 ### Priority Order
@@ -127,8 +127,7 @@ Configuration merging (highest to lowest):
 
 1. Runtime overrides via `setConfig()`
 2. Config file (`smrt.config.{js,ts,json}`)
-3. Environment variables
-4. Package/module defaults
+3. Package/module defaults
 
 ### Key Types
 

--- a/packages/config/src/export.test.ts
+++ b/packages/config/src/export.test.ts
@@ -39,6 +39,21 @@ describe('sanitizeConfig — secret-key stripping (issue #1357)', () => {
     'private_key',
     'secretKey',
     'secret_key',
+    // camelCase <vendor>Key keys — verified leaks until the `[a-z0-9]Key`
+    // pattern was added; their unlisted vendor prefix bypassed the hardcoded
+    // api/access/secret/signing/encryption/private/public prefixes and the
+    // segment-anchored standalone-`key` pattern.
+    'consumerKey',
+    'masterKey',
+    'sslKey',
+    'hmacKey',
+    'sharedKey',
+    'rootKey',
+    'clientKey',
+    'serverKey',
+    'deployKey',
+    'sshKey',
+    'consumerKeyId',
     // auth family
     'auth',
     'authorization',
@@ -419,6 +434,29 @@ describe('exportConfig — secret handling', () => {
     expect(parsed).not.toHaveProperty('api_key');
     expect(parsed).not.toHaveProperty('accessToken');
     expect(parsed.label).toBe('ok');
+  });
+
+  // Regression: camelCase `<vendor>Key` keys used to leak into the public SSG
+  // artifact because their unlisted vendor prefix bypassed `isSecretKey` and the
+  // raw hex/base64 *value* matched none of the value-level token shapes. The
+  // `[a-z0-9]Key` pattern closes the gap. Benign `key`-bearing keys must survive.
+  it('strips camelCase <vendor>Key secrets with raw values from the export', () => {
+    const json = exportConfig({
+      consumerKey: 'a3f1c0deadbeefcafe1234567890abcd',
+      masterKey: 'AAAABBBBCCCCDDDDEEEEFFFF0000',
+      sslKey: 'deadbeefdeadbeefdeadbeefdeadbeef',
+      // benign — must remain in the public artifact
+      keywords: ['news', 'sports'],
+      monkey: 'business',
+      keyboardShortcuts: { save: 'cmd+s' },
+    });
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    expect(parsed).not.toHaveProperty('consumerKey');
+    expect(parsed).not.toHaveProperty('masterKey');
+    expect(parsed).not.toHaveProperty('sslKey');
+    expect(parsed.keywords).toEqual(['news', 'sports']);
+    expect(parsed.monkey).toBe('business');
+    expect(parsed.keyboardShortcuts).toEqual({ save: 'cmd+s' });
   });
 });
 

--- a/packages/config/src/export.ts
+++ b/packages/config/src/export.ts
@@ -74,6 +74,17 @@ const SECRET_PATTERNS = [
   /encryption[_-]?key/i,
   /private[_-]?key/i,
   /public[_-]?key/i,
+  // camelCase `<vendor>Key` keys — `consumerKey`, `masterKey`, `sslKey`,
+  // `hmacKey`, `sharedKey`, `rootKey`, `clientKey`, `serverKey`, `deployKey`,
+  // `sshKey`, etc. The hardcoded prefixes above and the segment-anchored
+  // standalone-`key` pattern below only fire on a `_`/`-`/start boundary, so a
+  // camelCase secret key with an unlisted vendor prefix slips through (a raw
+  // hex/base64 secret then exports verbatim into the public SSG artifact).
+  // Mirrors the `[a-z0-9]Pass`/`[a-z0-9]Pwd` idiom: a capital `K` after a
+  // letter/digit, followed by a segment/`Id`/end boundary, so `consumerKey` and
+  // `masterKeyId` are stripped while benign `keywords`/`monkey`/
+  // `keyboardShortcuts` (lowercase `key`) are kept.
+  /[a-z0-9]Key([_-]|Id|$)/,
   /(^|[_-])key([_-]|id$|$)/i, // standalone `key`, `key_id`, `keyId`, `aws…KeyId`
   // Connection / database URLs that commonly embed credentials.
   /connection[_-]?string/i,

--- a/packages/config/src/loader.ts
+++ b/packages/config/src/loader.ts
@@ -140,16 +140,3 @@ export function clearConfigCache(): void {
     setExplorer(null);
   }
 }
-
-/**
- * Return whether the config has been loaded and cached.
- *
- * Checks `globalThis.__smrtLoaderCachedConfig` without triggering a load.
- * Primarily used internally; consumers can call {@link getConfig} which
- * returns `null` when the config has not yet been loaded.
- *
- * @returns `true` if a cached config object exists.
- */
-export function isConfigLoaded(): boolean {
-  return getCachedConfig() !== null;
-}

--- a/packages/config/vitest.config.ts
+++ b/packages/config/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.{test,spec}.ts'],
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',

--- a/packages/core/src/__tests__/collection-coverage.test.ts
+++ b/packages/core/src/__tests__/collection-coverage.test.ts
@@ -191,6 +191,41 @@ describe('SmrtCollection memory (collection-scoped)', () => {
     expect(await widgets.recall({ scope: 'wipe', key: 'a' })).toBeNull();
     expect(await widgets.recall({ scope: 'wipe', key: 'b' })).toBeNull();
   });
+
+  // #1378: a corrupted _smrt_contexts.value must not throw out of recall paths.
+  it('recall() skips a corrupted value (treats it as a miss)', async () => {
+    await widgets.remember({ scope: 'corrupt', key: 'bad', value: { ok: 1 } });
+    // Corrupt the stored JSON directly (systemDb === the test db).
+    await db.query(
+      `UPDATE _smrt_contexts SET value = $1 WHERE scope = $2 AND key = $3`,
+      '{not valid json',
+      'corrupt',
+      'bad',
+    );
+
+    let recalled: unknown;
+    await expect(
+      (async () => {
+        recalled = await widgets.recall({ scope: 'corrupt', key: 'bad' });
+      })(),
+    ).resolves.toBeUndefined();
+    expect(recalled).toBeNull();
+  });
+
+  it('recallAll() skips a corrupted row and returns the rest', async () => {
+    await widgets.remember({ scope: 'mix', key: 'good', value: 42 });
+    await widgets.remember({ scope: 'mix', key: 'bad', value: { ok: 1 } });
+    await db.query(
+      `UPDATE _smrt_contexts SET value = $1 WHERE scope = $2 AND key = $3`,
+      '<<<corrupt>>>',
+      'mix',
+      'bad',
+    );
+
+    const all = await widgets.recallAll({ scope: 'mix' });
+    expect(all.get('good')).toBe(42);
+    expect(all.has('bad')).toBe(false);
+  });
 });
 
 describe('SmrtCollection memory requires initialization', () => {

--- a/packages/core/src/__tests__/discover-base-classes.test.ts
+++ b/packages/core/src/__tests__/discover-base-classes.test.ts
@@ -8,6 +8,9 @@
  * extending ProfileRelationship/ProfileRelationshipTerm
  */
 
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   DEFAULT_BASE_CLASSES,
@@ -182,6 +185,105 @@ describe('Base Class Discovery', () => {
 
       // Pass if we at least have the defaults
       expect(baseClasses.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  // Regression for #1378: base-class extraction used to hardcode
+  // `node_modules/{pkg}/dist/manifest.json`, so a workspace package whose
+  // manifest lives at `.smrt/manifest.json` (source-only, not yet built to
+  // dist/) contributed ZERO base classes, silently degrading inheritance
+  // detection. Discovery resolves `.smrt/` and `src/manifest/` too, so base
+  // class extraction must follow the same resolution.
+  describe('non-dist manifest locations (#1378)', () => {
+    let testDir: string | null = null;
+    let originalCwd: string | null = null;
+    const packageName = '@happyvertical/smrt-smrtdir-fixture';
+
+    function buildWorkspaceWithSmrtDirManifest(): void {
+      testDir = mkdtempSync(join(tmpdir(), 'smrt-basecls-smrtdir-'));
+      const packageDir = join(
+        testDir,
+        'node_modules',
+        '@happyvertical',
+        'smrt-smrtdir-fixture',
+      );
+      // Manifest lives under .smrt/, NOT dist/.
+      const smrtDir = join(packageDir, '.smrt');
+      mkdirSync(smrtDir, { recursive: true });
+
+      writeFileSync(
+        join(testDir, 'package.json'),
+        JSON.stringify(
+          {
+            name: 'smrt-basecls-consumer',
+            type: 'module',
+            dependencies: { [packageName]: '1.0.0' },
+          },
+          null,
+          2,
+        ),
+      );
+      writeFileSync(
+        join(packageDir, 'package.json'),
+        JSON.stringify(
+          { name: packageName, type: 'module', main: './index.js' },
+          null,
+          2,
+        ),
+      );
+      writeFileSync(join(packageDir, 'index.js'), 'export {};\n');
+      writeFileSync(
+        join(smrtDir, 'manifest.json'),
+        JSON.stringify(
+          {
+            moduleType: 'smrt',
+            version: '1.0.0',
+            packageName,
+            objects: {
+              [`${packageName}:SmrtDirBase`]: {
+                className: 'SmrtDirBase',
+                qualifiedName: `${packageName}:SmrtDirBase`,
+                packageName,
+                collection: 'smrt_dir_bases',
+                fields: {},
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      // discoverBaseClasses() calls discoverSmrtPackages() with the default cwd,
+      // while it loads manifests relative to its `cwd` option — point both at
+      // the fixture and bypass the discovery cache.
+      originalCwd = process.cwd();
+      process.chdir(testDir);
+      process.env.SMRT_DISABLE_DISCOVERY_CACHE = 'true';
+    }
+
+    afterEach(() => {
+      if (originalCwd) {
+        process.chdir(originalCwd);
+        originalCwd = null;
+      }
+      delete process.env.SMRT_DISABLE_DISCOVERY_CACHE;
+      if (testDir) {
+        rmSync(testDir, { recursive: true, force: true });
+        testDir = null;
+      }
+    });
+
+    it('contributes base classes from a .smrt/manifest.json package (sync)', () => {
+      buildWorkspaceWithSmrtDirManifest();
+      const baseClasses = discoverBaseClassesSync({ cwd: testDir as string });
+      expect(baseClasses).toContain('SmrtDirBase');
+    });
+
+    it('contributes base classes from a .smrt/manifest.json package (async)', async () => {
+      buildWorkspaceWithSmrtDirManifest();
+      const baseClasses = await discoverBaseClasses({ cwd: testDir as string });
+      expect(baseClasses).toContain('SmrtDirBase');
     });
   });
 });

--- a/packages/core/src/__tests__/issue-735-json-defaults.test.ts
+++ b/packages/core/src/__tests__/issue-735-json-defaults.test.ts
@@ -9,11 +9,15 @@
  * - 'null' for null/undefined
  * - '[]' for empty arrays
  * - '{}' for empty objects
+ *
+ * The JSON-default logic now lives in the shared formatter
+ * (schema/sql-identifiers.ts) and is exercised here through the public
+ * `formatDefaultValue(value, 'JSON')` API rather than reaching into the
+ * strategy's protected internals (#1378 consolidation).
  */
 
 import { describe, expect, it } from 'vitest';
 import { BaseDDLStrategy } from '../schema/ddl/base-strategy';
-import { SQLiteDDLStrategy } from '../schema/ddl/sqlite-strategy';
 
 // Concrete implementation for testing
 class TestDDLStrategy extends BaseDDLStrategy {
@@ -23,46 +27,45 @@ class TestDDLStrategy extends BaseDDLStrategy {
 describe('Issue #735: JSON Default Values in DDL', () => {
   const strategy = new TestDDLStrategy();
 
-  describe('formatJSONDefault', () => {
+  describe('formatDefaultValue with JSON type', () => {
     it('should format empty string as valid JSON null', () => {
       // Empty string '' is not valid JSON - should become 'null'
-      const result = (strategy as any).formatJSONDefault('');
+      const result = strategy.formatDefaultValue('', 'JSON');
       expect(result).toBe("'null'");
       // Verify it's valid JSON when unquoted
       expect(() => JSON.parse('null')).not.toThrow();
     });
 
-    it('should format null as JSON null literal', () => {
-      const result = (strategy as any).formatJSONDefault(null);
-      // For JSON columns, null should be the JSON literal 'null', not SQL NULL
-      expect(result).toBe("'null'");
+    it('should format null as the JSON null literal (not SQL NULL)', () => {
+      // For JSON columns, a null default is the JSON literal 'null', not the
+      // SQL NULL keyword.
+      expect(strategy.formatDefaultValue(null, 'JSON')).toBe("'null'");
     });
 
-    it('should format undefined as JSON null literal', () => {
-      const result = (strategy as any).formatJSONDefault(undefined);
-      expect(result).toBe("'null'");
+    it('should format undefined as the JSON null literal', () => {
+      expect(strategy.formatDefaultValue(undefined, 'JSON')).toBe("'null'");
     });
 
     it('should format empty array as valid JSON', () => {
-      const result = (strategy as any).formatJSONDefault([]);
+      const result = strategy.formatDefaultValue([], 'JSON');
       expect(result).toBe("'[]'");
       expect(() => JSON.parse('[]')).not.toThrow();
     });
 
     it('should format empty object as valid JSON', () => {
-      const result = (strategy as any).formatJSONDefault({});
+      const result = strategy.formatDefaultValue({}, 'JSON');
       expect(result).toBe("'{}'");
       expect(() => JSON.parse('{}')).not.toThrow();
     });
 
     it('should format object with properties as valid JSON', () => {
-      const result = (strategy as any).formatJSONDefault({ key: 'value' });
+      const result = strategy.formatDefaultValue({ key: 'value' }, 'JSON');
       expect(result).toBe('\'{"key":"value"}\'');
       expect(() => JSON.parse('{"key":"value"}')).not.toThrow();
     });
 
     it('should format array with values as valid JSON', () => {
-      const result = (strategy as any).formatJSONDefault(['a', 'b']);
+      const result = strategy.formatDefaultValue(['a', 'b'], 'JSON');
       expect(result).toBe('\'["a","b"]\'');
       expect(() => JSON.parse('["a","b"]')).not.toThrow();
     });
@@ -70,20 +73,8 @@ describe('Issue #735: JSON Default Values in DDL', () => {
     it('should handle [object Object] string representation', () => {
       // This is a common bug - when toString() is called on an object
       // it returns '[object Object]' which is not valid JSON
-      const result = (strategy as any).formatJSONDefault('[object Object]');
-      // Should convert to empty object {}
-      expect(result).toBe("'{}'");
-    });
-  });
-
-  describe('formatDefaultValue with JSON type', () => {
-    it('should format empty string for JSON type as valid JSON', () => {
-      const result = strategy.formatDefaultValue('', 'JSON');
-      expect(result).toBe("'null'");
-    });
-
-    it('should format [object Object] for JSON type as valid JSON', () => {
       const result = strategy.formatDefaultValue('[object Object]', 'JSON');
+      // Should convert to empty object {}
       expect(result).toBe("'{}'");
     });
 
@@ -120,7 +111,9 @@ describe('Issue #735: JSON Default Values in DDL', () => {
         type: 'JSON',
         defaultValue: null,
       });
-      expect(columnDef).toContain('DEFAULT NULL');
+      // Converged behavior: a JSON null default is the JSON literal 'null'
+      // (valid JSON), not the SQL NULL keyword.
+      expect(columnDef).toContain("DEFAULT 'null'");
     });
   });
 });

--- a/packages/core/src/__tests__/recall-corruption.test.ts
+++ b/packages/core/src/__tests__/recall-corruption.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Regression tests for the recall() / recallAll() JSON-parse guard (#1378).
+ *
+ * A single corrupted `_smrt_contexts.value` row must not throw an uncaught
+ * SyntaxError out of SmrtObject.recall()/recallAll(): recall() treats it as a
+ * miss (returns null / continues the ancestor fallback) and recallAll() skips
+ * it while still returning the rest of the scope.
+ *
+ * Real in-memory SQLite (systemDb === the object's db) — no DB mocking.
+ */
+
+import { getDatabase } from '@happyvertical/sql';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { SmrtObject } from '../object';
+
+// Module-level so the AST scanner registers it during test manifest generation.
+class RecallCorruptionObject extends SmrtObject {
+  value: string = '';
+}
+
+describe('SmrtObject recall guards corrupted _smrt_contexts rows (#1378)', () => {
+  let obj: RecallCorruptionObject;
+  let db: Awaited<ReturnType<typeof getDatabase>>;
+
+  beforeEach(async () => {
+    db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+    // _skipLoad: the object's own table is never migrated here; recall/remember
+    // only touch the _smrt_contexts system table (created during initialize()).
+    obj = new RecallCorruptionObject({
+      db,
+      id: 'owner-1',
+      value: 'v',
+      _skipLoad: true,
+    });
+    await obj.initialize();
+  });
+
+  it('recall() returns null instead of throwing on a corrupted value', async () => {
+    await obj.remember({ scope: 'parser', key: 'k1', value: { ok: true } });
+    await db.query(
+      `UPDATE _smrt_contexts SET value = $1 WHERE scope = $2 AND key = $3`,
+      '{not valid json',
+      'parser',
+      'k1',
+    );
+
+    let result: unknown;
+    await expect(
+      (async () => {
+        result = await obj.recall({ scope: 'parser', key: 'k1' });
+      })(),
+    ).resolves.toBeUndefined();
+    expect(result).toBeNull();
+  });
+
+  it('recall() still falls back to an ancestor scope when the child is corrupted', async () => {
+    await obj.remember({
+      scope: 'parser',
+      key: 'k1',
+      value: { from: 'parent' },
+    });
+    await obj.remember({
+      scope: 'parser/child',
+      key: 'k1',
+      value: { from: 'child' },
+    });
+    // Corrupt only the child-scope row.
+    await db.query(
+      `UPDATE _smrt_contexts SET value = $1 WHERE scope = $2 AND key = $3`,
+      'not-json',
+      'parser/child',
+      'k1',
+    );
+
+    const result = await obj.recall({
+      scope: 'parser/child',
+      key: 'k1',
+      includeAncestors: true,
+    });
+    expect(result).toEqual({ from: 'parent' });
+  });
+
+  it('recallAll() skips a corrupted row and returns the rest of the scope', async () => {
+    await obj.remember({ scope: 's', key: 'good', value: 1 });
+    await obj.remember({ scope: 's', key: 'bad', value: 2 });
+    await db.query(
+      `UPDATE _smrt_contexts SET value = $1 WHERE scope = $2 AND key = $3`,
+      '<<<corrupt>>>',
+      's',
+      'bad',
+    );
+
+    const all = await obj.recallAll({ scope: 's' });
+    expect(all.get('good')).toBe(1);
+    expect(all.has('bad')).toBe(false);
+  });
+});

--- a/packages/core/src/__tests__/save-error-contract.test.ts
+++ b/packages/core/src/__tests__/save-error-contract.test.ts
@@ -188,6 +188,23 @@ describe('classifyConstraintError matches all dialects (#1378)', () => {
     ).toBe('not_null');
   });
 
+  it('does not misclassify DuckDB foreign-key/check violations as unique (#1578)', () => {
+    // DuckDB phrases FK and CHECK failures with the same "Constraint Error ...
+    // violates" shape as unique violations. They must fall through to null so
+    // save() preserves the original DatabaseError instead of throwing a bogus
+    // ValidationError.uniqueConstraint('unknown_field').
+    expect(
+      SmrtObject.classifyConstraintError(
+        'Constraint Error: Violates foreign key constraint because key "owner_id: 7" does not exist in the referenced table',
+      ),
+    ).toBeNull();
+    expect(
+      SmrtObject.classifyConstraintError(
+        'Constraint Error: CHECK constraint failed: price_positive',
+      ),
+    ).toBeNull();
+  });
+
   it('returns null for unrelated / empty messages', () => {
     expect(
       SmrtObject.classifyConstraintError('some unrelated database error'),

--- a/packages/core/src/__tests__/save-error-contract.test.ts
+++ b/packages/core/src/__tests__/save-error-contract.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Regression tests for SmrtObject.save() error-contract fixes (#1378).
+ *
+ * 1. save()'s catch must re-throw SMRT errors AND duck-typed tenancy errors
+ *    (`code === 'TENANT_ISOLATION_VIOLATION'` / 'TENANT_CONTEXT_REQUIRED')
+ *    unwrapped, instead of burying them in a generic RuntimeError. The tenancy
+ *    package's TenantIsolationError / TenantContextError extend plain `Error`
+ *    (core cannot depend on tenancy), so they are matched by their stable code.
+ * 2. Constraint-violation detection must recognize SQLite, PostgreSQL and
+ *    DuckDB wording so violations map to a typed ValidationError on every
+ *    adapter. We unit-test the matcher + field extractor directly (no live
+ *    PG/DuckDB available here).
+ *
+ * Uses real in-memory SQLite via getTestDatabase — no DB mocking.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SmrtCollection } from '../collection';
+import { RuntimeError, TenantIsolationError } from '../errors';
+import { GlobalInterceptors } from '../interceptors';
+import { SmrtObject } from '../object';
+import { smrt } from '../registry';
+import { getTestDatabase } from '../testing/database';
+
+@smrt({ conflictColumns: ['sku'] })
+class ContractWidget extends SmrtObject {
+  name: string = '';
+  sku: string = '';
+}
+
+class ContractWidgetCollection extends SmrtCollection<ContractWidget> {
+  static readonly _itemClass = ContractWidget;
+}
+
+describe('save() preserves tenant error contract (#1378)', () => {
+  let collection: ContractWidgetCollection;
+
+  beforeEach(async () => {
+    GlobalInterceptors.clear();
+    const db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['ContractWidget'],
+    });
+    collection = await ContractWidgetCollection.create({ db });
+  });
+
+  afterEach(() => {
+    GlobalInterceptors.clear();
+  });
+
+  // Create the object cleanly first (collection.create() itself calls save()),
+  // THEN register the throwing beforeSave interceptor so the throw is observed
+  // on the explicit save() under test rather than during creation.
+  async function makeSavedWidget(sku: string): Promise<ContractWidget> {
+    const widget = await collection.create({ name: 'W', sku });
+    return widget;
+  }
+
+  it("propagates core's TenantIsolationError from save() unwrapped", async () => {
+    const widget = await makeSavedWidget('s-1');
+    GlobalInterceptors.register({
+      name: 'tenant-guard',
+      beforeSave() {
+        throw TenantIsolationError.crossTenantReference({
+          sourceClass: 'ContractWidget',
+          fieldName: 'tenantId',
+          sourceTenantId: 'tenant-a',
+          targetTenantId: 'tenant-b',
+        });
+      },
+    });
+
+    await expect(widget.save()).rejects.toBeInstanceOf(TenantIsolationError);
+    await expect(widget.save()).rejects.toMatchObject({
+      code: 'TENANT_ISOLATION_VIOLATION',
+    });
+  });
+
+  it("preserves a duck-typed tenancy TenantIsolationError's code (not SmrtError)", async () => {
+    // Mimics @happyvertical/smrt-tenancy's TenantIsolationError, which extends
+    // plain Error and is therefore NOT instanceof core's SmrtError.
+    class DuckTenantIsolationError extends Error {
+      readonly code = 'TENANT_ISOLATION_VIOLATION';
+      constructor() {
+        super('cross-tenant write blocked');
+        this.name = 'TenantIsolationError';
+      }
+    }
+
+    const widget = await makeSavedWidget('s-2');
+    GlobalInterceptors.register({
+      name: 'tenant-guard',
+      beforeSave() {
+        throw new DuckTenantIsolationError();
+      },
+    });
+
+    const error = await widget.save().then(
+      () => null,
+      (e) => e,
+    );
+    expect(error).toBeInstanceOf(DuckTenantIsolationError);
+    expect(error).not.toBeInstanceOf(RuntimeError);
+    expect(error.code).toBe('TENANT_ISOLATION_VIOLATION');
+  });
+
+  it("preserves a duck-typed TenantContextError's code", async () => {
+    class DuckTenantContextError extends Error {
+      readonly code = 'TENANT_CONTEXT_REQUIRED';
+      constructor() {
+        super('no active tenant');
+        this.name = 'TenantContextError';
+      }
+    }
+
+    const widget = await makeSavedWidget('s-3');
+    GlobalInterceptors.register({
+      name: 'tenant-guard',
+      beforeSave() {
+        throw new DuckTenantContextError();
+      },
+    });
+
+    const error = await widget.save().then(
+      () => null,
+      (e) => e,
+    );
+    expect(error.code).toBe('TENANT_CONTEXT_REQUIRED');
+    expect(error).not.toBeInstanceOf(RuntimeError);
+  });
+
+  it('still wraps a genuinely unexpected non-SMRT error in RuntimeError', async () => {
+    const widget = await makeSavedWidget('s-4');
+    GlobalInterceptors.register({
+      name: 'boom',
+      beforeSave() {
+        throw new Error('totally unexpected');
+      },
+    });
+
+    await expect(widget.save()).rejects.toBeInstanceOf(RuntimeError);
+  });
+});
+
+describe('classifyConstraintError matches all dialects (#1378)', () => {
+  it('detects SQLite unique/not-null wording', () => {
+    expect(
+      SmrtObject.classifyConstraintError(
+        'UNIQUE constraint failed: widgets.sku',
+      ),
+    ).toBe('unique');
+    expect(
+      SmrtObject.classifyConstraintError(
+        'NOT NULL constraint failed: widgets.name',
+      ),
+    ).toBe('not_null');
+  });
+
+  it('detects PostgreSQL unique/not-null wording', () => {
+    expect(
+      SmrtObject.classifyConstraintError(
+        'duplicate key value violates unique constraint "widgets_sku_key"',
+      ),
+    ).toBe('unique');
+    expect(
+      SmrtObject.classifyConstraintError(
+        'null value in column "name" of relation "widgets" violates not-null constraint',
+      ),
+    ).toBe('not_null');
+  });
+
+  it('detects DuckDB constraint wording', () => {
+    expect(
+      SmrtObject.classifyConstraintError(
+        'Constraint Error: Duplicate key "sku: abc" violates unique constraint.',
+      ),
+    ).toBe('unique');
+    expect(
+      SmrtObject.classifyConstraintError(
+        'Constraint Error: Duplicate key violates primary key constraint.',
+      ),
+    ).toBe('unique');
+    expect(
+      SmrtObject.classifyConstraintError(
+        'NOT NULL constraint failed: widgets.name',
+      ),
+    ).toBe('not_null');
+  });
+
+  it('returns null for unrelated / empty messages', () => {
+    expect(
+      SmrtObject.classifyConstraintError('some unrelated database error'),
+    ).toBeNull();
+    expect(SmrtObject.classifyConstraintError('')).toBeNull();
+  });
+});
+
+describe('extractConstraintField recovers the column across dialects (#1378)', () => {
+  it('extracts from SQLite/DuckDB wording', async () => {
+    const widget = await makeWidget();
+    expect(
+      widget.publicExtractConstraintField(
+        'UNIQUE constraint failed: widgets.sku',
+      ),
+    ).toBe('sku');
+  });
+
+  it('extracts from PostgreSQL not-null wording', async () => {
+    const widget = await makeWidget();
+    expect(
+      widget.publicExtractConstraintField(
+        'null value in column "email" of relation "widgets" violates not-null constraint',
+      ),
+    ).toBe('email');
+  });
+
+  it('extracts from a PostgreSQL unique DETAIL line', async () => {
+    const widget = await makeWidget();
+    expect(
+      widget.publicExtractConstraintField('Key (sku)=(abc) already exists.'),
+    ).toBe('sku');
+  });
+});
+
+/** Helper exposing the protected extractConstraintField for assertions. */
+class TestableWidget extends ContractWidget {
+  publicExtractConstraintField(message: string): string {
+    return this.extractConstraintField(message);
+  }
+}
+
+async function makeWidget(): Promise<TestableWidget> {
+  const widget = new TestableWidget({ name: 'X', sku: 'x', _skipLoad: true });
+  await widget.initialize();
+  return widget;
+}

--- a/packages/core/src/__tests__/utils-formatDataJs.test.ts
+++ b/packages/core/src/__tests__/utils-formatDataJs.test.ts
@@ -167,4 +167,44 @@ describe('formatDataJs', () => {
       expect(result.price).toBe(3.14);
     });
   });
+
+  describe('input immutability (#1378)', () => {
+    it('does not mutate the caller object when merging _meta_data', () => {
+      const data = {
+        id: 'abc',
+        _meta_type: 'Image',
+        _meta_data: '{"width":100,"height":50}',
+      };
+      const snapshot = { ...data };
+
+      const result = formatDataJs(data);
+
+      // Meta fields are surfaced on the RESULT...
+      expect(result.width).toBe(100);
+      expect(result.height).toBe(50);
+
+      // ...but the caller's object must be untouched: no injected meta fields
+      // and the original keys/values preserved.
+      expect(data).toEqual(snapshot);
+      expect('width' in data).toBe(false);
+      expect('height' in data).toBe(false);
+    });
+
+    it('does not mutate the caller object with an object-form _meta_data', () => {
+      const data: Record<string, any> = {
+        id: 'def',
+        _meta_data: { color: 'red' },
+      };
+      const originalMeta = data._meta_data;
+
+      const result = formatDataJs(data);
+
+      expect(result.color).toBe('red');
+      // Top-level meta field not injected onto the input...
+      expect('color' in data).toBe(false);
+      // ...and the nested _meta_data object reference is unchanged.
+      expect(data._meta_data).toBe(originalMeta);
+      expect(data._meta_data).toEqual({ color: 'red' });
+    });
+  });
 });

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -2436,7 +2436,19 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     }
 
     if (result) {
-      return JSON.parse(result.value);
+      // Guard against a corrupted _smrt_contexts row: a single malformed value
+      // must not throw an uncaught SyntaxError out of recall(). Treat it as a
+      // miss and continue to the ancestor fallback (#1378).
+      try {
+        return JSON.parse(result.value);
+      } catch (error) {
+        logger.warn('Skipping corrupted _smrt_contexts value in recall()', {
+          ownerClass: this._itemClass.name,
+          scope: options.scope,
+          key: options.key,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
 
     // Hierarchical fallback to parent scopes
@@ -2515,7 +2527,17 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     const { rows } = await this.systemDb.query(query, ...params);
 
     for (const row of rows) {
-      results.set(row.key, JSON.parse(row.value));
+      // Skip a corrupted row rather than aborting the whole recallAll() (#1378).
+      try {
+        results.set(row.key, JSON.parse(row.value));
+      } catch (error) {
+        logger.warn('Skipping corrupted _smrt_contexts value in recallAll()', {
+          ownerClass: this._itemClass.name,
+          scope: options.scope,
+          key: row.key,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
 
     return results;

--- a/packages/core/src/dispatch/bus.ts
+++ b/packages/core/src/dispatch/bus.ts
@@ -662,7 +662,15 @@ export class DispatchBus {
   async retry(options: DispatchRetryOptions = {}): Promise<number> {
     await this.initialize();
 
-    const retryable = await DispatchCollection.findRetryable(this.db, options);
+    // Tenant isolation (S5 #1398): only the active tenant's failed dispatches
+    // (plus global ones) are eligible — a tenant's retry() must not reset
+    // another tenant's rows. Scope is derived server-side; callers cannot widen
+    // it.
+    const retryable = await DispatchCollection.findRetryable(
+      this.db,
+      options,
+      resolveDispatchTenantScope(),
+    );
 
     for (const dispatch of retryable) {
       dispatch.resetForRetry();
@@ -682,7 +690,14 @@ export class DispatchBus {
     options: DispatchCleanupOptions = {},
   ): Promise<DispatchCleanupResult> {
     await this.initialize();
-    return DispatchCollection.cleanup(this.db, options);
+    // Tenant isolation (S5 #1398): only the active tenant's dispatches (plus
+    // global ones) are deleted — a tenant's cleanup() must not delete another
+    // tenant's rows. Scope is derived server-side; callers cannot widen it.
+    return DispatchCollection.cleanup(
+      this.db,
+      options,
+      resolveDispatchTenantScope(),
+    );
   }
 
   /**

--- a/packages/core/src/dispatch/collections/Dispatches.ts
+++ b/packages/core/src/dispatch/collections/Dispatches.ts
@@ -359,11 +359,17 @@ export class DispatchCollection {
   }
 
   /**
-   * Find failed dispatches eligible for retry
+   * Find failed dispatches eligible for retry.
+   *
+   * @param tenantScope - Active tenant scope (S5 #1398). Derived server-side by
+   *   the bus; restricts retryable rows to the active tenant (plus global) so a
+   *   tenant's `retry()` cannot reset another tenant's failed dispatches. See
+   *   {@link pushTenantPredicate} for the exact semantics.
    */
   static async findRetryable(
     db: DatabaseInterface,
     options: DispatchRetryOptions = {},
+    tenantScope?: DispatchTenantScope,
   ): Promise<Dispatch[]> {
     const conditions: string[] = ["status = 'failed'"];
     const params: unknown[] = [];
@@ -385,6 +391,12 @@ export class DispatchCollection {
         .join(', ');
       conditions.push(`type IN (${placeholders})`);
       params.push(...options.signalTypes);
+    }
+
+    if (
+      pushTenantPredicate(conditions, params, tenantScope, `$${paramIndex}`)
+    ) {
+      paramIndex++;
     }
 
     const { rows } = await db.query(
@@ -418,11 +430,17 @@ export class DispatchCollection {
   }
 
   /**
-   * Cleanup old dispatches
+   * Cleanup old dispatches.
+   *
+   * @param tenantScope - Active tenant scope (S5 #1398). Derived server-side by
+   *   the bus; restricts deletions to the active tenant (plus global) so a
+   *   tenant's `cleanup()` cannot delete another tenant's dispatches. See
+   *   {@link pushTenantPredicate} for the exact semantics.
    */
   static async cleanup(
     db: DatabaseInterface,
     options: DispatchCleanupOptions = {},
+    tenantScope?: DispatchTenantScope,
   ): Promise<DispatchCleanupResult> {
     const result: DispatchCleanupResult = {
       completedDeleted: 0,
@@ -433,9 +451,16 @@ export class DispatchCollection {
       const cutoff = new Date();
       cutoff.setDate(cutoff.getDate() - options.completedOlderThanDays);
 
+      const conditions: string[] = [
+        "status = 'completed'",
+        'processed_at < $1',
+      ];
+      const params: unknown[] = [cutoff.toISOString()];
+      pushTenantPredicate(conditions, params, tenantScope, '$2');
+
       const { rowCount } = await db.query(
-        `DELETE FROM _smrt_dispatch WHERE status = 'completed' AND processed_at < $1`,
-        cutoff.toISOString(),
+        `DELETE FROM _smrt_dispatch WHERE ${conditions.join(' AND ')}`,
+        ...params,
       );
       result.completedDeleted = rowCount || 0;
     }
@@ -444,9 +469,13 @@ export class DispatchCollection {
       const cutoff = new Date();
       cutoff.setDate(cutoff.getDate() - options.failedOlderThanDays);
 
+      const conditions: string[] = ["status = 'failed'", 'updated_at < $1'];
+      const params: unknown[] = [cutoff.toISOString()];
+      pushTenantPredicate(conditions, params, tenantScope, '$2');
+
       const { rowCount } = await db.query(
-        `DELETE FROM _smrt_dispatch WHERE status = 'failed' AND updated_at < $1`,
-        cutoff.toISOString(),
+        `DELETE FROM _smrt_dispatch WHERE ${conditions.join(' AND ')}`,
+        ...params,
       );
       result.failedDeleted = rowCount || 0;
     }

--- a/packages/core/src/dispatch/integration.test.ts
+++ b/packages/core/src/dispatch/integration.test.ts
@@ -9,6 +9,7 @@ import { randomUUID } from 'node:crypto';
 import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { getDatabase } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createDispatchBus, type DispatchBus } from './bus.js';
 import type { DispatchMetadata } from './types.js';
@@ -153,6 +154,58 @@ describe('Agent-to-Agent Communication', () => {
     const completed = await bus.list({ status: 'completed' });
     expect(completed).toHaveLength(1);
     expect(completed[0].attempts).toBe(2);
+  });
+
+  it('does not let one corrupted _smrt_dispatch row stall list()/process() (#1378)', async () => {
+    await bus.subscribe({ signalType: 'order.placed', subscriber: 'Worker' });
+
+    // A good, processable dispatch.
+    await bus.emit('order.placed', { orderId: 'good' }, { source: 'Checkout' });
+
+    // Inject a poison row directly into the table (corrupted payload JSON),
+    // simulating manual DB tampering / a partial write. A second connection to
+    // the same file is used rather than reaching into the bus internals.
+    const raw = await getDatabase({ type: 'sqlite', url: dbPath });
+    const now = new Date().toISOString();
+    await raw.query(
+      `INSERT INTO _smrt_dispatch
+        (id, type, source, source_id, payload, status, attempts, last_error,
+         processed_at, processed_by, target_subscriber, correlation_id,
+         tenant_id, metadata, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
+      'poison-1',
+      'order.placed',
+      'Checkout',
+      null,
+      '{not valid json', // corrupted payload
+      'pending',
+      0,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      '{}',
+      now,
+      now,
+    );
+
+    // list() must not throw on the corrupted row, and must still return both
+    // rows (the poison row falls back to an empty payload).
+    const listed = await bus.list({});
+    expect(listed).toHaveLength(2);
+    const poison = listed.find((d) => d.id === 'poison-1');
+    expect(poison?.payload).toEqual({});
+
+    // process() must not stall on the poison row; the good dispatch is still
+    // delivered with its real payload.
+    const seen: unknown[] = [];
+    const processed = await bus.process('Worker', async (payload) => {
+      seen.push(payload);
+    });
+    expect(processed).toBeGreaterThanOrEqual(1);
+    expect(seen).toContainEqual({ orderId: 'good' });
   });
 
   it('should support multiple subscribers to the same event', async () => {

--- a/packages/core/src/dispatch/models/Dispatch.test.ts
+++ b/packages/core/src/dispatch/models/Dispatch.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for the Dispatch model (src/dispatch/models/Dispatch.ts).
+ *
+ * Focus: the constructor / fromRow JSON-field guard (#1378). A single corrupted
+ * `payload`/`metadata` value in a `_smrt_dispatch` row must not throw out of the
+ * constructor, because process()/list() map fromRow over a whole batch — one
+ * poison row would otherwise stall every dispatch in the batch.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Dispatch, type DispatchData } from './Dispatch.js';
+
+function rowWith(overrides: Partial<DispatchData>): DispatchData {
+  return {
+    id: 'd-1',
+    type: 'order.placed',
+    source: 'orders',
+    source_id: null,
+    payload: '{}',
+    status: 'pending',
+    attempts: 0,
+    last_error: null,
+    processed_at: null,
+    processed_by: null,
+    target_subscriber: null,
+    correlation_id: null,
+    tenant_id: null,
+    metadata: '{}',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('Dispatch JSON-field parsing', () => {
+  it('parses well-formed payload and metadata', () => {
+    const dispatch = Dispatch.fromRow(
+      rowWith({
+        payload: JSON.stringify({ orderId: '42' }),
+        metadata: JSON.stringify({ traceId: 'abc' }),
+      }),
+    );
+    expect(dispatch.payload).toEqual({ orderId: '42' });
+    expect(dispatch.metadata).toEqual({ traceId: 'abc' });
+  });
+
+  it('does not throw on a corrupted payload; falls back to {}', () => {
+    expect(() =>
+      Dispatch.fromRow(rowWith({ payload: '{not valid json' })),
+    ).not.toThrow();
+
+    const dispatch = Dispatch.fromRow(rowWith({ payload: '{not valid json' }));
+    expect(dispatch.payload).toEqual({});
+  });
+
+  it('does not throw on corrupted metadata; falls back to {}', () => {
+    const dispatch = Dispatch.fromRow(rowWith({ metadata: 'not-json' }));
+    expect(dispatch.metadata).toEqual({});
+  });
+
+  it('keeps the other field intact when only one is corrupted', () => {
+    const dispatch = Dispatch.fromRow(
+      rowWith({
+        payload: JSON.stringify({ keep: true }),
+        metadata: '<<<corrupt>>>',
+      }),
+    );
+    expect(dispatch.payload).toEqual({ keep: true });
+    expect(dispatch.metadata).toEqual({});
+  });
+
+  it('treats null/empty JSON columns as {}', () => {
+    const dispatch = Dispatch.fromRow(
+      rowWith({ payload: null, metadata: null }),
+    );
+    expect(dispatch.payload).toEqual({});
+    expect(dispatch.metadata).toEqual({});
+  });
+});

--- a/packages/core/src/dispatch/models/Dispatch.ts
+++ b/packages/core/src/dispatch/models/Dispatch.ts
@@ -5,8 +5,39 @@
  * messages sent between agents. They support async processing with retry logic.
  */
 
+import { createLogger } from '@happyvertical/logger';
 import { makeId } from '@happyvertical/utils';
 import type { DispatchMetadata, DispatchStatus } from '../types.js';
+
+const logger = createLogger({ level: 'info' });
+
+/**
+ * Safely parses a JSON column from a `_smrt_dispatch` row.
+ *
+ * A single corrupted `payload`/`metadata` value must not throw out of the
+ * `Dispatch` constructor, since `process()`/`list()` map `fromRow` over a whole
+ * batch — one poison row would otherwise stall every dispatch in the batch
+ * (#1378). On a parse failure, logs the offending row id + field and falls back
+ * to an empty object so the rest of the batch keeps flowing.
+ */
+function parseJsonField(
+  raw: string,
+  field: 'payload' | 'metadata',
+  rowId: string,
+): Record<string, unknown> {
+  try {
+    // Only malformed JSON is treated as a poison value; valid JSON parses as
+    // before (preserving prior behavior for the well-formed path).
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch (error) {
+    logger.warn('Skipping corrupted _smrt_dispatch JSON field', {
+      dispatchId: rowId,
+      field,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return {};
+  }
+}
 
 /**
  * Raw dispatch data as stored in the database
@@ -107,9 +138,14 @@ export class Dispatch {
     this.updatedAt = data.updated_at ? new Date(data.updated_at) : new Date();
     this.processedAt = data.processed_at ? new Date(data.processed_at) : null;
 
-    // Parse JSON fields
-    this.payload = data.payload ? JSON.parse(data.payload) : {};
-    this.metadata = data.metadata ? JSON.parse(data.metadata) : {};
+    // Parse JSON fields. Guarded so a single corrupted row cannot stall an
+    // entire process()/list() batch (#1378).
+    this.payload = data.payload
+      ? parseJsonField(data.payload, 'payload', this.id)
+      : {};
+    this.metadata = data.metadata
+      ? parseJsonField(data.metadata, 'metadata', this.id)
+      : {};
   }
 
   /**

--- a/packages/core/src/dispatch/tenancy.test.ts
+++ b/packages/core/src/dispatch/tenancy.test.ts
@@ -361,6 +361,58 @@ describe('DispatchBus tenant isolation (S5 #1398)', () => {
     });
   });
 
+  describe('retry()/cleanup() are tenant-scoped (#1378)', () => {
+    // Drives a dispatch to `failed` status in the currently-active tenant by
+    // subscribing a worker and processing it with a throwing handler.
+    async function emitAndFail(signalType: string, id: string): Promise<void> {
+      await bus.subscribe({ signalType, subscriber: 'worker' });
+      await bus.emit(signalType, { id }, { source: 'test' });
+      await bus.process('worker', async () => {
+        throw new Error('boom');
+      });
+    }
+
+    it("tenant A retry() does not reset tenant B's failed dispatch", async () => {
+      activeTenant = 'tenant-a';
+      await emitAndFail('order.placed', 'a-1');
+      activeTenant = 'tenant-b';
+      await emitAndFail('order.placed', 'b-1');
+
+      // Both tenants have exactly one failed dispatch (tenant-scoped list).
+      activeTenant = 'tenant-a';
+      expect(await bus.list({ status: 'failed' })).toHaveLength(1);
+      activeTenant = 'tenant-b';
+      expect(await bus.list({ status: 'failed' })).toHaveLength(1);
+
+      // Tenant A retries — only its own failed dispatch is reset.
+      activeTenant = 'tenant-a';
+      const resetCount = await bus.retry({ maxAttempts: 5 });
+      expect(resetCount).toBe(1);
+      expect(await bus.list({ status: 'pending' })).toHaveLength(1);
+      expect(await bus.list({ status: 'failed' })).toHaveLength(0);
+
+      // Tenant B's failed dispatch is untouched.
+      activeTenant = 'tenant-b';
+      expect(await bus.list({ status: 'failed' })).toHaveLength(1);
+      expect(await bus.list({ status: 'pending' })).toHaveLength(0);
+    });
+
+    it("tenant A cleanup() does not delete tenant B's failed dispatch", async () => {
+      activeTenant = 'tenant-a';
+      await emitAndFail('order.placed', 'a-1');
+      activeTenant = 'tenant-b';
+      await emitAndFail('order.placed', 'b-1');
+
+      // Tenant A cleans up failed dispatches — must not reach tenant B's rows.
+      activeTenant = 'tenant-a';
+      await bus.cleanup({ failedOlderThanDays: 0 });
+
+      // Tenant B's failed dispatch survives regardless of A's cleanup.
+      activeTenant = 'tenant-b';
+      expect(await bus.list({ status: 'failed' })).toHaveLength(1);
+    });
+  });
+
   describe('atomic claim prevents double processing (S5 #1398)', () => {
     it('a single global dispatch is processed at most once across concurrent processors', async () => {
       // No tenancy → both processors share the same global compete dispatch.

--- a/packages/core/src/generators/mcp.test.ts
+++ b/packages/core/src/generators/mcp.test.ts
@@ -133,6 +133,32 @@ class MCPNestedResultAgent extends SmrtObject {
   }
 }
 
+// Custom action whose public METHOD name itself contains an underscore (#1378).
+// Tool name becomes `mcpunderscoremethodagent_record_payment`; handleToolCall
+// must split on the FIRST underscore so `action` is `record_payment`, not
+// `record`.
+@smrt({
+  mcp: {
+    include: ['record_payment'],
+  },
+})
+class MCPUnderscoreMethodAgent extends SmrtObject {
+  name = '';
+
+  constructor(options: any) {
+    super(options);
+    const { db, ai, fs, ...safeOptions } = options;
+    Object.assign(this, safeOptions);
+  }
+
+  async record_payment(options: any = {}): Promise<any> {
+    return {
+      action: 'record_payment',
+      amount: options.amount ?? 0,
+    };
+  }
+}
+
 describe('MCPGenerator with Custom Actions', () => {
   let generator: MCPGenerator;
 
@@ -282,6 +308,49 @@ describe('MCPGenerator with Custom Actions', () => {
 
       // Restore original method
       (generator as any).getCollection = originalGetCollection;
+    });
+
+    it('routes a snake_case method tool by splitting on the first underscore (#1378)', async () => {
+      const mockObject = new MCPUnderscoreMethodAgent({
+        db: null,
+        ai: null,
+        fs: null,
+        id: 'pay-id',
+        name: 'Payer',
+      });
+      const mockCollection = {
+        get: vi.fn().mockResolvedValue(mockObject),
+      };
+
+      // Tool name is `<objectname>_record_payment`. A naive split('_') would
+      // take the action as `record` and fail to find the method; the fix slices
+      // at the first underscore so `action` is the full `record_payment`.
+      const request = {
+        method: 'tools/call',
+        params: {
+          name: 'mcpunderscoremethodagent_record_payment',
+          arguments: {
+            id: 'pay-id',
+            options: { amount: 42 },
+          },
+        },
+      };
+
+      (generator as any).getCollection = vi
+        .fn()
+        .mockReturnValue(mockCollection);
+      (generator as any).collections = new Map([
+        ['MCPUnderscoreMethodAgent', mockCollection],
+      ]);
+
+      const response = await generator.handleToolCall(request);
+
+      expect(response.content[0].type).toBe('text');
+      const result = JSON.parse(response.content[0].text);
+      // Routed to the right method, not "Object type ... not found" or
+      // "Method 'record' not found".
+      expect(result.action).toBe('record_payment');
+      expect(result.amount).toBe(42);
     });
 
     it('should handle custom actions without ID (collection-level)', async () => {

--- a/packages/core/src/generators/mcp.ts
+++ b/packages/core/src/generators/mcp.ts
@@ -515,8 +515,17 @@ export class MCPGenerator {
         throw new Error(`Unknown tool: ${name}`);
       }
 
-      // Parse tool name: objectname_action
-      const [objectName, action] = name.split('_');
+      // Parse tool name: `objectname_action`. Split on the FIRST underscore
+      // only — a custom method name can itself contain underscores (e.g.
+      // `record_payment` → tool `invoice_record_payment`). A naive
+      // `name.split('_')` would take `action` as just `record` and mis-route
+      // the call. The emitted stdio servers switch on the full tool name, so
+      // splitting greedily here also kept the in-process path divergent (#1378).
+      const firstUnderscore = name.indexOf('_');
+      const objectName =
+        firstUnderscore === -1 ? '' : name.slice(0, firstUnderscore);
+      const action =
+        firstUnderscore === -1 ? '' : name.slice(firstUnderscore + 1);
 
       if (!objectName || !action) {
         throw new Error(`Invalid tool name format: ${name}`);

--- a/packages/core/src/manifest/discover-base-classes.ts
+++ b/packages/core/src/manifest/discover-base-classes.ts
@@ -23,8 +23,41 @@
 
 import { readFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
-import { discoverSmrtPackages } from './discover-smrt-packages.js';
+import { createLogger } from '@happyvertical/logger';
+import {
+  discoverSmrtPackages,
+  resolveManifestPath,
+} from './discover-smrt-packages.js';
+
+const logger = createLogger({ level: 'info' });
+
+/**
+ * Log a manifest-load failure during base-class discovery without aborting the
+ * whole scan. ENOENT (a package that simply hasn't built/published a manifest)
+ * is benign and logged at debug; malformed JSON or other read errors are
+ * surfaced at warn so a stale/corrupt manifest is not silently ignored.
+ */
+function logBaseClassLoadError(
+  pkgName: string,
+  manifestPath: string,
+  error: unknown,
+): void {
+  const code =
+    error && typeof error === 'object' && 'code' in error
+      ? (error as { code?: string }).code
+      : undefined;
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (code === 'ENOENT') {
+    logger.debug(
+      `[discoverBaseClasses] No manifest for ${pkgName} at ${manifestPath}; skipping.`,
+    );
+  } else {
+    logger.warn(
+      `[discoverBaseClasses] Failed to load manifest for ${pkgName} at ${manifestPath}: ${message}`,
+    );
+  }
+}
 
 /**
  * Framework base classes that should be skipped during manifest generation
@@ -77,17 +110,22 @@ export async function discoverBaseClasses(
   // Discover external SMRT packages
   const smrtDependencies = discoverSmrtPackages();
 
-  // Load external base classes from SMRT package manifests
+  // Load external base classes from SMRT package manifests.
+  // Resolve each manifest the same way discovery does (honoring `.smrt/` and
+  // `src/manifest/` in addition to `dist/`), so a workspace package not yet
+  // built to dist/ still contributes its base classes (#1378). A hardcoded
+  // `node_modules/{pkg}/dist/manifest.json` path silently degraded inheritance
+  // detection for source-only packages.
   for (const pkgName of smrtDependencies) {
-    try {
-      const manifestPath = resolve(
-        cwd,
-        'node_modules',
-        pkgName,
-        'dist',
-        'manifest.json',
+    const manifestPath = resolveManifestPath(pkgName, cwd);
+    if (!manifestPath) {
+      logger.debug(
+        `[discoverBaseClasses] No SMRT manifest resolved for ${pkgName}; skipping.`,
       );
+      continue;
+    }
 
+    try {
       const manifestContent = await readFile(manifestPath, 'utf-8');
       const manifest = JSON.parse(manifestContent);
 
@@ -104,7 +142,9 @@ export async function discoverBaseClasses(
           }
         }
       }
-    } catch (error) {}
+    } catch (error) {
+      logBaseClassLoadError(pkgName, manifestPath, error);
+    }
   }
 
   return baseClasses;
@@ -137,17 +177,19 @@ export function discoverBaseClassesSync(
   // Discover external SMRT packages
   const smrtDependencies = discoverSmrtPackages();
 
-  // Load external base classes from SMRT package manifests
+  // Load external base classes from SMRT package manifests. Same resolution as
+  // the async variant (honors `.smrt/` and `src/manifest/`, not just `dist/`),
+  // so source-only workspace packages still contribute base classes (#1378).
   for (const pkgName of smrtDependencies) {
-    try {
-      const manifestPath = resolve(
-        cwd,
-        'node_modules',
-        pkgName,
-        'dist',
-        'manifest.json',
+    const manifestPath = resolveManifestPath(pkgName, cwd);
+    if (!manifestPath) {
+      logger.debug(
+        `[discoverBaseClassesSync] No SMRT manifest resolved for ${pkgName}; skipping.`,
       );
+      continue;
+    }
 
+    try {
       // Use fs.readFileSync for synchronous loading (works in ESM)
       const manifestContent = readFileSync(manifestPath, 'utf-8');
       const manifest = JSON.parse(manifestContent);
@@ -165,7 +207,9 @@ export function discoverBaseClassesSync(
           }
         }
       }
-    } catch (error) {}
+    } catch (error) {
+      logBaseClassLoadError(pkgName, manifestPath, error);
+    }
   }
 
   return baseClasses;

--- a/packages/core/src/manifest/discover-smrt-packages.ts
+++ b/packages/core/src/manifest/discover-smrt-packages.ts
@@ -186,7 +186,7 @@ function resolvePackageDir(
   return null;
 }
 
-function resolveManifestPath(
+export function resolveManifestPath(
   packageName: string,
   baseDir: string = process.cwd(),
 ): string | null {

--- a/packages/core/src/manifest/generator.ts
+++ b/packages/core/src/manifest/generator.ts
@@ -10,7 +10,10 @@ import { ManifestGenerator } from '../scanner/manifest-generator.js';
 import type { SmartObjectManifest } from '../scanner/types.js';
 import { importWorkspaceModule } from '../utils/import-workspace-module.js';
 import type { ScannerModule } from '../utils/scanner-module.js';
-import { discoverSmrtPackages } from './discover-smrt-packages.js';
+import {
+  discoverSmrtPackages,
+  resolveManifestPath,
+} from './discover-smrt-packages.js';
 import { ManifestManager } from './manager.js';
 
 async function importScanner() {
@@ -497,15 +500,16 @@ export default ${exportName};
     const externalBaseClasses: string[] = [];
 
     for (const pkgName of packages) {
-      try {
-        const manifestPath = resolve(
-          process.cwd(),
-          'node_modules',
-          pkgName,
-          'dist',
-          'manifest.json',
-        );
+      // Resolve the manifest the same way discovery does (honors `.smrt/` and
+      // `src/manifest/`, not just `dist/`) so source-only workspace packages
+      // still contribute base classes (#1378).
+      const manifestPath = resolveManifestPath(pkgName, process.cwd());
+      if (!manifestPath) {
+        console.log(`[smrt]   ${pkgName}: no SMRT manifest resolved`);
+        continue;
+      }
 
+      try {
         const manifestContent = readFileSync(manifestPath, 'utf-8');
         const manifest = JSON.parse(manifestContent);
 

--- a/packages/core/src/migrations/__tests__/generator-branches.test.ts
+++ b/packages/core/src/migrations/__tests__/generator-branches.test.ts
@@ -18,13 +18,17 @@ import { MigrationGenerator } from '../generator.js';
 
 describe('MigrationGenerator branch coverage', () => {
   describe('generateCreateTable from columns (no pre-supplied ddl)', () => {
-    it('builds CREATE TABLE with all column modifiers and FK constraints', () => {
+    it('delegates to the engine DDL strategy for column modifiers + escaped defaults', () => {
+      // #1378: with no pre-generated `ddl`, generateCreateTable delegates to
+      // the engine DDL strategy (like the orchestrator) rather than building
+      // the statement inline with abstract column types. Column modifiers and
+      // escaped defaults still come through; FK constraints are intentionally
+      // NOT emitted on this path (see the next test).
       const diff: SchemaDiff = {
         has_changes: true,
         added_tables: [
           {
             tableName: 'orders',
-            // No `ddl` field — forces the column-by-column build path.
             columns: {
               id: { type: 'TEXT', primaryKey: true, notNull: true },
               code: { type: 'TEXT', unique: true, notNull: true },
@@ -71,22 +75,24 @@ describe('MigrationGenerator branch coverage', () => {
 
       const up = migration.up.join('\n');
       expect(up).toContain('CREATE TABLE IF NOT EXISTS "orders"');
-      expect(up).toContain('"id" TEXT PRIMARY KEY NOT NULL');
+      // The DDL strategy omits the redundant NOT NULL on a PRIMARY KEY column
+      // (PK implies NOT NULL) — this is the orchestrator-aligned output.
+      expect(up).toContain('"id" TEXT PRIMARY KEY');
       expect(up).toContain('"code" TEXT NOT NULL UNIQUE');
       expect(up).toContain('"quantity" INTEGER NOT NULL DEFAULT 0');
       // String default escapes single quotes.
       expect(up).toContain(`"note" TEXT DEFAULT 'O''Brien'`);
-      // FK constraint with both actions.
-      expect(up).toContain(
-        'FOREIGN KEY ("customer_id") REFERENCES "customers"("id") ON DELETE CASCADE ON UPDATE RESTRICT',
-      );
       // DOWN drops the table.
       expect(migration.down.join('\n')).toContain(
         'DROP TABLE IF EXISTS "orders"',
       );
     });
 
-    it('omits ON DELETE/ON UPDATE when the FK declares no actions', () => {
+    it('does not emit inline FK constraints on the delegated path (orchestrator parity)', () => {
+      // The DDL strategy (and thus the delegated generateCreateTable) does not
+      // emit FOREIGN KEY constraints — SMRT manages relationships via
+      // cross-package refs and avoids circular DDL FKs (#1333). This matches
+      // the migration orchestrator's CREATE TABLE path.
       const diff: SchemaDiff = {
         has_changes: true,
         added_tables: [
@@ -116,11 +122,8 @@ describe('MigrationGenerator branch coverage', () => {
       });
 
       const up = migration.up.join('\n');
-      expect(up).toContain(
-        'FOREIGN KEY ("target_id") REFERENCES "targets"("id")',
-      );
-      expect(up).not.toContain('ON DELETE');
-      expect(up).not.toContain('ON UPDATE');
+      expect(up).toContain('CREATE TABLE IF NOT EXISTS "links"');
+      expect(up).not.toContain('FOREIGN KEY');
     });
   });
 

--- a/packages/core/src/migrations/__tests__/generator.test.ts
+++ b/packages/core/src/migrations/__tests__/generator.test.ts
@@ -202,6 +202,86 @@ describe('MigrationGenerator', () => {
     });
   });
 
+  describe('generateCreateTable without pre-generated ddl', () => {
+    it('delegates to the engine DDL strategy for per-engine column types (Postgres)', () => {
+      // #1378: when a schema has no `ddl`, the generator must delegate to the
+      // engine strategy (like the orchestrator) instead of emitting the
+      // ABSTRACT column type verbatim. Otherwise Postgres would get JSON/REAL
+      // and the next compare() would flag spurious type drift.
+      const diff: SchemaDiff = {
+        has_changes: true,
+        added_tables: [
+          {
+            tableName: 'metrics',
+            // No `ddl` — forces the delegated fallback path.
+            columns: {
+              id: { type: 'UUID', primaryKey: true },
+              payload: { type: 'JSON' },
+              ratio: { type: 'REAL' },
+            },
+            indexes: [],
+            triggers: [],
+            foreignKeys: [],
+            dependencies: [],
+            version: '1.0.0',
+          } as SchemaDefinition,
+        ],
+        dropped_tables: [],
+        changes: [],
+      };
+
+      const generator = new MigrationGenerator({
+        engine: 'postgres',
+        format: 'sql',
+        includeDown: true,
+      });
+
+      const migration = generator.generateFromDiff(diff, {
+        name: '0001_metrics',
+        description: 'Add metrics table',
+      });
+
+      const up = migration.up.join('\n');
+      // Per-engine Postgres types, NOT the abstract JSON/REAL.
+      expect(up).toContain('JSONB');
+      expect(up).toContain('DOUBLE PRECISION');
+      expect(up).not.toMatch(/"payload"\s+JSON\b/);
+      expect(up).not.toMatch(/"ratio"\s+REAL\b/);
+      // Native uuid type for the id column (R11).
+      expect(up).toContain('"id" uuid');
+    });
+
+    it('delegates to the SQLite strategy (JSON→TEXT, REAL stays REAL)', () => {
+      const diff: SchemaDiff = {
+        has_changes: true,
+        added_tables: [
+          {
+            tableName: 'metrics',
+            columns: {
+              id: { type: 'TEXT', primaryKey: true },
+              payload: { type: 'JSON' },
+            },
+            indexes: [],
+            triggers: [],
+            foreignKeys: [],
+            dependencies: [],
+            version: '1.0.0',
+          } as SchemaDefinition,
+        ],
+        dropped_tables: [],
+        changes: [],
+      };
+
+      const generator = new MigrationGenerator({ engine: 'sqlite' });
+      const up = generator
+        .generateFromDiff(diff, { name: '0001_metrics' })
+        .up.join('\n');
+      // SQLite maps JSON → TEXT.
+      expect(up).toContain('"payload" TEXT');
+      expect(up).not.toContain('JSONB');
+    });
+  });
+
   describe('generateFromSQL', () => {
     it('should wrap SQL in migration format', () => {
       const generator = new MigrationGenerator({

--- a/packages/core/src/migrations/generator.ts
+++ b/packages/core/src/migrations/generator.ts
@@ -5,6 +5,7 @@
  * Supports both SQL and TypeScript formats.
  */
 
+import { getDDLStrategy } from '../schema/ddl/index.js';
 import type {
   MigrationDefinition,
   SchemaChange,
@@ -271,40 +272,16 @@ ${downStatementsStr}
       return schema.ddl;
     }
 
-    const tableName = this.quoteIdentifier(schema.tableName);
-    const columns: string[] = [];
-
-    for (const [colName, colDef] of Object.entries(schema.columns)) {
-      const parts: string[] = [this.quoteIdentifier(colName), colDef.type];
-
-      if (colDef.primaryKey) {
-        parts.push('PRIMARY KEY');
-      }
-      if (colDef.notNull) {
-        parts.push('NOT NULL');
-      }
-      if (colDef.unique && !colDef.primaryKey) {
-        parts.push('UNIQUE');
-      }
-      if (colDef.defaultValue !== undefined) {
-        parts.push(`DEFAULT ${this.formatDefaultValue(colDef.defaultValue)}`);
-      }
-
-      columns.push(parts.join(' '));
-    }
-
-    // Add foreign key constraints
-    for (const fk of schema.foreignKeys) {
-      const fkConstraint = `FOREIGN KEY (${this.quoteIdentifier(fk.column)}) REFERENCES ${this.quoteIdentifier(fk.referencesTable)}(${this.quoteIdentifier(fk.referencesColumn)})`;
-      const actions: string[] = [];
-      if (fk.onDelete) actions.push(`ON DELETE ${fk.onDelete}`);
-      if (fk.onUpdate) actions.push(`ON UPDATE ${fk.onUpdate}`);
-      columns.push(
-        `${fkConstraint}${actions.length > 0 ? ` ${actions.join(' ')}` : ''}`,
-      );
-    }
-
-    return `CREATE TABLE IF NOT EXISTS ${tableName} (\n  ${columns.join(',\n  ')}\n)`;
+    // No pre-generated DDL: delegate to the engine's DDL strategy, exactly as
+    // the migration orchestrator does (orchestrate.ts). Building the statement
+    // inline here previously emitted the *abstract* column type verbatim
+    // (JSON/REAL/UUID) instead of the per-engine type (JSONB/DOUBLE
+    // PRECISION/native uuid), so the very next `compare()` flagged spurious
+    // type drift. The strategy also escapes identifiers/defaults safely. (Like
+    // the orchestrator's CREATE TABLE path, foreign-key constraints are not
+    // emitted here — SMRT manages relationships via cross-package refs and
+    // avoids circular DDL FKs, see #1333.)
+    return getDDLStrategy(this.engine).generateCreateTable(schema);
   }
 
   /**

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -18,6 +18,7 @@ import {
   DatabaseError,
   ErrorUtils,
   RuntimeError,
+  SmrtError,
   TenantIsolationError,
   ValidationError,
 } from './errors';
@@ -1661,16 +1662,20 @@ export class SmrtObject extends SmrtClass {
               await this.db.upsert(this.tableName, upsertConflictColumns, data);
             }
           } catch (error) {
-            // Detect specific database error types
+            // Detect specific database error types. `@happyvertical/sql` does
+            // not normalize driver errors, so match SQLite, PostgreSQL and
+            // DuckDB constraint strings to preserve the advertised typed-error
+            // parity (#1378) across adapters.
             if (error instanceof Error) {
-              if (error.message.includes('UNIQUE constraint failed')) {
+              const kind = SmrtObject.classifyConstraintError(error.message);
+              if (kind === 'unique') {
                 const field = this.extractConstraintField(error.message);
                 throw ValidationError.uniqueConstraint(
                   field,
                   this.getFieldValue(field),
                 );
               }
-              if (error.message.includes('NOT NULL constraint failed')) {
+              if (kind === 'not_null') {
                 const field = this.extractConstraintField(error.message);
                 throw ValidationError.requiredField(field, className);
               }
@@ -1731,8 +1736,21 @@ export class SmrtObject extends SmrtClass {
 
       return this;
     } catch (error) {
-      // Re-throw SMRT errors as-is, wrap others
-      if (error instanceof ValidationError || error instanceof DatabaseError) {
+      // Re-throw SMRT errors as-is (ValidationError, DatabaseError,
+      // TenantIsolationError, etc. all extend SmrtError) so their stable
+      // `code`/`instanceof` contract survives the save() boundary.
+      if (error instanceof SmrtError) {
+        throw error;
+      }
+
+      // Preserve tenancy errors thrown by the `beforeSave` interceptor. The
+      // `@happyvertical/smrt-tenancy` TenantIsolationError / TenantContextError
+      // extend plain `Error` (core cannot depend on the tenancy package), so
+      // they are NOT instanceof SmrtError. Re-throw them as-is by their stable
+      // `code` (or class name fallback) so handlers can still match
+      // `err.code === 'TENANT_ISOLATION_VIOLATION'` / 'TENANT_CONTEXT_REQUIRED'
+      // on the write path, just like on the relationship-load path.
+      if (this.isTenantContractError(error)) {
         throw error;
       }
 
@@ -1742,6 +1760,35 @@ export class SmrtObject extends SmrtClass {
         error instanceof Error ? error : new Error(String(error)),
       );
     }
+  }
+
+  /**
+   * Detects tenant-boundary errors that must propagate from `save()` unwrapped.
+   *
+   * Matches both core's {@link TenantIsolationError} and the duck-typed
+   * tenancy-package errors (`TenantIsolationError` / `TenantContextError`) that
+   * the `beforeSave` interceptor throws. Those tenancy classes extend plain
+   * `Error` — core cannot import the tenancy package (the dependency runs the
+   * other way) — so they are matched by their stable `code` constants, with a
+   * class-name fallback for resilience.
+   */
+  private isTenantContractError(error: unknown): boolean {
+    if (error instanceof TenantIsolationError) {
+      return true;
+    }
+    const candidate = error as
+      | { code?: unknown; name?: unknown }
+      | null
+      | undefined;
+    const code = candidate?.code;
+    if (
+      code === 'TENANT_ISOLATION_VIOLATION' ||
+      code === 'TENANT_CONTEXT_REQUIRED'
+    ) {
+      return true;
+    }
+    const name = candidate?.name;
+    return name === 'TenantIsolationError' || name === 'TenantContextError';
   }
 
   /**
@@ -1899,13 +1946,70 @@ export class SmrtObject extends SmrtClass {
   }
 
   /**
-   * Extracts field name from database constraint error messages
+   * Classifies a raw database driver error message as a unique-constraint or
+   * not-null-constraint violation, across SQLite, PostgreSQL and DuckDB.
+   *
+   * `@happyvertical/sql` does not normalize driver errors, so each dialect's
+   * native wording is matched case-insensitively. Returns `null` when the
+   * message is not a recognized unique/not-null violation (the caller then
+   * falls back to a generic `DatabaseError`). Kept as a pure static so the
+   * cross-dialect matching can be unit-tested directly without a live PG/DuckDB
+   * connection (#1378).
+   *
+   * @param message - The raw driver error message.
+   * @returns `'unique'`, `'not_null'`, or `null`.
+   */
+  static classifyConstraintError(
+    message: string,
+  ): 'unique' | 'not_null' | null {
+    if (!message) {
+      return null;
+    }
+
+    // NOT NULL — checked first because DuckDB's "violates" wording would
+    // otherwise be misread as a unique violation below.
+    // SQLite/DuckDB: "NOT NULL constraint failed: t.col"
+    // PostgreSQL:    'null value in column "col" ... violates not-null constraint'
+    if (
+      /NOT NULL constraint failed/i.test(message) ||
+      /null value in column .* violates not-null/i.test(message)
+    ) {
+      return 'not_null';
+    }
+
+    // UNIQUE
+    // SQLite:     "UNIQUE constraint failed: t.col"
+    // PostgreSQL: "duplicate key value violates unique constraint ..."
+    // DuckDB:     "Constraint Error: ... violates unique/primary key constraint"
+    if (
+      /UNIQUE constraint failed/i.test(message) ||
+      /duplicate key value violates unique/i.test(message) ||
+      (/constraint error/i.test(message) && /violates/i.test(message))
+    ) {
+      return 'unique';
+    }
+
+    return null;
+  }
+
+  /**
+   * Extracts field name from database constraint error messages.
+   *
+   * Handles SQLite, PostgreSQL and DuckDB phrasings. Returns
+   * `'unknown_field'` when no column name can be recovered.
    */
   protected extractConstraintField(errorMessage: string): string {
-    // Try to extract field name from common SQLite constraint patterns
+    // Try to extract field name from common constraint patterns across dialects.
     const patterns = [
-      /UNIQUE constraint failed: \w+\.(\w+)/,
-      /NOT NULL constraint failed: \w+\.(\w+)/,
+      // SQLite / DuckDB: "UNIQUE constraint failed: products.slug"
+      /UNIQUE constraint failed: \w+\.(\w+)/i,
+      // SQLite / DuckDB: "NOT NULL constraint failed: products.name"
+      /NOT NULL constraint failed: \w+\.(\w+)/i,
+      // PostgreSQL not-null: 'null value in column "name" ...'
+      /null value in column "([^"]+)"/i,
+      // PostgreSQL unique DETAIL line: 'Key (slug)=(foo) already exists.'
+      /Key \(([^)]+)\)=/i,
+      // SQLite / DuckDB generic fallback: "constraint failed: slug"
       /constraint failed: (\w+)/i,
     ];
 
@@ -2991,7 +3095,20 @@ export class SmrtObject extends SmrtClass {
     }
 
     if (result) {
-      return JSON.parse(result.value);
+      // Guard against a corrupted _smrt_contexts row: a single malformed value
+      // must not throw an uncaught SyntaxError out of recall(). Treat it as a
+      // miss and continue to the ancestor fallback (#1378).
+      try {
+        return JSON.parse(result.value);
+      } catch (error) {
+        logger.warn('Skipping corrupted _smrt_contexts value in recall()', {
+          ownerClass: this._className,
+          ownerId: this.id,
+          scope: options.scope,
+          key: options.key,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
 
     // Hierarchical fallback to parent scopes
@@ -3077,7 +3194,18 @@ export class SmrtObject extends SmrtClass {
     const rows = await this.systemDb.list('_smrt_contexts', where);
 
     for (const row of rows) {
-      results.set(row.key, JSON.parse(row.value));
+      // Skip a corrupted row rather than aborting the whole recallAll() (#1378).
+      try {
+        results.set(row.key, JSON.parse(row.value));
+      } catch (error) {
+        logger.warn('Skipping corrupted _smrt_contexts value in recallAll()', {
+          ownerClass: this._className,
+          ownerId: this.id,
+          scope: options.scope,
+          key: row.key,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
 
     return results;

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -1977,14 +1977,19 @@ export class SmrtObject extends SmrtClass {
       return 'not_null';
     }
 
-    // UNIQUE
+    // UNIQUE — match unique/primary-key wording specifically. Do NOT match a
+    // bare "Constraint Error ... violates", because DuckDB phrases foreign-key
+    // failures the same way ("Constraint Error: violates foreign key
+    // constraint"); a broad match would misreport an FK violation as a unique
+    // one. Unmatched constraint kinds (FK, CHECK) fall through to a generic
+    // DatabaseError, preserving the original error contract.
     // SQLite:     "UNIQUE constraint failed: t.col"
     // PostgreSQL: "duplicate key value violates unique constraint ..."
     // DuckDB:     "Constraint Error: ... violates unique/primary key constraint"
     if (
       /UNIQUE constraint failed/i.test(message) ||
-      /duplicate key value violates unique/i.test(message) ||
-      (/constraint error/i.test(message) && /violates/i.test(message))
+      /violates unique constraint/i.test(message) ||
+      /violates primary key constraint/i.test(message)
     ) {
       return 'unique';
     }

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -71,6 +71,12 @@ import {
   resolveEmbeddingConfig as _resolveEmbeddingConfig,
 } from './registry/embedding-manager';
 import {
+  getAllFields as _getAllFields,
+  getAllMethods as _getAllMethods,
+  getInheritanceChain as _getInheritanceChain,
+  mergeFieldConfigs as _mergeFieldConfigs,
+} from './registry/inheritance-resolver';
+import {
   createFieldFromManifest,
   manifestFieldDiffers,
   mergeManifestField,
@@ -78,7 +84,6 @@ import {
 import {
   findClass as _findClass,
   findClassesByName as _findClassesByName,
-  findClassStrict as _findClassStrict,
   getAllClasses as _getAllClasses,
   getCanonicalClassName as _getCanonicalClassName,
   getClass as _getClass,
@@ -114,7 +119,6 @@ import {
   getDiscoveryAttemptCache,
   getFieldDecorators,
   getInheritanceCache,
-  getInheritanceConfig,
   getNextDbId,
   getStiSiblingsLoaded,
   setNextDbId,
@@ -135,7 +139,6 @@ import type {
   ValidationRule,
 } from './scanner/types.js';
 import type { ColumnDefinition, SchemaDefinition } from './schema/types.js';
-import { prependSmrtSystemFields } from './system-fields';
 import { classnameToTablename, toSnakeCase } from './utils';
 import { LRUCache } from './utils/lru-cache';
 import {
@@ -603,36 +606,10 @@ export class ObjectRegistry {
     return _findClass(name);
   }
 
-  /**
-   * Strict class lookup with package-aware disambiguation.
-   *
-   * Unlike `findClass()` which silently returns the first match when a simple
-   * name is ambiguous, this method throws a `ConfigurationError` — making it
-   * safe for inheritance-critical paths where wrong resolution creates phantom
-   * circular chains.
-   *
-   * Lookup priority:
-   * 1. Direct hit on classes map (works for qualified names as keys)
-   * 2. If input contains ':', treat as qualified name — direct only, no fallback
-   * 3. If `fromPackage` provided, try qualified name `fromPackage:name` first
-   * 4. classNameMap lookup by simple name (lowercase)
-   *    - Unambiguous (1 entry) → return it
-   *    - Ambiguous (>1 entry) → throw ConfigurationError
-   * 5. Case-insensitive iteration fallback (backward compat)
-   *
-   * @param name - Name of the class to find (simple or qualified)
-   * @param fromPackage - Optional package context for disambiguation
-   * @returns Registered class information or undefined if not found
-   * @throws {ConfigurationError} When simple name is ambiguous and no package context resolves it
-   * @see https://github.com/happyvertical/smrt/issues/1005
-   * @private
-   */
-  private static findClassStrict(
-    name: string,
-    fromPackage?: string,
-  ): RegisteredClass | undefined {
-    return _findClassStrict(name, fromPackage);
-  }
+  // The private `findClassStrict` wrapper that used to live here was removed
+  // with the inline inheritance-chain copy (#1378); strict, package-aware
+  // resolution now lives solely in registry/inheritance-resolver, which calls
+  // the name-resolver helper directly.
 
   /**
    * Get a registered class by name (case-insensitive)
@@ -2210,105 +2187,13 @@ export class ObjectRegistry {
    * ```
    */
   static getInheritanceChain(className: string): string[] {
-    const cache = ObjectRegistry.getInheritanceCache();
-
-    // Check cache first
-    const cached = cache.get(className);
-    if (cached) {
-      return cached;
-    }
-
-    // Get registered class
-    const registered = ObjectRegistry.findClass(className);
-    if (!registered) {
-      return [];
-    }
-
-    // Check if already computed and stored
-    if (registered.inheritanceChain) {
-      cache.set(className, registered.inheritanceChain);
-      return registered.inheritanceChain;
-    }
-
-    // Build chain from `extends` field (works for manifest-loaded classes)
-    // This is critical because manifest-loaded classes have stub constructors
-    // that only extend SmrtObject, not their actual parent class.
-    // The `extends` field IS stored correctly during registerFromManifest().
-    const chain: string[] = [];
-    const visited = new Set<any>(); // Cycle detection using object identity
-    let current: any = registered;
-    let circularDetected = false;
-    while (current) {
-      // Cycle detection: use object identity to handle cases where distinct
-      // classes share the same name (e.g., histrio:Performer vs smrt-video:Performer)
-      if (visited.has(current)) {
-        // Self-referential (chain length 1) is expected when a child package
-        // extends a parent with the same className and only one is installed.
-        // Longer cycles indicate misconfigured manifests.
-        if (chain.length > 1) {
-          logger.warn(
-            `[ObjectRegistry] Circular inheritance detected in chain: ${chain.join(' -> ')} -> ${current.name}. ` +
-              `Check that '${current.extends ?? current.name}' resolves to the correct package class.`,
-          );
-          circularDetected = true;
-        }
-        break;
-      }
-      visited.add(current);
-
-      // R5-canon: emit the qualified name when the registration has one
-      // so chain entries are unambiguous across packages. Falls back to
-      // the simple `current.name` for classes that lack a package context
-      // (some tests, or classes that bypassed manifest registration).
-      chain.unshift(current.qualifiedName ?? current.name); // [ancestor, ..., descendant]
-      if (!current.extends) break;
-
-      // Skip framework base classes that are never registered
-      if (
-        current.extends === 'SmrtObject' ||
-        current.extends === 'SmrtClass' ||
-        current.extends === 'SmrtCollection'
-      ) {
-        break;
-      }
-
-      // Try to find the parent class
-      // Issue #1004/#1005: Use findClassStrict with package context for
-      // unambiguous resolution. If extends is already qualified (from
-      // qualifyExtendsName), this is an O(1) direct lookup.
-      // If ambiguous, let the ConfigurationError propagate — callers
-      // should fix their manifests rather than silently get wrong results.
-      const parent = ObjectRegistry.findClassStrict(
-        current.extends,
-        current.packageName,
-      );
-
-      // Issue #1007: Parent not found — the class is not registered.
-      // After loadAllManifests() completes at startup, all classes are
-      // pre-registered so this path is only hit when a package is not
-      // installed or the manifest is stale. We gracefully end the chain
-      // here instead of mutating registry state during a read operation.
-      if (!parent) {
-        verboseLog(
-          `[ObjectRegistry] Parent class '${current.extends}' not found ` +
-            `while building inheritance chain. Ensure the parent package ` +
-            `is installed and loadAllManifests() was called at startup.`,
-        );
-      }
-
-      current = parent;
-    }
-
-    // Only cache complete, non-circular chains.
-    // Caching a broken chain from a circular detection would cause all future
-    // lookups to return incorrect inheritance data (e.g., ["VideoShot","VideoShot"]
-    // instead of ["Content","VideoShot"]), breaking STI table resolution.
-    if (!circularDetected) {
-      registered.inheritanceChain = chain;
-      cache.set(className, chain);
-    }
-
-    return chain;
+    // Delegate to the single source of truth in registry/inheritance-resolver.
+    // The inline copy that used to live here drifted from the module (it lacked
+    // the SmrtHierarchical `parentId` normalization in field merging), so the
+    // duplication was removed (#1378). The module shares the same name-resolver
+    // and shared-state helpers this class delegates to, so behavior is
+    // identical aside from the drift fix.
+    return _getInheritanceChain(className);
   }
 
   /**
@@ -2322,201 +2207,34 @@ export class ObjectRegistry {
    * @returns Map of all fields (including inherited)
    */
   static async getAllFields(className: string): Promise<Map<string, any>> {
-    let registered = ObjectRegistry.findClass(className);
-    if (!registered) {
-      const loaded = await ObjectRegistry.tryLoadFromExternalPackage(className);
-      if (!loaded) {
-        return new Map();
-      }
-      registered = ObjectRegistry.findClass(className);
-      if (!registered) {
-        return new Map();
-      }
-    }
-
-    // Ensure manifest is loaded (handles external packages)
-    await ObjectRegistry.ensureManifestLoaded(className);
-
-    // Check if class has inheritedFields cache (set during manifest loading)
-    if (registered.inheritedFields) {
-      return prependSmrtSystemFields(new Map(registered.inheritedFields));
-    }
-
-    // Get config for error handling behavior
-    const { onMissingAncestor } = getInheritanceConfig();
-
-    // For local classes (not from manifests), merge fields from inheritance chain
-    const allFields = new Map<string, any>();
-    const chain = ObjectRegistry.getInheritanceChain(className);
-
-    // Walk chain from base to child (parent fields first)
-    for (const ancestorName of chain) {
-      // Skip framework base classes
-      if (
-        ancestorName === 'SmrtObject' ||
-        ancestorName === 'SmrtClass' ||
-        ancestorName === 'SmrtCollection'
-      ) {
-        continue;
-      }
-
-      try {
-        await ObjectRegistry.ensureManifestLoaded(ancestorName);
-      } catch {
-        // Local classes and pure test fixtures may not have manifests. In that
-        // case we still want to use whatever runtime metadata is already
-        // registered instead of failing the entire inheritance walk.
-      }
-
-      const ancestor = ObjectRegistry.findClass(ancestorName);
-      if (!ancestor) {
-        // Handle missing ancestors according to config
-        const message = `Missing ancestor class "${ancestorName}" in inheritance chain for "${className}"`;
-
-        if (onMissingAncestor === 'error') {
-          throw new Error(
-            `${message}\n\n` +
-              `This usually means:\n` +
-              `  1. The parent class is not registered with @smrt()\n` +
-              `  2. The parent class file is not imported\n` +
-              `  3. The manifest does not include the parent class\n\n` +
-              `To fix:\n` +
-              `  - Ensure all parent classes use @smrt() decorator\n` +
-              `  - Import all parent class files before child classes\n` +
-              `  - Rebuild to regenerate manifest\n` +
-              `  - Or set smrt.inheritance.onMissingAncestor='warn' in config`,
-          );
-        } else if (onMissingAncestor === 'warn') {
-          logger.warn(`[ObjectRegistry] ${message}`);
-        }
-
-        continue;
-      }
-
-      // Merge fields from this ancestor
-      for (const [fieldName, field] of ancestor.fields) {
-        const existingField = allFields.get(fieldName);
-        if (!existingField) {
-          // New field from parent
-          allFields.set(fieldName, field);
-        } else {
-          // Field exists - merge configs
-          allFields.set(
-            fieldName,
-            ObjectRegistry.mergeFieldConfigs(existingField, field, fieldName),
-          );
-        }
-      }
-    }
-
-    registered.inheritedFields = new Map(allFields);
-
-    return prependSmrtSystemFields(allFields);
+    // Delegate to registry/inheritance-resolver (#1378). The inline copy
+    // omitted the SmrtHierarchical `parentId` normalization the module applies,
+    // so inherited self-FK fields could surface with the wrong shape. Removing
+    // the duplicate keeps field merging consistent everywhere.
+    return _getAllFields(className);
   }
 
   /**
-   * Merge field configurations from parent and child
+   * Merge field configurations from parent and child.
    *
-   * Rules:
-   * - Type: Child wins (warn if different)
-   * - _meta: Deep merge with child precedence
-   * - Numeric constraints: Take strictest (max of mins, min of maxes)
-   * - Validators: Combine (both must pass)
-   * - Unique: Take OR (unique if either says unique)
-   * - Value: Child wins
+   * Thin wrapper around the single shared implementation in
+   * registry/inheritance-resolver (#1378). The previous inline copy here had
+   * drifted from the module; both paths now run the same code. Kept as a
+   * private static so existing reach-in tests (issue #841 field-merge coverage)
+   * still resolve it.
    *
    * @param parentField - Field config from parent class
    * @param childField - Field config from child class
    * @param fieldName - Name of the field (for warning messages)
    * @returns Merged field configuration
    */
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: reached in by issue #841 field-merge tests via `(ObjectRegistry as any).mergeFieldConfigs`; kept as the registry-side surface delegating to the shared resolver impl.
   private static mergeFieldConfigs(
     parentField: any,
     childField: any,
     fieldName: string,
   ): any {
-    // Start with parent field as base
-    const merged = { ...parentField };
-
-    // Type: Child wins (warn if different)
-    if (childField.type && childField.type !== parentField.type) {
-      // Don't warn for tenantId field - expected type conflict between decorator and AST
-      // The @tenantId decorator registers as 'foreignKey' but AST sees 'text' from type annotation
-      // __tenancy can be at root level (from @tenantId decorator) or under _meta (from @smrt({ tenantScoped: true }))
-      const isTenantField =
-        parentField.__tenancy?.isTenantIdField ||
-        parentField._meta?.__tenancy?.isTenantIdField;
-      if (!(isTenantField && fieldName === 'tenantId')) {
-        logger.warn(
-          `Field type mismatch: "${fieldName}" is ${parentField.type} in parent but ${childField.type} in child. Using child type.`,
-        );
-      }
-      merged.type = childField.type;
-    }
-
-    // _meta: Merge with child precedence
-    if (childField._meta || parentField._meta) {
-      merged._meta = {
-        ...(parentField._meta || {}),
-        ...(childField._meta || {}),
-      };
-
-      // Special handling for numeric constraints (take strictest)
-      if (
-        parentField._meta?.min !== undefined &&
-        childField._meta?.min !== undefined
-      ) {
-        // Take the larger min (strictest lower bound)
-        merged._meta.min = Math.max(
-          parentField._meta.min,
-          childField._meta.min,
-        );
-      }
-      if (
-        parentField._meta?.max !== undefined &&
-        childField._meta?.max !== undefined
-      ) {
-        // Take the smaller max (strictest upper bound)
-        merged._meta.max = Math.min(
-          parentField._meta.max,
-          childField._meta.max,
-        );
-      }
-
-      // Validators: Combine (both must pass)
-      if (parentField._meta?.validate && childField._meta?.validate) {
-        const parentValidator = parentField._meta.validate;
-        const childValidator = childField._meta.validate;
-        merged._meta.validate = async (value: any) => {
-          const parentResult = await parentValidator(value);
-          const childResult = await childValidator(value);
-          return parentResult && childResult;
-        };
-      }
-
-      // Unique: Take OR (unique if either says unique)
-      if (parentField._meta?.unique || childField._meta?.unique) {
-        merged._meta.unique = true;
-      }
-    }
-
-    // __tenancy: Preserve from parent (decorator takes precedence)
-    // This ensures @tenantId decorator metadata survives type conflicts (Issue #841)
-    // The decorator registers __tenancy metadata, but AST scanner may override the type.
-    // We need to preserve __tenancy so the interceptor can identify tenant fields.
-    if (parentField.__tenancy || childField.__tenancy) {
-      merged.__tenancy = {
-        ...(childField.__tenancy || {}),
-        ...(parentField.__tenancy || {}), // Parent (decorator) wins
-      };
-    }
-
-    // Value: Child wins
-    if (childField.value !== undefined) {
-      merged.value = childField.value;
-    }
-
-    return merged;
+    return _mergeFieldConfigs(parentField, childField, fieldName);
   }
 
   /**
@@ -2540,54 +2258,9 @@ export class ObjectRegistry {
    * ```
    */
   static async getAllMethods(className: string): Promise<Map<string, any>> {
-    const registered = ObjectRegistry.findClass(className);
-    if (!registered) {
-      return new Map();
-    }
-
-    // Check cache first
-    if (registered.inheritedMethods) {
-      return new Map(registered.inheritedMethods);
-    }
-
-    // Build merged methods from inheritance chain
-    const allMethods = new Map<string, any>();
-    const chain = ObjectRegistry.getInheritanceChain(className);
-
-    // Walk chain from base to child (parent methods first)
-    for (const ancestorName of chain) {
-      // Skip framework base classes (check BEFORE looking up in registry)
-      if (
-        ancestorName === 'SmrtObject' ||
-        ancestorName === 'SmrtClass' ||
-        ancestorName === 'SmrtCollection'
-      ) {
-        continue;
-      }
-
-      // Load manifest for ancestor class (handles external packages)
-      // This ensures inherited methods from external packages are available
-      try {
-        await ObjectRegistry.ensureManifestLoaded(ancestorName);
-      } catch (error) {
-        // Manifest loading failed - this is expected for classes not in manifest
-        // Continue to next ancestor
-      }
-
-      const ancestor = ObjectRegistry.findClass(ancestorName);
-      if (!ancestor) continue;
-
-      // Merge parent methods into result
-      for (const [methodName, method] of ancestor.methods) {
-        // Child methods override parent methods (no merging)
-        allMethods.set(methodName, method);
-      }
-    }
-
-    // Cache the merged result
-    registered.inheritedMethods = allMethods;
-
-    return new Map(allMethods);
+    // Delegate to registry/inheritance-resolver (#1378) — single source of
+    // truth for inheritance-chain method merging.
+    return _getAllMethods(className);
   }
 
   /**

--- a/packages/core/src/registry/__tests__/inheritance-resolver.test.ts
+++ b/packages/core/src/registry/__tests__/inheritance-resolver.test.ts
@@ -1,11 +1,12 @@
 /**
  * Coverage tests for registry/inheritance-resolver.ts.
  *
- * IMPORTANT: ObjectRegistry.getInheritanceChain / getAllFields / getAllMethods
- * are INLINE re-implementations in registry.ts — they do NOT call the
- * inheritance-resolver module. So inheritance.test.ts (which goes through
- * ObjectRegistry) leaves this module at ~26%. These tests import the module
- * functions DIRECTLY to cover their real branches.
+ * As of #1378, ObjectRegistry.getInheritanceChain / getAllFields /
+ * getAllMethods / mergeFieldConfigs DELEGATE to this module — the inline copies
+ * in registry.ts (which had drifted on SmrtHierarchical `parentId`
+ * normalization) were removed. These tests import the module functions DIRECTLY
+ * to cover their real branches; a separate suite below additionally exercises
+ * the ObjectRegistry delegation so the public path can never silently re-drift.
  *
  * The module functions read/write the same globalThis registry + caches the
  * decorator populates, so we register real `@smrt()` fixtures and, for the
@@ -20,6 +21,7 @@ import {
   IRConstraintChild,
   IRLeaf,
   IRSolo,
+  IRTreeNode,
 } from '../../__tests__/fixtures/inheritance-resolver-fixtures.js';
 import { ConfigurationError } from '../../errors';
 import { SmrtObject } from '../../object';
@@ -402,5 +404,53 @@ describe('inheritance-resolver: end-to-end constraint merge via getAllFields', (
     expect(amount._meta.max).toBe(80);
     // Reference the parent fixture so the import is load-bearing.
     expect(typeof IRConstraintChild).toBe('function');
+  });
+});
+
+// Regression suite for #1378: the public ObjectRegistry methods must delegate
+// to this module. Before the fix, ObjectRegistry.getAllFields ran an inline
+// copy that omitted the SmrtHierarchical `parentId` normalization, so the
+// public path and the module path disagreed. These tests go through
+// ObjectRegistry (not the module functions) to lock the delegation in place.
+describe('ObjectRegistry delegates to inheritance-resolver (#1378)', () => {
+  it('getAllFields normalizes inherited SmrtHierarchical parentId to a nullable self-FK', async () => {
+    // Reference the fixture so its import is load-bearing.
+    expect(typeof IRTreeNode).toBe('function');
+
+    const fields = await ObjectRegistry.getAllFields('IRTreeNode');
+    const parentId = fields.get('parentId');
+    expect(parentId).toBeDefined();
+    // This is the behavior the inline copy lacked: a self-referential,
+    // nullable foreignKey back to the child class.
+    expect(parentId.type).toBe('foreignKey');
+    expect(parentId.related).toBe('IRTreeNode');
+    expect(parentId.required).toBe(false);
+    expect(parentId._meta?.nullable).toBe(true);
+  });
+
+  it('getAllFields (ObjectRegistry) matches the module function for the same class', async () => {
+    // Clear caches so both calls recompute from scratch.
+    ObjectRegistry.invalidateAllInheritanceCaches();
+    const viaRegistry = await ObjectRegistry.getAllFields('IRLeaf');
+    ObjectRegistry.invalidateAllInheritanceCaches();
+    const viaModule = await getAllFields('IRLeaf');
+    expect(Array.from(viaRegistry.keys()).sort()).toEqual(
+      Array.from(viaModule.keys()).sort(),
+    );
+  });
+
+  it('getInheritanceChain (ObjectRegistry) returns the qualified chain', () => {
+    const chain = ObjectRegistry.getInheritanceChain('IRLeaf');
+    expect(chain).toEqual([
+      '@happyvertical/smrt-core:IRBase',
+      '@happyvertical/smrt-core:IRMiddle',
+      '@happyvertical/smrt-core:IRLeaf',
+    ]);
+  });
+
+  it('getAllMethods (ObjectRegistry) merges the chain with child override', async () => {
+    const methods = await ObjectRegistry.getAllMethods('IRLeaf');
+    expect(methods.has('baseMethod')).toBe(true);
+    expect(methods.has('middleMethod')).toBe(true);
   });
 });

--- a/packages/core/src/registry/__tests__/schema-builder-helpers.test.ts
+++ b/packages/core/src/registry/__tests__/schema-builder-helpers.test.ts
@@ -31,11 +31,25 @@ describe('schema-builder: formatDefaultValue', () => {
     expect(formatDefaultValue(undefined, 'TEXT')).toBe('NULL');
   });
 
-  it('passes through SQL function calls (anything containing "(")', () => {
+  it('passes through well-formed SQL function-call defaults', () => {
+    // #1378: the formatter now allowlists *well-formed* function calls
+    // (identifier + a balanced arg list of literals/nested calls) instead of
+    // accepting "anything containing `(`".
     expect(formatDefaultValue('uuid_generate_v4()', 'UUID')).toBe(
       'uuid_generate_v4()',
     );
-    expect(formatDefaultValue('coalesce(a, b)', 'TEXT')).toBe('coalesce(a, b)');
+    expect(formatDefaultValue("coalesce('a', 'b')", 'TEXT')).toBe(
+      "coalesce('a', 'b')",
+    );
+  });
+
+  it('quotes a TEXT default that merely contains parentheses', () => {
+    // #1378 regression: bare-identifier "calls" and free text with parens are
+    // no longer passed through raw — they are quoted as data.
+    expect(formatDefaultValue('coalesce(a, b)', 'TEXT')).toBe(
+      "'coalesce(a, b)'",
+    );
+    expect(formatDefaultValue('Acme (Inc)', 'TEXT')).toBe("'Acme (Inc)'");
   });
 
   it('passes through recognized SQL keywords case-insensitively', () => {
@@ -45,7 +59,13 @@ describe('schema-builder: formatDefaultValue', () => {
     expect(formatDefaultValue('current_date', 'TIMESTAMP')).toBe(
       'current_date',
     );
-    expect(formatDefaultValue('NULL', 'TEXT')).toBe('NULL');
+  });
+
+  it('does NOT fold a literal string "null"/"NULL" for TEXT into SQL NULL', () => {
+    // #1378 regression: the keyword allowlist previously contained `null`, so a
+    // TEXT default of the *string* "NULL" silently became the SQL NULL keyword.
+    expect(formatDefaultValue('NULL', 'TEXT')).toBe("'NULL'");
+    expect(formatDefaultValue('null', 'TEXT')).toBe("'null'");
   });
 
   it('single-quotes and escapes TEXT/VARCHAR values', () => {

--- a/packages/core/src/registry/schema-builder.ts
+++ b/packages/core/src/registry/schema-builder.ts
@@ -6,6 +6,10 @@
 
 import { ObjectRegistry } from '../registry';
 import type { FieldDefinition } from '../scanner/types.js';
+import {
+  formatDefaultValue as formatDefaultValueShared,
+  quoteIdentifier,
+} from '../schema/sql-identifiers.js';
 import type {
   ColumnDefinition,
   IndexDefinition,
@@ -411,8 +415,12 @@ export function getAllSchemas(): Record<
     if (tableSchema.indexes.length > 0) {
       indexSQL = tableSchema.indexes.map((idx) => {
         const indexType = idx.unique ? 'UNIQUE INDEX' : 'INDEX';
-        const columnList = idx.columns.map((col) => `"${col}"`).join(', ');
-        return `CREATE ${indexType} IF NOT EXISTS "${idx.name}" ON "${tableName}" (${columnList});`;
+        const columnList = idx.columns
+          .map((col) => quoteIdentifier(col))
+          .join(', ');
+        return `CREATE ${indexType} IF NOT EXISTS ${quoteIdentifier(
+          idx.name,
+        )} ON ${quoteIdentifier(tableName)} (${columnList});`;
       });
     }
 
@@ -614,14 +622,14 @@ export function generateDDLFromColumns(
   columns: Record<string, ColumnDefinition>,
   isSTI = false,
 ): string {
-  let sql = `CREATE TABLE IF NOT EXISTS "${tableName}" (\n`;
+  let sql = `CREATE TABLE IF NOT EXISTS ${quoteIdentifier(tableName)} (\n`;
 
   const columnLines: string[] = [];
   for (const [columnName, columnDef] of Object.entries(columns)) {
     const parts: string[] = [];
 
     // Column name and type
-    parts.push(`  "${columnName}" ${columnDef.type}`);
+    parts.push(`  ${quoteIdentifier(columnName)} ${columnDef.type}`);
 
     // Primary key
     if (columnDef.primaryKey) {
@@ -669,64 +677,20 @@ export function generateDDLFromColumns(
 }
 
 /**
- * Format default value for SQL DDL
+ * Format default value for SQL DDL.
+ *
+ * Thin wrapper over the shared, injection-safe formatter
+ * (`schema/sql-identifiers.ts`) so the registry schema-builder uses the same
+ * rules as the DDL strategies and schema generator: an allowlist of SQL
+ * keyword/function defaults (not "contains `(`"), type-driven literal quoting,
+ * and no folding of a literal string `"null"` into the SQL NULL keyword.
  *
  * @param value - Default value
  * @param type - Column SQL type
  * @returns Formatted SQL default value
  */
 export function formatDefaultValue(value: any, type: string): string {
-  // Handle NULL
-  if (value === null || value === undefined) {
-    return 'NULL';
-  }
-
-  // Handle SQL functions and keywords
-  if (typeof value === 'string') {
-    if (value.includes('(')) {
-      return value;
-    }
-    const sqlKeywords = [
-      'current_timestamp',
-      'current_date',
-      'current_time',
-      'now()',
-      'uuid_generate_v4()',
-      'null',
-    ];
-    if (sqlKeywords.some((kw) => value.toLowerCase() === kw)) {
-      return value;
-    }
-  }
-
-  // Handle by type
-  if (type === 'TEXT' || type === 'VARCHAR') {
-    return `'${String(value).replace(/'/g, "''")}'`;
-  }
-  if (type === 'INTEGER' || type === 'REAL') {
-    return String(value);
-  }
-  if (type === 'BOOLEAN') {
-    return value ? 'TRUE' : 'FALSE';
-  }
-  if (type === 'JSON') {
-    if (typeof value === 'string') {
-      if (value === '') return "'null'";
-      if (value === '[object Object]') return "'{}'";
-      try {
-        JSON.parse(value);
-        return `'${value.replace(/'/g, "''")}'`;
-      } catch {
-        const json = JSON.stringify(value);
-        return `'${json.replace(/'/g, "''")}'`;
-      }
-    }
-    const json = JSON.stringify(value);
-    return `'${json.replace(/'/g, "''")}'`;
-  }
-
-  // Fallback: quote as string
-  return `'${String(value).replace(/'/g, "''")}'`;
+  return formatDefaultValueShared(value, type);
 }
 
 /**

--- a/packages/core/src/runtime/server.test.ts
+++ b/packages/core/src/runtime/server.test.ts
@@ -178,6 +178,110 @@ describe('Express-style route adapters', () => {
     const res = await dispatch(new Request(`${BASE}/api/v1/fail`));
     expect(res.status).toBe(500);
   });
+
+  it('settles an async rejecting handler as 500 instead of hanging (#1378)', async () => {
+    const { server, dispatch } = makeServer({ cors: false });
+    server.get('/async-fail', async () => {
+      await Promise.resolve();
+      throw new Error('async fail');
+    });
+
+    // Race against a timeout: a hung (never-settling) response would lose the
+    // race. The fix must let the dispatch promise settle to a 500.
+    const result = await Promise.race([
+      dispatch(new Request(`${BASE}/api/v1/async-fail`)).then((r) => r.status),
+      new Promise<'TIMEOUT'>((resolve) =>
+        setTimeout(() => resolve('TIMEOUT'), 1000),
+      ),
+    ]);
+    expect(result).toBe(500);
+  });
+
+  it('500s an async handler that resolves without responding (#1378)', async () => {
+    const { server, dispatch } = makeServer({ cors: false });
+    // Handler completes but never calls res.json/send/end.
+    server.get('/no-response', async () => {
+      await Promise.resolve();
+    });
+
+    const result = await Promise.race([
+      dispatch(new Request(`${BASE}/api/v1/no-response`)).then((r) => r.status),
+      new Promise<'TIMEOUT'>((resolve) =>
+        setTimeout(() => resolve('TIMEOUT'), 1000),
+      ),
+    ]);
+    expect(result).toBe(500);
+  });
+
+  it('awaits a slow async handler that eventually responds', async () => {
+    const { server, dispatch } = makeServer({ cors: false });
+    server.post('/slow', async (_req, res) => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      res.status(202).json({ queued: true });
+    });
+
+    const res = await dispatch(
+      new Request(`${BASE}/api/v1/slow`, { method: 'POST' }),
+    );
+    expect(res.status).toBe(202);
+    expect(await res.json()).toEqual({ queued: true });
+  });
+});
+
+describe('request body parsing (#1378)', () => {
+  it('returns 400 (not 500) for a malformed JSON body', async () => {
+    const { server, dispatch } = makeServer({ cors: false });
+    server.addRoute('POST', '/echo', async (req) => {
+      const data = await req.json();
+      return new Response(JSON.stringify(data));
+    });
+
+    const res = await dispatch(
+      new Request(`${BASE}/api/v1/echo`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{ not: valid json',
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('treats an empty JSON body as no body (handler runs, body undefined)', async () => {
+    const { server, dispatch } = makeServer({ cors: false });
+    server.addRoute('POST', '/maybe', async (req) => {
+      return new Response(JSON.stringify({ hasBody: req.body !== undefined }), {
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+
+    const res = await dispatch(
+      new Request(`${BASE}/api/v1/maybe`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '',
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ hasBody: false });
+  });
+
+  it('still parses a well-formed JSON body', async () => {
+    const { server, dispatch } = makeServer({ cors: false });
+    server.addRoute('POST', '/echo', async (req) => {
+      const data = await req.json();
+      return new Response(JSON.stringify(data));
+    });
+
+    const res = await dispatch(
+      new Request(`${BASE}/api/v1/echo`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ ok: true }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
 });
 
 describe('CORS handling', () => {

--- a/packages/core/src/runtime/server.ts
+++ b/packages/core/src/runtime/server.ts
@@ -8,6 +8,18 @@ import type { SmrtRequest, SmrtServerOptions } from './types';
 
 const logger = createLogger({ level: 'info' });
 
+/**
+ * Signals a malformed client request (e.g. invalid JSON body) so that
+ * {@link SmrtServer.handleRequest} can answer 400 instead of a generic 500
+ * (#1378). Internal to this module.
+ */
+class BadRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BadRequestError';
+  }
+}
+
 export class SmrtServer {
   private options: Required<SmrtServerOptions>;
   private routes: Map<string, (req: SmrtRequest) => Promise<Response>> =
@@ -73,6 +85,20 @@ export class SmrtServer {
   ) {
     const smrtHandler = async (req: SmrtRequest): Promise<Response> => {
       return new Promise((resolve, reject) => {
+        // Tracks whether the handler ever produced a response. A handler that
+        // returns/resolves without calling json/send/end would otherwise leave
+        // this promise pending forever (server hang) — we 500 instead (#1378).
+        let settled = false;
+        const settle = (response: Response) => {
+          if (settled) return;
+          settled = true;
+          resolve(response);
+        };
+        const fail = (error: unknown) => {
+          if (settled) return;
+          settled = true;
+          reject(error);
+        };
         // Create Express-style response object
         const res = {
           status: (code: number) => {
@@ -80,7 +106,7 @@ export class SmrtServer {
             return res;
           },
           json: (data: any) => {
-            resolve(
+            settle(
               new Response(JSON.stringify(data), {
                 status: res.statusCode || 200,
                 headers: {
@@ -92,7 +118,7 @@ export class SmrtServer {
           },
           send: (data: any) => {
             const body = typeof data === 'string' ? data : JSON.stringify(data);
-            resolve(
+            settle(
               new Response(body, {
                 status: res.statusCode || 200,
                 headers: {
@@ -106,7 +132,7 @@ export class SmrtServer {
             );
           },
           end: (data?: any) => {
-            resolve(
+            settle(
               new Response(data || '', {
                 status: res.statusCode || 200,
                 headers: res.headers,
@@ -122,11 +148,24 @@ export class SmrtServer {
           headers: {} as Record<string, string>,
         };
 
-        try {
-          handler(req, res);
-        } catch (error) {
-          reject(error);
-        }
+        // Await the handler so async rejections propagate. Express-style
+        // handlers signal completion via res.json/send/end; a sync throw or an
+        // async rejection is surfaced as 500 by handleRequest. Promise.resolve
+        // wraps both sync and async handlers uniformly (#1378).
+        Promise.resolve()
+          .then(() => handler(req, res))
+          .then(() => {
+            // Handler completed without producing a response (never called
+            // json/send/end). Resolve a 500 rather than hanging forever.
+            if (!settled) {
+              settle(
+                new Response('Internal Server Error', {
+                  status: 500,
+                }),
+              );
+            }
+          })
+          .catch((error) => fail(error));
       });
     };
 
@@ -270,6 +309,11 @@ export class SmrtServer {
 
       return response;
     } catch (error) {
+      // A malformed request (e.g. invalid JSON body) is the client's fault →
+      // 400, not 500 (#1378).
+      if (error instanceof BadRequestError) {
+        return new Response(error.message, { status: 400 });
+      }
       logger.error('[smrt] Request error', { error });
       return new Response('Internal Server Error', { status: 500 });
     }
@@ -293,7 +337,10 @@ export class SmrtServer {
       query[key] = value;
     });
 
-    // Parse body if present
+    // Parse body if present. `request.body` is a stream and stays truthy even
+    // for an empty body, so reading text first lets us treat an empty body as
+    // "no body" (undefined) and surface only genuinely malformed JSON as a 400
+    // rather than letting request.json() throw a generic 500 (#1378).
     let body: any;
     if (
       request.body &&
@@ -302,10 +349,21 @@ export class SmrtServer {
         request.method === 'PATCH')
     ) {
       const contentType = request.headers.get('content-type') || '';
-      if (contentType.includes('application/json')) {
-        body = await request.json();
+      const rawBody = await request.text();
+      if (rawBody.trim() === '') {
+        // Empty body → no body. Leave `body` undefined.
+      } else if (contentType.includes('application/json')) {
+        try {
+          body = JSON.parse(rawBody);
+        } catch (error) {
+          throw new BadRequestError(
+            `Invalid JSON request body: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
       } else {
-        body = await request.text();
+        body = rawBody;
       }
     }
 

--- a/packages/core/src/schema/ddl/base-strategy.ts
+++ b/packages/core/src/schema/ddl/base-strategy.ts
@@ -6,6 +6,12 @@
  */
 
 import { createLogger } from '@happyvertical/logger';
+import {
+  formatDefaultValue as formatDefaultValueShared,
+  isSafeIdentifierPath,
+  quoteIdentifier,
+  quoteStringLiteral,
+} from '../sql-identifiers.js';
 import type {
   ColumnDefinition,
   IndexDefinition,
@@ -16,6 +22,30 @@ import type {
 import type { DatabaseEngine, DDLStrategy } from './types.js';
 
 const logger = createLogger({ level: 'info' });
+
+/**
+ * Validate the column + JSON path used to build a JSON-path index expression.
+ *
+ * The path segment is embedded as a SQL string literal inside a dialect
+ * function/operator (`json_extract("col", '$.path')` / `"col"->>'path'`), and
+ * the column as a delimited identifier. We escape both, but also reject paths
+ * or columns that aren't simple (dotted) identifiers so a malformed `@meta`
+ * field name can't smuggle structure into the expression even after escaping.
+ * These names are developer-controlled build-time inputs, so an invalid one is
+ * a programming error and throwing is the safest, loudest outcome.
+ */
+function assertSafeJsonPathTarget(jsonColumn: string, path: string): void {
+  if (!isSafeIdentifierPath(jsonColumn)) {
+    throw new Error(
+      `[DDL] Unsafe JSON-path index column "${jsonColumn}": must be a simple identifier`,
+    );
+  }
+  if (!isSafeIdentifierPath(path)) {
+    throw new Error(
+      `[DDL] Unsafe JSON-path index path "${path}": must be a simple (dotted) identifier`,
+    );
+  }
+}
 
 /**
  * Abstract base class for DDL strategies
@@ -32,7 +62,7 @@ export abstract class BaseDDLStrategy implements DDLStrategy {
   generateCreateTable(schema: SchemaDefinition): string {
     const { tableName, columns, indexes = [] } = schema;
 
-    let sql = `CREATE TABLE IF NOT EXISTS "${tableName}" (\n`;
+    let sql = `CREATE TABLE IF NOT EXISTS ${quoteIdentifier(tableName)} (\n`;
 
     // Generate column definitions
     const columnDefs: string[] = [];
@@ -61,7 +91,10 @@ export abstract class BaseDDLStrategy implements DDLStrategy {
     columnName: string,
     columnDef: ColumnDefinition,
   ): string {
-    const parts: string[] = [`"${columnName}"`, this.mapType(columnDef.type)];
+    const parts: string[] = [
+      quoteIdentifier(columnName),
+      this.mapType(columnDef.type),
+    ];
 
     // Primary key
     if (columnDef.primaryKey) {
@@ -116,7 +149,7 @@ export abstract class BaseDDLStrategy implements DDLStrategy {
       }
 
       if (index.unique && index.columns.length > 0) {
-        const columns = index.columns.map((c) => `"${c}"`).join(', ');
+        const columns = index.columns.map((c) => quoteIdentifier(c)).join(', ');
         constraints.push(`UNIQUE(${columns})`);
       }
     }
@@ -166,9 +199,11 @@ export abstract class BaseDDLStrategy implements DDLStrategy {
             jsonPath.column,
             jsonPath.path,
           )})`
-        : index.columns.map((c) => `"${c}"`).join(', ');
+        : index.columns.map((c) => quoteIdentifier(c)).join(', ');
 
-      let sql = `CREATE ${indexType} IF NOT EXISTS "${index.name}" ON "${tableName}" (${target})`;
+      let sql = `CREATE ${indexType} IF NOT EXISTS ${quoteIdentifier(
+        index.name,
+      )} ON ${quoteIdentifier(tableName)} (${target})`;
 
       // Partial index condition
       if (index.where) {
@@ -192,7 +227,8 @@ export abstract class BaseDDLStrategy implements DDLStrategy {
     jsonColumn: string,
     path: string,
   ): string {
-    return `"${jsonColumn}"->>'${path}'`;
+    assertSafeJsonPathTarget(jsonColumn, path);
+    return `${quoteIdentifier(jsonColumn)}->>${quoteStringLiteral(path)}`;
   }
 
   /**
@@ -230,8 +266,8 @@ export abstract class BaseDDLStrategy implements DDLStrategy {
     trigger: TriggerDefinition,
   ): string {
     // Default SQLite-style trigger syntax
-    let sql = `CREATE TRIGGER IF NOT EXISTS "${trigger.name}"\n`;
-    sql += `${trigger.when} ${trigger.event} ON "${tableName}"\n`;
+    let sql = `CREATE TRIGGER IF NOT EXISTS ${quoteIdentifier(trigger.name)}\n`;
+    sql += `${trigger.when} ${trigger.event} ON ${quoteIdentifier(tableName)}\n`;
 
     if (trigger.condition) {
       sql += `WHEN ${trigger.condition}\n`;
@@ -274,60 +310,22 @@ export abstract class BaseDDLStrategy implements DDLStrategy {
   }
 
   /**
-   * Format default value for SQL
-   * Override in engine-specific strategies for different syntax
+   * Format default value for SQL.
+   *
+   * Delegates to the shared, injection-safe `formatDefaultValue`
+   * (`schema/sql-identifiers.ts`) so every DDL path uses one set of rules:
+   * an allowlist of SQL keyword/function defaults (not "contains `(`"),
+   * type-driven literal quoting, and no folding of the string `"null"` into
+   * the SQL NULL keyword. Boolean rendering is bridged through
+   * `formatBooleanDefault` so engine overrides (SQLite → 0/1) still apply.
    */
   formatDefaultValue(value: any, type: SQLDataType): string {
-    // Handle SQL functions and keywords (pass through unchanged)
-    if (typeof value === 'string') {
-      // Check for SQL function calls
-      if (value.includes('(')) {
-        return value;
-      }
-      // Check for SQL keywords
-      const sqlKeywords = [
-        'current_timestamp',
-        'current_date',
-        'current_time',
-        'now()',
-        'uuid_generate_v4()',
-        'null',
-      ];
-      if (sqlKeywords.some((kw) => value.toLowerCase() === kw)) {
-        return value;
-      }
-    }
-
-    // Handle NULL
-    if (value === null || value === undefined) {
-      return 'NULL';
-    }
-
-    // Handle by type
-    switch (type) {
-      case 'TEXT':
-        return this.formatStringDefault(String(value));
-      case 'INTEGER':
-        return String(Math.floor(Number(value) || 0));
-      case 'REAL':
-        return String(Number(value) || 0);
-      case 'BOOLEAN':
-        return this.formatBooleanDefault(value);
-      case 'TIMESTAMP':
-        return this.formatTimestampDefault(value);
-      case 'JSON':
-        return this.formatJSONDefault(value);
-      default:
-        return this.formatStringDefault(String(value));
-    }
-  }
-
-  /**
-   * Format string default - escape single quotes
-   */
-  protected formatStringDefault(value: string): string {
-    const escaped = value.replace(/'/g, "''");
-    return `'${escaped}'`;
+    return formatDefaultValueShared(value, type, {
+      booleanLiterals: [
+        this.formatBooleanDefault(true),
+        this.formatBooleanDefault(false),
+      ],
+    });
   }
 
   /**
@@ -336,56 +334,6 @@ export abstract class BaseDDLStrategy implements DDLStrategy {
    */
   protected formatBooleanDefault(value: any): string {
     return value ? 'TRUE' : 'FALSE';
-  }
-
-  /**
-   * Format timestamp default
-   */
-  protected formatTimestampDefault(value: any): string {
-    if (typeof value === 'string') {
-      return `'${value}'`;
-    }
-    return 'CURRENT_TIMESTAMP';
-  }
-
-  /**
-   * Format JSON default
-   *
-   * Ensures the default value is valid JSON for PostgreSQL/SQLite.
-   * Invalid inputs like empty strings or '[object Object]' are converted to 'null'.
-   * @see https://github.com/happyvertical/smrt/issues/735
-   */
-  protected formatJSONDefault(value: any): string {
-    // Handle null/undefined
-    if (value === null || value === undefined) {
-      return "'null'";
-    }
-
-    // Handle string inputs - need to validate they're valid JSON
-    if (typeof value === 'string') {
-      // Empty string is not valid JSON
-      if (value === '') {
-        return "'null'";
-      }
-      // '[object Object]' is a common bug from accidental toString()
-      if (value === '[object Object]') {
-        return "'{}'";
-      }
-      // Try to parse as JSON to validate
-      try {
-        JSON.parse(value);
-        // It's valid JSON, use it as-is (escaped for SQL)
-        return `'${value.replace(/'/g, "''")}'`;
-      } catch {
-        // Not valid JSON - encode the string as a JSON string
-        const json = JSON.stringify(value);
-        return `'${json.replace(/'/g, "''")}'`;
-      }
-    }
-
-    // Objects and arrays - stringify them
-    const json = JSON.stringify(value);
-    return `'${json.replace(/'/g, "''")}'`;
   }
 
   /**

--- a/packages/core/src/schema/ddl/base-strategy.ts
+++ b/packages/core/src/schema/ddl/base-strategy.ts
@@ -8,6 +8,7 @@
 import { createLogger } from '@happyvertical/logger';
 import {
   formatDefaultValue as formatDefaultValueShared,
+  isSafeIdentifier,
   isSafeIdentifierPath,
   quoteIdentifier,
   quoteStringLiteral,
@@ -35,7 +36,7 @@ const logger = createLogger({ level: 'info' });
  * a programming error and throwing is the safest, loudest outcome.
  */
 function assertSafeJsonPathTarget(jsonColumn: string, path: string): void {
-  if (!isSafeIdentifierPath(jsonColumn)) {
+  if (!isSafeIdentifier(jsonColumn)) {
     throw new Error(
       `[DDL] Unsafe JSON-path index column "${jsonColumn}": must be a simple identifier`,
     );

--- a/packages/core/src/schema/ddl/sqlite-strategy.ts
+++ b/packages/core/src/schema/ddl/sqlite-strategy.ts
@@ -9,6 +9,11 @@
  * - UNIQUE can be inline or separate indexes
  */
 
+import {
+  isSafeIdentifierPath,
+  quoteIdentifier,
+  quoteStringLiteral,
+} from '../sql-identifiers.js';
 import type { SQLDataType } from '../types.js';
 import { BaseDDLStrategy } from './base-strategy.js';
 import type { DatabaseEngine } from './types.js';
@@ -25,7 +30,19 @@ export class SQLiteStrategy extends BaseDDLStrategy {
     jsonColumn: string,
     path: string,
   ): string {
-    return `json_extract("${jsonColumn}", '$.${path}')`;
+    if (!isSafeIdentifierPath(jsonColumn)) {
+      throw new Error(
+        `[DDL] Unsafe JSON-path index column "${jsonColumn}": must be a simple identifier`,
+      );
+    }
+    if (!isSafeIdentifierPath(path)) {
+      throw new Error(
+        `[DDL] Unsafe JSON-path index path "${path}": must be a simple (dotted) identifier`,
+      );
+    }
+    return `json_extract(${quoteIdentifier(jsonColumn)}, ${quoteStringLiteral(
+      `$.${path}`,
+    )})`;
   }
 
   /**
@@ -48,57 +65,15 @@ export class SQLiteStrategy extends BaseDDLStrategy {
   }
 
   /**
-   * Format boolean as 0/1 for SQLite
+   * Format boolean as 0/1 for SQLite.
+   *
+   * `formatDefaultValue` is inherited from BaseDDLStrategy, which delegates to
+   * the shared safe formatter and bridges this override in as the boolean
+   * literals — so SQLite booleans render as 0/1 and no CAST expression is ever
+   * emitted in a DEFAULT clause.
    */
   protected formatBooleanDefault(value: any): string {
     return value ? '1' : '0';
-  }
-
-  /**
-   * Format default value for SQLite
-   *
-   * CRITICAL: SQLite does NOT support CAST expressions in DEFAULT values.
-   * We use plain literals instead.
-   */
-  formatDefaultValue(value: any, type: SQLDataType): string {
-    // Handle SQL functions and keywords
-    if (typeof value === 'string') {
-      if (value.includes('(')) {
-        return value;
-      }
-      const sqlKeywords = [
-        'current_timestamp',
-        'current_date',
-        'current_time',
-        'null',
-      ];
-      if (sqlKeywords.some((kw) => value.toLowerCase() === kw)) {
-        return value;
-      }
-    }
-
-    // Handle NULL
-    if (value === null || value === undefined) {
-      return 'NULL';
-    }
-
-    // Handle by type - NO CAST expressions!
-    switch (type) {
-      case 'TEXT':
-        return this.formatStringDefault(String(value));
-      case 'INTEGER':
-        return String(Math.floor(Number(value) || 0));
-      case 'REAL':
-        return String(Number(value) || 0);
-      case 'BOOLEAN':
-        return this.formatBooleanDefault(value);
-      case 'TIMESTAMP':
-        return this.formatTimestampDefault(value);
-      case 'JSON':
-        return this.formatJSONDefault(value);
-      default:
-        return this.formatStringDefault(String(value));
-    }
   }
 
   /**

--- a/packages/core/src/schema/generator.ts
+++ b/packages/core/src/schema/generator.ts
@@ -15,6 +15,11 @@ import type {
 import { classnameToTablename } from '../utils/naming.js';
 import { getDDLStrategy } from './ddl/index.js';
 import type { DatabaseEngine } from './ddl/types.js';
+import {
+  formatDefaultValue as formatDefaultValueShared,
+  quoteIdentifier,
+  quoteStringLiteral,
+} from './sql-identifiers.js';
 import type {
   ColumnDefinition,
   ForeignKeyDefinition,
@@ -361,7 +366,7 @@ export class SchemaGenerator {
         name: `trg_${tableName}_updated_at`,
         when: 'BEFORE',
         event: 'UPDATE',
-        body: `UPDATE "${tableName}" SET "updated_at" = current_timestamp WHERE "id" = NEW."id";`,
+        body: `UPDATE ${quoteIdentifier(tableName)} SET "updated_at" = current_timestamp WHERE "id" = NEW."id";`,
         description: 'Automatically update updated_at timestamp',
       },
     ];
@@ -994,7 +999,7 @@ export class SchemaGenerator {
         indexes.push({
           name: `idx_${tableName}_${fkColumn}_${className.toLowerCase()}`,
           columns: [fkColumn],
-          where: `_meta_type = '${className}'`,
+          where: `_meta_type = ${quoteStringLiteral(className)}`,
           description: `Partial index for ${fkColumn} in ${className} rows`,
         });
       }
@@ -1528,10 +1533,10 @@ export class SchemaGenerator {
     }
 
     const { tableName, columns } = schema;
-    let sql = `CREATE TABLE IF NOT EXISTS "${tableName}" (\n`;
+    let sql = `CREATE TABLE IF NOT EXISTS ${quoteIdentifier(tableName)} (\n`;
 
     for (const [columnName, columnDef] of Object.entries(columns)) {
-      const parts = [`  "${columnName}" ${columnDef.type}`];
+      const parts = [`  ${quoteIdentifier(columnName)} ${columnDef.type}`];
 
       if (columnDef.primaryKey) {
         parts.push('PRIMARY KEY');
@@ -1571,84 +1576,14 @@ export class SchemaGenerator {
    * @returns Formatted SQL default value expression
    */
   private formatDefaultValue(value: any, type: SQLDataType): string {
-    // Handle SQL functions and keywords (like current_timestamp, datetime('now'), CURRENT_DATE, etc.)
-    if (typeof value === 'string') {
-      // SQL function with parentheses (e.g., datetime('now'))
-      if (value.includes('(')) {
-        return value;
-      }
-      // SQL standard keywords (e.g., current_timestamp, CURRENT_DATE, CURRENT_TIME)
-      const sqlKeywords = [
-        'current_timestamp',
-        'current_date',
-        'current_time',
-        'now()',
-        'uuid_generate_v4()',
-      ];
-      if (sqlKeywords.some((keyword) => value.toLowerCase() === keyword)) {
-        return value;
-      }
-    }
-
-    // Handle different types - use plain literals (SQLite doesn't support CAST in DEFAULT)
-    if (type === 'TEXT') {
-      const stringValue = String(value);
-      return `'${stringValue.replace(/'/g, "''")}'`;
-    }
-
-    if (type === 'INTEGER' || type === 'REAL') {
-      // For null values, return NULL
-      if (value === null || value === undefined) {
-        return 'NULL';
-      }
-      return String(value);
-    }
-
-    if (type === 'BOOLEAN') {
-      return value ? 'TRUE' : 'FALSE';
-    }
-
-    if (type === 'TIMESTAMP') {
-      if (typeof value === 'string') {
-        return `'${value}'`;
-      }
-      return 'current_timestamp';
-    }
-
-    if (type === 'JSON') {
-      // Handle null/undefined
-      if (value === null || value === undefined) {
-        return "'null'";
-      }
-
-      // Handle string inputs - need to validate they're valid JSON
-      if (typeof value === 'string') {
-        // Empty string is not valid JSON
-        if (value === '') {
-          return "'null'";
-        }
-        // '[object Object]' is a common bug from accidental toString()
-        if (value === '[object Object]') {
-          return "'{}'";
-        }
-        // Try to parse as JSON to validate
-        try {
-          JSON.parse(value);
-          // It's valid JSON, use it as-is (escaped for SQL)
-          return `'${value.replace(/'/g, "''")}'`;
-        } catch {
-          // Not valid JSON - encode the string as a JSON string
-          const json = JSON.stringify(value);
-          return `'${json.replace(/'/g, "''")}'`;
-        }
-      }
-
-      // Objects and arrays - stringify them
-      const json = JSON.stringify(value);
-      return `'${json.replace(/'/g, "''")}'`;
-    }
-
-    // Fallback for other types
-    return `'${String(value).replace(/'/g, "''")}'`;
+    // Delegate to the shared, injection-safe formatter so all DDL paths
+    // converge on one set of rules (allowlisted keyword/function defaults
+    // instead of "contains `(`", type-driven quoting, no string-"null" fold).
+    // This path is engine-agnostic and never emits CAST expressions, so the
+    // output stays valid for SQLite and DuckDB. Non-string TIMESTAMP defaults
+    // fall back to lowercase `current_timestamp` to preserve prior output.
+    return formatDefaultValueShared(value, type, {
+      nonStringTimestampDefault: 'current_timestamp',
+    });
   }
 }

--- a/packages/core/src/schema/index-utils.ts
+++ b/packages/core/src/schema/index-utils.ts
@@ -10,6 +10,7 @@
 
 import type { DatabaseEngine } from './ddl/types.js';
 import {
+  isSafeIdentifier,
   isSafeIdentifierPath,
   quoteIdentifier,
   quoteStringLiteral,
@@ -38,7 +39,7 @@ export function renderIndexTarget(
     // literal. Validate both against an identifier allowlist (these are
     // developer-controlled `@meta` field names) so a malformed name can't
     // smuggle structure into the expression even after escaping.
-    if (!isSafeIdentifierPath(col)) {
+    if (!isSafeIdentifier(col)) {
       throw new Error(
         `[index-utils] Unsafe JSON-path index column "${col}": must be a simple identifier`,
       );

--- a/packages/core/src/schema/index-utils.ts
+++ b/packages/core/src/schema/index-utils.ts
@@ -9,6 +9,11 @@
  */
 
 import type { DatabaseEngine } from './ddl/types.js';
+import {
+  isSafeIdentifierPath,
+  quoteIdentifier,
+  quoteStringLiteral,
+} from './sql-identifiers.js';
 import type { IndexDefinition } from './types.js';
 
 /**
@@ -29,9 +34,25 @@ export function renderIndexTarget(
   if (index.jsonPath?.column && index.jsonPath.path) {
     const col = index.jsonPath.column;
     const path = index.jsonPath.path;
+    // The column is interpolated as an identifier and the path as a SQL string
+    // literal. Validate both against an identifier allowlist (these are
+    // developer-controlled `@meta` field names) so a malformed name can't
+    // smuggle structure into the expression even after escaping.
+    if (!isSafeIdentifierPath(col)) {
+      throw new Error(
+        `[index-utils] Unsafe JSON-path index column "${col}": must be a simple identifier`,
+      );
+    }
+    if (!isSafeIdentifierPath(path)) {
+      throw new Error(
+        `[index-utils] Unsafe JSON-path index path "${path}": must be a simple (dotted) identifier`,
+      );
+    }
     if (engine === 'sqlite') {
       // SQLite's json_extract is a function call — no extra wrapping needed.
-      return `json_extract("${col}", '$.${path}')`;
+      return `json_extract(${quoteIdentifier(col)}, ${quoteStringLiteral(
+        `$.${path}`,
+      )})`;
     }
     // Postgres / DuckDB JSON path access via `->>`. PostgreSQL requires
     // operator expressions in index elements to be parenthesized — the
@@ -39,9 +60,9 @@ export function renderIndexTarget(
     // the expression itself needs its own parens. Returning the wrapped
     // form here keeps the rule local to this helper and works on DuckDB
     // (extra parens are harmless).
-    return `("${col}"->>'${path}')`;
+    return `(${quoteIdentifier(col)}->>${quoteStringLiteral(path)})`;
   }
-  return (index.columns ?? []).map((c) => `"${c}"`).join(', ');
+  return (index.columns ?? []).map((c) => quoteIdentifier(c)).join(', ');
 }
 
 /**

--- a/packages/core/src/schema/schema-aggregator.ts
+++ b/packages/core/src/schema/schema-aggregator.ts
@@ -31,6 +31,7 @@ import { join } from 'node:path';
 import { discoverSmrtPackages } from '../manifest/discover-smrt-packages.js';
 import { loadExternalManifestSync } from '../manifest/manifest-loader.js';
 import type { SmartObjectManifest } from '../scanner/types.js';
+import { quoteIdentifier } from './sql-identifiers.js';
 import { renderIndexTarget } from './utils.js';
 
 // ============================================================================
@@ -452,9 +453,11 @@ export class SchemaAggregator {
     engine: 'sqlite' | 'postgres' | 'duckdb' = 'sqlite',
   ): string {
     const target = renderIndexTarget(idx, engine);
+    const indexName = quoteIdentifier(idx.name);
+    const table = quoteIdentifier(tableName);
     return idx.unique
-      ? `CREATE UNIQUE INDEX IF NOT EXISTS "${idx.name}" ON "${tableName}" (${target});`
-      : `CREATE INDEX IF NOT EXISTS "${idx.name}" ON "${tableName}" (${target});`;
+      ? `CREATE UNIQUE INDEX IF NOT EXISTS ${indexName} ON ${table} (${target});`
+      : `CREATE INDEX IF NOT EXISTS ${indexName} ON ${table} (${target});`;
   }
 
   /**

--- a/packages/core/src/schema/sql-identifiers.test.ts
+++ b/packages/core/src/schema/sql-identifiers.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Unit tests for the shared SQL identifier / literal / default-value
+ * formatters (schema/sql-identifiers.ts) and their adoption by the DDL
+ * strategies, index-utils, and the schema generator.
+ *
+ * These are the regression tests for issue #1378's "Divergent SQL formatters"
+ * majors: identifier/literal injection safety, the allowlist-based default
+ * formatter (no "contains `(`" pass-through), and the literal-"null" fold bug.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getDDLStrategy } from './ddl/index.js';
+import { renderIndexTarget } from './index-utils.js';
+import {
+  formatDefaultValue,
+  isSafeIdentifierPath,
+  isSafeSqlFunctionDefault,
+  quoteIdentifier,
+  quoteStringLiteral,
+} from './sql-identifiers.js';
+import type { SchemaDefinition } from './types.js';
+
+describe('quoteIdentifier', () => {
+  it('wraps plain identifiers in double quotes', () => {
+    expect(quoteIdentifier('users')).toBe('"users"');
+    expect(quoteIdentifier('created_at')).toBe('"created_at"');
+  });
+
+  it('escapes embedded double quotes so the token cannot break out', () => {
+    // A name containing a `"` must double the quote, producing ONE valid token.
+    expect(quoteIdentifier('we"ird')).toBe('"we""ird"');
+    // The classic injection: name tries to close the identifier and inject DDL.
+    const malicious = 'x" ); DROP TABLE users; --';
+    const quoted = quoteIdentifier(malicious);
+    expect(quoted).toBe('"x"" ); DROP TABLE users; --"');
+    // The only unescaped quotes are the wrapping pair (start + end).
+    expect(quoted.startsWith('"')).toBe(true);
+    expect(quoted.endsWith('"')).toBe(true);
+    // Every interior `"` is doubled (no lone quote that would terminate early).
+    const interior = quoted.slice(1, -1);
+    expect(interior.replace(/""/g, '')).not.toContain('"');
+  });
+});
+
+describe('quoteStringLiteral', () => {
+  it('wraps strings in single quotes and escapes embedded single quotes', () => {
+    expect(quoteStringLiteral('hello')).toBe("'hello'");
+    expect(quoteStringLiteral("O'Hara")).toBe("'O''Hara'");
+  });
+
+  it('neutralizes a single-quote breakout attempt', () => {
+    expect(quoteStringLiteral("'); DROP TABLE t; --")).toBe(
+      "'''); DROP TABLE t; --'",
+    );
+  });
+});
+
+describe('isSafeIdentifierPath', () => {
+  it('accepts simple and dotted identifier paths', () => {
+    expect(isSafeIdentifierPath('a')).toBe(true);
+    expect(isSafeIdentifierPath('a.b.c')).toBe(true);
+    expect(isSafeIdentifierPath('_meta_data')).toBe(true);
+  });
+
+  it('rejects paths with quotes, spaces, or punctuation', () => {
+    expect(isSafeIdentifierPath("x'); DROP TABLE t; --")).toBe(false);
+    expect(isSafeIdentifierPath('a b')).toBe(false);
+    expect(isSafeIdentifierPath('a-b')).toBe(false);
+    expect(isSafeIdentifierPath('')).toBe(false);
+    expect(isSafeIdentifierPath('.a')).toBe(false);
+  });
+});
+
+describe('isSafeSqlFunctionDefault', () => {
+  it('accepts well-formed function-call defaults', () => {
+    expect(isSafeSqlFunctionDefault("datetime('now')")).toBe(true);
+    expect(isSafeSqlFunctionDefault('now()')).toBe(true);
+    expect(isSafeSqlFunctionDefault('uuid_generate_v4()')).toBe(true);
+    expect(isSafeSqlFunctionDefault('coalesce(0, 1)')).toBe(true);
+    expect(isSafeSqlFunctionDefault("date('now', '-1 day')")).toBe(true);
+  });
+
+  it('rejects strings that merely contain a parenthesis or inject SQL', () => {
+    // The old "contains `(`" heuristic accepted ALL of these.
+    expect(isSafeSqlFunctionDefault('Acme (Inc)')).toBe(false);
+    expect(isSafeSqlFunctionDefault('Smith (Jr.)')).toBe(false);
+    expect(isSafeSqlFunctionDefault("f(x') ; DROP TABLE t; --")).toBe(false);
+    expect(isSafeSqlFunctionDefault('evil() ; DROP TABLE t')).toBe(false);
+    expect(isSafeSqlFunctionDefault('fn()extra')).toBe(false);
+  });
+});
+
+describe('formatDefaultValue (shared)', () => {
+  it('passes through allowlisted keyword/function defaults verbatim', () => {
+    expect(formatDefaultValue('current_timestamp', 'TIMESTAMP')).toBe(
+      'current_timestamp',
+    );
+    expect(formatDefaultValue('CURRENT_TIMESTAMP', 'TIMESTAMP')).toBe(
+      'CURRENT_TIMESTAMP',
+    );
+    expect(formatDefaultValue('uuid_generate_v4()', 'TEXT')).toBe(
+      'uuid_generate_v4()',
+    );
+    expect(formatDefaultValue("datetime('now')", 'TEXT')).toBe(
+      "datetime('now')",
+    );
+  });
+
+  it('quotes a TEXT default that contains parentheses instead of passing it raw', () => {
+    // Regression: "contains `(`" used to emit this raw, producing broken DDL.
+    expect(formatDefaultValue('Acme (Inc)', 'TEXT')).toBe("'Acme (Inc)'");
+    expect(formatDefaultValue('Smith (Jr.)', 'TEXT')).toBe("'Smith (Jr.)'");
+  });
+
+  it('does NOT fold a literal string "null"/"NULL" for TEXT into SQL NULL', () => {
+    // Regression: the keyword allowlist used to include `null`, so a TEXT
+    // column defaulting to the *string* "null" silently became SQL NULL.
+    expect(formatDefaultValue('null', 'TEXT')).toBe("'null'");
+    expect(formatDefaultValue('NULL', 'TEXT')).toBe("'NULL'");
+  });
+
+  it('still maps JS null/undefined to the SQL NULL keyword', () => {
+    expect(formatDefaultValue(null, 'TEXT')).toBe('NULL');
+    expect(formatDefaultValue(undefined, 'INTEGER')).toBe('NULL');
+  });
+
+  it('formats numeric, boolean and JSON defaults by type', () => {
+    expect(formatDefaultValue(42, 'INTEGER')).toBe('42');
+    expect(formatDefaultValue(3.14, 'REAL')).toBe('3.14');
+    expect(formatDefaultValue(true, 'BOOLEAN')).toBe('TRUE');
+    expect(formatDefaultValue(false, 'BOOLEAN')).toBe('FALSE');
+    expect(formatDefaultValue('', 'JSON')).toBe("'null'");
+    expect(formatDefaultValue({ a: 1 }, 'JSON')).toBe(`'{"a":1}'`);
+  });
+
+  it('honours engine-specific boolean literals and timestamp fallback', () => {
+    expect(
+      formatDefaultValue(true, 'BOOLEAN', { booleanLiterals: ['1', '0'] }),
+    ).toBe('1');
+    expect(
+      formatDefaultValue(123, 'TIMESTAMP', {
+        nonStringTimestampDefault: 'current_timestamp',
+      }),
+    ).toBe('current_timestamp');
+  });
+});
+
+function baseSchema(overrides: Partial<SchemaDefinition>): SchemaDefinition {
+  return {
+    tableName: 'widgets',
+    columns: { id: { type: 'TEXT', primaryKey: true } },
+    indexes: [],
+    triggers: [],
+    foreignKeys: [],
+    version: '1.0.0',
+    dependencies: [],
+    ...overrides,
+  };
+}
+
+describe('DDL strategy identifier safety (CREATE TABLE / INDEX)', () => {
+  it('renders a table name containing a double quote as a single valid token', () => {
+    const sql = getDDLStrategy('sqlite').generateCreateTable(
+      baseSchema({ tableName: 'we"ird' }),
+    );
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS "we""ird"');
+    // No statement-terminating lone quote leaked into the DDL.
+    expect(sql).not.toContain('"we"ird"');
+  });
+
+  it('quotes a malicious column name rather than letting it break out', () => {
+    const sql = getDDLStrategy('postgres').generateCreateTable(
+      baseSchema({
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          ['evil" ); DROP TABLE x; --']: { type: 'TEXT' },
+        },
+      }),
+    );
+    expect(sql).toContain('"evil"" ); DROP TABLE x; --"');
+  });
+
+  it('quotes a TEXT default that contains parentheses in CREATE TABLE', () => {
+    const sql = getDDLStrategy('sqlite').generateCreateTable(
+      baseSchema({
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          vendor: { type: 'TEXT', defaultValue: 'Acme (Inc)' },
+        },
+      }),
+    );
+    expect(sql).toContain("DEFAULT 'Acme (Inc)'");
+    expect(sql).not.toContain('DEFAULT Acme (Inc)');
+  });
+
+  it('keeps a literal string "null" TEXT default as a quoted string', () => {
+    const sql = getDDLStrategy('sqlite').generateCreateTable(
+      baseSchema({
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          note: { type: 'TEXT', defaultValue: 'null' },
+        },
+      }),
+    );
+    expect(sql).toContain("DEFAULT 'null'");
+    // Must NOT collapse to the SQL NULL keyword.
+    expect(sql).not.toMatch(/"note"\s+TEXT\s+DEFAULT NULL/);
+  });
+
+  it('passes known function/keyword defaults through unquoted', () => {
+    const sql = getDDLStrategy('postgres').generateCreateTable(
+      baseSchema({
+        columns: {
+          id: {
+            type: 'TEXT',
+            primaryKey: true,
+            defaultValue: 'uuid_generate_v4()',
+          },
+          ts: { type: 'TIMESTAMP', defaultValue: 'current_timestamp' },
+        },
+      }),
+    );
+    expect(sql).toContain('DEFAULT uuid_generate_v4()');
+    expect(sql).toContain('DEFAULT current_timestamp');
+  });
+
+  it('escapes the JSON path literal in a jsonPath index expression', () => {
+    // Valid dotted path renders escaped; the column is a delimited identifier.
+    const sqlite = renderIndexTarget(
+      { columns: [], jsonPath: { column: '_meta_data', path: 'a.b' } },
+      'sqlite',
+    );
+    expect(sqlite).toBe(`json_extract("_meta_data", '$.a.b')`);
+    const pg = renderIndexTarget(
+      { columns: [], jsonPath: { column: '_meta_data', path: 'a' } },
+      'postgres',
+    );
+    expect(pg).toBe(`("_meta_data"->>'a')`);
+  });
+
+  it('rejects a jsonPath path that tries to inject SQL', () => {
+    expect(() =>
+      renderIndexTarget(
+        {
+          columns: [],
+          jsonPath: { column: '_meta_data', path: "x'); DROP TABLE t; --" },
+        },
+        'sqlite',
+      ),
+    ).toThrow(/Unsafe JSON-path index path/);
+  });
+});

--- a/packages/core/src/schema/sql-identifiers.test.ts
+++ b/packages/core/src/schema/sql-identifiers.test.ts
@@ -13,6 +13,7 @@ import { getDDLStrategy } from './ddl/index.js';
 import { renderIndexTarget } from './index-utils.js';
 import {
   formatDefaultValue,
+  isSafeIdentifier,
   isSafeIdentifierPath,
   isSafeSqlFunctionDefault,
   quoteIdentifier,
@@ -68,6 +69,23 @@ describe('isSafeIdentifierPath', () => {
     expect(isSafeIdentifierPath('a-b')).toBe(false);
     expect(isSafeIdentifierPath('')).toBe(false);
     expect(isSafeIdentifierPath('.a')).toBe(false);
+  });
+});
+
+describe('isSafeIdentifier (no dots — for column names)', () => {
+  it('accepts a simple identifier', () => {
+    expect(isSafeIdentifier('a')).toBe(true);
+    expect(isSafeIdentifier('_meta_data')).toBe(true);
+  });
+  it('rejects a dotted identifier (unlike isSafeIdentifierPath)', () => {
+    // A JSON-path index *column* is a real column name and must be simple;
+    // only the *path* segment may be dotted.
+    expect(isSafeIdentifier('a.b')).toBe(false);
+    expect(isSafeIdentifierPath('a.b')).toBe(true);
+  });
+  it('rejects injection / malformed input', () => {
+    expect(isSafeIdentifier("x'); DROP TABLE t; --")).toBe(false);
+    expect(isSafeIdentifier('')).toBe(false);
   });
 });
 
@@ -173,7 +191,7 @@ describe('DDL strategy identifier safety (CREATE TABLE / INDEX)', () => {
       baseSchema({
         columns: {
           id: { type: 'TEXT', primaryKey: true },
-          ['evil" ); DROP TABLE x; --']: { type: 'TEXT' },
+          'evil" ); DROP TABLE x; --': { type: 'TEXT' },
         },
       }),
     );
@@ -248,5 +266,14 @@ describe('DDL strategy identifier safety (CREATE TABLE / INDEX)', () => {
         'sqlite',
       ),
     ).toThrow(/Unsafe JSON-path index path/);
+  });
+
+  it('rejects a dotted jsonPath column (must be a simple identifier)', () => {
+    expect(() =>
+      renderIndexTarget(
+        { columns: [], jsonPath: { column: 'a.b', path: 'x' } },
+        'sqlite',
+      ),
+    ).toThrow(/Unsafe JSON-path index column/);
   });
 });

--- a/packages/core/src/schema/sql-identifiers.ts
+++ b/packages/core/src/schema/sql-identifiers.ts
@@ -333,3 +333,13 @@ function formatJsonDefault(value: unknown): string {
 export function isSafeIdentifierPath(value: string): boolean {
   return /^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/.test(value);
 }
+
+/**
+ * Allowlist for a single SQL identifier with no dots (e.g. a column name).
+ * Stricter than {@link isSafeIdentifierPath}: use this for the *column* of a
+ * JSON-path index (a real column name is always a simple identifier), and
+ * {@link isSafeIdentifierPath} for the dotted *path* segment.
+ */
+export function isSafeIdentifier(value: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
+}

--- a/packages/core/src/schema/sql-identifiers.ts
+++ b/packages/core/src/schema/sql-identifiers.ts
@@ -1,0 +1,335 @@
+/**
+ * Shared SQL identifier / literal / default-value formatters.
+ *
+ * SMRT's schema + migration layers previously re-implemented identifier
+ * quoting and default-value formatting in several places, and a few of those
+ * copies interpolated values raw (`"${name}"`, `'${path}'`) or treated any
+ * string containing `(` as raw SQL. Those unsafe copies allowed a developer
+ * free-string (a `tableName`, a `@meta` field name used as a JSON path, a
+ * column default) that happened to contain a `"` or `'` to break out of the
+ * intended token and inject arbitrary DDL.
+ *
+ * This module is the single safe implementation that every DDL strategy,
+ * the schema generator/aggregator, the registry schema-builder, and the
+ * migration generator route through. It matches the escaping semantics that
+ * `migrations/differ.ts` and `schema/schema-manager.ts` already used
+ * correctly, so the codebase converges on one behaviour.
+ *
+ * IMPORTANT: keep this a pure, dependency-free utility (no runtime imports of
+ * registry/collection/object). It is imported by `schema/ddl/*`,
+ * `schema/index-utils.ts`, `schema/schema-aggregator.ts`,
+ * `schema/generator.ts`, `registry/schema-builder.ts`, and
+ * `migrations/generator.ts`.
+ */
+
+/**
+ * Quote a SQL identifier (table/column/index/trigger name) by wrapping it in
+ * double quotes and escaping any embedded double quote as `""`.
+ *
+ * This is the ANSI / PostgreSQL / SQLite / DuckDB delimited-identifier rule.
+ * A name containing a `"` is rendered as a single valid token rather than
+ * closing the identifier early and leaking the remainder into the statement.
+ *
+ * @example
+ * quoteIdentifier('users')        // => "users"
+ * quoteIdentifier('we"ird')       // => "we""ird"   (single valid token)
+ */
+export function quoteIdentifier(name: string): string {
+  return `"${String(name).replace(/"/g, '""')}"`;
+}
+
+/**
+ * Quote a SQL string literal by wrapping it in single quotes and escaping any
+ * embedded single quote as `''`.
+ *
+ * @example
+ * quoteStringLiteral("O'Hara")    // => 'O''Hara'
+ */
+export function quoteStringLiteral(value: string): string {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+/**
+ * SQL keyword / niladic-function defaults that are passed through verbatim.
+ *
+ * Compared case-insensitively against the *entire* trimmed value. This is an
+ * explicit allowlist — unlike the old "value contains `(`" heuristic, an
+ * arbitrary string that merely contains a parenthesis is NOT treated as raw
+ * SQL.
+ *
+ * Deliberately excludes `null`/`NULL`: a literal string `"null"` used as a
+ * default for a TEXT column must be stored as the string, not folded into the
+ * SQL NULL keyword. Real SQL NULL is produced from a JS `null`/`undefined`
+ * value (see formatDefaultValue), not from the string `"null"`.
+ */
+const SQL_DEFAULT_KEYWORDS = new Set<string>([
+  'current_timestamp',
+  'current_date',
+  'current_time',
+  'localtime',
+  'localtimestamp',
+  'now()',
+  'uuid_generate_v4()',
+  'gen_random_uuid()',
+  "datetime('now')",
+  "date('now')",
+  "time('now')",
+]);
+
+/**
+ * Validate that a string is a well-formed, injection-safe SQL scalar
+ * function-call default, e.g. `datetime('now')` or `coalesce(0, 1)`.
+ *
+ * The old formatters treated ANY string containing `(` as raw SQL, so a
+ * "default" like `f(x') ; DROP TABLE t; --` was passed through untouched and
+ * injected. This validator instead requires the value to be *only* a function
+ * call whose arguments are themselves safe literals (numbers, properly-quoted
+ * string literals, the NULL keyword, or nested function calls). Anything that
+ * doesn't parse cleanly — stray quotes, statement terminators, trailing
+ * tokens — is rejected and the caller falls back to quoting it as data.
+ *
+ * @internal exported for testing
+ */
+export function isSafeSqlFunctionDefault(value: string): boolean {
+  const trimmed = value.trim();
+  // Fast structural pre-check: identifier ... ( ... ) and nothing after.
+  if (!/^[A-Za-z_][A-Za-z0-9_.]*\s*\(.*\)$/s.test(trimmed)) {
+    return false;
+  }
+
+  let pos = 0;
+  const n = trimmed.length;
+
+  const skipWs = () => {
+    while (pos < n && /\s/.test(trimmed[pos])) pos++;
+  };
+
+  // Parse a single argument: a number, a single-quoted string literal, the
+  // NULL keyword, or a nested function call. Returns true on success and
+  // advances `pos`.
+  const parseArgument = (): boolean => {
+    skipWs();
+    if (pos >= n) return false;
+    const ch = trimmed[pos];
+
+    // Single-quoted string literal with doubled-quote escaping.
+    if (ch === "'") {
+      pos++; // opening quote
+      while (pos < n) {
+        if (trimmed[pos] === "'") {
+          if (trimmed[pos + 1] === "'") {
+            pos += 2; // escaped quote
+            continue;
+          }
+          pos++; // closing quote
+          return true;
+        }
+        pos++;
+      }
+      return false; // unterminated string
+    }
+
+    // Number (integer or decimal, optional sign).
+    if (ch === '+' || ch === '-' || /[0-9]/.test(ch)) {
+      const numMatch = /^[+-]?(?:\d+\.?\d*|\.\d+)/.exec(trimmed.slice(pos));
+      if (!numMatch) return false;
+      pos += numMatch[0].length;
+      return true;
+    }
+
+    // Identifier-led: either the NULL/TRUE/FALSE keyword or a nested call.
+    if (/[A-Za-z_]/.test(ch)) {
+      const identMatch = /^[A-Za-z_][A-Za-z0-9_.]*/.exec(trimmed.slice(pos));
+      if (!identMatch) return false;
+      pos += identMatch[0].length;
+      skipWs();
+      if (trimmed[pos] === '(') {
+        return parseCall();
+      }
+      // Bare identifier is only allowed for a small set of literal keywords.
+      const kw = identMatch[0].toLowerCase();
+      return kw === 'null' || kw === 'true' || kw === 'false';
+    }
+
+    return false;
+  };
+
+  // Parse `( arg, arg, ... )` starting at the current `(`. Advances `pos`.
+  const parseCall = (): boolean => {
+    skipWs();
+    if (trimmed[pos] !== '(') return false;
+    pos++; // consume '('
+    skipWs();
+    if (trimmed[pos] === ')') {
+      pos++;
+      return true; // empty arg list, e.g. now()
+    }
+    while (true) {
+      if (!parseArgument()) return false;
+      skipWs();
+      if (trimmed[pos] === ',') {
+        pos++;
+        continue;
+      }
+      if (trimmed[pos] === ')') {
+        pos++;
+        return true;
+      }
+      return false; // unexpected token between args
+    }
+  };
+
+  // Top-level: identifier then a call, consuming the whole string.
+  const topIdent = /^[A-Za-z_][A-Za-z0-9_.]*/.exec(trimmed);
+  if (!topIdent) return false;
+  pos = topIdent[0].length;
+  skipWs();
+  if (!parseCall()) return false;
+  skipWs();
+  return pos === n; // no trailing tokens
+}
+
+/**
+ * Format a column default value into a safe SQL fragment for a `DEFAULT`
+ * clause.
+ *
+ * Behaviour (converging the previously-divergent copies):
+ * - JS `null`/`undefined` => the SQL `NULL` keyword.
+ * - A string that exactly matches a known SQL keyword/niladic-function default
+ *   (case-insensitive, e.g. `current_timestamp`, `uuid_generate_v4()`) =>
+ *   passed through verbatim.
+ * - A string that is a well-formed, injection-safe SQL function call
+ *   (e.g. `datetime('now')`) => passed through verbatim.
+ * - Everything else is formatted *by column type* and always quoted/escaped
+ *   as data. A literal string `"null"`/`"NULL"` is therefore stored as the
+ *   string for a TEXT column, NOT folded to SQL NULL.
+ *
+ * @param value - The raw default value (any JS value).
+ * @param type - The column's SQL type (case-insensitive). Controls literal
+ *   formatting (TEXT/VARCHAR quote, INTEGER/REAL numeric, BOOLEAN, JSON, ...).
+ * @param options - Engine-specific overrides:
+ *   - `booleanLiterals`: how to render boolean true/false (default `TRUE`/`FALSE`;
+ *     SQLite passes `['1','0']`).
+ *   - `nonStringTimestampDefault`: what a non-string TIMESTAMP default falls
+ *     back to (default `CURRENT_TIMESTAMP`).
+ */
+export function formatDefaultValue(
+  value: unknown,
+  type: string,
+  options: {
+    booleanLiterals?: [trueLiteral: string, falseLiteral: string];
+    nonStringTimestampDefault?: string;
+  } = {},
+): string {
+  const [trueLiteral, falseLiteral] = options.booleanLiterals ?? [
+    'TRUE',
+    'FALSE',
+  ];
+  const nonStringTimestampDefault =
+    options.nonStringTimestampDefault ?? 'CURRENT_TIMESTAMP';
+
+  const upperTypeEarly = type.toUpperCase();
+  const isJsonType = upperTypeEarly === 'JSON' || upperTypeEarly === 'JSONB';
+
+  // JS null/undefined => SQL NULL — EXCEPT for JSON columns, where a null
+  // default means the JSON `null` literal (`'null'`), not the SQL NULL keyword.
+  // (formatJsonDefault handles the null/undefined case.)
+  if ((value === null || value === undefined) && !isJsonType) {
+    return 'NULL';
+  }
+
+  // Allowlisted SQL keyword / niladic-function defaults, plus well-formed,
+  // injection-safe function calls (e.g. datetime('now')) — passed through.
+  if (typeof value === 'string') {
+    const candidate = value.trim();
+    if (SQL_DEFAULT_KEYWORDS.has(candidate.toLowerCase())) {
+      return value;
+    }
+    if (isSafeSqlFunctionDefault(value)) {
+      return value;
+    }
+  }
+
+  switch (upperTypeEarly) {
+    case 'TEXT':
+    case 'VARCHAR':
+    case 'CHAR':
+    case 'CLOB':
+    case 'STRING':
+      return quoteStringLiteral(String(value));
+    case 'INTEGER':
+    case 'INT':
+    case 'BIGINT':
+    case 'SMALLINT':
+      return String(Math.floor(Number(value) || 0));
+    case 'REAL':
+    case 'FLOAT':
+    case 'DOUBLE':
+    case 'DOUBLE PRECISION':
+    case 'DECIMAL':
+    case 'NUMERIC':
+      return String(Number(value) || 0);
+    case 'BOOLEAN':
+    case 'BOOL':
+      return value ? trueLiteral : falseLiteral;
+    case 'TIMESTAMP':
+    case 'DATETIME':
+    case 'DATE':
+    case 'TIME':
+      if (typeof value === 'string') {
+        return quoteStringLiteral(value);
+      }
+      return nonStringTimestampDefault;
+    case 'JSON':
+    case 'JSONB':
+      return formatJsonDefault(value);
+    default:
+      return quoteStringLiteral(String(value));
+  }
+}
+
+/**
+ * Format a JSON column default, ensuring the emitted literal is valid JSON.
+ *
+ * Mirrors the long-standing behaviour from base-strategy/generator/
+ * schema-builder (issue #735): empty string and `[object Object]` are
+ * sanitised, valid JSON strings are used as-is, and anything else is
+ * JSON.stringify'd. The result is always a single-quoted, escaped SQL literal.
+ */
+function formatJsonDefault(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "'null'";
+  }
+
+  if (typeof value === 'string') {
+    if (value === '') {
+      return "'null'";
+    }
+    if (value === '[object Object]') {
+      return "'{}'";
+    }
+    try {
+      JSON.parse(value);
+      return quoteStringLiteral(value);
+    } catch {
+      return quoteStringLiteral(JSON.stringify(value));
+    }
+  }
+
+  return quoteStringLiteral(JSON.stringify(value));
+}
+
+/**
+ * Conservative identifier allowlist for values that will be interpolated into
+ * SQL contexts where quoting is not sufficient — specifically the JSON-path
+ * segment of a JSON-path index expression, which is embedded as a *string
+ * literal* into a dialect function/operator (`json_extract("col", '$.path')`,
+ * `"col"->>'path'`).
+ *
+ * Allows a dotted path of simple identifier segments (e.g. `a`, `a.b.c`).
+ * A JSON path / column that doesn't match is rejected so it can be quoted as
+ * a plain literal instead of being interpolated raw.
+ */
+export function isSafeIdentifierPath(value: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/.test(value);
+}

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -295,8 +295,11 @@ export function formatDataJs(
     });
   }
 
-  // STI: If _meta_data exists, merge it into data first
-  // This ensures meta fields are available during formatting
+  // STI: If _meta_data exists, merge it into a FRESH object first so meta
+  // fields are available during formatting. This must never mutate the caller's
+  // `data` argument — `formatDataJs` is a public export and external callers may
+  // pass shared objects that would otherwise get silent field injection (#1378).
+  let mergedData: Record<string, any> = data;
   if (data._meta_data) {
     const metaData =
       typeof data._meta_data === 'string'
@@ -310,17 +313,18 @@ export function formatDataJs(
       });
     }
 
-    // Merge meta fields into data (will be formatted below)
-    Object.assign(data, metaData);
+    // Merge meta fields into a copy (will be formatted below). Spreading
+    // `metaData` last preserves the original precedence of Object.assign.
+    mergedData = { ...data, ...metaData };
 
     if (process.env.DEBUG_STI) {
       logger.debug('[formatDataJs] After merge, data keys', {
-        keys: Object.keys(data),
+        keys: Object.keys(mergedData),
       });
     }
   }
 
-  for (const [key, value] of Object.entries(data)) {
+  for (const [key, value] of Object.entries(mergedData)) {
     // Preserve keys with leading underscore (e.g., _meta_type, _meta_data)
     // These are special STI/framework fields that should not be camelCased
     const camelKey = key.startsWith('_') ? key : toCamelCase(key);

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -56,10 +56,6 @@ export interface SmrtPluginOptions {
   typeDeclarationsPath?: string;
   /** Plugin execution mode - controls Node.js vs browser compatibility */
   mode?: 'server' | 'client' | 'auto';
-  /** Pre-generated manifest for client mode (avoids file scanning) */
-  staticManifest?: SmartObjectManifest;
-  /** Path to static manifest file for client mode */
-  manifestPath?: string;
   /**
    * @deprecated OXC scanner is now the only scanner. This option is ignored.
    */
@@ -124,7 +120,6 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
     followImports = true, // Default true: needed for multi-package inheritance
     typeDeclarationsPath = 'src/types',
     mode = 'auto',
-    manifestPath,
     svelteKit = {
       enabled: false,
       routesDir: 'src/routes/api',
@@ -164,7 +159,6 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
 
   let server: ViteDevServer | undefined;
   let manifest: SmartObjectManifest | null = null;
-  const manifestGenerator: any = null; // Will be lazily created in server mode
   let pluginMode: 'server' | 'client' = 'server';
   let projectRoot: string = process.cwd();
   let config: any = null; // Store resolved config for closeBundle hook
@@ -538,98 +532,122 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
         // Watch for file changes
         const watcher = devServer.watcher;
 
+        // Guard each watcher handler: scanAndGenerateManifest re-throws on a
+        // mid-edit scan error, and an unhandled rejection in a watcher callback
+        // can crash the dev server. Log and keep the previous manifest (#1378).
         watcher.on('change', async (file) => {
-          if (await shouldRescan(file)) {
-            console.log(`[smrt] Rescanning due to change in ${file}`);
-            manifest = await scanAndGenerateManifest(projectRoot);
+          try {
+            if (await shouldRescan(file)) {
+              console.log(`[smrt] Rescanning due to change in ${file}`);
+              manifest = await scanAndGenerateManifest(projectRoot);
 
-            // Write local manifest for CLI discovery (Issue #963)
-            if (manifest) {
-              await writeLocalManifest(manifest, projectRoot);
-              warnCliApiCoherenceViolations(manifest);
-            }
+              // Write local manifest for CLI discovery (Issue #963)
+              if (manifest) {
+                await writeLocalManifest(manifest, projectRoot);
+                warnCliApiCoherenceViolations(manifest);
+              }
 
-            // Generate SvelteKit routes if enabled
-            if (svelteKit.enabled && manifest && server) {
-              await generateSvelteKitRoutes(server.config.root, manifest, {
-                enabled: svelteKit.enabled,
-                routesDir: svelteKit.routesDir || 'src/routes/api',
-                objectsDir: svelteKit.objectsDir || 'src/lib/objects',
-                configPath: svelteKit.configPath || 'src/lib/server',
-                configFileName: svelteKit.configFileName || 'smrt.ts',
-                kebabRoutes: svelteKit.kebabRoutes ?? false,
-                knowledge: await resolveKnowledgeConfig(
-                  server.config.root,
-                  manifest,
-                ),
+              // Generate SvelteKit routes if enabled
+              if (svelteKit.enabled && manifest && server) {
+                await generateSvelteKitRoutes(server.config.root, manifest, {
+                  enabled: svelteKit.enabled,
+                  routesDir: svelteKit.routesDir || 'src/routes/api',
+                  objectsDir: svelteKit.objectsDir || 'src/lib/objects',
+                  configPath: svelteKit.configPath || 'src/lib/server',
+                  configFileName: svelteKit.configFileName || 'smrt.ts',
+                  kebabRoutes: svelteKit.kebabRoutes ?? false,
+                  knowledge: await resolveKnowledgeConfig(
+                    server.config.root,
+                    manifest,
+                  ),
+                });
+              }
+
+              // Invalidate virtual modules
+              Object.values(VIRTUAL_MODULES).forEach((id) => {
+                const module = server?.moduleGraph.getModuleById(id);
+                if (module) {
+                  server?.reloadModule(module);
+                }
               });
             }
-
-            // Invalidate virtual modules
-            Object.values(VIRTUAL_MODULES).forEach((id) => {
-              const module = server?.moduleGraph.getModuleById(id);
-              if (module) {
-                server?.reloadModule(module);
-              }
-            });
+          } catch (error) {
+            console.error(
+              `[smrt] Failed to rescan after change in ${file}:`,
+              error,
+            );
           }
         });
 
         watcher.on('add', async (file) => {
-          if (await shouldRescan(file)) {
-            console.log(`[smrt] Rescanning due to new file ${file}`);
-            manifest = await scanAndGenerateManifest(projectRoot);
+          try {
+            if (await shouldRescan(file)) {
+              console.log(`[smrt] Rescanning due to new file ${file}`);
+              manifest = await scanAndGenerateManifest(projectRoot);
 
-            // Write local manifest for CLI discovery (Issue #963)
-            if (manifest) {
-              await writeLocalManifest(manifest, projectRoot);
-              warnCliApiCoherenceViolations(manifest);
-            }
+              // Write local manifest for CLI discovery (Issue #963)
+              if (manifest) {
+                await writeLocalManifest(manifest, projectRoot);
+                warnCliApiCoherenceViolations(manifest);
+              }
 
-            // Generate SvelteKit routes if enabled
-            if (svelteKit.enabled && manifest && server) {
-              await generateSvelteKitRoutes(server.config.root, manifest, {
-                enabled: svelteKit.enabled,
-                routesDir: svelteKit.routesDir || 'src/routes/api',
-                objectsDir: svelteKit.objectsDir || 'src/lib/objects',
-                configPath: svelteKit.configPath || 'src/lib/server',
-                configFileName: svelteKit.configFileName || 'smrt.ts',
-                kebabRoutes: svelteKit.kebabRoutes ?? false,
-                knowledge: await resolveKnowledgeConfig(
-                  server.config.root,
-                  manifest,
-                ),
-              });
+              // Generate SvelteKit routes if enabled
+              if (svelteKit.enabled && manifest && server) {
+                await generateSvelteKitRoutes(server.config.root, manifest, {
+                  enabled: svelteKit.enabled,
+                  routesDir: svelteKit.routesDir || 'src/routes/api',
+                  objectsDir: svelteKit.objectsDir || 'src/lib/objects',
+                  configPath: svelteKit.configPath || 'src/lib/server',
+                  configFileName: svelteKit.configFileName || 'smrt.ts',
+                  kebabRoutes: svelteKit.kebabRoutes ?? false,
+                  knowledge: await resolveKnowledgeConfig(
+                    server.config.root,
+                    manifest,
+                  ),
+                });
+              }
             }
+          } catch (error) {
+            console.error(
+              `[smrt] Failed to rescan after adding ${file}:`,
+              error,
+            );
           }
         });
 
         watcher.on('unlink', async (file) => {
-          if (await shouldRescan(file)) {
-            console.log(`[smrt] Rescanning due to removed file ${file}`);
-            manifest = await scanAndGenerateManifest(projectRoot);
+          try {
+            if (await shouldRescan(file)) {
+              console.log(`[smrt] Rescanning due to removed file ${file}`);
+              manifest = await scanAndGenerateManifest(projectRoot);
 
-            // Write local manifest for CLI discovery (Issue #963)
-            if (manifest) {
-              await writeLocalManifest(manifest, projectRoot);
-              warnCliApiCoherenceViolations(manifest);
-            }
+              // Write local manifest for CLI discovery (Issue #963)
+              if (manifest) {
+                await writeLocalManifest(manifest, projectRoot);
+                warnCliApiCoherenceViolations(manifest);
+              }
 
-            // Generate SvelteKit routes if enabled
-            if (svelteKit.enabled && manifest && server) {
-              await generateSvelteKitRoutes(server.config.root, manifest, {
-                enabled: svelteKit.enabled,
-                routesDir: svelteKit.routesDir || 'src/routes/api',
-                objectsDir: svelteKit.objectsDir || 'src/lib/objects',
-                configPath: svelteKit.configPath || 'src/lib/server',
-                configFileName: svelteKit.configFileName || 'smrt.ts',
-                kebabRoutes: svelteKit.kebabRoutes ?? false,
-                knowledge: await resolveKnowledgeConfig(
-                  server.config.root,
-                  manifest,
-                ),
-              });
+              // Generate SvelteKit routes if enabled
+              if (svelteKit.enabled && manifest && server) {
+                await generateSvelteKitRoutes(server.config.root, manifest, {
+                  enabled: svelteKit.enabled,
+                  routesDir: svelteKit.routesDir || 'src/routes/api',
+                  objectsDir: svelteKit.objectsDir || 'src/lib/objects',
+                  configPath: svelteKit.configPath || 'src/lib/server',
+                  configFileName: svelteKit.configFileName || 'smrt.ts',
+                  kebabRoutes: svelteKit.kebabRoutes ?? false,
+                  knowledge: await resolveKnowledgeConfig(
+                    server.config.root,
+                    manifest,
+                  ),
+                });
+              }
             }
+          } catch (error) {
+            console.error(
+              `[smrt] Failed to rescan after removing ${file}:`,
+              error,
+            );
           }
         });
       }
@@ -772,31 +790,6 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
       }
     },
   };
-
-  async function _loadStaticManifest(): Promise<SmartObjectManifest | null> {
-    if (!manifestPath) return null;
-
-    try {
-      // Conditionally import fs for Node.js environments
-      const { readFileSync } = await import('node:fs');
-      const manifestContent = readFileSync(manifestPath, 'utf-8');
-      return JSON.parse(manifestContent);
-    } catch (error) {
-      console.warn(
-        `[smrt] Could not load static manifest from ${manifestPath}:`,
-        error,
-      );
-      return null;
-    }
-  }
-
-  function createEmptyManifest(): SmartObjectManifest {
-    return {
-      version: '1.0.0',
-      timestamp: Date.now(),
-      objects: {},
-    };
-  }
 
   async function scanAndGenerateManifest(
     rootDir: string,

--- a/packages/core/src/vite-plugin/watcher-error-guard.test.ts
+++ b/packages/core/src/vite-plugin/watcher-error-guard.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Regression test for #1378: the smrtPlugin file-watcher handlers must not let
+ * a mid-edit scan error escape as an unhandled promise rejection (which can
+ * crash the dev server). Each `watcher.on(...)` handler is wrapped in try/catch
+ * and logs via console.error.
+ *
+ * We drive `configureServer` with a minimal mock devServer whose `watcher` is a
+ * real EventEmitter, then invoke the registered `change`/`add`/`unlink`
+ * handlers directly. The scan is forced to fail by placing a MALFORMED source
+ * file in the project root: the OXC scanner reports a parse error, so
+ * scanAndGenerateManifest (via scanWithOxc) throws. The handler must swallow it
+ * and log via console.error instead of leaking an unhandled rejection.
+ */
+
+import { EventEmitter } from 'node:events';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { smrtPlugin } from './index.js';
+
+describe('smrtPlugin watcher error guard (#1378)', () => {
+  let testDir: string | null = null;
+  let originalCwd: string | null = null;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // projectRoot defaults to process.cwd(); chdir into a temp dir so the scan
+    // targets it. A MALFORMED .ts file makes the OXC scanner report a parse
+    // error, which scanWithOxc turns into a thrown Error — the deterministic
+    // failure the watcher handler must catch.
+    testDir = mkdtempSync(join(tmpdir(), 'smrt-watcher-guard-'));
+    mkdirSync(join(testDir, 'src'), { recursive: true });
+    // Matches the default include glob (src/**/*.ts) so shouldRescan() is true.
+    writeFileSync(
+      join(testDir, 'src', 'thing.ts'),
+      'export class @@@ { not valid typescript ((( \n',
+    );
+    originalCwd = process.cwd();
+    process.chdir(testDir);
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    logSpy.mockRestore();
+    if (originalCwd) {
+      process.chdir(originalCwd);
+      originalCwd = null;
+    }
+    if (testDir) {
+      rmSync(testDir, { recursive: true, force: true });
+      testDir = null;
+    }
+  });
+
+  function buildMockServer(watcher: EventEmitter) {
+    return {
+      watcher,
+      middlewares: { use: () => {} },
+      config: { root: testDir as string },
+      moduleGraph: { getModuleById: () => undefined },
+      reloadModule: () => {},
+      transformIndexHtml: async (_url: string, html: string) => html,
+    };
+  }
+
+  it('swallows a scan failure in the "change" handler and logs it', async () => {
+    const watcher = new EventEmitter();
+    const plugin: any = smrtPlugin({ watch: true, hmr: true });
+
+    // configureServer registers the watcher handlers synchronously.
+    plugin.configureServer(buildMockServer(watcher));
+
+    const changeListeners = watcher.listeners('change');
+    expect(changeListeners.length).toBeGreaterThan(0);
+    const changeHandler = changeListeners[0] as (file: string) => Promise<void>;
+
+    // The handler returns a promise; the guard means it must RESOLVE even
+    // though the underlying scan rejects.
+    await expect(changeHandler('src/thing.ts')).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to rescan after change in'),
+      expect.anything(),
+    );
+  });
+
+  it('swallows a scan failure in the "add" handler and logs it', async () => {
+    const watcher = new EventEmitter();
+    const plugin: any = smrtPlugin({ watch: true, hmr: true });
+    plugin.configureServer(buildMockServer(watcher));
+
+    const addHandler = watcher.listeners('add')[0] as (
+      file: string,
+    ) => Promise<void>;
+    expect(addHandler).toBeDefined();
+
+    await expect(addHandler('src/thing.ts')).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to rescan after adding'),
+      expect.anything(),
+    );
+  });
+
+  it('swallows a scan failure in the "unlink" handler and logs it', async () => {
+    const watcher = new EventEmitter();
+    const plugin: any = smrtPlugin({ watch: true, hmr: true });
+    plugin.configureServer(buildMockServer(watcher));
+
+    const unlinkHandler = watcher.listeners('unlink')[0] as (
+      file: string,
+    ) => Promise<void>;
+    expect(unlinkHandler).toBeDefined();
+
+    await expect(unlinkHandler('src/thing.ts')).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to rescan after removing'),
+      expect.anything(),
+    );
+  });
+});

--- a/packages/scanner/AGENTS.md
+++ b/packages/scanner/AGENTS.md
@@ -1,29 +1,69 @@
 # @happyvertical/smrt-scanner
 
-AST-based scanner for discovering SMRT objects in TypeScript source. Uses oxc-parser (Rust, 2-3x faster than tsc).
+AST-based scanner for discovering SMRT objects in TypeScript source. Uses
+oxc-parser (Rust, 2-3x faster than tsc) for syntactic parsing — it never
+executes the source.
 
 ## Key Exports
 
-- `ManifestBuilder` — scans source files, builds `SmartObjectManifest` (`.generate()`)
-- `discoverBaseClasses({ cwd })` — finds SMRT base classes in node_modules
-- `SmartObjectDefinition`, `FieldDefinition` — scanned class metadata types
-- `verifyManifestCompleteness({ packageDir })` — publish guard: re-scans `src/` and asserts every `@smrt()` object reached `dist/manifest.json` (issue #1483). Driven by `scripts/verify-manifest-completeness.mjs` from `prepack`.
+- `OxcScanner` — class that globs `.ts` files (`fast-glob`) and parses each into
+  raw class/field/method metadata. `scan()` parses; `scanAndResolve()` parses
+  then resolves inheritance in one call.
+- `InheritanceResolver` — resolves class inheritance chains across files
+  (`addClasses()` → `resolveAll()`), merging inherited fields/config into each
+  `@smrt()` subclass.
+- `ManifestAdapter` — converts resolved classes into the SMRT manifest shape
+  (`toManifest()`); owns field-type inference (the `0` vs `0.0` integer/decimal
+  heuristic, decorator interpretation, union/alias resolution).
+- `parseFile` / `parseSource` — parse a single file or a source string to a
+  `FileScanResult` (classes, errors, type aliases, SMRT imports).
+- `extractSmrtImports` — pull SMRT-related imports from a parsed file.
+- `verifyManifestCompleteness({ packageDir })` — publish guard: re-scans `src/`
+  and asserts every `@smrt()` object reached `dist/manifest.json` (issue #1483).
+  Returns `ok` / `incomplete` / `missing-manifest` / `scan-error` / `skipped`.
+  Driven by `scripts/verify-manifest-completeness.mjs` from `prepack`.
+- Types (re-exported from `./types`): `RawClassDefinition`,
+  `RawFieldDefinition`, `RawMethodDefinition`, `ResolvedClassDefinition`,
+  `ScanResults`, `FileScanResult`, `OxcScannerOptions`, `InferredFieldType`,
+  `FieldTypeInference`.
 
 ## How It Works
 
-1. `fast-glob` finds `.ts` files matching include/exclude patterns
-2. `oxc-parser` parses each file's AST
-3. Extracts: `@smrt()` config, class hierarchy, field defaults (0 vs 0.0 heuristic), relationships, static properties (`uiSlots`, `adminRoutes`)
-4. Outputs manifest JSON consumed by code generators, vitest plugin, and CLI
+1. `fast-glob` finds `.ts` files matching include/exclude patterns.
+2. `oxc-parser` parses each file's AST (TS-ESTree shape).
+3. Extracts: `@smrt()` config, class hierarchy, field defaults (0 vs 0.0
+   heuristic, including negative initializers via `UnaryExpression` unwrap),
+   relationships, static properties (`uiSlots`, `adminRoutes`).
+4. `InheritanceResolver` merges inherited members; `ManifestAdapter` emits the
+   manifest JSON consumed by code generators, the vitest plugin, and the CLI.
 
 ## Key Files
 
-- `src/oxc-scanner.ts` — core AST scanning logic
-- `src/manifest-builder.ts` — orchestrates scanning → manifest
-- `src/base-class-discovery.ts` — resolves base classes from node_modules
+- `src/oxc-parser.ts` — core AST → raw metadata extraction (`parseFile`,
+  `parseSource`, `extractSmrtImports`, field/decorator/type extractors).
+- `src/scanner.ts` — `OxcScanner`: globbing + multi-file orchestration
+  (`scan` / `scanAndResolve`).
+- `src/inheritance-resolver.ts` — `InheritanceResolver`: cross-file inheritance
+  merging.
+- `src/manifest-adapter.ts` — `ManifestAdapter`: raw → manifest conversion and
+  field-type inference.
+- `src/verify-completeness.ts` — `verifyManifestCompleteness` publish guard.
+- `src/types.ts` — shared raw/resolved/result type definitions.
+- `src/cli.ts` / `bin/smrt-scan.js` — the `smrt-scan` CLI.
 
 ## Gotchas
 
-- **CWD-relative**: `ManifestBuilder.generate()` resolves all paths relative to `process.cwd()`
-- **Used by vitest plugin**: `smrtVitestPlugin()` calls ManifestBuilder at startup
-- **Static property capture**: captures `uiSlots` and `adminRoutes` for agent manifest generation
+- **Syntactic only**: the scanner parses, it does not type-check or execute.
+  Type aliases are resolved heuristically (bounded depth), not via the TS type
+  system.
+- **Build-time consumers**: `smrtVitestPlugin()` and the build's vite-plugin run
+  the scanner at startup; add a new `@smrt()` class → rebuild/restart so it
+  reaches the manifest.
+- **`ManifestBuilder` / `discoverBaseClasses` live in `@happyvertical/smrt-core`,
+  not here.** This package is the lower-level AST layer; core orchestrates
+  manifest generation and base-class discovery on top of it.
+- **0 vs 0.0 heuristic**: `count = 0` → integer, `price = 0.0` → decimal; the
+  raw initializer text (not the parsed value) decides, and negative defaults are
+  unwrapped from their `UnaryExpression` before the check.
+- **Static property capture**: captures `uiSlots` and `adminRoutes` for agent
+  manifest generation.

--- a/packages/scanner/src/__tests__/manifest-adapter-conversion.test.ts
+++ b/packages/scanner/src/__tests__/manifest-adapter-conversion.test.ts
@@ -367,6 +367,9 @@ describe('ManifestAdapter conversion', () => {
   describe('collection pluralization', () => {
     const cases: Array<[string, string]> = [
       ['City', 'cities'],
+      // Vowel + y → +s, not +ies (regression: Day must not become "daies").
+      ['Day', 'days'],
+      ['Key', 'keys'],
       ['Box', 'boxes'],
       ['Bus', 'buses'],
       ['Dish', 'dishes'],

--- a/packages/scanner/src/__tests__/manifest-adapter.test.ts
+++ b/packages/scanner/src/__tests__/manifest-adapter.test.ts
@@ -245,6 +245,73 @@ describe('ManifestAdapter', () => {
       });
     });
 
+    describe('negative numeric defaults (0 vs 0.0 heuristic)', () => {
+      // Regression for the negative-initializer gap: the oxc extractor must
+      // unwrap `UnaryExpression('-')` so `numericValue`/`hasDecimalPoint` are
+      // populated for negatives. These assert the downstream inference the
+      // populated fields drive.
+      it('infers decimal with the negative default for `price: number = -1.5`', () => {
+        const field: RawFieldDefinition = {
+          name: 'price',
+          accessibility: 'public',
+          typeAnnotation: 'number',
+          initializer: '-1.5',
+          optional: false,
+          hasDecimalPoint: true,
+          numericValue: -1.5,
+          decorators: [],
+          isStatic: false,
+          readonly: false,
+          line: 1,
+        };
+
+        const result = adapter.inferFieldType(field);
+        expect(result.type).toBe('decimal');
+        expect(result.defaultValue).toBe(-1.5);
+      });
+
+      it('infers integer with the negative default for `count: number = -5`', () => {
+        const field: RawFieldDefinition = {
+          name: 'count',
+          accessibility: 'public',
+          typeAnnotation: 'number',
+          initializer: '-5',
+          optional: false,
+          hasDecimalPoint: false,
+          numericValue: -5,
+          decorators: [],
+          isStatic: false,
+          readonly: false,
+          line: 1,
+        };
+
+        const result = adapter.inferFieldType(field);
+        expect(result.type).toBe('integer');
+        expect(result.defaultValue).toBe(-5);
+      });
+
+      it('infers integer (not text) for unannotated `balance = -100`', () => {
+        const field: RawFieldDefinition = {
+          name: 'balance',
+          accessibility: 'public',
+          typeAnnotation: null,
+          initializer: '-100',
+          optional: false,
+          hasDecimalPoint: false,
+          numericValue: -100,
+          decorators: [],
+          isStatic: false,
+          readonly: false,
+          line: 1,
+        };
+
+        const result = adapter.inferFieldType(field);
+        expect(result.type).toBe('integer');
+        expect(result.defaultValue).toBe(-100);
+        expect(result.source).toBe('heuristic');
+      });
+    });
+
     describe('string literal union types', () => {
       it('should infer text for inline string literal union', () => {
         const field: RawFieldDefinition = {

--- a/packages/scanner/src/__tests__/oxc-parser.test.ts
+++ b/packages/scanner/src/__tests__/oxc-parser.test.ts
@@ -77,6 +77,40 @@ describe('OXC Parser', () => {
       expect(tagsField?.typeAnnotation).toBe('string[]');
     });
 
+    it('should extract negative numeric defaults (UnaryExpression unwrap)', () => {
+      // A negative initializer parses as UnaryExpression{op:'-', arg:Literal},
+      // not a bare Literal. The 0-vs-0.0 heuristic must unwrap it, otherwise the
+      // default is dropped and `-1.5` mis-infers as integer.
+      const source = `
+        @smrt()
+        class Account extends SmrtObject {
+          price: number = -1.5;
+          count: number = -5;
+          balance = -100;
+        }
+      `;
+
+      const result = parseSource(source);
+
+      expect(result.classes).toHaveLength(1);
+      const fields = result.classes[0].fields;
+
+      // Negative decimal: default captured, decimal point detected.
+      const priceField = fields.find((f) => f.name === 'price');
+      expect(priceField?.numericValue).toBe(-1.5);
+      expect(priceField?.hasDecimalPoint).toBe(true);
+
+      // Negative integer: default captured, no decimal point.
+      const countField = fields.find((f) => f.name === 'count');
+      expect(countField?.numericValue).toBe(-5);
+      expect(countField?.hasDecimalPoint).toBe(false);
+
+      // Unannotated negative integer: numericValue drives integer inference.
+      const balanceField = fields.find((f) => f.name === 'balance');
+      expect(balanceField?.numericValue).toBe(-100);
+      expect(balanceField?.hasDecimalPoint).toBe(false);
+    });
+
     it('should extract decorator config', () => {
       const source = `
         @smrt({

--- a/packages/scanner/src/__tests__/verify-completeness.test.ts
+++ b/packages/scanner/src/__tests__/verify-completeness.test.ts
@@ -166,6 +166,42 @@ export class Widget extends SmrtObject {
     expect(result.reason).toMatch(/not valid JSON/);
   });
 
+  it('reports scan-error when a source file fails to parse', async () => {
+    // A @smrt() class with a syntax error parses to errors:[...], body:[], so it
+    // is dropped from BOTH the re-scanned `expected` set and `dist`. The
+    // `expected ⊆ dist` comparison would wave that through as `ok`; the guard
+    // must instead surface the parse error (regression for the #1483 hole).
+    writeFileSync(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({
+        name: '@happyvertical/smrt-fixture',
+        version: '0.0.0',
+        exports: { './manifest': './dist/manifest.json' },
+      }),
+    );
+    mkdirSync(join(pkgDir, 'src'), { recursive: true });
+    // Unterminated string literal → oxc emits a severity:'error' parse error.
+    writeFileSync(
+      join(pkgDir, 'src', 'broken.ts'),
+      [
+        "import { smrt, SmrtObject } from '@happyvertical/smrt-core';",
+        "@smrt({ tableName: 'broken' })",
+        'export class Broken extends SmrtObject {',
+        "  label: string = 'unterminated",
+        '}',
+        '',
+      ].join('\n'),
+    );
+    // A complete manifest would otherwise let `expected ⊆ dist` pass as `ok`.
+    writeDistManifest(['@happyvertical/smrt-fixture:Broken']);
+
+    const result = await verifyManifestCompleteness({ packageDir: pkgDir });
+
+    expect(result.status).toBe('scan-error');
+    expect(result.reason).toMatch(/parse error/i);
+    expect(result.reason).toMatch(/broken\.ts/);
+  });
+
   it('skips framework-infrastructure packages by basename', async () => {
     const skipDir = join(pkgDir, 'core');
     mkdirSync(skipDir, { recursive: true });

--- a/packages/scanner/src/manifest-adapter.ts
+++ b/packages/scanner/src/manifest-adapter.ts
@@ -1255,12 +1255,20 @@ export class ManifestAdapter {
   }
 
   /**
-   * Simple pluralization for collection names
+   * Simple pluralization for collection names.
+   *
+   * This produces the manifest's `collection` label only; the authoritative DDL
+   * table name is derived independently by core (`classnameToTablename` →
+   * the `pluralize` library), so this needs to stay self-consistent rather than
+   * cover every irregular plural. Note the `y → ies` rule fires only after a
+   * consonant, so vowel+y words pluralise correctly (`Day` → `days`, not
+   * `daies`).
    */
   private pluralize(name: string): string {
     // Lowercase the name first for consistent collection/table names
     const lower = name.toLowerCase();
-    if (lower.endsWith('y')) {
+    // Consonant + y → ies (City → cities); vowel + y → +s (Day → days).
+    if (/[^aeiou]y$/.test(lower)) {
       return `${lower.slice(0, -1)}ies`;
     }
     if (lower.endsWith('s') || lower.endsWith('x') || lower.endsWith('z')) {

--- a/packages/scanner/src/oxc-parser.ts
+++ b/packages/scanner/src/oxc-parser.ts
@@ -1394,8 +1394,26 @@ function extractPropertyDefinition(
   let numericValue: number | null = null;
 
   if (node.value) {
-    // Check for numeric literal with decimal point
-    if (node.value.type === 'Literal' && typeof node.value.value === 'number') {
+    // Check for numeric literal with decimal point. Unwrap a leading unary
+    // minus first: a negative initializer (`= -5`, `= -1.5`) parses as a
+    // `UnaryExpression{ operator: '-', argument: Literal }`, not a bare
+    // `Literal`, so without this the 0-vs-0.0 heuristic mis-infers negatives as
+    // `integer` and drops the default. Mirrors the `extractValue` pattern above.
+    if (
+      node.value.type === 'UnaryExpression' &&
+      node.value.operator === '-' &&
+      node.value.argument?.type === 'Literal' &&
+      typeof node.value.argument.value === 'number'
+    ) {
+      numericValue = -node.value.argument.value;
+      // Check the inner literal's raw string for a decimal point (0.0 vs 0).
+      if (node.value.argument.raw) {
+        hasDecimalPoint = node.value.argument.raw.includes('.');
+      }
+    } else if (
+      node.value.type === 'Literal' &&
+      typeof node.value.value === 'number'
+    ) {
       numericValue = node.value.value;
       // Check raw string for decimal point (0.0 vs 0)
       if (node.value.raw) {

--- a/packages/scanner/src/verify-completeness.ts
+++ b/packages/scanner/src/verify-completeness.ts
@@ -20,6 +20,12 @@
  * comparison is `expected ⊆ dist`: enrichment passes that add keys to `dist`
  * (e.g. STI children) never trigger a false failure.
  *
+ * Parse errors are handled before the set comparison: a syntactically broken
+ * source file drops its objects from `expected` AND `dist` symmetrically, which
+ * a naive `expected ⊆ dist` would wave through as `ok`. The scan's
+ * `severity:'error'` entries therefore short-circuit to a distinct `scan-error`
+ * status so a broken source can never masquerade as a complete manifest.
+ *
  * @see https://github.com/happyvertical/smrt/issues/1483
  */
 
@@ -69,6 +75,7 @@ export type VerifyManifestStatus =
   | 'ok'
   | 'incomplete'
   | 'missing-manifest'
+  | 'scan-error'
   | 'skipped';
 
 export interface VerifyManifestCompletenessOptions {
@@ -188,6 +195,33 @@ export async function verifyManifestCompleteness(
   // adapter the build uses (vite-plugin scanWithOxc).
   const scanner = new OxcScanner({ cwd: packageDir, include, exclude });
   const { results, resolved } = await scanner.scanAndResolve();
+
+  // A source file with a syntax error parses to `errors:[...], body:[]`, so any
+  // @smrt() class in it is dropped from BOTH the re-scanned `expected` set and
+  // (having never built) the published `dist`. Because the completeness check is
+  // `expected ⊆ dist`, the object vanishes symmetrically and the guard would
+  // return `ok` — silently defeating the #1483 guarantee for the exact case
+  // (broken source) that most needs catching. Surface scan errors as a distinct
+  // non-`ok` status instead of computing `expected` from a partial scan.
+  const scanErrors = results.errors.filter((e) => e.severity === 'error');
+  if (scanErrors.length > 0) {
+    const detail = scanErrors
+      .map((e) => {
+        const where = e.line ? `${e.filePath}:${e.line}` : e.filePath;
+        return `${where} — ${e.message}`;
+      })
+      .join('; ');
+    return {
+      status: 'scan-error',
+      packageName,
+      manifestPath,
+      missing: [],
+      expectedCount: 0,
+      distCount: 0,
+      reason: `source scan reported ${scanErrors.length} parse error(s): ${detail}`,
+    };
+  }
+
   const adapter = new ManifestAdapter();
   const expected = adapter.toManifest(resolved, {
     packageName,

--- a/packages/scanner/vitest.config.ts
+++ b/packages/scanner/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.{test,spec}.ts'],
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,8 +1,8 @@
 /**
- * @have/types - Shared type definitions for the HAVE SDK
+ * @happyvertical/smrt-types - Shared type definitions for the SMRT SDK
  *
  * This package provides shared TypeScript type definitions and interfaces
- * used across multiple HAVE SDK packages to prevent circular dependencies.
+ * used across multiple SMRT SDK packages to prevent circular dependencies.
  */
 
 // Module standardization types

--- a/packages/types/src/knowledge.ts
+++ b/packages/types/src/knowledge.ts
@@ -1,5 +1,7 @@
+/** Kind of generated surface a knowledge entry describes (REST/CLI/MCP/AI). */
 export type DomainKnowledgeSurfaceKind = 'api' | 'cli' | 'mcp' | 'ai';
 
+/** A single generated surface (one api/cli/mcp/ai operation) exposed by an object. */
 export interface DomainKnowledgeSurface {
   kind: DomainKnowledgeSurfaceKind;
   name: string;
@@ -10,6 +12,7 @@ export interface DomainKnowledgeSurface {
   objectName?: string;
 }
 
+/** Per-object configuration controlling domain-knowledge generation and exposure. */
 export interface DomainKnowledgeConfig {
   enabled?: boolean;
   api?: {
@@ -35,6 +38,7 @@ export interface DomainKnowledgeConfig {
   risks?: string[];
 }
 
+/** One object's entry in the domain-knowledge manifest (fields, relationships, surfaces). */
 export interface DomainKnowledgeObject {
   name: string;
   qualifiedName?: string;
@@ -65,6 +69,7 @@ export interface DomainKnowledgeObject {
   risks: string[];
 }
 
+/** The package-level domain-knowledge artifact (`smrt-knowledge.json`) — the agent/developer contract. */
 export interface DomainKnowledgeManifest {
   schemaVersion: 1;
   generatedAt: string;
@@ -97,6 +102,7 @@ export interface DomainKnowledgeManifest {
   agentDoc?: string;
 }
 
+/** Result of a domain-knowledge freshness check (stale references, error/warning counts). */
 export interface DomainKnowledgeFreshnessResult {
   ok: boolean;
   checkedAt: string;

--- a/scripts/verify-manifest-completeness.mjs
+++ b/scripts/verify-manifest-completeness.mjs
@@ -67,6 +67,19 @@ if (result.status === 'skipped') {
   process.exit(0);
 }
 
+if (result.status === 'scan-error') {
+  // A source parse error drops @smrt classes from the re-scan, so the manifest
+  // cannot be verified — fail loudly rather than waving the package through.
+  console.error(
+    `\n[verify-manifest] ❌ ${label}: source scan failed; manifest completeness cannot be verified.`,
+  );
+  console.error(`[verify-manifest]    ${result.reason}`);
+  console.error(
+    '[verify-manifest]    Fix: resolve the parse error(s) in src/ and rebuild.',
+  );
+  process.exit(1);
+}
+
 // status: 'incomplete' | 'missing-manifest'
 console.error(
   `\n[verify-manifest] ❌ ${label}: published manifest is stale or incomplete.`,


### PR DESCRIPTION
## Summary

Combined remediation for the **T1 Deep code review track** (epic #1354) — the confirmed, source-verified, in-scope bug fixes from all five T1 packages, cherry-picked from per-package fix branches into one PR (29 commits; the #1564/#1566 serial-CI-avoidance pattern). The full read-only findings reports are posted on each issue (#1378, #1380, #1382, #1383, #1385).

**Process:** 12 parallel review agents (read-only, dedicated worktrees) produced confirmed-vs-speculative findings, each adversarially verified against source (logic claims executed with `node`). Fix agents then remediated only the verified in-scope items with regression tests in isolated worktrees. Cross-cutting sweeps were deferred to follow-ups rather than bloating this diff (see below).

## Highlights

🔴 **BLOCKER — data loss (cli):** `smrt db:rollback --dry-run` read `options.dryRun` while the CLI parser produces the kebab key `options['dry-run']`, so `--dry-run` was silently ignored and executed **real destructive rollbacks**. The same defect made `git merge-json --dry-run` overwrite the "ours" file. Both fixed; regression tests route through `parseCliArgs` (the existing tests called handlers directly with the camel key the CLI never produces, which is why it shipped).

**Major:**
- **config** — camelCase `<vendor>Key` secrets (`consumerKey`, `masterKey`, `sslKey`, …) bypassed SSG-export redaction and leaked verbatim. Added a camelCase-anchored pattern (verified: catches all leak keys, keeps `keywords`/`monkey` safe).
- **core (schema)** — consolidated 3+ divergent SQL formatters into one injection-safe `schema/sql-identifiers.ts`: identifiers now escape `"`→`""`, jsonPath literals escape `'`→`''` + identifier-allowlist validation, and the `value.includes('(')` default pass-through (which let `f(x') ; DROP--` through and broke DDL for `'Acme (Inc)'`) is replaced by a recursive function-call validator. (Also caught 2 extra raw-interpolation sites.)
- **core (object)** — `save()` wrapped `TenantIsolationError`/`TenantContextError`, destroying the `instanceof`/`code` contract on the write path; now re-throws SMRT + tenant-coded errors. Unique/not-null detection was SQLite-string-only; now maps Postgres/DuckDB violations to typed `ValidationError`.
- **core (generators)** — MCP `handleToolCall` split tool names on every `_`, mis-routing snake_case methods (`record_payment` → 404); now splits on the first underscore.
- **core (dispatch/runtime)** — `DispatchBus.retry()`/`cleanup()` bypassed tenant isolation (could reset/delete other tenants' rows) — now scoped; the Express-compat route wrapper hung on async-handler rejections — now awaited + 500-guarded; unguarded `JSON.parse` in `Dispatch` (poison-row stalled the queue) and the request-body parser (empty body → 500) — now guarded.
- **core (manifest)** — base-class discovery hardcoded `dist/manifest.json`, silently contributing zero base classes for `.smrt`/`src`-only workspace packages; two empty `catch {}` swallowed the failure. Fixed to use the shared resolver + logged catches.
- **scanner** — the 0-vs-0.0 inference missed **negative** defaults (`= -1.5` → integer w/ default dropped); the publish-completeness guard ignored parse errors (a syntax-error class vanished from both sides → silent pass). Both fixed.

**Minor/cleanup:** `formatDataJs` no longer mutates its input; vite-plugin watcher handlers are try/caught + dead static-manifest code removed; `quoteIdentifier` deduped in cli; config doc drift (phantom env-var layer, wrong signatures) corrected; types stale header + missing JSDoc; dead `isConfigLoaded` removed; `*.spec.ts` test discovery widened (config/scanner).

## Verification (integrated branch)
- `turbo build` — 50/50 tasks pass
- Tests: **config 261 · scanner 153 · cli 770 (+4 skip) · core 2623 (+29 skip) — 0 failed** (≈ +40 new regression tests across the fixes)
- `typecheck` clean (core, cli)
- All cherry-picks applied with zero conflicts (non-overlapping file ownership)

## Deferred to follow-ups (intentionally NOT in this PR)
- **relationship-graph qualified-name keying (#1378)** — *investigated and NOT applied.* The relayed fix contradicts issue #951's deliberate, **tested** simple-name contract (`"should use simple names in getDependencyGraph()"`), and the real `loadRelated` consumers look up by `this.constructor.name` (simple), so re-keying broke 10 tests. This needs a coordinated design change, not a "minor" patch — flagging on #1378 rather than forcing it.
- **dim-2 `noExplicitAny` ratchet** for core (esp. `runtime/*`) — package-wide; belongs to the strictness ratchet.
- **dim-9 `console.*` → `@happyvertical/logger`** in `scanner/manifest-generator.ts` + `manifest/generator.ts` (~43 calls) — tracked under S14 #1432.
- Larger de-duplications (`manifest-loader` vs `store` resolver twins; two `discoverSmrtPackages`), config `deepMerge` aliasing + loader silent-empty (need decisions), and the speculative-needs-runtime items (DuckDB `sqlite_master`, STI sibling-cache, embeddings qualified-name). I'll file a consolidated follow-up issue.

Part of epic #1354. Refs #1378, #1380, #1382, #1383, #1385 (closing each with a per-issue summary once this lands).
