### PR TITLE
fix: T2 deep-review remediation — smrt-ui, smrt-svelte, chat, jobs (#1354)

### DIFF
--- a/packages/chat/src/__tests__/chat-security.test.ts
+++ b/packages/chat/src/__tests__/chat-security.test.ts
@@ -383,6 +383,69 @@ describe('chat security (S5 #1392)', () => {
       });
       expect(agentMsg.role).toBe('assistant');
     });
+
+    // T2 #1391: the whitelist gate previously only fired for `tool_call`
+    // messageType, the `tool` role, or a truthy toolCallData. A `tool_result`
+    // emitted with the default `assistant` kind and no toolCallData slipped
+    // through, rendering a "tool result" bubble for a never-whitelisted tool.
+    // The gate now also covers the `tool_result` messageType.
+    it('rejects a tool_result for a non-whitelisted tool even with the default kind and no toolCallData', async () => {
+      const { session } = await chat.createAgentSession({
+        tenantId: 'tenant-1',
+        agentId: 'agent-1',
+        actorProfileId: 'profile-1',
+        allowedTools: ['search'],
+      });
+
+      await expect(
+        sendAgentReply(chat, {
+          tenantId: 'tenant-1',
+          agentSessionId: session.id as string,
+          content: 'pretend tool output',
+          // kind omitted => defaults to 'assistant' (role 'assistant')
+          messageType: 'tool_result',
+          // toolCallData omitted => null; the OLD gate skipped entirely here
+        }),
+      ).rejects.toThrow(/missing a tool name|not allowed/i);
+    });
+
+    it('rejects a tool_result naming a tool that is NOT on the whitelist', async () => {
+      const { session } = await chat.createAgentSession({
+        tenantId: 'tenant-1',
+        agentId: 'agent-1',
+        actorProfileId: 'profile-1',
+        allowedTools: ['search'],
+      });
+
+      await expect(
+        sendAgentReply(chat, {
+          tenantId: 'tenant-1',
+          agentSessionId: session.id as string,
+          content: 'shell output',
+          messageType: 'tool_result',
+          toolCallData: { name: 'exec_shell', result: 'rooted' },
+        }),
+      ).rejects.toThrow(/not allowed/i);
+    });
+
+    it('allows a tool_result for a whitelisted tool', async () => {
+      const { session } = await chat.createAgentSession({
+        tenantId: 'tenant-1',
+        agentId: 'agent-1',
+        actorProfileId: 'profile-1',
+        allowedTools: ['search'],
+      });
+
+      const msg = await sendAgentReply(chat, {
+        tenantId: 'tenant-1',
+        agentSessionId: session.id as string,
+        content: 'search results',
+        messageType: 'tool_result',
+        toolCallData: { name: 'search', result: ['a', 'b'] },
+      });
+      expect(msg.id).toBeDefined();
+      expect(msg.messageType).toBe('tool_result');
+    });
   });
 
   describe('caller cannot post as the agent through any public method', () => {

--- a/packages/chat/src/services/ChatService.ts
+++ b/packages/chat/src/services/ChatService.ts
@@ -861,11 +861,16 @@ export class ChatService {
 
     const role: ChatMessageRole = params.kind === 'tool' ? 'tool' : 'assistant';
 
-    // Enforce the per-session tool allow-list, fail-closed (S5 #1392). A tool
-    // call carries its tool name in toolCallData.name (or .tool); any call to a
-    // tool not on the session's whitelist is rejected.
+    // Enforce the per-session tool allow-list, fail-closed (S5 #1392, broadened
+    // T2 #1391). A tool message carries its tool name in toolCallData.name (or
+    // .tool); any call to a tool not on the session's whitelist is rejected.
+    // The gate covers every tool-shaped message — `tool_call` AND `tool_result`
+    // message types, the `tool` role, and any payload that carries toolCallData
+    // — so a `tool_result` emitted with the default `assistant` kind and no
+    // toolCallData can never render a tool bubble for a non-whitelisted tool.
     if (
       params.messageType === 'tool_call' ||
+      params.messageType === 'tool_result' ||
       role === 'tool' ||
       params.toolCallData
     ) {

--- a/packages/chat/src/svelte/components/agent/AgentChat.svelte
+++ b/packages/chat/src/svelte/components/agent/AgentChat.svelte
@@ -539,4 +539,10 @@ $effect(() => {
     0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }
     30% { transform: translateY(-4px); opacity: 1; }
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    .thinking-dots span {
+      animation: none;
+    }
+  }
 </style>

--- a/packages/chat/src/svelte/components/agent/ToolCallDisplay.svelte
+++ b/packages/chat/src/svelte/components/agent/ToolCallDisplay.svelte
@@ -19,21 +19,6 @@ const { t } = useI18n();
 
 let isExpanded = $state(false);
 
-const statusIcon = $derived.by(() => {
-  switch (toolCall.status) {
-    case 'pending':
-      return '...';
-    case 'running':
-      return '...';
-    case 'success':
-      return '...';
-    case 'error':
-      return '...';
-    default:
-      return '';
-  }
-});
-
 const statusLabel = $derived.by(() => {
   switch (toolCall.status) {
     case 'pending':
@@ -145,11 +130,11 @@ function formatDuration(ms: number | undefined): string {
   }
 
   .tool-call--success {
-    border-left: 3px solid var(--smrt-color-success, #4caf50);
+    border-left: 3px solid var(--smrt-color-success, #1e8e3e);
   }
 
   .tool-call--error {
-    border-left: 3px solid var(--smrt-color-error, #ba1a1a);
+    border-left: 3px solid var(--smrt-color-error, #b3261e);
   }
 
   .tool-call__header {
@@ -193,11 +178,11 @@ function formatDuration(ms: number | undefined): string {
   }
 
   .tool-call--success .tool-call__status-dot {
-    background: var(--smrt-color-success, #4caf50);
+    background: var(--smrt-color-success, #1e8e3e);
   }
 
   .tool-call--error .tool-call__status-dot {
-    background: var(--smrt-color-error, #ba1a1a);
+    background: var(--smrt-color-error, #b3261e);
   }
 
   .tool-call__name {

--- a/packages/chat/src/svelte/components/agent/__tests__/ToolCallDisplay.test.ts
+++ b/packages/chat/src/svelte/components/agent/__tests__/ToolCallDisplay.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for ToolCallDisplay via the shared S11 harness (#1416).
+ *
+ * Locks the T2 #1391 dead-code removal: the unused `statusIcon` $derived (which
+ * returned '...'/'' for every branch and was never rendered) was removed. The
+ * component must still render the tool name and status, and expand on click.
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it } from 'vitest';
+import type { ToolCallDisplayData } from '../../../types.js';
+import ToolCallDisplay from '../ToolCallDisplay.svelte';
+
+function makeToolCall(
+  overrides: Partial<ToolCallDisplayData> = {},
+): ToolCallDisplayData {
+  return {
+    toolName: 'search',
+    toolCallId: 'tc-1',
+    arguments: { q: 'hello' },
+    status: 'success',
+    result: ['a', 'b'],
+    duration: 1200,
+    ...overrides,
+  };
+}
+
+describe('ToolCallDisplay', () => {
+  it('renders the tool name and a human status label', () => {
+    render(ToolCallDisplay, { props: { toolCall: makeToolCall() } });
+    expect(screen.getByText('search')).toBeInTheDocument();
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+  });
+
+  it('expands to reveal arguments and result on click', async () => {
+    render(ToolCallDisplay, { props: { toolCall: makeToolCall() } });
+    const header = screen.getByRole('button');
+    expect(header).toHaveAttribute('aria-expanded', 'false');
+    await userEvent.click(header);
+    expect(header).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Arguments')).toBeInTheDocument();
+    expect(screen.getByText('Result')).toBeInTheDocument();
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(ToolCallDisplay, {
+      props: { toolCall: makeToolCall({ status: 'error', error: 'boom' }) },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/chat/src/svelte/components/dialogs/RoomCreateDialog.svelte
+++ b/packages/chat/src/svelte/components/dialogs/RoomCreateDialog.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
 /**
  * RoomCreateDialog - Modal dialog for creating a new chat room
- * Provides name, type selector, and description fields
+ * Provides name, type selector, and description fields.
+ *
+ * Built on the shared smrt-ui `Modal` (T2 #1391) so it inherits a focus trap,
+ * Escape handling, scrim, and focus-restore-to-trigger on close — the
+ * hand-rolled backdrop it replaced had none of those.
  */
+import { Modal } from '@happyvertical/smrt-ui/feedback';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { M } from '../../i18n.js';
 
@@ -74,27 +79,8 @@ function resetForm() {
   description = '';
 }
 
-function handleKeydown(event: KeyboardEvent) {
-  if (event.key === 'Escape') {
-    handleClose();
-  }
-}
-
-$effect(() => {
-  if (!isOpen || typeof window === 'undefined') {
-    return;
-  }
-
-  const onWindowKeydown = (event: KeyboardEvent) => {
-    handleKeydown(event);
-  };
-
-  window.addEventListener('keydown', onWindowKeydown);
-  return () => {
-    window.removeEventListener('keydown', onWindowKeydown);
-  };
-});
-
+// Modal traps focus and moves it to the dialog itself; nudge initial focus to
+// the name field once the dialog is open and the input is mounted.
 $effect(() => {
   if (isOpen && nameInput) {
     nameInput.focus();
@@ -102,146 +88,110 @@ $effect(() => {
 });
 </script>
 
-{#if isOpen}
-  <div class="dialog-backdrop">
+<Modal
+  open={isOpen}
+  onClose={handleClose}
+  title={t(M['chat.room_create_dialog.title'])}
+  size="md"
+  ariaLabel={t(M['chat.room_create_dialog.title'])}
+>
+  <form
+    class="dialog__form"
+    onsubmit={(e) => { e.preventDefault(); handleSubmit(); }}
+  >
+    <div class="field">
+      <label class="field__label" for="room-name">
+        {t(M['chat.room_create_dialog.room_name'])} <span class="field__required" aria-label={t(M['chat.room_create_dialog.required'])}>*</span>
+      </label>
+      <input
+        bind:this={nameInput}
+        bind:value={name}
+        id="room-name"
+        type="text"
+        class="field__input"
+        placeholder={t(M['chat.room_create_dialog.name_placeholder'])}
+        maxlength="100"
+        autocomplete="off"
+      />
+    </div>
+
+    <fieldset class="field">
+      <legend class="field__label">{t(M['chat.room_create_dialog.room_type'])}</legend>
+      <div class="type-options">
+        {#each roomTypes as option (option.value)}
+          <label
+            class="type-option"
+            class:type-option--selected={roomType === option.value}
+          >
+            <input
+              type="radio"
+              name="roomType"
+              value={option.value}
+              bind:group={roomType}
+              class="type-option__radio"
+            />
+            <span class="type-option__content">
+              <span class="type-option__label">{option.label}</span>
+              <span class="type-option__description">{option.description}</span>
+            </span>
+          </label>
+        {/each}
+      </div>
+    </fieldset>
+
+    <div class="field">
+      <label class="field__label" for="room-description">Description</label>
+      <textarea
+        bind:value={description}
+        id="room-description"
+        class="field__textarea"
+        placeholder={t(M['chat.room_create_dialog.description_placeholder'])}
+        rows="3"
+        maxlength="500"
+      ></textarea>
+      <span class="field__hint">{description.length}/500</span>
+    </div>
+
+    <!-- Hidden submit keeps Enter-to-submit working inside the Modal body. -->
+    <button type="submit" class="visually-hidden" tabindex="-1" disabled={!canCreate} aria-hidden="true"></button>
+  </form>
+
+  {#snippet footer()}
     <button
       type="button"
-      class="dialog-backdrop__dismiss"
-      tabindex="-1"
-      aria-label={t(M['chat.room_create_dialog.close'])}
+      class="btn btn--secondary"
       onclick={handleClose}
-    ></button>
-    <div
-      class="dialog"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="create-room-title"
-      tabindex="-1"
     >
-      <h2 id="create-room-title" class="dialog__title">{t(M['chat.room_create_dialog.title'])}</h2>
-
-      <form
-        class="dialog__form"
-        onsubmit={(e) => { e.preventDefault(); handleSubmit(); }}
-      >
-        <div class="field">
-          <label class="field__label" for="room-name">
-            {t(M['chat.room_create_dialog.room_name'])} <span class="field__required" aria-label={t(M['chat.room_create_dialog.required'])}>*</span>
-          </label>
-          <input
-            bind:this={nameInput}
-            bind:value={name}
-            id="room-name"
-            type="text"
-            class="field__input"
-            placeholder={t(M['chat.room_create_dialog.name_placeholder'])}
-            maxlength="100"
-            autocomplete="off"
-          />
-        </div>
-
-        <fieldset class="field">
-          <legend class="field__label">{t(M['chat.room_create_dialog.room_type'])}</legend>
-          <div class="type-options">
-            {#each roomTypes as option (option.value)}
-              <label
-                class="type-option"
-                class:type-option--selected={roomType === option.value}
-              >
-                <input
-                  type="radio"
-                  name="roomType"
-                  value={option.value}
-                  bind:group={roomType}
-                  class="type-option__radio"
-                />
-                <span class="type-option__content">
-                  <span class="type-option__label">{option.label}</span>
-                  <span class="type-option__description">{option.description}</span>
-                </span>
-              </label>
-            {/each}
-          </div>
-        </fieldset>
-
-        <div class="field">
-          <label class="field__label" for="room-description">Description</label>
-          <textarea
-            bind:value={description}
-            id="room-description"
-            class="field__textarea"
-            placeholder={t(M['chat.room_create_dialog.description_placeholder'])}
-            rows="3"
-            maxlength="500"
-          ></textarea>
-          <span class="field__hint">{description.length}/500</span>
-        </div>
-
-        <div class="dialog__actions">
-          <button
-            type="button"
-            class="btn btn--secondary"
-            onclick={handleClose}
-          >
-            Cancel
-          </button>
-          <button
-            type="submit"
-            class="btn btn--primary"
-            disabled={!canCreate}
-          >
-            {t(M['chat.room_create_dialog.create_room'])}
-          </button>
-        </div>
-      </form>
-    </div>
-  </div>
-{/if}
+      Cancel
+    </button>
+    <button
+      type="button"
+      class="btn btn--primary"
+      disabled={!canCreate}
+      onclick={handleSubmit}
+    >
+      {t(M['chat.room_create_dialog.create_room'])}
+    </button>
+  {/snippet}
+</Modal>
 
 <style>
-  .dialog-backdrop {
-    position: fixed;
-    inset: 0;
-    background: var(--smrt-color-scrim, rgba(0, 0, 0, 0.32));
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 1rem;
-    z-index: var(--smrt-z-index-dialog, 1300);
-    position: relative;
-  }
-
-  .dialog-backdrop__dismiss {
-    position: absolute;
-    inset: 0;
-    padding: 0;
-    border: 0;
-    background: transparent;
-  }
-
-  .dialog {
-    background: var(--smrt-color-surface, #fefbff);
-    border-radius: var(--smrt-radius-extra-large, 28px);
-    box-shadow: var(--smrt-elevation-3, 0 4px 8px 3px rgba(0, 0, 0, 0.15), 0 1px 3px rgba(0, 0, 0, 0.3));
-    width: 100%;
-    max-width: 32rem;
-    padding: 1.5rem;
-    max-height: calc(100vh - 2rem);
-    overflow-y: auto;
-    position: relative;
-    z-index: 1;
-  }
-
-  .dialog__title {
-    margin: 0 0 1.25rem;
-    font: var(--smrt-typography-headline-small-font, 400 1.5rem / 2rem sans-serif);
-    color: var(--smrt-color-on-surface, #1a1c1e);
-  }
-
   .dialog__form {
     display: flex;
     flex-direction: column;
     gap: 1.25rem;
+  }
+
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .field {
@@ -259,7 +209,7 @@ $effect(() => {
   }
 
   .field__required {
-    color: var(--smrt-color-error, #ba1a1a);
+    color: var(--smrt-color-error, #b3261e);
   }
 
   .field__input {
@@ -349,13 +299,6 @@ $effect(() => {
   .type-option__description {
     font: var(--smrt-typography-body-small-font, 0.75rem / 1.25 sans-serif);
     color: var(--smrt-color-on-surface-variant, #43474e);
-  }
-
-  .dialog__actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 0.5rem;
-    margin-top: 0.25rem;
   }
 
   .btn {

--- a/packages/chat/src/svelte/components/layout/ChatLayout.svelte
+++ b/packages/chat/src/svelte/components/layout/ChatLayout.svelte
@@ -20,12 +20,20 @@ export interface Props {
   currentProfileId: string;
   /** Callback when a room is selected */
   onselectroom: (roomId: string) => void;
+  /** Callback to open the create-room affordance in the room list */
+  oncreateroom?: () => void;
   /** Main content slot */
   children: Snippet;
 }
 
-let { rooms, currentRoomId, currentProfileId, onselectroom, children }: Props =
-  $props();
+let {
+  rooms,
+  currentRoomId,
+  currentProfileId,
+  onselectroom,
+  oncreateroom,
+  children,
+}: Props = $props();
 
 let sidebarWidth = $state(260);
 let isResizing = $state(false);
@@ -60,6 +68,7 @@ function handlePointerUp() {
       {rooms}
       {currentRoomId}
       {onselectroom}
+      {oncreateroom}
     />
   </aside>
 

--- a/packages/chat/src/svelte/components/layout/MemberList.svelte
+++ b/packages/chat/src/svelte/components/layout/MemberList.svelte
@@ -32,12 +32,14 @@ const offlineMembers = $derived(
 
 function getStatusColor(status: string): string {
   switch (status) {
+    // "online" reconciled to the success token (was --smrt-color-tertiary)
+    // so it matches UserPresence and stays semantically green (T2 #1391).
     case 'online':
-      return 'var(--smrt-color-tertiary, #006c4f)';
+      return 'var(--smrt-color-success, #1e8e3e)';
     case 'away':
-      return 'var(--smrt-color-warning, #f0a000)';
+      return 'var(--smrt-color-warning, #f9ab00)';
     case 'dnd':
-      return 'var(--smrt-color-error, #ba1a1a)';
+      return 'var(--smrt-color-error, #b3261e)';
     default:
       return 'var(--smrt-color-outline, #74777f)';
   }

--- a/packages/chat/src/svelte/components/layout/__tests__/ChatLayout.test.ts
+++ b/packages/chat/src/svelte/components/layout/__tests__/ChatLayout.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for ChatLayout via the shared S11 harness (#1416).
+ *
+ * Regression for T2 #1391: ChatLayout rendered RoomList but never forwarded
+ * `oncreateroom`, so the bundled layout's create-room affordance was dead.
+ * ChatLayout must now accept and forward `oncreateroom` to RoomList.
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it, vi } from 'vitest';
+import type { ChatRoomData } from '../../../types.js';
+import ChatLayout from '../ChatLayout.svelte';
+
+const ROOMS: ChatRoomData[] = [
+  {
+    id: 'room-1',
+    name: 'General',
+    description: '',
+    roomType: 'public',
+    topic: '',
+    participantCount: 1,
+    unreadCount: 0,
+  },
+];
+
+// Minimal main-content snippet for the required `children` prop.
+const content = createRawSnippet(() => ({
+  render: () => '<div data-testid="main">Main content</div>',
+}));
+
+describe('ChatLayout', () => {
+  it('forwards oncreateroom to RoomList so the create affordance is wired', async () => {
+    const oncreateroom = vi.fn();
+    render(ChatLayout, {
+      props: {
+        rooms: ROOMS,
+        currentProfileId: 'p1',
+        onselectroom: vi.fn(),
+        oncreateroom,
+        children: content,
+      },
+    });
+
+    const createBtn = screen.getByRole('button', { name: 'Create new room' });
+    await userEvent.click(createBtn);
+    expect(oncreateroom).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the create affordance when no oncreateroom is supplied', () => {
+    render(ChatLayout, {
+      props: {
+        rooms: ROOMS,
+        currentProfileId: 'p1',
+        onselectroom: vi.fn(),
+        children: content,
+      },
+    });
+    expect(
+      screen.queryByRole('button', { name: 'Create new room' }),
+    ).toBeNull();
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(ChatLayout, {
+      props: {
+        rooms: ROOMS,
+        currentProfileId: 'p1',
+        onselectroom: vi.fn(),
+        oncreateroom: vi.fn(),
+        children: content,
+      },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/chat/src/svelte/components/messages/MessageItem.svelte
+++ b/packages/chat/src/svelte/components/messages/MessageItem.svelte
@@ -60,6 +60,12 @@ const hasActions = $derived(
   Boolean(onreact || onreply || (isOwn && (onedit || ondelete))),
 );
 
+// Stable id linking the disclosure trigger (aria-controls) to the revealed
+// action group. The actions are a labelled group of independently
+// keyboard-operable buttons, not an ARIA menu, so the trigger is a plain
+// disclosure toggle (aria-expanded) rather than aria-haspopup="menu".
+const actionsId = $derived(`message-actions-${message.id}`);
+
 function handleReact(emoji: string) {
   onreact?.(message.id, emoji);
   showReactionPicker = false;
@@ -195,15 +201,20 @@ function handleEscape(event: KeyboardEvent) {
         onclick={openActions}
         onfocus={openActions}
         aria-label={t(M['chat.message_item.more_actions'])}
-        aria-haspopup="menu"
         aria-expanded={showActions}
+        aria-controls={actionsId}
       >
         <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><circle cx="3" cy="8" r="1.3" fill="currentColor" /><circle cx="8" cy="8" r="1.3" fill="currentColor" /><circle cx="13" cy="8" r="1.3" fill="currentColor" /></svg>
       </button>
     {/if}
 
     {#if showActions}
-      <div class="message-item__actions" role="menu">
+      <div
+        class="message-item__actions"
+        role="group"
+        id={actionsId}
+        aria-label={t(M['chat.message_item.more_actions'])}
+      >
         {#if onreact}
           <button
             class="message-item__action-btn"

--- a/packages/chat/src/svelte/components/messages/MessageItem.svelte
+++ b/packages/chat/src/svelte/components/messages/MessageItem.svelte
@@ -56,6 +56,10 @@ const formattedTime = $derived.by(() => {
   });
 });
 
+const hasActions = $derived(
+  Boolean(onreact || onreply || (isOwn && (onedit || ondelete))),
+);
+
 function handleReact(emoji: string) {
   onreact?.(message.id, emoji);
   showReactionPicker = false;
@@ -64,7 +68,39 @@ function handleReact(emoji: string) {
 function toggleReactionPicker() {
   showReactionPicker = !showReactionPicker;
 }
+
+// The "more actions" button is the keyboard/touch-reachable entry point that
+// opens the action bar (a11y blocker, T2 #1391). It opens rather than toggles
+// so it stays robust against the focus-then-click ordering a tap/keyboard
+// activation produces; the bar is dismissed by Escape, blur, or mouse-leave.
+function openActions() {
+  showActions = true;
+}
+
+// Collapse the action bar (and any open picker) once focus leaves the row — the
+// keyboard/touch counterpart to onmouseleave so the actions are not hover-only.
+function handleFocusOut(event: FocusEvent) {
+  const next = event.relatedTarget as Node | null;
+  const row = event.currentTarget as HTMLElement;
+  if (next && row.contains(next)) return;
+  showActions = false;
+  showReactionPicker = false;
+}
+
+// Escape closes the action bar / picker when open. Bound on the window (gated
+// on open state) rather than the noninteractive row element so Svelte's
+// a11y_no_noninteractive_element_interactions rule stays satisfied.
+function handleEscape(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    showReactionPicker = false;
+    showActions = false;
+  }
+}
 </script>
+
+<svelte:window
+  onkeydown={showActions || showReactionPicker ? handleEscape : undefined}
+/>
 
 {#if message.messageType === 'system' || message.messageType === 'action'}
   <div class="message-item message-item--system">
@@ -78,6 +114,7 @@ function toggleReactionPicker() {
     aria-label={t(M['chat.message_item.message_from'], { name: message.senderName })}
     onmouseenter={() => showActions = true}
     onmouseleave={() => { showActions = false; showReactionPicker = false; }}
+    onfocusout={handleFocusOut}
   >
     {#if !isOwn}
       <div class="message-item__avatar">
@@ -151,8 +188,22 @@ function toggleReactionPicker() {
       </div>
     </div>
 
+    {#if hasActions}
+      <button
+        class="message-item__more-btn"
+        type="button"
+        onclick={openActions}
+        onfocus={openActions}
+        aria-label={t(M['chat.message_item.more_actions'])}
+        aria-haspopup="menu"
+        aria-expanded={showActions}
+      >
+        <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><circle cx="3" cy="8" r="1.3" fill="currentColor" /><circle cx="8" cy="8" r="1.3" fill="currentColor" /><circle cx="13" cy="8" r="1.3" fill="currentColor" /></svg>
+      </button>
+    {/if}
+
     {#if showActions}
-      <div class="message-item__actions">
+      <div class="message-item__actions" role="menu">
         {#if onreact}
           <button
             class="message-item__action-btn"
@@ -379,6 +430,49 @@ function toggleReactionPicker() {
     font-style: italic;
   }
 
+  .message-item__more-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    position: absolute;
+    top: 0;
+    right: var(--smrt-spacing-4, 1rem);
+    border: 1px solid var(--smrt-color-outline-variant, #c4c6cf);
+    border-radius: var(--smrt-radius-small, 0.25rem);
+    background: var(--smrt-color-surface, #ffffff);
+    color: var(--smrt-color-on-surface-variant, #43474e);
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
+  }
+
+  .message-item--own .message-item__more-btn {
+    right: auto;
+    left: var(--smrt-spacing-4, 1rem);
+  }
+
+  /* Reveal the keyboard/touch affordance on hover OR when focus is inside the
+     row, so it is never strictly hover-only (a11y blocker, T2 #1391). Always
+     visible to coarse pointers (touch) which cannot hover. */
+  .message-item:hover .message-item__more-btn,
+  .message-item:focus-within .message-item__more-btn {
+    opacity: 1;
+  }
+
+  .message-item__more-btn:focus-visible {
+    opacity: 1;
+    outline: 2px solid var(--smrt-color-primary, #005ac1);
+    outline-offset: 1px;
+  }
+
+  @media (hover: none) {
+    .message-item__more-btn {
+      opacity: 1;
+    }
+  }
+
   .message-item__actions {
     display: flex;
     align-items: center;
@@ -391,6 +485,7 @@ function toggleReactionPicker() {
     border-radius: var(--smrt-radius-small, 0.25rem);
     padding: var(--smrt-spacing-1, 4px);
     box-shadow: var(--smrt-elevation-1, 0 1px 3px rgba(0, 0, 0, 0.12));
+    z-index: 1;
   }
 
   .message-item--own .message-item__actions {
@@ -427,5 +522,13 @@ function toggleReactionPicker() {
   .message-item--own .message-item__picker-popover {
     right: auto;
     left: var(--smrt-spacing-4, 1rem);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .message-item__more-btn,
+    .message-item__action-btn,
+    .message-item__reaction {
+      transition: none;
+    }
   }
 </style>

--- a/packages/chat/src/svelte/components/messages/__tests__/MessageItem.test.ts
+++ b/packages/chat/src/svelte/components/messages/__tests__/MessageItem.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for MessageItem via the shared S11 harness (#1416).
+ *
+ * Regression for the T2 #1391 a11y blocker: the per-message actions
+ * (reply/edit/delete/react) used to be revealed ONLY by mouseenter/mouseleave,
+ * so keyboard- and touch-only users could never reach them. There must now be a
+ * keyboard-reachable "more actions" button that toggles the action bar, and
+ * focusing into the row must reveal the actions.
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import type { ChatMessageData } from '../../../types.js';
+import MessageItem from '../MessageItem.svelte';
+
+function makeMessage(
+  overrides: Partial<ChatMessageData> = {},
+): ChatMessageData {
+  return {
+    id: 'm1',
+    roomId: 'room-1',
+    threadId: null,
+    senderProfileId: 'p1',
+    senderName: 'Ada',
+    senderAvatarUrl: undefined,
+    agentSessionId: null,
+    content: 'Hello there',
+    messageType: 'text',
+    role: 'user',
+    isEdited: false,
+    isDeleted: false,
+    replyTo: null,
+    reactions: [],
+    attachments: [],
+    toolCallData: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('MessageItem', () => {
+  it('renders a keyboard-reachable "more actions" button when actions are available', () => {
+    render(MessageItem, {
+      props: {
+        message: makeMessage(),
+        isOwn: false,
+        onreply: vi.fn(),
+        onreact: vi.fn(),
+      },
+    });
+    const moreBtn = screen.getByRole('button', { name: 'Message actions' });
+    expect(moreBtn).toBeInTheDocument();
+    // A real <button> is inherently in the tab order (no tabindex="-1").
+    expect(moreBtn.getAttribute('tabindex')).not.toBe('-1');
+  });
+
+  it('reveals the action bar via the more-actions button without any mouse hover', async () => {
+    const onreply = vi.fn();
+    render(MessageItem, {
+      props: {
+        message: makeMessage(),
+        isOwn: false,
+        onreply,
+        onreact: vi.fn(),
+      },
+    });
+
+    // Actions are hidden until requested — no hover, no focus yet.
+    expect(screen.queryByRole('button', { name: 'Reply' })).toBeNull();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Message actions' }),
+    );
+
+    // The action bar is now reachable; clicking Reply invokes the callback.
+    const replyBtn = await screen.findByRole('button', { name: 'Reply' });
+    await userEvent.click(replyBtn);
+    expect(onreply).toHaveBeenCalledWith('m1');
+  });
+
+  it("exposes edit/delete actions for the user's own message", async () => {
+    const onedit = vi.fn();
+    const ondelete = vi.fn();
+    render(MessageItem, {
+      props: {
+        message: makeMessage(),
+        isOwn: true,
+        onedit,
+        ondelete,
+      },
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Message actions' }),
+    );
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Edit' }));
+    expect(onedit).toHaveBeenCalledWith('m1');
+
+    // The bar stays open while focus remains inside the row, so Delete is
+    // reachable in the same interaction.
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(ondelete).toHaveBeenCalledWith('m1');
+  });
+
+  it('does not render the more-actions affordance when no action callbacks are provided', () => {
+    render(MessageItem, {
+      props: {
+        message: makeMessage(),
+        isOwn: false,
+      },
+    });
+    expect(
+      screen.queryByRole('button', { name: 'Message actions' }),
+    ).toBeNull();
+  });
+
+  it('is axe-clean with the action affordance present', async () => {
+    const { container } = render(MessageItem, {
+      props: {
+        message: makeMessage(),
+        isOwn: false,
+        onreply: vi.fn(),
+        onreact: vi.fn(),
+      },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/chat/src/svelte/components/shared/MentionAutocomplete.svelte
+++ b/packages/chat/src/svelte/components/shared/MentionAutocomplete.svelte
@@ -19,9 +19,11 @@ export interface Props {
   onselect: (id: string) => void;
   /** Whether the popup is visible */
   isVisible: boolean;
+  /** Dismiss the popup (e.g. Escape pressed) without selecting */
+  oncancel?: () => void;
 }
 
-const { query, suggestions, onselect, isVisible }: Props = $props();
+const { query, suggestions, onselect, isVisible, oncancel }: Props = $props();
 
 let activeIndex = $state(0);
 
@@ -50,6 +52,8 @@ function handleKeydown(event: KeyboardEvent) {
       onselect(suggestions[activeIndex].id);
       break;
     case 'Escape':
+      event.preventDefault();
+      oncancel?.();
       break;
   }
 }

--- a/packages/chat/src/svelte/components/shared/UserPresence.svelte
+++ b/packages/chat/src/svelte/components/shared/UserPresence.svelte
@@ -42,15 +42,15 @@ const labelText: Record<string, string> = {
   }
 
   .presence__dot.online {
-    background: var(--smrt-color-success, #4caf50);
+    background: var(--smrt-color-success, #1e8e3e);
   }
 
   .presence__dot.away {
-    background: var(--smrt-color-warning, #ff9800);
+    background: var(--smrt-color-warning, #f9ab00);
   }
 
   .presence__dot.dnd {
-    background: var(--smrt-color-error, #f44336);
+    background: var(--smrt-color-error, #b3261e);
   }
 
   .presence__dot.offline {

--- a/packages/chat/src/svelte/components/shared/__tests__/MentionAutocomplete.test.ts
+++ b/packages/chat/src/svelte/components/shared/__tests__/MentionAutocomplete.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for MentionAutocomplete via the shared S11 harness (#1416).
+ *
+ * Regression for T2 #1391: `case 'Escape': break;` was a no-op, so the
+ * suggestion popup could not be dismissed from the keyboard. Escape must now
+ * invoke the `oncancel` callback so a parent can close the popup.
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import MentionAutocomplete from '../MentionAutocomplete.svelte';
+
+const SUGGESTIONS = [
+  { id: 'p1', name: 'Ada Lovelace' },
+  { id: 'p2', name: 'Alan Turing' },
+];
+
+describe('MentionAutocomplete', () => {
+  it('invokes oncancel when Escape is pressed while visible', async () => {
+    const oncancel = vi.fn();
+    render(MentionAutocomplete, {
+      props: {
+        query: 'a',
+        suggestions: SUGGESTIONS,
+        onselect: vi.fn(),
+        isVisible: true,
+        oncancel,
+      },
+    });
+
+    await userEvent.keyboard('{Escape}');
+    expect(oncancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw on Escape when no oncancel is provided', async () => {
+    render(MentionAutocomplete, {
+      props: {
+        query: 'a',
+        suggestions: SUGGESTIONS,
+        onselect: vi.fn(),
+        isVisible: true,
+      },
+    });
+    await expect(userEvent.keyboard('{Escape}')).resolves.not.toThrow();
+  });
+
+  it('selects the active suggestion on Enter', async () => {
+    const onselect = vi.fn();
+    render(MentionAutocomplete, {
+      props: {
+        query: 'a',
+        suggestions: SUGGESTIONS,
+        onselect,
+        isVisible: true,
+      },
+    });
+    await userEvent.keyboard('{Enter}');
+    expect(onselect).toHaveBeenCalledWith('p1');
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(MentionAutocomplete, {
+      props: {
+        query: 'a',
+        suggestions: SUGGESTIONS,
+        onselect: vi.fn(),
+        isVisible: true,
+      },
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/chat/src/svelte/i18n.messages.ts
+++ b/packages/chat/src/svelte/i18n.messages.ts
@@ -44,6 +44,7 @@ export const M = defineMessages({
   'chat.message_item.reply': 'Reply',
   'chat.message_item.edit': 'Edit',
   'chat.message_item.delete': 'Delete',
+  'chat.message_item.more_actions': 'Message actions',
 
   // MessageList
   'chat.message_list.messages_label': 'Messages',

--- a/packages/jobs/AGENTS.md
+++ b/packages/jobs/AGENTS.md
@@ -29,6 +29,24 @@ Polling-based execution engine. Config: `concurrency` (5), `pollInterval` (1s), 
 7. Retry: uses strategy from `@happyvertical/jobs`, schedules future `runAt` on failure
 8. Events: `job:started`, `job:completed`, `job:failed`, `job:retrying`, `runner:started/stopped`
 
+A rejection from `processJob` can never escape the poll loop: the caller attaches `.catch(e => emit('runner:error', e))` and the error path (`handleJobError`) is itself try/caught, so a failure-path write that rejects is surfaced as a `runner:error` event instead of crashing the worker with an unhandled rejection.
+
+## Timeouts & at-least-once
+
+**Execution is at-least-once, never exactly-once. Make job handlers idempotent.**
+
+A job `timeout` only races the handler's promise — JavaScript cannot preempt an already-running function. When a handler exceeds its timeout:
+
+- The job is **failed terminally and NOT auto-retried** (a timed-out handler is still running; re-queueing it would let a second worker run a concurrent duplicate). This narrows, but does not eliminate, the overlap window — the orphaned handler keeps running until it returns on its own.
+- The orphaned handler's eventual terminal write is dropped by the ownership guard (`WHERE worker_id=? AND status='running'`), so it cannot resurrect the failed row — but any **side effects** it performs (external API calls, writes to other tables) still happen.
+- Key any non-idempotent work by `context.job.jobId` or a caller-supplied idempotency key.
+
+`timeoutBehavior` (persisted + shown in the UI) is now honored:
+
+- **`'fail'`** (default): on timeout the job fails (and, per above, is not retried).
+- **`'warn'`**: the handler is **not** raced against the timeout — it runs to completion, and at the deadline the runner logs a warning and emits a `timeout-warning` job event. A slow-but-successful handler still completes successfully.
+- **`'kill'`**: treated identically to `'fail'`. In-process JavaScript has no thread interruption, so a true "kill" of a running handler is impossible without worker isolation; this value is honest that it only fails the job row, it does not stop the handler. Prefer `'fail'` unless you specifically want the label.
+
 ## Worker liveness & recovery (#1474)
 
 Recovery keys on **worker-process liveness**, never per-job heartbeat freshness (a CPU-bound synchronous handler used to starve the heartbeat and false-recover its own running jobs).
@@ -43,7 +61,11 @@ Recovery keys on **worker-process liveness**, never per-job heartbeat freshness 
 
 Polls `_smrt_agent_schedules` every 60s for due entries. Creates SmrtJob with `queue='agents'`, `priority=75`. Wires to TaskRunner events for completion/failure tracking. Slot reconciliation keys on worker liveness (it has no in-process active-job set, so the lease/live-set is its whole mechanism).
 
-Custom cron parser: 5-field (minute hour dom month dow). `*`, ranges, lists, steps supported. **Not timezone-aware** (UTC).
+The job is enqueued **before** `next_run` is advanced and `running_count` is incremented: a transient enqueue failure (tenant-cap hit, DB blip) therefore leaves `next_run` and `status='active'` untouched so the same due slot is retried on the next poll, rather than losing the slot and disabling the schedule.
+
+`next_run` is always recomputed from *now*, never from the previous `next_run` — this is **fire-once-forward**: runs that came due while the runner was down are not caught up, only the next future occurrence fires. There is no missed-run backfill.
+
+Custom cron parser: 5-field (minute hour dom month dow). `*`, ranges, lists, steps supported. **Not timezone-aware**: cron fields are matched against the **server's local time** (the parser uses `getHours`/`getDate`/`getDay`/… local accessors), so `0 0 * * *` fires at local midnight on the host, not at 00:00 UTC. Deploy runners in a known timezone (e.g. `TZ=UTC`) for UTC semantics. A per-schedule timezone option is a possible future enhancement.
 
 ## JobBuilder — Fluent API
 
@@ -62,7 +84,8 @@ Mixin that adds `bg()` and `background()` to any SmrtObject. Uses WeakMap for co
 
 ## Gotchas
 
-- **Cron not timezone-aware**: all times treated as UTC
+- **Cron not timezone-aware**: cron fields match the server's **local** time, not UTC (set `TZ` for UTC); no missed-run catch-up (fire-once-forward)
+- **At-least-once execution**: a timeout cannot preempt a running handler; timed-out jobs fail without retry but the handler keeps running — make handlers idempotent (see "Timeouts & at-least-once")
 - **No dead letter queue**: failed jobs stay in DB with `status='failed'` — manual intervention
 - **Result storage**: `resultPointer` is just a string — app must implement result backend
 - **Lazy builder**: `background()` returns builder — nothing happens until `enqueue()`

--- a/packages/jobs/src/__tests__/job-builder.test.ts
+++ b/packages/jobs/src/__tests__/job-builder.test.ts
@@ -45,6 +45,18 @@ describe('JobBuilder utilities', () => {
       expect(parseDelay(5000)).toBe(5000);
     });
 
+    it('throws on a non-finite numeric delay', () => {
+      // A non-finite delay flows into `new Date(Date.now() + delay)`, persisting
+      // an `Invalid Date` runAt that the claim query can never match (S3 #1401).
+      expect(() => parseDelay(Number.NaN)).toThrow('Invalid delay value');
+      expect(() => parseDelay(Number.POSITIVE_INFINITY)).toThrow(
+        'Invalid delay value',
+      );
+      expect(() => parseDelay(Number.NEGATIVE_INFINITY)).toThrow(
+        'Invalid delay value',
+      );
+    });
+
     it('throws error for invalid format', () => {
       expect(() => parseDelay('invalid')).toThrow('Invalid delay format');
       expect(() => parseDelay('abc123')).toThrow('Invalid delay format');

--- a/packages/jobs/src/__tests__/runner-remediation.test.ts
+++ b/packages/jobs/src/__tests__/runner-remediation.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Regression tests for the #1401 (Tier T2) jobs remediation:
+ *
+ * - #1 fire-and-forget crash risk: a throwing error path must surface as a
+ *   `runner:error` event, never as an unhandled promise rejection.
+ * - #2/#3 timeout honesty: a `'fail'` timeout fails the job WITHOUT auto-retry
+ *   (the original handler keeps running; re-queueing would duplicate it).
+ * - #3 `'warn'` behavior: a slow-but-successful handler that exceeds its
+ *   timeout still completes successfully and emits a `timeout-warning` event.
+ *
+ * Real in-memory SQLite + smrtVitestPlugin; the runner and business logic are
+ * never mocked (per .claude/rules/testing.md).
+ */
+
+import {
+  getTestDatabase,
+  ObjectRegistry,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { afterEach, describe, expect, it } from 'vitest';
+import { backgroundEligible } from '../background-policy.js';
+import { createTaskRunner } from '../runner.js';
+import { type SmrtJob, SmrtJobCollection } from '../smrt-job.js';
+
+/**
+ * A handler we can release on demand, so a "hangs past its timeout" test does
+ * not leave a forever-pending promise keeping the worker (and the test) alive.
+ */
+let releaseHang: (() => void) | null = null;
+
+@smrt()
+class RemediationProbe extends SmrtObject {
+  // Hangs until the test releases it. With a short `timeout` this exercises the
+  // timeout path; the external release lets teardown finish cleanly.
+  @backgroundEligible()
+  async hangs(): Promise<string> {
+    await new Promise<void>((resolve) => {
+      releaseHang = resolve;
+    });
+    return 'eventually';
+  }
+
+  // Slower than its timeout but finite: under `timeoutBehavior='warn'` it must
+  // still complete successfully.
+  @backgroundEligible()
+  async slowButFinite(): Promise<string> {
+    await new Promise<void>((resolve) => setTimeout(resolve, 150));
+    return 'done-slowly';
+  }
+
+  // Throws so the runner enters its error/retry path.
+  @backgroundEligible()
+  async alwaysThrows(): Promise<never> {
+    throw new Error('boom');
+  }
+}
+
+function canonicalProbeType(): string {
+  return (
+    ObjectRegistry.getClass('RemediationProbe')?.qualifiedName ||
+    'RemediationProbe'
+  );
+}
+
+afterEach(() => {
+  // Release any still-hanging handler so its promise settles and nothing leaks
+  // into the next test.
+  releaseHang?.();
+  releaseHang = null;
+  ObjectRegistry.clearCollectionCache?.();
+});
+
+describe('TaskRunner remediation (#1401)', () => {
+  it('does not emit an unhandled rejection when the error path throws (#1)', async () => {
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    const collection = await SmrtJobCollection.create({ db });
+
+    const job = await collection.create({
+      objectType: canonicalProbeType(),
+      method: 'alwaysThrows',
+      args: {},
+      maxAttempts: 1,
+    });
+    await job.save();
+
+    // Make the failure-path persistence write reject — the exact scenario in
+    // the finding: handleJobError's `db.query` rejecting while writing the
+    // terminal 'failed' state (a failure mode correlated with whatever is
+    // already failing the job). Without the guards, this rejection escapes the
+    // fire-and-forget processJob() caller as a process-level unhandled
+    // rejection and crashes the worker.
+    //
+    // writeOwnedJob binds the status as a parameter (`SET status = ?`), so the
+    // terminal-failed write is identified by the ownership-guarded UPDATE shape
+    // plus a `'failed'` first parameter — not by a literal in the SQL text.
+    const originalQuery = db.query.bind(db);
+    (db as unknown as { query: typeof db.query }).query = ((
+      sql: string,
+      ...params: unknown[]
+    ) => {
+      if (
+        typeof sql === 'string' &&
+        sql.includes('UPDATE _smrt_jobs') &&
+        sql.includes("AND status = 'running'") &&
+        params[0] === 'failed'
+      ) {
+        return Promise.reject(new Error('failure-write exploded'));
+      }
+      return originalQuery(sql, ...params);
+    }) as typeof db.query;
+
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', onUnhandled);
+
+    const runner = createTaskRunner({ concurrency: 1, pollInterval: 10 });
+    await runner.initialize(db);
+
+    const runnerError = new Promise<Error>((resolve) => {
+      runner.once('runner:error', (error) => resolve(error as Error));
+    });
+
+    await runner.start();
+    try {
+      // The guard converts the rejecting failure-write into a runner:error
+      // event...
+      const error = await runnerError;
+      expect(error.message).toContain('failure-write exploded');
+      // ...and after a tick for any pending microtasks to flush...
+      await new Promise((r) => setTimeout(r, 50));
+      // ...no unhandled rejection escaped to the process.
+      expect(unhandled).toHaveLength(0);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+      (db as unknown as { query: typeof db.query }).query = originalQuery;
+      await runner.stop();
+    }
+  });
+
+  it('fails a timed-out job WITHOUT auto-retrying it (#2/#3 fail)', async () => {
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    const collection = await SmrtJobCollection.create({ db });
+
+    // maxAttempts=3 would normally retry an ordinary failure; a timeout must
+    // NOT be retried (the original handler is still running).
+    const job = await collection.create({
+      objectType: canonicalProbeType(),
+      method: 'hangs',
+      args: {},
+      timeout: 50,
+      timeoutBehavior: 'fail',
+      maxAttempts: 3,
+    });
+    await job.save();
+
+    const runner = createTaskRunner({
+      concurrency: 1,
+      pollInterval: 10,
+      shutdownTimeout: 100,
+    });
+    await runner.initialize(db);
+
+    const retried: SmrtJob[] = [];
+    runner.on('job:retrying', (j) => retried.push(j));
+    const failed = new Promise<SmrtJob>((resolve, reject) => {
+      runner.once('job:failed', (j) => resolve(j));
+      runner.once('job:completed', () =>
+        reject(new Error('unexpected complete')),
+      );
+    });
+
+    await runner.start();
+    try {
+      await failed;
+      // Release the hung handler so shutdown can drain promptly.
+      releaseHang?.();
+
+      const persisted = await collection.get({ id: job.id ?? '' });
+      expect(persisted?.status).toBe('failed');
+      // Claimed exactly once (attempts incremented on claim), never re-queued.
+      expect(persisted?.attempts).toBe(1);
+      expect(retried).toHaveLength(0);
+    } finally {
+      releaseHang?.();
+      await runner.stop();
+    }
+  });
+
+  it("completes a slow handler under timeoutBehavior='warn' (#3 warn)", async () => {
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    const collection = await SmrtJobCollection.create({ db });
+    const eventCollection = await (
+      await import('../smrt-job-event.js')
+    ).SmrtJobEventCollection.create({ db });
+
+    const job = await collection.create({
+      objectType: canonicalProbeType(),
+      method: 'slowButFinite',
+      args: {},
+      timeout: 50, // shorter than the handler's ~150ms
+      timeoutBehavior: 'warn',
+      maxAttempts: 1,
+    });
+    await job.save();
+
+    const runner = createTaskRunner({ concurrency: 1, pollInterval: 10 });
+    await runner.initialize(db);
+
+    const completed = new Promise<unknown>((resolve, reject) => {
+      runner.once('job:completed', (_j, result) => resolve(result));
+      runner.once('job:failed', (_j, error) => reject(error));
+    });
+
+    await runner.start();
+    try {
+      const result = (await completed) as { result?: unknown };
+      expect(result.result).toBe('done-slowly');
+
+      const persisted = await collection.get({ id: job.id ?? '' });
+      expect(persisted?.status).toBe('completed');
+
+      // A warning event was recorded at the deadline (honest 'warn'). The job
+      // is global (no tenant), so the tenant-scoped query needs tenantId: null.
+      const events = await eventCollection.listByJob(job.id ?? '', {
+        tenantId: null,
+      });
+      expect(events.some((e) => e.stage === 'timeout-warning')).toBe(true);
+    } finally {
+      await runner.stop();
+    }
+  });
+});

--- a/packages/jobs/src/__tests__/schedule-enqueue-failure.test.ts
+++ b/packages/jobs/src/__tests__/schedule-enqueue-failure.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Regression test for the #1401 (Tier T2) jobs remediation, finding #4:
+ *
+ * `triggerSchedule` used to advance `next_run` and increment `running_count`
+ * BEFORE enqueuing the job. A transient `enqueueJob` failure (tenant cap, DB
+ * blip) then disabled the schedule (`status='error'`) without rolling `next_run`
+ * back — permanently losing that run slot AND taking the schedule out of the
+ * poll until manual re-activation.
+ *
+ * The fix enqueues first and only advances the slot on success. This test
+ * induces a transient enqueue failure and asserts the schedule is preserved:
+ * `next_run` unchanged, still `active`, slot not consumed.
+ *
+ * Real in-memory SQLite; nothing in the runner is mocked except a single
+ * forced enqueue rejection (the transient-failure scenario under test).
+ */
+
+import { getTestDatabase } from '@happyvertical/smrt-core';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { describe, expect, it } from 'vitest';
+import { createScheduleRunner } from '../schedule-runner.js';
+import { SmrtJobCollection } from '../smrt-job.js';
+
+/**
+ * Minimal `_smrt_agent_schedules` table covering the columns the ScheduleRunner
+ * reads and writes. The full table is owned by `@happyvertical/smrt-agents`;
+ * this package only touches it via raw SQL, so the test stands up just the
+ * shape the runner needs (no cross-package dependency).
+ */
+async function createSchedulesTable(db: DatabaseInterface): Promise<void> {
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS _smrt_agent_schedules (
+      id TEXT PRIMARY KEY,
+      agent_type TEXT,
+      agent_id TEXT,
+      tenant_id TEXT,
+      agent_config TEXT,
+      cron TEXT,
+      method TEXT,
+      method_args TEXT,
+      timeout INTEGER,
+      enabled BOOLEAN DEFAULT TRUE,
+      status TEXT DEFAULT 'active',
+      next_run TEXT,
+      running_count INTEGER DEFAULT 0,
+      max_concurrent INTEGER DEFAULT 1,
+      last_run TEXT,
+      last_status TEXT,
+      last_error TEXT,
+      run_count INTEGER DEFAULT 0,
+      success_count INTEGER DEFAULT 0,
+      failure_count INTEGER DEFAULT 0
+    )
+  `);
+}
+
+describe('ScheduleRunner triggerSchedule enqueue failure (#1401 #4)', () => {
+  it('preserves next_run and keeps the schedule active when enqueue fails', async () => {
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    // Provision _smrt_jobs (used by the collection) and the schedules table.
+    await SmrtJobCollection.create({ db });
+    await createSchedulesTable(db);
+
+    const originalNextRun = '2026-06-22T00:00:00.000Z';
+    await db.query(
+      `INSERT INTO _smrt_agent_schedules
+         (id, agent_type, agent_id, tenant_id, cron, method, next_run,
+          enabled, status, running_count, max_concurrent)
+       VALUES (?, ?, ?, ?, ?, ?, ?, TRUE, 'active', 0, 1)`,
+      'sched-1',
+      'SomeAgent',
+      null,
+      null,
+      '0 0 * * *',
+      'run',
+      originalNextRun,
+    );
+
+    const runner = createScheduleRunner();
+    await runner.initialize(db);
+
+    // Force a transient enqueue failure on the runner's own collection.
+    const jobCollection = (
+      runner as unknown as { jobCollection: SmrtJobCollection }
+    ).jobCollection;
+    let enqueueCalled = false;
+    jobCollection.enqueueJob = async () => {
+      enqueueCalled = true;
+      throw new Error('transient db blip');
+    };
+
+    const scheduleRow = {
+      id: 'sched-1',
+      agent_type: 'SomeAgent',
+      agent_id: null,
+      tenant_id: null,
+      agent_config: null,
+      cron: '0 0 * * *',
+      method: 'run',
+      method_args: null,
+      timeout: null,
+    };
+
+    // Drive the private trigger directly (class under test).
+    await (
+      runner as unknown as {
+        triggerSchedule(row: typeof scheduleRow): Promise<void>;
+      }
+    ).triggerSchedule(scheduleRow);
+
+    expect(enqueueCalled).toBe(true);
+
+    const result = await db.query(
+      `SELECT next_run, status, running_count, last_error
+         FROM _smrt_agent_schedules WHERE id = ?`,
+      'sched-1',
+    );
+    const row = result.rows[0] as {
+      next_run: string;
+      status: string;
+      running_count: number;
+      last_error: string | null;
+    };
+
+    // The slot is preserved: next_run untouched, schedule still pollable.
+    expect(row.next_run).toBe(originalNextRun);
+    expect(row.status).toBe('active');
+    expect(Number(row.running_count)).toBe(0);
+    // The failure is recorded for visibility.
+    expect(row.last_error).toContain('transient db blip');
+  });
+
+  it('advances next_run and consumes a slot when enqueue succeeds', async () => {
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    await SmrtJobCollection.create({ db });
+    await createSchedulesTable(db);
+
+    const originalNextRun = '2026-06-22T00:00:00.000Z';
+    await db.query(
+      `INSERT INTO _smrt_agent_schedules
+         (id, agent_type, agent_id, tenant_id, cron, method, next_run,
+          enabled, status, running_count, max_concurrent)
+       VALUES (?, ?, ?, ?, ?, ?, ?, TRUE, 'active', 0, 1)`,
+      'sched-ok',
+      'SomeAgent',
+      null,
+      null,
+      '0 0 * * *',
+      'run',
+      originalNextRun,
+    );
+
+    const runner = createScheduleRunner();
+    await runner.initialize(db);
+
+    const scheduleRow = {
+      id: 'sched-ok',
+      agent_type: 'SomeAgent',
+      agent_id: null,
+      tenant_id: null,
+      agent_config: null,
+      cron: '0 0 * * *',
+      method: 'run',
+      method_args: null,
+      timeout: null,
+    };
+
+    await (
+      runner as unknown as {
+        triggerSchedule(row: typeof scheduleRow): Promise<void>;
+      }
+    ).triggerSchedule(scheduleRow);
+
+    const result = await db.query(
+      `SELECT next_run, status, running_count
+         FROM _smrt_agent_schedules WHERE id = ?`,
+      'sched-ok',
+    );
+    const row = result.rows[0] as {
+      next_run: string;
+      status: string;
+      running_count: number;
+    };
+
+    // On success the slot is consumed and next_run advances to the future.
+    expect(row.next_run).not.toBe(originalNextRun);
+    expect(new Date(row.next_run).getTime()).toBeGreaterThan(
+      new Date(originalNextRun).getTime(),
+    );
+    expect(row.status).toBe('active');
+    expect(Number(row.running_count)).toBe(1);
+
+    // A job was actually enqueued.
+    const jobs = await db.query(
+      `SELECT COUNT(*) as count FROM _smrt_jobs WHERE queue = 'agents'`,
+    );
+    expect(Number((jobs.rows[0] as { count: number }).count)).toBe(1);
+  });
+});

--- a/packages/jobs/src/index.ts
+++ b/packages/jobs/src/index.ts
@@ -87,6 +87,7 @@ export {
 // Task runner
 export {
   createTaskRunner,
+  JobTimeoutError,
   TaskRunner,
   type TaskRunnerConfig,
   type TaskRunnerEvents,

--- a/packages/jobs/src/job-builder.ts
+++ b/packages/jobs/src/job-builder.ts
@@ -35,7 +35,15 @@ export function priorityToNumber(priority: Priority): number {
  * Parse delay string to milliseconds
  */
 export function parseDelay(delay: string | number): number {
-  if (typeof delay === 'number') return delay;
+  if (typeof delay === 'number') {
+    // Guard against NaN/Infinity: a non-finite delay flows into
+    // `new Date(Date.now() + delay)`, persisting an `Invalid Date` `runAt`
+    // that the claim query can never match (S3 in the #1401 review).
+    if (!Number.isFinite(delay)) {
+      throw new Error(`Invalid delay value: ${delay}`);
+    }
+    return delay;
+  }
 
   const match = delay.match(/^(\d+)(ms|s|m|h|d)?$/);
   if (!match) {

--- a/packages/jobs/src/runner.ts
+++ b/packages/jobs/src/runner.ts
@@ -92,6 +92,24 @@ export interface TaskRunnerEvents {
 const LIVENESS_THREAD_START_TIMEOUT_MS = 10000;
 
 /**
+ * Raised when a job exceeds its timeout under `timeoutBehavior` `'fail'`/`'kill'`.
+ *
+ * Distinguished from an ordinary handler error so the failure path can choose
+ * NOT to auto-retry: the original handler keeps running after a timeout (JS
+ * can't preempt it), so re-queueing the row as `pending` while the original
+ * still executes guarantees concurrent duplicate execution (see #2 in the
+ * #1401 review). A timed-out job is therefore failed terminally rather than
+ * retried, shrinking — though, given the at-least-once contract, not fully
+ * eliminating — the overlap window.
+ */
+export class JobTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'JobTimeoutError';
+  }
+}
+
+/**
  * Default configuration
  */
 const DEFAULT_CONFIG: Required<TaskRunnerConfig> = {
@@ -337,13 +355,34 @@ export class TaskRunner extends EventEmitter {
       const jobId = job.id;
       if (!jobId) continue;
 
-      // Process asynchronously
-      this.processJob(job);
+      // Process asynchronously. We deliberately do NOT await — concurrency is
+      // bounded by `activeJobs` above, not by serializing here. But a bare
+      // fire-and-forget call means any unexpected rejection (e.g. the failure-
+      // path write in handleJobError rejecting, a failure mode correlated with
+      // whatever is already failing the job) escapes as an unhandled promise
+      // rejection and crashes the worker under Node's default
+      // `--unhandled-rejections=throw`. handleJobError is itself wrapped in
+      // try/catch, but guard the caller too as defense in depth so no rejection
+      // can ever escape the poll loop.
+      this.processJob(job).catch((error) => {
+        this.emit('runner:error', error as Error);
+      });
     }
   }
 
   /**
-   * Process a single job
+   * Process a single job.
+   *
+   * AT-LEAST-ONCE EXECUTION CONTRACT: a `timeout` only races the handler's
+   * promise — JavaScript cannot preempt an already-running handler, so on a
+   * `'fail'` (or `'kill'`) timeout the original handler keeps executing in the
+   * background while the job row is failed. Timeouts are NOT auto-retried (see
+   * handleJobError) precisely so a still-running handler is not duplicated by a
+   * retry; but the orphaned handler's own side effects still happen, and an
+   * ordinary (non-timeout) failure IS retried and re-claimable by any worker.
+   * Handlers invoked from a job MUST be idempotent (e.g. keyed by
+   * `context.job.jobId` or a caller-supplied idempotency key); do not rely on a
+   * job body running exactly once. See AGENTS.md "Timeouts & at-least-once".
    */
   private async processJob(job: SmrtJob): Promise<void> {
     const jobId = job.id;
@@ -362,16 +401,16 @@ export class TaskRunner extends EventEmitter {
       message: `Started job: ${job.getDescription()}`,
     });
 
-    try {
-      // Set up timeout
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(() => {
-          reject(new Error(`Job timeout after ${job.timeout}ms`));
-        }, job.timeout);
-      });
+    // Capture the timeout handle so it is always cleared in `finally`. Without
+    // this, every fast job left a ~5-min (default) armed timer on the heap
+    // until it fired and was swallowed by the settled race — timer-heap
+    // pressure plus a delayed clean process exit.
+    let timeoutHandle: NodeJS.Timeout | null = null;
 
-      // Execute the job with timeout
-      const result = await Promise.race([this.executeJob(job), timeoutPromise]);
+    try {
+      const result = await this.runWithTimeout(job, (handle) => {
+        timeoutHandle = handle;
+      });
 
       // Job completed successfully. Write the terminal state conditionally so a
       // recovered/reclaimed row (worker died, recovery ran, the work finished
@@ -398,10 +437,68 @@ export class TaskRunner extends EventEmitter {
         this.emit('job:completed', job, result);
       }
     } catch (error) {
-      await this.handleJobError(job, error as Error);
+      // handleJobError is wrapped so its own failure-path write (a `db.query`
+      // that may reject for the same reason the job is failing) cannot turn
+      // into an unhandled rejection / unbounded crash. A failure to persist the
+      // failure is surfaced as a runner error, not a thrown rejection.
+      try {
+        await this.handleJobError(job, error as Error);
+      } catch (handlerError) {
+        this.emit('runner:error', handlerError as Error);
+      }
     } finally {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
       this.activeJobs.delete(jobId);
     }
+  }
+
+  /**
+   * Execute a job honoring its {@link SmrtJob.timeoutBehavior}.
+   *
+   * - `'fail'` (default) and `'kill'`: race the handler against a timeout. On
+   *   timeout the race rejects and the caller fails/retries the job.
+   *   `'kill'` cannot actually preempt the handler in-process (JavaScript has
+   *   no thread interruption), so it is treated identically to `'fail'` — the
+   *   handler keeps running in the background; only the job row is failed. This
+   *   is documented in AGENTS.md so `'kill'` is honest about what it does
+   *   rather than silently behaving like a no-op.
+   * - `'warn'`: do NOT fail on timeout. Arm a one-shot warning (logged + emitted
+   *   as a job event) at the deadline, but await the handler to completion so a
+   *   slow-but-successful handler still completes. This makes `'warn'` honest:
+   *   previously every timeout was treated as `'fail'` regardless of the
+   *   persisted/UI-shown behavior.
+   */
+  private async runWithTimeout(
+    job: SmrtJob,
+    captureHandle: (handle: NodeJS.Timeout) => void,
+  ): Promise<{ result?: unknown; resultPointer?: string }> {
+    if (job.timeoutBehavior === 'warn') {
+      const handle = setTimeout(() => {
+        this.logger.warn(
+          `Job exceeded timeout (${job.timeout}ms) but timeoutBehavior='warn'; letting it finish: ${job.getDescription()}`,
+        );
+        // Best-effort telemetry; must not change the job outcome.
+        void this.appendJobEvent(job, {
+          type: 'status',
+          level: 'warn',
+          stage: 'timeout-warning',
+          message: `Job exceeded timeout of ${job.timeout}ms (timeoutBehavior='warn')`,
+          data: { timeout: job.timeout },
+        });
+      }, job.timeout);
+      captureHandle(handle);
+      return this.executeJob(job);
+    }
+
+    // 'fail' (default) and 'kill' (treated as 'fail'; see doc comment).
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      const handle = setTimeout(() => {
+        reject(new JobTimeoutError(`Job timeout after ${job.timeout}ms`));
+      }, job.timeout);
+      captureHandle(handle);
+    });
+
+    return Promise.race([this.executeJob(job), timeoutPromise]);
   }
 
   /**
@@ -568,6 +665,15 @@ export class TaskRunner extends EventEmitter {
     const jobId = job.id;
     if (!jobId) return;
 
+    // A timed-out handler keeps running in the background (JS can't preempt it).
+    // Re-queueing the row as `pending` while the original still executes would
+    // make the next worker run a *second* concurrent copy. So do not auto-retry
+    // a timeout — fail it terminally. This narrows the duplicate-execution
+    // window from the at-least-once contract (#2 in the #1401 review); it does
+    // not remove it (the orphaned handler can still finish and write a terminal
+    // state, which writeOwnedJob's ownership guard then drops).
+    const isTimeout = error instanceof JobTimeoutError;
+
     // `last_error` is persisted to the durable `_smrt_jobs` row and is readable
     // through generated (tenant-scoped) list/get routes. Strip secret-shaped
     // substrings before persistence so a failing job that echoes a credential
@@ -577,7 +683,7 @@ export class TaskRunner extends EventEmitter {
     // (no `.message`) would otherwise persist an empty `last_error`.
     const safeMessage = redactErrorForPersistence(error);
 
-    if (decision.shouldRetry && job.attempts < job.maxAttempts) {
+    if (!isTimeout && decision.shouldRetry && job.attempts < job.maxAttempts) {
       // Schedule retry
       const nextRunAt = new Date(Date.now() + decision.delay);
 

--- a/packages/jobs/src/schedule-runner.ts
+++ b/packages/jobs/src/schedule-runner.ts
@@ -495,18 +495,6 @@ export class ScheduleRunner extends EventEmitter {
       // Compute next run time from cron before creating the job
       const nextRun = getNextCronDate(schedule.cron as string);
 
-      // Increment running count and advance next_run in one update
-      await this.db.query(
-        `UPDATE _smrt_agent_schedules
-         SET agent_type = ?,
-             running_count = running_count + 1,
-             next_run = ?
-         WHERE id = ?`,
-        canonicalAgentType,
-        nextRun.toISOString(),
-        schedule.id,
-      );
-
       // Create a job for this schedule
       // Nest agent_config under _agentConfig so TaskRunner can pass it
       // to the agent constructor separately from method args
@@ -518,11 +506,20 @@ export class ScheduleRunner extends EventEmitter {
         args._agentConfig = agentConfig;
       }
 
+      // Enqueue the job BEFORE advancing next_run / incrementing running_count.
+      // Previously next_run was advanced and running_count incremented first; if
+      // enqueueJob then threw (a transient tenant-cap hit or DB blip), the catch
+      // disabled the schedule but never rolled next_run back, permanently losing
+      // that run slot AND taking the schedule out of the poll until manual
+      // re-activation (#4 in the #1401 review). By enqueuing first, a transient
+      // failure leaves next_run untouched, so the same due slot is retried on
+      // the next poll and the schedule stays active.
+      //
       // Route scheduled jobs through the same centralized creation path as the
       // fluent builder so the per-tenant in-flight cap and retry ceiling apply
-      // here too — previously this direct create() bypassed both (S5 audit
-      // #1402). The schedule's own tenant is passed explicitly so the cap is
-      // enforced for the owning tenant even with no ambient context.
+      // here too — previously a direct create() bypassed both (S5 audit #1402).
+      // The schedule's own tenant is passed explicitly so the cap is enforced
+      // for the owning tenant even with no ambient context.
       const job = await this.jobCollection.enqueueJob({
         tenantId:
           typeof schedule.tenant_id === 'string' &&
@@ -539,6 +536,19 @@ export class ScheduleRunner extends EventEmitter {
         timeout: (schedule.timeout as number) || 3600000,
       });
 
+      // Only now that the job is durably enqueued do we consume the slot:
+      // increment running_count and advance next_run in one update.
+      await this.db.query(
+        `UPDATE _smrt_agent_schedules
+         SET agent_type = ?,
+             running_count = running_count + 1,
+             next_run = ?
+         WHERE id = ?`,
+        canonicalAgentType,
+        nextRun.toISOString(),
+        schedule.id,
+      );
+
       this.emit('schedule:triggered', scheduleInfo);
       this.logger.info('Schedule triggered', {
         scheduleId: schedule.id,
@@ -547,12 +557,14 @@ export class ScheduleRunner extends EventEmitter {
         nextRun: nextRun.toISOString(),
       });
     } catch (error) {
-      // Decrement running count on failure
+      // The slot was NOT consumed (enqueue runs before the next_run/
+      // running_count advance), so there is nothing to roll back: leave
+      // next_run and status='active' untouched so the next poll retries the
+      // same due slot rather than skipping it or disabling the schedule on a
+      // transient failure (#4). Record last_error for operator visibility only.
       await this.db.query(
         `UPDATE _smrt_agent_schedules
-         SET running_count = running_count - 1,
-             status = 'error',
-             last_error = ?
+         SET last_error = ?
          WHERE id = ?`,
         // Tolerate non-Error throwables: a thrown string/object has no
         // `.message`, which would otherwise persist an empty `last_error`.

--- a/packages/jobs/src/svelte/components/JobActions.svelte
+++ b/packages/jobs/src/svelte/components/JobActions.svelte
@@ -40,9 +40,7 @@ const canRetry = $derived(
   job.status === 'failed' || job.status === 'cancelled',
 );
 const canCancel = $derived(
-  job.status === 'pending' ||
-    job.status === 'ready' ||
-    job.status === 'running',
+  job.status === 'pending' || job.status === 'running',
 );
 
 function handleRetry() {

--- a/packages/jobs/src/svelte/components/JobDetail.svelte
+++ b/packages/jobs/src/svelte/components/JobDetail.svelte
@@ -200,7 +200,7 @@ const formattedArgs = $derived(JSON.stringify(job.args, null, 2));
     margin: 0 0 var(--spacing-sm, 0.5rem) 0;
     font-size: var(--smrt-typography-title-small-size, 0.875rem);
     font-weight: var(--smrt-typography-weight-semibold, 600);
-    color: var(--color-text-secondary, #6b7280);
+    color: var(--smrt-color-on-surface-variant, #6b7280);
     text-transform: uppercase;
     letter-spacing: var(--smrt-typography-title-small-tracking, 0.05em);
   }
@@ -210,7 +210,7 @@ const formattedArgs = $derived(JSON.stringify(job.args, null, 2));
   }
 
   .job-detail__section--error h3 {
-    color: var(--color-error, #dc2626);
+    color: var(--smrt-color-error, #dc2626);
   }
 
   .job-detail__list {

--- a/packages/jobs/src/svelte/components/JobList.svelte
+++ b/packages/jobs/src/svelte/components/JobList.svelte
@@ -53,6 +53,16 @@ function handleRowClick(job: JobData) {
   onJobClick?.(job);
 }
 
+// Keyboard activation for the row when it acts as a button (role="button").
+// Without this, keyboard users can focus the row (tabindex=0) but cannot
+// activate it — Enter/Space were dead. Space is prevented to stop page scroll.
+function handleRowKeydown(job: JobData, event: KeyboardEvent) {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    handleRowClick(job);
+  }
+}
+
 // Handle row selection
 function handleRowSelect(jobId: string, event: Event) {
   event.stopPropagation();
@@ -153,6 +163,9 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
             class="job-list__row"
             class:job-list__row--selected={isSelected}
             onclick={() => handleRowClick(job)}
+            onkeydown={onJobClick
+              ? (e) => handleRowKeydown(job, e)
+              : undefined}
             role={onJobClick ? 'button' : undefined}
             tabindex={onJobClick ? 0 : undefined}
           >

--- a/packages/smrt-svelte/AGENTS.md
+++ b/packages/smrt-svelte/AGENTS.md
@@ -198,7 +198,10 @@ await expectNoA11yViolations(container); // axe; color-contrast off (jsdom has n
 ## Dependencies
 
 - `@happyvertical/smrt-types` (shared types) — includes the identity data contracts (`User`, `Role`, `Membership`, `Tenant`) the role/membership components type against, so no dependency on `smrt-users` / `smrt-profiles` is needed
-- Peer: `svelte` >=5.18.2, `@happyvertical/smrt-agents`, `@happyvertical/smrt-jobs` (all optional)
+- `@happyvertical/smrt-ui` (UI runtime: primitives, theme system, i18n client, module registry) and `@happyvertical/smrt-agents` (admin shells type against its `/ui` contracts) are hard `dependencies`.
+- `@happyvertical/smrt-languages` is a hard `dependency` (not an optional peer): the Node-only `/i18n/server` subpath imports its resolver. The browser bundle still excludes it — the client `/i18n` layer never imports the languages root, so it tree-shakes out.
+- `@happyvertical/logger` (SDK) is a `dependency` — the browser-safe console logger used for voice/AI error reporting in the form components.
+- Peer (all optional): `svelte` >=5.18.2, plus the browser-AI engines (`@huggingface/transformers`, `@mlc-ai/web-llm`, `@remotion/whisper-web`, `@xenova/transformers`) and `chrono-node`.
 
 ## Workspace shell primitives
 

--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -90,6 +90,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@happyvertical/logger": "catalog:",
     "@happyvertical/smrt-agents": "workspace:*",
     "@happyvertical/smrt-languages": "workspace:*",
     "@happyvertical/smrt-types": "workspace:*",

--- a/packages/smrt-svelte/src/Provider.svelte
+++ b/packages/smrt-svelte/src/Provider.svelte
@@ -188,9 +188,13 @@ $effect(() => {
   }
 });
 
-// Cleanup on destroy
+// Cleanup on destroy. Dispose the whole manager (not just the socket) so it
+// unsubscribes its listeners from the module-surviving warm AI adapters; left
+// attached, each destroyed Provider would keep pinning its `_state` proxy via
+// those adapters' listener `Set`s and leak one set per navigation (R1). The
+// warm cache itself survives — dispose() leaves cached adapters intact.
 onDestroy(() => {
-  appState.disconnectSocket();
+  appState.dispose();
 });
 </script>
 

--- a/packages/smrt-svelte/src/Provider.svelte
+++ b/packages/smrt-svelte/src/Provider.svelte
@@ -7,6 +7,7 @@ import {
 import type { Snippet } from 'svelte';
 import { onDestroy, untrack } from 'svelte';
 import AILoadingOverlay from './browser-ai/svelte/components/AILoadingOverlay.svelte';
+import { logger } from './internal/logger.js';
 import type {
   AIConfig,
   AILoadingState,
@@ -194,7 +195,12 @@ $effect(() => {
 // those adapters' listener `Set`s and leak one set per navigation (R1). The
 // warm cache itself survives — dispose() leaves cached adapters intact.
 onDestroy(() => {
-  appState.dispose();
+  // dispose() is async; isolate + log its rejection so a failing adapter
+  // teardown surfaces as a logged error instead of an unhandled promise
+  // rejection during Provider teardown.
+  void appState.dispose().catch((error) => {
+    logger.error('AppState dispose failed during Provider teardown', { error });
+  });
 });
 </script>
 

--- a/packages/smrt-svelte/src/components/admin/AgentSettingsShell.svelte
+++ b/packages/smrt-svelte/src/components/admin/AgentSettingsShell.svelte
@@ -49,7 +49,11 @@ const {
   dbConfigs = {},
 }: Props = $props();
 
+// Stable per-instance id base so multiple shells don't collide on tab/panel ids.
+const idBase = $props.id();
+
 let activeAgentId = $state<string | null>(null);
+let tablistEl: HTMLElement | null = $state(null);
 
 // Initialize to first agent
 $effect(() => {
@@ -64,6 +68,50 @@ function handleAgentClick(agentId: string) {
   activeAgentId = agentId;
 }
 
+/**
+ * Roving-tabindex keyboard navigation for the agent switcher (C8). The list is
+ * a vertical tablist, so Up/Down move between agents (plus Home/End); mirrors
+ * the horizontal pattern in AgentAdminTabs.
+ */
+function handleAgentKeydown(event: KeyboardEvent, currentAgentId: string) {
+  const currentIndex = agents.findIndex((a) => a.id === currentAgentId);
+  if (currentIndex === -1) return;
+
+  let nextIndex: number | null = null;
+  switch (event.key) {
+    case 'ArrowDown':
+    case 'ArrowRight':
+      event.preventDefault();
+      nextIndex = (currentIndex + 1) % agents.length;
+      break;
+    case 'ArrowUp':
+    case 'ArrowLeft':
+      event.preventDefault();
+      nextIndex = (currentIndex - 1 + agents.length) % agents.length;
+      break;
+    case 'Home':
+      event.preventDefault();
+      nextIndex = 0;
+      break;
+    case 'End':
+      event.preventDefault();
+      nextIndex = agents.length - 1;
+      break;
+  }
+
+  if (nextIndex !== null && nextIndex !== currentIndex) {
+    const nextAgentId = agents[nextIndex].id;
+    activeAgentId = nextAgentId;
+    // Focus the newly-selected tab after the DOM updates.
+    requestAnimationFrame(() => {
+      const tabButton = tablistEl?.querySelector(
+        `[data-agent-id="${CSS.escape(nextAgentId)}"]`,
+      ) as HTMLElement | null;
+      tabButton?.focus();
+    });
+  }
+}
+
 async function handleSave(slotId: string, config: unknown) {
   if (activeAgentId && onSave) {
     await onSave(activeAgentId, slotId, config);
@@ -74,13 +122,26 @@ async function handleSave(slotId: string, config: unknown) {
 <div class="agent-settings-shell" class:single-agent={agents.length === 1}>
 	{#if agents.length > 1}
 		<aside class="agents-sidebar">
-			<h3 class="sidebar-title">Agents</h3>
-			<nav class="agents-list">
+			<h3 class="sidebar-title" id="{idBase}-agents-title">Agents</h3>
+			<div
+				class="agents-list"
+				role="tablist"
+				aria-orientation="vertical"
+				aria-labelledby="{idBase}-agents-title"
+				bind:this={tablistEl}
+			>
 				{#each agents as agent}
 					<button
 						class="agent-button"
 						class:active={activeAgentId === agent.id}
+						role="tab"
+						aria-selected={activeAgentId === agent.id}
+						aria-controls="{idBase}-panel"
+						id="{idBase}-tab-{agent.id}"
+						data-agent-id={agent.id}
+						tabindex={activeAgentId === agent.id ? 0 : -1}
 						onclick={() => handleAgentClick(agent.id)}
+						onkeydown={(e) => handleAgentKeydown(e, agent.id)}
 					>
 						<span class="agent-class">{agent.agentClass}</span>
 						{#if agent.name}
@@ -88,11 +149,18 @@ async function handleSave(slotId: string, config: unknown) {
 						{/if}
 					</button>
 				{/each}
-			</nav>
+			</div>
 		</aside>
 	{/if}
 
-	<main class="agent-content">
+	<main
+		class="agent-content"
+		id="{idBase}-panel"
+		role={agents.length > 1 ? 'tabpanel' : undefined}
+		aria-labelledby={agents.length > 1 && activeAgentId
+			? `${idBase}-tab-${activeAgentId}`
+			: undefined}
+	>
 		{#if activeAgent}
 			<header class="agent-header">
 				<h2 class="agent-title">{activeAgent.agentClass}</h2>

--- a/packages/smrt-svelte/src/components/admin/__tests__/AgentSettingsShell.tablist.test.ts
+++ b/packages/smrt-svelte/src/components/admin/__tests__/AgentSettingsShell.tablist.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Regression: the agent switcher is a proper ARIA tablist (C8).
+ *
+ * It was a <nav> of <button>s acting as single-select tabs, with no
+ * role/aria-selected/roving-tabindex/arrow-key nav — unlike sibling
+ * AgentAdminTabs which does the full tablist. The fix adds role="tablist" +
+ * role="tab" + aria-selected + roving tabindex + Up/Down/Home/End navigation,
+ * and marks the content panel role="tabpanel".
+ */
+import { createUIRegistry } from '@happyvertical/smrt-agents/ui';
+import { render, screen, waitFor, within } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import AgentSettingsShell from '../AgentSettingsShell.svelte';
+
+/**
+ * Roving focus moves via requestAnimationFrame, so wait for the expected tab to
+ * actually receive focus before dispatching the next key (otherwise the next
+ * keydown fires on the previously-focused tab).
+ */
+async function expectFocused(el: HTMLElement) {
+  await waitFor(() => expect(el).toHaveFocus());
+}
+
+function agents() {
+  return [
+    { id: 'a1', agentClass: 'Praeco', name: 'Alpha', slots: {} },
+    { id: 'a2', agentClass: 'Caelus', name: 'Beta', slots: {} },
+    { id: 'a3', agentClass: 'Nimbus', name: 'Gamma', slots: {} },
+  ];
+}
+
+function renderShell() {
+  return render(AgentSettingsShell, {
+    props: {
+      registry: createUIRegistry(),
+      agents: agents(),
+      configs: {},
+    },
+  });
+}
+
+/**
+ * The shell embeds AgentAdminTabs (its own slot tablist), so scope queries to
+ * the agent-switcher tablist — identified by its "Agents" accessible name.
+ */
+function switcher() {
+  return screen.getByRole('tablist', { name: 'Agents' });
+}
+function switcherTabs() {
+  return within(switcher()).getAllByRole('tab');
+}
+
+describe('AgentSettingsShell — agent switcher tablist (C8)', () => {
+  it('renders a tablist of tabs with the first selected', () => {
+    renderShell();
+    expect(switcher()).toBeInTheDocument();
+    const tabs = switcherTabs();
+    expect(tabs).toHaveLength(3);
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+    expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('uses a roving tabindex (only the selected tab is tabbable)', () => {
+    renderShell();
+    const tabs = switcherTabs();
+    expect(tabs[0]).toHaveAttribute('tabindex', '0');
+    expect(tabs[1]).toHaveAttribute('tabindex', '-1');
+    expect(tabs[2]).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('moves selection with ArrowDown / ArrowUp', async () => {
+    renderShell();
+    switcherTabs()[0].focus();
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(switcherTabs()[1]).toHaveAttribute('aria-selected', 'true');
+    await expectFocused(switcherTabs()[1]);
+
+    await userEvent.keyboard('{ArrowUp}');
+    expect(switcherTabs()[0]).toHaveAttribute('aria-selected', 'true');
+    await expectFocused(switcherTabs()[0]);
+  });
+
+  it('jumps to last/first with End / Home', async () => {
+    renderShell();
+    switcherTabs()[0].focus();
+
+    await userEvent.keyboard('{End}');
+    expect(switcherTabs()[2]).toHaveAttribute('aria-selected', 'true');
+    await expectFocused(switcherTabs()[2]);
+
+    await userEvent.keyboard('{Home}');
+    expect(switcherTabs()[0]).toHaveAttribute('aria-selected', 'true');
+    await expectFocused(switcherTabs()[0]);
+  });
+
+  it('exposes a tabpanel wired to the selected tab', () => {
+    renderShell();
+    const panel = screen.getByRole('tabpanel');
+    const selectedTab = switcherTabs().find(
+      (t) => t.getAttribute('aria-selected') === 'true',
+    );
+    expect(selectedTab).toBeTruthy();
+    expect(panel).toHaveAttribute('aria-labelledby', selectedTab?.id);
+    expect(selectedTab).toHaveAttribute('aria-controls', panel.id);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/DateRangeInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/DateRangeInput.svelte
@@ -4,6 +4,7 @@ import { onDestroy, onMount } from 'svelte';
 import { useAppState } from '../../hooks/useAppState.svelte.js';
 import { useSTT } from '../../hooks/useSTT.svelte.js';
 import { M } from '../../i18n/strings.forms.js';
+import { logger } from '../../internal/logger.js';
 import {
   type FieldDefinition,
   tryGetFormContext,
@@ -219,15 +220,26 @@ onDestroy(() => {
 async function startRecording() {
   if (!isSmrt || disabled || isParsing) return;
 
-  if (!stt.isReady || stt.adapterType !== 'whisper-wasm') {
-    await stt.initialize({ type: 'whisper-wasm' });
-  }
-
   parseError = null;
   recordingStartTime = Date.now();
   isRecording = true;
 
-  await stt.start({ continuous: true, interimResults: false });
+  // Guard STT init / mic acquisition so a rejection can't leave the field
+  // wedged in a permanent "Recording..." state with no visible error (C2).
+  try {
+    if (!stt.isReady || stt.adapterType !== 'whisper-wasm') {
+      await stt.initialize({ type: 'whisper-wasm' });
+    }
+    await stt.start({ continuous: true, interimResults: false });
+  } catch (err) {
+    isRecording = false;
+    parseError =
+      err instanceof Error ? err.message : 'Could not start voice input';
+    logger.error('DateRangeInput: failed to start voice recording', {
+      field: name,
+      error: err,
+    });
+  }
 }
 
 async function stopRecording() {
@@ -307,6 +319,17 @@ function handleTouchEnd() {
   stopRecording();
 }
 
+// Keyboard activation for the mic (WCAG 2.1.1): Enter/Space toggles recording.
+function handleMicKeydown(e: KeyboardEvent) {
+  if (e.key !== 'Enter' && e.key !== ' ') return;
+  e.preventDefault();
+  if (isRecording) {
+    stopRecording();
+  } else {
+    startRecording();
+  }
+}
+
 const primaryControlId = $derived(isSmrt ? `${name}_voice` : `${name}_start`);
 </script>
 
@@ -342,6 +365,7 @@ const primaryControlId = $derived(isSmrt ? `${name}_voice` : `${name}_start`);
           class="mic-btn"
           class:active={isRecording}
           disabled={disabled || isParsing}
+          onkeydown={handleMicKeydown}
           onmousedown={handleMouseDown}
           onmouseup={handleMouseUp}
           onmouseleave={handleMouseLeave}

--- a/packages/smrt-svelte/src/components/forms/DateTimeInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/DateTimeInput.svelte
@@ -5,6 +5,7 @@ import { onDestroy, onMount } from 'svelte';
 import { useAppState } from '../../hooks/useAppState.svelte.js';
 import { useSTT } from '../../hooks/useSTT.svelte.js';
 import { M } from '../../i18n/strings.forms.js';
+import { logger } from '../../internal/logger.js';
 import {
   type FieldDefinition,
   tryGetFormContext,
@@ -177,17 +178,28 @@ async function parseNaturalLanguage(text: string): Promise<string> {
 async function startHoldRecording() {
   if (!isSmrt || disabled || isParsing) return;
 
-  // Initialize STT with Whisper v2 for speed + accuracy
-  if (!stt.isReady || stt.adapterType !== 'whisper-wasm') {
-    await stt.initialize({ type: 'whisper-wasm' });
-  }
-
   parseError = null;
   recordingStartTime = Date.now();
   isHolding = true;
 
-  // Use continuous mode to capture all speech while holding
-  await stt.start({ continuous: true, interimResults: false });
+  // Guard STT init / mic acquisition so a rejection can't leave the field
+  // wedged in a permanent "Recording..." state with no visible error (C2).
+  try {
+    // Initialize STT with Whisper v2 for speed + accuracy
+    if (!stt.isReady || stt.adapterType !== 'whisper-wasm') {
+      await stt.initialize({ type: 'whisper-wasm' });
+    }
+    // Use continuous mode to capture all speech while holding
+    await stt.start({ continuous: true, interimResults: false });
+  } catch (err) {
+    isHolding = false;
+    parseError =
+      err instanceof Error ? err.message : 'Could not start voice input';
+    logger.error('DateTimeInput: failed to start voice recording', {
+      field: name,
+      error: err,
+    });
+  }
 }
 
 async function stopHoldRecording() {
@@ -276,6 +288,20 @@ function handleMicTouchStart(e: TouchEvent) {
   startHoldRecording();
 }
 
+// Keyboard activation for the mic (WCAG 2.1.1): Enter/Space toggles recording.
+// In SMRT mode the text field is read-only, so this is the only keyboard path
+// to enter a value — it must not be removed.
+function handleMicKeydown(e: KeyboardEvent) {
+  if (e.key !== 'Enter' && e.key !== ' ') return;
+  e.preventDefault();
+  e.stopPropagation();
+  if (isHolding) {
+    stopHoldRecording();
+  } else {
+    startHoldRecording();
+  }
+}
+
 function handleNativeChange(e: Event) {
   const target = e.target as HTMLInputElement;
   updateValue(target.value);
@@ -319,6 +345,7 @@ function handleNativeChange(e: Event) {
         class:active={isHolding}
         disabled={disabled || isParsing}
         onclick={handleMicClick}
+        onkeydown={handleMicKeydown}
         onmousedown={handleMicMouseDown}
         onmouseup={handleMouseUp}
         onmouseleave={handleMouseLeave}

--- a/packages/smrt-svelte/src/components/forms/FileUpload.svelte
+++ b/packages/smrt-svelte/src/components/forms/FileUpload.svelte
@@ -204,7 +204,9 @@ function formatFileSize(bytes: number): string {
   </div>
 
   {#if error}
-    <p class="file-upload__error">{error}</p>
+    <!-- Live region so async validation/reject errors are announced (C7),
+         matching the Form/TextInput announcing pattern. -->
+    <p class="file-upload__error" role="alert" aria-live="assertive">{error}</p>
   {/if}
 
   {#if files.length > 0}

--- a/packages/smrt-svelte/src/components/forms/Form.svelte
+++ b/packages/smrt-svelte/src/components/forms/Form.svelte
@@ -5,6 +5,7 @@ import { onDestroy } from 'svelte';
 import { useAppState } from '../../hooks/useAppState.svelte.js';
 import { useSTT } from '../../hooks/useSTT.svelte.js';
 import { M } from '../../i18n/strings.forms.js';
+import { logger } from '../../internal/logger.js';
 import {
   type FieldDefinition,
   type SMRTFormContext,
@@ -253,7 +254,6 @@ async function startAudioLevelMonitoring(stream: MediaStream) {
 
     const dataArray = new Uint8Array(analyser.frequencyBinCount);
     const SPEECH_THRESHOLD = 20; // Lowered from 30 for better sensitivity
-    let checksWithSpeech = 0;
 
     audioLevelInterval = setInterval(() => {
       if (!analyser || !isFormListening) return;
@@ -261,17 +261,22 @@ async function startAudioLevelMonitoring(stream: MediaStream) {
       analyser.getByteFrequencyData(dataArray);
       const average = dataArray.reduce((a, b) => a + b, 0) / dataArray.length;
 
-      // Log periodically to debug
-      checksWithSpeech++;
-      if (checksWithSpeech % 10 === 0) {
-      }
-
       if (average > SPEECH_THRESHOLD) {
         // Speech detected - reset silence timer
         resetSilenceTimer();
       }
     }, 200); // Check every 200ms
-  } catch (err) {}
+  } catch (err) {
+    // Audio-level monitoring is a silence-detection enhancement, not the
+    // recording path itself — surface the failure but don't abort listening.
+    // A getUserMedia/AudioContext denial here usually means mic-permission
+    // issues the user needs to see (C3).
+    extractError =
+      err instanceof Error
+        ? `Microphone monitoring unavailable: ${err.message}`
+        : 'Microphone monitoring unavailable';
+    logger.warn('Form: audio-level monitoring failed to start', { error: err });
+  }
 }
 
 // Stop audio level monitoring
@@ -369,37 +374,68 @@ async function startFormListening() {
   // Set starting flag to prevent premature stop detection
   isStarting = true;
 
-  // Initialize STT with selected adapter
-  if (!stt.isReady || stt.adapterType !== sttAdapter) {
-    await stt.initialize({ type: sttAdapter });
+  // STT init / start can reject (model fetch failure, mic-permission denial).
+  // Without this guard `isStarting`/`isFormListening` would stay set, the
+  // auto-stop $effect (gated on `!isStarting`) would stay suppressed, and the
+  // form would wedge in a permanent "listening" state with no surfaced error
+  // (C2). On failure: tear down, reset flags, and show the error.
+  try {
+    // Initialize STT with selected adapter
+    if (!stt.isReady || stt.adapterType !== sttAdapter) {
+      await stt.initialize({ type: sttAdapter });
+    }
+
+    extractError = null;
+    spokenText = '';
+    // Set to current stale result so the effect skips it, but new results will be processed
+    lastProcessedResult = stt.lastResult || '';
+    isFormListening = true;
+    isStopping = false;
+    lastSpeechTime = Date.now();
+
+    // Start silence timer
+    resetSilenceTimer();
+
+    // Start audio level monitoring for Whisper (no interim results)
+    // Browser STT has interim results so doesn't need this
+    if (sttAdapter === 'whisper-wasm') {
+      try {
+        const levelStream = await navigator.mediaDevices.getUserMedia({
+          audio: true,
+        });
+        startAudioLevelMonitoring(levelStream);
+      } catch (err) {
+        // Mic-permission denial / no device — surface it; the user must see
+        // why dictation isn't working (C3).
+        extractError =
+          err instanceof Error
+            ? `Microphone access failed: ${err.message}`
+            : 'Microphone access failed';
+        logger.warn('Form: getUserMedia failed for audio-level monitoring', {
+          error: err,
+        });
+      }
+    }
+
+    await stt.start({ continuous: true, interimResults: true });
+  } catch (err) {
+    // Reset listening state so the form isn't wedged, and stop any monitoring
+    // that may have started before the failure.
+    isFormListening = false;
+    stopAudioLevelMonitoring();
+    if (silenceTimer) {
+      clearTimeout(silenceTimer);
+      silenceTimer = null;
+    }
+    extractError =
+      err instanceof Error
+        ? err.message
+        : 'Could not start voice input. Check microphone permissions.';
+    logger.error('Form: failed to start form listening', { error: err });
+  } finally {
+    // Clear starting flag now that STT is actually listening (or has failed).
+    isStarting = false;
   }
-
-  extractError = null;
-  spokenText = '';
-  // Set to current stale result so the effect skips it, but new results will be processed
-  lastProcessedResult = stt.lastResult || '';
-  isFormListening = true;
-  isStopping = false;
-  lastSpeechTime = Date.now();
-
-  // Start silence timer
-  resetSilenceTimer();
-
-  // Start audio level monitoring for Whisper (no interim results)
-  // Browser STT has interim results so doesn't need this
-  if (sttAdapter === 'whisper-wasm') {
-    try {
-      const levelStream = await navigator.mediaDevices.getUserMedia({
-        audio: true,
-      });
-      startAudioLevelMonitoring(levelStream);
-    } catch (err) {}
-  }
-
-  await stt.start({ continuous: true, interimResults: true });
-
-  // Clear starting flag now that STT is actually listening
-  isStarting = false;
 }
 
 async function stopFormListening() {
@@ -730,7 +766,7 @@ function getFormData(): Record<string, unknown> {
        was never emitted (issue #1431); color-mix derives the alpha from the
        emitted `--smrt-color-primary` token instead. */
     background: color-mix(in srgb, var(--smrt-color-primary, #166534) 90%, transparent);
-    color: white;
+    color: var(--smrt-color-on-primary, #fff);
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     box-shadow: 0 -2px 12px color-mix(in srgb, var(--smrt-color-shadow) 15%, transparent);
     z-index: var(--smrt-z-index-toast, 1500);

--- a/packages/smrt-svelte/src/components/forms/FormMicButton.svelte
+++ b/packages/smrt-svelte/src/components/forms/FormMicButton.svelte
@@ -29,13 +29,8 @@ let isExtracting = $state(false);
 $effect(() => {
   const checkState = () => {
     if (formContext) {
-      const newListening = formContext.isFormListening;
-      const newExtracting = formContext.isExtracting;
-      // Only log on change to reduce noise
-      if (newListening !== isListening || newExtracting !== isExtracting) {
-      }
-      isListening = newListening;
-      isExtracting = newExtracting;
+      isListening = formContext.isFormListening;
+      isExtracting = formContext.isExtracting;
     }
   };
 
@@ -51,6 +46,14 @@ $effect(() => {
 function handleClick() {
   formContext?.toggleListening();
 }
+
+// Keyboard activation for the role="button" span. A native <button> activates
+// on both Enter and Space; this custom control must replicate both (CS2).
+function handleKeydown(e: KeyboardEvent) {
+  if (e.key !== 'Enter' && e.key !== ' ') return;
+  e.preventDefault();
+  handleClick();
+}
 </script>
 
 {#if isSmrt && formContext}
@@ -59,7 +62,7 @@ function handleClick() {
     class:listening={isListening}
     class:extracting={isExtracting}
     onclick={handleClick}
-    onkeydown={(e) => e.key === 'Enter' && handleClick()}
+    onkeydown={handleKeydown}
     role="button"
     tabindex="0"
     aria-label={isListening ? 'Stop listening' : 'Click to speak'}
@@ -131,8 +134,8 @@ function handleClick() {
     transform: translateX(-50%);
     margin-top: 0.5rem;
     padding: 0.5rem 0.75rem;
-    background: var(--smrt-color-on-surface, #1f2937);
-    color: white;
+    background: var(--smrt-color-inverse-surface, var(--smrt-color-on-surface, #1f2937));
+    color: var(--smrt-color-inverse-on-surface, #fff);
     font-size: var(--smrt-typography-label-medium-size, 0.75rem);
     font-weight: var(--smrt-typography-weight-normal, 400);
     border-radius: 0.375rem;
@@ -148,7 +151,7 @@ function handleClick() {
     left: 50%;
     transform: translateX(-50%);
     border: 6px solid transparent;
-    border-bottom-color: var(--smrt-color-on-surface);
+    border-bottom-color: var(--smrt-color-inverse-surface, var(--smrt-color-on-surface));
   }
 
   @keyframes pulse {

--- a/packages/smrt-svelte/src/components/forms/PhoneInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/PhoneInput.svelte
@@ -4,6 +4,7 @@ import { onDestroy, onMount } from 'svelte';
 import { useAppState } from '../../hooks/useAppState.svelte.js';
 import { useSTT } from '../../hooks/useSTT.svelte.js';
 import { M } from '../../i18n/strings.forms.js';
+import { logger } from '../../internal/logger.js';
 import {
   type FieldDefinition,
   tryGetFormContext,
@@ -162,15 +163,26 @@ onDestroy(() => {
 async function startHoldRecording() {
   if (!isSmrt || disabled || isProcessing) return;
 
-  if (!stt.isReady || stt.adapterType !== 'whisper-wasm') {
-    await stt.initialize({ type: 'whisper-wasm' });
-  }
-
   processError = null;
   recordingStartTime = Date.now();
   isHolding = true;
 
-  await stt.start({ continuous: true, interimResults: false });
+  // Guard STT init / mic acquisition so a rejection can't leave the field
+  // wedged in a permanent "Recording..." state with no visible error (C2).
+  try {
+    if (!stt.isReady || stt.adapterType !== 'whisper-wasm') {
+      await stt.initialize({ type: 'whisper-wasm' });
+    }
+    await stt.start({ continuous: true, interimResults: false });
+  } catch (err) {
+    isHolding = false;
+    processError =
+      err instanceof Error ? err.message : 'Could not start voice input';
+    logger.error('PhoneInput: failed to start voice recording', {
+      field: name,
+      error: err,
+    });
+  }
 }
 
 async function stopHoldRecording() {
@@ -232,6 +244,17 @@ function handleTouchEnd() {
   stopHoldRecording();
 }
 
+// Keyboard activation for the mic (WCAG 2.1.1): Enter/Space toggles recording.
+function handleMicKeydown(e: KeyboardEvent) {
+  if (e.key !== 'Enter' && e.key !== ' ') return;
+  e.preventDefault();
+  if (isHolding) {
+    stopHoldRecording();
+  } else {
+    startHoldRecording();
+  }
+}
+
 function handleInput(e: Event) {
   const target = e.target as HTMLInputElement;
   const formatted = formatPhoneNumber(target.value);
@@ -281,6 +304,7 @@ function handleInput(e: Event) {
         class="mic-btn"
         class:active={isHolding}
         {disabled}
+        onkeydown={handleMicKeydown}
         onmousedown={handleMouseDown}
         onmouseup={handleMouseUp}
         onmouseleave={handleMouseLeave}

--- a/packages/smrt-svelte/src/components/forms/TextInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/TextInput.svelte
@@ -9,6 +9,7 @@ import { onDestroy, onMount } from 'svelte';
 import { useAppState } from '../../hooks/useAppState.svelte.js';
 import { useSTT } from '../../hooks/useSTT.svelte.js';
 import { M } from '../../i18n/strings.forms.js';
+import { logger } from '../../internal/logger.js';
 import {
   type FieldDefinition,
   tryGetFormContext,
@@ -115,19 +116,31 @@ onDestroy(() => {
 async function startHoldRecording() {
   if (!isSmrt || disabled || isProcessing) return;
 
-  // Initialize STT with Whisper v2 for speed + accuracy
-  if (!stt.isReady || stt.adapterType !== 'whisper-wasm') {
-    await stt.initialize({ type: 'whisper-wasm' });
-  }
-
   // Store current value for append mode
   valueBeforeRecording = value;
   processError = null;
   recordingStartTime = Date.now();
   isHolding = true;
 
-  // Use continuous mode to capture all speech while holding
-  await stt.start({ continuous: true, interimResults: false });
+  // STT init / mic acquisition can reject (model fetch failure, mic-permission
+  // denial). Without this guard `isHolding` would stay true and no error would
+  // surface, wedging the field in a permanent "Recording..." state (C2).
+  try {
+    // Initialize STT with Whisper v2 for speed + accuracy
+    if (!stt.isReady || stt.adapterType !== 'whisper-wasm') {
+      await stt.initialize({ type: 'whisper-wasm' });
+    }
+    // Use continuous mode to capture all speech while holding
+    await stt.start({ continuous: true, interimResults: false });
+  } catch (err) {
+    isHolding = false;
+    processError =
+      err instanceof Error ? err.message : 'Could not start voice input';
+    logger.error('TextInput: failed to start voice recording', {
+      field: name,
+      error: err,
+    });
+  }
 }
 
 async function stopHoldRecording() {
@@ -202,6 +215,20 @@ function handleMicClick(e: MouseEvent) {
   e.stopPropagation();
 }
 
+// Keyboard activation for the mic (WCAG 2.1.1). The pointer flow is
+// hold-to-record; keyboard maps to a toggle — Enter/Space starts recording,
+// pressing again stops. preventDefault stops Space from also firing the
+// button's synthetic click and from scrolling the page.
+function handleMicKeydown(e: KeyboardEvent) {
+  if (e.key !== 'Enter' && e.key !== ' ') return;
+  e.preventDefault();
+  if (isHolding) {
+    stopHoldRecording();
+  } else {
+    startHoldRecording();
+  }
+}
+
 function handleInput(e: Event) {
   const target = e.target as HTMLInputElement;
   updateValue(target.value);
@@ -253,6 +280,7 @@ function handleInput(e: Event) {
         {disabled}
         use:ripple
         onclick={handleMicClick}
+        onkeydown={handleMicKeydown}
         onmousedown={(e) => { e.stopPropagation(); if (e.button === 0) startHoldRecording(); }}
         onmouseup={handleMouseUp}
         onmouseleave={handleMouseLeave}

--- a/packages/smrt-svelte/src/components/forms/TextareaInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/TextareaInput.svelte
@@ -6,6 +6,7 @@ import { onDestroy, onMount } from 'svelte';
 import { useAppState } from '../../hooks/useAppState.svelte.js';
 import { useSTT } from '../../hooks/useSTT.svelte.js';
 import { M } from '../../i18n/strings.forms.js';
+import { logger } from '../../internal/logger.js';
 import {
   type FieldDefinition,
   tryGetFormContext,
@@ -103,16 +104,27 @@ onDestroy(() => {
 async function startHoldRecording() {
   if (!isSmrt || disabled || isProcessing) return;
 
-  if (!stt.isReady || stt.adapterType !== 'whisper-wasm') {
-    await stt.initialize({ type: 'whisper-wasm' });
-  }
-
   valueBeforeRecording = value;
   processError = null;
   recordingStartTime = Date.now();
   isHolding = true;
 
-  await stt.start({ continuous: true, interimResults: false });
+  // Guard STT init / mic acquisition so a rejection can't leave the field
+  // wedged in a permanent "Recording..." state with no visible error (C2).
+  try {
+    if (!stt.isReady || stt.adapterType !== 'whisper-wasm') {
+      await stt.initialize({ type: 'whisper-wasm' });
+    }
+    await stt.start({ continuous: true, interimResults: false });
+  } catch (err) {
+    isHolding = false;
+    processError =
+      err instanceof Error ? err.message : 'Could not start voice input';
+    logger.error('TextareaInput: failed to start voice recording', {
+      field: name,
+      error: err,
+    });
+  }
 }
 
 async function stopHoldRecording() {
@@ -179,6 +191,17 @@ function handleTouchEnd() {
   stopHoldRecording();
 }
 
+// Keyboard activation for the mic (WCAG 2.1.1): Enter/Space toggles recording.
+function handleMicKeydown(e: KeyboardEvent) {
+  if (e.key !== 'Enter' && e.key !== ' ') return;
+  e.preventDefault();
+  if (isHolding) {
+    stopHoldRecording();
+  } else {
+    startHoldRecording();
+  }
+}
+
 function handleInput(e: Event) {
   const target = e.target as HTMLTextAreaElement;
   updateValue(target.value);
@@ -228,6 +251,7 @@ function handleInput(e: Event) {
         class:active={isHolding}
         {disabled}
         use:ripple
+        onkeydown={handleMicKeydown}
         onmousedown={(e) => { e.stopPropagation(); if (e.button === 0) startHoldRecording(); }}
         onmouseup={handleMouseUp}
         onmouseleave={handleMouseLeave}

--- a/packages/smrt-svelte/src/components/forms/__tests__/FileUpload.error-alert.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/FileUpload.error-alert.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression: FileUpload validation errors are announced (C7).
+ *
+ * The error `<p>` was a plain element, so async reject errors (wrong type /
+ * oversize) were not surfaced to screen readers — unlike Form/TextInput which
+ * announce. The fix makes it a live region (role="alert" + aria-live).
+ */
+import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import FileUpload from '../FileUpload.svelte';
+
+function fileInput(container: HTMLElement): HTMLInputElement {
+  const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+  if (!input) throw new Error('file input not found');
+  return input;
+}
+
+describe('FileUpload — error live region (C7)', () => {
+  it('announces a max-size error via role="alert"', async () => {
+    const { container } = render(FileUpload, {
+      // maxSize forces a validation error without an `accept` filter (which
+      // userEvent.upload would otherwise apply before the file reaches the
+      // component, suppressing the error path under test).
+      props: { label: 'Upload', maxSize: 4 },
+    });
+
+    const big = new File(['way too many bytes'], 'big.bin', {
+      type: 'application/octet-stream',
+    });
+    await userEvent.upload(fileInput(container), big);
+
+    await waitFor(() => {
+      const alert = screen.getByRole('alert');
+      expect(alert).toBeInTheDocument();
+      expect(alert).toHaveAttribute('aria-live');
+      expect(alert.textContent).toMatch(/maximum size/i);
+    });
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/Form.stt-error.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/Form.stt-error.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Regression: Form voice-listening init failures don't wedge the form (C2/C3).
+ *
+ * `startFormListening` awaited `stt.initialize()`/`stt.start()` with no
+ * try/catch. On rejection the listening flags stayed set, the auto-stop $effect
+ * (gated on !isStarting) was suppressed, and the form was stuck in a permanent
+ * "listening" state with no surfaced error. The fix wraps the flow in
+ * try/catch/finally: reset the flags and show the error.
+ */
+import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it, vi } from 'vitest';
+
+const sttStub = {
+  isListening: false,
+  isInitializing: false,
+  isReady: false,
+  adapterType: null as string | null,
+  downloadProgress: 0,
+  lastResult: '',
+  initialize: vi.fn(async () => {
+    throw new Error('model download failed');
+  }),
+  start: vi.fn(async () => {}),
+  stop: vi.fn(async () => {}),
+};
+
+vi.mock('../../../hooks/useAppState.svelte.js', () => ({
+  useAppState: () => ({ state: { mode: 'smrt' }, setMode: vi.fn() }),
+}));
+vi.mock('../../../hooks/useSTT.svelte.js', () => ({
+  useSTT: () => sttStub,
+}));
+
+import Form from '../Form.svelte';
+
+function child() {
+  return createRawSnippet(() => ({
+    render: () => '<span>fields</span>',
+  }));
+}
+
+describe('Form — voice-listening init failure (C2)', () => {
+  it('surfaces an error and does not wedge when STT init rejects', async () => {
+    render(Form, {
+      props: { children: child(), showFormListen: true },
+    });
+
+    // The form-listen button is shown in smrt mode; clicking it starts listening.
+    const listenBtn = screen.getByRole('button');
+    await userEvent.click(listenBtn);
+
+    // initialize() rejected — an error must be surfaced (role=alert region).
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('alert').textContent).toMatch(
+      /model download failed/i,
+    );
+
+    // And the form is NOT wedged: the polite status region is not stuck on the
+    // "listening" message (listening flag was reset).
+    const status = screen.getByRole('status');
+    expect(status.textContent?.trim()).toBe('');
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/FormMicButton.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/FormMicButton.test.ts
@@ -85,6 +85,14 @@ describe('FormMicButton', () => {
     expect(toggleListening).toHaveBeenCalledTimes(1);
   });
 
+  it('toggles listening when activated with Space (CS2)', async () => {
+    render(FormMicButton);
+    const button = screen.getByRole('button', { name: 'Click to speak' });
+    button.focus();
+    await userEvent.keyboard(' ');
+    expect(toggleListening).toHaveBeenCalledTimes(1);
+  });
+
   it('relabels to "Stop listening" once the form is listening', async () => {
     formState = { isFormListening: true, isExtracting: false };
     render(FormMicButton);

--- a/packages/smrt-svelte/src/components/forms/__tests__/mic-keyboard-a11y.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/mic-keyboard-a11y.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression: per-field voice mics are keyboard-operable (C1, WCAG 2.1.1).
+ *
+ * Before the fix the mic <button>s were bound only to mousedown/up + touch
+ * handlers (onclick was a no-op preventDefault), so a keyboard user could focus
+ * the mic but never record. The fix adds Enter/Space toggle activation, mirror-
+ * ing FormMicButton. TextInput is the representative editable field;
+ * DateTimeInput is covered too because its SMRT-mode text input is read-only —
+ * the mic is the ONLY keyboard entry path there.
+ *
+ * useAppState/useSTT throw outside a <Provider>, so both are mocked. The STT
+ * stub starts `isReady: true` so the hold flow skips initialize() and the
+ * start()/stop() spies fire synchronously enough to assert.
+ */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sttStub = {
+  isListening: false,
+  isInitializing: false,
+  isReady: true,
+  adapterType: 'whisper-wasm',
+  downloadProgress: 0,
+  lastResult: '',
+  initialize: vi.fn(async () => {}),
+  start: vi.fn(async () => {}),
+  stop: vi.fn(async () => {}),
+};
+
+vi.mock('../../../hooks/useAppState.svelte.js', () => ({
+  useAppState: () => ({ state: { mode: 'smrt' }, setMode: vi.fn() }),
+}));
+vi.mock('../../../hooks/useSTT.svelte.js', () => ({
+  useSTT: () => sttStub,
+}));
+
+import DateTimeInput from '../DateTimeInput.svelte';
+import TextInput from '../TextInput.svelte';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sttStub.adapterType = 'whisper-wasm';
+});
+
+describe('TextInput mic — keyboard activation (C1)', () => {
+  it('exposes the mic as a focusable button with an accessible name', () => {
+    render(TextInput, { props: { name: 'note', label: 'Note' } });
+    const mic = screen.getByRole('button', { name: /speak|mic|voice/i });
+    expect(mic).toBeInTheDocument();
+    // Native <button> => in the tab order (not an empty/dead tab stop).
+    expect(mic).not.toHaveAttribute('tabindex', '-1');
+  });
+
+  it('starts recording on Enter and stops on the next Enter (toggle)', async () => {
+    render(TextInput, { props: { name: 'note', label: 'Note' } });
+    const mic = screen.getByRole('button', { name: /speak|mic|voice/i });
+
+    mic.focus();
+    await userEvent.keyboard('{Enter}');
+    expect(sttStub.start).toHaveBeenCalledTimes(1);
+
+    await userEvent.keyboard('{Enter}');
+    expect(sttStub.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts recording on Space', async () => {
+    render(TextInput, { props: { name: 'note', label: 'Note' } });
+    const mic = screen.getByRole('button', { name: /speak|mic|voice/i });
+
+    mic.focus();
+    await userEvent.keyboard(' ');
+    expect(sttStub.start).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('DateTimeInput mic — keyboard activation (C1)', () => {
+  it('records via keyboard even though the text field is read-only', async () => {
+    render(DateTimeInput, { props: { name: 'when', label: 'When' } });
+    const mic = screen.getByRole('button', { name: /speak|mic|voice|date/i });
+
+    mic.focus();
+    await userEvent.keyboard('{Enter}');
+    expect(sttStub.start).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/smrt-svelte/src/hooks/__tests__/stt-consumer.fixture.svelte
+++ b/packages/smrt-svelte/src/hooks/__tests__/stt-consumer.fixture.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+/**
+ * Test consumer that calls the real `useSTT()` hook so its `onDestroy`
+ * per-hook ownership logic (R4) runs when this component unmounts.
+ */
+import { type UseSTTReturn, useSTT } from '../useSTT.svelte.js';
+
+interface Props {
+  /** Hand the live hook back to the test so it can call start()/stop(). */
+  onReady?: (stt: UseSTTReturn) => void;
+  /** If true, start a listening session as soon as this consumer mounts. */
+  autoStart?: boolean;
+}
+
+const { onReady, autoStart = false }: Props = $props();
+
+const stt = useSTT();
+// This fixture intentionally snapshots props during setup (test-only).
+// svelte-ignore state_referenced_locally
+onReady?.(stt);
+// svelte-ignore state_referenced_locally
+if (autoStart) {
+  void stt.start();
+}
+</script>

--- a/packages/smrt-svelte/src/hooks/__tests__/stt-ownership-harness.svelte
+++ b/packages/smrt-svelte/src/hooks/__tests__/stt-ownership-harness.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+/**
+ * R4 harness: sets a fake app-state manager on context, then mounts/unmounts
+ * `useSTT()` consumers so the test can prove per-hook ownership — unmounting a
+ * consumer that did NOT start listening must not stop the shared singleton.
+ */
+import type { SmrtAppStateManager } from '../../state/app-state.svelte.js';
+import { setAppStateContext } from '../../state/context.js';
+import type { UseSTTReturn } from '../useSTT.svelte.js';
+import SttConsumer from './stt-consumer.fixture.svelte';
+
+interface Props {
+  manager: SmrtAppStateManager;
+  showA?: boolean;
+  showB?: boolean;
+  onReadyA?: (stt: UseSTTReturn) => void;
+  onReadyB?: (stt: UseSTTReturn) => void;
+  autoStartA?: boolean;
+  autoStartB?: boolean;
+}
+
+const {
+  manager,
+  showA = true,
+  showB = true,
+  onReadyA,
+  onReadyB,
+  autoStartA = false,
+  autoStartB = false,
+}: Props = $props();
+
+// Context is set once during setup with the initial manager (test-only).
+// svelte-ignore state_referenced_locally
+setAppStateContext(manager);
+</script>
+
+{#if showA}
+  <SttConsumer onReady={onReadyA} autoStart={autoStartA} />
+{/if}
+{#if showB}
+  <SttConsumer onReady={onReadyB} autoStart={autoStartB} />
+{/if}

--- a/packages/smrt-svelte/src/hooks/__tests__/useSTT-ownership.test.ts
+++ b/packages/smrt-svelte/src/hooks/__tests__/useSTT-ownership.test.ts
@@ -1,0 +1,117 @@
+/**
+ * R4 regression (T2 #1403): useSTT()/useTTS() attach onDestroy to the
+ * Provider-level *singleton* manager. Before the fix, unmounting ANY hook
+ * consumer that found the manager listening would call stopListening() —
+ * aborting a recording another consumer had started. The fix tracks per-hook
+ * ownership: a consumer only stops the singleton if it started the session.
+ */
+import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { describe, expect, it, vi } from 'vitest';
+import type { SmrtAppStateManager } from '../../state/app-state.svelte.js';
+import type { UseSTTReturn } from '../useSTT.svelte.js';
+import Harness from './stt-ownership-harness.svelte';
+
+/**
+ * Minimal fake manager exposing only what useSTT touches. `isListening`
+ * flips true once any consumer calls startListening().
+ */
+function makeFakeManager() {
+  const listening = { value: false };
+  const startListening = vi.fn(async () => {
+    listening.value = true;
+  });
+  const stopListening = vi.fn(async () => {
+    listening.value = false;
+  });
+  const manager = {
+    startListening,
+    stopListening,
+    initializeSTT: vi.fn(async () => ({})),
+    get state() {
+      return {
+        ai: {
+          stt: {
+            get isListening() {
+              return listening.value;
+            },
+          },
+        },
+      };
+    },
+  } as unknown as SmrtAppStateManager;
+  return { manager, startListening, stopListening, listening };
+}
+
+describe('useSTT per-hook ownership (R4)', () => {
+  it("unmounting a non-owning consumer does not stop another consumer's recording", async () => {
+    const { manager, startListening, stopListening } = makeFakeManager();
+    let sttA: UseSTTReturn | undefined;
+
+    const { rerender, unmount } = render(Harness, {
+      props: {
+        manager,
+        showA: true,
+        showB: true,
+        onReadyA: (s: UseSTTReturn) => {
+          sttA = s;
+        },
+      },
+    });
+
+    // Consumer A starts the shared listening session.
+    await sttA?.start();
+    await tick();
+    expect(startListening).toHaveBeenCalledTimes(1);
+
+    // Unmount consumer B (which never started). It must NOT stop A's session.
+    await rerender({ manager, showA: true, showB: false });
+    await tick();
+    expect(stopListening).not.toHaveBeenCalled();
+
+    // Now unmount everything: the owning consumer A stops its own session.
+    unmount();
+    await tick();
+    expect(stopListening).toHaveBeenCalledTimes(1);
+  });
+
+  it('an owning consumer stops the session it started on unmount', async () => {
+    const { manager, startListening, stopListening } = makeFakeManager();
+    let sttA: UseSTTReturn | undefined;
+
+    const { unmount } = render(Harness, {
+      props: {
+        manager,
+        showA: true,
+        showB: false,
+        onReadyA: (s: UseSTTReturn) => {
+          sttA = s;
+        },
+      },
+    });
+
+    await sttA?.start();
+    await tick();
+    expect(startListening).toHaveBeenCalledTimes(1);
+
+    unmount();
+    await tick();
+    expect(stopListening).toHaveBeenCalledTimes(1);
+  });
+
+  it('a consumer that never started does not stop a session on unmount', async () => {
+    const { manager, stopListening, listening } = makeFakeManager();
+    // Simulate the singleton already listening (started elsewhere).
+    listening.value = true;
+
+    const { unmount } = render(Harness, {
+      props: { manager, showA: true, showB: false },
+    });
+    await tick();
+
+    // Consumer A never called start(); unmounting must leave the session alone.
+    unmount();
+    await tick();
+    expect(stopListening).not.toHaveBeenCalled();
+  });
+});

--- a/packages/smrt-svelte/src/hooks/useSTT.svelte.ts
+++ b/packages/smrt-svelte/src/hooks/useSTT.svelte.ts
@@ -73,6 +73,11 @@ export interface UseSTTReturn {
 export function useSTT(options: UseSTTOptions = {}): UseSTTReturn {
   const app = getAppStateContext();
 
+  // The STT manager is a Provider-level singleton shared by every useSTT()
+  // consumer. Track whether *this* hook started the current listening session
+  // so unmounting one <VoiceInput> doesn't abort another's recording (R4).
+  let startedByThisHook = false;
+
   // Auto-initialize if requested
   if (options.autoInit) {
     app.initializeSTT().catch(() => {
@@ -81,13 +86,20 @@ export function useSTT(options: UseSTTOptions = {}): UseSTTReturn {
   }
 
   const start = async (sttOptions?: STTOptions) => {
-    await app.startListening({
-      ...options.defaultOptions,
-      ...sttOptions,
-    });
+    startedByThisHook = true;
+    try {
+      await app.startListening({
+        ...options.defaultOptions,
+        ...sttOptions,
+      });
+    } catch (err) {
+      startedByThisHook = false;
+      throw err;
+    }
   };
 
   const stop = async () => {
+    startedByThisHook = false;
     await app.stopListening();
   };
 
@@ -95,11 +107,13 @@ export function useSTT(options: UseSTTOptions = {}): UseSTTReturn {
     await app.initializeSTT(initOptions);
   };
 
-  // Cleanup on destroy
+  // Cleanup on destroy: only stop the shared singleton if this hook owns the
+  // in-progress session (R4) — never stop a recording another hook started.
   onDestroy(() => {
-    if (app.state.ai.stt.isListening) {
+    if (startedByThisHook && app.state.ai.stt.isListening) {
       app.stopListening().catch(() => {});
     }
+    startedByThisHook = false;
   });
 
   return {

--- a/packages/smrt-svelte/src/hooks/useTTS.svelte.ts
+++ b/packages/smrt-svelte/src/hooks/useTTS.svelte.ts
@@ -70,6 +70,11 @@ export interface UseTTSReturn {
 export function useTTS(options: UseTTSOptions = {}): UseTTSReturn {
   const app = getAppStateContext();
 
+  // The TTS manager is a Provider-level singleton shared by every useTTS()
+  // consumer. Track whether *this* hook started the current speech so
+  // unmounting one component doesn't cut off another's playback (R4).
+  let startedByThisHook = false;
+
   // Auto-initialize if requested
   if (options.autoInit) {
     app.initializeTTS().catch(() => {
@@ -78,13 +83,20 @@ export function useTTS(options: UseTTSOptions = {}): UseTTSReturn {
   }
 
   const speak = async (text: string, ttsOptions?: TTSOptions) => {
-    await app.speak(text, {
-      ...options.defaultOptions,
-      ...ttsOptions,
-    });
+    startedByThisHook = true;
+    try {
+      await app.speak(text, {
+        ...options.defaultOptions,
+        ...ttsOptions,
+      });
+    } finally {
+      // Speech has finished (or errored) — this hook no longer owns playback.
+      startedByThisHook = false;
+    }
   };
 
   const stop = () => {
+    startedByThisHook = false;
     app.stopSpeaking();
   };
 
@@ -104,11 +116,13 @@ export function useTTS(options: UseTTSOptions = {}): UseTTSReturn {
     return app.getTTSVoices();
   };
 
-  // Cleanup on destroy
+  // Cleanup on destroy: only stop the shared singleton if this hook owns the
+  // in-progress speech (R4) — never cut off speech another hook started.
   onDestroy(() => {
-    if (app.state.ai.tts.isSpeaking) {
+    if (startedByThisHook && app.state.ai.tts.isSpeaking) {
       app.stopSpeaking();
     }
+    startedByThisHook = false;
   });
 
   return {

--- a/packages/smrt-svelte/src/i18n/server.ts
+++ b/packages/smrt-svelte/src/i18n/server.ts
@@ -9,11 +9,11 @@
  * A consumer's load function calls `buildI18nSnapshot` for the request locale
  * and passes the result to `<Provider i18n={snapshot}>`.
  *
- * Requires `@happyvertical/smrt-languages` to be installed. It is an *optional*
- * peer of smrt-svelte by design — the client i18n layer (`/i18n`) is
- * languages-free, so apps that never use this server bridge are not forced to
- * pull the languages server dependency tree (smrt-core/sql/ai/jobs). Importing
- * this subpath without languages installed is a clear module-not-found error.
+ * `@happyvertical/smrt-languages` is a hard `dependency` of smrt-svelte (see
+ * `package.json`), so it is always installed. The client i18n layer (`/i18n`)
+ * stays languages-free regardless: it never imports the languages root, so the
+ * server tree (smrt-core/sql/ai/jobs) is tree-shaken out of the browser bundle
+ * — only this Node-only `/i18n/server` subpath pulls it in.
  */
 import {
   defineLanguageString,

--- a/packages/smrt-svelte/src/internal/logger.ts
+++ b/packages/smrt-svelte/src/internal/logger.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared package logger for `@happyvertical/smrt-svelte`.
+ *
+ * Browser-safe: the `@happyvertical/logger` console adapter pulls no Node
+ * built-ins and its `@sentry/node` integration is an optional peer that is
+ * never imported here. Centralising the instance keeps voice/AI error reporting
+ * consistent across the form components (mic permission denials, STT init
+ * failures) instead of swallowing them in empty `catch` blocks or scattering
+ * raw `console.*` calls.
+ */
+import { createLogger, type Logger } from '@happyvertical/logger';
+
+export const logger: Logger = createLogger({ level: 'warn' });

--- a/packages/smrt-svelte/src/state/__tests__/app-state-ai-lifecycle.test.ts
+++ b/packages/smrt-svelte/src/state/__tests__/app-state-ai-lifecycle.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Regression tests for the browser-AI warm-cache lifecycle (T2 #1403):
+ *
+ * - R1 (listener leak): warm-cached adapters survive Provider remounts. Each
+ *   manager that subscribes must capture + later remove its listeners on
+ *   dispose(), and a shared adapter must never accumulate more than one live
+ *   listener set across managers.
+ * - R2 (state lies): dispose() must not leave a disposed adapter cached as
+ *   'ready'; unloadLLM() must downgrade the warm-cache entry so the next init
+ *   re-runs (reports progress) instead of cache-hitting a model-less adapter.
+ * - R3 (scheduler thrash): setAIConfig() must no-op on a deep-equal config
+ *   (inline `ai={{…}}` literal => new identity every render), and concurrent
+ *   executePreload() passes must be guarded.
+ * - R7 (nit): the empty-config early-return must reset loaded/failed too.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Fakes -----------------------------------------------------------------
+
+/**
+ * A fake STT/TTS adapter whose event-subscription methods return real
+ * unsubscribe handles backed by Sets — so a test can read the live listener
+ * count and prove subscriptions are torn down (R1).
+ */
+function makeFakeSTT(type = 'whisper-cpp') {
+  const sets = {
+    result: new Set<(r: unknown) => void>(),
+    start: new Set<() => void>(),
+    end: new Set<() => void>(),
+    error: new Set<(e: Error) => void>(),
+  };
+  const sub = <T>(set: Set<T>, cb: T) => {
+    set.add(cb);
+    return () => {
+      set.delete(cb);
+    };
+  };
+  return {
+    type,
+    dispose: vi.fn(async () => {}),
+    ensureInitialized: vi.fn(async () => {}),
+    start: vi.fn(async () => {}),
+    stop: vi.fn(async () => {}),
+    abort: vi.fn(),
+    isListening: () => false,
+    onResult: (cb: (r: unknown) => void) => sub(sets.result, cb),
+    onStart: (cb: () => void) => sub(sets.start, cb),
+    onEnd: (cb: () => void) => sub(sets.end, cb),
+    onError: (cb: (e: Error) => void) => sub(sets.error, cb),
+    /** total live listeners across all event sets */
+    listenerCount: () =>
+      sets.result.size + sets.start.size + sets.end.size + sets.error.size,
+  };
+}
+
+function makeFakeTTS(type = 'browser-synthesis') {
+  const sets = {
+    start: new Set<() => void>(),
+    end: new Set<() => void>(),
+    error: new Set<(e: Error) => void>(),
+  };
+  const sub = <T>(set: Set<T>, cb: T) => {
+    set.add(cb);
+    return () => {
+      set.delete(cb);
+    };
+  };
+  return {
+    type,
+    dispose: vi.fn(async () => {}),
+    ensureInitialized: vi.fn(async () => {}),
+    speak: vi.fn(async () => {}),
+    stop: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    getVoices: () => [],
+    onStart: (cb: () => void) => sub(sets.start, cb),
+    onEnd: (cb: () => void) => sub(sets.end, cb),
+    onError: (cb: (e: Error) => void) => sub(sets.error, cb),
+    listenerCount: () => sets.start.size + sets.end.size + sets.error.size,
+  };
+}
+
+function makeFakeLLM(type: 'webllm' = 'webllm', model = 'tiny-model') {
+  return {
+    type,
+    currentModel: model,
+    dispose: vi.fn(async () => {}),
+    ensureInitialized: vi.fn(async () => {}),
+    unloadModel: vi.fn(async () => {}),
+    message: vi.fn(async () => 'ok'),
+  };
+}
+
+// --- Module mocks ----------------------------------------------------------
+// The manager imports the AI factories + capability helpers from the browser-ai
+// barrel. Mock only those; keep everything else (types) real via importOriginal.
+
+const fakeSTT = makeFakeSTT();
+const fakeTTS = makeFakeTTS();
+const fakeLLM = makeFakeLLM();
+
+vi.mock('../../browser-ai/index.js', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    detectCapabilities: () => ({}),
+    canEnableSmrtMode: () => false,
+    getSTT: vi.fn(async () => fakeSTT),
+    getTTS: vi.fn(async () => fakeTTS),
+    getLLM: vi.fn(async () => fakeLLM),
+  };
+});
+
+import {
+  createAppState,
+  type SmrtAppStateManager,
+} from '../app-state.svelte.js';
+import { clearAllCaches, getCachedLLM, getCachedSTT } from '../warm-clients.js';
+
+beforeEach(async () => {
+  await clearAllCaches();
+});
+
+afterEach(async () => {
+  await clearAllCaches();
+  vi.clearAllMocks();
+});
+
+describe('R1: warm-adapter listener lifecycle', () => {
+  it("removes a manager's listeners on dispose()", async () => {
+    const m = createAppState();
+    await m.initializeSTT({ type: 'whisper-cpp' });
+    expect(fakeSTT.listenerCount()).toBeGreaterThan(0);
+
+    await m.dispose();
+    expect(fakeSTT.listenerCount()).toBe(0);
+  });
+
+  it('does not accumulate listeners across remounts of the same cached adapter', async () => {
+    // Manager 1 subscribes then disposes.
+    const m1 = createAppState();
+    await m1.initializeSTT({ type: 'whisper-cpp' });
+    const afterFirst = fakeSTT.listenerCount();
+    await m1.dispose();
+
+    // Manager 2 cache-hits the SAME warm adapter, subscribes, disposes.
+    const m2 = createAppState();
+    await m2.initializeSTT({ type: 'whisper-cpp' });
+    // Exactly one manager's worth of listeners while live — not doubled.
+    expect(fakeSTT.listenerCount()).toBe(afterFirst);
+    await m2.dispose();
+
+    expect(fakeSTT.listenerCount()).toBe(0);
+  });
+
+  it('keeps at most one live listener set when two managers coexist', async () => {
+    const m1 = createAppState();
+    await m1.initializeSTT({ type: 'whisper-cpp' });
+    const single = fakeSTT.listenerCount();
+
+    // A second live manager taking over the shared adapter must evict the
+    // first's listeners rather than stack a second set.
+    const m2 = createAppState();
+    await m2.initializeSTT({ type: 'whisper-cpp' });
+    expect(fakeSTT.listenerCount()).toBe(single);
+
+    await m1.dispose();
+    await m2.dispose();
+    expect(fakeSTT.listenerCount()).toBe(0);
+  });
+
+  it('removes TTS listeners on dispose()', async () => {
+    const m = createAppState();
+    await m.initializeTTS({ type: 'browser-synthesis' });
+    expect(fakeTTS.listenerCount()).toBeGreaterThan(0);
+    await m.dispose();
+    expect(fakeTTS.listenerCount()).toBe(0);
+  });
+
+  it('subscribing the same adapter twice on one manager is idempotent', async () => {
+    const m = createAppState();
+    await m.initializeSTT({ type: 'whisper-cpp' });
+    const once = fakeSTT.listenerCount();
+    // Second init cache-hits and re-enters subscribeToSTTEvents.
+    await m.initializeSTT({ type: 'whisper-cpp' });
+    expect(fakeSTT.listenerCount()).toBe(once);
+    await m.dispose();
+  });
+});
+
+describe('R2: dispose()/unloadLLM() do not leave the cache lying', () => {
+  it('dispose() leaves the warm STT adapter intact (not disposed) and cached ready', async () => {
+    const m = createAppState();
+    await m.initializeSTT({ type: 'whisper-cpp' });
+    await m.dispose();
+
+    // Cached adapter survives navigation and was NOT disposed — so a later
+    // init won't restore a dead engine reported as 'ready'.
+    const cached = getCachedSTT('whisper-cpp');
+    expect(cached?.initState).toBe('ready');
+    expect(cached?.adapter).toBe(fakeSTT);
+    expect(fakeSTT.dispose).not.toHaveBeenCalled();
+  });
+
+  it('unloadLLM() downgrades the warm-cache entry to uninitialized', async () => {
+    const m = createAppState();
+    await m.initializeLLM('tiny-model', { type: 'webllm' });
+    expect(getCachedLLM('webllm', 'tiny-model')?.initState).toBe('ready');
+
+    await m.unloadLLM();
+
+    // Next initializeLLM must re-run (report progress) rather than cache-hit a
+    // model-less adapter reported as 'ready'.
+    expect(getCachedLLM('webllm', 'tiny-model')?.initState).toBe(
+      'uninitialized',
+    );
+    await m.dispose();
+  });
+});
+
+describe('R3: setAIConfig scheduler thrash + preload re-entrancy', () => {
+  it('no-ops on a deep-equal config of a different identity', async () => {
+    const m: SmrtAppStateManager = createAppState();
+    const spy = vi.spyOn(
+      m as unknown as { schedulePreload: () => void },
+      'schedulePreload',
+    );
+
+    m.setAIConfig({ preload: 'none', stt: { type: 'whisper-cpp' } });
+    const callsAfterFirst = spy.mock.calls.length;
+    expect(callsAfterFirst).toBeGreaterThan(0);
+
+    // Same shape, brand-new object literal (what an inline `ai={{…}}` produces).
+    m.setAIConfig({ preload: 'none', stt: { type: 'whisper-cpp' } });
+    expect(spy.mock.calls.length).toBe(callsAfterFirst); // no re-schedule
+  });
+
+  it('re-schedules when the config actually changes', async () => {
+    const m: SmrtAppStateManager = createAppState();
+    const spy = vi.spyOn(
+      m as unknown as { schedulePreload: () => void },
+      'schedulePreload',
+    );
+
+    m.setAIConfig({ preload: 'none', stt: { type: 'whisper-cpp' } });
+    const before = spy.mock.calls.length;
+    m.setAIConfig({ preload: 'none', stt: { type: 'whisper-wasm' } });
+    expect(spy.mock.calls.length).toBe(before + 1);
+  });
+
+  it('guards executePreload against concurrent passes', async () => {
+    const m = createAppState();
+    m.setAIConfig({
+      preload: 'none',
+      stt: { type: 'whisper-cpp' },
+    });
+
+    const exec = (
+      m as unknown as { executePreload: () => Promise<void> }
+    ).executePreload.bind(m);
+
+    // Two overlapping passes: the second must early-return (guarded), so the
+    // STT factory is invoked once, not twice.
+    const { getSTT } = (await import(
+      '../../browser-ai/index.js'
+    )) as unknown as {
+      getSTT: ReturnType<typeof vi.fn>;
+    };
+    getSTT.mockClear();
+    await Promise.all([exec(), exec()]);
+    expect(getSTT).toHaveBeenCalledTimes(1);
+    await m.dispose();
+  });
+});
+
+describe('R7: empty-config preload early-return resets loaded/failed', () => {
+  it('clears stale loaded/failed entries', async () => {
+    const m = createAppState();
+    // Seed stale entries through a normal pass, then re-run with empty config.
+    m.setAIConfig({ preload: 'none', stt: { type: 'whisper-cpp' } });
+    await (
+      m as unknown as { executePreload: () => Promise<void> }
+    ).executePreload();
+    expect(m.aiLoading.loaded.length).toBeGreaterThan(0);
+
+    // Now an empty config — the early-return path must reset loaded/failed.
+    m.setAIConfig({ preload: 'none' });
+    await (
+      m as unknown as { executePreload: () => Promise<void> }
+    ).executePreload();
+
+    expect(m.aiLoading.phase).toBe('idle');
+    expect(m.aiLoading.loaded).toEqual([]);
+    expect(m.aiLoading.failed).toEqual([]);
+    await m.dispose();
+  });
+});

--- a/packages/smrt-svelte/src/state/app-state.svelte.ts
+++ b/packages/smrt-svelte/src/state/app-state.svelte.ts
@@ -50,6 +50,34 @@ import {
 } from './warm-clients.js';
 
 /**
+ * Module-scope record of the single active listener teardown for each warm
+ * adapter. Warm adapters live in the module-level cache and survive Provider
+ * remounts, so their event-listener `Set`s would otherwise accumulate one
+ * closure set per manager that ever subscribed (R1 leak). Keying the teardown
+ * by **adapter identity at module scope** (not a per-manager `WeakSet`)
+ * guarantees at most one live subscription per shared adapter: before a new
+ * manager subscribes, the previous owner's listeners are removed.
+ */
+const sttAdapterTeardowns = new WeakMap<STTAdapter, () => void>();
+const ttsAdapterTeardowns = new WeakMap<TTSAdapter, () => void>();
+
+/**
+ * Structural equality for two AI configs (R3). Used to no-op `setAIConfig` when
+ * an inline `ai={{…}}` literal re-renders with the same effective settings but a
+ * new object identity. A shallow JSON compare is sufficient: AIConfig is a flat
+ * tree of plain primitives/objects with no functions or class instances.
+ */
+function configsEqual(a: AIConfig, b: AIConfig): boolean {
+  if (a === b) return true;
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    // Non-serializable (shouldn't happen for AIConfig) — treat as different.
+    return false;
+  }
+}
+
+/**
  * Reactive app state manager for Svelte 5
  */
 export class SmrtAppStateManager {
@@ -63,15 +91,25 @@ export class SmrtAppStateManager {
   private _aiConfig: AIConfig | null = null;
   private _preloadScheduled = false;
   private _idleCallbackId: number | null = null;
+  // Guards a single executePreload() pass from running concurrently. The
+  // Provider's `ai` $effect can re-fire setAIConfig on every parent render
+  // (inline `ai={{…}}` literal => new identity), and an `idle`/`eager` strategy
+  // would otherwise launch overlapping preloads that interleave aiLoading
+  // writes and double-download models (R3).
+  private _preloadInFlight = false;
 
   // Socket management
   private _socket: WebSocket | null = null;
   private _socketConfig: SocketConfig | null = null;
   private _reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
 
-  // Track adapters we've already subscribed to (prevents duplicate listeners)
-  private _subscribedSTTAdapters = new WeakSet<STTAdapter>();
-  private _subscribedTTSAdapters = new WeakSet<TTSAdapter>();
+  // Adapters this manager currently owns a subscription on, mapped to the
+  // teardown that removes its listeners. Used both for dedup (skip re-subscribe
+  // when this manager already owns the adapter) and to unsubscribe on dispose()
+  // so a destroyed Provider stops pinning its `_state` proxy via the adapter's
+  // module-surviving listener `Set`s (R1).
+  private _sttSubscriptions = new Map<STTAdapter, () => void>();
+  private _ttsSubscriptions = new Map<TTSAdapter, () => void>();
 
   constructor(options: CreateAppStateOptions = {}) {
     this.options = options;
@@ -157,9 +195,23 @@ export class SmrtAppStateManager {
   // === AI Preloading Methods ===
 
   /**
-   * Set or update AI configuration
+   * Set or update AI configuration.
+   *
+   * No-ops when the incoming config is deep-equal to the current one. The
+   * Provider's `ai` $effect depends on the prop's identity, and the documented
+   * usage passes an inline `ai={{…}}` object literal — a fresh identity on every
+   * parent render. Without this guard each render would cancel the idle
+   * callback, reset `_preloadScheduled`, and re-schedule (and, for `eager`,
+   * re-launch a full preload), thrashing the scheduler and double-downloading
+   * models (R3).
    */
   setAIConfig(config: AIConfig): void {
+    if (this._aiConfig && configsEqual(this._aiConfig, config)) {
+      // Same effective config (different object identity) — nothing to do.
+      this._aiConfig = config;
+      return;
+    }
+
     this._aiConfig = config;
 
     // Cancel any pending preload scheduling so we can re-schedule with new config
@@ -225,9 +277,28 @@ export class SmrtAppStateManager {
   }
 
   /**
-   * Execute the preloading of configured adapters
+   * Execute the preloading of configured adapters.
+   *
+   * Re-entrancy guarded: an `idle`/`eager` strategy can be re-scheduled while a
+   * pass is still awaiting model downloads. Without the guard the overlapping
+   * passes interleave their aiLoading writes and double-download models (R3).
    */
   private async executePreload(): Promise<void> {
+    if (!this._aiConfig) return;
+    if (this._preloadInFlight) return;
+    this._preloadInFlight = true;
+    try {
+      await this.runPreload();
+    } finally {
+      this._preloadInFlight = false;
+    }
+  }
+
+  /**
+   * The actual preload pass. Always invoked behind the `_preloadInFlight` guard
+   * in {@link executePreload}.
+   */
+  private async runPreload(): Promise<void> {
     if (!this._aiConfig) return;
 
     const adaptersToLoad: string[] = [];
@@ -247,7 +318,10 @@ export class SmrtAppStateManager {
     }
 
     if (adaptersToLoad.length === 0) {
-      this.updateLoadingState({ phase: 'idle' });
+      // Reset loaded/failed too (R7) — the main path clears them via the
+      // 'checking' update below, so the early-return must not leave stale
+      // entries from a prior pass behind.
+      this.updateLoadingState({ phase: 'idle', loaded: [], failed: [] });
       return;
     }
 
@@ -612,43 +686,63 @@ export class SmrtAppStateManager {
   }
 
   /**
-   * Subscribe to STT adapter events
-   * Only subscribes once per adapter instance to prevent duplicate listeners
+   * Subscribe to STT adapter events.
+   *
+   * Captures every unsubscribe handle the adapter returns and stores a single
+   * teardown both per-manager (called on dispose()) and at module scope keyed
+   * by adapter identity. Because warm adapters are shared singletons, any
+   * previous owner's listeners are torn down first — guaranteeing exactly one
+   * live listener set per adapter, with the latest manager owning it (R1).
    */
   private subscribeToSTTEvents(adapter: STTAdapter): void {
-    // Prevent duplicate subscriptions
-    if (this._subscribedSTTAdapters.has(adapter)) {
+    // Dedup: this manager already owns the adapter's subscription.
+    if (this._sttSubscriptions.has(adapter)) {
       return;
     }
-    this._subscribedSTTAdapters.add(adapter);
 
-    adapter.onResult((result) => {
-      if (result.isFinal) {
-        // Accumulate final results (for continuous mode where multiple phrases are spoken)
-        const existing = this._state.ai.stt.lastResult;
-        if (existing) {
-          this._state.ai.stt.lastResult = `${existing} ${result.text}`;
+    // Evict any prior owner (e.g. a destroyed Provider that failed to dispose)
+    // so the adapter never fires more than one manager's listeners.
+    sttAdapterTeardowns.get(adapter)?.();
+
+    const unsubs: Array<() => void> = [
+      adapter.onResult((result) => {
+        if (result.isFinal) {
+          // Accumulate final results (continuous mode emits multiple phrases)
+          const existing = this._state.ai.stt.lastResult;
+          if (existing) {
+            this._state.ai.stt.lastResult = `${existing} ${result.text}`;
+          } else {
+            this._state.ai.stt.lastResult = result.text;
+          }
+          this._state.ai.stt.interimResult = '';
         } else {
-          this._state.ai.stt.lastResult = result.text;
+          // Interim result - update live
+          this._state.ai.stt.interimResult = result.text;
         }
-        this._state.ai.stt.interimResult = '';
-      } else {
-        // Interim result - update live
-        this._state.ai.stt.interimResult = result.text;
+      }),
+      adapter.onStart(() => {
+        this._state.ai.stt.isListening = true;
+      }),
+      adapter.onEnd(() => {
+        this._state.ai.stt.isListening = false;
+      }),
+      adapter.onError((error) => {
+        this._state.ai.stt.error = error;
+      }),
+    ];
+
+    const teardown = () => {
+      for (const unsub of unsubs) {
+        unsub();
       }
-    });
+      this._sttSubscriptions.delete(adapter);
+      if (sttAdapterTeardowns.get(adapter) === teardown) {
+        sttAdapterTeardowns.delete(adapter);
+      }
+    };
 
-    adapter.onStart(() => {
-      this._state.ai.stt.isListening = true;
-    });
-
-    adapter.onEnd(() => {
-      this._state.ai.stt.isListening = false;
-    });
-
-    adapter.onError((error) => {
-      this._state.ai.stt.error = error;
-    });
+    this._sttSubscriptions.set(adapter, teardown);
+    sttAdapterTeardowns.set(adapter, teardown);
   }
 
   /**
@@ -735,30 +829,48 @@ export class SmrtAppStateManager {
   }
 
   /**
-   * Subscribe to TTS adapter events
-   * Only subscribes once per adapter instance to prevent duplicate listeners
+   * Subscribe to TTS adapter events.
+   *
+   * Mirrors {@link subscribeToSTTEvents}: captures unsubscribe handles, dedups
+   * per-manager, and evicts any prior owner so a shared warm adapter never
+   * pins more than one manager's `_state` proxy (R1).
    */
   private subscribeToTTSEvents(adapter: TTSAdapter): void {
-    // Prevent duplicate subscriptions
-    if (this._subscribedTTSAdapters.has(adapter)) {
+    // Dedup: this manager already owns the adapter's subscription.
+    if (this._ttsSubscriptions.has(adapter)) {
       return;
     }
-    this._subscribedTTSAdapters.add(adapter);
 
-    adapter.onStart(() => {
-      this._state.ai.tts.isSpeaking = true;
-      this._state.ai.tts.isPaused = false;
-    });
+    // Evict any prior owner so the adapter fires only this manager's listeners.
+    ttsAdapterTeardowns.get(adapter)?.();
 
-    adapter.onEnd(() => {
-      this._state.ai.tts.isSpeaking = false;
-      this._state.ai.tts.isPaused = false;
-    });
+    const unsubs: Array<() => void> = [
+      adapter.onStart(() => {
+        this._state.ai.tts.isSpeaking = true;
+        this._state.ai.tts.isPaused = false;
+      }),
+      adapter.onEnd(() => {
+        this._state.ai.tts.isSpeaking = false;
+        this._state.ai.tts.isPaused = false;
+      }),
+      adapter.onError((error) => {
+        this._state.ai.tts.error = error;
+        this._state.ai.tts.isSpeaking = false;
+      }),
+    ];
 
-    adapter.onError((error) => {
-      this._state.ai.tts.error = error;
-      this._state.ai.tts.isSpeaking = false;
-    });
+    const teardown = () => {
+      for (const unsub of unsubs) {
+        unsub();
+      }
+      this._ttsSubscriptions.delete(adapter);
+      if (ttsAdapterTeardowns.get(adapter) === teardown) {
+        ttsAdapterTeardowns.delete(adapter);
+      }
+    };
+
+    this._ttsSubscriptions.set(adapter, teardown);
+    ttsAdapterTeardowns.set(adapter, teardown);
   }
 
   /**
@@ -906,13 +1018,44 @@ export class SmrtAppStateManager {
    * Unload LLM model to free memory
    */
   async unloadLLM(): Promise<void> {
-    await this._state.ai.llm.adapter?.unloadModel();
+    const adapter = this._state.ai.llm.adapter;
+    await adapter?.unloadModel();
+
+    // Downgrade (or remove) the warm-cache entry for the unloaded model so a
+    // later initializeLLM() re-runs ensureInitialized() — re-downloading and
+    // reporting progress — instead of cache-hitting a `'ready'` entry whose
+    // model is now gone (R2). `unloadModel()` keeps the adapter instance
+    // reusable, so downgrade to `'uninitialized'` rather than dispose it.
+    if (adapter) {
+      updateLLMCacheState(adapter.type, adapter.currentModel ?? undefined, {
+        initState: 'uninitialized',
+        downloadProgress: null,
+        error: null,
+      });
+    }
+
     this._state.ai.llm.adapter = null;
     this._state.ai.llm.initState = 'uninitialized';
     this._state.ai.llm.currentModel = null;
   }
 
   // === Cleanup ===
+
+  /**
+   * Unsubscribe every adapter-event listener this manager owns (R1). Called on
+   * dispose() so a destroyed Provider stops being pinned by the shared warm
+   * adapters' module-surviving listener `Set`s.
+   */
+  private unsubscribeAllAdapterEvents(): void {
+    for (const teardown of [...this._sttSubscriptions.values()]) {
+      teardown();
+    }
+    for (const teardown of [...this._ttsSubscriptions.values()]) {
+      teardown();
+    }
+    this._sttSubscriptions.clear();
+    this._ttsSubscriptions.clear();
+  }
 
   /**
    * Dispose of all resources
@@ -927,13 +1070,43 @@ export class SmrtAppStateManager {
       this._idleCallbackId = null;
     }
 
+    // Stop any in-flight preload so it can't write to a torn-down state (R3).
+    this._preloadInFlight = false;
+
     // Disconnect socket
     this.disconnectSocket();
 
-    // Dispose AI adapters (but don't clear the cache - they survive navigation)
-    await this._state.ai.stt.adapter?.dispose();
-    await this._state.ai.tts.adapter?.dispose();
-    await this._state.ai.llm.adapter?.dispose();
+    // Remove this manager's adapter-event listeners (R1).
+    this.unsubscribeAllAdapterEvents();
+
+    // Adapter lifecycle is owned by the warm cache (it survives navigation by
+    // design). For adapters this manager holds that the cache no longer tracks
+    // — e.g. an instance orphaned by a mid-session type switch — dispose them
+    // directly so they don't leak. Adapters still backed by a warm-cache entry
+    // are left intact and genuinely `'ready'`; previously they were disposed
+    // here yet left cached as `'ready'`, so the next init cache-hit restored a
+    // dead engine with no download progress (R2). Full teardown remains
+    // available via `clearAllCaches()`.
+    //
+    // NOTE: state adapters are `$state` proxies, so identity (`!==`) comparison
+    // against the raw cached instance is unreliable (Svelte proxy-equality
+    // gotcha). Gate on whether the cache *has* a live entry for the adapter's
+    // type/model instead of comparing instances.
+    const sttAdapter = this._state.ai.stt.adapter;
+    if (sttAdapter && !getCachedSTT(sttAdapter.type as STTType)) {
+      await sttAdapter.dispose?.();
+    }
+    const ttsAdapter = this._state.ai.tts.adapter;
+    if (ttsAdapter && !getCachedTTS(ttsAdapter.type as TTSType)) {
+      await ttsAdapter.dispose?.();
+    }
+    const llmAdapter = this._state.ai.llm.adapter;
+    if (
+      llmAdapter &&
+      !getCachedLLM(llmAdapter.type, llmAdapter.currentModel ?? undefined)
+    ) {
+      await llmAdapter.dispose?.();
+    }
 
     this._state = createInitialState();
   }

--- a/packages/smrt-svelte/src/state/app-state.svelte.ts
+++ b/packages/smrt-svelte/src/state/app-state.svelte.ts
@@ -1019,6 +1019,10 @@ export class SmrtAppStateManager {
    */
   async unloadLLM(): Promise<void> {
     const adapter = this._state.ai.llm.adapter;
+    // Capture the model id BEFORE unloadModel(): a real WebLLM adapter clears
+    // `currentModel` on unload, so reading it afterward would key the cache
+    // downgrade off `undefined` and leave the actual `'ready'` entry stale (R2).
+    const unloadedModel = adapter?.currentModel ?? undefined;
     await adapter?.unloadModel();
 
     // Downgrade (or remove) the warm-cache entry for the unloaded model so a
@@ -1027,7 +1031,7 @@ export class SmrtAppStateManager {
     // model is now gone (R2). `unloadModel()` keeps the adapter instance
     // reusable, so downgrade to `'uninitialized'` rather than dispose it.
     if (adapter) {
-      updateLLMCacheState(adapter.type, adapter.currentModel ?? undefined, {
+      updateLLMCacheState(adapter.type, unloadedModel, {
         initState: 'uninitialized',
         downloadProgress: null,
         error: null,

--- a/packages/smrt-ui/src/actions/__tests__/ripple.test.ts
+++ b/packages/smrt-ui/src/actions/__tests__/ripple.test.ts
@@ -1,8 +1,14 @@
 /**
  * Unit test for the ripple action (coverage uplift, S6 gate).
  */
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ripple } from '../ripple';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  // Drop any matchMedia stub a test installed.
+  Reflect.deleteProperty(window, 'matchMedia');
+});
 
 describe('ripple action', () => {
   it('appends a ripple element on pointer down', () => {
@@ -31,6 +37,73 @@ describe('ripple action', () => {
       new TouchEvent('touchstart', { touches: [touch], bubbles: true }),
     );
     expect(node.querySelectorAll('span').length).toBeGreaterThan(0);
+
+    action?.destroy?.();
+    node.remove();
+  });
+
+  it('fills the ripple with the canonical --smrt-color-primary token (#1586)', () => {
+    // Regression: the canonical theme system only emits `--smrt-color-*`; the
+    // old `--md-sys-color-primary` namespace always fell back to currentColor.
+    const node = document.createElement('button');
+    document.body.appendChild(node);
+    const action = ripple(node);
+
+    node.dispatchEvent(
+      new MouseEvent('mousedown', { clientX: 5, clientY: 5, bubbles: true }),
+    );
+    const span = node.querySelector('span') as HTMLElement;
+    expect(span.style.backgroundColor).toContain('--smrt-color-primary');
+    expect(span.style.backgroundColor).not.toContain('--md-sys');
+
+    action?.destroy?.();
+    node.remove();
+  });
+
+  it('destroy() removes pending ripple spans and clears window listeners (#1586)', () => {
+    const node = document.createElement('button');
+    document.body.appendChild(node);
+    const action = ripple(node);
+
+    // Press without releasing: the ripple span stays appended, and a one-shot
+    // window mouseup listener is still registered.
+    node.dispatchEvent(
+      new MouseEvent('mousedown', { clientX: 5, clientY: 5, bubbles: true }),
+    );
+    expect(node.querySelectorAll('span.smrt-ripple').length).toBe(1);
+
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    action?.destroy?.();
+
+    // The leaked span is gone immediately (no waiting for a later global mouseup).
+    expect(node.querySelectorAll('span.smrt-ripple').length).toBe(0);
+    // And the pending window pointer-up listeners were detached.
+    expect(removeSpy).toHaveBeenCalledWith('mouseup', expect.any(Function));
+    expect(removeSpy).toHaveBeenCalledWith('touchend', expect.any(Function));
+
+    node.remove();
+  });
+
+  it('skips the ripple when prefers-reduced-motion is set (#1586)', () => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query.includes('prefers-reduced-motion'),
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as unknown as typeof window.matchMedia;
+
+    const node = document.createElement('button');
+    document.body.appendChild(node);
+    const action = ripple(node);
+
+    node.dispatchEvent(
+      new MouseEvent('mousedown', { clientX: 5, clientY: 5, bubbles: true }),
+    );
+    expect(node.querySelectorAll('span.smrt-ripple').length).toBe(0);
 
     action?.destroy?.();
     node.remove();

--- a/packages/smrt-ui/src/actions/ripple.ts
+++ b/packages/smrt-ui/src/actions/ripple.ts
@@ -2,10 +2,31 @@ import type { Action } from 'svelte/action';
 
 /**
  * Svelte action to add a Material 3 ripple effect to an element.
- * Respects CSS variables defined by ThemeProvider.
+ *
+ * Uses the canonical `--smrt-color-primary` token (the SMRT theme system only
+ * ever emits `--smrt-color-*`; the legacy `--md-sys-*` namespace is not produced
+ * by the canonical providers), falling back to `currentColor`.
+ *
+ * Respects `prefers-reduced-motion`: when the user requests reduced motion the
+ * ripple is skipped entirely. On `destroy()` all pending ripple spans, their
+ * removal timeouts, and the window pointer-up listeners are cleaned up so an
+ * unmount mid-press cannot leak DOM nodes or listeners.
  */
 export const ripple: Action<HTMLElement> = (node) => {
+  const prefersReducedMotion = (): boolean =>
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  // Track in-flight ripples so destroy() can tear them down deterministically.
+  const activeSpans = new Set<HTMLElement>();
+  const pendingTimeouts = new Set<ReturnType<typeof setTimeout>>();
+  const pendingPointerUp = new Set<() => void>();
+
   const handleStart = (e: MouseEvent | TouchEvent) => {
+    // Honor reduced-motion: no ripple animation at all.
+    if (prefersReducedMotion()) return;
+
     const rect = node.getBoundingClientRect();
     const clientX =
       'touches' in e
@@ -31,8 +52,7 @@ export const ripple: Action<HTMLElement> = (node) => {
     rippleEl.style.width = rippleEl.style.height = `${diameter}px`;
     rippleEl.style.left = `${x - radius}px`;
     rippleEl.style.top = `${y - radius}px`;
-    rippleEl.style.backgroundColor =
-      'var(--md-sys-color-primary, currentColor)';
+    rippleEl.style.backgroundColor = 'var(--smrt-color-primary, currentColor)';
     rippleEl.style.opacity = '0.12';
     rippleEl.style.transform = 'scale(0)';
     rippleEl.style.transition =
@@ -41,21 +61,37 @@ export const ripple: Action<HTMLElement> = (node) => {
     rippleEl.classList.add('smrt-ripple');
 
     node.appendChild(rippleEl);
+    activeSpans.add(rippleEl);
 
     // Trigger animation
     requestAnimationFrame(() => {
       rippleEl.style.transform = 'scale(1)';
     });
 
-    const removeRipple = () => {
+    // Bound to this ripple so the pointer-up handler and its timeout can be
+    // forgotten once they run (or torn down early in destroy()).
+    let removeRipple: () => void;
+
+    const detachPointerUp = () => {
+      window.removeEventListener('mouseup', removeRipple);
+      window.removeEventListener('touchend', removeRipple);
+      pendingPointerUp.delete(removeRipple);
+    };
+
+    removeRipple = () => {
+      detachPointerUp();
       rippleEl.style.opacity = '0';
-      setTimeout(() => {
+      const timeout = setTimeout(() => {
+        pendingTimeouts.delete(timeout);
+        activeSpans.delete(rippleEl);
         if (rippleEl.parentNode === node) {
           node.removeChild(rippleEl);
         }
       }, 600);
+      pendingTimeouts.add(timeout);
     };
 
+    pendingPointerUp.add(removeRipple);
     window.addEventListener('mouseup', removeRipple, { once: true });
     window.addEventListener('touchend', removeRipple, { once: true });
   };
@@ -63,7 +99,7 @@ export const ripple: Action<HTMLElement> = (node) => {
   node.addEventListener('mousedown', handleStart);
   node.addEventListener('touchstart', handleStart, { passive: true });
 
-  // Ensure node is prepared
+  // Ensure node is prepared (and remember prior values so destroy() can restore).
   const originalPosition = node.style.position;
   const originalOverflow = node.style.overflow;
 
@@ -76,7 +112,27 @@ export const ripple: Action<HTMLElement> = (node) => {
     destroy() {
       node.removeEventListener('mousedown', handleStart);
       node.removeEventListener('touchstart', handleStart);
-      // Restore styles if necessary, though usually fine to keep for UI components
+
+      // Cancel pending removal timeouts.
+      for (const timeout of pendingTimeouts) clearTimeout(timeout);
+      pendingTimeouts.clear();
+
+      // Detach any window pointer-up listeners still waiting for a release.
+      for (const handler of pendingPointerUp) {
+        window.removeEventListener('mouseup', handler);
+        window.removeEventListener('touchend', handler);
+      }
+      pendingPointerUp.clear();
+
+      // Remove any ripple spans still appended to the node.
+      for (const span of activeSpans) {
+        if (span.parentNode === node) node.removeChild(span);
+      }
+      activeSpans.clear();
+
+      // Restore the node's original inline layout styles.
+      node.style.position = originalPosition;
+      node.style.overflow = originalOverflow;
     },
   };
 };

--- a/packages/smrt-ui/src/components/display/ConfidenceBadge.svelte
+++ b/packages/smrt-ui/src/components/display/ConfidenceBadge.svelte
@@ -40,26 +40,30 @@ const level = $derived.by(() => {
   return 'low';
 });
 
-// Color scheme based on level - uses CSS variables with fallbacks
+// Color scheme based on level, referencing the canonical `--smrt-color-*`
+// tokens directly. Literal hex fallbacks are intentionally omitted: smrt-ui owns
+// the theme system so the tokens are always defined, and the old hardcoded
+// fallbacks were the wrong colors (e.g. high → green #dcfce7, real material
+// primary-container light is the blue #d3e3fd) — see #1586.
 const colors = $derived.by(() => {
   switch (level) {
     case 'high':
       return {
-        bg: 'var(--smrt-color-primary-container, #dcfce7)',
-        text: 'var(--smrt-color-on-primary-container, #166534)',
-        bar: 'var(--smrt-color-primary, #22c55e)',
+        bg: 'var(--smrt-color-primary-container)',
+        text: 'var(--smrt-color-on-primary-container)',
+        bar: 'var(--smrt-color-primary)',
       };
     case 'medium':
       return {
-        bg: 'var(--smrt-color-secondary-container, #fef3c7)',
-        text: 'var(--smrt-color-on-secondary-container, #92400e)',
-        bar: 'var(--smrt-color-secondary, #f59e0b)',
+        bg: 'var(--smrt-color-secondary-container)',
+        text: 'var(--smrt-color-on-secondary-container)',
+        bar: 'var(--smrt-color-secondary)',
       };
     case 'low':
       return {
-        bg: 'var(--smrt-color-error-container, #fee2e2)',
-        text: 'var(--smrt-color-on-error-container, #dc2626)',
-        bar: 'var(--smrt-color-error, #ef4444)',
+        bg: 'var(--smrt-color-error-container)',
+        text: 'var(--smrt-color-on-error-container)',
+        bar: 'var(--smrt-color-error)',
       };
   }
 });

--- a/packages/smrt-ui/src/components/display/StatusBadge.svelte
+++ b/packages/smrt-ui/src/components/display/StatusBadge.svelte
@@ -30,167 +30,173 @@ const {
   label,
 }: Props = $props();
 
-// Color mappings for different status domains - uses CSS variables with fallbacks
+// Color mappings for different status domains, referencing the canonical
+// `--smrt-color-*` tokens directly. smrt-ui owns the theme system, so every
+// preset (material/glass/studio) always defines these tokens. Literal hex
+// fallbacks are intentionally omitted: a fallback only belongs here if it equals
+// the token's real light value, and the previous hardcoded greens/blues did not
+// (e.g. primary-container fell back to green #dcfce7, real material light is the
+// blue #d3e3fd) — see #1586.
 const colorSchemes: Record<
   StatusType,
   Record<string, { bg: string; text: string; border?: string }>
 > = {
   default: {
     active: {
-      bg: 'var(--smrt-color-primary-container, #dcfce7)',
-      text: 'var(--smrt-color-on-primary-container, #166534)',
+      bg: 'var(--smrt-color-primary-container)',
+      text: 'var(--smrt-color-on-primary-container)',
     },
     inactive: {
-      bg: 'var(--smrt-color-surface-container-highest, #f3f4f6)',
-      text: 'var(--smrt-color-on-surface-variant, #6b7280)',
+      bg: 'var(--smrt-color-surface-container-highest)',
+      text: 'var(--smrt-color-on-surface-variant)',
     },
     pending: {
-      bg: 'var(--smrt-color-secondary-container, #fef3c7)',
-      text: 'var(--smrt-color-on-secondary-container, #92400e)',
+      bg: 'var(--smrt-color-secondary-container)',
+      text: 'var(--smrt-color-on-secondary-container)',
     },
     error: {
-      bg: 'var(--smrt-color-error-container, #fee2e2)',
-      text: 'var(--smrt-color-on-error-container, #dc2626)',
+      bg: 'var(--smrt-color-error-container)',
+      text: 'var(--smrt-color-on-error-container)',
     },
     success: {
-      bg: 'var(--smrt-color-primary-container, #dcfce7)',
-      text: 'var(--smrt-color-on-primary-container, #166534)',
+      bg: 'var(--smrt-color-primary-container)',
+      text: 'var(--smrt-color-on-primary-container)',
     },
     warning: {
-      bg: 'var(--smrt-color-secondary-container, #fef3c7)',
-      text: 'var(--smrt-color-on-secondary-container, #92400e)',
+      bg: 'var(--smrt-color-secondary-container)',
+      text: 'var(--smrt-color-on-secondary-container)',
     },
   },
   invoice: {
     draft: {
-      bg: 'var(--smrt-color-surface-container-highest, #f3f4f6)',
-      text: 'var(--smrt-color-on-surface-variant, #6b7280)',
+      bg: 'var(--smrt-color-surface-container-highest)',
+      text: 'var(--smrt-color-on-surface-variant)',
     },
     sent: {
-      bg: 'var(--smrt-color-tertiary-container, #dbeafe)',
-      text: 'var(--smrt-color-on-tertiary-container, #1e40af)',
+      bg: 'var(--smrt-color-tertiary-container)',
+      text: 'var(--smrt-color-on-tertiary-container)',
     },
     viewed: {
-      bg: 'var(--smrt-color-primary-container, #e0e7ff)',
-      text: 'var(--smrt-color-on-primary-container, #4338ca)',
+      bg: 'var(--smrt-color-primary-container)',
+      text: 'var(--smrt-color-on-primary-container)',
     },
     paid: {
-      bg: 'var(--smrt-color-primary-container, #dcfce7)',
-      text: 'var(--smrt-color-on-primary-container, #166534)',
+      bg: 'var(--smrt-color-primary-container)',
+      text: 'var(--smrt-color-on-primary-container)',
     },
     overdue: {
-      bg: 'var(--smrt-color-error-container, #fee2e2)',
-      text: 'var(--smrt-color-on-error-container, #dc2626)',
+      bg: 'var(--smrt-color-error-container)',
+      text: 'var(--smrt-color-on-error-container)',
     },
     cancelled: {
-      bg: 'var(--smrt-color-error-container, #fecaca)',
-      text: 'var(--smrt-color-on-error-container, #991b1b)',
+      bg: 'var(--smrt-color-error-container)',
+      text: 'var(--smrt-color-on-error-container)',
     },
   },
   project: {
     lead: {
-      bg: 'var(--smrt-color-primary-container, #e0e7ff)',
-      text: 'var(--smrt-color-on-primary-container, #4338ca)',
+      bg: 'var(--smrt-color-primary-container)',
+      text: 'var(--smrt-color-on-primary-container)',
     },
     quoted: {
-      bg: 'var(--smrt-color-secondary-container, #fef3c7)',
-      text: 'var(--smrt-color-on-secondary-container, #92400e)',
+      bg: 'var(--smrt-color-secondary-container)',
+      text: 'var(--smrt-color-on-secondary-container)',
     },
     active: {
-      bg: 'var(--smrt-color-tertiary-container, #dbeafe)',
-      text: 'var(--smrt-color-on-tertiary-container, #1e40af)',
+      bg: 'var(--smrt-color-tertiary-container)',
+      text: 'var(--smrt-color-on-tertiary-container)',
     },
     on_hold: {
-      bg: 'var(--smrt-color-secondary-container, #fef3c7)',
-      text: 'var(--smrt-color-on-secondary-container, #92400e)',
+      bg: 'var(--smrt-color-secondary-container)',
+      text: 'var(--smrt-color-on-secondary-container)',
     },
     completed: {
-      bg: 'var(--smrt-color-primary-container, #dcfce7)',
-      text: 'var(--smrt-color-on-primary-container, #166534)',
+      bg: 'var(--smrt-color-primary-container)',
+      text: 'var(--smrt-color-on-primary-container)',
     },
     archived: {
-      bg: 'var(--smrt-color-surface-container-highest, #f3f4f6)',
-      text: 'var(--smrt-color-on-surface-variant, #6b7280)',
+      bg: 'var(--smrt-color-surface-container-highest)',
+      text: 'var(--smrt-color-on-surface-variant)',
     },
   },
   expense: {
     unbilled: {
-      bg: 'var(--smrt-color-secondary-container, #fef3c7)',
-      text: 'var(--smrt-color-on-secondary-container, #92400e)',
+      bg: 'var(--smrt-color-secondary-container)',
+      text: 'var(--smrt-color-on-secondary-container)',
     },
     billed: {
-      bg: 'var(--smrt-color-primary-container, #dcfce7)',
-      text: 'var(--smrt-color-on-primary-container, #166534)',
+      bg: 'var(--smrt-color-primary-container)',
+      text: 'var(--smrt-color-on-primary-container)',
     },
     reimbursed: {
-      bg: 'var(--smrt-color-tertiary-container, #dbeafe)',
-      text: 'var(--smrt-color-on-tertiary-container, #1e40af)',
+      bg: 'var(--smrt-color-tertiary-container)',
+      text: 'var(--smrt-color-on-tertiary-container)',
     },
     rejected: {
-      bg: 'var(--smrt-color-error-container, #fee2e2)',
-      text: 'var(--smrt-color-on-error-container, #dc2626)',
+      bg: 'var(--smrt-color-error-container)',
+      text: 'var(--smrt-color-on-error-container)',
     },
   },
   time: {
     draft: {
-      bg: 'var(--smrt-color-surface-container-highest, #f3f4f6)',
-      text: 'var(--smrt-color-on-surface-variant, #6b7280)',
+      bg: 'var(--smrt-color-surface-container-highest)',
+      text: 'var(--smrt-color-on-surface-variant)',
     },
     submitted: {
-      bg: 'var(--smrt-color-tertiary-container, #dbeafe)',
-      text: 'var(--smrt-color-on-tertiary-container, #1e40af)',
+      bg: 'var(--smrt-color-tertiary-container)',
+      text: 'var(--smrt-color-on-tertiary-container)',
     },
     approved: {
-      bg: 'var(--smrt-color-primary-container, #dcfce7)',
-      text: 'var(--smrt-color-on-primary-container, #166534)',
+      bg: 'var(--smrt-color-primary-container)',
+      text: 'var(--smrt-color-on-primary-container)',
     },
     rejected: {
-      bg: 'var(--smrt-color-error-container, #fee2e2)',
-      text: 'var(--smrt-color-on-error-container, #dc2626)',
+      bg: 'var(--smrt-color-error-container)',
+      text: 'var(--smrt-color-on-error-container)',
     },
     billed: {
-      bg: 'var(--smrt-color-primary-container, #e0e7ff)',
-      text: 'var(--smrt-color-on-primary-container, #4338ca)',
+      bg: 'var(--smrt-color-primary-container)',
+      text: 'var(--smrt-color-on-primary-container)',
     },
   },
   compliance: {
     valid: {
-      bg: 'var(--smrt-color-primary-container, #dcfce7)',
-      text: 'var(--smrt-color-on-primary-container, #166534)',
+      bg: 'var(--smrt-color-primary-container)',
+      text: 'var(--smrt-color-on-primary-container)',
     },
     expiring: {
-      bg: 'var(--smrt-color-secondary-container, #fef3c7)',
-      text: 'var(--smrt-color-on-secondary-container, #92400e)',
+      bg: 'var(--smrt-color-secondary-container)',
+      text: 'var(--smrt-color-on-secondary-container)',
     },
     expired: {
-      bg: 'var(--smrt-color-error-container, #fee2e2)',
-      text: 'var(--smrt-color-on-error-container, #dc2626)',
+      bg: 'var(--smrt-color-error-container)',
+      text: 'var(--smrt-color-on-error-container)',
     },
     pending: {
-      bg: 'var(--smrt-color-tertiary-container, #dbeafe)',
-      text: 'var(--smrt-color-on-tertiary-container, #1e40af)',
+      bg: 'var(--smrt-color-tertiary-container)',
+      text: 'var(--smrt-color-on-tertiary-container)',
     },
   },
   estimate: {
     draft: {
-      bg: 'var(--smrt-color-surface-container-highest, #f3f4f6)',
-      text: 'var(--smrt-color-on-surface-variant, #6b7280)',
+      bg: 'var(--smrt-color-surface-container-highest)',
+      text: 'var(--smrt-color-on-surface-variant)',
     },
     presented: {
-      bg: 'var(--smrt-color-tertiary-container, #dbeafe)',
-      text: 'var(--smrt-color-on-tertiary-container, #1e40af)',
+      bg: 'var(--smrt-color-tertiary-container)',
+      text: 'var(--smrt-color-on-tertiary-container)',
     },
     accepted: {
-      bg: 'var(--smrt-color-primary-container, #dcfce7)',
-      text: 'var(--smrt-color-on-primary-container, #166534)',
+      bg: 'var(--smrt-color-primary-container)',
+      text: 'var(--smrt-color-on-primary-container)',
     },
     declined: {
-      bg: 'var(--smrt-color-error-container, #fee2e2)',
-      text: 'var(--smrt-color-on-error-container, #dc2626)',
+      bg: 'var(--smrt-color-error-container)',
+      text: 'var(--smrt-color-on-error-container)',
     },
     expired: {
-      bg: 'var(--smrt-color-error-container, #fecaca)',
-      text: 'var(--smrt-color-on-error-container, #991b1b)',
+      bg: 'var(--smrt-color-error-container)',
+      text: 'var(--smrt-color-on-error-container)',
     },
   },
 };
@@ -203,8 +209,8 @@ const colors = $derived.by(() => {
   const scheme = colorSchemes[type] ?? colorSchemes.default;
   return (
     scheme[normalizedStatus] ?? {
-      bg: 'var(--smrt-color-surface-container-highest, #e5e7eb)',
-      text: 'var(--smrt-color-on-surface-variant, #374151)',
+      bg: 'var(--smrt-color-surface-container-highest)',
+      text: 'var(--smrt-color-on-surface-variant)',
     }
   );
 });

--- a/packages/smrt-ui/src/components/display/__tests__/ConfidenceBadge.test.ts
+++ b/packages/smrt-ui/src/components/display/__tests__/ConfidenceBadge.test.ts
@@ -92,6 +92,20 @@ describe('ConfidenceBadge', () => {
     );
   });
 
+  it('emits bare design tokens with no literal hex fallback', () => {
+    // Regression for #1586: the old `var(--token, #hex)` fallbacks were the
+    // wrong colors (high → green #dcfce7 vs real material light blue #d3e3fd).
+    const { container } = render(ConfidenceBadge, {
+      props: { confidence: 90 },
+    });
+    const badge = container.querySelector('.confidence-badge') as HTMLElement;
+    for (const prop of ['--badge-bg', '--badge-text', '--bar-color']) {
+      const value = badge.style.getPropertyValue(prop);
+      expect(value).toMatch(/^var\(--smrt-color-[a-z-]+\)$/);
+      expect(value).not.toContain('#');
+    }
+  });
+
   it('appends a custom class alongside the base class', () => {
     const { container } = render(ConfidenceBadge, {
       props: { confidence: 50, class: 'my-badge' },

--- a/packages/smrt-ui/src/components/display/__tests__/StatusBadge.test.ts
+++ b/packages/smrt-ui/src/components/display/__tests__/StatusBadge.test.ts
@@ -79,8 +79,30 @@ describe('StatusBadge', () => {
       props: { status: 'totally-unknown', type: 'invoice' },
     });
     const span = container.querySelector('span') as HTMLElement;
-    expect(span.style.getPropertyValue('--badge-bg')).toContain('#e5e7eb');
-    expect(span.style.getPropertyValue('--badge-text')).toContain('#374151');
+    // The neutral fallback resolves to canonical surface tokens, not a literal
+    // hex. smrt-ui owns the theme system, so the tokens are always defined; a
+    // hardcoded fallback would freeze the wrong color across presets (#1586).
+    expect(span.style.getPropertyValue('--badge-bg')).toBe(
+      'var(--smrt-color-surface-container-highest)',
+    );
+    expect(span.style.getPropertyValue('--badge-text')).toBe(
+      'var(--smrt-color-on-surface-variant)',
+    );
+  });
+
+  it('uses bare design tokens with no literal hex fallback in scheme colors', () => {
+    // Regression for #1586: the `var(--token, #hex)` fallbacks were the wrong
+    // colors (e.g. primary-container → green #dcfce7 vs real material light blue
+    // #d3e3fd). Every emitted custom property must be a bare token reference.
+    const { container } = render(StatusBadge, {
+      props: { status: 'paid', type: 'invoice' },
+    });
+    const span = container.querySelector('span') as HTMLElement;
+    expect(span.style.getPropertyValue('--badge-bg')).toBe(
+      'var(--smrt-color-primary-container)',
+    );
+    expect(span.style.getPropertyValue('--badge-bg')).not.toContain('#');
+    expect(span.style.getPropertyValue('--badge-text')).not.toContain('#');
   });
 
   it('normalizes spaces and hyphens when matching a scheme key', () => {

--- a/packages/smrt-ui/src/components/feedback/ConfirmDialog.svelte
+++ b/packages/smrt-ui/src/components/feedback/ConfirmDialog.svelte
@@ -5,7 +5,14 @@
  *
  * Provides a consistent confirmation dialog for destructive actions
  * or important decisions.
+ *
+ * Accessibility (#1586): the dialog is a `role="dialog" aria-modal="true"`
+ * surface with managed focus — on open it records the previously-focused element
+ * and moves focus to the confirm button; Tab/Shift+Tab are trapped within the
+ * dialog; Escape (caught at the document level while open) cancels; and focus is
+ * restored to the opener when the dialog closes.
  */
+import { tick } from 'svelte';
 import { ripple } from '../../actions/ripple.js';
 
 /** Props for ConfirmDialog component */
@@ -42,33 +49,101 @@ const {
   oncancel,
 }: Props = $props();
 
+let backdropEl = $state<HTMLElement | null>(null);
+let confirmBtnEl = $state<HTMLButtonElement | null>(null);
+// The element focused before the dialog opened, restored on close.
+let previouslyFocused: HTMLElement | null = null;
+
+function focusableEls(): HTMLElement[] {
+  if (!backdropEl) return [];
+  return Array.from(
+    backdropEl.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  );
+}
+
+// Move focus into the dialog on open; restore it to the opener on close.
+$effect(() => {
+  if (typeof document === 'undefined') return;
+
+  if (open) {
+    previouslyFocused = document.activeElement as HTMLElement | null;
+    // Wait for the dialog DOM to mount, then move focus into the dialog: the
+    // confirm action by default, the first focusable if confirm is disabled, or
+    // the dialog container itself when every control is disabled (loading) so
+    // focus is still contained and Escape stays reachable.
+    void tick().then(() => {
+      if (!open) return;
+      const target = confirmBtnEl?.disabled
+        ? (focusableEls()[0] ?? backdropEl)
+        : confirmBtnEl;
+      target?.focus();
+    });
+  } else if (previouslyFocused) {
+    previouslyFocused.focus();
+    previouslyFocused = null;
+  }
+});
+
 function handleBackdropClick(e: MouseEvent) {
   if (e.target === e.currentTarget) {
     oncancel?.();
   }
 }
 
+// Escape handling lives at the document level (below) so it fires regardless of
+// where focus currently is. This handler, bound to the dialog, only traps Tab.
 function handleKeydown(e: KeyboardEvent) {
-  if (e.key === 'Escape') {
+  if (e.key !== 'Tab') return;
+
+  // Trap focus within the dialog so Tab can't escape to the page behind.
+  const focusables = focusableEls();
+  if (focusables.length === 0) {
+    e.preventDefault();
+    return;
+  }
+  const first = focusables[0];
+  const last = focusables[focusables.length - 1];
+  const active = document.activeElement;
+
+  if (e.shiftKey) {
+    if (active === first || !backdropEl?.contains(active)) {
+      e.preventDefault();
+      last.focus();
+    }
+  } else if (active === last || !backdropEl?.contains(active)) {
+    e.preventDefault();
+    first.focus();
+  }
+}
+
+function handleWindowKeydown(e: KeyboardEvent) {
+  if (open && e.key === 'Escape') {
+    e.preventDefault();
     oncancel?.();
   }
 }
 </script>
 
+<svelte:window onkeydown={handleWindowKeydown} />
+
 {#if open}
   <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
   <div
+    bind:this={backdropEl}
     class="dialog-backdrop"
     role="dialog"
     aria-modal="true"
     aria-labelledby="dialog-title"
+    aria-describedby="dialog-message"
     tabindex="-1"
     onclick={handleBackdropClick}
     onkeydown={handleKeydown}
   >
     <div class="dialog-content">
       <h2 id="dialog-title" class="dialog-title">{title}</h2>
-      <p class="dialog-message">{message}</p>
+      <p id="dialog-message" class="dialog-message">{message}</p>
 
       <div class="dialog-actions">
         <button
@@ -81,6 +156,7 @@ function handleKeydown(e: KeyboardEvent) {
           {cancelLabel}
         </button>
         <button
+          bind:this={confirmBtnEl}
           type="button"
           class="btn btn-filled"
           class:destructive

--- a/packages/smrt-ui/src/components/feedback/LoadingOverlay.svelte
+++ b/packages/smrt-ui/src/components/feedback/LoadingOverlay.svelte
@@ -114,7 +114,12 @@ function handleKeydown(e: KeyboardEvent) {
 			{/if}
 
 			{#if error}
-				<p class="error-message">{error.message}</p>
+				<!-- role="alert" (assertive live region) so the failure is announced
+				     to screen readers when it appears (#1586). aria-busy flips to
+				     false on error, so without this the overlay changed visually only. -->
+				<p class="error-message" role="alert" aria-live="assertive">
+					{error.message}
+				</p>
 			{/if}
 
 			{#if dismissible}

--- a/packages/smrt-ui/src/components/feedback/__tests__/ConfirmDialog.test.ts
+++ b/packages/smrt-ui/src/components/feedback/__tests__/ConfirmDialog.test.ts
@@ -3,10 +3,12 @@
  *
  * ConfirmDialog renders a backdrop `<div role="dialog" aria-modal="true">` only
  * while `open` is true, with a title, message, and cancel/confirm buttons. It
- * exposes `onconfirm`/`oncancel` callbacks; Escape and backdrop clicks both
- * route to `oncancel`.
+ * exposes `onconfirm`/`oncancel` callbacks; Escape (handled at the document
+ * level) and backdrop clicks both route to `oncancel`. On open it manages focus:
+ * focus moves to the confirm button, Tab is trapped within the dialog, and focus
+ * is restored to the opener on close (#1586).
  */
-import { render, screen } from '@testing-library/svelte';
+import { render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { expectNoA11yViolations } from '../../../test-support/a11y';
@@ -85,6 +87,72 @@ describe('ConfirmDialog', () => {
     render(ConfirmDialog, { props: { ...baseProps, oncancel } });
     await userEvent.click(screen.getByRole('heading', { name: 'Delete item' }));
     expect(oncancel).not.toHaveBeenCalled();
+  });
+
+  describe('focus management (#1586)', () => {
+    it('moves focus to the confirm button when opened', async () => {
+      render(ConfirmDialog, { props: baseProps });
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: 'Confirm' })).toHaveFocus(),
+      );
+    });
+
+    it('traps Tab focus within the dialog', async () => {
+      render(ConfirmDialog, { props: baseProps });
+      const confirm = screen.getByRole('button', { name: 'Confirm' });
+      const cancel = screen.getByRole('button', { name: 'Cancel' });
+      await waitFor(() => expect(confirm).toHaveFocus());
+
+      // Tab from the last focusable (confirm) wraps to the first (cancel).
+      await userEvent.tab();
+      expect(cancel).toHaveFocus();
+
+      // Shift+Tab from the first focusable (cancel) wraps back to confirm.
+      await userEvent.tab({ shift: true });
+      expect(confirm).toHaveFocus();
+    });
+
+    it('restores focus to the opener when closed', async () => {
+      // An external trigger holds focus before the dialog opens.
+      const opener = document.createElement('button');
+      opener.textContent = 'Open';
+      document.body.appendChild(opener);
+      opener.focus();
+      expect(opener).toHaveFocus();
+
+      const { rerender } = render(ConfirmDialog, { props: baseProps });
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: 'Confirm' })).toHaveFocus(),
+      );
+
+      await rerender({ ...baseProps, open: false });
+      expect(opener).toHaveFocus();
+
+      opener.remove();
+    });
+
+    it('cancels via Escape even when focus is outside the dialog', async () => {
+      const oncancel = vi.fn();
+      const outside = document.createElement('input');
+      document.body.appendChild(outside);
+      render(ConfirmDialog, { props: { ...baseProps, oncancel } });
+
+      // Move focus out of the dialog, then press Escape: the document-level
+      // handler still fires because the dialog is open.
+      outside.focus();
+      await userEvent.keyboard('{Escape}');
+      expect(oncancel).toHaveBeenCalledTimes(1);
+
+      outside.remove();
+    });
+
+    it('focuses the dialog container when all controls are disabled (loading)', async () => {
+      // Both buttons are disabled while loading, so there is no focusable
+      // control; focus falls back to the dialog container (tabindex=-1) to stay
+      // contained and keep Escape reachable.
+      render(ConfirmDialog, { props: { ...baseProps, loading: true } });
+      await waitFor(() => expect(screen.getByRole('dialog')).toHaveFocus());
+    });
   });
 
   it('disables both buttons while loading', () => {

--- a/packages/smrt-ui/src/components/feedback/__tests__/LoadingOverlay.test.ts
+++ b/packages/smrt-ui/src/components/feedback/__tests__/LoadingOverlay.test.ts
@@ -64,6 +64,22 @@ describe('LoadingOverlay', () => {
     expect(screen.getByText('Import failed')).toBeInTheDocument();
   });
 
+  it('announces the error via an assertive alert region (#1586)', () => {
+    // aria-busy flips to false on error, so without a live region the failure
+    // would change visually only and never reach a screen reader.
+    render(LoadingOverlay, {
+      props: { show: true, error: { message: 'Import failed' } },
+    });
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('Import failed');
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+  });
+
+  it('exposes no alert region while loading without an error (#1586)', () => {
+    render(LoadingOverlay, { props: { show: true, message: 'Working' } });
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
   it('omits the dismiss button unless dismissible', () => {
     render(LoadingOverlay, { props: { show: true } });
     expect(screen.queryByRole('button', { name: 'Continue' })).toBeNull();

--- a/packages/smrt-ui/src/components/roles/RoleSelector.svelte
+++ b/packages/smrt-ui/src/components/roles/RoleSelector.svelte
@@ -1,5 +1,17 @@
 <script lang="ts">
+/**
+ * RoleSelector — a trigger button and a single-select listbox of roles.
+ *
+ * Implements keyboard support per the WAI-ARIA listbox pattern, mirroring the
+ * roving-focus approach in `ui/Dropdown.svelte`: the trigger opens on
+ * ArrowDown/ArrowUp/Enter/Space; the open list moves focus onto the selected
+ * (or first) option; ArrowUp/Down/Home/End move roving focus; Enter/Space pick
+ * the focused option; Escape closes and refocuses the trigger; Tab closes.
+ * Click-outside also dismisses.
+ */
+
 import type { Role } from '@happyvertical/smrt-types';
+import { tick } from 'svelte';
 
 export interface Props {
   roles: Role[];
@@ -20,28 +32,98 @@ const {
 }: Props = $props();
 
 let open = $state(false);
+let wrapEl = $state<HTMLElement | null>(null);
+let triggerEl = $state<HTMLButtonElement | null>(null);
+let optionEls = $state<Array<HTMLButtonElement | null>>([]);
 const selectedRole = $derived(roles.find((r) => r.id === value));
+
+async function openList() {
+  if (disabled || roles.length === 0) return;
+  open = true;
+  await tick();
+  // Focus the selected option if there is one, otherwise the first.
+  const selectedIndex = roles.findIndex((r) => r.id === value);
+  const target = selectedIndex >= 0 ? selectedIndex : 0;
+  optionEls[target]?.focus();
+}
+
+function closeList(refocus = true) {
+  open = false;
+  if (refocus) triggerEl?.focus();
+}
 
 function handleSelect(roleId: string) {
   onchange(roleId);
-  open = false;
+  closeList();
 }
 
-function handleKeydown(e: KeyboardEvent) {
-  if (e.key === 'Escape') {
-    open = false;
+function focusByOffset(offset: number) {
+  if (roles.length === 0) return;
+  const current = optionEls.indexOf(
+    document.activeElement as HTMLButtonElement | null,
+  );
+  const from = current < 0 ? 0 : current;
+  const next = (from + offset + roles.length) % roles.length;
+  optionEls[next]?.focus();
+}
+
+function onTriggerKeydown(e: KeyboardEvent) {
+  if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault();
+    openList();
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    openList();
   }
 }
+
+function onListKeydown(e: KeyboardEvent) {
+  switch (e.key) {
+    case 'ArrowDown':
+      e.preventDefault();
+      focusByOffset(1);
+      break;
+    case 'ArrowUp':
+      e.preventDefault();
+      focusByOffset(-1);
+      break;
+    case 'Home':
+      e.preventDefault();
+      optionEls[0]?.focus();
+      break;
+    case 'End':
+      e.preventDefault();
+      optionEls[roles.length - 1]?.focus();
+      break;
+    case 'Escape':
+      e.preventDefault();
+      closeList();
+      break;
+    case 'Tab':
+      closeList(false);
+      break;
+  }
+}
+
+// Dismiss on outside click while open.
+$effect(() => {
+  if (!open) return;
+  const onDocPointer = (event: MouseEvent) => {
+    if (wrapEl && !wrapEl.contains(event.target as Node)) closeList(false);
+  };
+  document.addEventListener('click', onDocPointer, true);
+  return () => document.removeEventListener('click', onDocPointer, true);
+});
 </script>
 
-<svelte:window onkeydown={handleKeydown} />
-
-<div class="role-selector" class:disabled>
+<div class="role-selector" class:disabled bind:this={wrapEl}>
   <button
+    bind:this={triggerEl}
     type="button"
     class="trigger"
     class:open
-    onclick={() => (open = !open)}
+    onclick={() => (open ? closeList(false) : openList())}
+    onkeydown={onTriggerKeydown}
     {disabled}
     aria-haspopup="listbox"
     aria-expanded={open}
@@ -56,7 +138,7 @@ function handleKeydown(e: KeyboardEvent) {
     {:else}
       <span class="placeholder">{placeholder}</span>
     {/if}
-    <svg class="chevron" viewBox="0 0 20 20" fill="currentColor">
+    <svg class="chevron" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
       <path
         fill-rule="evenodd"
         d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
@@ -66,14 +148,23 @@ function handleKeydown(e: KeyboardEvent) {
   </button>
 
   {#if open}
-    <div class="dropdown" role="listbox">
-      {#each roles as role (role.id)}
+    <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+    <div
+      class="dropdown"
+      role="listbox"
+      tabindex={-1}
+      aria-label={placeholder}
+      onkeydown={onListKeydown}
+    >
+      {#each roles as role, i (role.id)}
         <button
+          bind:this={optionEls[i]}
           type="button"
           class="option"
           class:selected={role.id === value}
           onclick={() => handleSelect(role.id!)}
           role="option"
+          tabindex={-1}
           aria-selected={role.id === value}
         >
           <div class="option-content">
@@ -115,7 +206,7 @@ function handleKeydown(e: KeyboardEvent) {
     text-align: left;
   }
 
-  .trigger:focus {
+  .trigger:focus-visible {
     outline: none;
     border-color: var(--smrt-color-primary, #005ac1);
     box-shadow: 0 0 0 3px color-mix(in srgb, var(--smrt-color-primary, #005ac1) 10%, transparent);
@@ -179,8 +270,10 @@ function handleKeydown(e: KeyboardEvent) {
     text-align: left;
   }
 
-  .option:hover {
+  .option:hover,
+  .option:focus-visible {
     background: var(--smrt-color-surface-container-high, #f3f4f6);
+    outline: none;
   }
 
   .option.selected {

--- a/packages/smrt-ui/src/components/roles/__tests__/RoleSelector.test.ts
+++ b/packages/smrt-ui/src/components/roles/__tests__/RoleSelector.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Component test for RoleSelector (#1586 remediation, epic #1354).
+ *
+ * RoleSelector is a single-select listbox: a trigger button (`aria-haspopup`/
+ * `aria-expanded`) opens a `role="listbox"` of `role="option"` buttons. This
+ * suite covers the keyboard support added to match the WAI-ARIA listbox pattern
+ * (mirroring `ui/Dropdown.svelte`): open on Enter/ArrowDown, focus-into-list,
+ * Arrow/Home/End roving focus, Enter to select, and Escape to close + refocus
+ * the trigger. Axe-cleanliness is asserted for both open and closed states.
+ */
+
+import type { Role } from '@happyvertical/smrt-types';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import RoleSelector from '../RoleSelector.svelte';
+
+function role(id: string, name: string, isSystem = false): Role {
+  return {
+    id,
+    slug: id,
+    created_at: null,
+    updated_at: null,
+    tenantId: null,
+    name,
+    description: `${name} role`,
+    isSystem,
+  };
+}
+
+const ROLES: Role[] = [
+  role('admin', 'Admin', true),
+  role('editor', 'Editor'),
+  role('viewer', 'Viewer'),
+];
+
+describe('RoleSelector', () => {
+  it('exposes a collapsed listbox trigger by default', () => {
+    render(RoleSelector, { props: { roles: ROLES, onchange: vi.fn() } });
+    const trigger = screen.getByRole('button');
+    expect(trigger).toHaveAttribute('aria-haspopup', 'listbox');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('shows the placeholder when no role is selected', () => {
+    render(RoleSelector, {
+      props: { roles: ROLES, onchange: vi.fn(), placeholder: 'Pick one' },
+    });
+    expect(screen.getByText('Pick one')).toBeInTheDocument();
+  });
+
+  it('opens via click and exposes the options as a listbox', async () => {
+    render(RoleSelector, { props: { roles: ROLES, onchange: vi.fn() } });
+    await userEvent.click(screen.getByRole('button'));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(screen.getAllByRole('option')).toHaveLength(3);
+  });
+
+  it('opens on Enter and moves focus onto the first option', async () => {
+    render(RoleSelector, { props: { roles: ROLES, onchange: vi.fn() } });
+    screen.getByRole('button').focus();
+    await userEvent.keyboard('{Enter}');
+    const options = screen.getAllByRole('option');
+    expect(options[0]).toHaveFocus();
+  });
+
+  it('opens on ArrowDown and focuses the already-selected option', async () => {
+    render(RoleSelector, {
+      props: { roles: ROLES, value: 'viewer', onchange: vi.fn() },
+    });
+    screen.getByRole('button').focus();
+    await userEvent.keyboard('{ArrowDown}');
+    const viewer = screen.getByRole('option', { name: /Viewer/ });
+    expect(viewer).toHaveFocus();
+  });
+
+  it('roves focus with ArrowDown/ArrowUp and wraps at the ends', async () => {
+    render(RoleSelector, { props: { roles: ROLES, onchange: vi.fn() } });
+    screen.getByRole('button').focus();
+    await userEvent.keyboard('{Enter}'); // focuses option 0 (Admin)
+    const options = screen.getAllByRole('option');
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(options[1]).toHaveFocus();
+    await userEvent.keyboard('{ArrowDown}');
+    expect(options[2]).toHaveFocus();
+    await userEvent.keyboard('{ArrowDown}'); // wraps to first
+    expect(options[0]).toHaveFocus();
+    await userEvent.keyboard('{ArrowUp}'); // wraps to last
+    expect(options[2]).toHaveFocus();
+  });
+
+  it('jumps to the first/last option with Home/End', async () => {
+    render(RoleSelector, { props: { roles: ROLES, onchange: vi.fn() } });
+    screen.getByRole('button').focus();
+    await userEvent.keyboard('{Enter}');
+    const options = screen.getAllByRole('option');
+
+    await userEvent.keyboard('{End}');
+    expect(options[2]).toHaveFocus();
+    await userEvent.keyboard('{Home}');
+    expect(options[0]).toHaveFocus();
+  });
+
+  it('selects the focused option with Enter and fires onchange', async () => {
+    const onchange = vi.fn();
+    render(RoleSelector, { props: { roles: ROLES, onchange } });
+    screen.getByRole('button').focus();
+    await userEvent.keyboard('{Enter}'); // open, focus Admin
+    await userEvent.keyboard('{ArrowDown}'); // focus Editor
+    await userEvent.keyboard('{Enter}'); // select Editor
+    expect(onchange).toHaveBeenCalledWith('editor');
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('closes on Escape and restores focus to the trigger', async () => {
+    render(RoleSelector, { props: { roles: ROLES, onchange: vi.fn() } });
+    const trigger = screen.getByRole('button');
+    trigger.focus();
+    await userEvent.keyboard('{Enter}');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    await userEvent.keyboard('{Escape}');
+    expect(screen.queryByRole('listbox')).toBeNull();
+    expect(trigger).toHaveFocus();
+  });
+
+  it('does not open when disabled', async () => {
+    render(RoleSelector, {
+      props: { roles: ROLES, onchange: vi.fn(), disabled: true },
+    });
+    const trigger = screen.getByRole('button');
+    await userEvent.click(trigger);
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('is axe-clean when closed', async () => {
+    const { container } = render(RoleSelector, {
+      props: { roles: ROLES, value: 'admin', onchange: vi.fn() },
+    });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean when open', async () => {
+    const { container } = render(RoleSelector, {
+      props: { roles: ROLES, onchange: vi.fn(), showDescription: true },
+    });
+    await userEvent.click(screen.getByRole('button'));
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-ui/src/components/ui/Button.svelte
+++ b/packages/smrt-ui/src/components/ui/Button.svelte
@@ -139,8 +139,14 @@ const linkProps = $derived(() => {
     color: var(--smrt-color-on-primary);
   }
 
+  /* M3 hover state layer: 8% of the on-color blended over the base, so the
+     button visibly darkens on hover instead of repeating its base color. */
   .primary:hover:not(:disabled):not(.disabled) {
-    background: var(--smrt-color-primary);
+    background: color-mix(
+      in srgb,
+      var(--smrt-color-on-primary) 8%,
+      var(--smrt-color-primary)
+    );
   }
 
   .secondary {
@@ -168,7 +174,11 @@ const linkProps = $derived(() => {
   }
 
   .danger:hover:not(:disabled):not(.disabled) {
-    background: var(--smrt-color-error);
+    background: color-mix(
+      in srgb,
+      var(--smrt-color-on-error) 8%,
+      var(--smrt-color-error)
+    );
   }
 
   /* Full width */

--- a/packages/smrt-ui/src/components/ui/Pagination.svelte
+++ b/packages/smrt-ui/src/components/ui/Pagination.svelte
@@ -136,7 +136,9 @@ const isLastPage = $derived(currentPage === totalPages);
     {/if}
 
     <ul class="page-numbers">
-      {#each pageNumbers as page}
+      <!-- Key by index: getPageNumbers can emit two 'ellipsis' sentinels, whose
+           value-identity would collide under a value-based key (#1586). -->
+      {#each pageNumbers as page, i (i)}
         {#if page === 'ellipsis'}
           <li class="page-numbers__item">
             <span class="ellipsis" aria-hidden="true">&hellip;</span>

--- a/packages/smrt-ui/src/components/ui/__tests__/Pagination.test.ts
+++ b/packages/smrt-ui/src/components/ui/__tests__/Pagination.test.ts
@@ -97,6 +97,22 @@ describe('Pagination', () => {
     expect(page2).toHaveAttribute('href', '/articles/page/2');
   });
 
+  it('renders both ellipses on a deep middle page without key collision (#1586)', async () => {
+    // currentPage in the middle of many pages emits two 'ellipsis' sentinels.
+    // Keying the {#each} by value would collide; keying by index keeps both.
+    const onPageChange = vi.fn();
+    const { container, rerender } = render(Pagination, {
+      props: { currentPage: 10, totalPages: 20, onPageChange },
+    });
+    expect(container.querySelectorAll('.ellipsis')).toHaveLength(2);
+
+    // Re-render to an adjacent deep page: still two ellipses, still one current.
+    await rerender({ currentPage: 11, totalPages: 20, onPageChange });
+    expect(container.querySelectorAll('.ellipsis')).toHaveLength(2);
+    expect(container.querySelectorAll('[aria-current="page"]')).toHaveLength(1);
+    expect(screen.getByText('11')).toHaveAttribute('aria-current', 'page');
+  });
+
   it('is axe-clean in callback mode on a middle page', async () => {
     const { container } = render(Pagination, {
       props: { currentPage: 3, totalPages: 10, onPageChange: vi.fn() },

--- a/packages/smrt-ui/src/themes/__tests__/create-theme.test.ts
+++ b/packages/smrt-ui/src/themes/__tests__/create-theme.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression tests for createTheme color handling (#1586, epic #1354).
+ *
+ * The dark-color derivation and primary-container derivation used to assume the
+ * primary was 6-digit hex. For `rgb()`, 3-digit hex, or a named color they
+ * emitted invalid CSS — `rgb(0,122,255)20`, `#f6320`, `#NaNNaNNaN`. Inputs are
+ * now normalized to RGB first (or rejected with a clear error), so the generated
+ * palette is always valid CSS.
+ */
+import { describe, expect, it } from 'vitest';
+import { createTheme } from '../create-theme';
+import type { ColorPalette } from '../types';
+
+const HEX6 = /^#[0-9a-fA-F]{6}$/;
+const HEX_ALPHA = /^#[0-9a-fA-F]{8}$/;
+
+/** Every color value in a palette must be syntactically valid CSS. */
+function expectAllColorsValid(colors: ColorPalette) {
+  for (const [key, value] of Object.entries(colors)) {
+    expect(typeof value).toBe('string');
+    // The regression: derivations used to emit '#NaNNaNNaN' / 'rgb(...)20'.
+    expect(value, `${key}=${value}`).not.toContain('NaN');
+    // Hex values must be well-formed: exactly 3, 4, 6, or 8 digits (all valid
+    // CSS). A 5- or 7-digit hex (e.g. the '#f6320' the bug produced) must fail.
+    // rgb()/rgba() and other formats pass through unchanged.
+    if (value.startsWith('#')) {
+      expect(value, `${key}=${value}`).toMatch(
+        /^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/,
+      );
+    }
+  }
+}
+
+describe('createTheme color handling (#1586)', () => {
+  it('derives a valid primary container from a 6-digit hex primary', () => {
+    const theme = createTheme({
+      id: 'brand6',
+      name: 'Brand 6',
+      light: { primary: '#0b57d0', background: '#ffffff' },
+    });
+    // 8-digit hex alpha form: primary + "20".
+    expect(theme.light.primaryContainer).toMatch(HEX_ALPHA);
+    expect(theme.light.primaryContainer.toLowerCase()).toBe('#0b57d020');
+    expectAllColorsValid(theme.light);
+    expectAllColorsValid(theme.dark);
+  });
+
+  it('normalizes an rgb() primary instead of emitting invalid CSS', () => {
+    const theme = createTheme({
+      id: 'brandRgb',
+      name: 'Brand RGB',
+      light: { primary: 'rgb(0, 122, 255)', background: '#ffffff' },
+    });
+    // Was 'rgb(0, 122, 255)20' (invalid); now a normalized 8-digit hex.
+    expect(theme.light.primaryContainer).not.toContain('rgb(');
+    expect(theme.light.primaryContainer).toMatch(HEX_ALPHA);
+    expect(theme.light.primaryContainer.toLowerCase()).toBe('#007aff20');
+    // Auto-generated dark colors used to be '#NaNNaNNaN' for an rgb() input;
+    // every value is now valid CSS (hex values are well-formed, rgb() values
+    // pass through unchanged).
+    expectAllColorsValid(theme.light);
+    expectAllColorsValid(theme.dark);
+    // The brightness-derived dark colors normalize to proper hex.
+    expect(theme.dark.onPrimary).toMatch(HEX6);
+    expect(theme.dark.secondary).toMatch(HEX6);
+  });
+
+  it('expands a 3-digit hex primary correctly', () => {
+    const theme = createTheme({
+      id: 'brand3',
+      name: 'Brand 3',
+      light: { primary: '#07f', background: '#fff' },
+    });
+    // '#07f' -> '#0077ff', container '#0077ff20'.
+    expect(theme.light.primaryContainer.toLowerCase()).toBe('#0077ff20');
+    expectAllColorsValid(theme.light);
+    expectAllColorsValid(theme.dark);
+    expect(theme.dark.onPrimary).toMatch(HEX6);
+  });
+
+  it('throws a clear error for an unsupported named color', () => {
+    expect(() =>
+      createTheme({
+        id: 'brandNamed',
+        name: 'Brand Named',
+        light: { primary: 'tomato', background: '#ffffff' },
+      }),
+    ).toThrow(/unsupported color "tomato"/);
+  });
+});

--- a/packages/smrt-ui/src/themes/__tests__/css-generator.test.ts
+++ b/packages/smrt-ui/src/themes/__tests__/css-generator.test.ts
@@ -1,6 +1,8 @@
 /**
  * Unit tests for the theme CSS generator (coverage uplift, S6 gate).
  */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   generateAllThemesCSS,
@@ -9,6 +11,39 @@ import {
   variablesToStyleString,
 } from '../css-generator';
 import { getTheme } from '../registry';
+
+// Raw CSS text of the static studio preset, used to prove the static-CSS
+// delivery path and the JS generator emit identical elevation values (#1586).
+// Resolved from the package root (the test runner's cwd) to avoid `import.meta`
+// URL-scheme differences between the vite and node loaders.
+const studioCss = readFileSync(
+  join(process.cwd(), 'src/themes/styles/studio.css'),
+  'utf8',
+);
+
+/**
+ * Pull the `--smrt-elevation-0..5` values out of a specific
+ * `[data-theme="<preset>"][data-color-scheme="<scheme>"]` block of a static CSS
+ * preset file.
+ */
+function staticElevation(
+  css: string,
+  preset: string,
+  scheme: 'light' | 'dark',
+): Record<string, string> {
+  const selector = `[data-theme="${preset}"][data-color-scheme="${scheme}"]`;
+  const start = css.indexOf(selector);
+  if (start === -1) throw new Error(`block not found: ${selector}`);
+  const open = css.indexOf('{', start);
+  const close = css.indexOf('}', open);
+  const body = css.slice(open + 1, close);
+  const out: Record<string, string> = {};
+  for (const line of body.split('\n')) {
+    const m = line.match(/(--smrt-elevation-\d):\s*(.+);/);
+    if (m) out[m[1]] = m[2].trim();
+  }
+  return out;
+}
 
 describe('theme CSS generator', () => {
   const theme = getTheme('material');
@@ -38,5 +73,33 @@ describe('theme CSS generator', () => {
   it('generateAllThemesCSS resolves to a non-empty string', async () => {
     const css = await generateAllThemesCSS();
     expect(css.length).toBeGreaterThan(0);
+  });
+
+  describe('studio per-scheme elevation (#1586)', () => {
+    const studio = getTheme('studio');
+
+    it('emits distinct dark-scheme elevation, not the light values', () => {
+      const light = generateThemeVariables(studio, false);
+      const dark = generateThemeVariables(studio, true);
+      // Level 1 is a white inset hairline in dark vs a tinted inset in light.
+      expect(dark['--smrt-elevation-1']).toContain('rgba(255, 255, 255');
+      expect(light['--smrt-elevation-1']).toContain('rgba(60, 64, 67');
+      expect(dark['--smrt-elevation-1']).not.toBe(light['--smrt-elevation-1']);
+      // Deeper black shadows above level 1.
+      expect(dark['--smrt-elevation-5']).toContain('rgba(0, 0, 0, 0.25)');
+    });
+
+    it('matches the static studio.css for both schemes (drift guard)', () => {
+      // The static-CSS delivery path and the JS generator must agree on VALUES,
+      // not just token names — this is what let the studio dark shadows diverge.
+      for (const scheme of ['light', 'dark'] as const) {
+        const generated = generateThemeVariables(studio, scheme === 'dark');
+        const fromCss = staticElevation(studioCss, 'studio', scheme);
+        for (let level = 0; level <= 5; level += 1) {
+          const key = `--smrt-elevation-${level}`;
+          expect(fromCss[key], `${scheme} ${key}`).toBe(generated[key]);
+        }
+      }
+    });
   });
 });

--- a/packages/smrt-ui/src/themes/__tests__/css-generator.test.ts
+++ b/packages/smrt-ui/src/themes/__tests__/css-generator.test.ts
@@ -14,8 +14,10 @@ import { getTheme } from '../registry';
 
 // Raw CSS text of the static studio preset, used to prove the static-CSS
 // delivery path and the JS generator emit identical elevation values (#1586).
-// Resolved from the package root (the test runner's cwd) to avoid `import.meta`
-// URL-scheme differences between the vite and node loaders.
+// Resolved from process.cwd() (NOT import.meta.url): the smrt-vitest plugin runs
+// each package's suite with cwd === the package root, so this is stable here,
+// whereas `new URL('…', import.meta.url)` fails to resolve under the vite-node
+// loader this suite runs in.
 const studioCss = readFileSync(
   join(process.cwd(), 'src/themes/styles/studio.css'),
   'utf8',

--- a/packages/smrt-ui/src/themes/create-theme.ts
+++ b/packages/smrt-ui/src/themes/create-theme.ts
@@ -4,6 +4,7 @@
  * Helper functions for creating custom themes that match the SMRT theme system.
  */
 
+import { hexToRgb, rgbToHex } from '../utils/theme/color.js';
 import {
   hasCustomTheme,
   registerCustomTheme,
@@ -104,18 +105,22 @@ const defaultColorStructure: Omit<
 };
 
 /**
- * Helper function to clamp a value between min and max
+ * Normalize any supported CSS color string to a canonical 6-digit hex.
+ *
+ * Accepts 6-digit hex, 3-digit shorthand hex, and `rgb()`/`rgba()` (via the
+ * shared `hexToRgb`). Throws on input that can't be parsed (e.g. a named color
+ * like `tomato`) so an unsupported value fails loudly instead of silently
+ * producing invalid CSS like `#NaNNaNNaN` or `rgb(...)20` (#1586).
  */
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
-}
-
-/**
- * Helper function to convert RGB component to 2-digit hex
- */
-function toHexComponent(value: number): string {
-  const clamped = Math.round(clamp(value, 0, 255));
-  return clamped.toString(16).padStart(2, '0');
+function normalizeHex(color: string): string {
+  const { r, g, b } = hexToRgb(color);
+  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) {
+    throw new Error(
+      `createTheme: unsupported color "${color}". Use 6-digit hex (#rrggbb), ` +
+        '3-digit hex (#rgb), or rgb()/rgba() notation.',
+    );
+  }
+  return rgbToHex(r, g, b);
 }
 
 /**
@@ -123,19 +128,18 @@ function toHexComponent(value: number): string {
  * Uses simple inversion logic - for production use, manually define dark colors
  */
 function generateDarkColors(light: ColorPalette): ColorPalette {
-  // Helper to adjust color brightness with proper rounding and hex conversion
-  const adjustBrightness = (hex: string, factor: number): string => {
-    // Handle 3-character hex codes
-    let fullHex = hex;
-    if (hex.length === 4 && hex[0] === '#') {
-      fullHex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+  // Adjust color brightness by a multiplicative factor. Normalizes the input to
+  // RGB first (via the shared parser), so 3-digit hex and rgb()/rgba() inputs no
+  // longer NaN-poison the output into `#NaNNaNNaN` (#1586).
+  const adjustBrightness = (color: string, factor: number): string => {
+    const { r, g, b } = hexToRgb(color);
+    if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) {
+      throw new Error(
+        `createTheme: unsupported color "${color}". Use 6-digit hex (#rrggbb), ` +
+          '3-digit hex (#rgb), or rgb()/rgba() notation.',
+      );
     }
-
-    const r = parseInt(fullHex.slice(1, 3), 16) * factor;
-    const g = parseInt(fullHex.slice(3, 5), 16) * factor;
-    const b = parseInt(fullHex.slice(5, 7), 16) * factor;
-
-    return `#${toHexComponent(r)}${toHexComponent(g)}${toHexComponent(b)}`;
+    return rgbToHex(r * factor, g * factor, b * factor);
   };
 
   return {
@@ -338,9 +342,13 @@ export function createTheme(options: CreateThemeOptions): Theme {
     ...defaultColorStructure,
     ...baseTheme?.light,
     ...lightPartial,
-    // Generate derived colors
+    // Generate derived colors. The container is the primary at ~12.5% alpha,
+    // expressed as 8-digit hex. Normalize the primary to canonical 6-hex first
+    // so a 3-digit hex or rgb()/rgba() primary can't yield invalid CSS like
+    // `rgb(0,122,255)20` or `#f6320` (#1586).
     primaryContainer:
-      lightPartial.primaryContainer || `${lightPartial.primary}20`,
+      lightPartial.primaryContainer ||
+      `${normalizeHex(lightPartial.primary)}20`,
     onPrimaryContainer: lightPartial.onPrimaryContainer || lightPartial.primary,
     inversePrimary: lightPartial.inversePrimary || lightPartial.primary,
   } as ColorPalette;

--- a/packages/smrt-ui/src/themes/css-generator.ts
+++ b/packages/smrt-ui/src/themes/css-generator.ts
@@ -239,6 +239,10 @@ export function generateThemeVariables(
 ): Record<string, string> {
   const { prefix = '--smrt' } = options;
   const colors = isDark ? theme.dark : theme.light;
+  // Per-scheme elevation: dark uses `darkElevation` when the preset defines it,
+  // so the JS generator and the static dark CSS stay in lockstep (#1586).
+  const elevation =
+    isDark && theme.darkElevation ? theme.darkElevation : theme.elevation;
 
   return {
     // Theme identification
@@ -260,7 +264,7 @@ export function generateThemeVariables(
     ...generateBorderRadiusVariables(theme.borderRadius, prefix),
 
     // Elevation
-    ...generateElevationVariables(theme.elevation, prefix),
+    ...generateElevationVariables(elevation, prefix),
 
     // Duration
     ...generateDurationVariables(theme.duration, prefix),

--- a/packages/smrt-ui/src/themes/studio/index.ts
+++ b/packages/smrt-ui/src/themes/studio/index.ts
@@ -276,7 +276,7 @@ const typography: TypographyScale = {
 };
 
 /**
- * Studio elevation - Minimal, subtle shadows
+ * Studio elevation (light) - Minimal, subtle shadows
  * Flat design philosophy with only slight depth indication
  */
 const elevation: ElevationScale = {
@@ -289,6 +289,24 @@ const elevation: ElevationScale = {
 };
 
 /**
+ * Studio elevation (dark) - Tuned for a near-black surface.
+ *
+ * The flat light shadows (tinted with the light surface color, very low alpha)
+ * read as invisible on a dark surface, so dark mode uses a white inset hairline
+ * at level 1 and deeper black shadows above it. Defining this here — rather than
+ * only in the static `styles/studio.css` — keeps the JS ThemeProvider output and
+ * the static dark CSS in lockstep (#1586).
+ */
+const darkElevation: ElevationScale = {
+  0: 'none',
+  1: 'inset 0 0 0 1px rgba(255, 255, 255, 0.08)',
+  2: '0 1px 2px 0 rgba(0, 0, 0, 0.2), 0 1px 3px 0 rgba(0, 0, 0, 0.1)',
+  3: '0 2px 4px 0 rgba(0, 0, 0, 0.2), 0 1px 2px 0 rgba(0, 0, 0, 0.1)',
+  4: '0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 2px 4px 0 rgba(0, 0, 0, 0.1)',
+  5: '0 8px 16px 0 rgba(0, 0, 0, 0.25), 0 4px 8px 0 rgba(0, 0, 0, 0.1)',
+};
+
+/**
  * Studio theme definition
  */
 export const studioTheme: Theme = {
@@ -298,6 +316,7 @@ export const studioTheme: Theme = {
   dark: darkColors,
   typography,
   elevation,
+  darkElevation,
   spacing: spacingScale,
   borderRadius: borderRadiusScale,
   duration: durationScale,

--- a/packages/smrt-ui/src/themes/types.ts
+++ b/packages/smrt-ui/src/themes/types.ts
@@ -228,8 +228,15 @@ export interface Theme {
   dark: ColorPalette;
   /** Typography scale */
   typography: TypographyScale;
-  /** Elevation shadows */
+  /** Elevation shadows (used for both schemes unless `darkElevation` is set) */
   elevation: ElevationScale;
+  /**
+   * Optional dark-scheme elevation overrides. When present, the CSS generator
+   * emits these for the dark scheme instead of `elevation`. Lets a preset tune
+   * shadows for a dark surface (e.g. studio's punchier dark shadows) so the JS
+   * generator and the static dark CSS can't diverge (#1586).
+   */
+  darkElevation?: ElevationScale;
   /** Spacing scale */
   spacing: SpacingScale;
   /** Border radius scale */

--- a/packages/smrt-ui/src/utils/theme/__tests__/color.test.ts
+++ b/packages/smrt-ui/src/utils/theme/__tests__/color.test.ts
@@ -16,6 +16,25 @@ describe('Theme Color Utilities', () => {
     expect(hexToRgb('#FF5733')).toEqual({ r: 255, g: 87, b: 51 });
   });
 
+  it('expands 3-digit shorthand hex (#abc -> #aabbcc) (#1586)', () => {
+    // Regression: shorthand hex used to NaN-poison the b channel (only the first
+    // 2 chars were read), corrupting any palette generated from a 3-digit seed.
+    expect(hexToRgb('#abc')).toEqual({ r: 170, g: 187, b: 204 });
+    expect(hexToRgb('#000')).toEqual({ r: 0, g: 0, b: 0 });
+    expect(hexToRgb('#fff')).toEqual({ r: 255, g: 255, b: 255 });
+  });
+
+  it('parses functional rgb()/rgba() notation (#1586)', () => {
+    expect(hexToRgb('rgb(0, 122, 255)')).toEqual({ r: 0, g: 122, b: 255 });
+    expect(hexToRgb('rgb(0 122 255)')).toEqual({ r: 0, g: 122, b: 255 });
+    expect(hexToRgb('rgba(0, 122, 255, 0.5)')).toEqual({
+      r: 0,
+      g: 122,
+      b: 255,
+    });
+    expect(hexToRgb('rgb(100%, 0%, 50%)')).toEqual({ r: 255, g: 0, b: 128 });
+  });
+
   it('should convert rgb to hex correctly', () => {
     expect(rgbToHex(0, 0, 0)).toBe('#000000');
     expect(rgbToHex(255, 255, 255)).toBe('#ffffff');

--- a/packages/smrt-ui/src/utils/theme/color.ts
+++ b/packages/smrt-ui/src/utils/theme/color.ts
@@ -50,11 +50,50 @@ export interface Theme {
   surfaceContainerHighest: string;
 }
 
+/**
+ * Parse a CSS color string into an {@link Rgb}.
+ *
+ * Accepts 6-digit hex (`#rrggbb`), 3-digit shorthand hex (`#rgb`, expanded by
+ * doubling each nibble), and functional `rgb()` / `rgba()` notation (commas or
+ * spaces, integer or percentage channels). Named colors and other formats are
+ * not supported and yield `{ r: NaN, g: NaN, b: NaN }`; callers that accept
+ * arbitrary input should validate before relying on the result.
+ *
+ * The leading `#` is optional for hex input.
+ */
 export function hexToRgb(hex: string): Rgb {
-  const cleanHex = hex.replace('#', '');
-  const r = parseInt(cleanHex.substring(0, 2), 16);
-  const g = parseInt(cleanHex.substring(2, 4), 16);
-  const b = parseInt(cleanHex.substring(4, 6), 16);
+  const input = hex.trim();
+
+  // Functional rgb()/rgba() notation, e.g. rgb(0, 122, 255) or rgb(0 122 255 / .5).
+  const rgbMatch = input.match(/^rgba?\(([^)]+)\)$/i);
+  if (rgbMatch) {
+    const channels = rgbMatch[1]
+      .split(/[\s,/]+/)
+      .filter(Boolean)
+      .slice(0, 3);
+    const toChannel = (part: string): number => {
+      if (part.endsWith('%')) {
+        return Math.round((Number.parseFloat(part) / 100) * 255);
+      }
+      return Number.parseInt(part, 10);
+    };
+    const [r, g, b] = channels.map(toChannel);
+    return { r, g, b };
+  }
+
+  const cleanHex = input.replace('#', '');
+
+  // 3-digit shorthand hex: #abc -> #aabbcc.
+  if (cleanHex.length === 3) {
+    const r = Number.parseInt(cleanHex[0] + cleanHex[0], 16);
+    const g = Number.parseInt(cleanHex[1] + cleanHex[1], 16);
+    const b = Number.parseInt(cleanHex[2] + cleanHex[2], 16);
+    return { r, g, b };
+  }
+
+  const r = Number.parseInt(cleanHex.substring(0, 2), 16);
+  const g = Number.parseInt(cleanHex.substring(2, 4), 16);
+  const b = Number.parseInt(cleanHex.substring(4, 6), 16);
   return { r, g, b };
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1905,6 +1905,9 @@ importers:
 
   packages/smrt-svelte:
     dependencies:
+      '@happyvertical/logger':
+        specifier: ^0.74.7
+        version: 0.74.7(@sentry/node@10.51.0)
       '@happyvertical/smrt-agents':
         specifier: workspace:*
         version: link:../agents

--- a/scripts/check-svelte-tokens.mjs
+++ b/scripts/check-svelte-tokens.mjs
@@ -14,11 +14,12 @@
  * in domain packages (e.g. `--smrt-elevation-level1`, `--smrt-typography-body`,
  * `--smrt-primary`). It now scans every `packages/<pkg>/src`.
  *
- * Emitted tokens are collected from every runtime delivery path:
- *   - static preset CSS: packages/smrt-svelte/src/themes/styles/*.css
- *   - JS theme generator: packages/smrt-svelte/src/themes/css-generator.ts
+ * Emitted tokens are collected from every runtime delivery path (the theme
+ * system lives in the smrt-ui leaf since #1582 Phase 2):
+ *   - static preset CSS: packages/smrt-ui/src/themes/styles/*.css
+ *   - JS theme generator: packages/smrt-ui/src/themes/css-generator.ts
  *     (resolved structurally against the theme token scales)
- *   - simple ThemeProvider tokens: packages/smrt-svelte/src/theme/tokens.ts
+ *   - simple ThemeProvider tokens: packages/smrt-ui/src/theme/tokens.ts
  *   - tokens any package defines inline in component CSS (e.g. --smrt-ws-*,
  *     --smrt-role-color) — a legit component-scoped pattern, not a dangling ref
  *
@@ -370,7 +371,7 @@ if (staticMissingByPreset.length > 0) {
   console.error(
     '\nStatic preset CSS should expose the same token names as the JS preset\n' +
       'generator for that preset. Add missing definitions to\n' +
-      'packages/smrt-svelte/src/themes/styles/*.css.',
+      'packages/smrt-ui/src/themes/styles/*.css.',
   );
 }
 


### PR DESCRIPTION
## Summary
First-batch remediation of the **T2 deep code + UI review track** (epic #1354). Four packages were deep-reviewed (read-only, adversarially verified) and their confirmed, in-scope findings fixed here with regression tests. Non-overlapping file ownership → conflict-free integration.

Review findings: #1586 (smrt-ui) · #1403 (smrt-svelte) · #1391 (chat) · #1401 (jobs). This batch validated the UI-review mode (design tokens / a11y / primitive reuse) before the rest of T2 fans out.

## What's fixed (by package)

**smrt-ui (#1586)** — the new domain-agnostic UI leaf (extracted in #1584):
- **[a11y blocker]** `ConfirmDialog`: real focus-trap + focus-restore + working Escape (was `role=dialog` with no trap and a dead Esc handler).
- `LoadingOverlay` error → `role=alert`/`aria-live`; `RoleSelector` full listbox keyboard nav.
- `createTheme()`/`hexToRgb` normalize `rgb()`/3-char-hex (was invalid CSS / `#NaNNaNNaN`); ripple `--md-sys-*` → `--smrt-color-*`; **studio dark-elevation drift** fixed + a **value-level drift-guard test** CI was missing; badge color fallbacks corrected; Pagination ellipses keyed; ripple leak + `prefers-reduced-motion`.

**smrt-svelte (#1403)** — top-of-stack integration layer:
- Browser-AI **warm-cache lifecycle**: listener leak (R1), disposed-adapters-cached-as-`ready` (R2), preload-scheduler thrash + concurrent-run guard (R3), per-hook STT/TTS ownership so one component unmount doesn't stop AI globally (R4).
- **[a11y blocker]** keyboard-accessible per-field mic across all 5 voice inputs (Enter/Space) — incl. the `readonly` `DateTimeInput` where the mic is the only keyboard entry path.
- `stt.start()` failures no longer wedge the control (try/catch/finally + surfaced error); empty catches now log + surface mic-permission denial; `AgentSettingsShell` tablist ARIA; `color:white` → token; `FileUpload` `role=alert`.

**chat (#1391)** — domain/ORM layer verified clean (S5 #1392 hardening holds); UI remediated:
- **[a11y blocker]** `MessageItem` actions reachable by keyboard/touch (was hover-only `onmouseenter`).
- `RoomCreateDialog` → shared smrt-ui `Modal` (focus-trap/ESC/restore/scrim); `MentionAutocomplete` Escape dismiss; `ChatLayout` `oncreateroom` wired; color-fallback fixes; dead `statusIcon` removed.
- **[security, defense-in-depth]** `ChatService` whitelist gate broadened to `tool_result` (reachable only via the trusted agent-runtime subpath — a fidelity gap, not cross-actor/tenant escalation).

**jobs (#1401)** — mature package; timeout cluster hardened:
- **[crash risk]** fire-and-forget `processJob` → unhandled-rejection guard (`.catch` + try/catch the error path).
- `timeoutBehavior` made honest (`'warn'` honored; `'kill'`→`'fail'` documented since JS can't preempt); timeouts no longer auto-retry (narrows the at-least-once duplicate-exec window, now documented loudly); schedule `next_run` rollback on enqueue failure; timeout timer leak fixed; `JobList` keyboard activation.

## ⚠️ Breaking
- `fix(chat)!` — a11y markup changes (`MessageItem` action-reveal; `RoomCreateDialog` now composes smrt-ui `Modal`) — downstream custom selectors/snapshots may need updating.
- jobs — timeouts no longer auto-retry; new `JobTimeoutError` exported.

(All `@happyvertical/smrt-*` are version-locked → this is a coordinated major bump.)

## New dependency
- smrt-svelte adds `@happyvertical/logger` (SDK, `catalog:` spec) for a browser-safe logger (`src/internal/logger.ts`). **DAG-compliant** — not an inter-smrt peer; `check-no-smrt-peers` + `check-package-dag` pass.

## Testing
- **~1,153 tests pass** across the four packages (smrt-ui 401 · smrt-svelte 464 · chat 185 · jobs 103; ~+44 new regression tests, incl. a11y/DOM + the timeout/concurrency cases).
- Full `turbo build` **51/51**; typecheck + `svelte-check` (+a11y) clean; all pre-push token/DAG/knowledge gates green.

## Deferred (intentionally not in this PR)
- Cross-cutting sweeps → **#1579** (color-fallback re-audit, i18n coverage, console→logger in browser-AI adapters, z-index/spacing, the orphaned `tokens.css` public export, smrt-ui dead code).
- smrt-ui **primitive adoption** migration (chat re-rolls smrt-ui/chat primitives; smrt-svelte composites import no visual primitives) → **#1589**.
- Candidate follow-up surfaced by the smrt-ui agent: `SummaryCard {@html icon}` XSS-hardening — real only if a consumer passes untrusted SVG (the prop is documented as trusted), and a proper fix is breaking or needs a sanitizer dep — flagged for triage.

Addresses #1586, #1403, #1391, #1401.
