### PR TITLE
fix(smrt-ui): make disabled link-mode Button non-navigable

### DIFF
--- a/packages/smrt-ui/src/components/ui/Button.svelte
+++ b/packages/smrt-ui/src/components/ui/Button.svelte
@@ -73,11 +73,12 @@ const linkProps = $derived(() => {
 
 {#if isLink}
   <a
-    {href}
+    href={isDisabled ? undefined : href}
     class="button {variant} {size} {className}"
     class:disabled={isDisabled}
     class:full-width={fullWidth}
     class:loading
+    tabindex={isDisabled ? -1 : undefined}
     aria-disabled={isDisabled}
     aria-busy={loading}
     onclick={onclick as HTMLAnchorAttributes['onclick']}

--- a/packages/smrt-ui/src/components/ui/Button.svelte
+++ b/packages/smrt-ui/src/components/ui/Button.svelte
@@ -63,10 +63,22 @@ const buttonOnlyProps = new Set([
   'formTarget',
 ]);
 
-// Filter out button-specific props for link mode
+// Attributes the disabled link sets itself. `rest` is spread *after* the
+// explicit attributes on the <a>, so without excluding these a caller-supplied
+// `tabindex` / `aria-disabled` in `rest` would win and make a "disabled" link
+// focusable or announced as enabled again (PR #1602 review). Only stripped
+// while disabled, so an enabled link still honors a caller's tabindex.
+const disabledControlledProps = new Set(['tabindex', 'aria-disabled']);
+
+// Filter out button-specific props (always) and the self-controlled disabled
+// attributes (while disabled) for link mode.
 const linkProps = $derived(() => {
   return Object.fromEntries(
-    Object.entries(rest).filter(([key]) => !buttonOnlyProps.has(key)),
+    Object.entries(rest).filter(
+      ([key]) =>
+        !buttonOnlyProps.has(key) &&
+        !(isDisabled && disabledControlledProps.has(key)),
+    ),
   ) as HTMLAnchorAttributes;
 });
 </script>

--- a/packages/smrt-ui/src/components/ui/__tests__/Button.test.ts
+++ b/packages/smrt-ui/src/components/ui/__tests__/Button.test.ts
@@ -93,6 +93,29 @@ describe('Button', () => {
     expect(link).toHaveClass('button');
   });
 
+  it('is not navigable when disabled in link mode', async () => {
+    const { container } = render(Button, {
+      props: { children: textSnippet('Home'), href: '/home', disabled: true },
+    });
+    // A disabled link-mode Button must be genuinely non-navigable: it drops its
+    // href (no navigation target), leaves the tab order, and is announced as
+    // disabled. Previously it kept a live href + tab stop and only blocked the
+    // mouse via CSS pointer-events, so keyboard/AT users could still activate
+    // it (flagged by the PR #1599 auto-review).
+    const anchor = container.querySelector('a');
+    if (anchor === null)
+      throw new Error('expected a rendered <a> in link mode');
+    expect(anchor).not.toHaveAttribute('href');
+    expect(anchor).toHaveAttribute('tabindex', '-1');
+    expect(anchor).toHaveAttribute('aria-disabled', 'true');
+    // No href => no implicit link role => not reachable as a link by AT.
+    expect(screen.queryByRole('link')).toBeNull();
+    // ...and keyboard focus can't land on it, so Enter can't navigate.
+    await userEvent.tab();
+    expect(anchor).not.toHaveFocus();
+    await expectNoA11yViolations(container);
+  });
+
   it('is axe-clean', async () => {
     const { container } = render(Button, {
       props: { children: textSnippet('Accessible') },

--- a/packages/smrt-ui/src/components/ui/__tests__/Button.test.ts
+++ b/packages/smrt-ui/src/components/ui/__tests__/Button.test.ts
@@ -116,6 +116,29 @@ describe('Button', () => {
     await expectNoA11yViolations(container);
   });
 
+  it('keeps a disabled link non-navigable even when the caller passes tabindex/aria-disabled', async () => {
+    const { container } = render(Button, {
+      props: {
+        children: textSnippet('Home'),
+        href: '/home',
+        disabled: true,
+        // Passthrough props that must NOT win over the disabled semantics:
+        // `rest` is spread after the component's own attributes on the <a>.
+        tabindex: 0,
+        'aria-disabled': false,
+      },
+    });
+    const anchor = container.querySelector('a');
+    if (anchor === null)
+      throw new Error('expected a rendered <a> in link mode');
+    expect(anchor).toHaveAttribute('tabindex', '-1');
+    expect(anchor).toHaveAttribute('aria-disabled', 'true');
+    expect(anchor).not.toHaveAttribute('href');
+    await userEvent.tab();
+    expect(anchor).not.toHaveFocus();
+    await expectNoA11yViolations(container);
+  });
+
   it('is axe-clean', async () => {
     const { container } = render(Button, {
       props: { children: textSnippet('Accessible') },


### PR DESCRIPTION
## Problem

`Button` renders as an `<a>` when `href` is provided. When it was **also** `disabled` or `loading` (`isDisabled`), the link branch only set `aria-disabled` and a `class:disabled` (which applies `pointer-events: none`). But the `<a>` kept a **real `href`** and **stayed in the tab order**, so:

- a keyboard user could Tab to it and press Enter to navigate,
- assistive tech still announced it as an enabled link,
- `pointer-events: none` blocked only the mouse.

So a "disabled" link-mode Button wasn't actually disabled. Surfaced by an auto-reviewer on [#1599](https://github.com/happyvertical/smrt/pull/1599).

## Fix

Scoped entirely to the `{#if isLink}` branch of [Button.svelte](packages/smrt-ui/src/components/ui/Button.svelte):

- `href={isDisabled ? undefined : href}` — when disabled there is no navigation target, and an `<a>` with no `href` has **no implicit `link` role**, so it's no longer exposed as a navigable link.
- `tabindex={isDisabled ? -1 : undefined}` — removes it from the tab order when disabled (no attribute otherwise, preserving natural focusability).
- `aria-disabled={isDisabled}` — kept, so it's still announced as disabled.

The enabled link case and the entire `<button>` branch (which already uses the native `disabled` attribute) are untouched, as is the `class` passthrough from #1589.

## Tests

Added a regression test to the golden [Button.test.ts](packages/smrt-ui/src/components/ui/__tests__/Button.test.ts) asserting a disabled link-mode Button: has **no** `href`, has `tabindex="-1"` and `aria-disabled="true"`, exposes **no** `link` role, **cannot receive keyboard focus** (so Enter can't navigate), and stays **axe-clean**.

## Verification

- `pnpm exec vitest run` (smrt-ui): **404 passed** (39 files) — no consumer regressions.
- `pnpm --filter @happyvertical/smrt-ui typecheck` (tsc + svelte-check a11y): **0 errors, 0 warnings**.
- `npx biome check`: clean. `gitleaks`: no leaks. `pnpm knowledge:check --strict`: fresh.
- Svelte MCP autofixer: no issues with the change.
