### PR TITLE
feat(smrt-ui): Button class passthrough + ratchet escape-hatch (#1589 Wave 0)

### DIFF
--- a/packages/smrt-ui/src/components/ui/Button.svelte
+++ b/packages/smrt-ui/src/components/ui/Button.svelte
@@ -26,6 +26,12 @@ export interface Props extends Omit<HTMLButtonAttributes, 'class' | 'href'> {
   fullWidth?: boolean;
   /** Loading state */
   loading?: boolean;
+  /**
+   * Extra class(es) appended after the base `button {variant} {size}` styling.
+   * Lets callers adopt Button for custom-styled buttons without losing their
+   * own CSS (issue #1589) — the base button styling still applies.
+   */
+  class?: string;
 }
 
 const {
@@ -36,6 +42,7 @@ const {
   loading = false,
   type = 'button',
   fullWidth = false,
+  class: className = '',
   onclick,
   children,
   ...rest
@@ -67,7 +74,7 @@ const linkProps = $derived(() => {
 {#if isLink}
   <a
     {href}
-    class="button {variant} {size}"
+    class="button {variant} {size} {className}"
     class:disabled={isDisabled}
     class:full-width={fullWidth}
     class:loading
@@ -88,7 +95,7 @@ const linkProps = $derived(() => {
     {type}
     disabled={isDisabled}
     aria-busy={loading}
-    class="button {variant} {size}"
+    class="button {variant} {size} {className}"
     class:full-width={fullWidth}
     class:loading
     {onclick}

--- a/packages/smrt-ui/src/components/ui/__tests__/Button.test.ts
+++ b/packages/smrt-ui/src/components/ui/__tests__/Button.test.ts
@@ -68,6 +68,31 @@ describe('Button', () => {
     expect(link).toHaveAttribute('href', '/home');
   });
 
+  it('appends a custom class while keeping the base button styling (#1589)', () => {
+    render(Button, {
+      props: { children: textSnippet('Save'), class: 'topic-action-btn' },
+    });
+    const button = screen.getByRole('button', { name: 'Save' });
+    // Caller's class is applied (so custom-styled buttons can adopt Button)...
+    expect(button).toHaveClass('topic-action-btn');
+    // ...without dropping the primitive's own base/variant styling.
+    expect(button).toHaveClass('button');
+    expect(button).toHaveClass('primary');
+  });
+
+  it('appends a custom class in link mode too', () => {
+    render(Button, {
+      props: {
+        children: textSnippet('Home'),
+        href: '/home',
+        class: 'nav-link',
+      },
+    });
+    const link = screen.getByRole('link', { name: 'Home' });
+    expect(link).toHaveClass('nav-link');
+    expect(link).toHaveClass('button');
+  });
+
   it('is axe-clean', async () => {
     const { container } = render(Button, {
       props: { children: textSnippet('Accessible') },

--- a/scripts/check-raw-primitives.mjs
+++ b/scripts/check-raw-primitives.mjs
@@ -127,8 +127,14 @@ function markupOnly(source) {
     .replace(/<!--[\s\S]*?-->/g, blank);
 }
 
-/** Escape-hatch annotation: `<!-- raw-primitive-allow: <reason> -->`. */
-const ALLOW_RE = /<!--\s*raw-primitive-allow\b[^>]*?-->/gi;
+/**
+ * Escape-hatch annotation: `<!-- raw-primitive-allow: <reason> -->`.
+ *
+ * A `:` followed by a non-empty reason is REQUIRED (the `:\s*\S`) — a bare
+ * `<!-- raw-primitive-allow -->` does NOT match, so the exemption is never
+ * silent: the author must say why the raw element is justified.
+ */
+const ALLOW_RE = /<!--\s*raw-primitive-allow:\s*\S[^>]*?-->/gi;
 
 /**
  * Collect raw-primitive violations in a single `.svelte` file's source.

--- a/scripts/check-raw-primitives.mjs
+++ b/scripts/check-raw-primitives.mjs
@@ -31,6 +31,13 @@
  *   - `<script>` / `<style>` blocks and `<!-- -->` comments are blanked before
  *     scanning, so an element name mentioned in JS, CSS, or a comment is never
  *     matched (line numbers are preserved).
+ *   - `__tests__` directories — test fixtures are not shippable product UI.
+ *   - An element immediately preceded by an escape-hatch annotation:
+ *       <!-- raw-primitive-allow: <reason> -->
+ *     for genuinely-structural / semantic controls that no primitive should own
+ *     (e.g. a click-catching backdrop, a custom mic toggle). The reason is
+ *     required so the exception is self-documenting and reviewable — the same
+ *     spirit as the color ratchet's value-allowlist.
  *
  * Run: `node scripts/check-raw-primitives.mjs` or `pnpm check:raw-primitives`.
  * Exit code: 0 if no strict-package violations, 1 otherwise.
@@ -88,14 +95,15 @@ function listFiles(dir, exts) {
   for (const entry of entries) {
     const full = join(dir, entry.name);
     if (entry.isDirectory()) {
-      // Skip dependency + build/cache trees. `.svelte-kit` in particular holds
-      // generated `__package__` copies of every component — scanning them would
-      // double-count (and they are not the authored source anyway).
+      // Skip dependency, build/cache, and test-fixture trees. `.svelte-kit`
+      // holds generated `__package__` copies of every component; `__tests__`
+      // holds test fixtures — neither is authored, shippable product UI.
       if (
         entry.name === 'node_modules' ||
         entry.name === 'dist' ||
         entry.name === '.svelte-kit' ||
-        entry.name === '.turbo'
+        entry.name === '.turbo' ||
+        entry.name === '__tests__'
       )
         continue;
       out.push(...listFiles(full, exts));
@@ -119,18 +127,37 @@ function markupOnly(source) {
     .replace(/<!--[\s\S]*?-->/g, blank);
 }
 
+/** Escape-hatch annotation: `<!-- raw-primitive-allow: <reason> -->`. */
+const ALLOW_RE = /<!--\s*raw-primitive-allow\b[^>]*?-->/gi;
+
 /**
  * Collect raw-primitive violations in a single `.svelte` file's source.
  *
  * Matches against the whole markup (NOT line-by-line) so a multi-line opening
  * tag — `<button\n  class="...">`, where the terminating whitespace is the
  * newline — is still caught; line numbers are derived from the match index.
+ *
+ * An element is exempt when a `raw-primitive-allow` annotation sits immediately
+ * before it (only whitespace between the annotation and the element). The
+ * annotations are read from the ORIGINAL source — `markupOnly` blanks comments
+ * but preserves character positions, so indices line up.
  */
 function findViolations(source) {
   const text = markupOnly(source);
+  const allowEnds = [...source.matchAll(ALLOW_RE)].map(
+    (m) => m.index + m[0].length,
+  );
   const hits = [];
   for (const m of text.matchAll(RAW_ELEMENT_RE)) {
     const idx = m.index;
+    // Exempt if an allow annotation immediately precedes this element.
+    if (
+      allowEnds.some(
+        (end) => end <= idx && /^\s*$/.test(source.slice(end, idx)),
+      )
+    ) {
+      continue;
+    }
     const line = text.slice(0, idx).split('\n').length;
     const lineStart = text.lastIndexOf('\n', idx - 1) + 1;
     const nl = text.indexOf('\n', idx);
@@ -220,9 +247,11 @@ for (const { file, hits } of strictViolations.sort((a, b) =>
 console.error(
   '\nReplace raw interactive elements with the shared primitives so components\n' +
     'get consistent a11y / focus / disabled-state behavior (#1589):\n' +
-    '  <button>  → Button         (@happyvertical/smrt-ui)\n' +
+    '  <button>  → Button         (@happyvertical/smrt-ui; pass `class` for custom styling)\n' +
     '  <input>/<textarea>/<select>/<form> → Input/Textarea/Select/Form\n' +
     '                              (@happyvertical/smrt-svelte)\n' +
+    'For a genuinely-structural control no primitive should own (backdrop, custom\n' +
+    'toggle), annotate it: <!-- raw-primitive-allow: <reason> --> on the line above.\n' +
     'Primitive-source files (smrt-ui/src, smrt-svelte/src/components/forms) are\n' +
     'exempt — see PRIMITIVE_SOURCE_FRAGMENTS in this script.',
 );


### PR DESCRIPTION
## #1589 Wave 0 — primitive-readiness

Follow-up to #1597. Investigating the smrt-svelte migration surfaced that the primitives can't yet absorb the real-world buttons, so this PR makes them ready **before** the per-package migrations begin (decisions confirmed with the owner).

### Why
- smrt-ui `Button` **omitted `class`** by design — so it could absorb *variant*-styled buttons (`class="secondary"` → `variant="secondary"`) but not *custom*-styled ones (`topic-action-btn`, `secondary-button`). A large fraction of the 554 are custom-styled.
- Some raw controls are **genuinely structural** and shouldn't be any primitive — click-catching backdrops, custom mic toggles. The ratchet had no way to allow those, which would block ever flipping a package strict.

### What's here
- **`Button` accepts a `class` prop** (documented), appended after the base `button {variant} {size}` styling so custom-styled buttons adopt Button without losing their CSS. Destructured out of `...rest` so it doesn't double-apply via the spread; handled in both the `<button>` and `<a>` (link-mode) branches. **+2 golden tests** (class applied *and* base styling retained, both render modes; axe-clean). Full smrt-ui suite green (403 tests).
- **Ratchet escape-hatch** — `<!-- raw-primitive-allow: <reason> -->` immediately above an element exempts it (reason required, so exceptions are self-documenting and reviewable). For structural controls no primitive should own.
- **Ratchet excludes `__tests__`** — test fixtures aren't shippable UI. Baseline **556 → 554**.

### Not here (next)
The first **domain-package migration** (content or a smaller pkg): adopt Button (now class-capable) for action buttons, `Tabs` for the tab/segmented controls, escape-hatch the structural ones, flip strict. smrt-svelte (all-structural) comes later.

Refs #1589.
