### PR TITLE
fix(deps): break inter-smrt peerDependency cycles into a DAG (#1582)

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -1,5 +1,18 @@
 /** @type {import('dependency-cruiser').IConfiguration} */
 module.exports = {
+  forbidden: [
+    {
+      name: 'no-circular',
+      severity: 'error',
+      comment:
+        'Circular module/package dependencies reintroduce the peer fan-out and ' +
+        'nominal-identity hazards behind happyvertical/smrt#1582. Break the cycle: ' +
+        'extract a shared leaf, invert the edge, or use @crossPackageRef / registry ' +
+        'indirection. (Tests are excluded below, so a test-only edge cannot trip this.)',
+      from: {},
+      to: { circular: true },
+    },
+  ],
   options: {
     doNotFollow: {
       path: 'node_modules',

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -197,6 +197,15 @@ jobs:
       - name: Run standards check
         run: node scripts/check-standards.mjs
 
+      # DAG guardrails (#1582). Node-only, no node_modules: inter-smrt
+      # peerDependencies drive pnpm's per-peer-set physical fan-out, and a
+      # cross-package cycle is what let the smrt-svelte keystone re-form.
+      - name: Check no smrt-* peerDependencies
+        run: node scripts/check-no-smrt-peers.mjs
+
+      - name: Check smrt package graph is acyclic
+        run: node scripts/check-package-dag.mjs
+
       # Fails if any --smrt-* token consumed by smrt-svelte components is never
       # emitted by a theme-delivery path (issue #1431). Node-only, no deps.
       - name: Check smrt-svelte design tokens

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -203,6 +203,23 @@ pre-push:
         Either use an emitted token or fix the name.
         Run: node scripts/check-svelte-tokens.mjs
 
+    no-smrt-peers:
+      # DAG guardrail (#1582): no @happyvertical/smrt-* peerDependencies — they
+      # drive pnpm's per-peer-set physical fan-out. Template scaffolds are exempt.
+      run: node scripts/check-no-smrt-peers.mjs
+      fail_text: |
+        ❌ A @happyvertical/smrt-* package is declared as a peerDependency.
+        Use a dependency / devDependency / @crossPackageRef indirection.
+        Run: pnpm check:no-smrt-peers
+
+    deps-acyclic:
+      # DAG guardrail (#1582): the smrt package graph (deps + peers) must stay
+      # acyclic. Node-only; `pnpm deps:check` is the deeper source-import variant.
+      run: pnpm check:package-dag
+      fail_text: |
+        ❌ The @happyvertical/smrt-* dependency graph has a cycle.
+        Break it (extract a leaf / invert the edge). Run: pnpm check:package-dag
+
     validate-all-workflows:
       run: |
         echo "🔍 Validating ALL workflow files before push..."

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "check:typography": "node scripts/check-typography.mjs",
     "check:hardcoded-strings": "node scripts/check-hardcoded-strings.mjs",
     "check:coverage": "node scripts/check-coverage.mjs",
+    "check:no-smrt-peers": "node scripts/check-no-smrt-peers.mjs",
+    "check:package-dag": "node scripts/check-package-dag.mjs",
     "knowledge:check": "tsx scripts/check-knowledge.ts",
     "changeset": "changeset",
     "changeset:auto": "npx tsx scripts/auto-changeset.ts",
@@ -47,7 +49,8 @@
     "docs:site:dev": "pnpm --dir docs dev",
     "deps:graph": "(echo '```mermaid' && npx depcruise packages/*/src --config .dependency-cruiser.cjs --output-type mermaid --include-only '^packages' --collapse '^packages/[^/]+' && echo '```') > SKILL_TREE.md",
     "deps:modules": "for pkg in packages/*; do [ -d \"$pkg/src\" ] && (cd \"$pkg\" && (echo '```mermaid' && npx depcruise src --config ../../.dependency-cruiser.cjs --output-type mermaid --include-only '^src' && echo '```') > SKILL_TREE.md); done",
-    "deps:all": "pnpm run deps:graph && pnpm run deps:modules"
+    "deps:all": "pnpm run deps:graph && pnpm run deps:modules",
+    "deps:check": "depcruise packages/*/src --config .dependency-cruiser.cjs --collapse '^packages/[^/]+'"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.11",

--- a/packages/ads/package.json
+++ b/packages/ads/package.json
@@ -31,27 +31,8 @@
     "@happyvertical/smrt-core": "workspace:*",
     "@happyvertical/smrt-tenancy": "workspace:*"
   },
-  "peerDependencies": {
-    "@happyvertical/smrt-assets": "workspace:*",
-    "@happyvertical/smrt-commerce": "workspace:*",
-    "@happyvertical/smrt-properties": "workspace:*",
-    "@happyvertical/smrt-tags": "workspace:*"
-  },
-  "peerDependenciesMeta": {
-    "@happyvertical/smrt-commerce": {
-      "optional": true
-    },
-    "@happyvertical/smrt-properties": {
-      "optional": true
-    },
-    "@happyvertical/smrt-assets": {
-      "optional": true
-    },
-    "@happyvertical/smrt-tags": {
-      "optional": true
-    }
-  },
   "devDependencies": {
+    "@happyvertical/smrt-commerce": "workspace:*",
     "@happyvertical/smrt-vitest": "workspace:*",
     "@happyvertical/sql": "catalog:",
     "@types/node": "25.0.9",

--- a/packages/affiliates/package.json
+++ b/packages/affiliates/package.json
@@ -29,26 +29,6 @@
   "dependencies": {
     "@happyvertical/smrt-core": "workspace:*"
   },
-  "peerDependencies": {
-    "@happyvertical/smrt-ads": "workspace:*",
-    "@happyvertical/smrt-commerce": "workspace:*",
-    "@happyvertical/smrt-profiles": "workspace:*",
-    "@happyvertical/smrt-properties": "workspace:*"
-  },
-  "peerDependenciesMeta": {
-    "@happyvertical/smrt-ads": {
-      "optional": true
-    },
-    "@happyvertical/smrt-commerce": {
-      "optional": true
-    },
-    "@happyvertical/smrt-profiles": {
-      "optional": true
-    },
-    "@happyvertical/smrt-properties": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@happyvertical/smrt-vitest": "workspace:*",
     "@happyvertical/sql": "catalog:",

--- a/packages/app-cli/package.json
+++ b/packages/app-cli/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "@happyvertical/smrt-core": "workspace:*",
-    "@happyvertical/smrt-users": "workspace:*",
     "@types/node": "25.0.9",
     "typescript": "^5.9.3",
     "vite": "^7.3.1",

--- a/packages/app-cli/package.json
+++ b/packages/app-cli/package.json
@@ -30,15 +30,8 @@
     "prepack": "node ../../scripts/prepack-package.js"
   },
   "dependencies": {
+    "@happyvertical/smrt-users": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.25.2"
-  },
-  "peerDependencies": {
-    "@happyvertical/smrt-users": "workspace:*"
-  },
-  "peerDependenciesMeta": {
-    "@happyvertical/smrt-users": {
-      "optional": true
-    }
   },
   "devDependencies": {
     "@happyvertical/smrt-core": "workspace:*",

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -72,17 +72,9 @@
     "@happyvertical/smrt-ui": "workspace:*"
   },
   "peerDependencies": {
-    "@happyvertical/smrt-agents": "workspace:*",
-    "@happyvertical/smrt-profiles": "workspace:*",
     "svelte": "^5.18.0"
   },
   "peerDependenciesMeta": {
-    "@happyvertical/smrt-agents": {
-      "optional": true
-    },
-    "@happyvertical/smrt-profiles": {
-      "optional": true
-    },
     "svelte": {
       "optional": true
     }

--- a/packages/commerce/AGENTS.md
+++ b/packages/commerce/AGENTS.md
@@ -20,7 +20,7 @@ E-commerce with Contract STI hierarchy, invoice lifecycle, payment tracking, pay
 
 ## Ledger Integration
 
-Dynamic import of `@happyvertical/smrt-ledgers` — optional dependency. Invoice stores `arJournalId` and `revenueJournalId` as string references. `recognizeRevenue()` returns null if ledgers not available.
+`@happyvertical/smrt-ledgers` is a regular dependency, loaded lazily via dynamic `import()` so the coupling stays runtime-only (no hard static import; the package graph stays a DAG — see #1582). Invoice stores `arJournalId` and `revenueJournalId` as string references. `recognizeRevenue()` creates a balanced AR journal entry; `getArJournal()` returns null when no journal has been recognized yet.
 
 ## Cross-Package References
 

--- a/packages/commerce/package.json
+++ b/packages/commerce/package.json
@@ -65,8 +65,6 @@
     "@happyvertical/smrt-ui": "workspace:*"
   },
   "peerDependencies": {
-    "@happyvertical/smrt-ledgers": "workspace:*",
-    "@happyvertical/smrt-profiles": "workspace:*",
     "svelte": "^5.18.0"
   },
   "peerDependenciesMeta": {

--- a/packages/commerce/package.json
+++ b/packages/commerce/package.json
@@ -60,6 +60,7 @@
   },
   "dependencies": {
     "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-ledgers": "workspace:*",
     "@happyvertical/smrt-tenancy": "workspace:*",
     "@happyvertical/smrt-types": "workspace:*",
     "@happyvertical/smrt-ui": "workspace:*"
@@ -73,7 +74,6 @@
     }
   },
   "devDependencies": {
-    "@happyvertical/smrt-ledgers": "workspace:*",
     "@happyvertical/smrt-vitest": "workspace:*",
     "@sveltejs/package": "^2.5.7",
     "@sveltejs/vite-plugin-svelte": "^6.2.4",

--- a/packages/profiles/package.json
+++ b/packages/profiles/package.json
@@ -38,13 +38,11 @@
     "@happyvertical/smrt-assets": "workspace:*",
     "@happyvertical/smrt-core": "workspace:*",
     "@happyvertical/smrt-prompts": "workspace:*",
+    "@happyvertical/smrt-tenancy": "workspace:*",
     "@happyvertical/sql": "catalog:",
     "@happyvertical/utils": "catalog:",
     "@noble/curves": "^1.8.1",
     "bech32": "^2.0.0"
-  },
-  "peerDependencies": {
-    "@happyvertical/smrt-tenancy": "workspace:*"
   },
   "devDependencies": {
     "@faker-js/faker": "^10.2.0",

--- a/packages/properties/package.json
+++ b/packages/properties/package.json
@@ -32,18 +32,6 @@
     "@happyvertical/smrt-prompts": "workspace:*",
     "@happyvertical/smrt-tenancy": "workspace:*"
   },
-  "peerDependencies": {
-    "@happyvertical/smrt-profiles": "workspace:*",
-    "@happyvertical/smrt-projects": "workspace:*"
-  },
-  "peerDependenciesMeta": {
-    "@happyvertical/smrt-profiles": {
-      "optional": true
-    },
-    "@happyvertical/smrt-projects": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@happyvertical/smrt-cli": "workspace:*",
     "@happyvertical/smrt-vitest": "workspace:*",

--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -41,14 +41,6 @@
     "vite": "7.3.1",
     "vitest": "^4.0.17"
   },
-  "peerDependencies": {
-    "@happyvertical/smrt-core": "workspace:*"
-  },
-  "peerDependenciesMeta": {
-    "@happyvertical/smrt-core": {
-      "optional": true
-    }
-  },
   "scripts": {
     "build": "vite build",
     "build:watch": "vite build --watch",

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -31,14 +31,6 @@
     "@happyvertical/smrt-core": "workspace:*",
     "@happyvertical/smrt-tenancy": "workspace:*"
   },
-  "peerDependencies": {
-    "@happyvertical/smrt-agents": "workspace:*"
-  },
-  "peerDependenciesMeta": {
-    "@happyvertical/smrt-agents": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@happyvertical/smrt-cli": "workspace:*",
     "@happyvertical/smrt-vitest": "workspace:*",

--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -90,28 +90,21 @@
     "access": "public"
   },
   "dependencies": {
+    "@happyvertical/smrt-agents": "workspace:*",
+    "@happyvertical/smrt-languages": "workspace:*",
     "@happyvertical/smrt-types": "workspace:*",
     "@happyvertical/smrt-ui": "workspace:*",
     "esm-env": "^1.2.2"
   },
   "peerDependencies": {
-    "@happyvertical/smrt-agents": "workspace:*",
-    "@happyvertical/smrt-jobs": "workspace:*",
     "@huggingface/transformers": ">=3.0.0",
     "@mlc-ai/web-llm": ">=0.2.0",
     "@remotion/whisper-web": ">=4.0.0",
     "@xenova/transformers": "^2.17.2",
     "chrono-node": "^2.9.0",
-    "svelte": "^5.18.2",
-    "@happyvertical/smrt-languages": "workspace:*"
+    "svelte": "^5.18.2"
   },
   "peerDependenciesMeta": {
-    "@happyvertical/smrt-agents": {
-      "optional": true
-    },
-    "@happyvertical/smrt-jobs": {
-      "optional": true
-    },
     "@huggingface/transformers": {
       "optional": true
     },
@@ -125,9 +118,6 @@
       "optional": true
     },
     "chrono-node": {
-      "optional": true
-    },
-    "@happyvertical/smrt-languages": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,25 +140,16 @@ importers:
 
   packages/ads:
     dependencies:
-      '@happyvertical/smrt-assets':
-        specifier: workspace:*
-        version: link:../assets
-      '@happyvertical/smrt-commerce':
-        specifier: workspace:*
-        version: link:../commerce
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
-      '@happyvertical/smrt-properties':
-        specifier: workspace:*
-        version: link:../properties
-      '@happyvertical/smrt-tags':
-        specifier: workspace:*
-        version: link:../tags
       '@happyvertical/smrt-tenancy':
         specifier: workspace:*
         version: link:../tenancy
     devDependencies:
+      '@happyvertical/smrt-commerce':
+        specifier: workspace:*
+        version: link:../commerce
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
         version: link:../vitest
@@ -183,21 +174,9 @@ importers:
 
   packages/affiliates:
     dependencies:
-      '@happyvertical/smrt-ads':
-        specifier: workspace:*
-        version: link:../ads
-      '@happyvertical/smrt-commerce':
-        specifier: workspace:*
-        version: link:../commerce
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
-      '@happyvertical/smrt-profiles':
-        specifier: workspace:*
-        version: link:../profiles
-      '@happyvertical/smrt-properties':
-        specifier: workspace:*
-        version: link:../properties
     devDependencies:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
@@ -342,6 +321,9 @@ importers:
 
   packages/app-cli:
     dependencies:
+      '@happyvertical/smrt-users':
+        specifier: workspace:*
+        version: link:../users
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.2
         version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
@@ -349,9 +331,6 @@ importers:
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
-      '@happyvertical/smrt-users':
-        specifier: workspace:*
-        version: link:../users
       '@types/node':
         specifier: 24.10.9
         version: 24.10.9
@@ -609,9 +588,6 @@ importers:
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
-      '@happyvertical/smrt-profiles':
-        specifier: workspace:*
-        version: link:../profiles
       '@happyvertical/smrt-tenancy':
         specifier: workspace:*
         version: link:../tenancy
@@ -1688,12 +1664,6 @@ importers:
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
-      '@happyvertical/smrt-profiles':
-        specifier: workspace:*
-        version: link:../profiles
-      '@happyvertical/smrt-projects':
-        specifier: workspace:*
-        version: link:../projects
       '@happyvertical/smrt-prompts':
         specifier: workspace:*
         version: link:../prompts
@@ -1728,9 +1698,6 @@ importers:
 
   packages/scanner:
     dependencies:
-      '@happyvertical/smrt-core':
-        specifier: workspace:*
-        version: link:../core
       fast-glob:
         specifier: 3.3.3
         version: 3.3.3
@@ -1796,9 +1763,6 @@ importers:
 
   packages/sites:
     dependencies:
-      '@happyvertical/smrt-agents':
-        specifier: workspace:*
-        version: link:../agents
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
@@ -1944,9 +1908,6 @@ importers:
       '@happyvertical/smrt-agents':
         specifier: workspace:*
         version: link:../agents
-      '@happyvertical/smrt-jobs':
-        specifier: workspace:*
-        version: link:../jobs
       '@happyvertical/smrt-languages':
         specifier: workspace:*
         version: link:../languages

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -588,6 +588,9 @@ importers:
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
+      '@happyvertical/smrt-ledgers':
+        specifier: workspace:*
+        version: link:../ledgers
       '@happyvertical/smrt-tenancy':
         specifier: workspace:*
         version: link:../tenancy
@@ -598,9 +601,6 @@ importers:
         specifier: workspace:*
         version: link:../smrt-ui
     devDependencies:
-      '@happyvertical/smrt-ledgers':
-        specifier: workspace:*
-        version: link:../ledgers
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
         version: link:../vitest

--- a/scripts/check-no-smrt-peers.mjs
+++ b/scripts/check-no-smrt-peers.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * DAG guardrail (happyvertical/smrt#1582).
+ *
+ * Fails if any package declares another `@happyvertical/smrt-*` package as a
+ * `peerDependency`. Inter-smrt peers are what drove pnpm's per-peer-set physical
+ * fan-out — the same package version resolving into multiple incompatible
+ * instances — that broke consumer typechecks non-deterministically. With every
+ * `@happyvertical/smrt-*` package version-locked, a plain `dependency` dedupes to
+ * one instance; a `peerDependency` does not.
+ *
+ * Use instead:
+ *   - a regular `dependency` for a real (value/type) cross-package edge;
+ *   - `@crossPackageRef('@happyvertical/smrt-x:Class')` (string-keyed, resolved
+ *     at runtime via the ObjectRegistry) for an optional integration that needs
+ *     no package edge at all;
+ *   - a `devDependency` when only tests touch the other package.
+ *
+ * Exempt: the `template-*` scaffolds, whose peers describe what the *generated*
+ * project must provide (the template itself is not a runtime consumer and is not
+ * depended on by other packages, so it cannot fan out).
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const PACKAGES = join(import.meta.dirname, '..', 'packages');
+
+const EXEMPT = new Set([
+  '@happyvertical/smrt-template-site-static-json',
+  '@happyvertical/smrt-template-sveltekit',
+]);
+
+const violations = [];
+for (const entry of readdirSync(PACKAGES, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(join(PACKAGES, entry.name, 'package.json'), 'utf8'));
+  } catch {
+    continue;
+  }
+  if (!pkg.name || EXEMPT.has(pkg.name)) continue;
+  const smrtPeers = Object.keys(pkg.peerDependencies ?? {}).filter((k) =>
+    k.startsWith('@happyvertical/smrt-'),
+  );
+  if (smrtPeers.length) violations.push({ pkg: pkg.name, peers: smrtPeers });
+}
+
+if (violations.length > 0) {
+  console.error(
+    '✗ no-smrt-peer-deps: @happyvertical/smrt-* must not be a peerDependency (drives pnpm peer fan-out — #1582).\n',
+  );
+  for (const { pkg, peers } of violations) {
+    console.error(`  ${pkg}:`);
+    for (const peer of peers) console.error(`    - ${peer}`);
+  }
+  console.error(
+    '\nUse a regular dependency, a devDependency (test-only), or @crossPackageRef\n' +
+      'string refs / registry indirection for optional integrations. Templates are exempt.',
+  );
+  process.exit(1);
+}
+
+console.log(
+  '✓ no-smrt-peer-deps: no @happyvertical/smrt-* peerDependencies (template scaffolds exempt).',
+);

--- a/scripts/check-package-dag.mjs
+++ b/scripts/check-package-dag.mjs
@@ -80,7 +80,10 @@ function strongConnect(v) {
       onStack.delete(w);
       comp.push(w);
     } while (w !== v);
-    if (comp.length > 1) cycles.push(comp);
+    // A component of size > 1 is a cycle. A size-1 component is also a cycle if
+    // the node depends on itself (a self-loop — e.g. a package listing its own
+    // name under workspace:* deps), which Tarjan otherwise drops silently.
+    if (comp.length > 1 || edges.get(comp[0]).has(comp[0])) cycles.push(comp);
   }
 }
 for (const v of nodes) if (!index.has(v)) strongConnect(v);

--- a/scripts/check-package-dag.mjs
+++ b/scripts/check-package-dag.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * DAG guardrail (happyvertical/smrt#1582).
+ *
+ * Fails if the `@happyvertical/smrt-*` package graph contains a cycle over
+ * `dependencies` + `peerDependencies`. A cross-package cycle is what let the
+ * `smrt-svelte` keystone fan out — domain packages peering `smrt-svelte` while
+ * `smrt-svelte` reached back into the domain layer. The graph must stay a DAG so
+ * a plain dependency always dedupes to one physical instance.
+ *
+ * Reads package.json only (no build / node_modules needed). `devDependencies`
+ * are intentionally NOT counted: a test-only edge (e.g. a fixture importing the
+ * package that depends on it) is resolved via workspace hoisting and does not
+ * affect the shipped dependency graph.
+ *
+ * The companion `pnpm deps:check` (dependency-cruiser, collapsed to package
+ * level) validates the same property over *actual source imports* once packages
+ * are built — run it locally for a deeper check.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const PACKAGES = join(import.meta.dirname, '..', 'packages');
+
+const nodes = new Set();
+const edges = new Map(); // name -> Set(workspace dep/peer names)
+const dirs = readdirSync(PACKAGES, { withFileTypes: true })
+  .filter((e) => e.isDirectory())
+  .map((e) => e.name);
+
+const pkgs = {};
+for (const d of dirs) {
+  let p;
+  try {
+    p = JSON.parse(readFileSync(join(PACKAGES, d, 'package.json'), 'utf8'));
+  } catch {
+    continue;
+  }
+  if (!p.name) continue;
+  pkgs[p.name] = p;
+  nodes.add(p.name);
+  edges.set(p.name, new Set());
+}
+
+const isWorkspace = (v) => typeof v === 'string' && v.startsWith('workspace:');
+for (const p of Object.values(pkgs)) {
+  for (const block of [p.dependencies, p.peerDependencies]) {
+    for (const [dep, ver] of Object.entries(block ?? {})) {
+      if (nodes.has(dep) && isWorkspace(ver)) edges.get(p.name).add(dep);
+    }
+  }
+}
+
+// Tarjan strongly-connected components.
+let idx = 0;
+const stack = [];
+const onStack = new Set();
+const index = new Map();
+const low = new Map();
+const cycles = [];
+function strongConnect(v) {
+  index.set(v, idx);
+  low.set(v, idx);
+  idx += 1;
+  stack.push(v);
+  onStack.add(v);
+  for (const w of edges.get(v)) {
+    if (!index.has(w)) {
+      strongConnect(w);
+      low.set(v, Math.min(low.get(v), low.get(w)));
+    } else if (onStack.has(w)) {
+      low.set(v, Math.min(low.get(v), index.get(w)));
+    }
+  }
+  if (low.get(v) === index.get(v)) {
+    const comp = [];
+    let w;
+    do {
+      w = stack.pop();
+      onStack.delete(w);
+      comp.push(w);
+    } while (w !== v);
+    if (comp.length > 1) cycles.push(comp);
+  }
+}
+for (const v of nodes) if (!index.has(v)) strongConnect(v);
+
+if (cycles.length > 0) {
+  console.error(
+    '✗ package-dag: the @happyvertical/smrt-* dependency graph is not acyclic (#1582).\n',
+  );
+  for (const comp of cycles) {
+    console.error(`  cycle: ${comp.map((n) => n.replace('@happyvertical/', '')).join(' → ')}`);
+    for (const v of comp) {
+      for (const w of edges.get(v)) {
+        if (comp.includes(w)) {
+          const kind = pkgs[v].peerDependencies?.[w] ? 'peer' : 'dep';
+          console.error(`    ${v.replace('@happyvertical/', '')} --${kind}--> ${w.replace('@happyvertical/', '')}`);
+        }
+      }
+    }
+  }
+  console.error('\n  Break it: extract a shared leaf, invert the edge, or use @crossPackageRef indirection.');
+  process.exit(1);
+}
+
+console.log(`✓ package-dag: ${nodes.size} smrt packages form a DAG (deps + peers, no cycles).`);


### PR DESCRIPTION
## Phase 3 of the #1582 dependency-DAG refactor

Closes the root cause of **#1582** (consumer typechecks breaking because
`@happyvertical/smrt-*` packages resolved into multiple physical instances).

### Why peers were the problem
pnpm materializes **one physical copy of a package per unique peer-set**. Only
`peerDependencies` drive that fan-out — plain version-locked `dependencies`
dedupe to a single instance. A cross-package *cycle* (domain packages peering
`smrt-svelte`, while `smrt-svelte` reached back into the domain layer) forced
consumers to resolve several copies of the same class. Those copies are mutually
unassignable under TS nominal typing (`private`/`protected`/`#` members), so the
consumer's typecheck failed even though every copy was the same source.

### The three phases
- **Phase 1 (#1583, merged)** — extracted the cross-package identity contracts
  into the `smrt-types` leaf, dissolving the 12-node identity SCC.
- **Phase 2 (#1584, merged)** — extracted `smrt-ui` as a leaf, dissolving the
  7-node `smrt-svelte` keystone SCC.
- **Phase 3 (this PR)** — converts every *remaining* inter-smrt
  `peerDependency` to its true nature and locks the DAG in with CI guardrails.

### Peer dispositions in this PR
| Disposition | Edges |
|---|---|
| → `dependency` (real runtime value import) | `profiles→tenancy`, `app-cli→users`, `smrt-svelte→{agents,languages}` |
| → `devDependency` (test/build only) | `ads→commerce`, `commerce→ledgers` |
| removed (phantom / `@crossPackageRef`-only; resolved at runtime via `ObjectRegistry`) | `affiliates→{ads,commerce,profiles,properties}`, `chat→{agents,profiles}`, `properties→{profiles,projects}`, `sites→agents`, `commerce→profiles`, `ads→{assets,properties,tags}`, `smrt-svelte→jobs` |
| removed entirely | `scanner→core` — `scanner/src` copies the manifest types to avoid the cycle; its tests resolve `core` via workspace hoisting. A devDep would reintroduce the **turbo** build cycle (turbo orders on deps+devDeps, not peers). |

### Guardrails (lock the DAG permanently)
Node-only, no `node_modules` — run in lefthook **pre-push** and the CI
**check-standards** job:
- `scripts/check-no-smrt-peers.mjs` — no `@happyvertical/smrt-*`
  `peerDependency` may exist (template scaffolds exempt).
- `scripts/check-package-dag.mjs` — Tarjan SCC over `dependencies` +
  `peerDependencies` must be acyclic; prints the offending cycle + edge kinds on
  failure.

Also adds a `dependency-cruiser` `no-circular` rule and a `pnpm deps:check`
script for the deeper **source-import-level** check.

### Verification
- `check-no-smrt-peers` + `check-package-dag`: both pass; verified they also
  **catch** a re-introduced peer / cycle (exit 1 with a clear message).
- Full build: **51/51**. Full test suite: **101/101** turbo tasks.
- `scanner` tests **153/153** without `smrt-core` in its `package.json`.
- Knowledge freshness: **0 errors, 0 warnings**.
- The whole `@happyvertical/smrt-*` graph is now a DAG → a plain version-locked
  dependency dedupes to a single physical instance.
