### PR TITLE
fix(release): use workspace:* for template smrt peer deps

### DIFF
--- a/packages/template-site-static-json/package.json
+++ b/packages/template-site-static-json/package.json
@@ -33,8 +33,8 @@
     "directory": "packages/template-site-static-json"
   },
   "peerDependencies": {
-    "@happyvertical/smrt-core": "^0.29.1",
-    "@happyvertical/smrt-config": "^0.29.1"
+    "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-config": "workspace:*"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",

--- a/packages/template-sveltekit/package.json
+++ b/packages/template-sveltekit/package.json
@@ -29,7 +29,7 @@
     "directory": "packages/template-sveltekit"
   },
   "peerDependencies": {
-    "@happyvertical/smrt-core": "^0.29.1"
+    "@happyvertical/smrt-core": "workspace:*"
   },
   "scripts": {
     "test": "vitest run",


### PR DESCRIPTION
## Fixes the broken on-merge release (changeset publish abort)

Every `On Merge to Main` run since the release batch first needed a `0.30.0`
bump has failed at **`changeset publish`** (Phases 1–3 of #1582 + the prior
`fix(core)` merges all failed to publish — so v0.30.0 never shipped). The error:

```
Package "@happyvertical/smrt-template-site-static-json" must depend on the
current version of "@happyvertical/smrt-core": "0.30.0" vs "^1.0.0"
Package "@happyvertical/smrt-template-sveltekit" must depend on the
current version of "@happyvertical/smrt-core": "0.30.0" vs "^1.0.0"
```

### Root cause
The two template packages were the **only** ones in the monorepo declaring
internal smrt deps as a literal semver range — `smrt-core`/`smrt-config`
**peerDependencies** at `^0.29.1` — instead of `workspace:*` (the other 47 all
use `workspace:*`).

1. The release crosses out of `^0.29.1` (→ `0.30.0`). Changeset's
   peer-out-of-range rule (`onlyUpdatePeerDependentsWhenOutOfRange`) escalates
   the templates to a **major bump → `1.0.0`** and rewrites their peer ranges to
   `^1.0.0`.
2. `publish.yml`'s safeguard caps the overshoot — but it only rewrites each
   package's `version` **field** back to `0.30.0`, never **dependency ranges**.
3. So the templates ship `version: 0.30.0` while still declaring peer
   `smrt-core: ^1.0.0` → `changeset publish` aborts the entire release.

### Fix
Use `workspace:*` for the templates' smrt peer deps. `workspace:*` is never
rewritten to a literal range by changeset (it resolves at pack time), so it is
immune to the cap-loop blind spot and matches every other package. This also
dovetails with #1582, which removed all *other* inter-smrt peers — the templates
(exempt from the no-peers guardrail) were the last literal-range holdout.

### Validation
Reproduced the Prepare Release bump locally (`changeset:auto` + `changeset:version`):
- changeset still overshoots to `1.0.0` (a separate, already-capped concern) —
  but the template peers **stay `workspace:*`**, not `^1.0.0`.
- After the bump, **zero** packages have a literal `1.x` smrt range anywhere, so
  the cap loop + `workspace:*` produce a publishable tree and `changeset publish`
  no longer aborts.
- Both templates build/test green (25 tests).

> **Note:** `publish-dry-run.yml` runs `changeset:version` + the cap loop but
> **not** `changeset publish`, so it shares the same blind spot and did not catch
> this pre-merge. Hardening the dry-run (or the cap loop to rewrite ranges) is a
> reasonable follow-up but is intentionally out of scope here.
