### PR TITLE
feat(users)!: session-id rotation on tenant switch + tenant-DENY hard block (#1399)

### DIFF
--- a/packages/users/AGENTS.md
+++ b/packages/users/AGENTS.md
@@ -77,13 +77,22 @@ await switchSessionTenant(event, tenantId, { db });
   structural regression test (`security-audit-1400.test.ts`) enumerates the
   registry to assert no authority model exposes a mutating op. (`cli` stays
   enabled — local-operator surface, outside the network/agent threat model.)
-- **`switchTenant` is fail-closed.** `SessionService.switchTenant` /
-  `switchSessionTenant` verify the session's user has an ACTIVE membership in the
-  target tenant before writing `session.tenantId` (the tenant-isolation key for
-  every `@TenantScoped` query). A non-member switch returns `false` without
-  mutating the session; `null` clears the context and is always allowed. The
-  low-level `SessionCollection.setSessionTenant` is the UNGUARDED primitive —
-  never call it with an untrusted tenant id.
+- **`switchTenant` is fail-closed AND rotates the session id.**
+  `SessionService.switchTenant` / `switchSessionTenant` verify the session's user
+  has an ACTIVE membership in the target tenant before any write (the tenant id
+  is the isolation key for every `@TenantScoped` query). A non-member/unknown-
+  session switch returns `{ switched: false, sessionId: null, ... }` and mutates
+  nothing. On a successful switch into a NON-null tenant the session id is
+  ROTATED: a fresh `Session` (new secure id, fresh TTL, same user, new tenant,
+  device context carried over) is minted and the old session is REVOKED — so a
+  captured pre-switch id immediately stops validating, shrinking the blast radius
+  of a leaked id across a tenant boundary. `switchTenant` returns a
+  `SwitchTenantResult` (`{ switched, sessionId, session, rotated }`); callers MUST
+  persist the returned `sessionId`. `switchSessionTenant` does this for you by
+  re-setting the session cookie (preserving httpOnly/secure/sameSite) to the new
+  id. A `null` clear stays in place (no rotation, no cookie change). The
+  low-level `SessionCollection.setSessionTenant` is the UNGUARDED primitive (used
+  for the null-clear path) — never call it with an untrusted tenant id.
 - **OIDC `email_verified` is enforced.** `UserCollection.getOrCreateFromOidc`
   refuses to provision a user when the IdP explicitly returns
   `email_verified: false` (opt out with `{ allowUnverifiedEmail: true }`). An

--- a/packages/users/AGENTS.md
+++ b/packages/users/AGENTS.md
@@ -39,6 +39,9 @@ each later layer overrides earlier ones:
 So a permission a role grants but the tenant DENYs is **removed**, unless that
 exact user also has a membership-GRANT override for it. A membership-DENY always
 wins. Tenant-DENY of an inherited/cascade grant still blocks it (unchanged).
+The hard block reflects the tenant cascade's **net** resolution, not an
+unconditional union of every DENY in the chain — so a more-specific tenant GRANT
+(e.g. a child sub-tenant re-granting a permission its parent DENYs) still wins.
 
 **Critical**: `getGroupIdsForTenant(userId, tenantId)` (joins with groups table to scope by tenant). Never use `getGroupIds()` — it's cross-tenant.
 

--- a/packages/users/AGENTS.md
+++ b/packages/users/AGENTS.md
@@ -18,14 +18,27 @@ Multi-tenant user management with RBAC, hierarchical tenants, session handling, 
 | MembershipOverride | Per-user permission grant/deny. **DENY always wins.** |
 | TenantPermissionOverride | Tenant-level cascade overrides. Effect: INHERIT/GRANT/DENY. |
 
-## Permission Resolution — 4-Level Cascade
+## Permission Resolution — Precedence (broad → specific, most-specific wins)
 
-PermissionResolver evaluates in order (each level can add/remove permissions):
+`PermissionResolver.resolvePermissions` builds the effective set in this order;
+each later layer overrides earlier ones:
 
-1. **Tenant hierarchy** — walk ancestors, apply TenantPermissionOverride at each level
-2. **Membership role** — base permissions from user's role in tenant
-3. **Group roles** — permissions from all groups user belongs to **in that tenant**
-4. **Membership overrides** — final GRANT/DENY per-user (DENY takes absolute precedence)
+1. **Tenant-inherited** — walk ancestors, apply each `TenantPermissionOverride`
+   down the cascade (GRANT adds, DENY removes within the hierarchy)
+2. **Membership role** — base permissions from the user's role in the tenant
+3. **Group roles** — permissions from all groups the user belongs to **in that tenant**
+4. **Tenant-level DENY** *(removes; overrides role/group grants, tenant-wide)* — a
+   `TenantPermissionOverride` with effect `DENY` is a HARD, tenant-wide block: it
+   subtracts the DENY'd slug even if a role or group granted it (steps 2–3). It
+   sits just **above** the per-user membership overrides and **below** role/group.
+5. **Membership GRANT override** *(re-adds; most specific)* — a per-user GRANT can
+   re-add a slug a tenant DENY'd in step 4, because it is more specific.
+6. **Membership DENY override** *(absolute; always wins)* — a per-user DENY removes
+   the slug last and is never overridden.
+
+So a permission a role grants but the tenant DENYs is **removed**, unless that
+exact user also has a membership-GRANT override for it. A membership-DENY always
+wins. Tenant-DENY of an inherited/cascade grant still blocks it (unchanged).
 
 **Critical**: `getGroupIdsForTenant(userId, tenantId)` (joins with groups table to scope by tenant). Never use `getGroupIds()` — it's cross-tenant.
 

--- a/packages/users/src/__tests__/permission-resolver.test.ts
+++ b/packages/users/src/__tests__/permission-resolver.test.ts
@@ -748,6 +748,228 @@ describe('PermissionResolver', () => {
     expect(result.deniedPermissionIds).toContain(inheritedPermission.id);
   });
 
+  it('tenant-level DENY removes a permission the role grants', async () => {
+    // NEW behavior: a tenant-DENY is a hard, tenant-wide block that overrides
+    // role/group grants — not just the inherited cascade. This case fails on
+    // the pre-change resolver, which only let tenant-DENY shrink inheritance.
+    const user = await users.create({ email: 'tenant-deny-role@example.com' });
+    await user.save();
+
+    const tenant = await tenants.create({ name: 'Tenant Deny Role Org' });
+    await tenant.save();
+
+    const role = await roles.create({ name: 'Admin' });
+    await role.save();
+
+    const deletePerm = await permissions.create({
+      slug: 'articles.delete',
+      name: 'Delete Articles',
+    });
+    await deletePerm.save();
+
+    // Role grants delete...
+    await rolePermissions.addPermission(role.id!, deletePerm.id!);
+
+    const membership = await memberships.create({
+      userId: user.id,
+      tenantId: tenant.id,
+      roleId: role.id,
+    });
+    await membership.save();
+
+    // ...but the tenant DENYs it for everyone.
+    await tenantOverrides.denyPermission(tenant.id!, deletePerm.id!);
+
+    const resolver = await PermissionResolver.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+    const result = await resolver.resolvePermissions(user.id!, tenant.id!);
+
+    expect(result.permissions.has('articles.delete')).toBe(false);
+  });
+
+  it('tenant-level DENY removes a permission a group role grants', async () => {
+    // Same hard tenant-wide block, but the grant comes from a group role rather
+    // than the membership role.
+    const user = await users.create({ email: 'tenant-deny-group@example.com' });
+    await user.save();
+
+    const tenant = await tenants.create({ name: 'Tenant Deny Group Org' });
+    await tenant.save();
+
+    const baseRole = await roles.create({ name: 'Basic' });
+    await baseRole.save();
+
+    const groupRole = await roles.create({ name: 'Special Group Role' });
+    await groupRole.save();
+
+    const groupPerm = await permissions.create({
+      slug: 'special.access',
+      name: 'Special Access',
+    });
+    await groupPerm.save();
+
+    await rolePermissions.addPermission(groupRole.id!, groupPerm.id!);
+
+    const membership = await memberships.create({
+      userId: user.id,
+      tenantId: tenant.id,
+      roleId: baseRole.id,
+    });
+    await membership.save();
+
+    const group = await groups.create({
+      tenantId: tenant.id,
+      name: 'Special Group',
+    });
+    await group.save();
+
+    await groupRoles.addRole(group.id!, groupRole.id!);
+    await groupMembers.addMember(group.id!, user.id!);
+
+    // Tenant DENYs the group-granted permission.
+    await tenantOverrides.denyPermission(tenant.id!, groupPerm.id!);
+
+    const resolver = await PermissionResolver.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+    const result = await resolver.resolvePermissions(user.id!, tenant.id!);
+
+    expect(result.permissions.has('special.access')).toBe(false);
+  });
+
+  it("membership GRANT override re-adds a tenant-DENY'd permission (most specific wins)", async () => {
+    // Precedence: tenant-DENY sits ABOVE role/group but BELOW the most-specific
+    // membership overrides, so a membership GRANT can re-add a tenant-DENY'd slug.
+    const user = await users.create({
+      email: 'tenant-deny-regrant@example.com',
+    });
+    await user.save();
+
+    const tenant = await tenants.create({ name: 'Tenant Deny Regrant Org' });
+    await tenant.save();
+
+    const role = await roles.create({ name: 'Editor' });
+    await role.save();
+
+    const perm = await permissions.create({
+      slug: 'articles.publish',
+      name: 'Publish Articles',
+    });
+    await perm.save();
+
+    await rolePermissions.addPermission(role.id!, perm.id!);
+
+    const membership = await memberships.create({
+      userId: user.id,
+      tenantId: tenant.id,
+      roleId: role.id,
+    });
+    await membership.save();
+
+    // Tenant DENYs it, but this user gets a more-specific membership GRANT.
+    await tenantOverrides.denyPermission(tenant.id!, perm.id!);
+    await membershipOverrides.grantPermission(membership.id!, perm.id!);
+
+    const resolver = await PermissionResolver.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+    const result = await resolver.resolvePermissions(user.id!, tenant.id!);
+
+    expect(result.permissions.has('articles.publish')).toBe(true);
+  });
+
+  it('membership DENY stays absolute even with a tenant-DENY and role grant', async () => {
+    // A membership DENY is the final, most-specific layer and always wins —
+    // even alongside a tenant-DENY of the same slug.
+    const user = await users.create({
+      email: 'tenant-deny-absolute@example.com',
+    });
+    await user.save();
+
+    const tenant = await tenants.create({ name: 'Tenant Deny Absolute Org' });
+    await tenant.save();
+
+    const role = await roles.create({ name: 'Admin' });
+    await role.save();
+
+    const perm = await permissions.create({
+      slug: 'articles.destroy',
+      name: 'Destroy Articles',
+    });
+    await perm.save();
+
+    await rolePermissions.addPermission(role.id!, perm.id!);
+
+    const membership = await memberships.create({
+      userId: user.id,
+      tenantId: tenant.id,
+      roleId: role.id,
+    });
+    await membership.save();
+
+    await tenantOverrides.denyPermission(tenant.id!, perm.id!);
+    await membershipOverrides.denyPermission(membership.id!, perm.id!);
+
+    const resolver = await PermissionResolver.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+    const result = await resolver.resolvePermissions(user.id!, tenant.id!);
+
+    expect(result.permissions.has('articles.destroy')).toBe(false);
+    expect(result.deniedPermissionIds).toContain(perm.id);
+  });
+
+  it('tenant-DENY still blocks an inherited cascade grant (existing behavior)', async () => {
+    // Regression guard for the original tenant-DENY semantics: a permission
+    // granted by a parent tenant and cascaded down is still removed when the
+    // child tenant DENYs it — even for a member with a role.
+    const parent = await tenants.create({
+      cascadePermissions: true,
+      name: 'Cascade Parent Org',
+    });
+    await parent.save();
+
+    const child = await tenants.create({
+      inheritPermissions: true,
+      name: 'Cascade Child Org',
+      parentTenantId: parent.id!,
+    });
+    await child.save();
+
+    const user = await users.create({
+      email: 'tenant-deny-cascade@example.com',
+    });
+    await user.save();
+
+    const role = await roles.create({ name: 'Member' });
+    await role.save();
+
+    const inheritedPerm = await permissions.create({
+      slug: 'reports.view',
+      name: 'View Reports',
+    });
+    await inheritedPerm.save();
+
+    // Parent grants + cascades; child DENYs.
+    await tenantOverrides.grantPermission(parent.id!, inheritedPerm.id!);
+    await tenantOverrides.denyPermission(child.id!, inheritedPerm.id!);
+
+    const membership = await memberships.create({
+      userId: user.id,
+      tenantId: child.id,
+      roleId: role.id,
+    });
+    await membership.save();
+
+    const resolver = await PermissionResolver.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+    const result = await resolver.resolvePermissions(user.id!, child.id!);
+
+    expect(result.permissions.has('reports.view')).toBe(false);
+  });
+
   it('should return empty permissions for non-member', async () => {
     const user = await users.create({ email: 'nonmember@example.com' });
     await user.save();

--- a/packages/users/src/__tests__/permission-resolver.test.ts
+++ b/packages/users/src/__tests__/permission-resolver.test.ts
@@ -970,6 +970,58 @@ describe('PermissionResolver', () => {
     expect(result.permissions.has('reports.view')).toBe(false);
   });
 
+  it('child-tenant GRANT overrides a parent-tenant DENY (most-specific tenant wins)', async () => {
+    // Netting guard for the hard tenant-wide DENY block: a parent tenant DENYs a
+    // permission org-wide but a child sub-tenant explicitly re-GRANTs it. The
+    // child GRANT is more specific and must win — the parent DENY must NOT be
+    // applied as a hard block over the child's own grant. Pre-netting-fix the
+    // unconditionally-collected parent DENY wrongly stripped it.
+    const parent = await tenants.create({
+      cascadePermissions: true,
+      name: 'Deny Parent Org',
+    });
+    await parent.save();
+
+    const child = await tenants.create({
+      inheritPermissions: true,
+      name: 'Grant Child Org',
+      parentTenantId: parent.id!,
+    });
+    await child.save();
+
+    const user = await users.create({
+      email: 'parent-deny-child-grant@example.com',
+    });
+    await user.save();
+
+    const role = await roles.create({ name: 'Member' });
+    await role.save();
+
+    const perm = await permissions.create({
+      slug: 'reports.export',
+      name: 'Export Reports',
+    });
+    await perm.save();
+
+    // Parent DENYs (and cascades); child re-GRANTs.
+    await tenantOverrides.denyPermission(parent.id!, perm.id!);
+    await tenantOverrides.grantPermission(child.id!, perm.id!);
+
+    const membership = await memberships.create({
+      userId: user.id,
+      tenantId: child.id,
+      roleId: role.id,
+    });
+    await membership.save();
+
+    const resolver = await PermissionResolver.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+    const result = await resolver.resolvePermissions(user.id!, child.id!);
+
+    expect(result.permissions.has('reports.export')).toBe(true);
+  });
+
   it('should return empty permissions for non-member', async () => {
     const user = await users.create({ email: 'nonmember@example.com' });
     await user.save();

--- a/packages/users/src/__tests__/security-audit-1400.test.ts
+++ b/packages/users/src/__tests__/security-audit-1400.test.ts
@@ -184,23 +184,31 @@ describe('switchTenant membership verification (#1400)', () => {
     return { user, home, foreign, sessionId };
   }
 
-  it('switches into a tenant the user is an active member of', async () => {
+  it('switches into a tenant the user is an active member of (rotating the id)', async () => {
     const { home, sessionId } = await seed(MembershipStatus.ACTIVE);
 
-    const switched = await sessionService.switchTenant(sessionId, home.id!);
+    const result = await sessionService.switchTenant(sessionId, home.id!);
 
-    expect(switched).toBe(true);
-    const session = await sessions.findValidSession(sessionId);
+    expect(result.switched).toBe(true);
+    // #1354 follow-up: a successful non-null switch rotates the session id and
+    // revokes the old one.
+    expect(result.rotated).toBe(true);
+    expect(result.sessionId).not.toBe(sessionId);
+    expect(await sessions.findValidSession(sessionId)).toBeNull();
+
+    const session = await sessions.findValidSession(result.sessionId!);
     expect(session?.tenantId).toBe(home.id);
   });
 
   it('refuses to switch into a tenant the user is not a member of', async () => {
     const { foreign, sessionId } = await seed(MembershipStatus.ACTIVE);
 
-    const switched = await sessionService.switchTenant(sessionId, foreign.id!);
+    const result = await sessionService.switchTenant(sessionId, foreign.id!);
 
-    expect(switched).toBe(false);
-    // The session must NOT be tainted with the foreign tenant id.
+    expect(result.switched).toBe(false);
+    expect(result.rotated).toBe(false);
+    // The original session must NOT be tainted (or rotated) — it still exists
+    // with a null tenant id.
     const session = await sessions.findValidSession(sessionId);
     expect(session?.tenantId).toBeNull();
   });
@@ -208,29 +216,35 @@ describe('switchTenant membership verification (#1400)', () => {
   it('refuses to switch when the membership is not active', async () => {
     const { home, sessionId } = await seed(MembershipStatus.INACTIVE);
 
-    const switched = await sessionService.switchTenant(sessionId, home.id!);
+    const result = await sessionService.switchTenant(sessionId, home.id!);
 
-    expect(switched).toBe(false);
+    expect(result.switched).toBe(false);
+    expect(result.rotated).toBe(false);
     const session = await sessions.findValidSession(sessionId);
     expect(session?.tenantId).toBeNull();
   });
 
-  it('always allows clearing the tenant context (null)', async () => {
+  it('always allows clearing the tenant context (null) without rotating', async () => {
     const { home, sessionId } = await seed(MembershipStatus.ACTIVE);
-    expect(await sessionService.switchTenant(sessionId, home.id!)).toBe(true);
+    // Switch in (rotates), then clear on the new id.
+    const switchedIn = await sessionService.switchTenant(sessionId, home.id!);
+    expect(switchedIn.switched).toBe(true);
+    const activeId = switchedIn.sessionId!;
 
-    const cleared = await sessionService.switchTenant(sessionId, null);
+    const cleared = await sessionService.switchTenant(activeId, null);
 
-    expect(cleared).toBe(true);
-    const session = await sessions.findValidSession(sessionId);
+    expect(cleared.switched).toBe(true);
+    expect(cleared.rotated).toBe(false);
+    expect(cleared.sessionId).toBe(activeId);
+    const session = await sessions.findValidSession(activeId);
     expect(session?.tenantId).toBeNull();
   });
 
-  it('returns false for an unknown session', async () => {
+  it('fail-closes for an unknown session', async () => {
     const { home } = await seed(MembershipStatus.ACTIVE);
-    expect(await sessionService.switchTenant('not-a-session', home.id!)).toBe(
-      false,
-    );
+    const result = await sessionService.switchTenant('not-a-session', home.id!);
+    expect(result.switched).toBe(false);
+    expect(result.sessionId).toBeNull();
   });
 });
 

--- a/packages/users/src/__tests__/session.test.ts
+++ b/packages/users/src/__tests__/session.test.ts
@@ -554,7 +554,7 @@ describe('SessionService', () => {
     expect(userSessions.length).toBe(0);
   });
 
-  it('should switch tenant context', async () => {
+  it('should switch tenant context by ROTATING the session id', async () => {
     const user = await users.create({ email: 'switch@example.com' });
     await user.save();
 
@@ -583,16 +583,136 @@ describe('SessionService', () => {
     const sessionId = await sessionService.createSession(user.id!, tenant1.id!);
 
     // Check initial tenant
-    let context = await sessionService.loadSessionContext(sessionId);
+    const context = await sessionService.loadSessionContext(sessionId);
     expect(context?.tenantId).toBe(tenant1.id);
 
-    // Switch tenant
-    const switched = await sessionService.switchTenant(sessionId, tenant2.id!);
-    expect(switched).toBe(true);
+    // Switch tenant — a successful non-null switch ROTATES the session id.
+    const result = await sessionService.switchTenant(sessionId, tenant2.id!);
+    expect(result.switched).toBe(true);
+    expect(result.rotated).toBe(true);
+    // A brand-new id is minted...
+    expect(result.sessionId).toBeDefined();
+    expect(result.sessionId).not.toBe(sessionId);
+    expect(result.session?.tenantId).toBe(tenant2.id);
 
-    // Check new tenant
-    context = await sessionService.loadSessionContext(sessionId);
-    expect(context?.tenantId).toBe(tenant2.id);
+    // ...the OLD session is no longer valid...
+    expect(await sessionService.loadSessionContext(sessionId)).toBeNull();
+
+    // ...and the NEW session carries the new tenant.
+    const newContext = await sessionService.loadSessionContext(
+      result.sessionId as string,
+    );
+    expect(newContext?.tenantId).toBe(tenant2.id);
+    expect(newContext?.user.id).toBe(user.id);
+  });
+
+  it('carries device context onto the rotated session', async () => {
+    const user = await users.create({ email: 'switch-device@example.com' });
+    await user.save();
+
+    const tenant = await tenants.create({ name: 'Device Org' });
+    await tenant.save();
+
+    const role = await roles.create({ name: 'Member' });
+    await role.save();
+    await (
+      await memberships.create({
+        userId: user.id!,
+        tenantId: tenant.id!,
+        roleId: role.id!,
+      })
+    ).save();
+
+    const sessionService = await SessionService.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+
+    const sessionId = await sessionService.createSession(user.id!, undefined, {
+      userAgent: 'Mozilla/5.0 RotationTest',
+      ipAddress: '203.0.113.7',
+    });
+
+    const result = await sessionService.switchTenant(sessionId, tenant.id!);
+    expect(result.rotated).toBe(true);
+    expect(result.session?.userAgent).toBe('Mozilla/5.0 RotationTest');
+    expect(result.session?.ipAddress).toBe('203.0.113.7');
+  });
+
+  it('fail-closes WITHOUT creating a new session for a non-member switch', async () => {
+    const user = await users.create({ email: 'switch-nonmember@example.com' });
+    await user.save();
+
+    const home = await tenants.create({ name: 'Home Org' });
+    await home.save();
+    const foreign = await tenants.create({ name: 'Foreign Org' });
+    await foreign.save();
+
+    // Member of home only.
+    const role = await roles.create({ name: 'Member' });
+    await role.save();
+    await (
+      await memberships.create({
+        userId: user.id!,
+        tenantId: home.id!,
+        roleId: role.id!,
+      })
+    ).save();
+
+    const sessionService = await SessionService.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+
+    const sessionId = await sessionService.createSession(user.id!, home.id!);
+    const sessionsBefore = await sessionService.getUserSessions(user.id!);
+
+    // Switch into a tenant the user is NOT a member of.
+    const result = await sessionService.switchTenant(sessionId, foreign.id!);
+    expect(result.switched).toBe(false);
+    expect(result.rotated).toBe(false);
+    expect(result.sessionId).toBeNull();
+    expect(result.session).toBeNull();
+
+    // No new session was minted, and the original session is untouched.
+    const sessionsAfter = await sessionService.getUserSessions(user.id!);
+    expect(sessionsAfter.length).toBe(sessionsBefore.length);
+
+    const context = await sessionService.loadSessionContext(sessionId);
+    expect(context?.tenantId).toBe(home.id);
+  });
+
+  it('clears the tenant context (null) in place without rotating', async () => {
+    const user = await users.create({ email: 'switch-clear@example.com' });
+    await user.save();
+
+    const tenant = await tenants.create({ name: 'Clear Org' });
+    await tenant.save();
+
+    const role = await roles.create({ name: 'Member' });
+    await role.save();
+    await (
+      await memberships.create({
+        userId: user.id!,
+        tenantId: tenant.id!,
+        roleId: role.id!,
+      })
+    ).save();
+
+    const sessionService = await SessionService.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+
+    const sessionId = await sessionService.createSession(user.id!, tenant.id!);
+
+    const result = await sessionService.switchTenant(sessionId, null);
+    expect(result.switched).toBe(true);
+    expect(result.rotated).toBe(false);
+    // The id is unchanged on a clear.
+    expect(result.sessionId).toBe(sessionId);
+
+    // Same session still valid, now with no tenant.
+    const context = await sessionService.loadSessionContext(sessionId);
+    expect(context).toBeDefined();
+    expect(context?.tenantId).toBeNull();
   });
 
   it('should check hasPermission', async () => {

--- a/packages/users/src/__tests__/sveltekit-switch-tenant.test.ts
+++ b/packages/users/src/__tests__/sveltekit-switch-tenant.test.ts
@@ -1,0 +1,172 @@
+/**
+ * SvelteKit switchSessionTenant tests
+ *
+ * Verifies the sveltekit helper rotates the session COOKIE to the new id on a
+ * successful tenant switch (#1354 follow-up) and fail-closes for a non-member.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { MembershipCollection } from '../collections/MembershipCollection.js';
+import { RoleCollection } from '../collections/RoleCollection.js';
+import { SessionCollection } from '../collections/SessionCollection.js';
+import { TenantCollection } from '../collections/TenantCollection.js';
+import { UserCollection } from '../collections/UserCollection.js';
+import { switchSessionTenant } from '../sveltekit/index.js';
+
+interface CookieSetCall {
+  name: string;
+  value: string;
+  options?: Record<string, unknown>;
+}
+
+function createCookieJar(initialValues: Record<string, string> = {}) {
+  const values = new Map(Object.entries(initialValues));
+  const setCalls: CookieSetCall[] = [];
+
+  return {
+    setCalls,
+    delete(name: string) {
+      values.delete(name);
+    },
+    get(name: string) {
+      return values.get(name);
+    },
+    set(name: string, value: string, options?: Record<string, unknown>) {
+      values.set(name, value);
+      setCalls.push({ name, value, options });
+    },
+  };
+}
+
+describe('switchSessionTenant (sveltekit)', () => {
+  let dbPath: string;
+  let users: UserCollection;
+  let tenants: TenantCollection;
+  let roles: RoleCollection;
+  let memberships: MembershipCollection;
+  let sessions: SessionCollection;
+  let options: { db: { type: 'sqlite'; url: string } };
+
+  beforeEach(async () => {
+    // Unique db path per test — switchSessionTenant caches its SessionService
+    // keyed by db config, so a fresh url avoids cross-test cache reuse.
+    dbPath = join(tmpdir(), `smrt-sveltekit-switch-${randomUUID()}.db`);
+    options = { db: { type: 'sqlite' as const, url: dbPath } };
+
+    users = await UserCollection.create(options);
+    tenants = await TenantCollection.create(options);
+    roles = await RoleCollection.create(options);
+    memberships = await MembershipCollection.create(options);
+    sessions = await SessionCollection.create(options);
+  });
+
+  afterEach(() => {
+    if (existsSync(dbPath)) {
+      try {
+        rmSync(dbPath, { force: true });
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+  });
+
+  async function seedMember() {
+    const user = await users.create({ email: `${randomUUID()}@example.com` });
+    await user.save();
+    const tenant = await tenants.create({ name: 'Target Org' });
+    await tenant.save();
+    const role = await roles.create({ name: 'Member' });
+    await role.save();
+    const membership = await memberships.create({
+      userId: user.id!,
+      tenantId: tenant.id!,
+      roleId: role.id!,
+    });
+    await membership.save();
+    return { user, tenant };
+  }
+
+  it('rotates the session cookie to the new id on a successful switch', async () => {
+    const { user, tenant } = await seedMember();
+    const session = await sessions.createSession({ userId: user.id! });
+    const oldId = session.id!;
+
+    const cookies = createCookieJar({ sid: oldId });
+    const event = {
+      cookies,
+      locals: {} as Record<string, unknown>,
+      url: { pathname: '/switch', protocol: 'https:' },
+      request: { headers: new Headers() },
+    };
+
+    const switched = await switchSessionTenant(event, tenant.id!, options);
+
+    expect(switched).toBe(true);
+
+    // The cookie now holds a DIFFERENT (rotated) id...
+    const newId = cookies.get('sid');
+    expect(newId).toBeDefined();
+    expect(newId).not.toBe(oldId);
+
+    // ...set with preserved security flags...
+    expect(cookies.setCalls).toHaveLength(1);
+    expect(cookies.setCalls[0].name).toBe('sid');
+    expect(cookies.setCalls[0].options).toMatchObject({
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      path: '/',
+    });
+
+    // ...the old session id is revoked...
+    expect(await sessions.findValidSession(oldId)).toBeNull();
+
+    // ...and the new session id is valid with the new tenant.
+    const rotated = await sessions.findValidSession(newId as string);
+    expect(rotated?.tenantId).toBe(tenant.id);
+  });
+
+  it('fail-closes and does not touch the cookie for a non-member switch', async () => {
+    const { user } = await seedMember();
+    const foreign = await tenants.create({ name: 'Foreign Org' });
+    await foreign.save();
+
+    const session = await sessions.createSession({ userId: user.id! });
+    const oldId = session.id!;
+
+    const cookies = createCookieJar({ sid: oldId });
+    const event = {
+      cookies,
+      locals: {} as Record<string, unknown>,
+      url: { pathname: '/switch', protocol: 'https:' },
+      request: { headers: new Headers() },
+    };
+
+    const switched = await switchSessionTenant(event, foreign.id!, options);
+
+    expect(switched).toBe(false);
+    // Cookie unchanged, no rotation, original session intact.
+    expect(cookies.setCalls).toHaveLength(0);
+    expect(cookies.get('sid')).toBe(oldId);
+    expect(await sessions.findValidSession(oldId)).not.toBeNull();
+  });
+
+  it('returns false when there is no session cookie', async () => {
+    const { tenant } = await seedMember();
+    const cookies = createCookieJar();
+    const event = {
+      cookies,
+      locals: {} as Record<string, unknown>,
+      url: { pathname: '/switch', protocol: 'https:' },
+      request: { headers: new Headers() },
+    };
+
+    const switched = await switchSessionTenant(event, tenant.id!, options);
+    expect(switched).toBe(false);
+    expect(cookies.setCalls).toHaveLength(0);
+  });
+});

--- a/packages/users/src/index.ts
+++ b/packages/users/src/index.ts
@@ -166,6 +166,7 @@ export {
   type SessionPermissionRuntimeOptions,
   SessionService,
   type SessionServiceOptions,
+  type SwitchTenantResult,
   syncPermissionCatalog,
   type TenantPermissionInheritanceResult,
   TenantService,

--- a/packages/users/src/services/PermissionResolver.ts
+++ b/packages/users/src/services/PermissionResolver.ts
@@ -290,8 +290,14 @@ export class PermissionResolver {
       }
 
       // Record the slugs DENY'd at any tenant level so callers can enforce the
-      // hard tenant-wide block over role/group grants.
+      // hard tenant-wide block over role/group grants — but NET against the
+      // cascade's own resolution: a slug a more-specific tenant GRANT re-added
+      // (so it survives in the net-granted `inheritedPermissions`) must NOT be
+      // in the hard-block set, because the cascade already decided GRANT
+      // (most-specific wins). Without this guard a parent-DENY + child-GRANT
+      // slug would wrongly override the child GRANT and any role/group grant.
       for (const permId of deniedPermissionIds) {
+        if (inheritedPermissions.has(permId)) continue;
         const perm = permissionsMap.get(permId);
         if (perm?.slug) {
           result.deniedPermissions.add(perm.slug);

--- a/packages/users/src/services/PermissionResolver.ts
+++ b/packages/users/src/services/PermissionResolver.ts
@@ -50,6 +50,17 @@ export interface TenantPermissionInheritanceResult {
   contributingTenantIds: string[];
   /** Whether inheritance was active (at least one tenant in chain had inheritPermissions: true) */
   inheritanceActive: boolean;
+  /**
+   * Permission slugs explicitly DENY'd by a `TenantPermissionOverride` anywhere
+   * in the tenant hierarchy. These are a HARD, tenant-wide block:
+   * `resolvePermissions` subtracts them AFTER role + group grants are applied,
+   * so a tenant-DENY overrides a permission a role/group otherwise grants. A
+   * more-specific membership-override GRANT can still re-add a slug listed here;
+   * a membership-override DENY stays absolute. (This set is independent of the
+   * net `permissions` above, which only reflects DENY's effect on the inherited
+   * cascade.)
+   */
+  deniedPermissions: Set<string>;
 }
 
 /**
@@ -169,6 +180,7 @@ export class PermissionResolver {
       permissions: new Set<string>(),
       contributingTenantIds: [],
       inheritanceActive: false,
+      deniedPermissions: new Set<string>(),
     };
 
     const tenant = await this.tenantCollection.get({ id: tenantId });
@@ -188,11 +200,19 @@ export class PermissionResolver {
         chainTenantIds,
       );
 
-    // Build a set of permission IDs for batch lookup
+    // Build a set of permission IDs for batch lookup. Also track every
+    // tenant-level DENY id across the chain: tenant-DENY is a hard, tenant-wide
+    // block that `resolvePermissions` subtracts from role/group grants too, so
+    // it must be reported independently of the net inherited `permissions` set
+    // (which only reflects DENY's effect on the cascade, not on roles).
     const allPermissionIds = new Set<string>();
+    const deniedPermissionIds = new Set<string>();
     for (const overrides of allOverridesMap.values()) {
       for (const id of overrides.grantedPermissionIds) allPermissionIds.add(id);
-      for (const id of overrides.deniedPermissionIds) allPermissionIds.add(id);
+      for (const id of overrides.deniedPermissionIds) {
+        allPermissionIds.add(id);
+        deniedPermissionIds.add(id);
+      }
     }
 
     // Process each tenant in the chain
@@ -268,6 +288,15 @@ export class PermissionResolver {
           result.permissions.add(perm.slug);
         }
       }
+
+      // Record the slugs DENY'd at any tenant level so callers can enforce the
+      // hard tenant-wide block over role/group grants.
+      for (const permId of deniedPermissionIds) {
+        const perm = permissionsMap.get(permId);
+        if (perm?.slug) {
+          result.deniedPermissions.add(perm.slug);
+        }
+      }
     }
 
     return result;
@@ -314,13 +343,23 @@ export class PermissionResolver {
   }
 
   /**
-   * Resolve all effective permissions for a user in a tenant
+   * Resolve all effective permissions for a user in a tenant.
+   *
+   * Precedence (broad -> specific, most-specific wins):
+   *   tenant-inherited (cascade)
+   *     -> role
+   *     -> group roles
+   *     -> tenant-DENY      (removes; overrides role/group grants, tenant-wide)
+   *     -> membership GRANT (re-adds; most specific, can win over a tenant-DENY)
+   *     -> membership DENY  (absolute; always wins)
    *
    * Algorithm:
    * 1. Get membership and collect all permission IDs from all sources
    * 2. Batch fetch all permissions in a single query
-   * 3. Apply permissions from role, groups, and overrides
-   * 4. DENY overrides take precedence over GRANT
+   * 3. Apply permissions from role, then groups
+   * 4. Subtract tenant-level DENY'd slugs (hard tenant-wide block)
+   * 5. Apply membership GRANT overrides (can re-add a tenant-DENY'd slug)
+   * 6. Subtract membership DENY overrides (absolute precedence)
    */
   async resolvePermissions(
     userId: string,
@@ -447,7 +486,17 @@ export class PermissionResolver {
       }
     }
 
-    // 6. Apply granted overrides
+    // 6. Subtract tenant-level DENY'd slugs. A tenant-DENY is a HARD,
+    // tenant-wide block that overrides role and group grants too — sitting just
+    // above the most-specific membership overrides in precedence. It runs
+    // BEFORE the membership GRANT pass so a more-specific membership GRANT (step
+    // 7) can deliberately re-add a slug a tenant DENYs.
+    for (const slug of tenantPermissions.deniedPermissions) {
+      result.permissions.delete(slug);
+    }
+
+    // 7. Apply granted membership overrides (most specific GRANT; can re-add a
+    // tenant-DENY'd slug).
     for (const permId of grantedPermissionIds) {
       const slug = permissionIdToSlug.get(permId);
       if (slug) {
@@ -455,8 +504,8 @@ export class PermissionResolver {
       }
     }
 
-    // 7. Remove denied overrides (DENY takes precedence over tenant, role,
-    // group, and granted membership permissions)
+    // 8. Remove denied membership overrides (DENY takes absolute precedence over
+    // tenant, role, group, and granted membership permissions).
     for (const permId of deniedPermissionIds) {
       const slug = permissionIdToSlug.get(permId);
       if (slug) {

--- a/packages/users/src/services/SessionService.ts
+++ b/packages/users/src/services/SessionService.ts
@@ -287,8 +287,12 @@ export class SessionService {
       return failClosed;
     }
 
-    // Rotate: mint a fresh session for the new tenant, carrying over the device
-    // context, then revoke the old one.
+    // Rotate FAIL-CLOSED: revoke the old session FIRST, then mint the fresh one.
+    // If the second write fails the caller ends up needing to re-auth (the old
+    // id is already invalid) rather than retaining a still-valid stale-tenant
+    // session — so a captured pre-switch id provably stops validating before we
+    // ever report success.
+    await this.sessionCollection.revokeSession(sessionId);
     const rotated = await this.sessionCollection.createSession({
       userId: session.userId,
       tenantId,
@@ -297,7 +301,6 @@ export class SessionService {
       ipAddress: session.ipAddress,
       data: session.data,
     });
-    await this.sessionCollection.revokeSession(sessionId);
 
     return {
       switched: true,

--- a/packages/users/src/services/SessionService.ts
+++ b/packages/users/src/services/SessionService.ts
@@ -11,7 +11,7 @@ import {
 } from '../collections/SessionCollection.js';
 import { UserCollection } from '../collections/UserCollection.js';
 import type { Membership } from '../models/Membership.js';
-import { DEFAULT_SESSION_TTL } from '../models/Session.js';
+import { DEFAULT_SESSION_TTL, type Session } from '../models/Session.js';
 import type { User } from '../models/User.js';
 import { PermissionResolver } from './PermissionResolver.js';
 
@@ -29,6 +29,29 @@ export interface SessionContext {
   tenantId: string | null;
   /** Session ID */
   sessionId: string;
+}
+
+/**
+ * Result of {@link SessionService.switchTenant}.
+ *
+ * A successful switch into a non-null tenant ROTATES the session id (#1354
+ * follow-up): a brand-new {@link Session} is minted and the old one is revoked,
+ * so a captured pre-switch id stops validating. Callers MUST persist `sessionId`
+ * (e.g. re-set the session cookie) after a rotation.
+ */
+export interface SwitchTenantResult {
+  /** Whether the switch succeeded (true also for a `null` clear). */
+  switched: boolean;
+  /**
+   * The session id to use going forward: the NEW id after a rotation, the
+   * unchanged id after a `null` clear, or `null` when the switch failed
+   * (unknown session or non-member — fail-closed).
+   */
+  sessionId: string | null;
+  /** The resulting session (new on rotation; existing on clear; null on failure). */
+  session: Session | null;
+  /** True only when a fresh session id was minted (non-null tenant switch). */
+  rotated: boolean;
 }
 
 /**
@@ -209,28 +232,79 @@ export class SessionService {
    * query, so it must never be set to a tenant the session's user is not an
    * active member of — otherwise a caller could read/write another tenant's data
    * by feeding an arbitrary id here (e.g. straight from untrusted form data).
-   * Fail-closed (#1400): returns `false` without switching when the session is
-   * unknown or the user has no active membership in the target tenant. Passing
-   * `null` clears the tenant context and is always allowed.
+   *
+   * Fail-closed (#1400): the user's ACTIVE membership in the target tenant is
+   * verified BEFORE any write. A non-member switch returns
+   * `{ switched: false, ... }` and mutates nothing.
+   *
+   * Session-id ROTATION (#1354 follow-up): a successful switch into a non-null
+   * tenant mints a BRAND-NEW session (fresh secure id, fresh TTL) for the same
+   * user with the new tenant, then REVOKES the old session — so any captured
+   * pre-switch session id immediately stops validating, shrinking the blast
+   * radius of a leaked id across a privilege/tenant boundary. The device context
+   * (user agent, IP, custom data) carries over to the new session. Callers MUST
+   * persist the returned `sessionId` (e.g. re-set the cookie).
+   *
+   * Passing `null` clears the tenant context, is always allowed, and stays
+   * in-place (no rotation — there is no privilege boundary being crossed).
+   *
+   * @returns A {@link SwitchTenantResult}; check `switched` for success.
    */
   async switchTenant(
     sessionId: string,
     tenantId: string | null,
-  ): Promise<boolean> {
-    const session = await this.sessionCollection.findValidSession(sessionId);
-    if (!session) return false;
+  ): Promise<SwitchTenantResult> {
+    const failClosed: SwitchTenantResult = {
+      switched: false,
+      sessionId: null,
+      session: null,
+      rotated: false,
+    };
 
-    if (tenantId !== null) {
-      const membership = await this.membershipCollection.findByUserAndTenant(
-        session.userId,
-        tenantId,
-      );
-      if (!membership || !membership.isActive()) {
-        return false;
-      }
+    const session = await this.sessionCollection.findValidSession(sessionId);
+    if (!session) return failClosed;
+
+    // Clearing the tenant context crosses no privilege boundary, so keep the
+    // existing session in place (no rotation needed).
+    if (tenantId === null) {
+      const ok = await this.sessionCollection.setSessionTenant(sessionId, null);
+      if (!ok) return failClosed;
+      const updated = await this.sessionCollection.findValidSession(sessionId);
+      return {
+        switched: true,
+        sessionId,
+        session: updated,
+        rotated: false,
+      };
     }
 
-    return this.sessionCollection.setSessionTenant(sessionId, tenantId);
+    // Fail-closed membership check BEFORE any write.
+    const membership = await this.membershipCollection.findByUserAndTenant(
+      session.userId,
+      tenantId,
+    );
+    if (!membership || !membership.isActive()) {
+      return failClosed;
+    }
+
+    // Rotate: mint a fresh session for the new tenant, carrying over the device
+    // context, then revoke the old one.
+    const rotated = await this.sessionCollection.createSession({
+      userId: session.userId,
+      tenantId,
+      ttl: this.defaultTTL,
+      userAgent: session.userAgent,
+      ipAddress: session.ipAddress,
+      data: session.data,
+    });
+    await this.sessionCollection.revokeSession(sessionId);
+
+    return {
+      switched: true,
+      sessionId: rotated.id as string,
+      session: rotated,
+      rotated: true,
+    };
   }
 
   /**

--- a/packages/users/src/services/index.ts
+++ b/packages/users/src/services/index.ts
@@ -68,6 +68,7 @@ export {
   type SessionContext,
   SessionService,
   type SessionServiceOptions,
+  type SwitchTenantResult,
 } from './SessionService.js';
 export {
   type EnsureTenantResult,

--- a/packages/users/src/sveltekit/index.ts
+++ b/packages/users/src/sveltekit/index.ts
@@ -514,6 +514,18 @@ export async function switchSessionTenant(
     const cookieSameSite = options.cookieSameSite ?? 'lax';
     const cookieSecure =
       options.cookieSecure ?? event.url.protocol === 'https:';
+    // Match the cookie lifetime to the rotated session's ACTUAL expiry rather
+    // than the request `ttl` — a cached SessionService (keyed on db config only)
+    // may have been created with a different defaultTTL, so `ttl` here can
+    // diverge from the session the service actually minted.
+    const maxAge = result.session
+      ? Math.max(
+          0,
+          Math.round(
+            (new Date(result.session.expiresAt).getTime() - Date.now()) / 1000,
+          ),
+        )
+      : ttl;
 
     event.cookies.set(cookieName, result.sessionId, {
       path: cookiePath,
@@ -522,7 +534,7 @@ export async function switchSessionTenant(
       httpOnly: true,
       secure: cookieSecure,
       sameSite: cookieSameSite,
-      maxAge: ttl,
+      maxAge,
     });
   }
 

--- a/packages/users/src/sveltekit/index.ts
+++ b/packages/users/src/sveltekit/index.ts
@@ -457,6 +457,12 @@ export async function destroySessionCookie(
  * target tenant id is therefore safe to take straight from untrusted form data,
  * but callers MUST honour the boolean result rather than assuming success.
  *
+ * Session-id ROTATION (#1354 follow-up): a successful switch into a non-null
+ * tenant mints a fresh session and revokes the old one. This helper transparently
+ * re-sets the session COOKIE to the new id (same flags), so the old cookie value
+ * stops working and the browser carries the rotated id forward. A `null` clear
+ * leaves the id (and cookie) unchanged.
+ *
  * @example
  * ```typescript
  * // +page.server.ts
@@ -485,6 +491,10 @@ export async function switchSessionTenant(
   tenantId: string | null,
   options: SmrtClassOptions & {
     cookieName?: string;
+    cookiePath?: string;
+    cookieDomain?: string;
+    cookieSecure?: boolean;
+    cookieSameSite?: 'strict' | 'lax' | 'none';
     ttl?: number;
   },
 ): Promise<boolean> {
@@ -495,7 +505,28 @@ export async function switchSessionTenant(
   if (!sessionId) return false;
 
   const service = await getOrCreateSessionService(options, ttl);
-  return service.switchTenant(sessionId, tenantId);
+  const result = await service.switchTenant(sessionId, tenantId);
+
+  // On rotation the old id is now revoked; point the cookie at the new id so
+  // the previous cookie value can no longer be replayed. Preserve cookie flags.
+  if (result.rotated && result.sessionId) {
+    const cookiePath = options.cookiePath ?? '/';
+    const cookieSameSite = options.cookieSameSite ?? 'lax';
+    const cookieSecure =
+      options.cookieSecure ?? event.url.protocol === 'https:';
+
+    event.cookies.set(cookieName, result.sessionId, {
+      path: cookiePath,
+      // undefined => SvelteKit scopes the cookie to the request host.
+      domain: options.cookieDomain,
+      httpOnly: true,
+      secure: cookieSecure,
+      sameSite: cookieSameSite,
+      maxAge: ttl,
+    });
+  }
+
+  return result.switched;
 }
 
 function getOidcProviderName(


### PR DESCRIPTION
## Summary
Implements the 2 maintainer-approved auth design decisions from the #1399 review (follow-up to the merged batch-2 #1592). `packages/users` only.

## Change 1 — Session-id rotation on tenant switch
`SessionService.switchTenant` now mints a fresh `Session` (new secure id, fresh TTL, carries `userAgent`/`ip`/`data`) and **revokes the old session** on a successful switch to a non-null tenant; `null`-clear stays in-place. The **fail-closed ACTIVE-membership check runs BEFORE any write** — a non-member switch mutates nothing. `sveltekit switchSessionTenant` re-sets the session cookie to the new id (httpOnly/secure/sameSite/path/domain preserved). New `SwitchTenantResult` return type (`{ switched, sessionId, session, rotated }`).

## Change 2 — Tenant-`DENY` hard tenant-wide block
A tenant-level `DENY` now overrides role/group `GRANT`s (was inheritance-chain only). **Precedence** (broad→specific, most-specific wins): tenant-inherited → role → group → **tenant-DENY (removes, overriding role/group)** → membership-GRANT (can re-add over a tenant-DENY) → membership-DENY (absolute). Documented in `packages/users/AGENTS.md`.

## ⚠️ Breaking (both commits `!` → major bump)
- `switchTenant`/`switchSessionTenant` return shape changed; a successful switch now **invalidates the old session token** (rotation). No external monorepo consumers (grepped).
- tenant-level `DENY` now removes a permission even if a role/group grants it (previously it did not) — a tenant-DENY'd permission a role currently grants will be revoked.

## Testing
**238 passed / 4 skipped** (the 4 skips are `permission-postgres-rls.test.ts` — need live Postgres), typecheck (tsc + svelte-check) clean, knowledge fresh. New tests pin: rotation → new id + old invalid; fail-closed → no session created; null-clear; cookie rotation; tenant-DENY removes a role-granted slug (fails on pre-fix code); membership-GRANT re-adds; membership-DENY absolute; cascade-DENY preserved.

Closes the 2 design decisions from #1399.
