### PR TITLE
fix(release): publish @happyvertical/smrt-* to npmjs, not GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -388,6 +388,24 @@ jobs:
           fi
           git commit -m "chore(release): v$RELEASE_VERSION [skip ci]"
 
+          # Route @happyvertical/smrt-* publishes to npmjs.org (each package's
+          # publishConfig.registry target). The repo .npmrc maps the whole
+          # @happyvertical scope to GitHub Packages so CI can *install* the SDK
+          # deps (@happyvertical/ai, …); during `pnpm publish` that scope mapping
+          # overrides each package's publishConfig.registry and sends the smrt
+          # packages to npm.pkg.github.com (E403 — wrong registry, npm token can't
+          # write there). The SDK is already installed by this point, so re-point
+          # the scope to npmjs for publishing only (project + user .npmrc, so it
+          # wins regardless of which pnpm reads first). Publishing only packs and
+          # uploads — it does not re-resolve the SDK deps — so npmjs is safe here.
+          for rc in .npmrc "${HOME}/.npmrc"; do
+            if [ -f "$rc" ]; then
+              sed -i '/^@happyvertical:registry=/d' "$rc"
+            fi
+          done
+          echo "@happyvertical:registry=https://registry.npmjs.org" >> .npmrc
+          echo "✓ Re-pointed @happyvertical scope to npmjs.org for publish"
+
           pnpm run changeset:publish
 
           git tag -f "v$RELEASE_VERSION"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -400,10 +400,15 @@ jobs:
           # uploads — it does not re-resolve the SDK deps — so npmjs is safe here.
           for rc in .npmrc "${HOME}/.npmrc"; do
             if [ -f "$rc" ]; then
-              sed -i '/^@happyvertical:registry=/d' "$rc"
+              # `-i.bak` + rm is the portable in-place form (GNU and BSD sed);
+              # editing in place avoids any redirect-clobber of the auth lines.
+              sed -i.bak '/^@happyvertical:registry=/d' "$rc"
+              rm -f "$rc.bak"
             fi
+            # Re-point in BOTH files so the npmjs mapping wins regardless of
+            # which .npmrc pnpm consults first.
+            printf '%s\n' "@happyvertical:registry=https://registry.npmjs.org" >> "$rc"
           done
-          echo "@happyvertical:registry=https://registry.npmjs.org" >> .npmrc
           echo "✓ Re-pointed @happyvertical scope to npmjs.org for publish"
 
           pnpm run changeset:publish


### PR DESCRIPTION
## Fixes the on-merge release publishing to the wrong registry

After the template `^1.0.0` fix ([#1587](https://github.com/happyvertical/smrt/pull/1587)), the on-merge release reached the **publish step for the first time** — and failed: all 50 `@happyvertical/smrt-*` packages tried to publish to **GitHub Packages** (`npm.pkg.github.com`) and got `E403 Forbidden`. Nothing published, and the run aborted before the tag/push, so there's **no partial release** to clean up.

### Root cause
The repo `.npmrc` maps the whole `@happyvertical` scope to GitHub Packages so CI can **install** the SDK deps (`@happyvertical/ai`, `@happyvertical/sql`, …):

```
@happyvertical:registry=https://npm.pkg.github.com
```

`@happyvertical/smrt-*` shares that scope. During `pnpm publish`, the scope-level registry **overrides** each package's `publishConfig.registry` (`registry.npmjs.org`), so the publishes route to GitHub Packages — authed with the npmjs `NPM_TOKEN`, which can't write there → `E403`.

`9fead5f9a` (*"fix(release): publish smrt packages to npmjs"*) started this migration but never completed it — every release since was blocked earlier by the `^1.0.0` template bug, so this code path never actually ran until now.

### Fix
In the publish step, **after** the SDK is already installed, re-point the `@happyvertical` scope to npmjs (in both project and user `.npmrc`, so it wins regardless of read order) right before `pnpm run changeset:publish`. The smrt packages then publish to npmjs per their `publishConfig`. Publishing only packs + uploads — it does not re-resolve the SDK deps — so npmjs is safe here. Installs (which need GitHub Packages) already ran in earlier jobs/steps.

### Validation
`pnpm publish --dry-run` on a smrt package, before vs after the `.npmrc` change:
- **before:** `npm notice Publishing to https://npm.pkg.github.com …`
- **after:**  `npm notice Publishing to https://registry.npmjs.org …`

> **Note 1:** `publish-dry-run.yml` doesn't run `changeset publish`, so PR CI can't exercise the real publish — final proof is the on-merge release after merge.
> **Note 2:** Requires `NPM_TOKEN` to have write access to the `@happyvertical` scope on **npmjs** (the scope/org must be claimed there). That's the one piece I can't verify from CI logs.
