### PR TITLE
chore: install lefthook hooks in git worktrees

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "format": "turbo format",
     "format-check": "turbo format-check",
-    "prepare": "git rev-parse --git-dir > /dev/null 2>&1 && lefthook install || echo 'Skipping lefthook install (not in git repository)'",
+    "prepare": "git rev-parse --git-dir > /dev/null 2>&1 && lefthook install --force || echo 'Skipping lefthook install (not in a git repository)'",
     "test": "turbo test",
     "test:watch": "turbo test:watch",
     "test:coverage": "npx vitest run --coverage",


### PR DESCRIPTION
## Problem

`pnpm install` in a **git worktree** silently skips hook installation:

```
prepare: core.hooksPath is set locally to '.../.git/hooks'
prepare: Skipping lefthook install (not in git repository)
```

The `prepare` script runs plain `lefthook install`, which **exits non-zero when `core.hooksPath` is already set** — and it always is inside a worktree (worktrees share the main checkout's git config, and the main repo's install pointed `core.hooksPath` at its `.git/hooks`). The `|| echo` fallback then masks the real error with a misleading *"not in git repository"* message, so worktrees never re-sync their hooks and silently run whatever stale hook scripts the last worktree installed (e.g. ones hardcoding a different worktree's lefthook binary path).

## Fix

```diff
-    "prepare": "... && lefthook install || echo 'Skipping lefthook install (not in git repository)'",
+    "prepare": "... && lefthook install --force || echo 'Skipping lefthook install (not in a git repository)'",
```

`lefthook install --force` installs into the existing `core.hooksPath` instead of erroring. Fresh clones (no `core.hooksPath` set yet) are unaffected — `--force` is a no-op there; worktrees now sync hooks on every install. Fallback message wording corrected for the genuine non-git (dependency-install) case.

Verified: in this worktree the new command prints `sync hooks: ✔️ (commit-msg, pre-push, pre-commit)` where plain `lefthook install` previously errored out.

> Context: surfaced while working on #1598 — lefthook couldn't be invoked from a worktree-based agent. (Separately, lefthook v2 needs a pty to *run* commands, so hooks still can't execute in fully sandboxed/no-tty environments; this PR only fixes the install/skip, which is what affects normal terminals.)