### PR TITLE
fix: T3 deep-review remediation — products, images, analytics (#1354)

### DIFF
--- a/packages/analytics/src/__tests__/analytics-event.test.ts
+++ b/packages/analytics/src/__tests__/analytics-event.test.ts
@@ -519,6 +519,99 @@ describe.skipIf(skipTests)(
         expect(stats.todayPageviews).toBe(0);
         expect(stats.trend).toBe('flat');
       });
+
+      it('should bucket an event near local midnight using the property time zone', async () => {
+        const propertyId = 'prop-tz';
+        // now = 2024-06-15T12:00:00Z = 2024-06-15 05:00 PDT (UTC-7).
+        const now = new Date('2024-06-15T12:00:00Z');
+        // 2024-06-15T06:30:00Z = 2024-06-14 23:30 PDT -> "yesterday" in LA, but
+        // "today" under naive UTC bucketing (it is >= 2024-06-15T00:00:00Z).
+        const nearMidnight = new Date('2024-06-15T06:30:00Z');
+
+        await (
+          await collection.create({
+            propertyId,
+            eventName: 'page_view',
+            clientId: 'client-a',
+            eventTimestamp: nearMidnight,
+          })
+        ).save();
+
+        // Default (UTC) bucketing puts it in today.
+        const utcStats = await collection.getPropertyStatsWithTrend(
+          propertyId,
+          now,
+        );
+        expect(utcStats.todayPageviews).toBe(1);
+        expect(utcStats.yesterdayPageviews).toBe(0);
+
+        // Los Angeles bucketing correctly puts it in yesterday.
+        const laStats = await collection.getPropertyStatsWithTrend(
+          propertyId,
+          now,
+          'America/Los_Angeles',
+        );
+        expect(laStats.todayPageviews).toBe(0);
+        expect(laStats.yesterdayPageviews).toBe(1);
+      });
+
+      it('should keep yesterday correct across a spring-forward DST boundary', async () => {
+        const propertyId = 'prop-dst';
+        // 2024-03-10 02:00 -> 03:00 in America/Los_Angeles (Mar 10 has 23h).
+        // now = 2024-03-11T09:00:00Z = 2024-03-11 02:00 PDT.
+        const now = new Date('2024-03-11T09:00:00Z');
+        // 2024-03-10 12:00 PST = 2024-03-10T20:00:00Z -> belongs to "yesterday".
+        const yesterdayLocalNoon = new Date('2024-03-10T20:00:00Z');
+
+        await (
+          await collection.create({
+            propertyId,
+            eventName: 'page_view',
+            clientId: 'client-a',
+            eventTimestamp: yesterdayLocalNoon,
+          })
+        ).save();
+
+        const stats = await collection.getPropertyStatsWithTrend(
+          propertyId,
+          now,
+          'America/Los_Angeles',
+        );
+
+        // A naive `todayStart - 24h` would skip Mar 10 entirely (landing in
+        // Mar 9), dropping this event from the window. Civil-date arithmetic
+        // keeps it in yesterday.
+        expect(stats.todayPageviews).toBe(0);
+        expect(stats.yesterdayPageviews).toBe(1);
+      });
+
+      it('should classify growth from a zero baseline as up with a null percent', async () => {
+        const propertyId = 'prop-zero-baseline';
+        const now = new Date('2024-06-15T12:00:00Z');
+        const todayTs = new Date('2024-06-15T06:00:00Z');
+
+        // Pageviews today, none yesterday.
+        for (const clientId of ['client-a', 'client-b']) {
+          await (
+            await collection.create({
+              propertyId,
+              eventName: 'page_view',
+              clientId,
+              eventTimestamp: todayTs,
+            })
+          ).save();
+        }
+
+        const stats = await collection.getPropertyStatsWithTrend(
+          propertyId,
+          now,
+        );
+
+        expect(stats.todayPageviews).toBe(2);
+        expect(stats.yesterdayPageviews).toBe(0);
+        expect(stats.trend).toBe('up');
+        expect(stats.trendPercent).toBeNull();
+      });
     });
 
     describe('getBatchPropertyStats', () => {

--- a/packages/analytics/src/collections/AnalyticsEventCollection.ts
+++ b/packages/analytics/src/collections/AnalyticsEventCollection.ts
@@ -14,6 +14,150 @@ export class AnalyticsEventCollection extends SmrtCollection<AnalyticsEvent> {
   static readonly _itemClass = AnalyticsEvent;
 
   /**
+   * Offset of `timeZone` at `instant`, in milliseconds (wall-clock minus UTC).
+   *
+   * Reads the zone's wall-clock Y/M/D h:m:s for `instant` via
+   * `Intl.DateTimeFormat` parts and subtracts the real UTC instant. Positive
+   * east of UTC, negative west (e.g. `America/Los_Angeles` returns roughly
+   * `-7h`/`-8h` depending on DST).
+   *
+   * @throws RangeError if `timeZone` is not a valid IANA identifier.
+   */
+  private zoneOffsetMs(instant: Date, timeZone: string): number {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    }).formatToParts(instant);
+    const lookup = (type: Intl.DateTimeFormatPartTypes): number =>
+      Number.parseInt(parts.find((p) => p.type === type)?.value ?? '0', 10);
+    let hour = lookup('hour');
+    // Intl can emit hour "24" for midnight under hour12:false; normalize to 0.
+    if (hour === 24) hour = 0;
+    const asUtc = Date.UTC(
+      lookup('year'),
+      lookup('month') - 1,
+      lookup('day'),
+      hour,
+      lookup('minute'),
+      lookup('second'),
+    );
+    return asUtc - instant.getTime();
+  }
+
+  /**
+   * Resolve the UTC instant marking the start of the calendar day (00:00) that
+   * `instant` falls on **within the given IANA time zone**.
+   *
+   * Day-over-day buckets ("today vs yesterday") must respect the property's
+   * configured `timeZone` (defaults to `America/Los_Angeles`), otherwise a
+   * pageview at 11:30pm local time — already the next UTC day — is bucketed
+   * into the wrong day. We read the wall-clock civil date for the zone, then
+   * map that date's local midnight back to a UTC instant, correcting for the
+   * zone offset (and re-correcting once across a DST boundary).
+   *
+   * Invalid/unknown zone identifiers fall back to UTC day boundaries (matching
+   * the previous behaviour) rather than throwing.
+   *
+   * @param instant - Reference instant.
+   * @param timeZone - IANA time zone (e.g. `America/Los_Angeles`).
+   * @returns UTC `Date` for local midnight of the day `instant` is in.
+   */
+  protected startOfDayInZone(instant: Date, timeZone: string): Date {
+    let civil: { year: number; month: number; day: number };
+    try {
+      const parts = new Intl.DateTimeFormat('en-US', {
+        timeZone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      }).formatToParts(instant);
+      const lookup = (type: Intl.DateTimeFormatPartTypes): number =>
+        Number.parseInt(parts.find((p) => p.type === type)?.value ?? '0', 10);
+      civil = {
+        year: lookup('year'),
+        month: lookup('month'),
+        day: lookup('day'),
+      };
+    } catch {
+      // Unknown/invalid time zone -> UTC day boundary.
+      return new Date(
+        Date.UTC(
+          instant.getUTCFullYear(),
+          instant.getUTCMonth(),
+          instant.getUTCDate(),
+        ),
+      );
+    }
+
+    // Local midnight of `civil`, as a UTC instant: treat civil-midnight as if
+    // UTC, then subtract the zone offset at that guess. Re-derive the offset at
+    // the corrected instant and re-correct once if it changed (DST edge).
+    const guess = Date.UTC(civil.year, civil.month - 1, civil.day);
+    const offset = this.zoneOffsetMs(new Date(guess), timeZone);
+    let utc = guess - offset;
+    const offset2 = this.zoneOffsetMs(new Date(utc), timeZone);
+    if (offset2 !== offset) utc = guess - offset2;
+    return new Date(utc);
+  }
+
+  /**
+   * Resolve the UTC instant for the start of the day *before* `todayStart`'s
+   * local day, in `timeZone`.
+   *
+   * Steps back 12h from local midnight (landing safely inside the previous
+   * civil day regardless of DST — a naive `- 24h` skips a day across
+   * spring-forward), then re-resolves start-of-day.
+   *
+   * @param todayStart - Local-midnight UTC instant from {@link startOfDayInZone}.
+   * @param timeZone - IANA time zone.
+   * @returns UTC `Date` for local midnight of the prior calendar day.
+   */
+  protected startOfYesterdayInZone(todayStart: Date, timeZone: string): Date {
+    return this.startOfDayInZone(
+      new Date(todayStart.getTime() - 12 * 3_600_000),
+      timeZone,
+    );
+  }
+
+  /**
+   * Classify a day-over-day change into a trend direction + percent.
+   *
+   * - `yesterday > 0`: percent = rounded delta; >5% up, <-5% down, else flat.
+   * - `yesterday === 0 && today > 0`: a brand-new surge from a zero baseline —
+   *   classified `up` with a `null` percent (no finite percentage exists), so
+   *   the UI renders "new" rather than a misleading flat 0%.
+   * - `yesterday === 0 && today === 0`: flat, 0%.
+   *
+   * @param today - Today's count.
+   * @param yesterday - Yesterday's count.
+   * @returns Trend direction and percent (null when growing from zero).
+   */
+  protected classifyTrend(
+    today: number,
+    yesterday: number,
+  ): { trend: 'up' | 'down' | 'flat'; trendPercent: number | null } {
+    if (yesterday > 0) {
+      const change = ((today - yesterday) / yesterday) * 100;
+      const trendPercent = Math.round(change);
+      let trend: 'up' | 'down' | 'flat' = 'flat';
+      if (change > 5) trend = 'up';
+      else if (change < -5) trend = 'down';
+      return { trend, trendPercent };
+    }
+    if (today > 0) {
+      // Growth from a zero baseline: a real surge, no finite percentage.
+      return { trend: 'up', trendPercent: null };
+    }
+    return { trend: 'flat', trendPercent: 0 };
+  }
+
+  /**
    * Find events by property
    *
    * @param propertyId - Parent property ID
@@ -234,25 +378,27 @@ export class AnalyticsEventCollection extends SmrtCollection<AnalyticsEvent> {
    *
    * Compares today's pageview count against yesterday's to produce a
    * trend direction and percentage change. A threshold of 5% is used
-   * to classify 'up' vs 'down' vs 'flat'.
+   * to classify 'up' vs 'down' vs 'flat'; growth from a zero baseline is
+   * classified `up` with a `null` percent (see {@link classifyTrend}).
+   *
+   * Day boundaries are computed in `timeZone` (an IANA identifier such as the
+   * property's `AnalyticsProperty.timeZone`, which defaults to
+   * `America/Los_Angeles`) so an event near local midnight buckets into the
+   * correct calendar day. Defaults to `'UTC'` when omitted.
    *
    * @param propertyId - Property ID
    * @param now - Optional current date (for testing)
+   * @param timeZone - IANA time zone for day boundaries (default `'UTC'`)
    * @returns Stats with trend
    */
   async getPropertyStatsWithTrend(
     propertyId: string,
     now?: Date,
+    timeZone: string = 'UTC',
   ): Promise<PropertyStatsWithTrend> {
     const currentTime = now || new Date();
-    const todayStart = new Date(
-      Date.UTC(
-        currentTime.getUTCFullYear(),
-        currentTime.getUTCMonth(),
-        currentTime.getUTCDate(),
-      ),
-    );
-    const yesterdayStart = new Date(todayStart.getTime() - 86_400_000);
+    const todayStart = this.startOfDayInZone(currentTime, timeZone);
+    const yesterdayStart = this.startOfYesterdayInZone(todayStart, timeZone);
 
     // Single query for both days to avoid concurrent DuckDB prepared statements
     const allPageviewEvents = await this.list({
@@ -280,17 +426,10 @@ export class AnalyticsEventCollection extends SmrtCollection<AnalyticsEvent> {
     const todayPageviews = todayPageviewEvents.length;
     const yesterdayPageviews = yesterdayPageviewEvents.length;
 
-    // Calculate trend
-    let trend: 'up' | 'down' | 'flat' = 'flat';
-    let trendPercent = 0;
-
-    if (yesterdayPageviews > 0) {
-      const change =
-        ((todayPageviews - yesterdayPageviews) / yesterdayPageviews) * 100;
-      trendPercent = Math.round(change);
-      if (change > 5) trend = 'up';
-      else if (change < -5) trend = 'down';
-    }
+    const { trend, trendPercent } = this.classifyTrend(
+      todayPageviews,
+      yesterdayPageviews,
+    );
 
     return {
       todayPageviews,
@@ -305,26 +444,27 @@ export class AnalyticsEventCollection extends SmrtCollection<AnalyticsEvent> {
   /**
    * Get day-over-day stats for multiple properties in batch.
    *
+   * Day boundaries are computed in `timeZone` (default `'UTC'`); see
+   * {@link getPropertyStatsWithTrend}. A single zone applies to the whole
+   * batch, so callers mixing properties with different `timeZone` values
+   * should batch per zone (or fall back to per-property calls).
+   *
    * @param propertyIds - Array of property IDs
    * @param now - Optional current date (for testing)
+   * @param timeZone - IANA time zone for day boundaries (default `'UTC'`)
    * @returns Map of propertyId to stats
    */
   async getBatchPropertyStats(
     propertyIds: string[],
     now?: Date,
+    timeZone: string = 'UTC',
   ): Promise<Map<string, PropertyStatsWithTrend>> {
     const results = new Map<string, PropertyStatsWithTrend>();
 
     // Fetch all date-ranged events once to avoid N+1 queries
     const currentTime = now || new Date();
-    const todayStart = new Date(
-      Date.UTC(
-        currentTime.getUTCFullYear(),
-        currentTime.getUTCMonth(),
-        currentTime.getUTCDate(),
-      ),
-    );
-    const yesterdayStart = new Date(todayStart.getTime() - 86_400_000);
+    const todayStart = this.startOfDayInZone(currentTime, timeZone);
+    const yesterdayStart = this.startOfYesterdayInZone(todayStart, timeZone);
 
     // Single query for both days to avoid concurrent DuckDB prepared statements
     const allEvents = await this.list({
@@ -358,16 +498,10 @@ export class AnalyticsEventCollection extends SmrtCollection<AnalyticsEvent> {
       const todayPageviews = todayPageviewEvents.length;
       const yesterdayPageviews = yesterdayPageviewEvents.length;
 
-      let trend: 'up' | 'down' | 'flat' = 'flat';
-      let trendPercent = 0;
-
-      if (yesterdayPageviews > 0) {
-        const change =
-          ((todayPageviews - yesterdayPageviews) / yesterdayPageviews) * 100;
-        trendPercent = Math.round(change);
-        if (change > 5) trend = 'up';
-        else if (change < -5) trend = 'down';
-      }
+      const { trend, trendPercent } = this.classifyTrend(
+        todayPageviews,
+        yesterdayPageviews,
+      );
 
       results.set(propertyId, {
         todayPageviews,

--- a/packages/analytics/src/svelte/AnalyticsSummary.svelte
+++ b/packages/analytics/src/svelte/AnalyticsSummary.svelte
@@ -52,8 +52,8 @@ const { stats }: Props = $props();
 	.analytics-empty {
 		text-align: center;
 		padding: 2rem;
-		color: var(--color-text-secondary, #6b7280);
-		background: var(--color-neutral-bg, #f9fafb);
+		color: var(--smrt-color-on-surface-variant);
+		background: var(--smrt-color-surface-container);
 		border-radius: 0.5rem;
 	}
 

--- a/packages/analytics/src/svelte/EventsTable.svelte
+++ b/packages/analytics/src/svelte/EventsTable.svelte
@@ -40,13 +40,14 @@ function statusClass(status: string): string {
 		<p class="events-empty">{t(M['analytics.events_table.empty'])}</p>
 	{:else}
 		<table class="events-table">
+			<caption class="events-caption">{t(M['analytics.events_table.caption'])}</caption>
 			<thead>
 				<tr>
-					<th>Event</th>
-					<th>Page</th>
-					<th>Client</th>
-					<th>Time</th>
-					<th>Status</th>
+					<th scope="col">Event</th>
+					<th scope="col">Page</th>
+					<th scope="col">Client</th>
+					<th scope="col">Time</th>
+					<th scope="col">Status</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -54,7 +55,7 @@ function statusClass(status: string): string {
 					<tr>
 						<td class="event-name">{event.eventName}</td>
 						<td class="event-page">{event.pagePath ?? '-'}</td>
-						<td class="event-client" title={event.clientId}>{event.clientId.slice(0, 8)}</td>
+						<td class="event-client" title={event.clientId}>{(event.clientId ?? '').slice(0, 8)}</td>
 						<td class="event-time">{formatTimestamp(event.eventTimestamp)}</td>
 						<td><span class="status-pill {statusClass(event.status)}">{event.status}</span></td>
 					</tr>
@@ -78,12 +79,25 @@ function statusClass(status: string): string {
 		font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
 	}
 
+	/* Visually hidden but available to assistive tech (table accessible name). */
+	.events-caption {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+
 	.events-table th {
 		text-align: left;
 		padding: 0.5rem 0.75rem;
 		font-weight: var(--smrt-typography-weight-semibold, 600);
-		color: var(--color-text-secondary, #6b7280);
-		border-bottom: 2px solid var(--color-border, #e5e7eb);
+		color: var(--smrt-color-on-surface-variant);
+		border-bottom: 2px solid var(--smrt-color-outline-variant);
 		font-size: var(--smrt-typography-label-medium-size, 0.75rem);
 		text-transform: uppercase;
 		letter-spacing: var(--smrt-typography-label-medium-tracking, 0.05em);
@@ -91,12 +105,12 @@ function statusClass(status: string): string {
 
 	.events-table td {
 		padding: 0.5rem 0.75rem;
-		border-bottom: 1px solid var(--color-border-light, #f3f4f6);
-		color: var(--color-text-primary, #111827);
+		border-bottom: 1px solid var(--smrt-color-outline-variant);
+		color: var(--smrt-color-on-surface);
 	}
 
 	.events-table tbody tr:hover {
-		background: var(--color-hover, #f9fafb);
+		background: var(--smrt-color-surface-container);
 	}
 
 	.event-name {
@@ -108,18 +122,18 @@ function statusClass(status: string): string {
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
-		color: var(--color-text-secondary, #6b7280);
+		color: var(--smrt-color-on-surface-variant);
 	}
 
 	.event-client {
 		font-family: var(--smrt-font-family-mono, monospace);
 		font-size: var(--smrt-typography-body-small-size, 0.75rem);
-		color: var(--color-text-secondary, #6b7280);
+		color: var(--smrt-color-on-surface-variant);
 	}
 
 	.event-time {
 		white-space: nowrap;
-		color: var(--color-text-secondary, #6b7280);
+		color: var(--smrt-color-on-surface-variant);
 		font-size: var(--smrt-typography-label-medium-size, 0.75rem);
 	}
 
@@ -132,30 +146,30 @@ function statusClass(status: string): string {
 	}
 
 	.status-sent {
-		background: var(--color-success-bg, #dcfce7);
-		color: var(--color-success-text, #166534);
+		background: var(--smrt-color-success-container);
+		color: var(--smrt-color-on-success-container);
 	}
 
 	.status-failed {
-		background: var(--color-error-bg, #fee2e2);
-		color: var(--color-error-text, #991b1b);
+		background: var(--smrt-color-error-container);
+		color: var(--smrt-color-on-error-container);
 	}
 
 	.status-pending {
-		background: var(--color-warning-bg, #fef9c3);
-		color: var(--color-warning-text, #854d0e);
+		background: var(--smrt-color-warning-container);
+		color: var(--smrt-color-on-warning-container);
 	}
 
 	.events-empty {
 		text-align: center;
 		padding: 2rem;
-		color: var(--color-text-secondary, #6b7280);
+		color: var(--smrt-color-on-surface-variant);
 	}
 
 	.events-overflow {
 		text-align: center;
 		padding: 0.5rem;
-		color: var(--color-text-tertiary, #9ca3af);
+		color: var(--smrt-color-on-surface-variant);
 		font-size: var(--smrt-typography-body-small-size, 0.75rem);
 	}
 </style>

--- a/packages/analytics/src/svelte/PropertyInfo.svelte
+++ b/packages/analytics/src/svelte/PropertyInfo.svelte
@@ -78,8 +78,8 @@ const lastSyncFormatted = $derived.by(() => {
 <style>
 	.property-info {
 		padding: 1rem;
-		background: var(--color-surface, #fff);
-		border: 1px solid var(--color-border, #e5e7eb);
+		background: var(--smrt-color-surface);
+		border: 1px solid var(--smrt-color-outline-variant);
 		border-radius: 0.5rem;
 	}
 
@@ -104,7 +104,7 @@ const lastSyncFormatted = $derived.by(() => {
 		display: flex;
 		justify-content: space-between;
 		padding: 0.375rem 0;
-		border-bottom: 1px solid var(--color-border-light, #f3f4f6);
+		border-bottom: 1px solid var(--smrt-color-outline-variant);
 	}
 
 	.detail-row:last-child {
@@ -113,27 +113,27 @@ const lastSyncFormatted = $derived.by(() => {
 
 	dt {
 		font-size: var(--smrt-typography-label-large-size, 0.8125rem);
-		color: var(--color-text-secondary, #6b7280);
+		color: var(--smrt-color-on-surface-variant);
 	}
 
 	dd {
 		margin: 0;
 		font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
 		font-weight: var(--smrt-typography-weight-medium, 500);
-		color: var(--color-text-primary, #111827);
+		color: var(--smrt-color-on-surface);
 	}
 
 	code {
 		font-family: var(--smrt-font-family-mono, monospace);
 		font-size: var(--smrt-typography-body-small-size, 0.75rem);
 		padding: 0.125rem 0.25rem;
-		background: var(--color-neutral-bg, #f3f4f6);
+		background: var(--smrt-color-surface-container);
 		border-radius: 0.25rem;
 	}
 
 	.no-property {
 		margin: 0;
-		color: var(--color-text-secondary, #6b7280);
+		color: var(--smrt-color-on-surface-variant);
 		font-size: var(--smrt-typography-body-medium-size, 0.875rem);
 	}
 </style>

--- a/packages/analytics/src/svelte/PropertyStatusBadge.svelte
+++ b/packages/analytics/src/svelte/PropertyStatusBadge.svelte
@@ -15,7 +15,7 @@ const label = $derived(
 </script>
 
 <span class="status-badge" class:connected={status === 'active'} class:pending={status === 'pending'} class:disconnected={status === 'inactive'}>
-	<span class="status-dot"></span>
+	<span class="status-dot" aria-hidden="true"></span>
 	{label}
 </span>
 
@@ -37,29 +37,29 @@ const label = $derived(
 	}
 
 	.connected {
-		background: var(--color-success-bg, #dcfce7);
-		color: var(--color-success-text, #166534);
+		background: var(--smrt-color-success-container);
+		color: var(--smrt-color-on-success-container);
 	}
 
 	.connected .status-dot {
-		background: var(--color-success-main, #22c55e);
+		background: var(--smrt-color-success);
 	}
 
 	.pending {
-		background: var(--color-warning-bg, #fef9c3);
-		color: var(--color-warning-text, #854d0e);
+		background: var(--smrt-color-warning-container);
+		color: var(--smrt-color-on-warning-container);
 	}
 
 	.pending .status-dot {
-		background: var(--color-warning-main, #eab308);
+		background: var(--smrt-color-warning);
 	}
 
 	.disconnected {
-		background: var(--color-neutral-bg, #f3f4f6);
-		color: var(--color-neutral-text, #4b5563);
+		background: var(--smrt-color-surface-container);
+		color: var(--smrt-color-on-surface-variant);
 	}
 
 	.disconnected .status-dot {
-		background: var(--color-neutral-main, #9ca3af);
+		background: var(--smrt-color-outline);
 	}
 </style>

--- a/packages/analytics/src/svelte/StatCard.svelte
+++ b/packages/analytics/src/svelte/StatCard.svelte
@@ -5,7 +5,9 @@ interface Props {
   label: string;
   value: number | string;
   trend?: 'up' | 'down' | 'flat';
-  trendPercent?: number;
+  // `null` is a valid value (growth from a zero baseline — TrendBadge shows
+  // "new"); only `undefined` suppresses the trend badge.
+  trendPercent?: number | null;
   subtitle?: string;
 }
 
@@ -28,15 +30,15 @@ const { label, value, trend, trendPercent, subtitle }: Props = $props();
 <style>
 	.stat-card {
 		padding: 1rem;
-		background: var(--color-surface, #fff);
-		border: 1px solid var(--color-border, #e5e7eb);
+		background: var(--smrt-color-surface);
+		border: 1px solid var(--smrt-color-outline-variant);
 		border-radius: 0.5rem;
 	}
 
 	.stat-label {
 		font-size: var(--smrt-typography-label-medium-size, 0.75rem);
 		font-weight: var(--smrt-typography-weight-medium, 500);
-		color: var(--color-text-secondary, #6b7280);
+		color: var(--smrt-color-on-surface-variant);
 		text-transform: uppercase;
 		letter-spacing: var(--smrt-typography-label-medium-tracking, 0.05em);
 		margin-bottom: 0.25rem;
@@ -51,13 +53,13 @@ const { label, value, trend, trendPercent, subtitle }: Props = $props();
 	.stat-value {
 		font-size: var(--smrt-typography-headline-small-size, 1.5rem);
 		font-weight: var(--smrt-typography-weight-bold, 700);
-		color: var(--color-text-primary, #111827);
+		color: var(--smrt-color-on-surface);
 		line-height: var(--smrt-typography-headline-small-line-height, 1.2);
 	}
 
 	.stat-subtitle {
 		font-size: var(--smrt-typography-body-small-size, 0.75rem);
-		color: var(--color-text-tertiary, #9ca3af);
+		color: var(--smrt-color-on-surface-variant);
 		margin-top: 0.25rem;
 	}
 </style>

--- a/packages/analytics/src/svelte/TrendBadge.svelte
+++ b/packages/analytics/src/svelte/TrendBadge.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 interface Props {
   trend: 'up' | 'down' | 'flat';
-  percent: number;
+  // `null` means growth from a zero baseline \u2014 no finite percentage exists, so
+  // the badge shows "new" instead of a misleading 0%.
+  percent: number | null;
 }
 
 const { trend, percent }: Props = $props();
@@ -9,11 +11,13 @@ const { trend, percent }: Props = $props();
 const arrow = $derived(
   trend === 'up' ? '\u2191' : trend === 'down' ? '\u2193' : '\u2192',
 );
+
+const display = $derived(percent === null ? 'new' : `${Math.abs(percent)}%`);
 </script>
 
 <span class="trend-badge" class:up={trend === 'up'} class:down={trend === 'down'} class:flat={trend === 'flat'}>
-	<span class="trend-arrow">{arrow}</span>
-	<span class="trend-percent">{Math.abs(percent)}%</span>
+	<span class="trend-arrow" aria-hidden="true">{arrow}</span>
+	<span class="trend-percent">{display}</span>
 </span>
 
 <style>
@@ -29,18 +33,18 @@ const arrow = $derived(
 	}
 
 	.trend-badge.up {
-		background: var(--color-success-bg, #dcfce7);
-		color: var(--color-success-text, #166534);
+		background: var(--smrt-color-success-container);
+		color: var(--smrt-color-on-success-container);
 	}
 
 	.trend-badge.down {
-		background: var(--color-error-bg, #fee2e2);
-		color: var(--color-error-text, #991b1b);
+		background: var(--smrt-color-error-container);
+		color: var(--smrt-color-on-error-container);
 	}
 
 	.trend-badge.flat {
-		background: var(--color-neutral-bg, #f3f4f6);
-		color: var(--color-neutral-text, #4b5563);
+		background: var(--smrt-color-surface-container);
+		color: var(--smrt-color-on-surface-variant);
 	}
 
 	.trend-arrow {

--- a/packages/analytics/src/svelte/i18n.ts
+++ b/packages/analytics/src/svelte/i18n.ts
@@ -3,6 +3,7 @@ import { defineMessages } from '@happyvertical/smrt-ui/i18n';
 export const M = defineMessages({
   'analytics.analytics_summary.empty': 'No analytics data available yet.',
   'analytics.events_table.empty': 'No recent events.',
+  'analytics.events_table.caption': 'Recent analytics events',
   'analytics.events_table.showing': 'Showing {maxRows} of {total} events',
   'analytics.property_info.title': 'Analytics Property',
   'analytics.property_info.measurement_id': 'Measurement ID',

--- a/packages/analytics/src/types/index.ts
+++ b/packages/analytics/src/types/index.ts
@@ -97,7 +97,12 @@ export interface PropertyStatsWithTrend {
   yesterdayPageviews: number;
   yesterdayUsers: number;
   trend: 'up' | 'down' | 'flat';
-  trendPercent: number;
+  /**
+   * Day-over-day percentage change. `null` when today grew from a zero
+   * yesterday-baseline (a "new" surge with no finite percentage); the UI
+   * renders this as "new" rather than 0%.
+   */
+  trendPercent: number | null;
 }
 
 // ============================================================================

--- a/packages/images/src/__tests__/categorizer.test.ts
+++ b/packages/images/src/__tests__/categorizer.test.ts
@@ -167,6 +167,69 @@ describe('ImageCategorizer', () => {
 
       expect(result.description).toBe('d');
     });
+
+    // ── #1407 remediation: validate the parsed object shape ──────────────────
+
+    it('defaults tags/subjects to [] when a valid JSON response omits them', async () => {
+      // Valid JSON, but `tags` and `subjects` are missing entirely. The old
+      // code returned this object as-is, so a later `for…of result.tags` threw
+      // "tags is not iterable".
+      chatMock.mockResolvedValue({
+        content: '{"description":"A red car","confidence":0.7}',
+      });
+
+      const categorizer = new ImageCategorizer(aiOptions);
+      const result = await categorizer.categorize(makeImage());
+
+      expect(result.tags).toEqual([]);
+      expect(result.subjects).toEqual([]);
+      expect(Array.isArray(result.tags)).toBe(true);
+      expect(result.description).toBe('A red car');
+      expect(result.confidence).toBe(0.7);
+    });
+
+    it('coerces a non-array tags field to [] rather than trusting the model', async () => {
+      // The model returned a string where an array was expected.
+      chatMock.mockResolvedValue({
+        content: '{"tags":"beach, ocean","description":"d","subjects":null}',
+      });
+
+      const categorizer = new ImageCategorizer(aiOptions);
+      const result = await categorizer.categorize(makeImage());
+
+      expect(result.tags).toEqual([]);
+      expect(result.subjects).toEqual([]);
+    });
+
+    it('extracts the first balanced JSON object when prose AND a second brace follow', async () => {
+      // The greedy /\{[\s\S]*\}/ would span to the LAST brace, producing
+      // invalid JSON. Balanced extraction stops at the first object's match.
+      chatMock.mockResolvedValue({
+        content:
+          '{"tags":["cat"],"description":"A cat","confidence":0.5,"subjects":["animal"]} ' +
+          'Note: confidence is approximate {not json}.',
+      });
+
+      const categorizer = new ImageCategorizer(aiOptions);
+      const result = await categorizer.categorize(makeImage());
+
+      expect(result.tags).toEqual(['cat']);
+      expect(result.description).toBe('A cat');
+      expect(result.subjects).toEqual(['animal']);
+    });
+
+    it('does not mistake a brace inside a string value for the object end', async () => {
+      chatMock.mockResolvedValue({
+        content:
+          '{"tags":["a"],"description":"price is {discounted}","confidence":1,"subjects":[]}',
+      });
+
+      const categorizer = new ImageCategorizer(aiOptions);
+      const result = await categorizer.categorize(makeImage());
+
+      expect(result.description).toBe('price is {discounted}');
+      expect(result.tags).toEqual(['a']);
+    });
   });
 
   describe('autoTag()', () => {
@@ -286,6 +349,34 @@ describe('ImageCategorizer', () => {
 
       expect(image.alt).toHaveLength(125);
       expect(image.description).toBe(longDesc);
+    });
+
+    it('does not throw "tags is not iterable" when the AI omits tags (#1407)', async () => {
+      // Valid JSON with description but no `tags` array. Pre-fix, autoTag's
+      // `for (const tag of result.tags)` threw because tags was undefined.
+      chatMock.mockResolvedValue({
+        content: '{"description":"A persisted scene","confidence":0.6}',
+      });
+
+      const image = await images.create({
+        name: 'no-tags.jpg',
+        mimeType: 'image/jpeg',
+        width: 640,
+        height: 480,
+        description: '',
+        alt: '',
+      });
+      await image.save();
+
+      const categorizer = new ImageCategorizer(aiOptions);
+      await expect(categorizer.autoTag(image, assets)).resolves.toBeUndefined();
+
+      // Description still applied; no tags persisted (none were returned).
+      expect(image.description).toBe('A persisted scene');
+      const rows = (await db.list('asset_tags', {
+        asset_id: image.id,
+      })) as Array<{ tag_slug: string }>;
+      expect(rows).toEqual([]);
     });
   });
 });

--- a/packages/images/src/__tests__/images-tenant-isolation.test.ts
+++ b/packages/images/src/__tests__/images-tenant-isolation.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Regression tests for the T3 images remediation finding (#1407, top item):
+ * tenant-isolation on ImageCollection's orientation/resolution helpers.
+ *
+ * Image inherits Asset's `@TenantScoped({ mode: 'optional' })`, and the
+ * interceptor's default `rawQueryPolicy` is `'throw'`. The original
+ * implementations of `getLandscape` / `getPortrait` / `getSquare` /
+ * `getHighResolution` / `getByAspectRatio` / `findWithGlobals` issued raw
+ * `this.query("SELECT * FROM assets ...")`, which — under any tenant context —
+ * either threw `TenantIsolationError` (the orientation/resolution `+server.ts`
+ * endpoints were broken) or, under a `'warn'`/`'allow'` policy, returned rows
+ * across all tenants AND across sibling Asset subclasses (no `_meta_type`
+ * scope).
+ *
+ * Each test below runs the method inside `withTenant()` with tenancy enabled
+ * (default throw policy) and asserts (a) it does not throw and (b) it returns
+ * only the current tenant's Image rows — never another tenant's images and
+ * never a non-Image Asset. Real in-memory SQLite, no DB mocking, per
+ * `.claude/rules/testing.md`.
+ */
+
+import { AssetCollection } from '@happyvertical/smrt-assets';
+import { getTestDatabase } from '@happyvertical/smrt-core/testing';
+import {
+  disableTenancy,
+  enableTenancy,
+  withTenant,
+} from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Image } from '../image';
+import { ImageCollection } from '../images';
+
+describe('ImageCollection tenant isolation (#1407)', () => {
+  let db: DatabaseInterface;
+  let images: ImageCollection;
+  let assets: AssetCollection;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    images = await ImageCollection.create({ db });
+    assets = await AssetCollection.create({ db });
+    enableTenancy(); // default rawQueryPolicy: 'throw'
+  });
+
+  afterEach(async () => {
+    disableTenancy();
+    if (db && typeof db.close === 'function') {
+      await db.close();
+    }
+  });
+
+  /**
+   * Seed a fixed fixture spanning two tenants plus a non-Image Asset.
+   * Created under each tenant's context so the interceptor auto-populates
+   * tenant_id; the non-Image Asset is created under tenant-1 too.
+   */
+  async function seed() {
+    await withTenant({ tenantId: 'tenant-1' }, async () => {
+      // Landscape, portrait, square, 4K, and a non-Image asset.
+      await (
+        await images.create({ name: 't1-land.jpg', width: 1920, height: 1080 })
+      ).save();
+      await (
+        await images.create({ name: 't1-port.jpg', width: 1080, height: 1920 })
+      ).save();
+      await (
+        await images.create({ name: 't1-square.jpg', width: 512, height: 512 })
+      ).save();
+      await (
+        await images.create({ name: 't1-4k.jpg', width: 3840, height: 2160 })
+      ).save();
+      await (
+        await assets.create({
+          name: 't1-doc.pdf',
+          mimeType: 'application/pdf',
+        })
+      ).save();
+    });
+
+    await withTenant({ tenantId: 'tenant-2' }, async () => {
+      // Tenant-2 has one of every shape so a leak would be obvious.
+      await (
+        await images.create({ name: 't2-land.jpg', width: 2560, height: 1440 })
+      ).save();
+      await (
+        await images.create({ name: 't2-port.jpg', width: 720, height: 1280 })
+      ).save();
+      await (
+        await images.create({ name: 't2-square.jpg', width: 256, height: 256 })
+      ).save();
+      await (
+        await images.create({ name: 't2-4k.jpg', width: 4096, height: 2160 })
+      ).save();
+    });
+  }
+
+  it('getLandscape() returns only the current tenant landscape images (no throw)', async () => {
+    await seed();
+    const result = await withTenant({ tenantId: 'tenant-1' }, () =>
+      images.getLandscape(),
+    );
+    // Both t1-land (1920×1080) and t1-4k (3840×2160) are landscape; tenant-2's
+    // landscape images must NOT appear, and the non-Image PDF must NOT appear.
+    expect(result.map((i) => i.name).sort()).toEqual([
+      't1-4k.jpg',
+      't1-land.jpg',
+    ]);
+    // Every result is an Image (STI scope), not a sibling Asset.
+    expect(result.every((i) => i instanceof Image)).toBe(true);
+  });
+
+  it('getPortrait() returns only the current tenant portrait images (no throw)', async () => {
+    await seed();
+    const result = await withTenant({ tenantId: 'tenant-2' }, () =>
+      images.getPortrait(),
+    );
+    expect(result.map((i) => i.name)).toEqual(['t2-port.jpg']);
+    expect(result.every((i) => i instanceof Image)).toBe(true);
+  });
+
+  it('getSquare() returns only the current tenant square images (no throw)', async () => {
+    await seed();
+    const result = await withTenant({ tenantId: 'tenant-1' }, () =>
+      images.getSquare(),
+    );
+    expect(result.map((i) => i.name)).toEqual(['t1-square.jpg']);
+  });
+
+  it('getHighResolution() returns only the current tenant 4K images (no throw)', async () => {
+    await seed();
+    const result = await withTenant({ tenantId: 'tenant-1' }, () =>
+      images.getHighResolution(),
+    );
+    expect(result.map((i) => i.name)).toEqual(['t1-4k.jpg']);
+  });
+
+  it('getByAspectRatio() returns only the current tenant images in range (no throw)', async () => {
+    await seed();
+    // [1.7, 1.9] matches both tenant-1 16:9-ish images (t1-land 1.78, t1-4k
+    // 1.78) but not t1-square (1.0). Tenant-2 also has in-range landscapes
+    // (t2-land 1.78, t2-4k 1.90) — a tenant leak would surface them, so an
+    // exact tenant-1-only result proves isolation.
+    const result = await withTenant({ tenantId: 'tenant-1' }, () =>
+      images.getByAspectRatio(1.7, 1.9),
+    );
+    expect(result.map((i) => i.name).sort()).toEqual([
+      't1-4k.jpg',
+      't1-land.jpg',
+    ]);
+  });
+
+  it('findWithGlobals() returns the tenant images plus globals, scoped to Images (no throw)', async () => {
+    await seed();
+    // Add a global (tenant-less) image and a global non-Image asset via system
+    // context so no tenant id is auto-populated.
+    const { withSystemContext } = await import('@happyvertical/smrt-tenancy');
+    await withSystemContext(async () => {
+      await (
+        await images.create({ name: 'global.jpg', width: 800, height: 600 })
+      ).save();
+      await (
+        await assets.create({
+          name: 'global-doc.pdf',
+          mimeType: 'application/pdf',
+        })
+      ).save();
+    });
+
+    const result = await withTenant({ tenantId: 'tenant-1' }, () =>
+      images.findWithGlobals('tenant-1'),
+    );
+    const names = result.map((i) => i.name).sort();
+    // tenant-1's four images + the one global image; NOT tenant-2's images and
+    // NOT either non-Image PDF.
+    expect(names).toEqual([
+      'global.jpg',
+      't1-4k.jpg',
+      't1-land.jpg',
+      't1-port.jpg',
+      't1-square.jpg',
+    ]);
+    expect(result.every((i) => i instanceof Image)).toBe(true);
+  });
+});

--- a/packages/images/src/__tests__/images-tenant-isolation.test.ts
+++ b/packages/images/src/__tests__/images-tenant-isolation.test.ts
@@ -182,4 +182,63 @@ describe('ImageCollection tenant isolation (#1407)', () => {
     ]);
     expect(result.every((i) => i instanceof Image)).toBe(true);
   });
+
+  it('findGlobal() returns only global images under an active tenant context (no throw)', async () => {
+    await seed();
+    // Add a global (tenant-less) image and a global non-Image asset via system
+    // context so no tenant id is auto-populated.
+    const { withSystemContext } = await import('@happyvertical/smrt-tenancy');
+    await withSystemContext(async () => {
+      await (
+        await images.create({ name: 'global.jpg', width: 800, height: 600 })
+      ).save();
+      await (
+        await assets.create({
+          name: 'global-doc.pdf',
+          mimeType: 'application/pdf',
+        })
+      ).save();
+    });
+
+    // Regression: re-declaring `@TenantScoped` made `list({ where: { tenantId:
+    // null } })` throw a TenantIsolationError under any active context (the
+    // interceptor treats an explicit null tenant filter as a violation). Under
+    // tenant-1, findGlobal must still return the tenant-less image — never a
+    // tenant-scoped image and never the non-Image PDF.
+    const result = await withTenant({ tenantId: 'tenant-1' }, () =>
+      images.findGlobal(),
+    );
+    expect(result.map((i) => i.name)).toEqual(['global.jpg']);
+    expect(result.every((i) => i instanceof Image)).toBe(true);
+  });
+
+  it('findWithGlobals() fails closed when asked for a tenant other than the active context (#1400)', async () => {
+    await seed();
+    // The raw bypass disables the interceptor's isolation guard, so the method
+    // replicates it: under tenant-1, a caller must not be able to read
+    // tenant-2's images by passing tenant-2's id (e.g. from untrusted params).
+    await expect(
+      withTenant({ tenantId: 'tenant-1' }, () =>
+        images.findWithGlobals('tenant-2'),
+      ),
+    ).rejects.toThrow(/isolation/i);
+  });
+
+  it('findWithGlobals() still serves an arbitrary tenant under system context (admin path)', async () => {
+    await seed();
+    // No enforced tenant (system context) preserves the deliberate cross-tenant
+    // capability: an admin path can fetch any tenant's images plus globals.
+    const { withSystemContext } = await import('@happyvertical/smrt-tenancy');
+    const result = await withSystemContext(() =>
+      images.findWithGlobals('tenant-2'),
+    );
+    // tenant-2's four images (no globals seeded in this case); only Images.
+    expect(result.map((i) => i.name).sort()).toEqual([
+      't2-4k.jpg',
+      't2-land.jpg',
+      't2-port.jpg',
+      't2-square.jpg',
+    ]);
+    expect(result.every((i) => i instanceof Image)).toBe(true);
+  });
 });

--- a/packages/images/src/categorizer.ts
+++ b/packages/images/src/categorizer.ts
@@ -10,6 +10,73 @@ import type { AssetCollection } from '@happyvertical/smrt-assets';
 import type { Image } from './image';
 import type { CategoryResult } from './types';
 
+/**
+ * Extract the first balanced top-level JSON object substring from arbitrary
+ * model output. Unlike a greedy `/\{[\s\S]*\}/` (which spans from the first
+ * `{` to the *last* `}` and so swallows trailing prose or a second object,
+ * producing invalid JSON), this scans brace depth from the first `{` and stops
+ * at its matching `}`, skipping braces that appear inside string literals.
+ *
+ * @returns the balanced `{...}` substring, or `null` if none is found.
+ */
+function extractFirstJsonObject(text: string): string | null {
+  const start = text.indexOf('{');
+  if (start === -1) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === '\\') {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === '{') {
+      depth++;
+    } else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        return text.slice(start, i + 1);
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Coerce an arbitrary parsed value into a well-formed `CategoryResult`,
+ * defaulting each field so a malformed or partial AI response can never
+ * produce a non-iterable `tags`/`subjects` or a missing `description`.
+ */
+function normalizeCategoryResult(
+  parsed: unknown,
+  fallbackDescription: string,
+): CategoryResult {
+  const p = (parsed ?? {}) as Record<string, unknown>;
+  return {
+    tags: Array.isArray(p.tags) ? (p.tags as string[]) : [],
+    description:
+      typeof p.description === 'string' && p.description
+        ? p.description
+        : fallbackDescription,
+    confidence: typeof p.confidence === 'number' ? p.confidence : 0,
+    subjects: Array.isArray(p.subjects) ? (p.subjects as string[]) : [],
+  };
+}
+
 export class ImageCategorizer {
   constructor(private readonly options: { ai: AIClientOptions }) {}
 
@@ -44,18 +111,23 @@ Respond in JSON format:
     const response = await ai.chat([{ role: 'user', content: prompt }]);
     const text = response.content;
 
-    try {
-      const jsonMatch = text.match(/\{[\s\S]*\}/);
-      if (jsonMatch) {
-        return JSON.parse(jsonMatch[0]) as CategoryResult;
+    const fallbackDescription = image.description || image.name;
+
+    const jsonText = extractFirstJsonObject(text);
+    if (jsonText) {
+      try {
+        return normalizeCategoryResult(
+          JSON.parse(jsonText),
+          fallbackDescription,
+        );
+      } catch {
+        // Malformed JSON — fall through to default below.
       }
-    } catch {
-      // Fall through to default
     }
 
     return {
       tags: [],
-      description: image.description || image.name,
+      description: fallbackDescription,
       confidence: 0,
       subjects: [],
     };
@@ -80,8 +152,10 @@ Respond in JSON format:
 
     await image.save();
 
-    // Add tags via the asset collection
-    for (const tag of result.tags) {
+    // Add tags via the asset collection. Guard against a non-array `tags`
+    // (e.g. a hand-built CategoryResult or future code path that bypasses
+    // `normalizeCategoryResult`) so the loop never throws "not iterable".
+    for (const tag of result.tags ?? []) {
       await assetCollection.addTag(image.id!, tag);
     }
   }

--- a/packages/images/src/image.ts
+++ b/packages/images/src/image.ts
@@ -11,12 +11,21 @@
 import { Asset } from '@happyvertical/smrt-assets';
 import { field, smrt } from '@happyvertical/smrt-core';
 import { resolvePrompt } from '@happyvertical/smrt-prompts';
+import { TenantScoped } from '@happyvertical/smrt-tenancy';
 import {
   promptMessageOptions,
   smrtImagesGenerateAltTextPrompt,
 } from './prompts';
 import type { ImageOptions } from './types';
 
+// The @TenantScoped decorator registers only the exact class name it's applied
+// to — it does NOT propagate to STI subclasses. Asset is `@TenantScoped`, but
+// without re-declaring it here `isTenantScopedClass('Image')` is false, so the
+// tenancy interceptor would neither tenant-filter Image's `list()` queries nor
+// guard its raw SQL. Re-declaring it (matching Asset's `mode: 'optional'`)
+// registers Image too, so the interceptor scopes Image collection reads by
+// tenant. The inherited `tenantId` field needs no re-declaration. (#1407)
+@TenantScoped({ mode: 'optional' })
 @smrt({
   api: { include: ['list', 'get', 'create', 'update', 'delete'] },
   mcp: { include: ['list', 'get', 'create', 'update', 'generateAltText'] },

--- a/packages/images/src/images.ts
+++ b/packages/images/src/images.ts
@@ -7,6 +7,19 @@
 import { SmrtCollection } from '@happyvertical/smrt-core';
 import { Image } from './image';
 
+/**
+ * Qualified STI discriminator for Image rows in the shared `assets` table.
+ *
+ * Raw SQL on this tenant-scoped collection must scope by `_meta_type` so it
+ * never returns sibling Asset subclasses. The orientation/resolution helpers
+ * below compare two columns (e.g. `width > height`), which `list()`'s
+ * value-based WHERE clause cannot express — so they either filter in-memory
+ * after a tenant-/STI-scoped `list()` (mirroring `ImageSearch.search()`) or,
+ * for `findWithGlobals`, run raw SQL with `{ allowRawOnTenantScoped: true }`
+ * after manually injecting both the tenant predicate and this `_meta_type`.
+ */
+const IMAGE_META_TYPE = '@happyvertical/smrt-images:Image';
+
 export class ImageCollection extends SmrtCollection<Image> {
   static readonly _itemClass = Image;
 
@@ -40,9 +53,17 @@ export class ImageCollection extends SmrtCollection<Image> {
    * @returns Array of tenant-specific and global images
    */
   async findWithGlobals(tenantId: string): Promise<Image[]> {
+    // Intentionally cross-tenant: returns the given tenant's images plus all
+    // global (tenant-less) images. `list()` would let the interceptor inject
+    // `tenant_id = <currentContext>` and strip the globals, so this stays raw —
+    // but we manually scope to the Image STI discriminator and pass the bypass
+    // flag since tenant filtering is handled by the explicit predicate here.
     return (await this.query(
-      `SELECT * FROM ${this.tableName} WHERE tenant_id = ? OR tenant_id IS NULL`,
-      [tenantId],
+      `SELECT * FROM ${this.tableName}
+       WHERE _meta_type = ?
+         AND (tenant_id = ? OR tenant_id IS NULL)`,
+      [IMAGE_META_TYPE, tenantId],
+      { allowRawOnTenantScoped: true },
     )) as Image[];
   }
 
@@ -90,9 +111,11 @@ export class ImageCollection extends SmrtCollection<Image> {
    * @returns Array of landscape-oriented images
    */
   async getLandscape(): Promise<Image[]> {
-    return (await this.query(
-      `SELECT * FROM ${this.tableName} WHERE width > height`,
-    )) as Image[];
+    // `width > height` is a column-to-column comparison `list()`'s WHERE can't
+    // express, so list (tenant- + STI-scoped) then filter in-memory via the
+    // `isLandscape` computed property — same pattern as ImageSearch.search().
+    const all = (await this.list({})) as Image[];
+    return all.filter((image) => image.isLandscape);
   }
 
   /**
@@ -101,9 +124,10 @@ export class ImageCollection extends SmrtCollection<Image> {
    * @returns Array of portrait-oriented images
    */
   async getPortrait(): Promise<Image[]> {
-    return (await this.query(
-      `SELECT * FROM ${this.tableName} WHERE height > width`,
-    )) as Image[];
+    // Column-to-column (`height > width`): list (tenant-/STI-scoped) then
+    // filter in-memory via the `isPortrait` computed property.
+    const all = (await this.list({})) as Image[];
+    return all.filter((image) => image.isPortrait);
   }
 
   /**
@@ -112,9 +136,11 @@ export class ImageCollection extends SmrtCollection<Image> {
    * @returns Array of square images
    */
   async getSquare(): Promise<Image[]> {
-    return (await this.query(
-      `SELECT * FROM ${this.tableName} WHERE width = height AND width > 0`,
-    )) as Image[];
+    // Column-to-column (`width = height AND width > 0`): list (tenant-/STI-
+    // scoped) then filter in-memory. `isSquare` already encodes the `width > 0`
+    // guard, so zero-dimension placeholders are excluded.
+    const all = (await this.list({})) as Image[];
+    return all.filter((image) => image.isSquare);
   }
 
   /**
@@ -134,9 +160,11 @@ export class ImageCollection extends SmrtCollection<Image> {
    * @returns Array of high resolution images
    */
   async getHighResolution(): Promise<Image[]> {
-    return (await this.query(
-      `SELECT * FROM ${this.tableName} WHERE width >= 3840 OR height >= 2160`,
-    )) as Image[];
+    // `width >= 3840 OR height >= 2160` needs an OR across two columns, which
+    // `list()`'s AND-only WHERE can't express. List (tenant-/STI-scoped) then
+    // filter in-memory via the `isHighResolution()` helper.
+    const all = (await this.list({})) as Image[];
+    return all.filter((image) => image.isHighResolution());
   }
 
   /**
@@ -147,13 +175,17 @@ export class ImageCollection extends SmrtCollection<Image> {
    * @returns Array of images within the aspect ratio range
    */
   async getByAspectRatio(minRatio: number, maxRatio: number): Promise<Image[]> {
-    // Use computed ratio in SQL: (CAST(width AS REAL) / NULLIF(height, 0))
-    return (await this.query(
-      `SELECT * FROM ${this.tableName}
-       WHERE height > 0
-         AND (CAST(width AS REAL) / height) >= ?
-         AND (CAST(width AS REAL) / height) <= ?`,
-      [minRatio, maxRatio],
-    )) as Image[];
+    // The aspect-ratio predicate is computed from two columns, which `list()`'s
+    // WHERE can't express. List (tenant-/STI-scoped) then filter in-memory via
+    // the `aspectRatio` computed property. `aspectRatio` returns 0 when height
+    // is 0, so the `height > 0` guard preserves the original semantics for any
+    // sensible positive ratio range.
+    const all = (await this.list({})) as Image[];
+    return all.filter(
+      (image) =>
+        image.height > 0 &&
+        image.aspectRatio >= minRatio &&
+        image.aspectRatio <= maxRatio,
+    );
   }
 }

--- a/packages/images/src/images.ts
+++ b/packages/images/src/images.ts
@@ -5,6 +5,11 @@
  */
 
 import { SmrtCollection } from '@happyvertical/smrt-core';
+import {
+  getCurrentTenant,
+  isSuperAdminBypass,
+  TenantIsolationError,
+} from '@happyvertical/smrt-tenancy';
 import { Image } from './image';
 
 /**
@@ -15,8 +20,11 @@ import { Image } from './image';
  * below compare two columns (e.g. `width > height`), which `list()`'s
  * value-based WHERE clause cannot express — so they either filter in-memory
  * after a tenant-/STI-scoped `list()` (mirroring `ImageSearch.search()`) or,
- * for `findWithGlobals`, run raw SQL with `{ allowRawOnTenantScoped: true }`
- * after manually injecting both the tenant predicate and this `_meta_type`.
+ * for the global-image lookups (`findGlobal`/`findWithGlobals`), run raw SQL
+ * with `{ allowRawOnTenantScoped: true }` after manually injecting both the
+ * tenant predicate and this `_meta_type`. A literal `tenant_id IS NULL` filter
+ * can't go through `list()` either — the interceptor rejects an explicit null
+ * tenant filter as an isolation violation.
  */
 const IMAGE_META_TYPE = '@happyvertical/smrt-images:Image';
 
@@ -43,7 +51,19 @@ export class ImageCollection extends SmrtCollection<Image> {
    * @returns Array of global images
    */
   async findGlobal(): Promise<Image[]> {
-    return (await this.list({ where: { tenantId: null } })) as Image[];
+    // `list({ where: { tenantId: null } })` throws under an active tenant
+    // context: the interceptor flags an explicit null tenant filter as an
+    // isolation violation (it cannot tell "give me shared rows" from "give me
+    // another tenant's rows"). Raw SQL with the bypass flag — manually scoped
+    // to the Image STI discriminator and `tenant_id IS NULL` — returns global
+    // images under any context, mirroring `findWithGlobals`. (#1407)
+    return (await this.query(
+      `SELECT * FROM ${this.tableName}
+       WHERE _meta_type = ?
+         AND tenant_id IS NULL`,
+      [IMAGE_META_TYPE],
+      { allowRawOnTenantScoped: true },
+    )) as Image[];
   }
 
   /**
@@ -58,6 +78,26 @@ export class ImageCollection extends SmrtCollection<Image> {
     // `tenant_id = <currentContext>` and strip the globals, so this stays raw —
     // but we manually scope to the Image STI discriminator and pass the bypass
     // flag since tenant filtering is handled by the explicit predicate here.
+    //
+    // The raw bypass disables the interceptor's isolation guard, so replicate
+    // it: `findByTenant`/`list()` throw when asked for another tenant's rows
+    // under an active context, and this must too — otherwise a caller could
+    // read another tenant's images by passing an arbitrary `tenantId` (e.g.
+    // straight from untrusted params). A system / super-admin-bypass context
+    // (no enforced tenant) keeps the deliberate cross-tenant capability for
+    // admin callers. (#1400 fail-closed)
+    const tenantContext = getCurrentTenant();
+    if (
+      tenantContext &&
+      !isSuperAdminBypass() &&
+      tenantContext.tenantId !== tenantId
+    ) {
+      throw new TenantIsolationError(
+        `Tenant isolation violation in Image.findWithGlobals: context tenant ` +
+          `is '${tenantContext.tenantId}' but query requested '${tenantId}'`,
+        { tenantId: tenantContext.tenantId, attemptedTenantId: tenantId },
+      );
+    }
     return (await this.query(
       `SELECT * FROM ${this.tableName}
        WHERE _meta_type = ?

--- a/packages/images/src/svelte/components/AssetsGallery.svelte
+++ b/packages/images/src/svelte/components/AssetsGallery.svelte
@@ -109,18 +109,25 @@ async function loadImages(reset = false) {
 // Initial load — must be in onMount to avoid SSR fetch errors
 onMount(() => loadImages(true));
 
-// Debounce search on filter changes using idiomatic Svelte 5 $effect cleanup
-let searchTimeout: ReturnType<typeof setTimeout> | undefined;
+// Debounce search on filter changes. Schedule the timer in the effect *body*
+// (not the cleanup) and clear it in the returned cleanup, so a pending reload
+// is cancelled — never fired — when the component unmounts. Skip the very first
+// run because onMount() already performs the initial load.
+let didInitialFilterRun = false;
 $effect(() => {
   // Register reactive deps
   const _q = searchQuery;
   const _o = orientationFilter;
   const _w = minWidth;
   const _h = minHeight;
-  return () => {
-    clearTimeout(searchTimeout);
-    searchTimeout = setTimeout(() => loadImages(true), 500);
-  };
+
+  if (!didInitialFilterRun) {
+    didInitialFilterRun = true;
+    return;
+  }
+
+  const id = setTimeout(() => loadImages(true), 500);
+  return () => clearTimeout(id);
 });
 
 function handleSelect(image: ImageLike) {

--- a/packages/images/src/svelte/components/ImageUploader.svelte
+++ b/packages/images/src/svelte/components/ImageUploader.svelte
@@ -56,6 +56,11 @@ let canvasElement: HTMLCanvasElement | undefined = $state();
 let stream: MediaStream | null = $state(null);
 let cameraError: string | null = $state(null);
 let isCameraActive = $state(false);
+// Set once the component tears down. `getUserMedia()` may still be resolving
+// (permission prompt) after unmount; this lets startCamera() detect that and
+// stop the just-granted tracks instead of leaking the camera (light stays on).
+// Not reactive — it only gates an async cleanup decision.
+let isDestroyed = false;
 
 // External state
 let externalUrl = $state('');
@@ -114,13 +119,28 @@ async function startCamera() {
   cameraError = null;
   isCameraActive = false;
   try {
-    stream = await navigator.mediaDevices.getUserMedia({
+    const acquired = await navigator.mediaDevices.getUserMedia({
       video: { facingMode: 'environment' },
       audio: false,
     });
+
+    // The permission prompt may have resolved after the user switched tabs or
+    // the component unmounted. If the camera is no longer the intended target,
+    // immediately stop the just-granted tracks so the camera light turns off,
+    // and don't attach the (now orphaned) stream.
+    if (isDestroyed || activeTab !== 'camera') {
+      for (const track of acquired.getTracks()) {
+        track.stop();
+      }
+      return;
+    }
+
+    stream = acquired;
     if (videoElement) {
       videoElement.srcObject = stream;
-      videoElement.play();
+      // play() can reject if autoplay is blocked; swallow it so it doesn't
+      // surface as an unhandled rejection (the user can still capture frames).
+      videoElement.play().catch(() => {});
       isCameraActive = true;
     }
   } catch (err: any) {
@@ -247,6 +267,7 @@ async function handleGenerateVariation() {
 }
 
 onDestroy(() => {
+  isDestroyed = true;
   stopCamera();
 });
 </script>

--- a/packages/products/src/app/App.svelte
+++ b/packages/products/src/app/App.svelte
@@ -2,17 +2,19 @@
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { onMount } from 'svelte';
 import { M } from '../lib/i18n.js';
+import DemoPage from './pages/DemoPage.svelte';
+import ProductsPage from './pages/ProductsPage.svelte';
 
 const { t } = useI18n();
 
 // Simple client-side routing (can be replaced with proper router)
-let _currentPage = $state('demo');
+let currentPage = $state('demo');
 
 onMount(() => {
   // Simple hash-based routing
   function handleHashChange() {
     const hash = window.location.hash.slice(1);
-    _currentPage = hash || 'products';
+    currentPage = hash || 'products';
   }
 
   window.addEventListener('hashchange', handleHashChange);

--- a/packages/products/src/app/layouts/AppLayout.svelte
+++ b/packages/products/src/app/layouts/AppLayout.svelte
@@ -58,7 +58,7 @@ const { t } = useI18n();
   }
 
   .app-header {
-    background: white;
+    background: var(--smrt-color-surface, #fff);
     border-bottom: 1px solid var(--smrt-color-outline-variant, #e2e8f0);
     box-shadow: var(--smrt-elevation-1, 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow, #000) 10%, transparent));
     position: sticky;
@@ -144,7 +144,7 @@ const { t } = useI18n();
   }
   
   .app-footer {
-    background: white;
+    background: var(--smrt-color-surface, #fff);
     border-top: 1px solid var(--smrt-color-outline-variant, #e2e8f0);
     margin-top: auto;
   }

--- a/packages/products/src/app/pages/DemoPage.svelte
+++ b/packages/products/src/app/pages/DemoPage.svelte
@@ -5,12 +5,15 @@
  */
 
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import AutoForm from '../../lib/components/auto-generated/AutoForm.svelte';
+import ProductCard from '../../lib/components/ProductCard.svelte';
+import ProductForm from '../../lib/components/ProductForm.svelte';
 import { M } from '../../lib/i18n.js';
 import type { ProductData } from '../../lib/types';
 
 const { t } = useI18n();
 
-const _currentTab = $state<'auto' | 'custom' | 'comparison'>('auto');
+let currentTab = $state<'auto' | 'custom' | 'comparison'>('auto');
 
 // Sample data for demonstration
 const sampleProduct: ProductData = $state({
@@ -27,15 +30,15 @@ const sampleProduct: ProductData = $state({
   tags: ['demo', 'widget', 'smrt'],
 });
 
-let _autoFormData = $state({ ...sampleProduct });
-let _customFormData = $state({ ...sampleProduct });
+let autoFormData = $state({ ...sampleProduct });
+let customFormData = $state({ ...sampleProduct });
 
-function _handleAutoSubmit(data: ProductData) {
-  _autoFormData = { ...data };
+function handleAutoSubmit(data: ProductData) {
+  autoFormData = { ...data };
 }
 
-function _handleCustomSubmit(data: ProductData) {
-  _customFormData = { ...data };
+function handleCustomSubmit(data: ProductData) {
+  customFormData = { ...data };
 }
 </script>
 
@@ -112,7 +115,7 @@ function _handleCustomSubmit(data: ProductData) {
             <h3>{t(M['products.demo_page.custom_form_heading'])}</h3>
             <ProductForm
               product={customFormData}
-              onSave={handleCustomSubmit}
+              onSubmit={handleCustomSubmit}
             />
           </div>
 
@@ -224,19 +227,19 @@ function _handleCustomSubmit(data: ProductData) {
     padding: 0.75rem 1.5rem;
     background: color-mix(in srgb, var(--smrt-color-surface, #fff) 90%, transparent);
     border: 2px solid transparent;
-    border-radius: 0.5rem;
+    border-radius: var(--smrt-radius-md, 0.5rem);
     font-weight: var(--smrt-typography-weight-medium, 500);
     cursor: pointer;
     transition: all 0.2s;
   }
 
   .nav-btn:hover {
-    background: white;
+    background: var(--smrt-color-surface, #fff);
     transform: translateY(-2px);
   }
 
   .nav-btn.active {
-    background: white;
+    background: var(--smrt-color-surface, #fff);
     border-color: var(--smrt-color-primary, #3b82f6);
     color: var(--smrt-color-primary, #3b82f6);
   }
@@ -249,7 +252,7 @@ function _handleCustomSubmit(data: ProductData) {
     max-width: 1200px;
     margin: 0 auto;
     background: color-mix(in srgb, var(--smrt-color-surface, #fff) 95%, transparent);
-    border-radius: 1rem;
+    border-radius: var(--smrt-radius-xl, 1rem);
     padding: 2rem;
     margin-bottom: 2rem;
   }
@@ -282,7 +285,7 @@ function _handleCustomSubmit(data: ProductData) {
   .comparison-column {
     padding: 1.5rem;
     background: var(--smrt-color-surface-container-low, #f9fafb);
-    border-radius: 0.5rem;
+    border-radius: var(--smrt-radius-md, 0.5rem);
     border: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
   }
 
@@ -334,7 +337,7 @@ function _handleCustomSubmit(data: ProductData) {
   .framework-info li {
     padding: 0.75rem;
     background: var(--smrt-color-surface-container, #f3f4f6);
-    border-radius: 0.375rem;
+    border-radius: var(--smrt-radius-sm, 0.375rem);
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
   }
 

--- a/packages/products/src/app/pages/ProductsPage.svelte
+++ b/packages/products/src/app/pages/ProductsPage.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import ProductCatalog from '../../lib/features/ProductCatalog.svelte';
 import { M } from '../../lib/i18n.js';
+import AppLayout from '../layouts/AppLayout.svelte';
 
 const { t } = useI18n();
 </script>
@@ -90,7 +92,7 @@ const { t } = useI18n();
   }
   
   .info-card {
-    background: white;
+    background: var(--smrt-color-surface, #fff);
     padding: 1.5rem;
     border-radius: var(--smrt-radius-md, 8px);
     border: 1px solid var(--smrt-color-outline-variant, #e2e8f0);

--- a/packages/products/src/federation/shared.config.ts
+++ b/packages/products/src/federation/shared.config.ts
@@ -20,12 +20,13 @@ export const sharedDependencies: Record<string, SharedDependency> = {
     eager: true,
   },
 
-  // SMRT framework
-  '@smrt/core': {
-    singleton: true,
-    requiredVersion: 'workspace:*',
-    eager: true,
-  },
+  // NOTE: do not add SMRT framework packages here as federation `shared`
+  // entries unless this remote actually imports them as a bare specifier.
+  // A previous `@smrt/core` entry (with a `workspace:*` requiredVersion)
+  // broke the federation build: @originjs/vite-plugin-federation treats every
+  // shared key as an entry module to resolve, and `@smrt/core` is not a real
+  // importable package (the framework package is `@happyvertical/smrt-core`,
+  // and nothing in the federated surface imports it).
 
   // Common utilities (add as needed)
   // 'lodash': {

--- a/packages/products/src/lib/components/ProductCard.svelte
+++ b/packages/products/src/lib/components/ProductCard.svelte
@@ -60,7 +60,7 @@ const { product, onEdit, onDelete }: Props = $props();
     border: 1px solid var(--smrt-color-outline-variant, #e2e8f0);
     border-radius: var(--smrt-radius-md, 8px);
     padding: 1rem;
-    background: white;
+    background: var(--smrt-color-surface, #fff);
     box-shadow: var(--smrt-elevation-1, 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow, #000) 10%, transparent));
     transition: box-shadow 0.2s;
   }

--- a/packages/products/src/lib/components/ProductForm.svelte
+++ b/packages/products/src/lib/components/ProductForm.svelte
@@ -39,7 +39,7 @@ function validateForm() {
   return Object.keys(errors).length === 0;
 }
 
-function _handleSubmit(event: Event) {
+function handleSubmit(event: Event) {
   event.preventDefault();
 
   if (!validateForm()) {
@@ -172,7 +172,7 @@ function _handleSubmit(event: Event) {
   .product-form {
     max-width: 500px;
     padding: 1.5rem;
-    background: white;
+    background: var(--smrt-color-surface, #fff);
     border-radius: var(--smrt-radius-md, 8px);
     border: 1px solid var(--smrt-color-outline-variant, #e2e8f0);
   }
@@ -263,7 +263,7 @@ function _handleSubmit(event: Event) {
   }
   
   .cancel-btn {
-    background: white;
+    background: var(--smrt-color-surface, #fff);
     border-color: var(--smrt-color-outline-variant, #d1d5db);
     color: var(--smrt-color-on-surface, #374151);
   }

--- a/packages/products/src/lib/components/auto-generated/AutoForm.svelte
+++ b/packages/products/src/lib/components/auto-generated/AutoForm.svelte
@@ -7,6 +7,7 @@
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { M } from '../../i18n.js';
 import type { ProductData } from '../../types';
+import FieldRenderer from './FieldRenderer.svelte';
 
 const { t } = useI18n();
 
@@ -79,7 +80,7 @@ $effect(() => {
   formData = { ...data };
 });
 
-function _updateField(fieldName: string, value: any) {
+function updateField(fieldName: string, value: any) {
   formData[fieldName as keyof ProductData] = value;
 
   // Trigger change callback
@@ -88,7 +89,7 @@ function _updateField(fieldName: string, value: any) {
   }
 }
 
-function _handleSubmit(event: Event) {
+function handleSubmit(event: Event) {
   event.preventDefault();
   if (onSubmit && !readonly) {
     onSubmit({ ...formData });
@@ -149,7 +150,7 @@ function _getFieldType(
     max-width: 600px;
     margin: 0 auto;
     padding: 1.5rem;
-    background: white;
+    background: var(--smrt-color-surface, #fff);
     border-radius: var(--smrt-radius-md, 8px);
     box-shadow: var(--smrt-elevation-1, 0 1px 3px color-mix(in srgb, var(--smrt-color-shadow, #000) 10%, transparent));
   }
@@ -191,7 +192,7 @@ function _getFieldType(
     color: var(--smrt-color-on-primary, white);
     border: none;
     padding: 0.75rem 1.5rem;
-    border-radius: 0.375rem;
+    border-radius: var(--smrt-radius-sm, 0.375rem);
     font-weight: var(--smrt-typography-weight-medium, 500);
     cursor: pointer;
     transition: background-color 0.2s;
@@ -206,7 +207,7 @@ function _getFieldType(
     color: var(--smrt-color-on-surface, #374151);
     border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
     padding: 0.75rem 1.5rem;
-    border-radius: 0.375rem;
+    border-radius: var(--smrt-radius-sm, 0.375rem);
     font-weight: var(--smrt-typography-weight-medium, 500);
     cursor: pointer;
     transition: background-color 0.2s;
@@ -220,7 +221,7 @@ function _getFieldType(
     margin-top: 2rem;
     padding: 1rem;
     background: var(--smrt-color-surface-container-low, #f9fafb);
-    border-radius: 0.375rem;
+    border-radius: var(--smrt-radius-sm, 0.375rem);
     border: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
   }
 

--- a/packages/products/src/lib/components/auto-generated/FieldRenderer.svelte
+++ b/packages/products/src/lib/components/auto-generated/FieldRenderer.svelte
@@ -32,12 +32,12 @@ const {
 }: Props = $props();
 
 // Auto-generate label from field name if not provided
-const _displayLabel =
+const displayLabel =
   label ||
   fieldName
     .replace(/([A-Z])/g, ' $1')
     .replace(/^./, (str) => str.toUpperCase());
-const _fieldId = `field-${fieldName}`;
+const fieldId = `field-${fieldName}`;
 
 function handleUpdate(newValue: any) {
   if (onUpdate && !readonly) {
@@ -45,22 +45,22 @@ function handleUpdate(newValue: any) {
   }
 }
 
-function _handleStringInput(event: Event) {
+function handleStringInput(event: Event) {
   const target = event.target as HTMLInputElement;
   handleUpdate(target.value);
 }
 
-function _handleNumberInput(event: Event) {
+function handleNumberInput(event: Event) {
   const target = event.target as HTMLInputElement;
   handleUpdate(Number.parseFloat(target.value) || 0);
 }
 
-function _handleBooleanInput(event: Event) {
+function handleBooleanInput(event: Event) {
   const target = event.target as HTMLInputElement;
   handleUpdate(target.checked);
 }
 
-function _handleArrayInput(event: Event) {
+function handleArrayInput(event: Event) {
   const target = event.target as HTMLTextAreaElement;
   try {
     // Simple array handling - comma separated values
@@ -74,7 +74,7 @@ function _handleArrayInput(event: Event) {
   }
 }
 
-function _handleObjectInput(event: Event) {
+function handleObjectInput(event: Event) {
   const target = event.target as HTMLTextAreaElement;
   try {
     const objectValue = JSON.parse(target.value);
@@ -169,7 +169,7 @@ function _handleObjectInput(event: Event) {
   .field-textarea {
     padding: 0.5rem 0.75rem;
     border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
-    border-radius: 0.375rem;
+    border-radius: var(--smrt-radius-sm, 0.375rem);
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     transition: border-color 0.2s, box-shadow 0.2s;
   }

--- a/packages/products/src/lib/features/ProductCatalog.svelte
+++ b/packages/products/src/lib/features/ProductCatalog.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { onMount } from 'svelte';
-import { productStore } from '$lib/stores/product-store.svelte';
+import ProductCard from '../components/ProductCard.svelte';
+import ProductForm from '../components/ProductForm.svelte';
 import { M } from '../i18n.js';
+import { productStore } from '../stores/product-store.svelte';
 import type { ProductData } from '../types';
 
 const { t } = useI18n();
@@ -14,13 +16,13 @@ interface Props {
 
 const { readonly = false, showCreateForm = false }: Props = $props();
 
-const searchQuery = $state('');
-const selectedCategory = $state('');
-let _showForm = $state(false);
+let searchQuery = $state('');
+let selectedCategory = $state('');
+let showForm = $state(false);
 let editingProduct = $state<ProductData | null>(null);
 
 // Reactive filtered products
-const _filteredProducts = $derived.by(() => {
+const filteredProducts = $derived.by(() => {
   let products = productStore.items;
 
   if (searchQuery) {
@@ -38,38 +40,45 @@ onMount(() => {
   productStore.loadProducts();
 });
 
-function _handleCreateProduct() {
+function handleCreateProduct() {
   editingProduct = null;
-  _showForm = true;
+  showForm = true;
 }
 
-function _handleEditProduct(product: ProductData) {
+function handleEditProduct(product: ProductData) {
   editingProduct = product;
-  _showForm = true;
+  showForm = true;
 }
 
-async function _handleDeleteProduct(id: string) {
+async function handleDeleteProduct(id: string) {
   if (confirm('Are you sure you want to delete this product?')) {
     try {
       await productStore.deleteProduct(id);
-    } catch (error) {}
+    } catch {
+      // deleteProduct already recorded the message on productStore.error;
+      // the error-state region below renders it. Swallow the re-thrown
+      // rejection so it doesn't become an unhandled promise rejection.
+    }
   }
 }
 
-async function _handleSubmitProduct(productData: Partial<ProductData>) {
+async function handleSubmitProduct(productData: Partial<ProductData>) {
   try {
     if (editingProduct?.id) {
       await productStore.updateProduct(editingProduct.id, productData);
     } else {
       await productStore.createProduct(productData);
     }
-    _showForm = false;
+    showForm = false;
     editingProduct = null;
-  } catch (error) {}
+  } catch {
+    // Keep the form open on failure; productStore.error holds the message
+    // and the error-state region renders it.
+  }
 }
 
-function _handleCancelForm() {
-  _showForm = false;
+function handleCancelForm() {
+  showForm = false;
   editingProduct = null;
 }
 </script>
@@ -97,6 +106,7 @@ function _handleCancelForm() {
         type="text"
         bind:value={searchQuery}
         placeholder={t(M['products.product_catalog.search_placeholder'])}
+        aria-label={t(M['products.product_catalog.search_placeholder'])}
         class="search-input"
       />
       
@@ -120,18 +130,18 @@ function _handleCancelForm() {
   </div>
   
   {#if productStore.loading}
-    <div class="loading-state">
+    <div class="loading-state" role="status" aria-live="polite">
       <p>{t(M['products.product_catalog.loading'])}</p>
     </div>
   {:else if productStore.error}
-    <div class="error-state">
+    <div class="error-state" role="alert" aria-live="assertive">
       <p>Error: {productStore.error}</p>
       <button type="button" onclick={() => productStore.loadProducts()}>
         Retry
       </button>
     </div>
   {:else if filteredProducts.length === 0}
-    <div class="empty-state">
+    <div class="empty-state" role="status" aria-live="polite">
       {#if productStore.items.length === 0}
         <p>{t(M['products.product_catalog.empty'])}</p>
         {#if !readonly}
@@ -281,7 +291,7 @@ function _handleCancelForm() {
   }
   
   .form-container {
-    background: white;
+    background: var(--smrt-color-surface, #fff);
     border-radius: var(--smrt-radius-md, 8px);
     max-width: 500px;
     width: 90vw;

--- a/packages/products/src/lib/mock-smrt-client.ts
+++ b/packages/products/src/lib/mock-smrt-client.ts
@@ -5,20 +5,12 @@
  * that demonstrates the intended functionality.
  */
 
-export interface ProductData {
-  id?: string;
-  name: string;
-  description?: string;
-  category: string;
-  manufacturer?: string;
-  model?: string;
-  price?: number;
-  inStock?: boolean;
-  specifications?: Record<string, any>;
-  tags?: string[];
-  createdAt?: string;
-  updatedAt?: string;
-}
+// Re-use the canonical UI ProductData shape so the mock client, the stores,
+// and the components all agree on one type. The shape uses snake_case
+// timestamps (`created_at`/`updated_at`) to match the SMRT server payload.
+import type { ProductData } from './types';
+
+export type { ProductData } from './types';
 
 export interface ApiResponse<T> {
   data: T;
@@ -39,8 +31,8 @@ const mockProducts: ProductData[] = [
     inStock: true,
     specifications: { weight: '1.2kg', color: 'Black' },
     tags: ['demo', 'sample'],
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
   },
   {
     id: '2',
@@ -53,8 +45,8 @@ const mockProducts: ProductData[] = [
     inStock: false,
     specifications: { size: 'small' },
     tags: ['budget', 'affordable'],
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
   },
 ];
 
@@ -102,8 +94,8 @@ class MockApiClient {
         inStock: productData.inStock ?? true,
         specifications: productData.specifications || {},
         tags: productData.tags || [],
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
       };
 
       mockProducts.push(newProduct);
@@ -129,7 +121,7 @@ class MockApiClient {
       const updatedProduct = {
         ...mockProducts[index],
         ...updates,
-        updatedAt: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
       };
 
       mockProducts[index] = updatedProduct;
@@ -164,7 +156,11 @@ class MockApiClient {
       await new Promise((resolve) => setTimeout(resolve, 200));
 
       const categories = Array.from(
-        new Set(mockProducts.map((p) => p.category).filter(Boolean)),
+        new Set(
+          mockProducts
+            .map((p) => p.category)
+            .filter((c): c is string => Boolean(c)),
+        ),
       );
 
       return {

--- a/packages/products/src/lib/models/Category.ts
+++ b/packages/products/src/lib/models/Category.ts
@@ -75,24 +75,4 @@ export class Category extends SmrtObject {
     this.productCount = options.productCount || 0;
     this.active = options.active !== undefined ? options.active : true;
   }
-
-  async getProducts() {
-    // Returns products in this category - implementation auto-generated
-    return [];
-  }
-
-  async getSubcategories() {
-    // Returns child categories - implementation auto-generated
-    return [];
-  }
-
-  async updateProductCount(): Promise<void> {
-    // Updates the cached product count
-    // Implementation will be auto-generated to count related products
-  }
-
-  static async getRootCategories(): Promise<Category[]> {
-    // Returns top-level categories (parentId is null/empty)
-    return [];
-  }
 }

--- a/packages/products/src/lib/models/Product.ts
+++ b/packages/products/src/lib/models/Product.ts
@@ -215,14 +215,4 @@ export class Product extends SmrtObject {
       relationship ? { relationship } : {},
     );
   }
-
-  static async searchByText(_query: string): Promise<Product[]> {
-    // Search implementation will be auto-generated
-    return [];
-  }
-
-  static async findByManufacturer(_manufacturer: string): Promise<Product[]> {
-    // Manufacturer search will be auto-generated
-    return [];
-  }
 }

--- a/packages/products/src/lib/utils/index.ts
+++ b/packages/products/src/lib/utils/index.ts
@@ -22,9 +22,12 @@ export function formatDate(date: string | Date): string {
 
 export function slugify(text: string): string {
   return text
+    .normalize('NFKD')
+    .replace(/[^\p{L}\p{N} ]+/gu, '')
+    .trim()
     .toLowerCase()
-    .replace(/[^\w ]+/g, '')
-    .replace(/ +/g, '-');
+    .replace(/ +/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
 export function generateId(): string {

--- a/packages/products/src/utils.test.ts
+++ b/packages/products/src/utils.test.ts
@@ -61,12 +61,39 @@ describe('slugify', () => {
     expect(slugify('Organic   Cotton')).toBe('organic-cotton');
   });
 
-  it('removes punctuation that is not a word character or space', () => {
-    expect(slugify('Café & Crème (2024)')).toBe('caf-crme-2024');
+  it('removes punctuation while folding accented letters to ASCII', () => {
+    // NFKD decomposes "é" into "e" + combining mark; the mark is not a
+    // letter/number so it is stripped, leaving the readable ASCII base.
+    expect(slugify('Café & Crème (2024)')).toBe('cafe-creme-2024');
   });
 
-  it('preserves underscores and digits as word characters', () => {
-    expect(slugify('SKU_001 Variant')).toBe('sku_001-variant');
+  it('strips underscores (not Unicode letters or numbers) but keeps digits', () => {
+    expect(slugify('SKU_001 Variant')).toBe('sku001-variant');
+  });
+
+  // Regression: a CJK/Cyrillic-only title must NOT collapse to an empty
+  // string. The previous ASCII-only `[^\w ]` regex stripped every
+  // non-Latin character, so a title like "已经" produced "" and every such
+  // product collided on the (slug, context, _meta_type) unique index.
+  it('preserves CJK characters instead of producing an empty slug', () => {
+    expect(slugify('已经')).toBe('已经');
+    expect(slugify('已经 Cotton')).toBe('已经-cotton');
+  });
+
+  it('preserves Cyrillic letters', () => {
+    expect(slugify('Привет Мир')).toBe('привет-мир');
+  });
+
+  // Regression: leading/trailing punctuation used to leave dangling hyphens
+  // (e.g. "-trim-me-"); they must be trimmed off both ends.
+  it('trims leading and trailing hyphens left by edge punctuation', () => {
+    expect(slugify('--Trim Me--')).toBe('trim-me');
+    expect(slugify('!!!Edge!!!')).toBe('edge');
+  });
+
+  it('returns an empty string for input with no letters or numbers', () => {
+    expect(slugify('   ')).toBe('');
+    expect(slugify('—–-')).toBe('');
   });
 });
 

--- a/packages/products/vite.config.ts
+++ b/packages/products/vite.config.ts
@@ -99,7 +99,23 @@ const libEntries = {
 	'lib/mock-smrt-client': resolve(packageDir, 'src/lib/mock-smrt-client.ts'),
 } as const;
 
-export default defineConfig(async () => {
+/**
+ * Vite mode → output target for the triple-consumption build.
+ *
+ * - `library`   (default): tree of ESM entries + .d.ts in `dist/lib`. This is
+ *   what `npm run build` / turbo run and what consumers import. Externalizes
+ *   workspace + node deps so nothing is bundled.
+ * - `standalone`: the browser app from `index.html` (mounts `App.svelte`)
+ *   into `dist/app`. Bundles everything for the browser (no `external`).
+ * - `federation`: module-federation remote exposing the browser-safe
+ *   components from `src/lib/federation-entry.ts` into `dist/federation`.
+ *
+ * Previously `build.lib` was unconditional, so `--mode standalone` /
+ * `--mode federation` silently re-ran the library build and emitted nothing
+ * to `dist/app` or `dist/federation` — the standalone + federation consumption
+ * paths were dead. Each mode now produces its own artifact.
+ */
+export default defineConfig(async ({ mode }) => {
 	// Import smrtPlugin for SMRT object scanning
 	const { importWorkspaceModule } = await import(
 		'../core/src/utils/import-workspace-module.js'
@@ -113,6 +129,93 @@ export default defineConfig(async () => {
 		purpose: 'products package Vite config',
 	});
 
+	// SMRT object scanning is shared by every mode.
+	const smrt = smrtPlugin({
+		include: ['src/**/*.ts'],
+		exclude: ['**/*.test.ts', '**/*.spec.ts'],
+		generateTypes: true,
+		hmr: false,
+	});
+
+	// The standalone app + federation remote bundle cross-package SMRT models
+	// (smrt-assets, smrt-tenancy) for the browser rather than externalizing
+	// them, so they need smrtConsumer() to emit `.smrt/register.js` for
+	// runtime class loading. The library build externalizes those packages and
+	// does not.
+	const loadSmrtConsumer = async () => {
+		const { smrtConsumer } = await importWorkspaceModule<
+			typeof import('@happyvertical/smrt-core/consumer-plugin')
+		>({
+			packageName: '@happyvertical/smrt-core/consumer-plugin',
+			distEntry: 'packages/core/dist/consumer-plugin.js',
+			sourceEntry: 'packages/core/src/consumer-plugin/index.ts',
+			purpose: 'products package consumer plugin',
+		});
+		return smrtConsumer({ projectRoot: packageDir });
+	};
+
+	// Standalone browser app: build index.html → dist/app. The app must bundle
+	// its dependencies for the browser, so we deliberately do NOT pass the
+	// library `external` predicate here.
+	if (mode === 'standalone') {
+		return {
+			build: {
+				outDir: resolve(packageDir, 'dist/app'),
+				emptyOutDir: true,
+				sourcemap: true,
+				target: 'es2022',
+				reportCompressedSize: false,
+				rollupOptions: {
+					input: resolve(packageDir, 'index.html'),
+				},
+			},
+			plugins: [svelte(), await loadSmrtConsumer(), smrt],
+		};
+	}
+
+	// Module-federation remote: expose browser-safe components → dist/federation.
+	if (mode === 'federation') {
+		const { default: federation } = await import(
+			'@originjs/vite-plugin-federation'
+		);
+		const { flattenedExposes } = await import(
+			'./src/federation/expose.config.js'
+		);
+		const { sharedDependencies } = await import(
+			'./src/federation/shared.config.js'
+		);
+		return {
+			build: {
+				outDir: resolve(packageDir, 'dist/federation'),
+				emptyOutDir: true,
+				sourcemap: true,
+				// Module federation requires a modern target that supports
+				// top-level await for the shared-scope bootstrap.
+				target: 'esnext',
+				minify: false,
+				reportCompressedSize: false,
+			},
+			plugins: [
+				svelte(),
+				await loadSmrtConsumer(),
+				smrt,
+				federation({
+					name: 'smrt_products',
+					filename: 'remoteEntry.js',
+					exposes: {
+						'./federation-entry': resolve(
+							packageDir,
+							'src/lib/federation-entry.ts',
+						),
+						...flattenedExposes,
+					},
+					shared: sharedDependencies,
+				}),
+			],
+		};
+	}
+
+	// Default + `library` mode: the published ESM library surface.
 	return {
 		build: {
 			lib: {
@@ -139,12 +242,7 @@ export default defineConfig(async () => {
 			// Svelte plugin for .svelte component files
 			svelte(),
 			// SMRT plugin for SMRT object scanning and code generation
-			smrtPlugin({
-				include: ['src/**/*.ts'],
-				exclude: ['**/*.test.ts', '**/*.spec.ts'],
-				generateTypes: true,
-				hmr: false,
-			}),
+			smrt,
 			// TypeScript declarations
 			dts({
 				outDir: resolve(packageDir, 'dist/lib'),


### PR DESCRIPTION
## Summary
Final-tier (**T3**) remediation of the deep-review track (epic #1354) — 3 packages reviewed + remediated, conflict-free integration. This completes the review track (T1+T2 already merged: #1578, #1581, #1590, #1592). Findings: #1405 (products) · #1407 (images) · #1409 (analytics).

## What's fixed

**products (#1405)** — the standalone-app path was **fully broken** (and products is *the* triple-consumption reference template):
- Repaired the broken **standalone + federation builds**: dropped a lint autofix's `_`-prefixed locals the templates still referenced (→ `ReferenceError`s), `const`→`let` for `bind:`-bound vars, added rendered-but-never-imported components (4 more than the review found), fixed a `$lib` import. Gated vite `build.lib` on `mode` and wired the standalone + federation branches (federation was never built) — `build:all` now emits **all 3 artifacts**.
- slugify made Unicode-aware (CJK/accented titles no longer collapse to an empty/colliding slug); `background: white` ×10 → `var(--smrt-color-surface, #fff)` (a real dark-mode bug — named color slips the ratchet); raw `border-radius` ×8 → tokens; deleted dead-code stubs; unified the divergent `ProductData` shape; a11y.

**images (#1407)** — **tenant-isolation**:
- The orientation/resolution `ImageCollection` methods **silently leaked cross-tenant** — the raw `query()` bypassed tenancy because `@TenantScoped` does **not** propagate to STI subclasses (it registered only `Asset`). Re-declared `@TenantScoped` on `Image` + rewrote the methods via tenant-aware `list()` (+ `_meta_type` scope; `findWithGlobals` keeps explicit tenant+global predicates). Hardened the categorizer AI-JSON parse (balanced-brace scan + field defaults), fixed the AssetsGallery post-unmount timer leak + the camera-stream leak race.
- ⚠️ **Systemic note:** STI children not inheriting tenant-scoping recognition is a **framework gap** — content's `Article`/`ContentDocument` and video's `*Asset` share the same latent leak. Filing a dedicated issue.

**analytics (#1409)** — theming + correctness:
- Migrated the **dead `--color-*` namespace** (45 refs across 6 components) → `--smrt-color-*` so they actually theme (they were always rendering the hex fallback — slipped both ratchets); fixed **UTC day-bucketing** to use the property timezone (+ a DST spring-forward edge the agent caught and regression-tested); zero-baseline trend → "new" instead of a misleading "flat"; `clientId` null guard; table `scope`/`caption` + decorative-glyph `aria-hidden`.

## Testing
analytics **21 files** · images **14** · products **7** — all green; full `turbo build` **51/51** (incl. products' 3 build modes); typecheck + svelte-check(+a11y) clean; all pre-push gates green.

## Deferred
Primitive reroll (products/images/analytics import ~0 smrt-ui primitives) → **#1589**; i18n → **#1579**; images orphan-rows / CSS-`url()` / search-window (speculative) noted; the **STI-tenant-scoping framework gap** → a new issue.

Addresses #1405, #1407, #1409.
