### PR TITLE
fix(core): enforce simple-identifier jsonPath column in SQLite DDL too

### DIFF
--- a/packages/core/src/schema/ddl/sqlite-strategy.ts
+++ b/packages/core/src/schema/ddl/sqlite-strategy.ts
@@ -10,6 +10,7 @@
  */
 
 import {
+  isSafeIdentifier,
   isSafeIdentifierPath,
   quoteIdentifier,
   quoteStringLiteral,
@@ -30,7 +31,11 @@ export class SQLiteStrategy extends BaseDDLStrategy {
     jsonColumn: string,
     path: string,
   ): string {
-    if (!isSafeIdentifierPath(jsonColumn)) {
+    // Column must be a simple identifier (no dots); only the path may be dotted.
+    // Mirrors BaseDDLStrategy.assertSafeJsonPathTarget so the SQLite override
+    // doesn't silently accept dotted columns that PG/DuckDB (and renderIndexTarget)
+    // reject.
+    if (!isSafeIdentifier(jsonColumn)) {
       throw new Error(
         `[DDL] Unsafe JSON-path index column "${jsonColumn}": must be a simple identifier`,
       );

--- a/packages/core/src/schema/ddl/sqlite-strategy.ts
+++ b/packages/core/src/schema/ddl/sqlite-strategy.ts
@@ -32,9 +32,9 @@ export class SQLiteStrategy extends BaseDDLStrategy {
     path: string,
   ): string {
     // Column must be a simple identifier (no dots); only the path may be dotted.
-    // Mirrors BaseDDLStrategy.assertSafeJsonPathTarget so the SQLite override
-    // doesn't silently accept dotted columns that PG/DuckDB (and renderIndexTarget)
-    // reject.
+    // Mirrors the `assertSafeJsonPathTarget` file-level helper in
+    // base-strategy.ts so this SQLite override doesn't silently accept dotted
+    // columns that PG/DuckDB (and renderIndexTarget) reject.
     if (!isSafeIdentifier(jsonColumn)) {
       throw new Error(
         `[DDL] Unsafe JSON-path index column "${jsonColumn}": must be a simple identifier`,

--- a/packages/core/src/schema/sql-identifiers.test.ts
+++ b/packages/core/src/schema/sql-identifiers.test.ts
@@ -291,7 +291,7 @@ describe('DDL strategy identifier safety (CREATE TABLE / INDEX)', () => {
         },
       ],
     });
-    for (const engine of ['sqlite', 'postgres', 'duckdb'] as const) {
+    for (const engine of ['sqlite', 'postgres', 'duckdb', 'json'] as const) {
       expect(() => getDDLStrategy(engine).generateIndexes(schema)).toThrow(
         /Unsafe JSON-path index column/,
       );

--- a/packages/core/src/schema/sql-identifiers.test.ts
+++ b/packages/core/src/schema/sql-identifiers.test.ts
@@ -276,4 +276,25 @@ describe('DDL strategy identifier safety (CREATE TABLE / INDEX)', () => {
       ),
     ).toThrow(/Unsafe JSON-path index column/);
   });
+
+  it('rejects a dotted jsonPath column in generateIndexes on every engine', () => {
+    // Regression (codex xhigh on #1578 fixups): SQLiteStrategy overrides
+    // formatJsonPathIndexExpression and used to validate the column with the
+    // dotted isSafeIdentifierPath, so SQLite accepted `a.b` while PG/DuckDB
+    // rejected it. All engines must reject a dotted column consistently.
+    const schema = baseSchema({
+      indexes: [
+        {
+          name: 'idx_meta_path',
+          columns: [],
+          jsonPath: { column: 'a.b', path: 'x' },
+        },
+      ],
+    });
+    for (const engine of ['sqlite', 'postgres', 'duckdb'] as const) {
+      expect(() => getDDLStrategy(engine).generateIndexes(schema)).toThrow(
+        /Unsafe JSON-path index column/,
+      );
+    }
+  });
 });


### PR DESCRIPTION
## Summary
Fast-follow to the T1 remediation (#1578), found by a **codex xhigh review of the #1578 fixup commits**.

#1578's round-2 fix added a simple-identifier guard for JSON-path index *columns* in `BaseDDLStrategy.assertSafeJsonPathTarget` (used by Postgres/DuckDB and `renderIndexTarget`). But **`SQLiteStrategy` overrides `formatJsonPathIndexExpression`** and kept validating the column with the dotted `isSafeIdentifierPath`, so SQLite DDL still accepted a dotted `jsonPath.column` (e.g. `a.b`) that the other engines reject — the simple-column contract wasn't enforced on the SQLite path.

Low severity (the column is a developer-controlled `@meta` field name resolved at build time, and `quoteIdentifier` still escapes it, so this is a consistency gap, not an injection vector), but it's a real incompleteness in the prior fix.

## Change
- `sqlite-strategy.ts`: validate the jsonPath **column** with `isSafeIdentifier` (no dots), matching `BaseDDLStrategy`; the dotted **path** keeps `isSafeIdentifierPath`.
- Regression test: `getDDLStrategy(engine).generateIndexes(...)` rejects a dotted jsonPath column for **all three engines** (sqlite/postgres/duckdb) — fails before this fix on SQLite.

## Verification
- `pnpm --filter @happyvertical/smrt-core build` ✓ · `typecheck` ✓
- `sql-identifiers.test.ts` → 26 passed (+1 new)

Refs #1378, #1579.